### PR TITLE
[IMP] l10n_id: unable to generate QR from PoS

### DIFF
--- a/addons/l10n_id/models/res_bank.py
+++ b/addons/l10n_id/models/res_bank.py
@@ -87,7 +87,7 @@ class ResBank(models.Model):
                 "do": "create-invoice",
                 "apikey": self.l10n_id_qris_api_key,
                 "mID": self.l10n_id_qris_mid,
-                "cliTrxNumber": structured_communication,
+                "cliTrxNumber": free_communication,
                 "cliTrxAmount": int(amount)
             }
             response = _l10n_id_make_qris_request('show_qris.php', params)

--- a/addons/l10n_id/tests/test_qris.py
+++ b/addons/l10n_id/tests/test_qris.py
@@ -93,6 +93,11 @@ class TestQris(AccountTestInvoicingCommon):
             result = self.qris_qr_invoice.with_context({'is_online_qr': True})._generate_qr_code()
             self.assertIsNotNone(result)
 
+            # when generating qr code, cliTrxNumber should not be empty string as it cannot
+            # generate QR code in practice
+            qr_param = patched.call_args[0][1]
+            self.assertTrue(qr_param.get('cliTrxNumber'))
+
             # Confirm that a transaction should be registered on the invoice
             qr_details = self.qris_qr_invoice.l10n_id_qris_transaction_ids
             self.assertEqual(len(qr_details), 1)

--- a/addons/l10n_id_pos/tests/test_qris_pos.py
+++ b/addons/l10n_id_pos/tests/test_qris_pos.py
@@ -214,6 +214,11 @@ class TestPosQris(AccountTestInvoicingHttpCommon):
             self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PayementScreenQRISFetchQR', login="pos_user")
             self.assertEqual(patched.call_count, 1)
 
+            # when generating QR, ensure that cliTrxNumber is non-empty, else it will generate
+            # error in practice
+            qr_params = patched.call_args[0][1]
+            self.assertTrue(qr_params.get('cliTrxNumber'))
+
     @freeze_time("2024-02-27 04:15:00")
     def test_qris_change_amount(self):
         """ Test that when user changes the amount of order after generating QRIS QR for the first time,


### PR DESCRIPTION
Issue found starting version 18.0 , API error is raised when generating QRIS from PoS. The issue is raised due to cliTrxNumber is an empty string when trying to generate the QR. This is due to PR https://github.com/odoo/odoo/pull/186703, which passed "" as structured_communication and later used when calling QRIS API. Instead of `structured_communication` we use `free_communication`. For invoice it remains the same result while for PoS we can still guarantee uniqueness.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
