### PR TITLE
[FIX] website_sale: prevent combo product traceback error

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -445,7 +445,7 @@ class ProductTemplate(models.Model):
             and website.show_line_subtotals_tax_selection == 'tax_included'
             and not all(
                 tax.price_include
-                for tax in product_or_template.combo_ids.combo_items_ids.product_id.taxes_id
+                for tax in product_or_template.combo_ids.combo_item_ids.product_id.taxes_id
             )
         ):
             combination_info['tax_disclaimer'] = _(


### PR DESCRIPTION
A typo caused a traceback error in combo products when the tax is included in the website.

Steps to reproduce:

- In Website settings, enable "Display Product Prices" with tax included.
- Go to Sales > Products > Products.
- Chose a combo product
- Click on "Go to Website."

opw-4613545