### PR TITLE
[I18N] base, web: revert incorrect boolean untranslations

### DIFF
--- a/addons/account/i18n/de.po
+++ b/addons/account/i18n/de.po
@@ -8,6 +8,7 @@
 # Larissa Manderfeld, 2025
 # Wil Odoo, 2025
 # Martin Trigaux, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -15,7 +16,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 10:33+0000\n"
 "PO-Revision-Date: 2023-10-26 23:09+0000\n"
-"Last-Translator: Martin Trigaux, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -6671,7 +6672,7 @@ msgstr ""
 #: code:addons/account/models/account_tax.py:0
 #, python-format
 msgid "False"
-msgstr "False"
+msgstr "Falsch"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_report__filter_aml_ir_filters
@@ -16009,7 +16010,7 @@ msgstr ""
 #: code:addons/account/models/account_tax.py:0
 #, python-format
 msgid "True"
-msgstr "True"
+msgstr "Wahr"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_search_inherit

--- a/addons/base_import/i18n/de.po
+++ b/addons/base_import/i18n/de.po
@@ -6,6 +6,7 @@
 # Martin Trigaux, 2024
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 10:34+0000\n"
 "PO-Revision-Date: 2023-10-26 23:09+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -709,7 +710,7 @@ msgstr "Einstellung: %s"
 #: code:addons/base_import/static/src/import_data_options/import_data_options.js:0
 #, python-format
 msgid "Set to: False"
-msgstr "Einstellung: False"
+msgstr "Einstellung: Falsch"
 
 #. module: base_import
 #. odoo-javascript

--- a/addons/spreadsheet/i18n/de.po
+++ b/addons/spreadsheet/i18n/de.po
@@ -5,6 +5,7 @@
 # Translators:
 # Wil Odoo, 2024
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -12,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 10:34+0000\n"
 "PO-Revision-Date: 2023-10-26 23:09+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -12054,7 +12055,7 @@ msgstr "genaues Datum"
 #: code:addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.xml:0
 #, python-format
 msgid "false"
-msgstr "False"
+msgstr "falsch"
 
 #. module: spreadsheet
 #. odoo-javascript

--- a/addons/web/i18n/de.po
+++ b/addons/web/i18n/de.po
@@ -6,6 +6,7 @@
 # Martin Trigaux, 2024
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 10:35+0000\n"
 "PO-Revision-Date: 2023-10-26 23:09+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3124,7 +3125,7 @@ msgstr "Emojis konnten nicht geladen werden ..."
 #: code:addons/web/static/src/core/tree_editor/tree_editor_value_editors.js:0
 #, python-format
 msgid "False"
-msgstr "False"
+msgstr "Falsch"
 
 #. module: web
 #. odoo-javascript
@@ -7547,7 +7548,7 @@ msgstr "Triton"
 #: code:addons/web/static/src/core/tree_editor/tree_editor_value_editors.js:0
 #, python-format
 msgid "True"
-msgstr "True"
+msgstr "Wahr"
 
 #. module: web
 #. odoo-javascript

--- a/odoo/addons/base/i18n/de.po
+++ b/odoo/addons/base/i18n/de.po
@@ -8,6 +8,7 @@
 # Martin Trigaux, 2024
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -15,7 +16,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 11:26+0000\n"
 "PO-Revision-Date: 2023-10-26 23:09+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28536,7 +28537,7 @@ msgstr "Niue"
 #. module: base
 #: model:ir.model.fields.selection,name:base.selection__ir_actions_server__update_boolean_value__false
 msgid "No (False)"
-msgstr "Nein (False)"
+msgstr "Nein (Falsch)"
 
 #. module: base
 #: model_terms:ir.actions.act_window,help:base.action_country
@@ -38954,7 +38955,7 @@ msgstr "Übergangsmodell"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.report_irmodeloverview
 msgid "Transient: False"
-msgstr "Übergang: False"
+msgstr "Übergang: Falsch"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.report_irmodeloverview
@@ -41898,7 +41899,7 @@ msgstr "externe ID"
 #: code:addons/base/models/ir_fields.py:0
 #, python-format
 msgid "false"
-msgstr "False"
+msgstr "falsch"
 
 #. module: base
 #: model:ir.model.fields.selection,name:base.selection__ir_model_fields__ttype__float
@@ -42274,7 +42275,7 @@ msgstr "Titel"
 #: code:addons/base/models/ir_fields.py:0
 #, python-format
 msgid "true"
-msgstr "True"
+msgstr "wahr"
 
 #. module: base
 #. odoo-python


### PR DESCRIPTION
Some "True"/"False" terms were incorrectly untranslated back into "True"/"False" in German. This cases a test to fail and was incorrect in these contexts. Revert it.

Note: Some inconsistency reverts may have been applied, but should have no effect on code. More thorough revert will be done later on by translator.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
