### PR TITLE
[FIX] Backport database locale changes for test_13_m2o_order_loop_multi from 18.0 to 17.0

### DIFF
--- a/doc/cla/individual/codebykyle.md
+++ b/doc/cla/individual/codebykyle.md
@@ -1,0 +1,11 @@
+United States of America, 2025-03-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Kyle Shovan. kyle@codebykyle.com https://github.com/codebykyle

--- a/odoo/addons/base/tests/test_search.py
+++ b/odoo/addons/base/tests/test_search.py
@@ -218,9 +218,16 @@ class test_search(TransactionCase):
         kw = dict(groups_id=[Command.set([self.ref('base.group_system'),
                                      self.ref('base.group_partner_manager')])])
 
-        u1 = Users.create(dict(name='Q', login='m', **kw)).id
+        # When creating with the superuser, the ordering by 'create_uid' will
+        # compare user logins with the superuser's login "__system__", which
+        # may give different results, because "_" may come before or after
+        # letters, depending on the database's locale.  In order to avoid this
+        # issue, use a user with a login that doesn't include "_".
+        u0 = Users.create(dict(name='A system', login='a', **kw)).id
+
+        u1 = Users.with_user(u0).create(dict(name='Q', login='m', **kw)).id
         u2 = Users.with_user(u1).create(dict(name='B', login='f', **kw)).id
-        u3 = Users.create(dict(name='C', login='c', **kw)).id
+        u3 = Users.with_user(u0).create(dict(name='C', login='c', **kw)).id
         u4 = Users.with_user(u2).create(dict(name='D', login='z', **kw)).id
 
         expected_ids = [u2, u4, u3, u1]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This is in reference to issue #200050 which back-ports the changes for `test_13_m2o_order_loop_multi` from the 18.0 branch to the 17.0 branch. These changes have already been discussed and gone through proper channels in the 18.0 branch, however, this issue is still affecting 17.0. This causes some automated test environments to fail, as per the original discussion.

Current behavior before PR:

```py
    def test_13_m2o_order_loop_multi(self):
        Users = self.env['res.users']

        # will sort by login desc of the creator, then by name
        self.patch_order('res.partner', 'create_uid, name')
        self.patch_order('res.users', 'partner_id, login desc')

        kw = dict(groups_id=[Command.set([self.ref('base.group_system'),
                                     self.ref('base.group_partner_manager')])])

        u1 = Users.create(dict(name='Q', login='m', **kw)).id
        u2 = Users.with_user(u1).create(dict(name='B', login='f', **kw)).id
        u3 = Users.create(dict(name='C', login='c', **kw)).id
        u4 = Users.with_user(u2).create(dict(name='D', login='z', **kw)).id

        expected_ids = [u2, u4, u3, u1]
        found_ids = Users.search([('id', 'in', expected_ids)]).ids
        self.assertEqual(found_ids, expected_ids)
```


Desired behavior after PR is merged:
```py
    def test_13_m2o_order_loop_multi(self):
        Users = self.env['res.users']

        # will sort by login desc of the creator, then by name
        self.patch_order('res.partner', 'create_uid, name')
        self.patch_order('res.users', 'partner_id, login desc')

        kw = dict(groups_id=[Command.set([self.ref('base.group_system'),
                                     self.ref('base.group_partner_manager')])])

        # When creating with the superuser, the ordering by 'create_uid' will
        # compare user logins with the superuser's login "__system__", which
        # may give different results, because "_" may come before or after
        # letters, depending on the database's locale.  In order to avoid this
        # issue, use a user with a login that doesn't include "_".
        u0 = Users.create(dict(name='A system', login='a', **kw)).id

        u1 = Users.with_user(u0).create(dict(name='Q', login='m', **kw)).id
        u2 = Users.with_user(u1).create(dict(name='B', login='f', **kw)).id
        u3 = Users.with_user(u0).create(dict(name='C', login='c', **kw)).id
        u4 = Users.with_user(u2).create(dict(name='D', login='z', **kw)).id

        expected_ids = [u2, u4, u3, u1]
        found_ids = Users.search([('id', 'in', expected_ids)]).ids
        self.assertEqual(found_ids, expected_ids)
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
