### PR TITLE
[IMP] web: speed up kanban record quick create

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.js
@@ -62,9 +62,7 @@ export class KanbanQuickCreateController extends Component {
         );
 
         const modelServices = Object.fromEntries(
-            this.props.Model.services.map((servName) => {
-                return [servName, useService(servName)];
-            })
+            this.props.Model.services.map((servName) => [servName, useService(servName)])
         );
         modelServices.orm = useService("orm");
         const config = {
@@ -163,12 +161,14 @@ export class KanbanQuickCreateController extends Component {
         }
 
         if (resId) {
-            await this.props.onValidate(resId, mode);
+            this.props.onValidate(resId, mode);
             if (mode === "add") {
                 await this.model.load({ resId: false });
+                this.state.disabled = false;
             }
+        } else {
+            this.state.disabled = false;
         }
-        this.state.disabled = false;
     }
 
     async cancel(force) {

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -445,20 +445,13 @@ export class KanbanRenderer extends Component {
     }
 
     async validateQuickCreate(recordId, mode, group) {
-        this.props.quickCreateState.groupId = false;
-        if (mode === "add") {
-            this.props.quickCreateState.groupId = group.id;
-        }
         const record = await group.addExistingRecord(recordId, true);
-        group.model.bus.trigger("group-updated", {
-            group: group,
-            withProgressBars: true,
-        });
         if (mode === "edit") {
             await this.props.openRecord(record);
         } else {
             this.props.progressBarState?.updateCounts(group);
         }
+        this.props.quickCreateState.groupId = mode === "add" ? group.id : false;
     }
 
     cancelQuickCreate() {

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -214,7 +214,7 @@ class ProgressBarState {
         this._updateProgressBar();
         if (this._aggregateFields.length) {
             this._updateAggregates();
-            this.updateAggreagteGroup(group);
+            this.updateAggregateGroup(group);
         }
 
         // If the selected bar is empty, remove the selection
@@ -225,7 +225,7 @@ class ProgressBarState {
         }
     }
 
-    updateAggreagteGroup(group) {
+    updateAggregateGroup(group) {
         if (group && this.activeBars[group.serverValue]) {
             const { bars } = this.getGroupInfo(group);
             this._updateAggregateGroup(group, bars, this.activeBars[group.serverValue]);


### PR DESCRIPTION
Before this commit, when quick creating a record in a grouped
kanban view, the quick create was disabled during the web_save,
the onchange and the reloading of the kanban view (loading of the
created record + reloading of progressbar and counters). On a slow
network, this would leave the quick create disabled for a while,
enforcing the feeling of slowness.

This commit improves the flow by no longer waiting for the kanban
to be reloaded before re-enabling the quick create. Indeed, that
reload is independant from the creation of another record, so we
can safely let the user creating a new record even if the kanban
hasn't been fully reloaded yet.

Task-4610822