### PR TITLE
[IMP] im_livechat: change LC statistic menus

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -256,8 +256,15 @@
             sequence="5"/>
 
         <menuitem
+            id="menu_livechat_sessions"
+            name="Sessions"
+            parent="menu_livechat_root"
+            groups="im_livechat_group_user"
+            sequence="10"/>
+
+        <menuitem
             id="menu_reporting_livechat"
-            name="Report"
+            name="Reporting"
             parent="menu_livechat_root"
             sequence="50"
             groups="im_livechat_group_manager"/>
@@ -266,7 +273,7 @@
         <menuitem
             id="session_history"
             name="Sessions History"
-            parent="menu_reporting_livechat"
+            parent="menu_livechat_sessions"
             action="discuss_channel_action"
             groups="im_livechat_group_user"
             sequence="5"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR improves the arrangement and names of the LiveChat menus

**Current behavior before PR:**
- There is a report menu
- The Sessions history menu is in the Report menu

**Desired behavior after PR is merged:**
- The report menu has been renamed reporting
- The Sessions history menu has been moved to a new menu "Settings" (after channels)

task-4614119



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
