### PR TITLE
[FIX] mail: ensure mail attachment is fully removed when user removes it.

### DIFF
--- a/addons/mail/static/src/core/web/mail_composer_attachment_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_list.js
@@ -19,7 +19,7 @@ export class MailComposerAttachmentList extends Many2ManyBinaryField {
      */
     async onFileRemove(fileId) {
         super.onFileRemove(fileId);
-        const attachment = this.mailStore.Attachment.get(fileId);
+        const attachment = this.mailStore.Attachment.insert(fileId);
         if (attachment) {
             await this.attachmentUploadService.unlink(attachment);
         }


### PR DESCRIPTION
Steps:
- Install sales app.
- Open a sale order and click 'Send by Email'.
- Remove file attachment from mail composer.

Issue:
- Removing mail attachment does not remove it completely at db level.

Cause:
- `.get` always returns undefined while removing the attachment.

Fix:
- Inserting `fileId` into `mailStore.Attachment` before unlinking resolves
  the issue.