### PR TITLE
[FIX] website_sale: prevent random runbot error in tour

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_zero_priced_product.js
+++ b/addons/website_sale/static/tests/tours/website_sale_zero_priced_product.js
@@ -1,7 +1,7 @@
 import { registry } from '@web/core/registry';
 
 registry.category('web_tour.tours').add('website_sale_contact_us_button', {
-    checkDelay: 50,
+    checkDelay: 500,
     steps: () => [
         {
             content: "Check that the red color attribute is selected",


### PR DESCRIPTION
Versions
--------
- 18.0+

Issue
-----
The `website_sale_contact_us_button` tour fails randomly on Runbot.

Cause
-----
50 ms check delay is inadequate.

Solution
--------
Set check delay to 500 ms.

runbot-145471
runbot-145473