### PR TITLE
[IMP] event_ticket_limiter: enforce maximum tickets per registration

### DIFF
--- a/addons/event_ticket_limiter/__init__.py
+++ b/addons/event_ticket_limiter/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/event_ticket_limiter/__manifest__.py
+++ b/addons/event_ticket_limiter/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'Event Ticket Limiter',
+    'description': """This module enforces a limit on the maximum number of tickets that can be booked in single registration.""",
+    'category': 'Events',
+    'license': 'LGPL-3',
+    'depends': ['website_event'],
+    'data': [
+        'views/event_ticket_views.xml',
+        'views/event_templates_page_registration.xml',
+    ],
+    'auto_install': True,
+    'installable': True,
+}

--- a/addons/event_ticket_limiter/models/__init__.py
+++ b/addons/event_ticket_limiter/models/__init__.py
@@ -1,0 +1,1 @@
+from . import event_ticket

--- a/addons/event_ticket_limiter/models/event_ticket.py
+++ b/addons/event_ticket_limiter/models/event_ticket.py
@@ -1,0 +1,8 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class EventTicket(models.Model):
+    _inherit = 'event.event.ticket'
+
+    tickets_per_registration = fields.Integer(string="Tickets Per Registration", copy=False, default=0)

--- a/addons/event_ticket_limiter/views/event_templates_page_registration.xml
+++ b/addons/event_ticket_limiter/views/event_templates_page_registration.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="event_ticket_registration" name="Modal for tickets registration" inherit_id="website_event.modal_ticket_registration">
+        <xpath expr="//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_limit" t-value="ticket.tickets_per_registration + 1 if ticket.tickets_per_registration > 0 else 10"/>
+        </xpath>
+        <xpath expr="//t[@t-set='seats_max']" position="attributes">
+            <attribute name="t-value">min(seats_max_limit, seats_max_ticket , seats_max_event)</attribute>
+        </xpath>
+        <xpath expr="//select[hasclass('d-inline', 'w-auto', 'form-select')]//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_limit" t-value="tickets.tickets_per_registration + 1 if tickets.tickets_per_registration > 0 else 10"/>
+        </xpath>
+        <xpath expr="//select[hasclass('d-inline', 'w-auto', 'form-select')]//t[@t-set='seats_max']" position="attributes">
+            <t t-if="tickets">
+                <attribute name="t-value">min(seats_max_limit, seats_max_ticket , seats_max_event)</attribute>
+            </t>
+            <t t-else="">
+                <attribute name="t-value">seats_max_event</attribute>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/event_ticket_limiter/views/event_ticket_views.xml
+++ b/addons/event_ticket_limiter/views/event_ticket_views.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="event_event_ticket_view_tree_inherit_event_ticket" model="ir.ui.view">
+        <field name="name">event.event.ticket.view.tree.inherit.event.ticket</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>
+        <field name="arch" type="xml">
+            <field name="description" position="after">
+                <field name="tickets_per_registration" width="160px"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
After this commit:
- Added `tickets_per_registration` field in `event.event.ticket` model.
- Implemented constraints to ensure valid ticket limits.
- Updated tree view to display `tickets_per_registration`.
- Modified event registration template to enforce the ticket limit in the UI.
- Ensured the maximum number of tickets per registration is respected.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
