### PR TITLE
[IMP] project: add sequence and default groupby in list view

### DIFF
--- a/addons/project/static/src/project_sharing/views/form/project_sharing_form_compiler.js
+++ b/addons/project/static/src/project_sharing/views/form/project_sharing_form_compiler.js
@@ -24,6 +24,7 @@ function compileChatter(node, params) {
     });
     const chatterContainerHookXml = createElement("div");
     chatterContainerHookXml.classList.add("o-mail-ChatterContainer", "o-mail-Form-chatter", "pt-2");
+    setAttributes(chatterContainerHookXml, { "t-if": "!__comp__.env.inDialog" });
     append(chatterContainerHookXml, chatterContainerXml);
     return chatterContainerHookXml;
 }

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -79,6 +79,8 @@
             <list position="attributes">
                 <attribute name="delete">0</attribute>
                 <attribute name="import">0</attribute>
+                <attribute name="group_create">0</attribute>
+                <attribute name="default_group_by">stage_id</attribute>
             </list>
             <xpath expr="//field[@widget='res_partner_many2one']" position="attributes">
                 <attribute name="widget">many2one</attribute>
@@ -348,12 +350,14 @@
     </record>
 
     <record id="project_sharing_kanban_action_view" model="ir.actions.act_window.view">
+        <field name="sequence" eval="10"/>
         <field name="view_mode">kanban</field>
         <field name="act_window_id" ref="project.project_sharing_project_task_action"/>
         <field name="view_id" ref="project.project_sharing_project_task_view_kanban"/>
     </record>
 
     <record id="project_sharing_tree_action_view" model="ir.actions.act_window.view">
+        <field name="sequence" eval="20"/>
         <field name="view_mode">list</field>
         <field name="act_window_id" ref="project.project_sharing_project_task_action"/>
         <field name="view_id" ref="project.project_sharing_project_task_view_tree"/>

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -13,6 +13,7 @@ export class FormViewDialog extends Component {
         resModel: String,
 
         context: { type: Object, optional: true },
+        expandedFormRef: { type: String, optional: true },
         nextRecordsContext: { type: Object, optional: true },
         readonly: { type: Boolean, optional: true },
         onRecordSaved: { type: Function, optional: true },
@@ -115,6 +116,10 @@ export class FormViewDialog extends Component {
                 res_model: this.props.resModel,
                 res_id: this.currentResId,
                 views: [[false, "form"]],
+                context: {
+                    ...this.props.context,
+                    form_view_ref: this.props.expandedFormRef,
+                },
             });
         }
     }

--- a/addons/web/static/tests/views/view_dialogs/form_view_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/form_view_dialog.test.js
@@ -428,13 +428,16 @@ test("existing record has an expand button", async () => {
                 actionRequest.res_model,
                 actionRequest.type,
                 actionRequest.views,
+                actionRequest.context,
             ]);
         },
     });
     await mountWithCleanup(WebClient);
     getService("dialog").add(FormViewDialog, {
+        expandedFormRef: "test_partner_form_view",
         resModel: "partner",
         resId: 1,
+        context: { key: "val" },
     });
     await animationFrame();
     expect(".o_dialog .o_form_view").toHaveCount(1);
@@ -442,7 +445,19 @@ test("existing record has an expand button", async () => {
     await fieldInput("foo").edit("hola");
     await click(".o_dialog .modal-header .o_expand_button");
     await animationFrame();
-    expect.verifySteps(["save", [1, "partner", "ir.actions.act_window", [[false, "form"]]]]);
+    expect.verifySteps([
+        "save",
+        [
+            1,
+            "partner",
+            "ir.actions.act_window",
+            [[false, "form"]],
+            {
+                key: "val",
+                form_view_ref: "test_partner_form_view",
+            },
+        ],
+    ]);
 });
 
 test("expand button with save and new", async () => {


### PR DESCRIPTION
**1. Hide chatter when form view is opened in a dialog**
     **Issue**:
        When the form view opens in a dialog, the chatter is visible.
     For example, in the Gantt view, when opening a task from the edit button on the pill, the chatter is displayed.

**2. Add sequence and default groupby in list** 
  Added default groupby by stage in the project sharing list view to align with the backend list view. Also, added  sequence in the Kanban view and tree action, ensuring proper order.This allows the addition of the Gantt action in the `project_enterprise` module, which will be applied after this view.
 - Hide the 'Add add Stage' option.


**3. web:  Use expandedFormRef to open specific form view**
   When a user expands the form view (e.g., from the Gantt view), a default low-priority form view is opened because the
   specific form view ID is not passed during dialog initialization.

   This commit introduces the expandedFormRef props to FormViewDialog, allowing users to specify the exact form view to be used when expanding.

  Use case:
    In project task sharing, when a portal user expands a task from the Gantt view, we want to open the project sharing    form view  instead of the default backend view.By passing the expandedFormRef (form view ID) while opening the dialog, we ensure the correct view is used.

```js
    this.dialogService.add(
       FormViewDialog,
       {
           title,
           resModel,
           ...
            context: {
	      expandedFormRef: formViewId,
	  }
      }
    );
```

task-4489162
