### PR TITLE
[FIX] pos_event: prevent loading unnecessary event registrations

### DIFF
--- a/addons/pos_event/static/src/app/models/data_service_options.js
+++ b/addons/pos_event/static/src/app/models/data_service_options.js
@@ -21,4 +21,7 @@ patch(DataServiceOptions.prototype, {
     get dynamicModels() {
         return [...super.dynamicModels, "event.registration", "event.registration.answer"];
     },
+    get pohibitedAutoLoadedModels() {
+        return [...super.pohibitedAutoLoadedModels, "event.registration"];
+    },
 });


### PR DESCRIPTION
Before this commit, selling an event in PoS would trigger the loading of all event registrations linked to the event. This was unnecessary and caused issues, as it also attempted to load the related PoS order lines, leading to potential errors.

opw-4613669

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
