### PR TITLE
[IMP] pos_add_salesperson: enable salesperson selection on billing screen

### DIFF
--- a/addons/pos_add_salesperson/__init__.py
+++ b/addons/pos_add_salesperson/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/pos_add_salesperson/__manifest__.py
+++ b/addons/pos_add_salesperson/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': "POS Salesperson Assignment",
+    'description': """
+    Module to select salesperson on POS billing screen.
+    """,
+    'version': '1.0',
+    'depends': ['point_of_sale', 'pos_hr'],
+    'license': 'LGPL-3',
+    'installable': True,
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_add_salesperson/static/src/**/*',
+        ],
+    },
+    'data': [
+        'views/pos_order_view.xml'
+    ]
+}

--- a/addons/pos_add_salesperson/models/__init__.py
+++ b/addons/pos_add_salesperson/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pos_order
+from . import pos_session

--- a/addons/pos_add_salesperson/models/pos_order.py
+++ b/addons/pos_add_salesperson/models/pos_order.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class PosOrder(models.Model):
+    _inherit = 'pos.order'
+
+    sales_person_id = fields.Many2one('hr.employee', string="Salesperson", help="Employee responsible for the sale")

--- a/addons/pos_add_salesperson/models/pos_session.py
+++ b/addons/pos_add_salesperson/models/pos_session.py
@@ -1,0 +1,12 @@
+from odoo import api, models
+
+
+class PosSession(models.Model):
+
+    _inherit = 'pos.session'
+
+    @api.model
+    def _load_pos_data_models(self, config_id):
+        data = super()._load_pos_data_models(config_id)
+        data.append("hr.employee")
+        return data

--- a/addons/pos_add_salesperson/static/src/app/generic_components/order_widget/order_widget.js
+++ b/addons/pos_add_salesperson/static/src/app/generic_components/order_widget/order_widget.js
@@ -1,0 +1,9 @@
+import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
+import { patch } from "@web/core/utils/patch";
+
+patch(OrderWidget, {
+    props: {
+        ...OrderWidget.props,
+        sales_person: { type: String, optional: true },
+    }
+});

--- a/addons/pos_add_salesperson/static/src/app/generic_components/order_widget/order_widget.xml
+++ b/addons/pos_add_salesperson/static/src/app/generic_components/order_widget/order_widget.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson_assignment.OrderWidget" t-inherit="point_of_sale.OrderWidget" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='props.lines?.length']/div[1]" position="before">
+            <div class="order-sales-person text-break mb-1 ms-1">
+                <h5>
+                    <t t-if="props.sales_person">
+                        Sales Person: <t t-esc="props.sales_person"/>
+                    </t>
+                </h5>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_add_salesperson/static/src/app/models/pos_order.js
+++ b/addons/pos_add_salesperson/static/src/app/models/pos_order.js
@@ -1,0 +1,8 @@
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosOrder.prototype, {
+    setSalesPerson(sales_person) {
+        this.update({ sales_person_id: sales_person })
+    },
+})

--- a/addons/pos_add_salesperson/static/src/app/sceens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_add_salesperson/static/src/app/sceens/product_screen/control_buttons/control_buttons.js
@@ -1,0 +1,10 @@
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { SelectSalespersonButton } from "./select_salesperson_button/select_salesperson_button";
+import { patch } from "@web/core/utils/patch";
+
+patch(ControlButtons, {
+    components: {
+        ...ControlButtons.components,
+        SelectSalespersonButton,
+    }
+});

--- a/addons/pos_add_salesperson/static/src/app/sceens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_add_salesperson/static/src/app/sceens/product_screen/control_buttons/control_buttons.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson_assignment.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath
+            expr="//button[@t-if='!props.showRemainingButtons and !ui.isSmall and props.onClickMore']"
+            position="before">
+                <SelectSalespersonButton/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_add_salesperson/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.js
+++ b/addons/pos_add_salesperson/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.js
@@ -1,0 +1,62 @@
+import { Component } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useService } from "@web/core/utils/hooks";
+import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+
+export class SelectSalespersonButton extends Component {
+    static template = "pos_salesperson_assignment.SelectSalespersonButton";
+
+    setup() {
+        this.pos = usePos();
+        this.dialog = useService("dialog");
+    }
+
+    prepareEmployeeList() {
+        const allEmployees = this.pos.models['hr.employee']
+        const employeeList = allEmployees.map((employee) => {
+            return {
+                id: employee.id,
+                item: employee,
+                label: employee.name,
+                isSelected: false
+            }
+        })
+
+        return employeeList;
+    }
+
+    async onClick() {
+        const order = this.pos.get_order();
+        const employeesList = this.prepareEmployeeList();
+    
+        if (!employeesList.length) {
+            return;
+        }
+    
+        let sales_person = await makeAwaitable(this.dialog, SelectionPopup, {
+            title: "Select Sales Person",
+            list: employeesList
+        });
+    
+        if (!sales_person) {
+            return;
+        }
+        
+        order.setSalesPerson(sales_person);
+    }
+
+    onRemove() {
+        const order = this.pos.get_order();
+        if (!order || !order.sales_person_id) {
+            return;
+        }
+
+        order.setSalesPerson(false);
+    }
+    
+    get salesperson() {
+        const order = this.pos.get_order();
+        return order.sales_person_id;
+    }
+}

--- a/addons/pos_add_salesperson/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.xml
+++ b/addons/pos_add_salesperson/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson_assignment.SelectSalespersonButton">
+        <button
+            class="set-salesperson btn btn-light text-truncate btn-lg lh-lg w-auto">
+                <div t-if="salesperson" class="d-flex justify-content-between align-items-center">
+                    <div class="text-truncate text-action" t-on-click="onClick">
+                        <t t-esc="salesperson.name"/>
+                    </div>
+                    <i class="fa fa-close" style="padding-left: 8px" t-on-click="onRemove"/>
+                </div>
+                <t t-else="">
+                    <div t-on-click="onClick">
+                        Salesperson
+                    </div>
+                </t>
+        </button>
+    </t>
+</templates>

--- a/addons/pos_add_salesperson/static/src/app/sceens/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_add_salesperson/static/src/app/sceens/product_screen/order_summary/order_summary.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson_assignment.OrderSummary"
+        t-inherit="point_of_sale.OrderSummary"
+        t-inherit-mode="extension">
+            <xpath expr="//OrderWidget" position="attributes">
+                <attribute name="sales_person">currentOrder.sales_person_id?.name</attribute>
+            </xpath>
+    </t>
+</templates>

--- a/addons/pos_add_salesperson/views/pos_order_view.xml
+++ b/addons/pos_add_salesperson/views/pos_order_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pos_order_tree_view_inherit_pos_salesperson_assignment" model="ir.ui.view">
+        <field name="name">view.pos.order.tree.view.inherit.pos.salesperson.assignment</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="sales_person_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_pos_pos_form_view_inherit_pos_salesperson_assignment" model="ir.ui.view">
+        <field name="name">view.pos.pos.form.view.inherit.pos.salesperson.assignment</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
+        <field name="arch" type="xml">
+            <field name="fiscal_position_id" position="after">
+                <field name="sales_person_id" readonly="1"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add sales_person_id field to pos.order to store the assigned salesperson.
- Salesperson id and names are derived from hr.employee model.
- Patched PosOrder Screen to manage salesperson assignment .
- Patched OrderWidget to display the selected salesperson in the order summary.
- Added a salesperson button on the billing screen to select, change, or remove the salesperson.
- Included salesperson information in the backend i.e form and list views of POS orders.
- Task ID : 4602962

Description of the issue/feature this PR addresses:

Current behavior before PR: There was no functionality to add Salesperson on a POS order

Desired behavior after PR is merged: A button is added to select ore remove Salesperson
corresponding to an order




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
