### PR TITLE
[I18N] base, web: revert incorrect boolean untranslations

### DIFF
--- a/addons/base_import/i18n/de.po
+++ b/addons/base_import/i18n/de.po
@@ -6,6 +6,7 @@
 # Martin Trigaux, 2023
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 08:27+0000\n"
 "PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1230,7 +1231,7 @@ msgstr "erstellen"
 #: code:addons/base_import/static/src/legacy/xml/base_import.xml:0
 #, python-format
 msgid "false"
-msgstr "False"
+msgstr "falsch"
 
 #. module: base_import
 #. odoo-javascript

--- a/addons/web/i18n/de.po
+++ b/addons/web/i18n/de.po
@@ -12,6 +12,7 @@
 # Martin Trigaux, 2023
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -19,7 +20,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 08:27+0000\n"
 "PO-Revision-Date: 2022-09-22 05:55+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2409,7 +2410,7 @@ msgstr "Suchkontext konnte nicht ausgewertet werden"
 #: code:addons/web/static/src/legacy/js/fields/field_utils.js:0
 #, python-format
 msgid "False"
-msgstr "False"
+msgstr "Falsch"
 
 #. module: web
 #. odoo-javascript
@@ -5640,7 +5641,7 @@ msgstr "Übersetzen: %s"
 #: code:addons/web/static/src/legacy/js/fields/field_utils.js:0
 #, python-format
 msgid "True"
-msgstr "True"
+msgstr "Wahr"
 
 #. module: web
 #. odoo-javascript

--- a/odoo/addons/base/i18n/de.po
+++ b/odoo/addons/base/i18n/de.po
@@ -10,9 +10,10 @@
 # Stephanie Speiser, 2023
 # Stefan Reisich <nafex@gmx.net>, 2023
 # Friederike Fasterling-Nesselbosch, 2024
-# Martin Trigaux, 2024
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Martin Trigaux, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -20,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 10:09+0000\n"
 "PO-Revision-Date: 2022-09-22 05:44+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -39052,7 +39053,7 @@ msgstr "externe ID"
 #: code:addons/base/models/ir_fields.py:0
 #, python-format
 msgid "false"
-msgstr "False"
+msgstr "falsch"
 
 #. module: base
 #: model:ir.model.fields.selection,name:base.selection__ir_model_fields__ttype__float
@@ -39471,7 +39472,7 @@ msgstr "Titel"
 #: code:addons/base/models/ir_fields.py:0
 #, python-format
 msgid "true"
-msgstr "True"
+msgstr "wahr"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_sale_delivery_mondialrelay


### PR DESCRIPTION
Some "True"/"False" terms were incorrectly untranslated back into "True"/"False" in German. This cases a test to fail and was incorrect in these contexts. Revert it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
