### PR TITLE
[FIX] mail: discuss sidebar compact call participant fixes

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -94,6 +94,13 @@ export class DiscussSidebarCallParticipants extends Component {
             : "";
     }
 
+    onClickAvatarStack() {
+        if (this.compact) {
+            return;
+        }
+        this.state.expanded = true;
+    }
+
     get title() {
         return this.state.expanded ? _t("Collapse participants") : _t("Expand participants");
     }

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCallParticipants">
         <t t-if="sessions.length gt 0">
-            <Dropdown t-if="compact" state="floating" position="'right-start'" manual="true" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary py-0'">
+            <Dropdown t-if="compact" state="floating" position="'right-start'" manual="true" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary py-0 shadow-sm'">
                 <t t-call="mail.DiscussSidebarCallParticipants.main"/>
                 <t t-set-slot="content">
                     <div class="p-2" t-ref="floating">
@@ -34,7 +34,7 @@
                 avatarClass="(p) => this.avatarClass(p)"
                 max="compact ? 1 : 7"
                 size="28"
-                onClick="() => this.state.expanded = true"
+                onClick.bind="onClickAvatarStack"
                 personas="sessions.map((s) => s.channel_member_id?.persona).filter(p => p)"
             >
                 <t t-if="compact" t-set-slot="avatarExtraInfo" t-slot-scope="scope">

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.AvatarStack">
         <div t-if="props.personas.length > 0" class="bg-inherit" style="margin: 1px;" t-att-class="props.containerClass" t-on-click="props.onClick">
             <div class="d-flex bg-inherit" t-att-class="{'flex-column': props.direction === 'v'}">
-                <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="bg-inherit rounded-circle" t-attf-style="{{getStyle(persona_index)}}">
+                <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="bg-inherit rounded-circle position-relative" t-attf-style="{{getStyle(persona_index)}}">
                     <img t-att-src="persona.avatarUrl" t-att-title="persona.name" class="w-100 h-100 rounded-circle o_object_fit_cover" t-attf-class="{{props.avatarClass(persona)}}"/>
                     <t t-slot="avatarExtraInfo" persona="persona"/>
                 </span>


### PR DESCRIPTION
When discuss sidebar is compact and there's a call in a channel, the call participant UI in discuss sidebar had the following issues:

- The floating menu had harsh shadow, whereas all other floating menu have soft shadow `.shadow-sm`.
- The short status of user was shown in the bottom-right of "+X" users in call, rather than bottom-right of the avatar.
- The avatar stack could be expanded when sidebar is compact, but there's no way to compact it again.

This commit fixes the issues as follow:
- Adds `.shadow-sm` in the floating menu of call participant.
- Position short status of active call participant in bottom-right as it should
- Remove expand feature on click avatar stack of call participant when sidebar is compact

Before / After
<img width="222" alt="Screenshot 2025-03-03 at 14 46 39" src="https://github.com/user-attachments/assets/27b86dda-ab5e-4f70-b467-f8af28945a7e" /> <img width="224" alt="Screenshot 2025-03-03 at 14 45 49" src="https://github.com/user-attachments/assets/906b8e81-d1db-409b-a42a-a90af0804639" />

Expand bug:
![Mar-03-2025 14-47-57](https://github.com/user-attachments/assets/92a706c7-2bb4-4715-afb1-449401a09234)
