### PR TITLE
[ADD] pos: support for second unit of measure (uom) in products

### DIFF
--- a/addons/pos_uom/__init__.py
+++ b/addons/pos_uom/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/pos_uom/__manifest__.py
+++ b/addons/pos_uom/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'POS - Second Unit of Measurement',
+    'version': '1.0',
+    'depends': ['point_of_sale'],
+    'description': "Second UoM for POS module",
+    'data': [
+        'views/product_template_views.xml',
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_uom/static/src/**/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/pos_uom/models/__init__.py
+++ b/addons/pos_uom/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/addons/pos_uom/models/product.py
+++ b/addons/pos_uom/models/product.py
@@ -1,0 +1,25 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    pos_second_uom = fields.Many2one("uom.uom", "POS Second UoM", domain="[('category_id', '=', uom_category_id), ('id','!=',uom_id)]")
+
+    @api.onchange('uom_id')
+    def _onchange_id(self):
+        if self.pos_second_uom and self.pos_second_uom.id == self.uom_id.id:
+            raise ValidationError(
+                _("Primary and Secondary units cannot be same")
+            )
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        fields = super()._load_pos_data_fields(config_id)
+        fields.append('pos_second_uom')
+        return fields

--- a/addons/pos_uom/static/src/overrides/components/control_buttons/control_buttons.js
+++ b/addons/pos_uom/static/src/overrides/components/control_buttons/control_buttons.js
@@ -1,0 +1,43 @@
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useService } from "@web/core/utils/hooks";
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+import { NumberPopup } from "@point_of_sale/app/utils/input_popups/number_popup";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+
+patch(ControlButtons.prototype, {
+    setup() {
+        super.setup();
+        this.pos = usePos();
+        this.dialog = useService("dialog");
+    },
+
+    async onClickAddQuantity() {
+        const selectedLine = this.currentOrder.get_selected_orderline();
+        const { uom_id: primaryUOM, pos_second_uom: secondUOM } = selectedLine.product_id;
+
+        if (!secondUOM) {
+            this.pos.dialog.add(AlertDialog, {
+                title: _t("Error"),
+                body: _t("Second UoM is not configured"),
+            });
+            return;
+        }
+
+        const quantity = await makeAwaitable(this.dialog, NumberPopup, {
+            title: `${_t("Enter Quantity in ")} ${secondUOM.name}`,
+            getPayload: (value) => parseFloat(value),
+        });
+
+        if (quantity < 0) {
+            this.pos.dialog.add(AlertDialog, {
+                title: _t("Error"),
+                body: _t("Quantity cannot be negative"),
+            });
+            return;
+        }
+        selectedLine.set_quantity(quantity * (primaryUOM.factor / secondUOM.factor));
+    },
+});

--- a/addons/pos_uom/static/src/overrides/components/control_buttons/control_buttons.xml
+++ b/addons/pos_uom/static/src/overrides/components/control_buttons/control_buttons.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_uom.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//SelectPartnerButton" position="after">
+            <button t-att-class="buttonClass" t-on-click="onClickAddQuantity" t-att-disabled="!currentOrder.get_selected_orderline()">
+                <span>Add Quantity</span>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_uom/views/product_template_views.xml
+++ b/addons/pos_uom/views/product_template_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_product_template_form_inherit_pos_second_uom" model="ir.ui.view">
+        <field name="name">product.template.form.inherit.pos.second.uom</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='pos_categ_ids']" position="before">
+                <field name="pos_second_uom" groups="uom.group_uom" options="{'no_create': True}" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit introduces support for configuring and using a second unit of measure (UoM) for products in the same category.
- Added a Second UoM field (pos_second_uom) in products, restricted to the same category as the primary UoM.
- Users can configure a second UoM for better flexibility in POS.
- In the POS module, users can input quantities using the second UoM, which automatically converts them to the primary UoM during checkout.