### PR TITLE
[FIX] mail: small flicker when expanding avatar stack

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -23,7 +23,7 @@
             'px-2': props.compact === false,
             'rounded-3': props.compact === undefined,
             'opacity-75': props.thread.notEq(rtc.state.channel) and compact,
-        }">
+        }" style="margin: 1px;">
             <button class="o-mail-DiscussSidebarCallParticipants-expandBtn btn btn-link p-1 my-n1 ms-n1 me-0 align-self-start d-flex rounded-circle" t-if="!compact" t-on-click="() => state.expanded = !state.expanded">
                 <i class="oi o-xxsmaller text-muted text-dark" t-att-class="{'oi-chevron-right': !state.expanded, 'oi-chevron-down': state.expanded}" t-att-title="title"/>
             </button>
@@ -33,7 +33,7 @@
                 containerClass="compact ? '' : 'cursor-pointer'"
                 avatarClass="(p) => this.avatarClass(p)"
                 max="compact ? 1 : 7"
-                size="28"
+                size="26"
                 onClick.bind="onClickAvatarStack"
                 personas="sessions.map((s) => s.channel_member_id?.persona).filter(p => p)"
             >
@@ -55,7 +55,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCallParticipants.list">
-        <div class="d-flex flex-column gap-1 flex-grow-1">
+        <div class="d-flex flex-column gap-1 flex-grow-1" style="padding: 1.5px;">
             <t t-foreach="sessions" t-as="session" t-key="session.localId">
                 <t t-call="mail.DiscussSidebarCallParticipants.participant">
                     <t t-set="session" t-value="session"/>
@@ -66,7 +66,7 @@
 
     <t t-name="mail.DiscussSidebarCallParticipants.participant">
         <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="{ 'justify-content-center bg-inherit': isCompact }">
-            <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:28px;height:28px;margin:1px">
+            <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px;margin:1px;">
                 <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-src="session.channel_member_id.persona.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id.persona.name"/>
             </div>
             <span t-if="!isCompact" class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bold smaller user-select-none" t-att-title="session.channel_member_id.persona.name" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.js
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.js
@@ -36,6 +36,7 @@ export class AvatarStack extends Component {
         const styles = [
             "box-sizing: content-box",
             `height: ${this.props.size}px`,
+            "margin: 1px",
             `padding: 1.5px`,
             `width: ${this.props.size}px`,
             `z-index: ${this.props.personas.length - index}`,

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.AvatarStack">
-        <div t-if="props.personas.length > 0" class="bg-inherit" style="margin: 1px;" t-att-class="props.containerClass" t-on-click="props.onClick">
+        <div t-if="props.personas.length > 0" class="bg-inherit" t-att-class="props.containerClass" t-on-click="props.onClick">
             <div class="d-flex bg-inherit" t-att-class="{'flex-column': props.direction === 'v'}">
                 <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="bg-inherit rounded-circle position-relative" t-attf-style="{{getStyle(persona_index)}}">
                     <img t-att-src="persona.avatarUrl" t-att-title="persona.name" class="w-100 h-100 rounded-circle o_object_fit_cover" t-attf-class="{{props.avatarClass(persona)}}"/>


### PR DESCRIPTION
In the Discuss sidebar, an avatar stack displays call participants and can be expanded for more details.

Expanding the stack caused a slight shift due to the stack using padding for a background-colored border, while the expanded list did not.

This PR fixes the issue by:
- Removing margin from the stack container for better flexibility (customizable via `containerClass`).
- Applying the same padding to the expanded list to maintain alignment.


| Before | After |
| ------------- | ------------- |
| ![stack_shift](https://github.com/user-attachments/assets/ff4941eb-ab21-4e11-821b-2935626fcb2c) | ![stack_no_shift](https://github.com/user-attachments/assets/ed254551-2edd-4a4c-84e5-81bd6e955ede)|