### PR TITLE
[FIX] mail: fix traceback when the user click schedule next without due date

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -201,7 +201,7 @@ class MailActivity(models.Model):
             # Date.context_today is correct because date_deadline is a Date and is meant to be
             # expressed in user TZ
             base = force_base_date
-        elif activity_type.delay_from == 'previous_activity' and 'activity_previous_deadline' in self.env.context:
+        elif activity_type.delay_from == 'previous_activity' and self.env.context.get('activity_previous_deadline'):
             base = fields.Date.from_string(self.env.context.get('activity_previous_deadline'))
         else:
             base = fields.Date.context_today(self)


### PR DESCRIPTION
Currently, a traceback is occurring when the user clicks the `Done & Schedule Next` 
button without having the due date.

To reproduce this issue:
1) Install Sales
2) Open any sale order and in the chatter, schedule an activity
3) Remove the `Due date` and click the `Done & Schedule Next` button

Error:-
```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'relativedelta'
```

This traceback is occurring because `date_deadline` is not a required field. So the user can remove it.

If there is no `date_deadline`, the context contains key with no value from the line below.

https://github.com/odoo/odoo/blob/da7f89d5683c0718644b5ca9fdf5adb86b54fb81/addons/mail/models/mail_activity.py#L510

But here we are only checking the presence of the key in the context; 
If yes, the base is calculated based on the context value(None in this case). 

https://github.com/odoo/odoo/blob/da7f89d5683c0718644b5ca9fdf5adb86b54fb81/addons/mail/models/mail_activity.py#L204-L208
This will lead to the above traceback.

sentry-6347875218
