### PR TITLE
[FIX] account: prevent stacktrace when defining a discount on existin…

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4443,11 +4443,11 @@ class AccountMove(models.Model):
 
         term_lines = self.line_ids.filtered(lambda line: line.display_type == 'payment_term')
         epd_installment = term_lines._get_epd_data()
+        discount_date = epd_installment and epd_installment['line'].discount_date
         epd_info = {}
-        if epd_installment:
+        if epd_installment and discount_date:
             installment_state = 'epd'
             amount_due = epd_installment['amount_residual_currency_unsigned']
-            discount_date = epd_installment['line'].discount_date
             discount_amount_currency = epd_installment['discount_amount_currency']
             days_left = (discount_date - fields.Date.context_today(self)).days  # should never be lower than 0 since epd is valid
             if days_left > 0:


### PR DESCRIPTION
…g payment term

Steps to reproduce:
- create an invoice
- define the "30 days payment term"
- save the invoice
- define a discount for the 30 days payment term 
- confirm the invoice
- Preview the invoice

Issue:
- Stack Trace

Cause:
There is no discount_date added when modifying the payment term (makes sense, we will not modify every line linked to move having that payment term)

Solution:
ugly fallback but but since the field is not required and no recomputation is done and the ps tech needs this for one of their module and the flow is easily reproducible we have enough reasons to apply it

opw-4619835
