### PR TITLE
[FIX] web_editor: cleanup of required inline fields before saving

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4761,8 +4761,11 @@ export class OdooEditor extends EventTarget {
         const allWhitespaceRegex = /^[\s\u200b]*$/;
         for (const emptyElement of [...element.querySelectorAll('[data-oe-zws-empty-inline]')].reverse()) {
             emptyElement.removeAttribute('data-oe-zws-empty-inline');
-            if (!allWhitespaceRegex.test(emptyElement.textContent)) {
-                // The element has some meaningful text. Remove the ZWS in it.
+            if (
+                !allWhitespaceRegex.test(emptyElement.textContent) ||
+                emptyElement.hasAttribute("data-oe-field")
+            ) {
+                // Remove ZWS if the element is field or has meaningful text.
                 cleanZWS(emptyElement);
             } else if (!emptyElement.classList.length) {
                 // We only remove the empty element if it has no class, to

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/odooFields.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/odooFields.test.js
@@ -20,4 +20,13 @@ describe('Odoo fields', () => {
             });
         });
     });
+    it('should remove data-oe-zws-empty-inline and zero-width space when emptying an inline field', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: `<p><span data-oe-model="product.template" data-oe-id="27" data-oe-field="name" data-oe-type="char" data-oe-expression="product.name" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable">a[]</span></p>`,
+            contentBeforeEdit: `<p><span data-oe-model="product.template" data-oe-id="27" data-oe-field="name" data-oe-type="char" data-oe-expression="product.name" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable">a[]</span></p>`,
+            stepFunction: (editor) => editor.execCommand('oDeleteBackward'),
+            contentAfterEdit: `<p><span data-oe-model="product.template" data-oe-id="27" data-oe-field="name" data-oe-type="char" data-oe-expression="product.name" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable" data-oe-zws-empty-inline="">[]\u200b</span><br></p>`,
+            contentAfter: `<p><span data-oe-model="product.template" data-oe-id="27" data-oe-field="name" data-oe-type="char" data-oe-expression="product.name" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable">[]</span><br></p>`,
+        });
+    });
 });


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- Block elements: When emptied, a `<br>` is added.
- Inline elements: Instead of a `<br>`, a zero-width space (ZWS) is inserted. This makes the field non-empty.

### Desired behavior after PR is merged:

 - Fields marked with `data-oe-zws-empty-inline` are cleaned by removing the zero-width space in cleanForSave, preventing non-empty fields from being saved.

task-4575400

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
