### PR TITLE
[FIX] im_livechat: prevent live chats from opening in compact mode

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -38,7 +38,10 @@ patch(Thread.prototype, {
         });
     },
     get autoOpenChatWindowOnNewMessage() {
-        return this.channel_type === "livechat" || super.autoOpenChatWindowOnNewMessage;
+        return (
+            (this.channel_type === "livechat" && !this.store.chatHub.compact) ||
+            super.autoOpenChatWindowOnNewMessage
+        );
     },
     get showCorrespondentCountry() {
         if (this.channel_type === "livechat") {

--- a/addons/im_livechat/static/tests/chat_hub_compact.test.js
+++ b/addons/im_livechat/static/tests/chat_hub_compact.test.js
@@ -1,0 +1,47 @@
+import { Command, serverState } from "@web/../tests/web_test_helpers";
+import { click, contains } from "@mail/../tests/mail_test_helpers_contains";
+import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helpers";
+import { setupChatHub, start, startServer } from "@mail/../tests/mail_test_helpers";
+import { withGuest } from "@mail/../tests/mock_server/mail_mock_server";
+import { describe, test } from "@odoo/hoot";
+import { rpc } from "@web/core/network/rpc";
+
+describe.current.tags("desktop");
+
+defineLivechatModels();
+test("Do not open chat windows automatically when chat hub is compact", async () => {
+    const pyEnv = await startServer();
+    setupChatHub({ folded: [pyEnv["discuss.channel"].create({ name: "General" })] });
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId }),
+        ],
+        channel_type: "livechat",
+        livechat_active: true,
+        livechat_operator_id: serverState.partnerId,
+        create_uid: serverState.publicUserId,
+    });
+    await start();
+    await click("button.fa.fa-ellipsis-h[title='Chat Options']");
+    await click("button.o-mail-ChatHub-option", { text: "Hide all conversations" });
+    await contains(".o-mail-ChatHub-bubbleBtn .fa-commenting");
+    await withGuest(guestId, () =>
+        rpc("/mail/message/post", {
+            post_data: {
+                body: "I need help!",
+                message_type: "comment",
+                subtype_xmlid: "mail.mt_comment",
+            },
+            thread_id: channelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-ChatHub-bubbleBtn .badge", { text: "1" });
+    await click("button.o-mail-ChatHub-bubbleBtn");
+    await contains(".o-mail-ChatBubble[name=Visitor] .badge", { text: "1" });
+    await contains(".o-mail-ChatWindow", { count: 0, text: "Visitor" });
+    await click(".o-mail-ChatBubble[name=Visitor] .o-mail-ChatHub-bubbleBtn");
+    await contains(".o-mail-ChatWindow", { text: "Visitor" });
+});


### PR DESCRIPTION
Live chat windows automatically open for new conversations to improve agent efficiency. However, when the chat hub is in compact mode, these windows are still opened in the background and become visible when returning to normal mode, which feels too intrusive.

Some agents prefer chats to open automatically, while others do not. This PR prevents automatic chat openings in compact mode, offering a better compromise for both.

task-4614339

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
