### PR TITLE
[IMP] (purchase|sale)_edi_ubl: RFQ export/import product

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1112,11 +1112,14 @@ class AccountEdiXmlUbl_20(models.AbstractModel):
                 './cac:Item/cbc:Description',
                 './cac:Item/cbc:Name',
             ],
-            'product': {
-                'default_code': './cac:Item/cac:SellersItemIdentification/cbc:ID',
-                'name': './cac:Item/cbc:Name',
-                'barcode': './cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID="0160"]',
-            },
+            'product': self._get_product_xpaths(),
+        }
+
+    def _get_product_xpaths(self):
+        return {
+            'default_code': './cac:Item/cac:SellersItemIdentification/cbc:ID',
+            'name': './cac:Item/cbc:Name',
+            'barcode': './cac:Item/cac:StandardItemIdentification/cbc:ID',
         }
 
     def _correct_invoice_tax_amount(self, tree, invoice):

--- a/addons/sale_edi_ubl/models/__init__.py
+++ b/addons/sale_edi_ubl/models/__init__.py
@@ -1,2 +1,4 @@
+
+from . import product_product
 from . import sale_edi_xml_ubl_bis3
 from . import sale_order

--- a/addons/sale_edi_ubl/models/product_product.py
+++ b/addons/sale_edi_ubl/models/product_product.py
@@ -1,0 +1,30 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import bisect
+
+from odoo import models
+from odoo.fields import Domain
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    def _get_product_domain_search_order(self, **vals):
+        """Override of `account` to include the variant identifiers in the search order.
+
+        If the product is not found using `*ItemIdentification:ID` elements, tries again with the
+        `*ItemIdentification:ExtendedID` elements. `ExtendedID` could be used to identify a product
+        variant.
+
+        Example:
+            StandardItemIdentification::ID == product.template.barcode           (product ID)
+            StandardItemIdentification::ExtendedID == product.product.barcode    (variant ID)
+        """
+        domains = super()._get_product_domain_search_order(**vals)
+
+        if variant_default_code := vals.get('variant_default_code'):
+            bisect.insort(domains, (12, Domain('default_code', '=', variant_default_code)))
+        if variant_barcode := vals.get('variant_barcode'):
+            bisect.insort(domains, (14, Domain('barcode', '=', variant_barcode)))
+
+        return domains

--- a/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
+++ b/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
@@ -291,3 +291,12 @@ class SaleEdiXmlUbl_Bis3(models.AbstractModel):
         # Recompute product price and discount according to sale price
         order._recompute_prices()
         return res
+
+    def _get_product_xpaths(self):
+        """Override of `account.edi.xml.ubl_bis3` to support the `ExtendedID` field used to
+        identify product variants."""
+        return {
+            **super()._get_product_xpaths(),
+            'variant_barcode': './cac:Item/cac:StandardItemIdentification/cbc:ExtendedID',
+            'variant_default_code': './cac:Item/cac:SellersItemIdentification/cbc:ExtendedID',
+        }


### PR DESCRIPTION
When importing an RFQ in quotations, the product matching process is
currently not using all data provided correctly.

This commit improves product export by adding SellersItemIdentification
information when there is a vendor product code in the supplier info of
a product.

This commit also improves product matching at import by using the two
following elements as a fallback if no product is found:
 - StandardItemIdentification:ExtendedID
 - SellersItemIdentification:ExtendedID

These elements are usually used to identify the variant of a product.

task-4461097

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
