### PR TITLE
[FIX] sale,_*: combo configurator access error

### DIFF
--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -41,7 +41,7 @@ class SaleProductConfiguratorController(Controller):
         """
         if company_id:
             request.update_context(allowed_company_ids=[company_id])
-        product_template = request.env['product.template'].browse(product_template_id)
+        product_template = self._get_product_template(product_template_id)
 
         combination = request.env['product.template.attribute.value']
         if ptav_ids:
@@ -114,7 +114,7 @@ class SaleProductConfiguratorController(Controller):
         :rtype: int
         :return: The product created, as a `product.product` id.
         """
-        product_template = request.env['product.template'].browse(product_template_id)
+        product_template = self._get_product_template(product_template_id)
         combination = request.env['product.template.attribute.value'].browse(ptav_ids)
         product = product_template._create_product_variant(combination)
         return product.id
@@ -156,7 +156,7 @@ class SaleProductConfiguratorController(Controller):
         """
         if company_id:
             request.update_context(allowed_company_ids=[company_id])
-        product_template = request.env['product.template'].browse(product_template_id)
+        product_template = self._get_product_template(product_template_id)
         pricelist = request.env['product.pricelist'].browse(pricelist_id)
         product_uom = request.env['uom.uom'].browse(product_uom_id)
         currency = request.env['res.currency'].browse(currency_id)
@@ -208,7 +208,7 @@ class SaleProductConfiguratorController(Controller):
         """
         if company_id:
             request.update_context(allowed_company_ids=[company_id])
-        product_template = request.env['product.template'].browse(product_template_id)
+        product_template = self._get_product_template(product_template_id)
         parent_combination = request.env['product.template.attribute.value'].browse(
             parent_ptav_ids + ptav_ids
         )
@@ -231,6 +231,9 @@ class SaleProductConfiguratorController(Controller):
             ) for optional_product_template in product_template.optional_product_ids if
             self._should_show_product(optional_product_template, parent_combination)
         ]
+
+    def _get_product_template(self, product_template_id):
+        return request.env['product.template'].browse(product_template_id)
 
     def _get_product_information(
         self,

--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -42,6 +42,18 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
             or not (single_product_variant.get('product_id') or is_product_configured)
         )
 
+    def _get_product_template(self, product_template_id):
+        if request.is_frontend:
+            combo_item = request.env['product.combo.item'].sudo().search([
+                ('product_id.product_tmpl_id.id', '=', product_template_id),
+            ])
+            if combo_item and request.env['product.template'].sudo().search_count([
+                ('combo_ids', 'in', combo_item.mapped('combo_id.id')),
+                ('website_published', '=', True),
+            ]):
+                return request.env['product.template'].sudo().browse(product_template_id)
+        return super()._get_product_template(product_template_id)
+
     @route(
         route='/website_sale/product_configurator/get_values',
         type='json',


### PR DESCRIPTION
_* : website_sale
Steps:
- Create a combo product with combo items containing unpublished configurable product
- on /shop as portal user add the combo product and try to configure any unpublished product

Issue:
- access error

Cause:
- The product configurator doesn't sudo the product which is being configured

Fix:
- if the product for product_configurator is part of published combo product, it will be sudo'ed

opw: 4567008

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
