### PR TITLE
[IMP] im_livechat: change LiveChat statistic menus

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
@@ -23,7 +23,7 @@ registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour
             run: "fill Live Chat",
         },
         {
-            trigger: ".o_command:contains(Sessions History)",
+            trigger: ".o_command:contains(Sessions)",
             run: "click",
         },
         {

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -90,7 +90,7 @@
 
 
         <record id="discuss_channel_action" model="ir.actions.act_window">
-            <field name="name">History</field>
+            <field name="name">Sessions</field>
             <field name="res_model">discuss.channel</field>
             <field name="view_mode">kanban,list,form</field>
             <field name="search_view_id" ref="im_livechat.discuss_channel_view_search"/>

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -256,20 +256,19 @@
             sequence="5"/>
 
         <menuitem
+            id="menu_livechat_sessions"
+            name="Sessions"
+            parent="menu_livechat_root"
+            action="discuss_channel_action"
+            groups="im_livechat_group_user"
+            sequence="10"/>
+
+        <menuitem
             id="menu_reporting_livechat"
-            name="Report"
+            name="Reporting"
             parent="menu_livechat_root"
             sequence="50"
             groups="im_livechat_group_manager"/>
-
-
-        <menuitem
-            id="session_history"
-            name="Sessions History"
-            parent="menu_reporting_livechat"
-            action="discuss_channel_action"
-            groups="im_livechat_group_user"
-            sequence="5"/>
 
         <menuitem id="rating_rating_menu_livechat"
             name="Customer Ratings"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR improves the arrangement and names of the LiveChat menus

Current behavior before PR:

There is a report menu
The Sessions history menu is in the Report menu
Desired behavior after PR is merged:

The report menu has been renamed reporting
The Sessions history menu has been moved to a new menu "Settings" (after channels)
task-4614119



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
