### PR TITLE
[IMP] website_event_track: remove date_delay from event tracks calendar view

### DIFF
--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -102,8 +102,8 @@ class EventTrack(models.Model):
         readonly=False, store=True, tracking=30)
     location_id = fields.Many2one('event.track.location', 'Location')
     # time information
-    date = fields.Datetime('Track Date')
-    date_end = fields.Datetime('Track End Date', compute='_compute_end_date', store=True)
+    date = fields.Datetime('Track Date', compute='_compute_date', inverse="_inverse_date", store=True)
+    date_end = fields.Datetime('Track End Date', compute='_compute_end_date', inverse="_inverse_end_date", store=True)
     duration = fields.Float('Duration', default=0.5)
     is_track_live = fields.Boolean(
         'Is Track Live', compute='_compute_track_time_data')
@@ -267,6 +267,20 @@ class EventTrack(models.Model):
 
     # TIME
 
+    @api.depends('date_end', 'duration')
+    def _compute_date(self):
+        for track in self:
+            if track.date_end:
+                delta = timedelta(minutes=60 * track.duration)
+                track.date = track.date_end - delta
+            else:
+                track.date = False
+
+    def _inverse_date(self):
+        for track in self:
+            if track.date and track.date_end:
+                track.duration = (track.date_end - track.date).total_seconds() / 3600
+
     @api.depends('date', 'duration')
     def _compute_end_date(self):
         for track in self:
@@ -276,6 +290,10 @@ class EventTrack(models.Model):
             else:
                 track.date_end = False
 
+    def _inverse_end_date(self):
+        for track in self:
+            if track.date and track.date_end:
+                track.duration = (track.date_end - track.date).total_seconds() / 3600
 
     # FRONTEND DESCRIPTION
 

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -71,7 +71,7 @@
         <field name="model">event.track</field>
         <field eval="2" name="priority"/>
         <field name="arch" type="xml">
-            <calendar date_start="date" date_delay="duration" string="Event Tracks" color="location_id" event_limit="5">
+            <calendar date_start="date" date_stop="date_end" string="Event Tracks" color="location_id" event_limit="5">
                 <field name="location_id" filters="1"/>
                 <field name="event_id"/>
                 <field name="partner_id" avatar_field="avatar_128"/>


### PR DESCRIPTION
As the framework plans to remove the attribute date_delay from the calendar view, this commit removes the attribute dete_delay from the related view and makes the date_end writeable.

Task-4582723
