### PR TITLE
[IMP] web, html_editor: color picker keyboard navigation

### DIFF
--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -1,5 +1,16 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { click, waitFor, queryOne, hover, press, waitUntil, edit, queryAll } from "@odoo/hoot-dom";
+import {
+    click,
+    waitFor,
+    queryOne,
+    hover,
+    press,
+    waitUntil,
+    edit,
+    queryAll,
+    queryFirst,
+    getActiveElement,
+} from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
@@ -535,6 +546,47 @@ test("should be able to select farthest-corner option in radial gradient", async
     await click("button[title='Extend to the farthest corner']");
     await animationFrame();
     expect("button[title='Extend to the farthest corner']").toHaveClass("active");
+});
+
+test("solid tab color navigation using keys", async () => {
+    const { el } = await setupEditor("<p>[test]</p>");
+    await expandToolbar();
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    await press("Tab");
+    expect(getActiveElement()).toBe(queryFirst('.o_font_color_selector button:contains("Custom")'));
+    await press("Tab");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button:contains("Gradient")')
+    );
+    await press("Tab");
+    expect(getActiveElement()).toBe(queryFirst(".o_font_color_selector button.fa-trash"));
+    await press("Tab");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button[data-color="o-color-1"]')
+    );
+    await press("ArrowDown");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button[data-color="#000000"]')
+    );
+    await press("ArrowRight");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button[data-color="#424242"]')
+    );
+    await press("ArrowDown");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button[data-color="#FF9C00"]')
+    );
+    await press("ArrowLeft");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button[data-color="#FF0000"]')
+    );
+    await press("ArrowUp");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button[data-color="#000000"]')
+    );
+    await press("Enter");
+    expect(getContent(el)).toBe(`<p><font style="color: rgb(0, 0, 0);">[test]</font></p>`);
 });
 
 describe.tags("desktop");

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -128,6 +128,32 @@ export class ColorPicker extends Component {
     toggleGradientPicker() {
         this.state.showGradientPicker = !this.state.showGradientPicker;
     }
+
+    colorPickerNavigation(ev) {
+        const { target, key } = ev;
+        if (!target.classList.contains("o_color_button")) {
+            return;
+        }
+
+        let targetBtn;
+        if (key === "ArrowRight") {
+            targetBtn = target.nextElementSibling;
+        } else if (key === "ArrowLeft") {
+            targetBtn = target.previousElementSibling;
+        } else if (key === "ArrowUp" || key === "ArrowDown") {
+            const buttonIndex = [...target.parentElement.children].indexOf(target);
+            const row =
+                key === "ArrowUp"
+                    ? target.parentElement.previousElementSibling
+                    : target.parentElement.nextElementSibling;
+            targetBtn =
+                row?.matches(".o_color_section, .o_colorpicker_section") &&
+                row.children[buttonIndex];
+        }
+        if (targetBtn?.classList.contains("o_color_button")) {
+            targetBtn.focus();
+        }
+    }
 }
 
 export function useColorPicker(refName, props, options = {}) {

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -12,6 +12,26 @@
     padding: 0px;
     box-shadow: inset 0 0 0 1px rgba(var(--border-rgb), .5);
     margin: 0.5px;
+
+    &:not(.o_gradient_color_button) {
+        &:focus,
+        &:hover {
+            transform: scale(1.1);
+        }
+    }
+}
+
+.o_gradient_color_button {
+  border-width: 0px;
+}
+
+.o_custom_gradient_button,
+.o_color_button {
+    &:focus,
+    &:hover {
+        outline: solid $o-enterprise-action-color;
+        transition: transform 0.1s ease-out;
+    }
 }
 
 .o_font_color_selector {

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -27,7 +27,9 @@
             <div class="p-1"
                 t-on-click="onColorApply"
                 t-on-mouseover="onColorHover"
-                t-on-mouseout="onColorHoverOut">
+                t-on-mouseout="onColorHoverOut"
+                t-ref="solidTabRef"
+                t-on-keydown="colorPickerNavigation">
                 <div class="o_colorpicker_section">
                     <button data-color="o-color-1" t-attf-style="background-color: var(--o-color-1)" class="btn o_color_button"/>
                     <button data-color="o-color-3" t-attf-style="background-color: var(--o-color-3)" class="btn o_color_button"/>
@@ -46,7 +48,7 @@
             </div>
         </t>
         <t t-if="state.activeTab==='custom'">
-            <div class="p-1">
+            <div class="p-1" t-on-keydown="colorPickerNavigation">
                 <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut">
                     <t t-foreach="this.usedCustomColors" t-as="color" t-key="color_index">
                         <button t-if="color !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
@@ -73,11 +75,11 @@
         <t t-if="state.activeTab==='gradient'">
             <div class="o_colorpicker_sections p-2" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut">
                 <t t-foreach="this.DEFAULT_GRADIENT_COLORS" t-as="gradient" t-key="gradient">
-                    <button class="w-50 m-0 o_color_button btn" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
+                    <button class="w-50 m-0 o_color_button o_gradient_color_button btn" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
                 </t>
             </div>
             <div class="px-2">
-                <button t-attf-style="background-image: {{ getCurrentGradientColor() }};" class="w-50 border btn mb-2" t-on-click="this.toggleGradientPicker" title="Define a custom gradient">Custom</button>
+                <button t-attf-style="background-image: {{ getCurrentGradientColor() }};" class="w-50 border btn mb-2 o_custom_gradient_button" t-on-click="this.toggleGradientPicker" title="Define a custom gradient">Custom</button>
                 <GradientPicker t-if="state.showGradientPicker" onGradientChange.bind="applyColor" selectedGradient="getCurrentGradientColor()"/>
             </div>
         </t>


### PR DESCRIPTION
Description of the feature this PR addresses:

This commit ensures that colors in the solid tab can now be navigated using both the Tab and Arrow keys.

task-4476842

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
