### PR TITLE
[FIX] web, website: fix form result cleanup

### DIFF
--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -326,10 +326,13 @@ export class Interaction {
      * @param { HTMLElement } el
      * @param { HTMLElement } [locationEl] the target
      * @param { "afterbegin" | "afterend" | "beforebegin" | "beforeend" } [position]
+     * @param { boolean } [removeOnClean]
      */
-    insert(el, locationEl = this.el, position = "beforeend") {
+    insert(el, locationEl = this.el, position = "beforeend", removeOnClean = true) {
         locationEl.insertAdjacentElement(position, el);
-        this.registerCleanup(() => el.remove());
+        if (removeOnClean) {
+            this.registerCleanup(() => el.remove());
+        }
         this.services["public.interactions"].startInteractions(el);
         this.refreshListeners();
     }
@@ -343,9 +346,17 @@ export class Interaction {
      * @param { HTMLElement } [locationEl] the target
      * @param { "afterbegin" | "afterend" | "beforebegin" | "beforeend" } [position]
      * @param { Function } callback called with rendered elements before insertion
+     * @param { boolean } [removeOnClean]
      * @returns { HTMLElement[] } rendered elements
      */
-    renderAt(template, renderContext, locationEl, position = "beforeend", callback) {
+    renderAt(
+        template,
+        renderContext,
+        locationEl,
+        position = "beforeend",
+        callback,
+        removeOnClean = true
+    ) {
         const fragment = renderToFragment(template, renderContext);
         const result = [...fragment.children];
         const els = [...fragment.children];
@@ -354,7 +365,7 @@ export class Interaction {
             els.reverse();
         }
         for (const el of els) {
-            this.insert(el, locationEl, position);
+            this.insert(el, locationEl, position, removeOnClean);
         }
         return result;
     }

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -1790,6 +1790,21 @@ describe("insert", () => {
         core.stopInteractions();
         expect(queryFirst("inserted")).toBe(null);
     });
+
+    test("inserted element is kept if removeOnClean is false", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            setup() {
+                const node = document.createElement("inserted");
+                this.insert(node, this.el, "beforeend", false);
+            }
+        }
+
+        const { core } = await startInteraction(Test, TemplateTest);
+        expect(queryOne(".test inserted:last-child")).toBeInstanceOf(HTMLElement);
+        core.stopInteractions();
+        expect(queryFirst("inserted")).toBeInstanceOf(HTMLElement);
+    });
 });
 
 describe("renderAt", () => {
@@ -1831,6 +1846,21 @@ describe("renderAt", () => {
         expect(queryFirst(".test [data-which]")).toBe(null);
         await click(subEls[0]);
         expect.verifySteps([]);
+    });
+
+    test("can neutralize cleanup of rendered template by setting removeOnClean to false", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            setup() {
+                this.renderAt("web.testRenderAt", {}, this.el, "beforeend", undefined, false);
+            }
+        }
+
+        const { core } = await startInteraction([Test], TemplateTest);
+        expect(core.interactions).toHaveLength(1);
+        expect(queryFirst(".test .rendered")).toBeInstanceOf(HTMLElement);
+        core.stopInteractions();
+        expect(queryFirst(".test .rendered")).toBeInstanceOf(HTMLElement);
     });
 
     function checkOrder(position) {

--- a/addons/web/static/tests/public/interaction.test.xml
+++ b/addons/web/static/tests/public/interaction.test.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
+    <t t-name="web.testRenderAt">
+        <div class="rendered">Test</div>
+    </t>
     <t t-name="web.TestSubInteraction1">
         <div class="sub1" t-att-data-which="first">Sub 1</div>
         <div class="sub2" t-att-data-which="second">Sub 2</div>

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -265,7 +265,7 @@ export class Form extends Interaction {
         buttonEl.classList.add("disabled"); // !compatibility
         buttonEl.setAttribute("disabled", "disabled");
         this.restoreBtnLoading = addLoadingEffect(buttonEl);
-        this.el.querySelector("#s_website_form_result, #o_website_form_result").replaceChildren(); // !compatibility
+        this.el.querySelector("#s_website_form_result, #o_website_form_result")?.replaceChildren(); // !compatibility
         if (!this.checkErrorFields({})) {
             if (this.fileInputError) {
                 const errorMessage = this.fileInputError.type === "number"
@@ -578,9 +578,16 @@ export class Form extends Interaction {
             message = _t("An error has occured, the form has not been sent.");
         }
 
-        this.renderAt(`website.s_website_form_status_${status}`, {
+        const renderedEls = this.renderAt(`website.s_website_form_status_${status}`, {
             message: message,
-        }, resultEl, "afterend");
+        }, resultEl, "afterend", undefined, false);
+        // Handle cleanup manually to keep s_website_form_result in DOM.
+        this.registerCleanup(() => {
+            for (const el of renderedEls) {
+                const renderedResultEl = el.matches("#s_website_form_result") ? el : el.querySelector("#s_website_form_result");
+                renderedResultEl.replaceChildren();
+            }
+        });
         resultEl.remove();
     }
 

--- a/addons/website/static/tests/interactions/snippets/form.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.test.js
@@ -287,6 +287,16 @@ test("(rpc) form checks conditions", async () => {
     expect(rpcCheck).toBe(true);
 });
 
+test("form submit result cleaned but not removed on stop", async () => {
+    const { core } = await startInteractions(formTemplate);
+    expect(core.interactions).toHaveLength(1);
+    expect(queryOne("#s_website_form_result").children.length).toEqual(0);
+    await click("a.s_website_form_send");
+    expect(queryOne("#s_website_form_result").children.length).toEqual(1);
+    core.stopInteractions();
+    expect(queryOne("#s_website_form_result").children.length).toEqual(0);
+});
+
 test("form prefilled conditional", async () => {
     onRpc("res.users", "read", ({ parent }) => {
         const result = parent();


### PR DESCRIPTION
Since [1] when the form public widget was converted into an interaction, the `s_website_form_result` span is removed if it had been re-rendered (e.g. by submitting the form) before entering edit mode. Because of this, the result span could not be located anymore to display further messages in case it was saved in that corrupted state.

This commit fixes this by neutralizing the implicit cleanup that removes the rendered element, and manually emptying it instead.

Steps to reproduce:
- Drop form
- Save
- Submit
- Edit
- Add a description on the first field
- Save
- Submit

=> An error popup was displayed.

[1]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f
