### PR TITLE
[FIX] website_event_sale: don't remind people of unavailable tickets

### DIFF
--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -136,10 +136,13 @@ class EventTicket(models.Model):
             if ticket.seats_max > 0:
                 ticket.seats_available = ticket.seats_max - (ticket.seats_reserved + ticket.seats_used)
 
-    @api.depends('seats_limited', 'seats_available')
+    @api.depends('seats_limited', 'seats_available', 'event_id.event_registrations_sold_out')
     def _compute_is_sold_out(self):
         for ticket in self:
-            ticket.is_sold_out = ticket.seats_limited and not ticket.seats_available
+            ticket.is_sold_out = (
+                (ticket.seats_limited and not ticket.seats_available)
+                or ticket.event_id.event_registrations_sold_out
+            )
 
     @api.constrains('start_sale_datetime', 'end_sale_datetime')
     def _constrains_dates_coherency(self):

--- a/addons/website_event_sale/models/sale_order.py
+++ b/addons/website_event_sale/models/sale_order.py
@@ -93,6 +93,12 @@ class SaleOrder(models.Model):
             ], offset=new_qty, limit=(old_qty - new_qty), order='create_date asc')
             attendees.action_cancel()
 
+    def _filter_can_send_abandoned_cart_mail(self):
+        """Prevent carts with expired/sold out tickets from being subject of reminder emails."""
+        return super()._filter_can_send_abandoned_cart_mail().filtered(
+            lambda so: all(ticket.sale_available for ticket in so.order_line.event_ticket_id)
+        )
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"

--- a/addons/website_event_sale/tests/__init__.py
+++ b/addons/website_event_sale/tests/__init__.py
@@ -3,4 +3,5 @@
 
 from . import common
 from . import test_frontend_buy_tickets
+from . import test_website_event_sale_cart
 from . import test_website_event_sale_pricelist

--- a/addons/website_event_sale/tests/test_website_event_sale_cart.py
+++ b/addons/website_event_sale/tests/test_website_event_sale_cart.py
@@ -1,0 +1,52 @@
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.website_event_sale.tests.common import TestWebsiteEventSaleCommon
+from odoo.addons.website_sale.tests.test_website_sale_cart_abandoned import (
+    TestWebsiteSaleCartAbandonedCommon,
+)
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteEventSaleCart(TestWebsiteEventSaleCommon, TestWebsiteSaleCartAbandonedCommon):
+    def test_sold_out_event_cart_reminder(self):
+        """Check that abandoned cart emails aren't sent for sold out tickets."""
+        cart1, cart2 = carts = self.so1before + self.so2before
+        carts.order_line.unlink()
+        carts.website_id.send_abandoned_cart_email = True
+
+        self.event.auto_confirm = True
+        self.ticket.write({
+            'seats_limited': True,
+            'seats_max': 1,
+        })
+
+        create_order_line = [Command.create({
+            'product_id': self.product_event.id,
+            'event_id': self.event.id,
+            'event_ticket_id': self.ticket.id,
+        })]
+        cart1.order_line = create_order_line
+        cart2.order_line = create_order_line
+        self.assertTrue(
+            self.send_mail_patched(cart1.id),
+            "Abandoned cart email should be sent for availlable tickets",
+        )
+
+        # Create registrations & confirm first order
+        editor = self.env['registration.editor'].new()
+        editor.with_context(default_sale_order_id=cart1.id).action_make_registration()
+        cart1.action_confirm()
+        self.assertEqual(self.ticket.seats_available, 0)
+        self.assertFalse(
+            self.send_mail_patched(cart2.id),
+            "Abandoned cart email should not be sent when ticket has no seats available",
+        )
+
+        # Reset sent state, increase seat limit, and try again
+        cart2.cart_recovery_email_sent = False
+        self.ticket.seats_max = 2
+        self.assertTrue(
+            self.send_mail_patched(cart2.id),
+            "Abandoned cart email can be sent after increasing seat count",
+        )


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Enable abandoned cart reminder emails;
2. have an event with a limited number of seats;
3. open a cart for a ticket to the event;
4. abandon the cart;
5. have available seats fill up.

Issue
-----
You still get an email reminding you to buy the ticket, even though it's no longer available. As a consequence, you can still pay the sales order, but it won't get confirmed.

Cause
-----
There is no custom logic in place for `website_event_sale` to filter out abandoned carts with tickets that are no longer eligible.

Additionally, the `is_sold_out` field of tickets can be `False` while the event's `event_registrations_sold_out` field is `True`.

Solution
--------
- Add the event's `event_registrations_sold_out` field as a dependency to `event.event.ticket`'s `_comute_is_sold_out` method.
- Add an override for `_filter_can_send_abandoned_cart_mail` which filters out carts with tickets that are sold out, or events with no free places remaining.

opw-4453539