### PR TITLE
[16.0][FIX] mrp_account: take into account the operation nº of cycles in _compute_bom_price

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -79,10 +79,13 @@ class ProductProduct(models.Model):
         for opt in bom.operation_ids:
             if opt._skip_operation_line(self):
                 continue
-
+            capacity = opt.workcenter_id._get_capacity(bom.product_id)
+            operation_cycle = float_round(
+                bom.product_qty / capacity, precision_rounding=1, rounding_method="UP"
+            )
             duration_expected = (
                 opt.workcenter_id._get_expected_duration(self) +
-                opt.time_cycle * 100 / opt.workcenter_id.time_efficiency)
+                operation_cycle * opt.time_cycle * 100 / opt.workcenter_id.time_efficiency)
             total += (duration_expected / 60) * opt._total_cost_per_hour()
 
         for line in bom.bom_line_ids:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When computing the cost price of a product, using the _compute_bom_price method, the workcenter capacities and the number of cycles to run are not taken into account. This causes a wrong computed cost when the BoM product_qty is greater than 1. 

**Current behavior before PR:**
Currently, the method is computing the operations cost without considering the number of cycles to run, therefore, it is computing the cost like if the number of cycles to run was 1 or the product quantity to produce was 1. Then when the total has been computed, also aggregating the components cost, the accumulated total is divided by the BoM product_qty. This together makes the computed cost incorrect.

_Steps to reproduce:_
1. Create a BoM with product_qty > 1 with different components and operations.
2. Configure the workcenter capacity so that product_qty / capacity > 1.
3. Navigate to the BoM product and press the "Compute Price from BoM" button.
4. Check that the computed cost does not align with the cost shown on the BoM overview.


**Desired behavior after PR is merged:**
After merging this PR, the total operations cost will take into account the number of cycles to run for each operation. The resulting cost set on the product will match the BoM overview cost.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
