### PR TITLE
[IMP] mail: discuss style improvements

### DIFF
--- a/addons/im_livechat/static/src/embed/common/thread_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/thread_patch.xml
@@ -3,7 +3,7 @@
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//*[@name='content']" position="before">
             <div t-if="props.thread?.livechatWelcomeMessage" class="bg-100 py-3">
-                <Message message="props.thread.livechatWelcomeMessage" hasActions="false" thread="props.thread" className="'px-3'"/>
+                <Message message="props.thread.livechatWelcomeMessage" hasActions="false" thread="props.thread"/>
             </div>
         </xpath>
         <xpath expr="(//div[hasclass('o-mail-Thread')])" position="inside">

--- a/addons/mail/static/src/chatter/web_portal/chatter.scss
+++ b/addons/mail/static/src/chatter/web_portal/chatter.scss
@@ -18,8 +18,16 @@
 .o-mail-Chatter-top, .o-mail-Chatter-content {
     --Chatter-default-padding-x: #{$o-spacer};
 
-    padding-left: var(--ChatterAsideForm-padding-left, var(--Chatter-default-padding-x));
     padding-right: var(--Chatter-default-padding-x);
+}
+
+.o-mail-Chatter-top {
+    padding-left: var(--ChatterAsideForm-padding-left, var(--Chatter-default-padding-x));
+}
+
+.o-mail-Chatter-content {
+    --mail-Chatter-contentPaddingLeft: var(--ChatterAsideForm-padding-left, var(--Chatter-default-padding-x));
+    padding-left: calc(var(--mail-Chatter-contentPaddingLeft) - #{($o-mail-Message-sidebarWidth - $o-mail-Avatar-size) / 2});
 }
 
 .o-mail-Followers-button:focus {

--- a/addons/mail/static/src/core/common/autoresize_input.scss
+++ b/addons/mail/static/src/core/common/autoresize_input.scss
@@ -12,7 +12,7 @@
             --o-input-border-color: #{$border-color};
         }
         &:focus {
-            --o-input-border-color: #{$black};
+            --o-input-border-color: #{rgba($black, .5)};
         }
     }
 }

--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -3,7 +3,7 @@
     height: auto !important;
     z-index: $o-mail-ChatBubble-zindex;
     border: none !important;
-    padding: 0 map-get($spacers, 2);
+    padding: 0;
     background-color: transparent !important;
 
     &:hover {
@@ -39,7 +39,7 @@
 }
 
 .o-mail-ChatBubble-close {
-    right: 3px;
+    right: -5px;
     top: -3px;
     z-index: 6;
     font-size: 11px;
@@ -65,7 +65,7 @@
 .o-mail-ChatBubble-counter {
     z-index: 7;
     top: -3px;
-    right: 3px;
+    right: 8px;
     display: inline-flex;
 }
 
@@ -73,12 +73,13 @@
     max-width: 225px;
     right: $o-mail-ChatHub-bubblesWidth;
     z-index: $o-mail-ChatBubble-zindex - 1;
-    border-color: mix($o-gray-300, $o-gray-400) !important;
+    border-color: $o-gray-300 !important;
     
     & + .popover-arrow {
         // puts arrow above preview border
+        z-index: 1 !important;
         &::before {
-            border-left-color: mix($o-gray-300, $o-gray-400) !important;
+            border-left-color: $o-gray-300 !important;
             right: 1px !important;
         }
         &::after {
@@ -98,7 +99,7 @@
 .o-mail-ChatBubble-unreadIndicator {
     font-size: .5rem;
     bottom: 40%;
-    right: -2px;
+    right: -10px;
 }
 
 @keyframes o-mail-ChatBubble-bouncing { 

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -15,8 +15,8 @@
 
     <t t-name="mail.ChatBubblePreview">
         <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 rounded">
-            <div class="text-truncate base-fs fw-bolder mb-0 mx-2" t-esc="props.chatWindow.displayName"/>
-            <div t-if="previewContent" class="text-truncate small mx-2 text-muted">
+            <div class="text-truncate base-fs fw-bolder mb-0 mx-2 px-1" t-esc="props.chatWindow.displayName"/>
+            <div t-if="previewContent" class="text-truncate small mx-2 px-1 text-muted">
                 <t t-call="mail.message_preview_prefix">
                     <t t-set="message" t-value="thread?.newestPersistentOfAllMessage"/>
                 </t>

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -9,6 +9,11 @@
     &.o-liftUp {
         transform: translateY(-25px);
     }
+
+    &.o-mobile {
+        margin-right: $o-mail-ChatHub-bubblesMargin + 5px;
+        transform: translateY(-35px);
+    }
 }
 
 .o-mail-ChatHub-bubbleBtn {
@@ -86,10 +91,13 @@
     font-size: 15px;
     width: 30px !important;
     height: 30px !important;
-    border: $border-width solid mix($o-gray-300, $o-gray-400) !important;
+    border: $border-width solid transparent !important;
 
     &:hover, &.show {
-        background-color: $o-gray-300 !important;
+        background-color: mix($o-gray-200, $o-gray-300) !important;
         opacity: 100% !important;
+    }
+    &.show {
+        border-color: mix($o-gray-300, $o-gray-400) !important;
     }
 }

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -7,14 +7,14 @@
         <t t-foreach="visibleChatWindows" t-as="cw" t-key="cw.localId">
             <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (visibleChatWindows.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
         </t>
-        <div class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto', 'o-liftUp': busMonitoring.hasConnectionIssues }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
+        <div class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto', 'o-liftUp': busMonitoring.hasConnectionIssues, 'o-mobile': isMobileOS }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
                 <t t-if="store.chatHub.compact">
                     <t t-call="mail.ChatHub.compactButton"/>
                 </t>
                 <t t-else="">
                     <Dropdown t-if="(chatHub.opened.length + chatHub.folded.length) gt 0" state="options" position="'top-end'" menuClass="'d-flex flex-column bg-100 shadow-sm m-0 p-0 mb-1 border-secondary'">
-                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-100 mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen and !isMobileOS, 'text-500': bubblesHover.isHover and !options.isOpen and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
+                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-100 mt-1 fs-3" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen and !isMobileOS, 'text-500': bubblesHover.isHover and !options.isOpen and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
                         <t t-set-slot="content">
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.hideAll()"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>

--- a/addons/mail/static/src/core/common/chat_window.dark.scss
+++ b/addons/mail/static/src/core/common/chat_window.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-ChatWindow {
+    --mail-ChatWindow-borderDesktopOpacity: .1;
+}
+
 .o-mail-ChatWindow-command {
     --mail-ChatWindow-commandHoverColor: white;
 }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -3,7 +3,7 @@
 
     z-index: $zindex-sticky;
     &:not(.o-mobile) {
-        --border-opacity: .15;
+        --border-opacity: var(--mail-ChatWindow-borderDesktopOpacity, .15);
         aspect-ratio: 9 / 15;
     }
     outline: none;

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -78,7 +78,7 @@
             <div t-if="thread and thread.importantCounter > 0" class="o-mail-ChatWindow-counter mx-1 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter">
                 <t t-out="thread.importantCounter"/>
             </div>
-            <div class="o-mail-ChatWindow-quickActions d-flex flex-shrink-0 me-2 o-gap-0_5">
+            <div class="o-mail-ChatWindow-quickActions d-flex flex-shrink-0 o-gap-0_5" t-att-class="{ 'me-2': !ui.isSmall }">
                 <t t-foreach="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 4).reverse()" t-as="action" t-key="action.id" t-call="mail.ChatWindow.quickAction">
                     <t t-if="action_last" t-set="itemClass" t-value="ui.isSmall ? 'mx-2' : ''"/>
                 </t>

--- a/addons/mail/static/src/core/common/composer.dark.scss
+++ b/addons/mail/static/src/core/common/composer.dark.scss
@@ -2,6 +2,10 @@
     --mail-Composer-bg: #{mix($gray-100, $o-view-background-color)};
 }
 
+.o-mail-Composer-bg {
+    --border-opacity: 0;
+}
+
 .o-mail-Composer-actions {
     --mail-Composer-actionHoverColor: white;
 }

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -11,8 +11,8 @@
     }
 
     .o-mail-Composer-sidebarMain {
-        padding-top: 0.1875rem; // avatar centered with composer text input: 36px (avatar) + 2*3px (this value) = 20px + 2 * { 10px (padding) + 1px (border) }
-        width: 48px;
+        padding-top: 0.125rem; // avatar centered with composer text input: 38px (avatar) + 2*2px (this value) = 20px + 2 * { 10px (padding) + 1px (border) }
+        width: $o-mail-Message-sidebarWidth;
     }
 
     .o-mail-Composer-coreHeader {
@@ -202,11 +202,11 @@
 .o-mail-Composer-inputContainer {
 
     &.o-iosPwa:not(:focus-within) {
-        margin-bottom: map-get($spacers, 5) !important;
+        margin-bottom: map-get($spacers, 3) !important;
     }
 
     &:has(textarea:focus) {
-        --border-opacity: 0.35;
+        --border-opacity: .25;
         border-color: rgba($o-action, var(--border-opacity)) !important;
     }
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -14,13 +14,13 @@
                     'pb-2': extended and !props.composer.message,
                     'o-extended': extended,
                     'o-isUiSmall': ui.isSmall,
-                    'px-3 pb-2': normal,
+                    'ps-2 pe-4 pb-2': normal,
                     'o-hasSelfAvatar': showComposerAvatar,
                     'o-focused': props.composer.isFocused,
                     'o-editing': props.composer.message,
                     'o-chatWindow mx-2': env.inChatWindow,
                     'mb-3': env.inChatWindow and !props.composer.message,
-                    'o-discussApp': env.inDiscussApp,
+                    'o-discussApp pt-1': env.inDiscussApp,
                     'm-1': !env.inDiscussApp,
                 }" t-attf-class="{{ props.className }}">
             <FileUploader t-if="allowUpload" multiUpload="isMultiUpload" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
@@ -29,7 +29,7 @@
                 </t>
             </FileUploader>
             <div t-if="showComposerAvatar" class="o-mail-Composer-sidebarMain flex-shrink-0">
-                <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
+                <img class="o-mail-Composer-avatar mx-auto o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -27,7 +27,6 @@ $o-discuss-talkingColor: lighten($success, 10%);
 
 .o-discuss-mobileContextMenu {
     top: auto !important;
-    border-top: $border-width solid $border-color !important;
 }
 
 .o-discuss-separator {

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -7,36 +7,32 @@
 }
 
 .o-mail-Message-author {
-    opacity: 75%;
-}
-
-.o-mail-Message-date {
     opacity: 50%;
 }
 
 .o-mail-Message-bubble {
     &.o-blue {
         background-color: mix($gray-100, $info, 87.5%) !important;
-        border-color: lighten(mix($gray-100, $info, 87.5%), 5%) !important;
-
+        border-color: lighten(mix($gray-100, $info, 87.5%), 2.5%) !important;
+    
         &.o-muted {
-            background-color: mix($gray-100, mix($gray-100, $info, 87.5%)) !important;
+            background-color: darken(mix($gray-100, $info, 87.5%), 5%) !important;
         }
     }
     &.o-green {
         background-color: mix($gray-100, $success, 87.5%) !important;
-        border-color: lighten(mix($gray-100, $success, 87.5%), 5%) !important;
-
+        border-color: lighten(mix($gray-100, $success, 87.5%), 2.5%) !important;
+    
         &.o-muted {
-            background-color: mix($gray-100, mix($gray-100, $success, 87.5%)) !important;
+            background-color: darken(mix($gray-100, $success, 87.5%), 5%) !important;
         }
     }
     &.o-orange {
         background-color: mix($gray-100, $warning, 72.5%) !important;
-        border-color: lighten(mix($gray-100, $warning, 72.5%), 5%) !important;
-
+        border-color: lighten(mix($gray-100, $warning, 72.5%), 2.5%) !important;
+    
         &.o-muted {
-            background-color: mix($gray-100, mix($gray-100, $warning, 72.5%), 85%) !important;
+            background-color: darken(mix($gray-100, $warning, 72.5%), 10%) !important;
         }
     }
 }

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -214,7 +214,7 @@ export class Message extends Component {
                 this.props.thread &&
                 !this.env.messageCard &&
                 !this.props.asCard,
-            "px-2": this.props.isInChatWindow,
+            "px-1": this.props.isInChatWindow,
             "opacity-50": this.props.messageToReplyTo?.isNotSelected(
                 this.props.thread,
                 this.props.message

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -13,14 +13,14 @@
     }
 
     &.o-actionMenuMobileOpen {
-        background-color: rgba($o-action, .1);
-        outline: 1px solid rgba($o-action, .15);
+        background-color: rgba($o-action, .075);
+        outline: 1px solid rgba($o-action, .125);
         outline-offset: -1px;
     }
 }
 
 .o-mail-Message-date {
-    opacity: 50%;
+    opacity: 35%;
 }
 
 .o-mail-Message-edited {
@@ -90,7 +90,7 @@
 .o-mail-Message-bubble {
     &.o-blue {
         background-color: mix($o-view-background-color, $info, 87.5%) !important;
-        border-color: darken(mix($o-view-background-color, $info, 87.5%), 10%) !important;
+        border-color: darken(mix($o-view-background-color, $info, 87.5%), 5%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $info, 87.5%)) !important;
@@ -98,7 +98,7 @@
     }
     &.o-green {
         background-color: mix($o-view-background-color, $success, 87.5%) !important;
-        border-color: darken(mix($o-view-background-color, $success, 87.5%), 10%) !important;
+        border-color: darken(mix($o-view-background-color, $success, 87.5%), 5%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $success, 87.5%)) !important;
@@ -106,7 +106,7 @@
     }
     &.o-orange {
         background-color: mix($o-view-background-color, $warning, 75%) !important;
-        border-color: darken(mix($o-view-background-color, $warning, 75%), 10%) !important;
+        border-color: darken(mix($o-view-background-color, $warning, 75%), 5%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $warning, 75%), 85%) !important;
@@ -136,7 +136,7 @@
     }
 
     button {
-        opacity: 50%;
+        opacity: 35%;
 
         &:hover, &.focus, &.show {
             opacity: 100%;
@@ -149,9 +149,13 @@
     z-index: $o-mail-NavigableList-zIndex;
 }
 
-.o-mail-Message-openActionMobile:active {
-    opacity: 75% !important;
-}
+.o-mail-Message-openActionMobile {
+    opacity: 15% !important;
+
+    &:active {
+        opacity: 75% !important;
+    }
+} 
 
 .o-mail-Message-pendingProgress {
     animation: o-mail-message-pendingProgress-animation 0s ease-in 0.5s forwards;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -18,7 +18,7 @@
                 t-if="message.exists()"
             >
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
-                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight, 'align-items-start justify-content-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
+                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0 justify-content-center" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
                         <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view" t-att-class="getAvatarContainerAttClass()">
                             <img class="o-mail-Message-avatar w-100 h-100 rounded" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
                         </div>
@@ -180,7 +180,7 @@
 
 <t t-name="mail.Message.expandAction">
     <button class="btn border-0 rounded-0 o-mail-Message-expandBtn" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
-        'o-mail-Message-openActionMobile opacity-25 p-2 mt-n2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
+        'o-mail-Message-openActionMobile p-2 mt-n2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
         'me-n2': isMobileOS and !mobileExpanded and isAlignedRight,
         'ms-n2': isMobileOS and !mobileExpanded and !isAlignedRight,
         'px-2 py-0': !isMobileOS,

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -123,7 +123,7 @@ messageActionsRegistry
             const component = useComponent();
             component.dialog = useService("dialog");
         },
-        sequence: 90,
+        sequence: 120,
     })
     .add("download_files", {
         condition: (component) =>

--- a/addons/mail/static/src/core/common/message_in_reply.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.scss
@@ -1,6 +1,6 @@
 .o-mail-MessageInReply-avatar {
     width: $o-mail-Avatar-size / 2;
-    height: $o-mail-Avatar-size / 2;
+    aspect-ratio: 1;
 }
 
 .o-mail-MessageInReply-core {

--- a/addons/mail/static/src/core/common/message_reaction_list.scss
+++ b/addons/mail/static/src/core/common/message_reaction_list.scss
@@ -1,11 +1,3 @@
-.o-mail-MessageReaction {
-    line-height: 1.25;
-    
-    &:not(.o-selfReacted):hover {
-        --border-color: #{$primary};
-    }
-}
-
 .o-mail-MessageReactionList-preview:hover {
     background-color: $o-gray-100 !important;
 }

--- a/addons/mail/static/src/core/common/message_reactions.dark.scss
+++ b/addons/mail/static/src/core/common/message_reactions.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-MessageReaction {
+    --mail-MessageReaction-selfReactedBorderOpacity: 1;
+}

--- a/addons/mail/static/src/core/common/message_reactions.scss
+++ b/addons/mail/static/src/core/common/message_reactions.scss
@@ -1,8 +1,17 @@
-.o-mail-MessageReactions:not(.o-emojiPickerOpen):not(:hover) .o-mail-MessageReactions-add {
-    visibility: hidden;
+.o-mail-MessageReaction {
+    line-height: 1.25;
+    --border-opacity: .5;
+
+    &:not(.o-selfReacted):hover {
+        border-color: rgba($primary, var(--mail-MessageReaction-selfReactedBorderOpacity, .35)) !important;
+    }
+
+    &.o-selfReacted {
+        --border-opacity: #{var(--mail-MessageReaction-selfReactedBorderOpacity, .35)};
+        background: mix($o-brand-primary, $o-view-background-color, 10%);
+    }
 }
 
-.o-mail-MessageReaction.o-selfReacted {
-    --border-opacity: 0.75;
-    background: mix($o-brand-primary, $o-view-background-color, 10%);
+.o-mail-MessageReactions:not(.o-emojiPickerOpen):not(:hover) .o-mail-MessageReactions-add {
+    visibility: hidden;
 }

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -10,7 +10,7 @@
         <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
             <MessageReactionList message="this.props.message" openReactionMenu="this.props.openReactionMenu" reaction="reaction"/>
         </t>
-        <button class="o-mail-MessageReactions-add btn bg-inherit d-flex px-1 py-0 border-0 rounded-0 mb-1 align-items-center fs-5 opacity-75 opacity-100-hover" title="Add Reaction" t-ref="add"><i class="oi fa-fw oi-smile-add"/></button>
+        <button class="o-mail-MessageReactions-add btn bg-inherit d-flex px-1 py-0 border-0 rounded-0 mb-1 align-items-center fs-5 opacity-25 opacity-100-hover" title="Add Reaction" t-ref="add"><i class="oi fa-fw oi-smile-add"/></button>
     </div>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -1,4 +1,4 @@
-$o-mail-Avatar-size: 36px !default;
+$o-mail-Avatar-size: 38px !default;
 $o-mail-Avatar-sizeSmall: 28px !default;
 $o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-ChatHub-bubblesWidth: 56px !default; // same value as BUBBLE
@@ -15,8 +15,8 @@ $o-mail-LinkPreview-width: 320px !default;
 $o-mail-LinkPreview-height: 240px !default;
 $o-mail-LinkPreviewCard-height: 80px !default;
 
-$o-mail-Message-sidebarSmallWidth: 34px !default;
-$o-mail-Message-sidebarWidth: 42px !default;
+$o-mail-Message-sidebarSmallWidth: 40px !default;
+$o-mail-Message-sidebarWidth: 60px !default;
 $o-mail-NavigableList-zIndex: 21;
 $o-mail-Chatter-minWidth: 530px !default;
 $o-mail-Discuss-inspector: 300px !default; // same value as INSPECTOR_WIDTH

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Thread">
-    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-3': !env.inChatter and !props.isInChatWindow }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1">
+    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-2': !env.inChatter and !props.isInChatWindow }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>

--- a/addons/mail/static/src/core/common/thread_icon.js
+++ b/addons/mail/static/src/core/common/thread_icon.js
@@ -3,6 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { Component } from "@odoo/owl";
 import { Thread } from "./thread_model";
 import { _t } from "@web/core/l10n/translation";
+import { ImStatus } from "./im_status";
 
 /**
  * @typedef {Object} Props
@@ -13,6 +14,7 @@ import { _t } from "@web/core/l10n/translation";
  */
 export class ThreadIcon extends Component {
     static template = "mail.ThreadIcon";
+    static components = { ImStatus };
     static props = {
         thread: { type: Thread },
         size: { optional: true, validate: (size) => ["small", "medium", "large"].includes(size) },

--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -11,11 +11,12 @@
             <t t-elif="props.thread.channel_type?.includes('chat') and correspondent">
                 <t name="chat">
                     <t name="chat_static">
-                        <div t-if="correspondent.persona.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online"/>
+                        <ImStatus member="correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
+                        <!-- <div t-if="correspondent.persona.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online"/>
                         <div t-elif="correspondent.persona.im_status === 'offline'" class="fa fa-fw fa-circle-o opacity-75" title="Offline"/>
                         <div t-elif="correspondent.persona.im_status === 'away'" class="fa fa-fw fa-circle o-yellow" title="Away"/>
                         <div t-elif="correspondent.persona.im_status === 'bot'" class="fa fa-fw fa-heart text-success" title="Bot"/>
-                        <div t-else="" class="fa-fw" t-att-class="largeClass" t-attf-class="#{ defaultChatIcon.class }" t-att-title="defaultChatIcon.title"/>
+                        <div t-else="" class="fa-fw" t-att-class="largeClass" t-attf-class="#{ defaultChatIcon.class }" t-att-title="defaultChatIcon.title"/> -->
                     </t>
                 </t>
             </t>

--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -3,6 +3,7 @@
 }
 
 .o-mail-Discuss-header {
+    --border-opacity: 0;
     background-color: mix($o-gray-100, $o-gray-200, 15%);
 }
 
@@ -20,6 +21,6 @@
     }
 }
 
-.o-mail-Discuss-headerActionsGroup {
-    --border-opacity: .1;
+.o-mail-Discuss-panelContainer {
+    --border-opacity: 0;
 }

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -62,8 +62,8 @@
 
 .o-mail-Discuss-threadAvatar {
     img {
-        height: 32px;
-        width: 32px;
+        height: $o-mail-Avatar-size;
+        width: $o-mail-Avatar-size;
     }
 
     a {

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -8,7 +8,7 @@
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
             <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
-                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
+                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center ms-1 me-2 my-1">
                         <img class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="!thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
@@ -19,7 +19,7 @@
                         </FileUploader>
                     </div>
                     <t t-else="">
-                        <ThreadIcon className="'me-2 align-self-center'" size="'large'" thread="thread"/>
+                        <ThreadIcon className="'mx-2 align-self-center fs-2 my-2 opacity-75'" size="'large'" thread="thread"/>
                     </t>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-Discuss-headerCountry border'"/>
                     <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'me-1'" member="thread.correspondent" />

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-DiscussSidebar {
+    --border-opacity: 0;
+}

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -38,10 +38,17 @@
         }
     }
 
-    &.o-active, &:hover {
+    &:hover {
+        background-color: mix($gray-100, $gray-200) !important;
+        outline-color: mix($gray-100, $gray-200) !important;
+    }
+
+    &.o-active {
         background-color: var(--mail-DiscussSidebar-itemActiveBgColor, mix($o-view-background-color, $o-action, 90%)) !important;
         outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, rgba($o-action, .2)) !important;
+    }
 
+    &.o-active, &:hover {
         .o-mail-DiscussSidebarChannel-itemName {
             filter: brightness(1.1);
         }

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
         <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor gap-1" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
-            <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
+            <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 mt-1 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
                 <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss.isSidebarCompact }">
                     <t name="options-btn">
                         <Dropdown position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary px-0 py-1 mx-2 my-0 min-w-0 shadow-sm'">

--- a/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
@@ -1,9 +1,4 @@
 .o-mail-MessagingMenu {
     --mail-MessagingMenu-bg: #{mix($gray-100, $gray-200)};
-}
-
-.o-mail-MessagingMenu-navbar button {
-    &.o-active, &:hover {
-        background-color: mix($o-gray-200, $o-gray-300);
-    }
+    --mail-MessagingMenu-activeBorderTopColor: #{lighten($primary, 5%)};
 }

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -5,7 +5,7 @@ import { useDiscussSystray } from "@mail/utils/common/hooks";
 
 import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
 
-import { hasTouch } from "@web/core/browser/feature_detection";
+import { hasTouch, isDisplayStandalone, isIOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { _t } from "@web/core/l10n/translation";
@@ -20,6 +20,7 @@ export class MessagingMenu extends Component {
 
     setup() {
         super.setup();
+        this.isIosPwa = isIOS() && isDisplayStandalone();
         this.discussSystray = useDiscussSystray();
         this.store = useService("mail.store");
         this.hasTouch = hasTouch;

--- a/addons/mail/static/src/core/public_web/messaging_menu.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.scss
@@ -9,10 +9,11 @@
     background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
 }
 
-.o-mail-MessagingMenu-navbar button.o-active {
-    background-color: mix($o-gray-100, $o-gray-200);
-}
+.o-mail-MessagingMenu-navbar button {
+    border-top: 2px solid !important;
+    border-color: transparent !important;
 
-.o-mail-MessagingMenu-navbar button:hover {
-    background-color: mix($o-gray-100, $o-gray-200);
+    &.o-active {
+        border-top-color: var(--mail-MessagingMenu-activeBorderTopColor, rgba($primary, .75)) !important;
+    }
 }

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -51,13 +51,14 @@
             </t>
         </div>
     </div>
-    <div t-if="ui.isSmall" class="o-mail-MessagingMenu-navbar d-flex border-top bg-view shadow-lg w-100 btn-group">
-        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 pb-4" t-att-class="{
-            'text-primary fw-bolder o-active': store.discuss.activeTab === tab.id,
-            'border-end': !tab_last,
+    <div t-if="ui.isSmall" class="o-mail-MessagingMenu-navbar d-flex bg-view shadow-lg w-100 btn-group">
+        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 rounded-0 bg-transparent" t-att-class="{
+            'text-primary fw-bold o-active': store.discuss.activeTab === tab.id,
+            'pb-4': isIosPwa,
+            'pb-2': !isIosPwa,
         }" t-on-click="() => this.onClickNavTab(tab.id)">
-            <i t-attf-class="p-2 fs-4 {{ tab.icon }}"/>
-            <span class="small" t-esc="tab.label"/>
+            <i t-attf-class="p-1 fs-2 {{ tab.icon }}" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id }"/>
+            <span class="smaller" t-esc="tab.label" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id }"/>
         </button>
     </div>
 </t>

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -17,13 +17,10 @@
             background-color: mix($o-gray-100, $o-info, 87.5%) !important;
         }
     }
-    &:not(.o-small) {
-        padding-left: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
-    }
 }
 
 .o-mail-NotificationItem-avatarContainer {
-    height: 40px;
+    height: 42px;
     aspect-ratio: 1;
     margin-top: map-get($spacers, 1) / 2;
     margin-bottom: map-get($spacers, 1) / 2;
@@ -60,12 +57,4 @@
         // invisible character so that typing status bar has constant height, regardless of text content.
         content: "\200b"; /* unicode zero width space character */
     }
-}
-
-.o-mail-NotificationItem-unreadIndicator {
-    color: darken($info, 5%);
-    font-size: 0.5rem;
-    left: 1px;
-    top: 40px;
-    transform: translateY(-125%);
 }

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -3,16 +3,15 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border rounded" t-on-click="onClick" t-ref="root" t-att-class="{
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border rounded py-2" t-on-click="onClick" t-ref="root" t-att-class="{
             'o-important': props.muted === 0,
             'text-muted border-transparent': props.muted === 1,
             'opacity-50 border-transparent': props.muted === 2,
-            'p-2 o-small': ui.isSmall,
+            'px-1 o-small': ui.isSmall,
             'border-top-0': props.first,
-            'pe-2 py-2': !ui.isSmall,
+            'p-2': !ui.isSmall,
             'o-active': props.isActive,
         }">
-            <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted, 'opacity-75': !props.muted }"><i class="fa fa-circle"/></span>
             <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.DiscussSidebarMailboxes">
-        <div class="d-flex flex-column flex-grow-0 o-gap-0_5 mt-2">
+        <div class="d-flex flex-column flex-grow-0 o-gap-0_5 mt-1">
             <Mailbox mailbox="store.inbox"/>
             <Mailbox mailbox="store.starred"/>
             <Mailbox mailbox="store.history"/>
@@ -23,7 +23,7 @@
 
     <t t-name="mail.Mailbox.main">
         <button
-            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-center px-0 mx-2 border-0 rounded-2 fw-normal text-reset"
+            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-baseline px-0 mx-2 border-0 rounded-2 fw-normal text-reset"
             t-att-class="{
                 'bg-inherit': mailbox.notEq(store.discuss.thread),
                 'o-active': mailbox.eq(store.discuss.thread),
@@ -31,13 +31,14 @@
                 'o-py-0_5': !store.discuss.isSidebarCompact,
                 'o-unread': mailbox.counter,
             }"
+            style="line-height: 1.65;"
             t-att-data-mailbox-id="mailbox.id"
             t-on-click="(ev) => this.openThread(ev)"
             t-ref="root"
         >
-            <ThreadIcon className="'bg-inherit ' + (store.discuss.isSidebarCompact ? '' : 'mx-2')" thread="mailbox"/>
+            <ThreadIcon className="'bg-inherit opacity-75 ' + (store.discuss.isSidebarCompact ? '' : 'mx-2 pt-1')" thread="mailbox" size="store.discuss.isSidebarCompact ? 'large' : 'medium'"/>
             <t t-if="!store.discuss.isSidebarCompact">
-                <div class="me-2 text-truncate small" style="line-height: 1.65;" t-esc="mailbox.display_name"/>
+                <div class="me-2 text-truncate text-muted" t-esc="mailbox.display_name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>
             </t>
             <span

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -15,6 +15,6 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.startMeetingButton">
-        <button class="btn btn-primary rounded d-flex align-items-center gap-1 mx-5" t-att-class="{ 'py-2': store.discuss.isSidebarCompact, 'btn-sm': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
+        <button class="btn btn-primary rounded d-flex align-items-center gap-1 mx-5" t-att-class="{ 'py-2': store.discuss.isSidebarCompact, 'btn-sm': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75" t-att-class="{ 'fa-lg': store.discuss.isSidebarCompact }"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
@@ -1,4 +1,4 @@
 .o-mail-DiscussSidebar-item {
     --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-200, $gray-300)};
-    --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .5)};
+    --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .25)};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
@@ -12,6 +12,7 @@
 }
 
 .o-mail-DiscussSidebarCategories-search {
+    --border-opacity: .5;
     --mail-DiscussSidebarCategories-searchContainerBg: #{$white};
     --mail-DiscussSidebarCategories-searchContainerBgHover: #{$gray-100};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -33,16 +33,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 
     &:hover .o-mail-DiscussSidebarChannel-commands {
         display: flex !important;
-        .btn-group .btn {
-            &:hover {
-                border-color: var(--mail-DiscussSidebarChannel-commandsHover, rgba($o-action, .15));
-                background-color: $o-view-background-color !important;
-            }
-            &:not(:hover) {
-                border-color: transparent;
-                background-color: transparent;
-            }
-        }
     }
 }
 
@@ -67,12 +57,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
     background-color: inherit !important; // Not 'bg-inherit' so it cancels btn hover effect too
 }
 
-.o-mail-DiscussSidebarChannel-threadIcon {
-    font-size: xx-small;
-    width: 14px;
-    height: 14px;
-}
-
 .o-mail-DiscussSidebarChannel-indicatorCompact {
     top: 3px;
     left: 3px;
@@ -84,7 +68,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 
 .o-mail-DiscussSidebar-unreadIndicator {
     font-size: 0.35rem;
-    left: 0px;
+    left: -2px;
 
     .o-mail-DiscussSidebarSubchannel &:not(.o-compact) {
         left: map-get($spacers, 2) + map-get($spacers, 1) / 2;
@@ -110,6 +94,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 
 .o-mail-DiscussSidebarSubchannel svg {
     color: var(--mail-DiscussSidebarSubchannel-svgColor, mix($gray-300, $gray-400, 75%));
-    left: 20px;
+    left: 22px;
     transform: scaleX(1) #{"/* rtl:scaleX(-1) */"};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -2,14 +2,14 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
         <Dropdown t-if="store.discuss.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm'" manual="true">
-            <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center px-1 mx-2 border opacity-75" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-search"/></button>
+            <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-lg fa-fw fa-search"/></button>
             <t t-set-slot="content">
                 <div class="p-2" t-ref="search-floating">
                     <span class="text-muted user-select-none">Find or start a conversation</span>
                 </div>
             </t>
         </Dropdown>
-        <div t-else="" class="o-mail-DiscussSidebarCategories-search rounded mx-3 my-2 border position-relative d-flex align-items-center justify-content-center gap-1" t-on-click="onClickFindOrStartConversation">
+        <div t-else="" class="o-mail-DiscussSidebarCategories-search rounded mx-3 my-2 border border-secondary position-relative d-flex align-items-center justify-content-center gap-1" t-on-click="onClickFindOrStartConversation">
             <input class="form-control rounded-3 border-0 bg-inherit" t-att-class="{ 'lh-1': !ui.isSmall }" disabled="true" placeholder="Find or start a conversation" tabindex="0"/>
             <div class="o-mail-DiscussSidebarCategories-searchClickable position-absolute z-1 opacity-0 cursor-pointer w-100 h-100"/>
         </div>
@@ -47,10 +47,10 @@
             <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start opacity-100-hover" t-att-class="{ 'align-items-baseline opacity-75 o-gap-0_5': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact opacity-50 gap-1': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
                 <t t-if="store.discuss.isSidebarCompact">
                     <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xxsmaller" t-att-class="{
-                        'oi oi-chevron-down': category.open,
+                        'oi oi-chevron-down opacity-75': category.open,
                         'oi oi-chevron-right opacity-50': !category.open,
                     }"/>
-                    <span class="rounded p-1" t-att-class="{ 'opacity-50': !category.open }"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin"/><i t-else="" class="fa-fw fa-lg" t-att-class="category.icon ?? 'fa fa-user'"/></span>
+                    <span class="rounded p-1" t-att-class="{ 'opacity-50': !category.open }"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin fs-3"/><i t-else="" class="fa-fw fa-lg fs-3" t-att-class="category.icon ?? 'fa fa-user'"/></span>
                 </t>
                 <t t-else="">
                     <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
@@ -71,7 +71,7 @@
                 <t name="action-group">
                     <t t-foreach="actions" t-as="action" t-key="action_index">
                         <button class="btn w-100 o-opacity-35 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
-                            <i role="img" class="fa-fw" t-att-class="action.icon"/>
+                            <i role="img" class="fa-fw fa-lg" t-att-class="action.icon"/>
                             <span t-if="store.discuss.isSidebarCompact" class="text-muted" t-esc="action.label"/>
                         </button>
                     </t>
@@ -155,9 +155,9 @@
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
-                <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
+                <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:32px;height:32px;margin-top:1px;margin-bottom:1px" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="thread.avatarUrl" alt="Thread Image"/>
-                    <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
+                    <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>
                 </div>
                 <span t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted ? 'o-item-unread fw-bolder' : 'text-muted'">
@@ -176,7 +176,7 @@
                 </div>
             </t>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
-            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge flex-shrink-0 fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
+            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge flex-shrink-0 fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 me-2': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
         </button>
     </t>
 
@@ -188,8 +188,8 @@
         }">
             <div t-att-class="{ 'd-flex flex-column align-items-start ps-1 pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm o-gap-0_5': !store.discuss.isSidebarCompact }">
                 <t t-foreach="sortedCommands" t-as="command" t-key="command_index">
-                    <button class="btn o-opacity-35 opacity-100-hover" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-on-click.stop="() => command.onSelect()" t-att-title="store.discuss.isSidebarCompact ? '' : command.label">
-                        <i role="img" class="fa-fw" t-att-class="command.icon"/>
+                    <button class="btn o-opacity-35 opacity-100-hover" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-on-click.stop="() => command.onSelect()" t-att-title="store.discuss.isSidebarCompact ? '' : command.label">
+                        <i role="img" class="fa-fw fa-lg" t-att-class="command.icon"/>
                         <span t-if="store.discuss.isSidebarCompact" t-esc="command.label"/>
                     </button>
                 </t>

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -20,7 +20,7 @@
             </t>
             <div class="o-mail-SubChannelList o-mail-Discuss-threadActionPopover mw-100 w-100 h-100" t-att-class="{ 'align-items-center justify-content-center': state.subChannels.length === 0 }">
                 <div t-if="state.subChannels.length === 0" class="flex-grow-1 d-flex flex-column justify-content-center align-items-center">
-                    <p class="my-1 pb-2 text-center fst-italic text-500">
+                    <p class="my-1 text-center fst-italic text-500">
                         <t t-if="state.searching" t-esc="NO_THREAD_FOUND"/>
                         <t t-else="">This channel has no thread yet.</t>
                     </p>

--- a/addons/mail/static/src/scss/variables/primary_variables.scss
+++ b/addons/mail/static/src/scss/variables/primary_variables.scss
@@ -1,12 +1,12 @@
 $o-mail-Avatar-size: 42px !default;
 $o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-Discuss-inspector: 300px !default;
-$o-mail-Avatar-sizeSmall: 28px !default;
+$o-mail-Avatar-sizeSmall: 24px !default;
 // Needed because $border-radius variations are all set to 0 in enterprise.
 $o-RoundedRectangle-small: .2rem !default;
 $o-RoundedRectangle-large: 3 * $o-RoundedRectangle-small !default;
 
-$o-mail-Message-sidebarWidth: 42px !default;
+$o-mail-Message-sidebarWidth: 60px !default;
 
 $o-mail-LinkPreview-width: 320px !default;
 $o-mail-LinkPreview-height: 240px !default;

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -284,7 +284,7 @@ test("sidebar: chat im_status rendering", async () => {
     await contains(".o-mail-DiscussSidebarChannel-threadIcon", { count: 3 });
     await contains(".o-mail-DiscussSidebarChannel", {
         text: "Partner1",
-        contains: [".o-mail-ThreadIcon div[title='Offline']"],
+        contains: [".o-mail-ThreadIcon [title='Offline']"],
     });
     await contains(".o-mail-DiscussSidebarChannel", {
         text: "Partner2",
@@ -292,7 +292,7 @@ test("sidebar: chat im_status rendering", async () => {
     });
     await contains(".o-mail-DiscussSidebarChannel", {
         text: "Partner3",
-        contains: [".o-mail-ThreadIcon div[title='Away']"],
+        contains: [".o-mail-ThreadIcon [title='Idle']"],
     });
 });
 
@@ -1810,7 +1810,7 @@ test('auto-select "Inbox nav bar" when discuss had inbox as active thread', asyn
     await start();
     await openDiscuss();
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
-    await contains(".o-mail-MessagingMenu-navbar button.fw-bolder", { text: "Mailboxes" });
+    await contains(".o-mail-MessagingMenu-navbar button.fw-bold", { text: "Mailboxes" });
     await contains("button.active.o-active", { text: "Inbox" });
     await contains("h4", { text: "Your inbox is empty" });
 });

--- a/addons/mail/static/tests/discuss_app/im_status.test.js
+++ b/addons/mail/static/tests/discuss_app/im_status.test.js
@@ -25,7 +25,7 @@ test("initially online", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-ImStatus i[title='Online']");
+    await contains(".o-mail-Discuss-header .o-mail-ImStatus i[title='Online']");
 });
 
 test("initially offline", async () => {
@@ -40,7 +40,7 @@ test("initially offline", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-ImStatus i[title='Offline']");
+    await contains(".o-mail-Discuss-header .o-mail-ImStatus i[title='Offline']");
 });
 
 test("initially away", async () => {
@@ -55,7 +55,7 @@ test("initially away", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-ImStatus i[title='Idle']");
+    await contains(".o-mail-Discuss-header .o-mail-ImStatus i[title='Idle']");
 });
 
 test("change icon on change partner im_status", async () => {
@@ -65,25 +65,25 @@ test("change icon on change partner im_status", async () => {
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "online" });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-ImStatus i[title='Online']");
+    await contains(".o-mail-Discuss-header .o-mail-ImStatus i[title='Online']");
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "offline" });
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
         partner_id: serverState.partnerId,
         im_status: "offline",
     });
-    await contains(".o-mail-ImStatus i[title='Offline']");
+    await contains(".o-mail-Discuss-header .o-mail-ImStatus i[title='Offline']");
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "away" });
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
         partner_id: serverState.partnerId,
         im_status: "away",
     });
-    await contains(".o-mail-ImStatus i[title='Idle']");
+    await contains(".o-mail-Discuss-header .o-mail-ImStatus i[title='Idle']");
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "online" });
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
         partner_id: serverState.partnerId,
         im_status: "online",
     });
-    await contains(".o-mail-ImStatus i[title='Online']");
+    await contains(".o-mail-Discuss-header .o-mail-ImStatus i[title='Online']");
 });
 
 test("show im status in messaging menu preview of chat", async () => {

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -579,7 +579,7 @@ test("mobile: active icon is highlighted", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu-tab", { text: "Chat" });
-    await contains(".o-mail-MessagingMenu-tab.fw-bolder", { text: "Chat" });
+    await contains(".o-mail-MessagingMenu-tab.fw-bold", { text: "Chat" });
 });
 
 test("open chat window from preview", async () => {

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -22,9 +22,9 @@ test("auto-select 'Inbox' when discuss had channel as active thread", async () =
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-ChatWindow [title*='Close Chat Window']");
-    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", { text: "Channel" });
+    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bold", { text: "Channel" });
     await click("button", { text: "Mailboxes" });
-    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", { text: "Mailboxes" });
+    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bold", { text: "Mailboxes" });
     await contains("button.active", { text: "Inbox" });
 });
 


### PR DESCRIPTION
1. more spacing between avatar and message horizontally
2. bigger avatars in discuss app desktop
3. message "..." expand action in mobile is less visible
4. message bubble border is softer in white theme, removed in dark theme
5. removed border in dark theme for discuss sidebar / header / panel, composer input and chat window
6. IM status in discuss sidebar matches member list im status
7. less padding below composer and discuss bottom bar in PWA
8. mobile conversation category improved in mobile: better colors, better icon/text size and spacing, better active indicator
9. Reduce message date opacity slightly
10. remove unread indicator in messaging menu items
11. chat bubble preview border is softer

The overall idea of these improvements are:
- more natural spacing of avatar / message
- avatar are consistently sized and easier to recognize.
- less distraction with borders and messaging menu unread indicator