### PR TITLE
[FIX] discuss: add odoo version to rtc logs

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -106,7 +106,7 @@ export class CallSettings extends Component {
         const data = JSON.stringify(this.rtc.state.globalLogs);
         const blob = new Blob([data], { type: "application/json" });
         const downloadLink = document.createElement("a");
-        const now = luxon.DateTime.now().toFormat("yyyy-ll-dd_HH-mm");
+        const now = luxon.DateTime.now().toFormat("yyyy-LL-dd_HH-mm");
         downloadLink.download = `RtcLogs_${now}.json`;
         const url = URL.createObjectURL(blob);
         downloadLink.href = url;

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -272,7 +272,7 @@ export class Rtc extends Record {
             connectionType: undefined,
             hasPendingRequest: false,
             channel: undefined,
-            globalLogs: {},
+            globalLogs: { odooInfo: odoo.info },
             logs: new Map(), // deprecated
             sendCamera: false,
             sendScreen: false,


### PR DESCRIPTION
This commit also fixes the filename date

log example:
![image](https://github.com/user-attachments/assets/993af556-ef0c-4723-9fc1-74a2424701f0)


