### PR TITLE
[FIX] l10n_jo_edi: Fixed access error for JO fields

### DIFF
--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -104,8 +104,8 @@ class AccountMove(models.Model):
     def _l10n_jo_build_jofotara_headers(self):
         self.ensure_one()
         return {
-            'Client-Id': self.company_id.l10n_jo_edi_client_identifier,
-            'Secret-Key': self.company_id.l10n_jo_edi_secret_key,
+            'Client-Id': self.sudo().company_id.l10n_jo_edi_client_identifier,
+            'Secret-Key': self.sudo().company_id.l10n_jo_edi_secret_key,
         }
 
     def _submit_to_jofotara(self):
@@ -146,9 +146,9 @@ class AccountMove(models.Model):
 
     def _l10n_jo_validate_config(self):
         error_msg = ''
-        if not self.company_id.l10n_jo_edi_client_identifier:
+        if not self.sudo().company_id.l10n_jo_edi_client_identifier:
             error_msg += _("Client ID is missing.\n")
-        if not self.company_id.l10n_jo_edi_secret_key:
+        if not self.sudo().company_id.l10n_jo_edi_secret_key:
             error_msg += _("Secret key is missing.\n")
         if not self.company_id.l10n_jo_edi_taxpayer_type:
             error_msg += _("Taxpayer type is missing.\n")


### PR DESCRIPTION
This commit fixed the access error issue that non-admin users would encounter when submitting a Jordanian e-invoice. It adds sudo access rights to the fields l10n_jo_edi_client_identifier and l10n_jo_edi_secret_key while reading them for e-invoice submission.

task-4577597




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
