### PR TITLE
[FIX] im_livechat: block composer when processing answer

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -13,6 +13,7 @@ export class Chatbot extends Record {
     static MULTILINE_STEP_DEBOUNCE_DELAY_TOUR = 500;
 
     isTyping = false;
+    isProcessingAnswer = false;
     script = Record.one("chatbot.script");
     currentStep = Record.one("ChatbotStep");
     steps = Record.many("ChatbotStep");
@@ -60,6 +61,7 @@ export class Chatbot extends Record {
         } else {
             await this._processAnswer(message);
         }
+        this.isProcessingAnswer = false;
     }
 
     async triggerNextStep() {

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -98,6 +98,9 @@ patch(Thread.prototype, {
     },
     /** @returns {Promise<import("models").Message} */
     async post(body, postData, extraData = {}) {
+        if (this.chatbot && this.chatbot.currentStep?.type !== "free_input_multi") {
+            this.chatbot.isProcessingAnswer = true;
+        }
         if (this.channel_type === "livechat" && this.isTransient) {
             // For smoother transition: post the temporary message and set the
             // selected chat bot answer if any. Then, simulate the chat bot is
@@ -142,6 +145,7 @@ patch(Thread.prototype, {
         const step = this.chatbot?.currentStep;
         return (
             super.composerDisabled ||
+            this.chatbot?.isProcessingAnswer ||
             (step &&
                 !step.operatorFound &&
                 (step.completed || !step.expectAnswer || step.answers.length > 0))


### PR DESCRIPTION
Before this PR, the composer was not always blocked after the user answered a question. This can lead to multiple answers being posted and inconsistent state.

Steps to reproduce:
- Create a chat bot with a free input step.
- Open a live chat with this chat bot.
- Throttle your network to 3G speed.
- You can send many messages during the delay.

This PR ensures the composer is disabled as soon as the user answers the bot until the next step is ready.

part of task-4607689

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
