### PR TITLE
[IMP] mail, im_livechat: option to close all live chat conversations

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.js
@@ -1,26 +1,55 @@
 import { DiscussSidebarCategory } from "@mail/discuss/core/public_web/discuss_sidebar_categories";
+import { CloseAllConfirmation } from "@mail/core/common/close_all_confirmation";
+
 import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
 
 /** @type {import("@mail/discuss/core/public_web/discuss_sidebar_categories").DiscussSidebarCategory} */
 const DiscussSidebarCategoryPatch = {
     get actions() {
         const actions = super.actions;
         if (this.store.has_access_livechat && this.category.livechatChannel && this.category.open) {
-            actions.push({
-                onSelect: () => {
-                    if (this.category.livechatChannel.are_you_inside) {
-                        this.category.livechatChannel.leave({ notify: false });
-                    } else {
-                        this.category.livechatChannel.join({ notify: false });
-                    }
+            actions.push(
+                {
+                    onSelect: () => {
+                        this.store.env.services.dialog.add(CloseAllConfirmation, {
+                            title: _t("Close live chat conversations"),
+                            message: _t(
+                                "This action will end all live chat conversations of %s. Proceed?",
+                                this.category.livechatChannel.name
+                            ),
+                            onConfirm: () => {
+                                const promises = [];
+                                for (const thread of this.category.livechatChannel.threads) {
+                                    promises.push(thread.leave());
+                                }
+                                Promise.all(promises);
+                            },
+                        });
+                    },
+                    label: _t("Leave all conversations"),
+                    icon: "fa fa-close text-danger",
+                    active: () =>
+                        this.category.livechatChannel.threads.filter(
+                            (thread) => thread.isLocallyPinned || thread.is_pinned
+                        ).length,
                 },
-                label: this.category.livechatChannel.are_you_inside
-                    ? this.category.livechatChannel.leaveTitle
-                    : this.category.livechatChannel.joinTitle,
-                icon: this.category.livechatChannel.are_you_inside
-                    ? "fa fa-sign-out text-danger"
-                    : "fa fa-sign-in text-success",
-            });
+                {
+                    onSelect: () => {
+                        if (this.category.livechatChannel.are_you_inside) {
+                            this.category.livechatChannel.leave({ notify: false });
+                        } else {
+                            this.category.livechatChannel.join({ notify: false });
+                        }
+                    },
+                    label: this.category.livechatChannel.are_you_inside
+                        ? this.category.livechatChannel.leaveTitle
+                        : this.category.livechatChannel.joinTitle,
+                    icon: this.category.livechatChannel.are_you_inside
+                        ? "fa fa-sign-out text-danger"
+                        : "fa fa-sign-in text-success",
+                }
+            );
         }
         return actions;
     },

--- a/addons/mail/static/src/core/common/close_all_confirmation.js
+++ b/addons/mail/static/src/core/common/close_all_confirmation.js
@@ -1,0 +1,22 @@
+import { Component } from "@odoo/owl";
+
+import { Dialog } from "@web/core/dialog/dialog";
+
+export class CloseAllConfirmation extends Component {
+    static template = "mail.CloseAllConfirmation";
+    static components = { Dialog };
+    static props = {
+        ...Dialog.props,
+        message: String,
+        close: Function,
+        onConfirm: Function,
+        slots: { optional: true },
+    };
+
+    onClickConfirm() {
+        if (this.props.onConfirm) {
+            this.props.onConfirm();
+        }
+        this.props.close();
+    }
+}

--- a/addons/mail/static/src/core/common/close_all_confirmation.xml
+++ b/addons/mail/static/src/core/common/close_all_confirmation.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.CloseAllConfirmation">
+        <Dialog size="'md'" title="props.title">
+            <p class="text-prewrap" t-out="props.message"/>
+            <t t-set-slot="footer">
+                <button class="btn btn-danger" t-on-click.stop="onClickConfirm" data-hotkey="q">
+                    <i class="fa fa-fw fa-check"/>Yes
+                </button>
+                <button class="btn btn-secondary" t-on-click.stop="props.close" data-hotkey="x">
+                    <i class="fa fa-fw fa-times"/>Cancel
+                </button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -70,7 +70,7 @@
             <div class="o-mail-DiscussSidebarCategory-actions" t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm mx-1 o-gap-0_5': !store.discuss.isSidebarCompact }">
                 <t name="action-group">
                     <t t-foreach="actions" t-as="action" t-key="action_index">
-                        <button class="btn w-100 o-opacity-35 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
+                        <button t-if="action.active?.() ?? true" class="btn w-100 o-opacity-35 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
                             <i role="img" class="fa-fw" t-att-class="action.icon"/>
                             <span t-if="store.discuss.isSidebarCompact" class="text-muted" t-esc="action.label"/>
                         </button>

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -308,6 +308,8 @@ test("Can close all chat windows at once", async () => {
     await hover(".o-mail-ChatHub-hiddenBtn");
     await click("button.fa.fa-ellipsis-h[title='Chat Options']");
     await click("button.o-mail-ChatHub-option", { text: "Close all conversations" });
+    await contains(".modal-title", { text: "Close all conversations" });
+    await click(".modal-footer .btn-danger", { text: "Yes" });
     await contains(".o-mail-ChatBubble", { count: 0 });
     assertChatHub({});
 });


### PR DESCRIPTION
**Current behavior before PR**:

There is no option to close and leave all the live chat conversations at once in discuss.

For closing all conversations chat bubbles, we require two clicks and it throws a warning before leaving each conversation, which also requires a click.

**Desired behavior after PR is merged**:

Added a button in discuss using which user can leave all the live chat conversations of a particular live chat channel in a single click.

Also we can close and leave all conversations bubbles in a single click now

**task-id**:[4536773](https://www.odoo.com/odoo/project/1519/tasks/4536773)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr