### PR TITLE
[IMP] google_address_autocomplete: use autocomplete widget for address field

### DIFF
--- a/addons/google_address_autocomplete/views/res_partner_views.xml
+++ b/addons/google_address_autocomplete/views/res_partner_views.xml
@@ -10,4 +10,15 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_partner_address_form_inherit_address_autocomplete" model="ir.ui.view">
+        <field name="name">view.partner.address.form.inherit.address.autocomplete</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_address_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='street']" position="attributes">
+                <attribute name="widget">google_address_autocomplete</attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
this commit enhance the user experience by adding Google address autocomplete widget to the partner address form view.
which provide address suggestions as on users input. which will make address entry faster and reduce the chances of incorrect addresses and save users time.

task-4461146






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
