### PR TITLE
[ADD] pos_customer_display: refund lines will shown in another section

### DIFF
--- a/addons/pos_customer_display/__manifest__.py
+++ b/addons/pos_customer_display/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'POS Customer Display',
+    'version': '1.0',
+    'summary': 'POS customer display',
+    'depends': ['point_of_sale'],
+    'application': True,
+    'installable': True,
+    'assets': {
+        'point_of_sale.assets_prod': [
+            'pos_customer_display/static/src/pos_order.js',
+        ],
+        'point_of_sale.customer_display_assets': [
+            'pos_customer_display/static/src/customer_display/**/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/pos_customer_display/static/src/customer_display/customer_display.xml
+++ b/addons/pos_customer_display/static/src/customer_display/customer_display.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_customer_display.CustomerDisplay" t-inherit="point_of_sale.CustomerDisplay" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o_customer_display_main')]/div" position="after">
+            <div>
+                <p>Partner: <t t-esc="order.partner?.name"/>
+                </p>
+                <p>
+                  Amount <t t-out="this.order.amount_per_guest?.toFixed(2)"/>/ Guest
+                </p>
+            </div>
+        </xpath>
+
+        <xpath expr="//div[hasclass('o_customer_display_main')]/OrderWidget" position="replace">
+            <OrderWidget t-if="!order.finalized" lines="order.lines"/>
+            <p>Refunds</p>
+            <OrderWidget t-if="!order.finalized" lines="order.refundLines"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_customer_display/static/src/pos_order.js
+++ b/addons/pos_customer_display/static/src/pos_order.js
@@ -1,0 +1,24 @@
+import { patch } from "@web/core/utils/patch";
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+
+patch(PosOrder.prototype, {
+    getCustomerDisplayData() {
+        const temp = this.getSortedOrderlines().map((l) => ({
+            ...l.getDisplayData(),
+            isRefund: l.refunded_orderline_id ? true : false,
+        }));
+
+        return {
+            ...super.getCustomerDisplayData(),
+            partner: this.partner_id
+                ? {
+                    id: this.partner_id.id,
+                    name: this.partner_id.name,
+                }
+                : null,
+            amount_per_guest: this.amountPerGuest(),
+            refundLines: temp.filter((x) => x.isRefund),
+            lines: temp.filter((x) => !x.isRefund),
+        };
+    },
+});


### PR DESCRIPTION
In this commit :
 - Show customer name on the customer Display
 - Show amount / guest  if we are on ticketscreen
 - Refunded lines should be separately segregated under refunds subsection

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
