### PR TITLE
[I18N] base, web: revert incorrect boolean untranslations

### DIFF
--- a/addons/account/i18n/de.po
+++ b/addons/account/i18n/de.po
@@ -7,6 +7,7 @@
 # Larissa Manderfeld, 2025
 # Martin Trigaux, 2025
 # Wil Odoo, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-06 13:57+0000\n"
 "PO-Revision-Date: 2024-12-24 16:05+0000\n"
-"Last-Translator: Wil Odoo, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -7395,7 +7396,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_tax.py:0
 msgid "False"
-msgstr "False"
+msgstr "Falsch"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_report__filter_aml_ir_filters
@@ -17337,7 +17338,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_tax.py:0
 msgid "True"
-msgstr "True"
+msgstr "Wahr"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_bank_search_inherit

--- a/addons/spreadsheet/i18n/de.po
+++ b/addons/spreadsheet/i18n/de.po
@@ -5,6 +5,7 @@
 # Translators:
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -12,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-20 08:42+0000\n"
 "PO-Revision-Date: 2024-12-24 16:06+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -12370,7 +12371,7 @@ msgstr "exponentiell"
 #. odoo-javascript
 #: code:addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.xml:0
 msgid "false"
-msgstr "False"
+msgstr "falsch"
 
 #. module: spreadsheet
 #. odoo-javascript

--- a/addons/web/i18n/de.po
+++ b/addons/web/i18n/de.po
@@ -5,6 +5,7 @@
 # Translators:
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -12,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-20 08:42+0000\n"
 "PO-Revision-Date: 2024-12-24 16:06+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2897,7 +2898,7 @@ msgstr "Emojis konnten nicht geladen werden ..."
 #. odoo-javascript
 #: code:addons/web/static/src/core/tree_editor/tree_editor_value_editors.js:0
 msgid "False"
-msgstr "False"
+msgstr "Falsch"
 
 #. module: web
 #. odoo-javascript
@@ -6922,7 +6923,7 @@ msgstr "Triton"
 #. odoo-javascript
 #: code:addons/web/static/src/core/tree_editor/tree_editor_value_editors.js:0
 msgid "True"
-msgstr "True"
+msgstr "Wahr"
 
 #. module: web
 #. odoo-javascript

--- a/odoo/addons/base/i18n/de.po
+++ b/odoo/addons/base/i18n/de.po
@@ -5,6 +5,7 @@
 # Translators:
 # Wil Odoo, 2025
 # Larissa Manderfeld, 2025
+# Tiffany Chang, 2025
 # 
 msgid ""
 msgstr ""
@@ -12,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-07 10:32+0000\n"
 "PO-Revision-Date: 2024-12-24 16:05+0000\n"
-"Last-Translator: Larissa Manderfeld, 2025\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -45850,7 +45851,7 @@ msgstr "externe ID"
 #. odoo-python
 #: code:addons/base/models/ir_fields.py:0
 msgid "false"
-msgstr "False"
+msgstr "falsch"
 
 #. module: base
 #: model:ir.model.fields.selection,name:base.selection__ir_model_fields__ttype__float
@@ -46204,7 +46205,7 @@ msgstr "Text"
 #. odoo-python
 #: code:addons/base/models/ir_fields.py:0
 msgid "true"
-msgstr "True"
+msgstr "wahr"
 
 #. module: base
 #. odoo-python


### PR DESCRIPTION
Some "True"/"False" terms were incorrectly untranslated back into "True"/"False" in German. This cases a test to fail and was incorrect in these contexts. Revert it.

Note: Some inconsistency reverts may have been applied, but should have no effect on code. More thorough revert will be done later on by translator.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
