### PR TITLE
[FIX] pos wallet: show all customers wallets on search pos

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
@@ -13,11 +13,15 @@ patch(PartnerList.prototype, {
     async searchPartner() {
         const res = await super.searchPartner();
         const programIds = this.pos.models["loyalty.program"].getAll().map((p) => p.id);
-        const coupons = await this.pos.fetchCoupons([
-            ["partner_id", "in", res.map((partner) => partner.id)],
-            ["program_id.active", "=", true],
-            ["program_id", "in", programIds],
-        ]);
+        const coupons = await this.pos.fetchCoupons(
+            [
+                ["partner_id", "in", res.map((partner) => partner.id)],
+                ["program_id.active", "=", true],
+                ["program_id", "in", programIds],
+                ["points", ">", 0],
+            ],
+            0
+        );
         this.pos.computePartnerCouponIds(coupons);
         return res;
     },


### PR DESCRIPTION
Show all customers wallets on search pos

### Impacted versions:

18.0 and later

### Steps to reproduce:
Add more than one customer with same first characters of their name
Add gift cards to them with positive balance
Search them by clicking customer button on a pos session

Video on runbot: https://drive.google.com/file/d/1kFAYjxWJmTNuNOK2ul684x_H_GAptsjB/view?usp=sharing

### Current behavior:
Only shows the first wallet found (fetchCoupons default limit 1)

### Expected behavior:
Show all wallets

Task: [4572808](https://www.odoo.com/odoo/project/49/tasks/4572808)