### PR TITLE
[FIX] point_of_sale: ensure required payment methods and product for test

### DIFF
--- a/addons/point_of_sale/tests/test_js.py
+++ b/addons/point_of_sale/tests/test_js.py
@@ -13,8 +13,11 @@ class WebSuite(HttpCase):
     def setUp(self):
         super().setUp()
         env = self.env(user=self.env.ref('base.user_admin'))
+        payment_method = env['pos.payment.method'].create({'name': 'Lets Pay for Tests'})
+        env['product.product'].create({'name': 'Test Product', 'available_in_pos': True})
         self.main_pos_config = self.main_pos_config = env['pos.config'].create({
             'name': 'Shop',
+            'payment_method_ids': [(4, payment_method.id)]
         })
 
     def test_pos_js(self):


### PR DESCRIPTION
Fixes an issue in `test_pos_js` when executed in a database without demo data, where missing payment methods cause test failures.

This commit adds the necessary payment methods and a required product to the configuration, ensuring proper test execution.

Runbot Error: 135208

