### PR TITLE
[I18N] base, web: revert incorrect boolean untranslations

### DIFF
--- a/addons/account/i18n/de.po
+++ b/addons/account/i18n/de.po
@@ -9,6 +9,7 @@
 # Larissa Manderfeld, 2025
 # Martin Trigaux, 2025
 # Wil Odoo, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -16,7 +17,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 13:22+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Wil Odoo, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -7314,7 +7315,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_tax.py:0
 msgid "False"
-msgstr "False"
+msgstr "Falsch"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_report__filter_aml_ir_filters
@@ -17196,7 +17197,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_tax.py:0
 msgid "True"
-msgstr "True"
+msgstr "Wahr"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_search_inherit

--- a/addons/account/i18n/nl.po
+++ b/addons/account/i18n/nl.po
@@ -9,6 +9,7 @@
 # Erwin van der Ploeg <erwin@odooexperts.nl>, 2025
 # Dylan Kiss, 2025
 # Wil Odoo, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -16,7 +17,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 13:22+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Wil Odoo, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -7291,7 +7292,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_tax.py:0
 msgid "False"
-msgstr "False"
+msgstr "Onwaar"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_report__filter_aml_ir_filters
@@ -17122,7 +17123,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_tax.py:0
 msgid "True"
-msgstr "True"
+msgstr "Waar"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_search_inherit

--- a/addons/spreadsheet/i18n/de.po
+++ b/addons/spreadsheet/i18n/de.po
@@ -3,11 +3,11 @@
 # 	* spreadsheet
 # 
 # Translators:
-# Tiffany Chang, 2024
 # Martin Trigaux, 2024
 # Friederike Fasterling-Nesselbosch, 2024
 # Wil Odoo, 2024
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -15,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-27 13:04+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -12015,7 +12015,7 @@ msgstr "exponentiell"
 #. odoo-javascript
 #: code:addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.xml:0
 msgid "false"
-msgstr "False"
+msgstr "falsch"
 
 #. module: spreadsheet
 #. odoo-javascript

--- a/addons/web/i18n/de.po
+++ b/addons/web/i18n/de.po
@@ -4,9 +4,10 @@
 # 
 # Translators:
 # Friederike Fasterling-Nesselbosch, 2024
-# Martin Trigaux, 2024
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Martin Trigaux, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 13:24+0000\n"
 "PO-Revision-Date: 2024-09-25 09:42+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2890,7 +2891,7 @@ msgstr "Emojis konnten nicht geladen werden ..."
 #. odoo-javascript
 #: code:addons/web/static/src/core/tree_editor/tree_editor_value_editors.js:0
 msgid "False"
-msgstr "False"
+msgstr "Falsch"
 
 #. module: web
 #. odoo-javascript
@@ -6918,7 +6919,7 @@ msgstr "Triton"
 #. odoo-javascript
 #: code:addons/web/static/src/core/tree_editor/tree_editor_value_editors.js:0
 msgid "True"
-msgstr "True"
+msgstr "Wahr"
 
 #. module: web
 #. odoo-javascript

--- a/addons/web/i18n/nl.po
+++ b/addons/web/i18n/nl.po
@@ -6,8 +6,9 @@
 # Martin Trigaux, 2024
 # Dylan Kiss, 2025
 # Wil Odoo, 2025
-# Erwin van der Ploeg <erwin@odooexperts.nl>, 2025
 # Manon Rondou, 2025
+# Erwin van der Ploeg <erwin@odooexperts.nl>, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -15,7 +16,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 13:24+0000\n"
 "PO-Revision-Date: 2024-09-25 09:42+0000\n"
-"Last-Translator: Manon Rondou, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2888,7 +2889,7 @@ msgstr "Kon emojis niet laden..."
 #. odoo-javascript
 #: code:addons/web/static/src/core/tree_editor/tree_editor_value_editors.js:0
 msgid "False"
-msgstr "False"
+msgstr "Onwaar"
 
 #. module: web
 #. odoo-javascript

--- a/odoo/addons/base/i18n/de.po
+++ b/odoo/addons/base/i18n/de.po
@@ -6,6 +6,7 @@
 # Martin Trigaux, 2024
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 16:32+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -46454,7 +46455,7 @@ msgstr "externe ID"
 #. odoo-python
 #: code:addons/base/models/ir_fields.py:0
 msgid "false"
-msgstr "False"
+msgstr "falsch"
 
 #. module: base
 #: model:ir.model.fields.selection,name:base.selection__ir_model_fields__ttype__float
@@ -46808,7 +46809,7 @@ msgstr "Text"
 #. odoo-python
 #: code:addons/base/models/ir_fields.py:0
 msgid "true"
-msgstr "True"
+msgstr "wahr"
 
 #. module: base
 #. odoo-python

--- a/odoo/addons/base/i18n/nl.po
+++ b/odoo/addons/base/i18n/nl.po
@@ -6,8 +6,9 @@
 # Martin Trigaux, 2024
 # Wil Odoo, 2025
 # Jolien De Paepe, 2025
-# Erwin van der Ploeg <erwin@odooexperts.nl>, 2025
 # Manon Rondou, 2025
+# Erwin van der Ploeg <erwin@odooexperts.nl>, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -15,7 +16,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-10 16:32+0000\n"
 "PO-Revision-Date: 2024-09-25 09:41+0000\n"
-"Last-Translator: Manon Rondou, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1463,6 +1464,10 @@ msgid ""
 "============================================\n"
 "- Corporate tax report\n"
 msgstr ""
+"\n"
+"Boekhoudkundige rapporten voor Bangladesh\n"
+"============================================\n"
+"- Rapport vennootschapsbelasting\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_be_reports
@@ -3093,6 +3098,12 @@ msgid ""
 "- Income tax credits handling\n"
 "- Introduced the income tax slabs calculations\n"
 msgstr ""
+"\n"
+"Salarisregels voor Bangladesh.\n"
+"=========================\n"
+"- Berekening salarisregels\n"
+"- Verwerking van inkomstenbelastingkredieten\n"
+"- Berekening van inkomstenbelastingschijven ingevoerd\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_et
@@ -4978,6 +4989,16 @@ msgid ""
 "- Tax break calculations and deductions\n"
 "- Master payroll export\n"
 msgstr ""
+"\n"
+"Egypte Payroll en regels voor einde dienstverband.\n"
+"=======================================\n"
+"- Basis berekening\n"
+"- Berekening einde dienst\n"
+"- Andere invoer (overwerk, loonbeslag, enz.)\n"
+"- Berekening sociale verzekeringen\n"
+"- Voorzieningen bij einde dienstverband\n"
+"- Berekeningen en aftrekposten voor belastingvoordeel\n"
+"- Master loonlijst export\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_account_edi
@@ -6591,6 +6612,13 @@ msgid ""
 "- Tax income brackets\n"
 "- National contribution tax and social security\n"
 msgstr ""
+"\n"
+"Loon- en belastingregels Jordanië\n"
+"========================================\n"
+"\n"
+"- Ondersteunt basisberekening\n"
+"- Schijven voor belastinginkomen\n"
+"- Nationale bijdrage belasting en sociale zekerheid\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_sa_pos
@@ -6665,6 +6693,17 @@ msgid ""
 "- WPS\n"
 "- Master Payroll Export\n"
 msgstr ""
+"\n"
+"Regels voor salarisadministratie en einde dienst in Saoedi-Arabië.\n"
+"===========================================================\n"
+"- Basisberekening\n"
+"- Berekening einde dienst\n"
+"- Andere invoerregels (overwerk, salarisbijlagen, enz.)\n"
+"- Splitsen van structuren voor EOS en maandsalarissen\n"
+"- GOSI Werknemersaftrek en bedrijfsbijdragen\n"
+"- Onbetaald verlof\n"
+"- WPS\n"
+"- Master salarisadministratie exporteren\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_stock_landed_costs
@@ -8180,6 +8219,11 @@ msgid ""
 "- Basic salaries calculations.\n"
 "- Tax bracket calculations/deductions\n"
 msgstr ""
+"\n"
+"Pakistaanse salarisadministratie en regels einde dienstverband\n"
+"=========================================\n"
+"- Berekening basissalarissen.\n"
+"- Berekening/aftrek belastingschijf\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_pa
@@ -12398,6 +12442,10 @@ msgid ""
 "=======================================================\n"
 "Adds the Corporate Tax Report which can be accessed by going to Accounting > Reporting > Corporate Tax Report\n"
 msgstr ""
+"\n"
+"Verslag vennootschapsbelasting Verenigde Arabische Emiraten\n"
+"=======================================================\n"
+"Voegt het rapport vennootschapsbelasting toe dat toegankelijk is via Boekhouding > Rapportage > Rapport vennootschapsbelasting\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ae_hr_payroll
@@ -12419,6 +12467,22 @@ msgid ""
 "- Master payroll export\n"
 "- WPS\n"
 msgstr ""
+"\n"
+"Payroll- en dienstbeëindigingsregels Verenigde Arabische Emiraten.\n"
+"=======================================================\n"
+"- Berekeningen basissalaris\n"
+"- EOS berekeningen\n"
+"- Voorzieningen voor jaarlijks verlof en EOS\n"
+"- Sociale verzekeringsregels voor lokale werknemers\n"
+"- Overwerkregeling voor de overige ingangen\n"
+"- Berekeningen ziekteverlof\n"
+"- DEWS-berekeningen\n"
+"- EOS-berekeningen voor vrije zones (DMCC)\n"
+"- Berekeningen voor buitencontracten\n"
+"- Berekening voor ongebruikt verlof voor EOS-berekening\n"
+"- Extra overige invoerregels voor (bonus, provisies, achterstallige betalingen, etc.)\n"
+"- Master salarisadministratie export\n"
+"- WPS\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ae
@@ -42383,6 +42447,16 @@ msgid ""
 "- Taxes\n"
 "- Tax report\n"
 msgstr ""
+"\n"
+"Dit is de basismodule om het boekhoudschema voor Bangladesh in Odoo te beheren\n"
+"============================\n"
+"Boekhoudkundige basisgrafieken en lokalisatie voor Bangladesh.\n"
+"\n"
+"Wordt geactiveerd:\n"
+"\n"
+"- Rekeningschema\n"
+"- Belastingen\n"
+"- Belastingrapport\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_pk
@@ -46351,7 +46425,7 @@ msgstr "externe id"
 #. odoo-python
 #: code:addons/base/models/ir_fields.py:0
 msgid "false"
-msgstr "false"
+msgstr "onwaar"
 
 #. module: base
 #: model:ir.model.fields.selection,name:base.selection__ir_model_fields__ttype__float
@@ -46704,7 +46778,7 @@ msgstr "tekst"
 #. odoo-python
 #: code:addons/base/models/ir_fields.py:0
 msgid "true"
-msgstr "true"
+msgstr "waar"
 
 #. module: base
 #. odoo-python


### PR DESCRIPTION
Some "True"/"False" terms were incorrectly untranslated back into "True"/"False" in German. This cases a test to fail and was incorrect in these contexts. Revert it.

Note: Some inconsistency reverts may have been applied, but should have no effect on code. More thorough revert will be done later on by translator.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
