### PR TITLE
[FIX] mail: discuss local settings crosstab sync

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -4,6 +4,7 @@ import { Record } from "./record";
 import { Deferred, Mutex } from "@web/core/utils/concurrency";
 
 export const CHAT_HUB_KEY = "mail.ChatHub";
+const CHAT_HUB_COMPACT_LS = "mail.user_setting.chathub_compact";
 
 export class ChatHub extends Record {
     BUBBLE = 56; // same value as $o-mail-ChatHub-bubblesWidth
@@ -32,6 +33,9 @@ export class ChatHub extends Record {
             } else if (ev.key === null) {
                 chatHub.load();
             }
+            if (ev.key === CHAT_HUB_COMPACT_LS) {
+                chatHub.compact = ev.newValue === "true";
+            }
         });
         chatHub
             .load(browser.localStorage.getItem(CHAT_HUB_KEY) ?? undefined)
@@ -39,7 +43,19 @@ export class ChatHub extends Record {
         return chatHub;
     }
 
-    compact = false;
+    compact = Record.attr(false, {
+        compute() {
+            return browser.localStorage.getItem(CHAT_HUB_COMPACT_LS) === "true";
+        },
+        /** @this {import("models").Chathub} */
+        onUpdate() {
+            if (this.compact) {
+                browser.localStorage.setItem(CHAT_HUB_COMPACT_LS, this.compact.toString());
+            } else {
+                browser.localStorage.removeItem(CHAT_HUB_COMPACT_LS);
+            }
+        },
+    });
     /** From left to right. Right-most will actually be folded */
     opened = Record.many("ChatWindow", {
         inverse: "hubAsOpened",

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -10,6 +10,13 @@ const MESSAGE_SOUND = "mail.user_setting.message_sound";
 export class Settings extends Record {
     id;
 
+    static new() {
+        const record = super.new(...arguments);
+        record.onStorage = record.onStorage.bind(record);
+        browser.addEventListener("storage", record.onStorage);
+        return record;
+    }
+
     setup() {
         super.setup();
         this.saveVoiceThresholdDebounce = debounce(() => {
@@ -306,8 +313,6 @@ export class Settings extends Record {
         this.backgroundBlurAmount = backgroundBlurAmount ? parseInt(backgroundBlurAmount) : 10;
         const edgeBlurAmount = browser.localStorage.getItem("mail_user_setting_edge_blur_amount");
         this.edgeBlurAmount = edgeBlurAmount ? parseInt(edgeBlurAmount) : 10;
-        this.onStorage = this.onStorage.bind(this);
-        browser.addEventListener("storage", this.onStorage);
     }
     /**
      * @private

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -1,6 +1,9 @@
 import { Record } from "@mail/core/common/record";
 import { browser } from "@web/core/browser/browser";
 
+const NO_MEMBERS_DEFAULT_OPEN_LS = "mail.user_setting.no_members_default_open";
+export const DISCUSS_SIDEBAR_COMPACT_LS = "mail.user_setting.discuss_sidebar_compact";
+
 export class DiscussApp extends Record {
     /** @returns {import("models").DiscussApp} */
     static get(data) {
@@ -18,39 +21,56 @@ export class DiscussApp extends Record {
     isActive = false;
     isMemberPanelOpenByDefault = Record.attr(true, {
         compute() {
-            return (
-                browser.localStorage.getItem("mail.user_setting.no_members_default_open") !== "true"
-            );
+            return browser.localStorage.getItem(NO_MEMBERS_DEFAULT_OPEN_LS) !== "true";
         },
         /** @this {import("models").DiscussApp} */
         onUpdate() {
             if (this.isMemberPanelOpenByDefault) {
-                browser.localStorage.removeItem("mail.user_setting.no_members_default_open");
+                browser.localStorage.removeItem(NO_MEMBERS_DEFAULT_OPEN_LS);
             } else {
-                browser.localStorage.setItem("mail.user_setting.no_members_default_open", "true");
+                browser.localStorage.setItem(NO_MEMBERS_DEFAULT_OPEN_LS, "true");
             }
         },
     });
     isSidebarCompact = Record.attr(false, {
         compute() {
-            return (
-                browser.localStorage.getItem("mail.user_setting.discuss_sidebar_compact") === "true"
-            );
+            return browser.localStorage.getItem(DISCUSS_SIDEBAR_COMPACT_LS) === "true";
         },
         /** @this {import("models").DiscussApp} */
         onUpdate() {
             if (this.isSidebarCompact) {
                 browser.localStorage.setItem(
-                    "mail.user_setting.discuss_sidebar_compact",
+                    DISCUSS_SIDEBAR_COMPACT_LS,
                     this.isSidebarCompact.toString()
                 );
             } else {
-                browser.localStorage.removeItem("mail.user_setting.discuss_sidebar_compact");
+                browser.localStorage.removeItem(DISCUSS_SIDEBAR_COMPACT_LS);
             }
         },
     });
     thread = Record.one("Thread");
     hasRestoredThread = false;
+
+    static new() {
+        const record = super.new(...arguments);
+        record.onStorage = record.onStorage.bind(record);
+        browser.addEventListener("storage", record.onStorage);
+        return record;
+    }
+
+    delete() {
+        browser.removeEventListener("storage", this.onStorage);
+        super.delete(...arguments);
+    }
+
+    onStorage(ev) {
+        if (ev.key === DISCUSS_SIDEBAR_COMPACT_LS) {
+            this.isSidebarCompact = ev.newValue === "true";
+        }
+        if (ev.key === NO_MEMBERS_DEFAULT_OPEN_LS) {
+            this.isMemberPanelOpenByDefault = ev.newValue !== "true";
+        }
+    }
 }
 
 DiscussApp.register();

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -330,6 +330,21 @@ test("Can compact chat hub", async () => {
     await contains(".o-mail-ChatBubble i.fa.fa-commenting");
 });
 
+test("Compact chat hub is crosstab synced", async () => {
+    const pyEnv = await startServer();
+    const channelIds = pyEnv["discuss.channel"].create([{ name: "ch-1" }, { name: "ch-2" }]);
+    setupChatHub({ folded: channelIds });
+    const env1 = await start({ asTab: true });
+    const env2 = await start({ asTab: true });
+    await contains(".o-mail-ChatBubble", { count: 2, target: env1 });
+    await contains(".o-mail-ChatBubble", { count: 2, target: env2 });
+    await hover(".o-mail-ChatBubble:eq(0)", { target: env1 });
+    await click("button.fa.fa-ellipsis-h[title='Chat Options']", { target: env1 });
+    await click("button.o-mail-ChatHub-option", { text: "Hide all conversations", target: env1 });
+    await contains(".o-mail-ChatBubble .fa-commenting", { target: env1 });
+    await contains(".o-mail-ChatBubble .fa-commenting", { target: env2 });
+});
+
 test("Compacted chat hub shows badge with amount of hidden chats with important messages", async () => {
     const pyEnv = await startServer();
     const channelIds = [];


### PR DESCRIPTION
Before this commit, some local settings were not properly synced in crosstab:

- discuss sidebar compact mode was only visible on reloading the page.
- chat hub compact mode was only affected the tab that triggered the compact mode.

The problem of discuss sidebar compact comes from lack of responsiveness from change in local storage value, which this commit fixes with `onStorage` in DiscussApp model. Note that settings model had already this implementation, but it made a typo: the `this` in `onStorage` could be the raw record instead of reactive record. This is fixed by registering the `onStorage` in the `static new`.

For the ChatHub compact mode, usually triggering this mode is intended for reduced footprint of chat windows when navigating on the webclient, including opening new or existing tabs. This means the compact mode should be applied on all tabs at once. This commit fixes it by using a similar technique as discuss sidebar compact mode to sync its state immediately accros all tabs.

![Mar-03-2025 16-10-43](https://github.com/user-attachments/assets/d4985cb6-b252-4c55-9c6f-4e6474af000e)
