### PR TITLE
[FIX] website_sale: pricelist recompute during checkout

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -21,6 +21,7 @@ def MockRequest(
         website=None, remote_addr=HOST, environ_base=None, url_root=None,
         # website_sale
         sale_order_id=None, website_sale_current_pl=None,
+        website_sale_selected_pl_id=None,
 ):
 
     lang_code = context.get('lang', env.context.get('lang', 'en_US'))
@@ -53,6 +54,7 @@ def MockRequest(
             odoo.http.get_default_session(),
             sale_order_id=sale_order_id,
             website_sale_current_pl=website_sale_current_pl,
+            website_sale_selected_pl_id=website_sale_selected_pl_id,
             context={'lang': ''},
         ),
         geoip=odoo.http.GeoIP('127.0.0.1'),

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -703,6 +703,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                         pass
                     redirect_url = decoded_url.replace(query=url_encode(args)).to_url()
             request.session['website_sale_current_pl'] = pricelist.id
+            request.session['website_sale_selected_pl_id'] = pricelist.id
             order_sudo = request.website.sale_get_order()
             if order_sudo:
                 order_sudo._cart_update_pricelist(pricelist_id=pricelist.id)
@@ -718,12 +719,14 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 return request.redirect("%s?code_not_available=1" % redirect)
 
             request.session['website_sale_current_pl'] = pricelist_sudo.id
+            request.session['website_sale_selected_pl_id'] = pricelist_sudo.id
             order_sudo = request.website.sale_get_order()
             if order_sudo:
                 order_sudo._cart_update_pricelist(pricelist_id=pricelist_sudo.id)
         else:
             # Reset the pricelist if empty promo code is given
             request.session.pop('website_sale_current_pl', None)
+            request.session.pop('website_sale_selected_pl_id', None)
             order_sudo = request.website.sale_get_order()
             if order_sudo:
                 pl_before = order_sudo.pricelist_id

--- a/addons/website_sale/controllers/website.py
+++ b/addons/website_sale/controllers/website.py
@@ -45,6 +45,7 @@ class Website(main.Website):
         # If we are logging in, clear the current pricelist to be able to find
         # the pricelist that corresponds to the user afterwards.
         request.session.pop('website_sale_current_pl', None)
+        request.session.pop('website_sale_selected_pl_id', None)
         return super()._login_redirect(uid, redirect=redirect)
 
     @route()

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -491,6 +491,7 @@ class Website(models.Model):
         request.session.pop('sale_order_id', None)
         request.session.pop('website_sale_current_pl', None)
         request.session.pop('website_sale_cart_quantity', None)
+        request.session.pop('website_sale_selected_pl_id', None)
 
     @api.model
     def action_dashboard_redirect(self):


### PR DESCRIPTION
Steps:
- Go to /shop as a guest (without logging in).
- Select a pricelist different from the default.
- Add a product to the cart and proceed to checkout.
- Fill in the address form and submit.
- Observe that the pricelist is reset to the default instead of retaining the
  selected one.

Issue
- When a user selects a pricelist on the /shop page without logging in, 
  the selected pricelist resets to the default during checkout after filling in
  the address form.

Cause
- The update_address method updates the partner_id of the sale.order
- During this process, the write method triggers a recomputation that resets the
  pricelist_id to the default instead of preserving the user-selected pricelist.

Fix
- Assign the selected pricelist to partner_sudo.property_product_pricelist
  before updating the sale order’s partner.
- This ensures that the pricelist remains unchanged throughout the checkout
  process.

Affected Version-saas-17.4
opw-4455367

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
