### PR TITLE
[FIX] point_of_sale: product info does not display

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ProductInfoPopup">
-        <Dialog title.translate="Product information">
+        <Dialog title="isVariant ? (props.product.display_name + ' | ' + env.utils.formatCurrency(props.info.productInfo.all_prices.price_with_tax)) : 'Product Info'">
             <ProductInfoBanner t-if="!props.product.isConfigurable()" product="props.product" info="props.info"/>
-            <div class="section-inventory mt-3 mb-4 pb-4 border-bottom text-start" t-if="!isVariant and props.info.productInfo.warehouses.length > 0">
+            <div class="section-inventory mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.info.productInfo.warehouses.length > 0">
                 <h3 class="section-title">
                     Inventory
                     <t t-if="pos.session.update_stock_at_closing">(as of opening)</t>

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -543,3 +543,24 @@ registry.category("web_tour.tours").add("ProductCardUoMPrecision", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("productwithvariantstour", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickInfoProduct("variant product"),
+            // check if the product info (price title and inventory) are present
+            {
+                content: "Check if modal title contains title",
+                trigger: `.modal-title.text-break.flex-grow-1:contains("variant product"):contains("172")`,
+            },
+            {
+                content: "Check if the inventory section is present",
+                trigger: ".section-inventory:contains('Units available,'):contains('forecasted')",
+            },
+            Dialog.confirm(),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1638,6 +1638,26 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductCardUoMPrecision', login="pos_user")
 
+    def test_product_with_variants(self):
+        product_template = self.env['product.template'].create({
+            'name': 'variant product',
+            'available_in_pos': True,
+            'list_price': 150,
+        })
+        color_attribute = self.env['product.attribute'].create({'name': 'Color'})
+        color_red = self.env['product.attribute.value'].create({'name': 'Red', 'attribute_id': color_attribute.id})
+        color_blue = self.env['product.attribute.value'].create({'name': 'Blue', 'attribute_id': color_attribute.id})
+
+        # Assign the color attribute to the product
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': color_attribute.id,
+            'value_ids': [(6, 0, [color_red.id, color_blue.id])],
+        })
+        product_template._create_variant_ids()
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'productwithvariantstour', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
When opening the `product information` of a product with variants in a POS session
We do not see the product name, price and inventory information

OPW-4544324


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
