### PR TITLE
[FIX] point_of_sale: deduplicate uuids via module upgrade

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Point of Sale',
-    'version': '1.0.1',
+    'version': '1.0.2',
     'category': 'Sales/Point of Sale',
     'sequence': 40,
     'summary': 'User-friendly PoS interface for shops and restaurants',

--- a/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py
+++ b/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py
@@ -1,0 +1,39 @@
+import uuid
+from psycopg2.extras import Json
+
+def migrate(cr, version):
+    """
+    When UUIDs were introduced for POS [order, order.line, payment] records,
+    they were initially generated on the backend, defined as the default value
+    on the column. The issue with this is that during the upgrade to 18.0+
+    from a version < 18.0, this default value is determined once for the column
+    and then applied to all records, resulting in one UUID, duplicated across 
+    all existing POS records.
+    
+    This migration fixes the issue by generating a new UUID for each record
+    that has the same UUID as another record. Specifically, it does this for
+    the following tables:
+    - pos_order
+    - pos_order_line
+    - pos_payment
+    """
+    def deduplicate_uuids(table):
+        cr.execute(
+            f"""
+                SELECT UNNEST(ARRAY_AGG(id))
+                  FROM {table}
+              GROUP BY uuid
+                HAVING COUNT(*) > 1
+            """
+        )
+
+        all_ids = [r[0] for r in cr.fetchall()]
+        for ids in cr.split_for_in_conditions(all_ids):
+            cr.execute(
+                f"UPDATE {table} SET uuid = (%s::json)->>(id::text) WHERE id IN %s",
+                [Json({id_: str(uuid.uuid4()) for id_ in ids}), ids]
+            )
+
+    deduplicate_uuids("pos_order")
+    deduplicate_uuids("pos_order_line")
+    deduplicate_uuids("pos_payment")


### PR DESCRIPTION
This PR introduces a local upgrade script to fix the duplicate UUID issue for customers who upgraded to 18.0 before this PR was merged:

#194990 

The creation of this local upgrade script was requested towards the end of the conversation on that PR.

Before the above PR was merged, older POS [order, order.line, payment] records all got the same UUID during the upgrade to 18.0 for the reason laid out in the conversation on the PR:
> [in reference to the default value for the uuid column calling `uuid4()`] ... when the ORM inits the column it will set the same value for all rows.

Current behavior before PR:
Post-upgrade POS tickets get sent to Tech for us to clean manually via a server action that duplicates UUIDs.

Desired behavior after PR is merged:
Post-upgrade POS tickets can be solved in Functional by "Upgrading" the `point_of_sale` module **or** the customer doesn't need to create a ticket because they solved it themselves by upgrading their module.