### PR TITLE
[FIX] pos_self_order: pricelist not applied in kiosk

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -5,7 +5,12 @@ import { markRaw } from "@odoo/owl";
 import { floatIsZero } from "@web/core/utils/numbers";
 import { registry } from "@web/core/registry";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { deduceUrl, random5Chars, uuidv4 } from "@point_of_sale/utils";
+import {
+    deduceUrl,
+    random5Chars,
+    uuidv4,
+    computeProductPricelistCache,
+} from "@point_of_sale/utils";
 import { Reactive } from "@web/core/utils/reactive";
 import { HWPrinter } from "@point_of_sale/app/printer/hw_printer";
 import { ConnectionLostError } from "@web/core/network/rpc";
@@ -22,7 +27,6 @@ import {
     ask,
     makeActionAwaitable,
 } from "@point_of_sale/app/store/make_awaitable_dialog";
-import { deserializeDate } from "@web/core/l10n/dates";
 import { PartnerList } from "../screens/partner_list/partner_list";
 import { ScaleScreen } from "../screens/scale_screen/scale_screen";
 import { computeComboLines } from "../models/utils/compute_combo_lines";
@@ -31,8 +35,6 @@ import { getTaxesAfterFiscalPosition, getTaxesValues } from "../models/utils/tax
 import { QRPopup } from "@point_of_sale/app/utils/qr_code_popup/qr_code_popup";
 import { ReceiptScreen } from "../screens/receipt_screen/receipt_screen";
 import { PaymentScreen } from "../screens/payment_screen/payment_screen";
-
-const { DateTime } = luxon;
 
 export class PosStore extends Reactive {
     loadingSkipButtonIsShown = false;
@@ -414,102 +416,12 @@ export class PosStore extends Reactive {
     async _onBeforeDeleteOrder(order) {
         return true;
     }
+
     computeProductPricelistCache(data) {
         if (data) {
             data = this.models[data.model].readMany(data.ids);
         }
-        // This function is called via the addEventListener callback initiated in the
-        // processServerData function when new products or pricelists are loaded into the PoS.
-        // It caches the heavy pricelist calculation when there are many products and pricelists.
-        const date = DateTime.now();
-        let pricelistItems = this.models["product.pricelist.item"].getAll();
-        let products = this.models["product.product"].getAll();
-
-        if (data && data.length > 0) {
-            if (data[0].model.modelName === "product.product") {
-                products = data;
-            }
-
-            if (data[0].model.modelName === "product.pricelist.item") {
-                pricelistItems = data;
-                // it needs only to compute for the products that are affected by the pricelist items
-                const productTmplIds = new Set(data.map((item) => item.raw.product_tmpl_id));
-                const productIds = new Set(data.map((item) => item.raw.product_id));
-                products = products.filter(
-                    (product) =>
-                        productTmplIds.has(product.raw.product_tmpl_id) ||
-                        productIds.has(product.id)
-                );
-            }
-        }
-
-        const pushItem = (targetArray, key, item) => {
-            if (!targetArray[key]) {
-                targetArray[key] = [];
-            }
-            targetArray[key].push(item);
-        };
-
-        const pricelistRules = {};
-
-        for (const item of pricelistItems) {
-            if (
-                (item.date_start && deserializeDate(item.date_start) > date) ||
-                (item.date_end && deserializeDate(item.date_end) < date)
-            ) {
-                continue;
-            }
-            const pricelistId = item.pricelist_id.id;
-
-            if (!pricelistRules[pricelistId]) {
-                pricelistRules[pricelistId] = {
-                    productItems: {},
-                    productTmlpItems: {},
-                    categoryItems: {},
-                    globalItems: [],
-                };
-            }
-
-            const productId = item.raw.product_id;
-            if (productId) {
-                pushItem(pricelistRules[pricelistId].productItems, productId, item);
-                continue;
-            }
-            const productTmplId = item.raw.product_tmpl_id;
-            if (productTmplId) {
-                pushItem(pricelistRules[pricelistId].productTmlpItems, productTmplId, item);
-                continue;
-            }
-            const categId = item.raw.categ_id;
-            if (categId) {
-                pushItem(pricelistRules[pricelistId].categoryItems, categId, item);
-            } else {
-                pricelistRules[pricelistId].globalItems.push(item);
-            }
-        }
-
-        for (const product of products) {
-            const applicableRules = product.getApplicablePricelistRules(pricelistRules);
-            for (const pricelistId in applicableRules) {
-                if (product.cachedPricelistRules[pricelistId]) {
-                    const existingRuleIds = product.cachedPricelistRules[pricelistId].map(
-                        (rule) => rule.id
-                    );
-                    const newRules = applicableRules[pricelistId].filter(
-                        (rule) => !existingRuleIds.includes(rule.id)
-                    );
-                    product.cachedPricelistRules[pricelistId] = [
-                        ...newRules,
-                        ...product.cachedPricelistRules[pricelistId],
-                    ];
-                } else {
-                    product.cachedPricelistRules[pricelistId] = applicableRules[pricelistId];
-                }
-            }
-        }
-        if (data && data.length > 0 && data[0].model.modelName === "product.product") {
-            this._loadMissingPricelistItems(products);
-        }
+        computeProductPricelistCache(this, data);
     }
 
     async _loadMissingPricelistItems(products) {

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,4 +1,4 @@
-import { parseDateTime } from "@web/core/l10n/dates";
+import { parseDateTime, deserializeDate } from "@web/core/l10n/dates";
 
 /*
  * comes from o_spreadsheet.js
@@ -122,4 +122,98 @@ export function loadAllImages(el) {
 }
 export function parseUTCString(utcStr) {
     return parseDateTime(utcStr, { format: "yyyy-MM-dd HH:mm:ss", tz: "utc" });
+}
+
+export function computeProductPricelistCache(service, data = []) {
+    // This function is called via the addEventListener callback initiated in the
+    // processServerData function when new products or pricelists are loaded into the PoS.
+    // It caches the heavy pricelist calculation when there are many products and pricelists.
+    const date = luxon.DateTime.now();
+    let pricelistItems = service.models["product.pricelist.item"].getAll();
+    let products = service.models["product.product"].getAll();
+
+    if (data.length > 0) {
+        if (data[0].model.modelName === "product.product") {
+            products = data;
+        }
+
+        if (data[0].model.modelName === "product.pricelist.item") {
+            pricelistItems = data;
+            // it needs only to compute for the products that are affected by the pricelist items
+            const productTmplIds = new Set(data.map((item) => item.raw.product_tmpl_id));
+            const productIds = new Set(data.map((item) => item.raw.product_id));
+            products = products.filter(
+                (product) =>
+                    productTmplIds.has(product.raw.product_tmpl_id) || productIds.has(product.id)
+            );
+        }
+    }
+
+    const pushItem = (targetArray, key, item) => {
+        if (!targetArray[key]) {
+            targetArray[key] = [];
+        }
+        targetArray[key].push(item);
+    };
+
+    const pricelistRules = {};
+
+    for (const item of pricelistItems) {
+        if (
+            (item.date_start && deserializeDate(item.date_start) > date) ||
+            (item.date_end && deserializeDate(item.date_end) < date)
+        ) {
+            continue;
+        }
+        const pricelistId = item.pricelist_id.id;
+
+        if (!pricelistRules[pricelistId]) {
+            pricelistRules[pricelistId] = {
+                productItems: {},
+                productTmlpItems: {},
+                categoryItems: {},
+                globalItems: [],
+            };
+        }
+
+        const productId = item.raw.product_id;
+        if (productId) {
+            pushItem(pricelistRules[pricelistId].productItems, productId, item);
+            continue;
+        }
+        const productTmplId = item.raw.product_tmpl_id;
+        if (productTmplId) {
+            pushItem(pricelistRules[pricelistId].productTmlpItems, productTmplId, item);
+            continue;
+        }
+        const categId = item.raw.categ_id;
+        if (categId) {
+            pushItem(pricelistRules[pricelistId].categoryItems, categId, item);
+        } else {
+            pricelistRules[pricelistId].globalItems.push(item);
+        }
+    }
+
+    for (const product of products) {
+        const applicableRules = product.getApplicablePricelistRules(pricelistRules);
+        for (const pricelistId in applicableRules) {
+            if (product.cachedPricelistRules[pricelistId]) {
+                const existingRuleIds = product.cachedPricelistRules[pricelistId].map(
+                    (rule) => rule.id
+                );
+                const newRules = applicableRules[pricelistId].filter(
+                    (rule) => !existingRuleIds.includes(rule.id)
+                );
+                product.cachedPricelistRules[pricelistId] = [
+                    ...newRules,
+                    ...product.cachedPricelistRules[pricelistId],
+                ];
+            } else {
+                product.cachedPricelistRules[pricelistId] = applicableRules[pricelistId];
+            }
+        }
+    }
+    if (data.length > 0 && data[0].model.modelName === "product.product") {
+        service._loadMissingPricelistItems(products);
+    }
 }

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -144,3 +144,18 @@ registry.category("web_tour.tours").add("self_order_language_changes", {
         ProductPage.clickProduct("Produit Test"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_order_pricelist", {
+    test: true,
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Coca-Cola"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "2.30", "2"),
+        Utils.clickBtn("Pay"),
+        Utils.clickBtn("Close"),
+        Utils.checkIsNoBtn("My Order"),
+    ],
+});


### PR DESCRIPTION
Steps to reproduce:
- Have a pricelist with rules.
- Add this pricelist as the default one for a POS (kiosk).
- Open the kiosk and add the products to trigger the price rule

Issue: The price rule is not taken into account.

This occurs because the kiosk currently does not set the order pricelist
in kiosk mode.
Also, pricelist rules are not loaded as it occurs in normal POS session [1]

[1] https://github.com/odoo/odoo/blob/c8d7452063a4712b03b6d23e944ff283bdcea857/addons/point_of_sale/static/src/app/store/pos_store.js#L417

This commit aim to restore the pricelist functionality by loading the
pricelist rules at startup like `computeProductPricelistCache` does

opw-4553345