### PR TITLE
[IMP] runbot: add metadata to log_db

### DIFF
--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -354,3 +354,11 @@ class TestSelectorSelection(TransactionCase):
         tags = TagsSelector('standard')
         position = TagsSelector('post_install')
         self.assertTrue(tags.check(post_install_obj) and position.check(post_install_obj))
+
+
+class TestTestClass(BaseCase):
+    def test_canonical_tag(self):
+        self.assertEqual(self.canonical_tag, '/base/tests/test_tests_tags.py:TestTestClass.test_canonical_tag')
+
+    def get_log_metadata(self):
+        self.assertEqual(self.log_metadata['canonical_tag'], '/base/tests/test_tests_tags.py:TestTestClass.test_canonical_tag')

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import contextlib
+import json
 import logging
 import logging.handlers
 import os
@@ -17,6 +18,7 @@ import werkzeug.serving
 from . import release
 from . import sql_db
 from . import tools
+from .modules import module
 
 _logger = logging.getLogger(__name__)
 
@@ -42,6 +44,15 @@ class PostgreSQLHandler(logging.Handler):
     """ PostgreSQL Logging Handler will store logs in the database, by default
     the current database, can be set using --log-db=DBNAME
     """
+
+    def __init__(self):
+        super().__init__()
+        self._support_metadata = False
+        if tools.config['log_db'] != '%d':
+            with contextlib.suppress(Exception), tools.mute_logger('odoo.sql_db'), sql_db.db_connect(tools.config['log_db'], allow_uri=True).cursor() as cr:
+                cr.execute("""SELECT 1 FROM information_schema.columns WHERE table_name='ir_logging' and column_name='metadata'""")
+                self._support_metadata = bool(cr.fetchone())
+
     def emit(self, record):
         ct = threading.current_thread()
         ct_db = getattr(ct, 'dbname', None)
@@ -61,7 +72,24 @@ class PostgreSQLHandler(logging.Handler):
             levelname = logging.getLevelName(record.levelno)
 
             val = ('server', ct_db, record.name, levelname, msg, record.pathname, record.lineno, record.funcName)
-            cr.execute("""
+
+            if self._support_metadata:
+                metadata = {}
+                if module.current_test:
+                    try:
+                        metadata['test'] = module.current_test.get_log_metadata()
+                    except:
+                        pass
+
+                if metadata:
+                    val = (*val, json.dumps(metadata))
+                    cr.execute(f"""
+                        INSERT INTO ir_logging(create_date, type, dbname, name, level, message, path, line, func, metadata)
+                        VALUES (NOW() at time zone 'UTC', %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """, val)
+                    return
+
+            cr.execute(f"""
                 INSERT INTO ir_logging(create_date, type, dbname, name, level, message, path, line, func)
                 VALUES (NOW() at time zone 'UTC', %s, %s, %s, %s, %s, %s, %s, %s)
             """, val)

--- a/odoo/tests/case.py
+++ b/odoo/tests/case.py
@@ -248,6 +248,20 @@ class TestCase(_TestCase):
             except Exception:
                 cls.tearDown_exceptions.append(sys.exc_info())
 
+    @property
+    def canonical_tag(self):
+        module = self.__module__
+        if module.startswith('odoo.addons.'):
+            module = module[12:]
+        module = module.replace('.', '/')
+        return f'/{module}.py:{self.__class__.__name__}.{self._testMethodName}'
+
+    def get_log_metadata(self):
+        metadata = {
+            'canonical_tag': self.canonical_tag,
+        }
+        return metadata
+
 
 class _SubTest(TestCase):
 

--- a/odoo/tests/suite.py
+++ b/odoo/tests/suite.py
@@ -20,6 +20,7 @@ from . import case
 from .common import HttpCase
 from .result import stats_logger
 from unittest import util, BaseTestSuite, TestCase
+from odoo.modules import module
 
 __unittest = True
 
@@ -36,6 +37,7 @@ class TestSuite(BaseTestSuite):
     def run(self, result, debug=False):
         for test in self:
             assert isinstance(test, (TestCase))
+            module.current_test = test
             self._tearDownPreviousClass(test, result)
             self._handleClassSetUp(test, result)
             result._previousTestClass = test.__class__


### PR DESCRIPTION
When handling errors on runbot, it can be difficult to know where a message comes from. It can be problematic to identify automatically the source of an error.

This branch give the possibility to add metadata to log_db.

The current only metadata is the canonical tag.

Some other information, like the stack, or the subtest could be added in the future. This is not the case for now to make the review easier. 

```patch
     def get_log_metadata(self):
+        stack = traceback.format_stack()
+        start = next((index for index, frame in enumerate(stack) if self._testMethodName in frame), 0)
         metadata = {
             'canonical_tag': self.canonical_tag,
+            'stack': '\n'.join(traceback.format_stack()[start:-7]),
+            'subtest': str(self._subtest),
         }
         return metadata
```
