### PR TITLE
[FIX] crm: improve lost / archived lead behavior and usage

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -753,7 +753,7 @@ class CrmLead(models.Model):
             if stage_updated and vals.get('stage_id'):
                 stage = self.env['crm.stage'].browse(vals['stage_id'])
                 if stage.is_won:
-                    vals.update({'probability': 100, 'automated_probability': 100})
+                    vals.update({'active': True, 'probability': 100, 'automated_probability': 100})
                     stage_is_won = True
         # user change; update date_open if at least one lead does not
         # have the same user

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1799,9 +1799,11 @@ class CrmLead(models.Model):
 
         domain = ['|'] * (len(domain) - 1) + domain
         if include_lost:
-            domain += ['|', ('type', '=', 'opportunity'), ('active', '=', True)]
+            # include lost means archived opportunities are allowed, if lost
+            domain += [('won_status', '!=', 'won'), '|', ('type', '=', 'opportunity'), ('active', '=', True)]
         else:
-            domain += [('active', '=', True), ('won_status', '!=', 'won')]
+            # always filter out archived, those are not actionable anymore
+            domain += [('won_status', '=', 'pending'), ('active', '=', True)]
 
         return self.with_context(active_test=False).search(domain)
 

--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -57,11 +57,14 @@ class ResPartner(models.Model):
                 partner = partner.parent_id
 
     def action_view_opportunity(self):
-        '''
-        This function returns an action that displays the opportunities from partner.
-        '''
         action = self.env['ir.actions.act_window']._for_xml_id('crm.crm_lead_opportunities')
         action['context'] = {}
+        action['context'] = {
+            'search_default_filter_won_status_won': 1,
+            'search_default_filter_won_status_lost': 1,
+            'search_default_filter_won_status_pending': 1,
+            'active_test': False,
+        }
         if self.is_company:
             action['domain'] = [('partner_id.commercial_partner_id', '=', self.id)]
         else:

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -79,6 +79,11 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
              'email_from': test_lead.email_from,
              'probability': 0, 'active': False,
             },
+            {'name': 'Duplicate lead: same email_from, archived (not lost)',
+             'type': 'lead',
+             'email_from': test_lead.email_from,
+             'probability': 50, 'active': False,
+            },
             {'name': 'Duplicate lead: same email_from, proba 0 but not lost',
              'type': 'lead',
              'email_from': test_lead.email_from,
@@ -93,31 +98,44 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
              'type': 'opportunity',
              'email_from': test_lead.email_from,
              'probability': 100, 'stage_id': self.stage_team1_2.id,
+            },
+            {'name': 'Duplicate opp: same email_from, archived (not lost)',
+             'type': 'opportunity',
+             'email_from': test_lead.email_from,
+             'probability': 50, 'stage_id': self.stage_team1_2.id,
+             'active': False,
             }
         ])
-        self.assertEqual(len(dup_leads), 8, 'Be sure below quick access are relevant')
+        self.assertEqual(len(dup_leads), 10, 'Be sure below quick access are relevant')
         opp_lost = dup_leads[3]
         lead_lost = dup_leads[4]
-        opp_won = dup_leads[6]
-        _opp_proba100 = dup_leads[7]
+        lead_archived = dup_leads[5]
+        opp_won = dup_leads[7]
+        _opp_proba100 = dup_leads[8]
+        opp_archived = dup_leads[9]
 
         test_lead.write({'partner_id': customer.id})
 
-        # not include_lost = remove archived leads as well as 'won' opportunities
+        # not include_lost = remove archived leads/opps, lost leads/opps as well
+        # as 'won' opportunities
         result = test_lead._get_lead_duplicates(
             partner=test_lead.partner_id,
             email=test_lead.email_from,
             include_lost=False
         )
-        self.assertEqual(result, test_lead + dup_leads - (lead_lost + opp_won + opp_lost))
+        self.assertEqual(
+            result,
+            test_lead + dup_leads - (lead_lost + lead_archived + opp_won + opp_archived + opp_lost),
+            'Should not include: lost lead or opp, archived lead / opp (aka: only active lead/opp not won nor lost)'
+        )
 
-        # include_lost = remove archived opp only
+        # include_lost = remove archived lead only (archived opp is ok)
         result = test_lead._get_lead_duplicates(
             partner=test_lead.partner_id,
             email=test_lead.email_from,
-            include_lost=True
+            include_lost=True,
         )
-        self.assertEqual(result, test_lead + dup_leads - (lead_lost))
+        self.assertEqual(result, test_lead + dup_leads - (lead_lost + lead_archived + opp_won))
 
     def test_initial_data(self):
         """ Ensure initial data to avoid spaghetti test update afterwards """

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -64,7 +64,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
 
     @classmethod
     def setUpClass(cls):
-        super(TestLeadConvert, cls).setUpClass()
+        super().setUpClass()
         date = Datetime.from_string('2020-01-20 16:00:00')
         cls.crm_lead_dt_mock.now.return_value = date
 
@@ -95,10 +95,11 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
              'probability': 100, 'stage_id': self.stage_team1_2.id,
             }
         ])
-        lead_lost = dup_leads.filtered(lambda lead: lead.name == 'Duplicate lead: same email_from, lost')
-        _opp_proba100 = dup_leads.filtered(lambda lead: lead.name == 'Duplicate opp: same email_from, proba 100 but not won')
-        opp_won = dup_leads.filtered(lambda lead: lead.name == 'Duplicate opp: same email_from, won')
-        opp_lost = dup_leads.filtered(lambda lead: lead.name == 'Duplicate: lost opportunity')
+        self.assertEqual(len(dup_leads), 8, 'Be sure below quick access are relevant')
+        opp_lost = dup_leads[3]
+        lead_lost = dup_leads[4]
+        opp_won = dup_leads[6]
+        _opp_proba100 = dup_leads[7]
 
         test_lead.write({'partner_id': customer.id})
 

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -18,7 +18,7 @@
                         <field name="stage_id" widget="statusbar_duration"
                             options="{'clickable': '1', 'fold_field': 'fold'}"
                             domain="['|', ('team_id', '=', team_id), ('team_id', '=', False)]"
-                            invisible="type == 'lead'" readonly="won_status == 'lost'"/>
+                            invisible="type == 'lead'" readonly="won_status == 'lost' or not active"/>
                     </header>
                     <sheet>
                         <field name="won_status" invisible="1"/>
@@ -175,7 +175,8 @@
                                         title="By saving this change, the customer phone number will also be updated."
                                         invisible="not partner_phone_update"/>
                                 </div>
-                                <field name="lost_reason_id" invisible="won_status != 'lost'"/>
+                                <field name="lost_reason_id" invisible="won_status != 'lost'"
+                                    placeholder="Not specified"/>
                                 <field name="date_conversion" invisible="1"/>
                                 <field name="user_company_ids" invisible="1"/>
                             </group>
@@ -512,6 +513,7 @@
                         </t>
                         <t t-name="card">
                             <widget name="web_ribbon" id="lost_ribbon" title="Lost" bg_color="text-bg-danger" invisible="won_status != 'lost'"/>
+                            <widget name="web_ribbon" id="archived_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or won_status in ['lost', 'won']"/>
                             <field class="fw-bold fs-5" name="name"/>
                             <div>
                                 <t t-if="record.expected_revenue.raw_value">
@@ -610,8 +612,7 @@
                             domain="[('user_id','=', False), ('type', '=', 'lead')]"
                             help="Leads that are not assigned"/>
                     <separator />
-                    <filter string="Lost" name="lost"
-                            domain="['&amp;', ('probability', '=', 0), ('active', '=', False)]"/>
+                    <filter string="Lost" name="lost" domain="[('won_status', '=', 'lost'), ('active', '=', False)]"/>
                     <separator/>
                     <filter string="Creation Date" name="filter_creation_date" date="create_date" default_period="month"/>
                     <filter name="filter_date_closed" date="date_closed"/>
@@ -929,8 +930,9 @@
                     <filter string="Closed Date" name="close_date" date="date_closed"/>
                     <separator/>
                     <filter string="Won" name="filter_won_status_won" domain="[('won_status', '=', 'won')]"/>
-                    <filter string="Ongoing" name="filter_won_status_pending" domain="[('won_status', '=', 'pending')]"/>
-                    <filter string="Lost" name="filter_won_status_lost" context="{'active_test': False}" domain="[('won_status', '=', 'lost')]"/>
+                    <!-- For ongoing: include 'active' as this filter is functional and should filter out archived leads -->
+                    <filter string="Ongoing" name="filter_won_status_pending" domain="[('won_status', '=', 'pending'), ('active', '=', True)]"/>
+                    <filter string="Lost" name="filter_won_status_lost" domain="[('won_status', '=', 'lost'), ('active', '=', False)]"/>
                     <separator/>
                     <filter invisible="1" string="Overdue Opportunities" name="overdue_opp" domain="['&amp;', ('date_closed', '=', False), ('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter invisible="1" string="Late Activities" name="activities_overdue"

--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -118,7 +118,7 @@ class CrmLead2opportunityPartner(models.TransientModel):
         return result_opportunity.redirect_lead_opportunity_view()
 
     def _action_merge(self):
-        to_merge = self.duplicated_lead_ids
+        to_merge = (self.duplicated_lead_ids | self.lead_id)
         result_opportunity = to_merge.merge_opportunity(auto_unlink=False)
         result_opportunity.action_unarchive()
 

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -12,9 +12,10 @@
                     <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                     <field name="team_id" options="{'no_open': True, 'no_create': True}" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                 </group>
-                <group string="Opportunities" invisible="name != 'merge'">
+                <group string="Opportunities" invisible="name != 'merge'" col="4">
                     <field name="lead_id" invisible="1"/>
-                    <field name="duplicated_lead_ids" nolabel="1">
+                    <field name="duplicated_lead_ids" nolabel="1" colspan="4"
+                        context="{'search_default_filter_won_status_pending': 1, 'crm_lead_view_list_short': 1}">
                         <list>
                             <field name="create_date"/>
                             <field name="name"/>

--- a/addons/crm_iap_mine/views/crm_lead_views.xml
+++ b/addons/crm_iap_mine/views/crm_lead_views.xml
@@ -9,7 +9,7 @@
             <xpath expr="//header" position="inside">
                 <button name="action_generate_leads" type="object" class="o_button_generate_leads"
                         string="Generate Leads" groups="sales_team.group_sale_manager" display="always"
-                        invisible="context.get('active_model', 'crm.lead') != 'crm.lead'"/>
+                        invisible="context.get('active_model', 'crm.lead') != 'crm.lead' or context.get('crm_lead_view_list_short')"/>
             </xpath>
         </field>
     </record>
@@ -23,7 +23,7 @@
                 <header>
                     <button name="action_generate_leads" type="object" class="o_button_generate_leads"
                             string="Generate Leads" groups="sales_team.group_sale_manager" display="always"
-                            invisible="context.get('active_model', 'crm.lead') != 'crm.lead'"/>
+                            invisible="context.get('active_model', 'crm.lead') != 'crm.lead' or context.get('crm_lead_view_list_short')"/>
                 </header>
             </xpath>
         </field>

--- a/addons/website_crm_partner_assign/models/res_partner.py
+++ b/addons/website_crm_partner_assign/models/res_partner.py
@@ -73,13 +73,14 @@ class ResPartner(models.Model):
         action = super().action_view_opportunity()
         action_domain_origin = action.get('domain')
         action_context_origin = action.get('context') or {}
+        action_context_origin['active_test'] = False
         action_domain_assign = [('partner_assigned_id', '=', self.id)]
         if not action_domain_origin:
             action['domain'] = action_domain_assign
             return action
         # perform searches independently as having OR with those leaves seems to
         # be counter productive
-        Lead = self.env['crm.lead'].with_context(**action_context_origin, active_test=False)
+        Lead = self.env['crm.lead'].with_context(**action_context_origin)
         ids_origin = Lead.search(action_domain_origin).ids
         ids_new = Lead.search(action_domain_assign).ids
         action['domain'] = [('id', 'in', sorted(list(set(ids_origin) | set(ids_new))))]


### PR DESCRIPTION
When moving leads to a won stage, they should be activated again. Indeed
we consider a won lead / opportunity has been actively worked on and
thus should be activated again.

Main idea is that duplicates should not count merged opportunities.
Indeed it is used notably in automatic merge process, and we should
not merge in won (therefore closed) opportunities. Updated domains
to better reflect the include_lost meaning since odoo/odoo#194654

Just some tweaks to improve display when dealing with lost or archived
leads.

Followup of odoo/odoo#194654

Task-4617724
