### PR TITLE
[FIX] l10n_es_edi_tbai: ensure epigrafe validation

### DIFF
--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -112,14 +112,12 @@ class L10nEsEdiTbaiDocument(models.Model):
         if not self.company_id.vat:
             return _("Please configure the Tax ID on your company for TicketBAI.")
 
-        if not values['is_sale'] :
-            if self.company_id._l10n_es_freelancer():
-                if not self.env['ir.config_parameter'].sudo().get_param('l10n_es_edi_tbai.epigrafe', False):
-                    return _("In order to use Ticketbai Batuz for freelancers, you will need to configure the "
-                             "Epigrafe or Main Activity.  In this version, you need to go in debug mode to "
-                             "Settings > Technical > System Parameters and set the parameter 'l10n_es_edi_tbai.epigrafe'"
-                             "to your epigrafe number. You can find them in %s",
-                             "https://www.batuz.eus/fitxategiak/batuz/lroe/batuz_lroe_lista_epigrafes_v1_0_3.xlsx")
+        if self.company_id._l10n_es_freelancer() and not self.env['ir.config_parameter'].sudo().get_param('l10n_es_edi_tbai.epigrafe', False):
+            return _("In order to use Ticketbai Batuz for freelancers, you will need to configure the "
+                        "Epigrafe or Main Activity.  In this version, you need to go in debug mode to "
+                        "Settings > Technical > System Parameters and set the parameter 'l10n_es_edi_tbai.epigrafe'"
+                        "to your epigrafe number. You can find them in %s",
+                        "https://www.batuz.eus/fitxategiak/batuz/lroe/batuz_lroe_lista_epigrafes_v1_0_3.xlsx")
 
         if values['is_sale'] and not self.is_cancel:
             if any(not base_line['tax_ids'] for base_line in values['base_lines']):


### PR DESCRIPTION
Previously, the epigrafe validation error was only triggered for non-'is_sale' documents. As a result, invoices without a defined epigrafe failed silently until submission to TicketBAI, causing an unclear TicketBAI error.

This fix ensures that the user error appears for invoices as well, preventing the misleading "El XML no cumple el esquema" error.

Steps to reproduce:
- Set up a Spanish freelance company
- Change tax agency to Bizkaia
- Try to send an invoice

The TicketBAi error `B4_1000001: El XML no cumple el esquema.[Linea:17 Columna:5] Error:cvc-complex-type.2.4.b: The content of element 'Ingreso' is not complete. One of '{Renta}' is expected.`

opw-4559069
