### PR TITLE
[ADD] pos_salesperson: add salesperson assignment feature to POS

### DIFF
--- a/addons/pos_salesperson/__init__.py
+++ b/addons/pos_salesperson/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/pos_salesperson/__manifest__.py
+++ b/addons/pos_salesperson/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': 'POS - Salesperson',
+    'description': """
+    Able to select salesperson(employee) on POS (billing screen).
+    """,
+    'version': '1.0',
+    'depends': ['point_of_sale','pos_hr'],
+    'data': [
+        'views/pos_order_view.xml'
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_salesperson/static/src/**/*',
+        ],
+    },
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/addons/pos_salesperson/models/__init__.py
+++ b/addons/pos_salesperson/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pos_order
+from . import pos_session

--- a/addons/pos_salesperson/models/pos_order.py
+++ b/addons/pos_salesperson/models/pos_order.py
@@ -1,0 +1,6 @@
+from odoo import fields, models
+
+class PosOrder(models.Model):
+    _inherit = 'pos.order'
+
+    salesperson_id =fields.Many2one('hr.employee',string="salesperson")

--- a/addons/pos_salesperson/models/pos_session.py
+++ b/addons/pos_salesperson/models/pos_session.py
@@ -1,0 +1,11 @@
+from odoo import api, models
+
+class PosSession(models.Model):
+    _inherit = 'pos.session'
+
+    @api.model
+    def _load_pos_data_models(self, config_id):
+        data = super()._load_pos_data_models(config_id)
+        if 'hr.employee' not in data:
+            data += ['hr.employee']
+        return data

--- a/addons/pos_salesperson/static/src/app/genric_components/order_widget/order_widget.js
+++ b/addons/pos_salesperson/static/src/app/genric_components/order_widget/order_widget.js
@@ -1,0 +1,9 @@
+import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
+import { patch } from "@web/core/utils/patch";
+
+patch(OrderWidget, {
+    props: {
+        ...OrderWidget.props,
+        salesperson: { type: String, optional: true },
+    },
+});

--- a/addons/pos_salesperson/static/src/app/genric_components/order_widget/order_widget.xml
+++ b/addons/pos_salesperson/static/src/app/genric_components/order_widget/order_widget.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson.OrderWidget" t-inherit="point_of_sale.OrderWidget" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='props.lines?.length']/div[1]" position="before">
+            <div class="order-sales-person text-break mb-1 ms-1">
+                <h5>
+                    <t t-if="props.salesperson">
+                        SalesPerson: <t t-out="props.salesperson"/>
+                    </t>
+                </h5>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_salesperson/static/src/app/models/pos_order.js
+++ b/addons/pos_salesperson/static/src/app/models/pos_order.js
@@ -1,0 +1,12 @@
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosOrder.prototype, {
+    setSalesPerson(salesperson) {
+        this.update({ salesperson_id: salesperson });
+    },
+
+    getSalesPerson() {
+        return this.salesperson_id;
+    },
+});

--- a/addons/pos_salesperson/static/src/app/screens/order_summary/order_summary.xml
+++ b/addons/pos_salesperson/static/src/app/screens/order_summary/order_summary.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson.OrderSummary"
+        t-inherit="point_of_sale.OrderSummary"
+        t-inherit-mode="extension">
+            <xpath expr="//OrderWidget" position="attributes">
+                <attribute name="salesperson">currentOrder.salesperson_id?.name</attribute>
+            </xpath>
+    </t>
+</templates>

--- a/addons/pos_salesperson/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_salesperson/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -1,0 +1,10 @@
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { SalespersonButton } from "@pos_salesperson/app/screens/product_screen/control_buttons/salesperson_button/salesperson_buutton";
+import { patch } from "@web/core/utils/patch";
+
+patch(ControlButtons, {
+    components: {
+        ...ControlButtons.components,
+        SalespersonButton,
+    },
+});

--- a/addons/pos_salesperson/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_salesperson/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath
+            expr="//button[@t-if='!props.showRemainingButtons and !ui.isSmall and props.onClickMore']"
+            position="before">
+                <SalespersonButton/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_salesperson/static/src/app/screens/product_screen/control_buttons/salesperson_button/salesperson_button.xml
+++ b/addons/pos_salesperson/static/src/app/screens/product_screen/control_buttons/salesperson_button/salesperson_button.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson.SalespersonButton">
+        <button
+            class="set-salesperson btn btn-light text-truncate btn-lg lh-lg w-auto">
+                <div t-if="salesperson" class="d-flex justify-content-between align-items-center">
+                    <div class="text-truncate text-action" t-on-click="onClick">
+                        <t t-out="salesperson.name"/>
+                    </div>
+                    <i class="fa fa-close" style="padding-left: 8px" t-on-click="onRemove"/>
+                </div>
+                <t t-else="">
+                    <div t-on-click="onClick">
+                        <i class="fa fa-user"/> Salesperson
+                    </div>
+                </t>
+        </button>
+    </t>
+</templates>

--- a/addons/pos_salesperson/static/src/app/screens/product_screen/control_buttons/salesperson_button/salesperson_buutton.js
+++ b/addons/pos_salesperson/static/src/app/screens/product_screen/control_buttons/salesperson_button/salesperson_buutton.js
@@ -1,0 +1,69 @@
+import { Component } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useService } from "@web/core/utils/hooks";
+import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
+import { _t } from "@web/core/l10n/translation";
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+
+export class SalespersonButton extends Component {
+    static template = "pos_salesperson.SalespersonButton";
+    static props = {};
+
+    setup() {
+        this.pos = usePos();
+        this.dialog = useService("dialog");
+    }
+
+    _prepareEmployeeList(currentSalesPerson) {
+        const allEmployees = this.pos.models["hr.employee"].filter(
+            (employee) => employee.id !== currentSalesPerson
+        );
+
+        const employeeList = allEmployees.map((employee) => {
+            return {
+                id: employee.id,
+                item: employee,
+                label: employee.name,
+                isSelected: false,
+            };
+        });
+        return employeeList;
+    }
+
+    async onClick() {
+        const order = this.pos.get_order();
+        if (!order || order.lines.length <= 0) {
+            return;
+        }
+
+        const employeesList = this._prepareEmployeeList(order.getSalesPerson()?.id);
+        if (!employeesList.length) {
+            return;
+        }
+
+        const salesperson = await makeAwaitable(this.dialog, SelectionPopup, {
+            title: _t("Select Sales Person"),
+            list: employeesList,
+        });
+
+        if (!salesperson) {
+            return;
+        }
+
+        order.setSalesPerson(salesperson);
+    }
+
+    async onRemove() {
+        const order = this.pos.get_order();
+        if (!order || !order.salesperson_id) {
+            return;
+        }
+
+        order.setSalesPerson(false);
+    }
+
+    get salesperson() {
+        const order = this.pos.get_order();
+        return order.salesperson_id;
+    }
+}

--- a/addons/pos_salesperson/views/pos_order_view.xml
+++ b/addons/pos_salesperson/views/pos_order_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pos_order_tree_view_inherit_pos_salesperson" model="ir.ui.view">
+        <field name="name">view.pos.order.tree.view.inherit.pos.salesperson</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="salesperson_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_pos_pos_form_view_inherit_pos_salesperson_assignment" model="ir.ui.view">
+        <field name="name">view.pos.pos.form.view.inherit.pos.salesperson</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
+        <field name="arch" type="xml">
+            <field name="fiscal_position_id" position="after">
+                <field name="salesperson_id" readonly="1"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
After this commit :
- Added a new 'Salesperson' button to the control buttons on the PoS product screen.
- Enabled assignment of a specific salesperson to each order.
- Added a 'Salesperson' column to the orders list view.
- Included a 'Salesperson' field in the individual order form view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
