### PR TITLE
[FIX] mail: fix for push notification that not are not working on Edge PWA

### DIFF
--- a/addons/mail/web_push.py
+++ b/addons/mail/web_push.py
@@ -129,7 +129,11 @@ def push_to_end_point(base_url, device, payload, vapid_private_key, vapid_public
         #  - "k" the base64url-encoded key that signed that token.
         'Authorization': 'vapid t={}, k={}'.format(token, vapid_public_key),
         'Content-Encoding': 'aes128gcm',
-        'TTL': '0',
+        # The TTL is set to '60' as workaround because the push notifications 
+        # are not received on Edge with TTL ='0'. 
+        # Using the TTL '0' , the microsoft endpoint returns a 400 bad request error.
+        # and we are sure that the notification will be received
+        'TTL': '60',
     }
 
     response = session.post(endpoint, headers=headers, data=payload, timeout=5)

--- a/addons/test_mail_full/tests/test_web_push.py
+++ b/addons/test_mail_full/tests/test_web_push.py
@@ -332,7 +332,7 @@ class TestWebPushNotification(SMSCommon):
         self.assertIn('t=', post.call_args.kwargs['headers']['Authorization'])
         self.assertIn('k=', post.call_args.kwargs['headers']['Authorization'])
         self.assertEqual('aes128gcm', post.call_args.kwargs['headers']['Content-Encoding'])
-        self.assertEqual('0', post.call_args.kwargs['headers']['TTL'])
+        self.assertEqual('60', post.call_args.kwargs['headers']['TTL'])
         self.assertIn('data', post.call_args.kwargs)
         self.assertIn('timeout', post.call_args.kwargs)
 


### PR DESCRIPTION
### Before this PR
The PUSH notifications on Edge PWA are not working.
This is caused by the TTL 0 . Edge PUSH are not working if TTL 0 is used.

### After This PR
I set the TTL to 1. It is a tricky way to make it work on Edge and also other browser. It is 1 seconds instead of 0(that means only if the browser is connected) 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
