### PR TITLE
[FIX] l10n_it_edi: include null candidate lines

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -524,7 +524,8 @@ class AccountMove(models.Model):
             base_lines.remove(downpayment_line)
 
         dispatched_results = self.env['account.tax']._dispatch_negative_lines(base_lines)
-        base_lines = dispatched_results['result_lines'] + dispatched_results['nulled_candidate_lines'] + dispatched_results['orphan_negative_lines'] + downpayment_lines
+        base_lines = (dispatched_results['result_lines'] + dispatched_results['orphan_negative_lines']
+                      + dispatched_results['nulled_candidate_lines'] + downpayment_lines)
         AccountTax._round_base_lines_tax_details(base_lines, self.company_id, tax_lines=tax_lines)
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, self._l10n_it_edi_grouping_function_base_lines)
         self._l10n_it_edi_add_base_lines_xml_values(base_lines_aggregated_values, is_downpayment)


### PR DESCRIPTION
Currently, when a negative line is added and dispatched with `_dispatch_negative_lines`, null candidates lines are excluded from the base line to include in the XML. This leads to issues where the invoice no longer contains all its original lines.

Steps to reproduce:
- Create an invoice with several positive lines and one negative line
    - (e.g., 5 lines at $100 and one at -$200)
- Click “Send” and select “Send to Tax Agency”
- Check the XML result, you’ll notice only 3 lines are present instead of 5

This fix restores the behavior seen in Odoo version 17.4, where null candidates lines from `_dispatch_negative_lines` are still included in the final XML generation.

opw-4604377