### PR TITLE
[FIX] hw_drivers: do not reprint status on Windows

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -86,7 +86,8 @@ class ConnectionManager(Thread):
             self.pairing_uuid = result['pairing_uuid']
             self.pairing_code_expires = time.monotonic() + PAIRING_CODE_TIMEOUT_SECONDS
             self.pairing_code_count += 1
-            self._try_print_pairing_code()
+            if platform.system() == 'Linux':
+                self._try_print_pairing_code()
 
     def _connect_to_server(self, url, token, db_uuid, enterprise_code):
         # Save DB URL and token


### PR DESCRIPTION
The PR #198791 introduced a reprinting of the pairing codes on the connected printers. However connected_by_usb variable isn't present in PrinterDriver_W which resulted in an error.
This PR only reprints the status on the connected printer if we are on a Linux system

