### PR TITLE
[IMP] point_of_sale: add configurable limits for products & customer

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -17,6 +17,7 @@
         'data/pos_note_data.xml',
         'data/mail_template_data.xml',
         'data/point_of_sale_tour.xml',
+        'data/ir_config_parameter_data.xml',
         'wizard/pos_details.xml',
         'wizard/pos_payment.xml',
         'wizard/pos_close_session_wizard.xml',

--- a/addons/point_of_sale/data/ir_config_parameter_data.xml
+++ b/addons/point_of_sale/data/ir_config_parameter_data.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <function model="pos.config" name="_set_default_pos_load_limit" />
+    </data>
+</odoo>


### PR DESCRIPTION
- Introduced `ir.config_parameter` settings for product and customer limits in POS.
- Refactored partner loading to use configurable customer limit.

task-id: 4610131




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
