### PR TITLE
[FIX] website: avoid jittering when changing page URL

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -288,6 +288,7 @@
             'website/static/tests/redirect_field_tests.js',
         ],
         'web.assets_unit_tests': [
+            'website/static/tests/page_url_field.test.js',
             'website/static/tests/website_html_editor.test.js',
         ],
         'web.tests_assets': [

--- a/addons/website/static/src/components/fields/fields.js
+++ b/addons/website/static/src/components/fields/fields.js
@@ -5,6 +5,7 @@ import {standardFieldProps} from '@web/views/fields/standard_field_props';
 import { UrlField, urlField } from "@web/views/fields/url/url_field";
 import {registry} from '@web/core/registry';
 import { _t } from '@web/core/l10n/translation';
+import { debounce } from "@web/core/utils/timing";
 import { Component, useEffect, useRef } from "@odoo/owl";
 
 /**
@@ -31,9 +32,20 @@ class PageUrlField extends UrlField {
         useEffect(
             (inputEl) => {
                 if (inputEl) {
-                    const fireChangeEvent = () => {
-                        inputEl.dispatchEvent(new Event("change"));
-                    };
+                    const originalValue = inputEl.value;
+                    let previousValueChanged = false;
+                    const fireChangeEvent = debounce(() => {
+                        const currentValue = inputEl.value;
+                        const valueChanged = currentValue !== originalValue;
+                        if (valueChanged !== previousValueChanged) {
+                            if (currentValue[0] !== '/') {
+                                inputEl.value = `/${currentValue}`;
+                            }
+                            inputEl.dispatchEvent(new Event("change"));
+                            inputEl.value = currentValue;
+                            previousValueChanged = valueChanged;
+                        }
+                    }, 100);
 
                     inputEl.addEventListener("input", fireChangeEvent);
                     return () => {

--- a/addons/website/static/tests/page_url_field.test.js
+++ b/addons/website/static/tests/page_url_field.test.js
@@ -1,0 +1,56 @@
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import { expect, test } from "@odoo/hoot";
+import { advanceTime } from "@odoo/hoot-mock";
+import {
+    defineModels,
+    fieldInput,
+    fields,
+    models,
+    mountView,
+    onRpc,
+} from "@web/../tests/web_test_helpers";
+
+class Product extends models.Model {
+    url = fields.Char({
+        onChange(record) {
+            // factice onchange to cause onchange calls
+        }
+    });
+    old_url = fields.Char();
+}
+
+defineModels([Product]);
+defineMailModels();
+
+test("PageUrlField in form view", async () => {
+    Product._records = [{ id: 1, url: "/test", old_url: "/test" }];
+    onRpc("onchange", ({ args }) => {
+        expect.step(`onchange ${args[1].url}`);
+    });
+    await mountView({
+        type: "form",
+        resModel: "product",
+        resId: 1,
+        arch: `<form>
+                   <field name="url" widget="page_url"/>
+                   <field name="old_url"/>
+                   <div invisible="old_url == url" id="changed">
+                       CHANGED
+                   </div>
+               </form>`,
+    });
+    expect(`.o_field_widget input#url_0`).toHaveValue("test");
+    expect(`#changed`).toHaveCount(0);
+    await fieldInput("url").press("a");
+    await fieldInput("url").press("b");
+    expect(`#changed`).toHaveCount(0);
+    await advanceTime(100);
+    expect(`#changed`).toHaveCount(1);
+
+    await fieldInput("url").press("Backspace");
+    await fieldInput("url").press("Backspace");
+    expect(`#changed`).toHaveCount(1);
+    await advanceTime(100);
+    expect(`#changed`).toHaveCount(0);
+    expect.verifySteps(['onchange /testab', 'onchange /test']);
+});


### PR DESCRIPTION
Scenario:

- edit a website page (eg: /test that you create)
- go to Site > Properties
- have a slow connection and write in field "Page URL" for some seconds

Result: the input jitter, if going too fast the text can be removed to
get previous version.

Secondary issue: if we cancel our change and set back the original URL,
the "Redirect Old Url" part is not hidden.

Reason: we trigger onchange at each input event, so if we write 20
letters we will possibly still have 20 onchange that are ongoing and
will set back older version of the field value.

The secondary issue is because we are using a field using useInputField
and FieldUrl but we are hacking it to remove the "/" prefix inside the
input. So when the invisible modifier is checked, we check eg.
"old_url=/test" against "url=test" that are always different.

With this fix:

Since the triggered onchange were only to update quicker the condition
`invisible="old_url == url"`, we trigger them only if that condition
will change, and debounce it to prevent the now single onchange of
happening in the middle of text input.

And for the secondary issue, we add and remove the / when triggering the
onchange.

opw-4517181