### PR TITLE
[IMP] account_payment, payment: Portal online payment fixes

### DIFF
--- a/addons/account_payment/i18n/account_payment.pot
+++ b/addons/account_payment/i18n/account_payment.pot
@@ -377,6 +377,12 @@ msgstr ""
 
 #. module: account_payment
 #. odoo-python
+#: code:addons/account_payment/wizards/payment_link_wizard.py:0
+msgid "Online payment option is not enabled in Configuration."
+msgstr ""
+
+#. module: account_payment
+#. odoo-python
 #: code:addons/account_payment/controllers/portal.py:0
 msgid "Overdue invoices should share the same company."
 msgstr ""
@@ -613,6 +619,18 @@ msgid "The source payment of related refund payments"
 msgstr ""
 
 #. module: account_payment
+#. odoo-python
+#: code:addons/account_payment/models/account_move.py:0
+msgid "There are pending transactions for this invoice."
+msgstr ""
+
+#. module: account_payment
+#. odoo-python
+#: code:addons/account_payment/models/account_move.py:0
+msgid "There is no amount to be paid."
+msgstr ""
+
+#. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_error
 msgid "There was an error processing your payment: invalid invoice."
 msgstr ""
@@ -635,8 +653,27 @@ msgid "There was en error processing your payment: invalid credit card ID."
 msgstr ""
 
 #. module: account_payment
-#: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_payment_paid
+#. odoo-python
+#: code:addons/account_payment/models/account_move.py:0
+msgid "This invoice cannot be paid online."
+msgstr ""
+
+#. module: account_payment
+#. odoo-python
+#: code:addons/account_payment/models/account_move.py:0
 msgid "This invoice has already been paid."
+msgstr ""
+
+#. module: account_payment
+#. odoo-python
+#: code:addons/account_payment/models/account_move.py:0
+msgid "This invoice isn't posted."
+msgstr ""
+
+#. module: account_payment
+#. odoo-python
+#: code:addons/account_payment/models/account_move.py:0
+msgid "This is not an outgoing invoice."
 msgstr ""
 
 #. module: account_payment

--- a/addons/account_payment/models/account_move.py
+++ b/addons/account_payment/models/account_move.py
@@ -2,6 +2,7 @@
 
 from odoo import api, fields, models
 from odoo.tools import format_date, str2bool
+from odoo.tools.translate import _
 
 from odoo.addons.payment import utils as payment_utils
 
@@ -68,6 +69,35 @@ class AccountMove(models.Model):
             and self.move_type == 'out_invoice'
             and not pending_transactions
         )
+
+    def _get_online_payment_error(self):
+        """
+        Returns the appropriate error message to be displayed if _has_to_be_paid() method returns False.
+        """
+        self.ensure_one()
+        transactions = self.transaction_ids.filtered(lambda tx: tx.state in ('pending', 'authorized', 'done'))
+        pending_transactions = transactions.filtered(
+            lambda tx: tx.state in {'pending', 'authorized'}
+                       and tx.provider_code not in {'none', 'custom'})
+        enabled_feature = str2bool(
+            self.env['ir.config_parameter'].sudo().get_param(
+                'account_payment.enable_portal_payment'
+            )
+        )
+        errors = []
+        if not enabled_feature:
+            errors.append(_("This invoice cannot be paid online."))
+        if transactions or self.currency_id.is_zero(self.amount_residual):
+            errors.append(_("There is no amount to be paid."))
+        if self.state != 'posted':
+            errors.append(_("This invoice isn't posted."))
+        if self.currency_id.is_zero(self.amount_residual):
+            errors.append(_("This invoice has already been paid."))
+        if self.move_type != 'out_invoice':
+            errors.append(_("This is not an outgoing invoice."))
+        if pending_transactions:
+            errors.append(_("There are pending transactions for this invoice."))
+        return '\n'.join(errors)
 
     def get_portal_last_transaction(self):
         self.ensure_one()

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -276,9 +276,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        <div class="alert alert-warning text-center" role="alert">
-                            This invoice has already been paid.
-                        </div>
+                        <div class="alert alert-warning text-center" role="alert" t-out="invoice._get_online_payment_error()"/>
                     </div>
                 </div>
             </div>

--- a/addons/account_payment/wizards/payment_link_wizard.py
+++ b/addons/account_payment/wizards/payment_link_wizard.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
-from odoo.tools import format_date, formatLang
+from odoo.tools import format_date, formatLang, str2bool
 
 from odoo.addons.payment import utils as payment_utils
 
@@ -25,6 +25,12 @@ class PaymentLinkWizard(models.TransientModel):
         string="Early Payment Discount Information",
         compute='_compute_epd_info',
     )
+
+    def _compute_warning_message(self):
+        super()._compute_warning_message()
+        for wizard in self:
+            if not wizard.warning_message and not str2bool(self.env['ir.config_parameter'].sudo().get_param('account_payment.enable_portal_payment')):
+                wizard.warning_message = _("Online payment option is not enabled in Configuration.")
 
     @api.depends('amount_max')
     def _compute_invoice_amount_due(self):


### PR DESCRIPTION
- Changed payment link error to list the causes instead of displaying 'This invoice is already paid' in all cases.
- Generating a payment link is now not possible while online payments are disabled in settings, a warning is displayed instead. 

task-4609554


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
