### PR TITLE
[FIX] web: download all attachments of a message in portal

### DIFF
--- a/addons/web/static/src/core/network/download.js
+++ b/addons/web/static/src/core/network/download.js
@@ -371,6 +371,7 @@ function _download(data, filename, mimetype) {
             anchor.className = "download-js-link";
             anchor.innerText = _t("downloading...");
             anchor.style.display = "none";
+            anchor.target = "_blank";
             document.body.appendChild(anchor);
             setTimeout(() => {
                 anchor.click();


### PR DESCRIPTION
When downloading all message attachments as a zip file in portal chatter, if there is an editor iframe on the page, instead of downloading the file, there is a blob url opened on the page. This happens because the web editor handles clicks and tries to open the URL in the current main window, which results in displaying the blob URL to users instead of ownloading it. Opening the attachment in a new window prevents interfering with the current page url and keeps the iframe managed by the web editor intact.

task-4545106

