### PR TITLE
[FIX] website_sale: typo in combination info

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -445,7 +445,7 @@ class ProductTemplate(models.Model):
             and website.show_line_subtotals_tax_selection == 'tax_included'
             and not all(
                 tax.price_include
-                for tax in product_or_template.combo_ids.combo_items_ids.product_id.taxes_id
+                for tax in product_or_template.combo_ids.combo_item_ids.product_id.taxes_id
             )
         ):
             combination_info['tax_disclaimer'] = _(


### PR DESCRIPTION
Fix a typo introduced in 4ec8d2198a1a042cde397b73e2afd56e108c7892
