### PR TITLE
[FIX] mail: no crash on edit message in mobile

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -465,6 +465,7 @@ export class Message extends Component {
                 message: this.props.message,
                 thread: this.props.thread,
                 isFirstMessage: this.props.isFirstMessage,
+                messageEdition: this.props.messageEdition,
                 messageToReplyTo: this.props.messageToReplyTo,
                 openReactionMenu: () => this.openReactionMenu(),
                 state: this.state,

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.js
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.js
@@ -10,6 +10,7 @@ export class MessageActionMenuMobile extends Component {
         "close?",
         "thread?",
         "isFirstMessage?",
+        "messageEdition?",
         "messageToReplyTo?",
         "openReactionMenu?",
         "state",

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -93,7 +93,7 @@ messageActionsRegistry
         title: _t("Edit"),
         onClick: (component) => {
             component.props.messageEdition.enterEditMode(component.props.message);
-            component.optionsDropdown.close();
+            component.optionsDropdown?.close();
         },
         sequence: 80,
     })

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -202,6 +202,7 @@ test("Can edit message comment in chatter", async () => {
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });
 });
 
+test.tags("mobile");
 test("Can edit message comment in chatter (mobile)", async () => {
     patchUiSize({ size: SIZES.SM });
     const pyEnv = await startServer();
@@ -216,7 +217,7 @@ test("Can edit message comment in chatter (mobile)", async () => {
     await start();
     await openFormView("res.partner", partnerId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click("button:contains('Edit')");
     await contains("button", { text: "Discard editing" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click("button[title='Save editing']");


### PR DESCRIPTION
Before this commit, editing a message on a mobile device resulted to a crash.

This happens because the 'edit' message action relies on presence of `props.messageEdition` on the component, which is present on `Message` but not `MessageActionMenuMobile` that is used in mobile.

This commit fixes the issue by propagating the message edition hook from `Message` to `MessageActionMenuMobile`, so that message edition is possible without crash in mobile.

There was a test to cover mobile, but due to test not being tagged as mobile, it was running with the screen size of mobile but without user agent as a mobile. The `MessageActionMenuMobile` component is shown when the device is considered mobile, therefore the mis-tag resulted in a test that takes into account screen size of mobile but on a desktop environment, thus this menu wasn't shown. The test has been fixed as a result.

Bug in action with crash:
![Mar-03-2025 21-01-53](https://github.com/user-attachments/assets/5b72ba4f-2f1f-4fd1-9201-f0faa1cb3b92)
