### PR TITLE
[IMP] hr_expense: enable multiple expenses scan

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1209,14 +1209,7 @@ class HrExpense(models.Model):
 
             expense._message_set_main_attachment_id(attachment, force=True)
             expenses += expense
-        return {
-            'name': _("Generated Expense(s)"),
-            'res_model': 'hr.expense',
-            'type': 'ir.actions.act_window',
-            'views': [[False, view_type], [False, "form"]],
-            'domain': [('id', 'in', expenses.ids)],
-            'context': self.env.context,
-        }
+        return expenses.ids
 
     def action_show_same_receipt_expense_ids(self):
         self.ensure_one()

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -8,7 +8,7 @@ import werkzeug
 
 from odoo import api, fields, Command, models, _
 from odoo.exceptions import RedirectWarning, UserError, ValidationError
-from odoo.tools import clean_context, email_normalize, float_repr, float_round, is_html_empty
+from odoo.tools import clean_context, email_normalize, float_repr, float_round, format_date, is_html_empty
 
 
 _logger = logging.getLogger(__name__)
@@ -1196,9 +1196,8 @@ class HrExpense(models.Model):
             raise UserError(_("You need to have at least one category that can be expensed in your database to proceed!"))
 
         for attachment in attachments:
-            attachment_name = '.'.join(attachment.name.split('.')[:-1])
             vals = {
-                'name': attachment_name,
+                'name': _("Untitled Expense %s", format_date(self.env, fields.Date.context_today(self))),
                 'price_unit': 0,
                 'product_id': product.id,
             }


### PR DESCRIPTION
**[IMP] hr_expense: enable multiple expenses scan**

Currently, users that wants to scan multiple expenses, have to wait that
the previous one has been processed.  This is annoying as the request
can take a bit of time as it calls the OCR.

The issue is that the client switch excutes a new window action, when
the upload has been processed (showing the created expense).
So if the user is beginning to scan a new expense (not waiting for the
previous one to be processed), then that the window changes in the
client (as previous process has been completed), then when the user send
the file to the client, nothing happens, because the `<input ...>`
element waiting for the file has been destroyed.

The fix here is to switch to the new window showing the scanned
expenses, only if there's no other upload process running.

**[IMP] hr_expense: don't take filename for descr of uploaded expenses**

Set description of uploaded expenses to: "Untitled Expense <Date>".

If the user is connected to the OCR, this value will be overriden by
the description sent by it.

task-4357969
