### PR TITLE
[FIX] website_sale: cart quantity management in last removal from cart

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -5,6 +5,7 @@ import VariantMixin from "@website_sale/js/variant_mixin";
 import wSaleUtils from "@website_sale/js/website_sale_utils";
 const cartHandlerMixin = wSaleUtils.cartHandlerMixin;
 import "@website/libs/zoomodoo/zoomodoo";
+import { browser } from "@web/core/browser/browser";
 import {extraMenuUpdateCallbacks} from "@website/js/content/menu";
 import { ProductImageViewer } from "@website_sale/js/components/website_sale_image_viewer";
 import { jsonrpc } from "@web/core/network/rpc_service";
@@ -236,6 +237,8 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
                 return;
             }
             if (!data.cart_quantity) {
+                // Ensures last cart removal is recorded
+                browser.sessionStorage.setItem('website_sale_cart_quantity', 0);
                 return window.location = '/shop/cart';
             }
             $input.val(data.quantity);

--- a/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
+++ b/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
@@ -62,6 +62,39 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
         {
             content: "Check that quantity is 1",
             trigger: ".js_quantity[value='1']",
+        },
+        // Fourth reorder making sure confirmation dialog doesn't pop up unnecessary
+        {
+            content: "Deleting All products from cart",
+            trigger: 'div.js_cart_lines',
+            run: async () => {
+                $('a.js_delete_product:first').click();
+                await new Promise((r) => setTimeout(r, 1000));
+                $('a.js_delete_product:first').click();
+                await new Promise((r) => setTimeout(r, 1000));
+                $('a.js_delete_product:first').click();
+                await new Promise((r) => setTimeout(r, 1000));
+                $('a.js_delete_product:first').click();
+                await new Promise((r) => setTimeout(r, 1000));
+            }
+        },
+        {
+            content: "Go to my orders",
+            trigger: 'body',
+            run: () => {
+                window.location = '/my/orders';
+            }
+        },
+        {
+            content: "Select first order",
+            trigger: '.o_portal_my_doc_table a:first',
+        },
+        wTourUtils.clickOnElement('Reorder Again', '.o_wsale_reorder_button'),
+        wTourUtils.clickOnElement('Confirm', '.o_wsale_reorder_confirm'),
+        wsTourUtils.assertCartContains({productName: 'Reorder Product 1'}),
+        {
+            content: "Check that quantity is 1",
+            trigger: ".js_quantity[value='1']",
             isCheck: true,
         },
     ]


### PR DESCRIPTION
Steps:
- Install Ecommerce
- Add some products to the cart
- Remove them using the 'remove' option
- Go to my/orders
- select any order, then click on Order again
- Click on the Add To Cart button
- You'll see one confirmation dialog

Issue:
- By clicking on the add to cart button, that confirmation dialog should not be there as the cart is empty

Cause:
- Cart quantity does not update when the last product is removed

Fix:
- While removing the last product, set cart quantity in sessionstorage to ensure that the last removal is recorded

affected version-17.0
opw-4566505

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
