### PR TITLE
[FIX] web: display invoice title on one line for bubble template

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -732,7 +732,7 @@
                 <t t-call="web.address_layout">
                     <t t-set="custom_layout_address" t-value="true"/>
                 </t>
-                <h2 t-attf-class="{{not information_block and 'mb-4'}} text-end" t-out="layout_document_title"/>
+                <h2 t-attf-class="{{not information_block and 'mb-4'}} text-nowrap text-end" t-out="layout_document_title"/>
             </div>
             <t t-out="0"/>
         </div>


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_in" and switch to an Indian company
- Settings > Document Layout > Configure Document Layout and select the "Bubble" layout
- Create a customer invoice and print it
- The title is on two lines

### Cause:
Adding a `t-field` for the journal name seems to break the layout.

### Solution:
Add `text-nowrap` on the layout_document_title to force the display on one line.

opw-4496715