### PR TITLE
[IMP] account: add warning when enabling audit trail

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -376,6 +376,11 @@
                         <block title="Audit Trail" name="audit_trail_setting_container">
                             <setting string="Audit Trail" company_dependent="1" help="Activate Audit Trail">
                                 <field name="check_account_audit_trail"/>
+                                <div class="alert alert-warning o_setting_box" role="alert" invisible= "check_account_audit_trail">
+                                    <p>
+                                        <strong>Warning:</strong> Once the Audit Trail is enabled, it cannot be disabled again if there are any existing journal items.
+                                    </p>
+                                </div>
                             </setting>
                         </block>
                     </app>


### PR DESCRIPTION
Description:
Adding a warning message when checking the option to enable the audit trail as this option can't be disabled if there are any existing move lines.
opw-4596812
opw-4346608

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr