### PR TITLE
[FIX] mail: properly render special mentions in text messages

### DIFF
--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -10,7 +10,7 @@ import { markup } from "@odoo/owl";
 import { stateToUrl } from "@web/core/browser/router";
 import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
 import { htmlEscape, setElementContent } from "@web/core/utils/html";
-import { escape, escapeRegExp, unaccent } from "@web/core/utils/strings";
+import { escapeRegExp, unaccent } from "@web/core/utils/strings";
 import { setAttributes } from "@web/core/utils/xml";
 
 const urlRegexp =
@@ -216,9 +216,10 @@ function generateMentionsLinks(body, { partners = [], threads = [], specialMenti
         body = htmlReplace(body, text, placeholder);
     }
     for (const special of specialMentions) {
-        body = body.replace(
-            `@${escape(special)}`,
-            `<a href="#" class="o-discuss-mention">@${escape(special)}</a>`
+        body = htmlReplace(
+            body,
+            `@${special}`,
+            markup(`<a href="#" class="o-discuss-mention">@${htmlEscape(special)}</a>`)
         );
     }
     for (const mention of mentions) {

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -409,6 +409,7 @@ test("Mention with @everyone", async () => {
     await contains(".o-mail-Composer-input", { value: "@everyone " });
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message-bubble.o-orange");
+    await contains(".o-mail-Message a:contains('@everyone')");
 });
 
 test("Suggestions that begin with the search term should have priority", async () => {


### PR DESCRIPTION
Before this commit:

Special mentions (@everyone) appeared as raw HTML instead of links because when message content is not `markup()`, it is rendered as text instead of HTML when using `t-out`.

After this commit:

This commit ensures special mentions are correctly rendered as links.

Before / After 
![image](https://github.com/user-attachments/assets/868f00b3-a3e0-47ee-a2e7-3d6c6d76b948)
![image](https://github.com/user-attachments/assets/063f0b41-d214-49b1-83fa-7403884006e1)