### PR TITLE
[IMP] mail, test_mail: add filter options for message search in chatter

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -89,12 +89,7 @@ class ChannelController(http.Controller):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel:
             raise NotFound()
-        domain = [
-            ("res_id", "=", channel_id),
-            ("model", "=", "discuss.channel"),
-            ("message_type", "!=", "user_notification"),
-        ]
-        res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
+        res = request.env["mail.message"]._message_fetch(domain=None, thread=channel, **(fetch_params or {}))
         messages = res.pop("messages")
         if not request.env.user._is_public():
             messages.set_message_done()

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -60,12 +60,8 @@ class ThreadController(http.Controller):
 
     @http.route("/mail/thread/messages", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_messages(self, thread_model, thread_id, fetch_params=None):
-        domain = [
-            ("res_id", "=", int(thread_id)),
-            ("model", "=", thread_model),
-            ("message_type", "!=", "user_notification"),
-        ]
-        res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
+        thread = self._get_thread_with_access(thread_model, thread_id, mode="read")
+        res = request.env["mail.message"]._message_fetch(domain=None, thread=thread, **(fetch_params or {}))
         messages = res.pop("messages")
         if not request.env.user._is_public():
             messages.set_message_done()

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -904,19 +904,40 @@ class MailMessage(models.Model):
         return Store().add(self, {"starred": self.starred}).get_result()
 
     @api.model
-    def _message_fetch(self, domain, search_term=None, before=None, after=None, around=None, limit=30):
+    def _message_fetch(self, domain, *, thread=None, search_term=None, is_notification=None, before=None, after=None, around=None, limit=30):
         res = {}
-        domain = Domain(domain)
+        domain = Domain(True if domain is None else domain)
+        if thread:
+            domain &= (
+                Domain("res_id", "=", thread.id)
+                & Domain("model", "=", thread._name)
+                & Domain("message_type", "!=", "user_notification")
+            )
+        if is_notification is True:
+            domain &= Domain("message_type", "=", "notification")
+        elif is_notification is False:
+            domain &= Domain("message_type", "!=", "notification")
         if search_term:
             # we replace every space by a % to avoid hard spacing matching
             search_term = search_term.replace(" ", "%")
-            domain &= Domain.OR([
+            message_domain = Domain.OR([
                 # sudo: access to attachment is allowed if you have access to the parent model
                 [("attachment_ids", "in", self.env["ir.attachment"].sudo()._search([("name", "ilike", search_term)]))],
                 [("body", "ilike", search_term)],
                 [("subject", "ilike", search_term)],
                 [("subtype_id.description", "ilike", search_term)],
             ])
+            if thread and is_notification is not False:
+                tracking_value_domain = (
+                    Domain("mail_message_id.res_id", "=", thread.id)
+                    & Domain("mail_message_id.model", "=", thread._name)
+                    & self._get_tracking_values_domain(search_term)
+                )
+                # sudo: mail.tracking.value - searching allowed tracking values for acessible records
+                tracking_values = self.env["mail.tracking.value"].sudo().search(tracking_value_domain)
+                accessible_tracking_value_ids = tracking_values._filter_has_field_access(self.env)
+                message_domain |= Domain("id", "in", accessible_tracking_value_ids.mail_message_id.ids)
+            domain &= message_domain
             res["count"] = self.search_count(domain)
         if around is not None:
             messages_before = self.search(domain & Domain('id', '<=', around), limit=limit // 2, order="id DESC")
@@ -930,6 +951,39 @@ class MailMessage(models.Model):
         if after:
             res["messages"] = res["messages"].sorted('id', reverse=True)
         return res
+
+    def _get_tracking_values_domain(self, search_term):
+        """Get the domain to search for tracking values."""
+        numeric_term = None
+        # try to convert the search term to a number
+        with contextlib.suppress(ValueError, TypeError):
+            numeric_term = float(search_term)
+        domain = Domain.OR(
+            Domain(field_name, "ilike", search_term)
+            for field_name in (
+                "old_value_char",
+                "new_value_char",
+                "old_value_text",
+                "new_value_text",
+                "old_value_datetime",
+                "new_value_datetime",
+                "field_id.name",
+                "field_id.field_description",
+            )
+        )
+        if numeric_term:
+            epsilon = 1e-9  # small epsilon to allow for floating point precision
+            domain |= Domain.OR(
+                Domain(field_name, ">=", numeric_term - epsilon)
+                & Domain(field_name, "<=", numeric_term + epsilon)
+                for field_name in ("old_value_float", "new_value_float")
+            )
+            if numeric_term.is_integer():
+                domain |= Domain.OR(
+                    Domain(field_name, "=", int(numeric_term))
+                    for field_name in ("old_value_integer", "new_value_integer")
+                )
+        return domain
 
     def _message_reaction(self, content, action, partner, guest, store: Store = None):
         self.ensure_one()

--- a/addons/mail/static/src/core/common/message_search_hook.js
+++ b/addons/mail/static/src/core/common/message_search_hook.js
@@ -72,7 +72,12 @@ export function useMessageSearch(thread) {
             if (this.searchTerm) {
                 this.searching = true;
                 const data = await sequential(() =>
-                    store.searchMessagesInThread(this.searchTerm, this.thread, before)
+                    store.searchMessagesInThread(
+                        this.searchTerm,
+                        this.thread,
+                        before,
+                        this.is_notification
+                    )
                 );
                 if (!data) {
                     return;
@@ -98,6 +103,8 @@ export function useMessageSearch(thread) {
             this.searching = false;
             this.searchTerm = undefined;
         },
+        /** @type {true | false | undefined} */
+        is_notification: undefined,
         loadMore: false,
         /** @type {import('@mail/core/common/message_model').Message[]} */
         messages: [],

--- a/addons/mail/static/src/core/common/search_message_input.js
+++ b/addons/mail/static/src/core/common/search_message_input.js
@@ -1,16 +1,28 @@
 import { Component, useExternalListener, useState } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { useAutofocus } from "@web/core/utils/hooks";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { _t } from "@web/core/l10n/translation";
+
+/**
+ * @typedef {Object} SearchFilter
+ * @property {string} label
+ * @property {string} name
+ * @property {true|false|undefined} [is_notification]
+ */
 
 /**
  * @typedef {Object} Props
+ * @property {ReturnType<typeof import("@mail/core/common/message_search_hook").useMessageSearch>} messageSearch
  * @property {import("@mail/core/common/thread_model").Thread} thread
  * @property {function} [closeSearch]
+ * @extends {Component<Props, Env>}
  */
-
 export class SearchMessageInput extends Component {
     static template = "mail.SearchMessageInput";
     static props = ["closeSearch?", "messageSearch", "thread"];
+    static components = { Dropdown, DropdownItem };
 
     setup() {
         super.setup();
@@ -50,5 +62,36 @@ export class SearchMessageInput extends Component {
         } else {
             this.search();
         }
+    }
+
+    /** @param {SearchFilter} searchFilter */
+    onChangeSearchFilter(searchFilter) {
+        if (searchFilter.is_notification !== this.props.messageSearch.is_notification) {
+            this.props.messageSearch.is_notification = searchFilter.is_notification;
+            if (this.state.searchTerm) {
+                this.search();
+            }
+        }
+    }
+
+    /** @returns {SearchFilter[]} */
+    get searchFilters() {
+        return [
+            {
+                label: "all",
+                name: _t("All"),
+                is_notification: undefined,
+            },
+            {
+                label: "conversations",
+                name: _t("Conversations"),
+                is_notification: false,
+            },
+            {
+                label: "tracked_changes",
+                name: _t("Tracked Changes"),
+                is_notification: true,
+            },
+        ];
     }
 }

--- a/addons/mail/static/src/core/common/search_message_input.xml
+++ b/addons/mail/static/src/core/common/search_message_input.xml
@@ -13,6 +13,19 @@
                     <i t-else="" class="fa fa-circle-o-notch fa-spin" aria-label="Search in progress" title="Search in progress"/>
                 </button>
             </div>
+            <Dropdown t-if="env.inChatter">
+                <button class="btn btn-outline-secondary ms-3" aria-label="Filter Messages" title="Filter Messages">
+                    <i class="fa fa-filter" role="img"/>
+                </button>
+                <t t-set-slot="content">
+                    <t t-foreach="searchFilters" t-as="searchFilter" t-key="searchFilter.label">
+                        <DropdownItem onSelected="() => this.onChangeSearchFilter(searchFilter)">
+                            <input type="radio" class="form-check-input ms-0 me-2" t-att-checked="searchFilter.is_notification === this.props.messageSearch.is_notification" value="searchFilter.label"/>
+                            <t t-esc="searchFilter.name"/>
+                        </DropdownItem>
+                    </t>
+                </t>
+            </Dropdown>
             <button t-if="env.inChatter" class="btn btn-outline-secondary ms-3" t-on-click="() => this.clear()" aria-label="Close button">
                 <i class="o_searchview_icon oi oi-close cursor-pointer" role="img" aria-label="Close search" title="Close"/>
             </button>

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -698,12 +698,14 @@ export class Store extends BaseStore {
     /**
      * @param {string} searchTerm
      * @param {Thread} thread
-     * @param {number|false} [before]
+     * @param {number} before
+     * @param {true|false|undefined} is_notification
      */
-    async searchMessagesInThread(searchTerm, thread, before = false) {
+    async searchMessagesInThread(searchTerm, thread, before, is_notification) {
         const { count, data, messages } = await rpc(thread.getFetchRoute(), {
             ...thread.getFetchParams(),
             fetch_params: {
+                is_notification,
                 search_term: await prettifyMessageContent(searchTerm), // formatted like message_post
                 before,
             },

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -129,6 +129,8 @@ patch(Message.prototype, {
      */
     formatTrackingOrNone(trackingFieldInfo, trackingValue) {
         const formattedValue = this.formatTracking(trackingFieldInfo, trackingValue);
-        return formattedValue || _t("None");
+        return formattedValue
+            ? this.props.messageSearch?.highlight(formattedValue) ?? formattedValue
+            : _t("None");
     },
 });

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -13,12 +13,12 @@
                         <ul class="mb-0 list-unstyled">
                             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
                                 <li class="o-mail-Message-tracking mb-1" role="group">
-                                    <span class="o-mail-Message-trackingOld text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.oldValue)"/>
+                                    <span class="o-mail-Message-trackingOld text-muted fw-bold" t-out="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.oldValue)"/>
                                     <t t-if="!trackingValue.fieldInfo.isPropertyField">
                                         <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-2 text-600"/>
-                                        <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.newValue)"/>
+                                        <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-out="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.newValue)"/>
                                     </t>
-                                    <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-esc="trackingValue.fieldInfo.changedField"/>)</span>
+                                    <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-out="props.messageSearch?.highlight(trackingValue.fieldInfo.changedField) ?? trackingValue.fieldInfo.changedField"/>)</span>
                                 </li>
                             </t>
                         </ul>

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -293,12 +293,8 @@ async function discuss_channel_messages(request) {
     const MailMessage = this.env["mail.message"];
 
     const { channel_id, fetch_params = {} } = await parseRequestParams(request);
-    const domain = [
-        ["res_id", "=", channel_id],
-        ["model", "=", "discuss.channel"],
-        ["message_type", "!=", "user_notification"],
-    ];
-    const res = MailMessage._message_fetch(domain, makeKwArgs(fetch_params));
+    const channel = this.env["discuss.channel"].browse(channel_id);
+    const res = MailMessage._message_fetch([], channel, makeKwArgs(fetch_params));
     const { messages } = res;
     delete res.messages;
     if (!fetch_params.around) {
@@ -870,12 +866,8 @@ async function mail_thread_messages(request) {
     const MailMessage = this.env["mail.message"];
 
     const { fetch_params = {}, thread_id, thread_model } = await parseRequestParams(request);
-    const domain = [
-        ["res_id", "=", thread_id],
-        ["model", "=", thread_model],
-        ["message_type", "!=", "user_notification"],
-    ];
-    const res = MailMessage._message_fetch(domain, makeKwArgs(fetch_params));
+    const thread = this.env[thread_model].browse(thread_id);
+    const res = MailMessage._message_fetch([], thread, makeKwArgs(fetch_params));
     const { messages } = res;
     delete res.messages;
     MailMessage.set_message_done(messages.map((message) => message.id));

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -137,11 +137,13 @@ export class MailThread extends models.ServerModel {
             );
         }
         email_from ||= false;
+        const message_type = kwargs.message_type || "notification";
         const values = unmakeKwArgs({
             ...kwargs,
             author_id,
             author_guest_id,
             email_from,
+            message_type,
             subtype_id: MailMessageSubtype._filter([
                 ["subtype_xmlid", "=", kwargs.subtype_xmlid || "mail.mt_note"],
             ])[0]?.id,

--- a/addons/test_mail/static/tests/tracking_value.test.js
+++ b/addons/test_mail/static/tests/tracking_value.test.js
@@ -345,3 +345,33 @@ test("rendering of tracked field of type many2one: from no related record to hav
     await click(".o_form_button_save");
     await contains(".o-mail-Message-tracking", { text: "NoneMarc(Many2one)" });
 });
+
+test("Search message with filter in chatter", async () => {
+    const pyEnv = await startServer();
+    const mailTestTrackAllId = pyEnv["mail.test.track.all"].create({});
+    pyEnv["mail.message"].create({
+        body: "Hermit",
+        model: "mail.test.track.all",
+        res_id: mailTestTrackAllId,
+    });
+    await start();
+    registerArchs(archs);
+    await openFormView("mail.test.track.all", mailTestTrackAllId);
+    await click("[name=many2one_field_id] input");
+    await click("[name=many2one_field_id] .o-autocomplete--dropdown-item", { text: "Hermit" });
+    await click(".o_form_button_save");
+    // Search message with filter
+    await click("[title='Search Messages']");
+    await insertText(".o_searchview_input", "Hermit");
+    await click("button[title='Filter Messages']");
+    await click("span", { text: "Conversations" });
+    await contains(".o-mail-SearchMessageResult .o-mail-Message", { text: "Hermit" });
+
+    await click("button[title='Filter Messages']");
+    await click("span", { text: "Tracked Changes" });
+    await contains(".o-mail-SearchMessageResult .o-mail-Message", { text: "Hermit" });
+
+    await click("button[title='Filter Messages']");
+    await click("span", { text: "All" });
+    await contains(".o-mail-SearchMessageResult .o-mail-Message", { count: 2 });
+});


### PR DESCRIPTION
This PR introduces a filter button in the chatter's search functionality,
allowing users to refine message searches. This helps users quickly find the
information they need in busy with conversations records. The filters include:

- **All** (default) shows all messages, including conversations and
  tracked changes.
- **Conversation** returns messages and log notes
- **Tracked changes** returns all other changes except messages and log notes

Task-4614500
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
