### PR TITLE
[IMP] l10n_it_edi_website_sale: compute codice fiscale in ecommerce

### DIFF
--- a/addons/l10n_it_edi_website_sale/__manifest__.py
+++ b/addons/l10n_it_edi_website_sale/__manifest__.py
@@ -21,6 +21,9 @@ Contains features for Italian eCommerce eInvoicing
     'auto_install': True,
     'license': 'OEEL-1',
     'assets': {
+        'web.assets_frontend': [
+            '/l10n_it_edi_website_sale/static/src/js/l10n_it_edi_website_sale.js',
+        ],
         'web.assets_tests': [
             'l10n_it_edi_website_sale/static/tests/**/*',
         ],

--- a/addons/l10n_it_edi_website_sale/static/src/js/l10n_it_edi_website_sale.js
+++ b/addons/l10n_it_edi_website_sale/static/src/js/l10n_it_edi_website_sale.js
@@ -1,0 +1,23 @@
+/** @odoo-module **/
+import { WebsiteSale } from 'website_sale.website_sale';
+
+WebsiteSale.include({
+    events: Object.assign(WebsiteSale.prototype.events, {
+        "change input[name='vat'], select[name='country_id']": "computeCodiceFiscale",
+    }),
+
+    computeCodiceFiscale: function() {
+        const vatValue = this.$('input[name="vat"]').val();
+        const countryValue = this.$('select[name="country_id"]').find(':selected').attr('code');
+        const l10nItCodiceFiscaleInput = this.$('input[name="l10n_it_codice_fiscale"]');
+
+        if (vatValue && (vatValue.startsWith('IT') || countryValue === 'IT')) {
+            if (/^IT[0-9]{11}$/.test(vatValue)) {
+                l10nItCodiceFiscaleInput.val(vatValue.slice(2, 13));
+            }
+            else {
+                l10nItCodiceFiscaleInput.val(vatValue);
+            }
+        }
+    },
+});

--- a/addons/l10n_it_edi_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_it_edi_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -46,4 +46,65 @@ tour.register('shop_checkout_address', {
     ]
 );
 
+tour.register('shop_checkout_address_create_partner', {
+    test: true,
+    url: '/shop',
+},
+    [
+        ...tourUtils.addToCart({ productName: "Storage Box" }),
+        tourUtils.goToCart(),
+        {
+            content: "go to address form",
+            trigger: 'a[href="/shop/checkout?express=1"]',
+        },
+        {
+            content: "Fill address form with VAT",
+            trigger: 'select[name="country_id"]',
+            run: function () {
+                $('input[name="name"]').val('abc');
+                $('input[name="phone"]').val('99999999');
+                $('input[name="email"]').val('abc@odoo.com');
+                $('input[name="vat"]').val('IT12345670017');
+                $('input[name="street"]').val('SO1 Billing Street, 33');
+                $('input[name="city"]').val('SO1BillingCity');
+                $('input[name="zip"]').val('10000');
+            },
+        },
+        {
+            content: "Select country with code 'IT' to trigger compute of Codice Fiscale",
+            trigger: "select[name='country_id']",
+            run: function () {
+                const countrySelect = $("select[name='country_id']");
+                countrySelect.find('option[code="IT"]').attr('selected', true);
+                countrySelect.trigger('change');
+            }
+        },
+        {
+            content: "Check if the Codice Fiscale value matches",
+            trigger: "input[name='l10n_it_codice_fiscale']",
+            run: function () {
+                if ($("input[name='l10n_it_codice_fiscale']").val() !== "12345670017") {
+                    console.error('Expected "12345670017" for Codice Fiscale.');
+                }
+            }
+        },
+        {
+            content: "Add state",
+            trigger: 'select[name="state_id"]',
+            run: function () {
+                $('#state_id option:contains(Cremona)').attr('selected', true);
+            },
+        },
+        {
+            content: "Click on next button",
+            trigger: '.oe_cart .btn:contains("Next")',
+        },
+        {
+            content: "Check selected billing address is same as typed in previous step",
+            trigger: '#shipping_and_billing:contains(SO1 Billing Street, 33):contains(SO1BillingCity)',
+            run: function () {}, // it's a check
+        },
+    ]
+);
+
 });

--- a/addons/l10n_it_edi_website_sale/tests/test_l10n_it_edi_website_sale.py
+++ b/addons/l10n_it_edi_website_sale/tests/test_l10n_it_edi_website_sale.py
@@ -11,9 +11,18 @@ class TestUi(HttpCase):
             'list_price': 79.0,
             'website_published': True,
         })
+        # set current company's fiscal country to italy
+        company = self.env['website'].get_current_website().company_id
+        company.account_fiscal_country_id = company.country_id = self.env.ref('base.it')
 
     def test_checkout_address(self):
-        # set current company's fiscal country to italy
-        website = self.env['website'].get_current_website()
-        website.company_id.account_fiscal_country_id = website.company_id.country_id = self.env.ref('base.it')
         self.start_tour("/", 'shop_checkout_address')
+
+    def test_public_user_codice_fiscale(self):
+        self.start_tour('/shop', 'shop_checkout_address_create_partner')
+        new_partner = self.env['res.partner'].search([('name', '=', 'abc')])
+        self.assertEqual(
+            new_partner.l10n_it_codice_fiscale,
+            '12345670017',
+            "The new partner should have the Codice Fiscale filled according to the VAT",
+        )

--- a/addons/l10n_it_edi_website_sale/views/templates.xml
+++ b/addons/l10n_it_edi_website_sale/views/templates.xml
@@ -15,6 +15,10 @@
                     </div>
                 </t>
             </xpath>
+            <!-- Sets the country code for every country option -->
+            <xpath expr="//t[@t-foreach='countries']//option" position="attributes">
+                <attribute name="t-att-code">c.code</attribute>
+            </xpath>
         </template>
     </data>
 </odoo>

--- a/addons/l10n_it_edi_website_sale/views/templates.xml
+++ b/addons/l10n_it_edi_website_sale/views/templates.xml
@@ -11,7 +11,7 @@
                     </div>
                     <div t-attf-class="mb-3 #{error.get('vat') and 'o_has_error' or ''} col-lg-6 div_l10n_it_pa_index mb-0" id="div_l10n_it_pa_index">
                         <label class="col-form-label fw-normal label-optional" for="l10n_it_pa_index">Destination Code (SDI)</label>
-                        <input type="text" name="l10n_it_pa_index" t-attf-class="form-control #{error.get('l10n_it_pa_index') and 'is-invalid' or ''}" t-att-value="'l10n_it_codice_fiscale' in checkout and checkout['l10n_it_codice_fiscale']"/>
+                        <input type="text" name="l10n_it_pa_index" t-attf-class="form-control #{error.get('l10n_it_pa_index') and 'is-invalid' or ''}" t-att-value="'l10n_it_pa_index' in checkout and checkout['l10n_it_pa_index']"/>
                     </div>
                 </t>
             </xpath>


### PR DESCRIPTION
When creating a partner with an italian VAT number in the backend, the field Codice Fiscale is automatically computed from the Tax ID. However, when a partner is created from the eCommerce of an italian company and the partner's VAT is filled, the Codice Fiscale is not filled in the newly created partner.

We extend WebsiteSale to add `computeCodiceFiscale`, which will be triggered when the input field VAT or the select field Country change in the Address form. The function fills the Codice Fiscale if the VAT field is filled, and it starts with 'IT' or the country selected is Italy.

Task [link](https://www.odoo.com/odoo/project/967/tasks/4596227)
task-4596227