### PR TITLE
[FIX] project: import missing assets for editor in `iframe`

### DIFF
--- a/addons/project/views/project_sharing_project_task_templates.xml
+++ b/addons/project/views/project_sharing_project_task_templates.xml
@@ -24,6 +24,7 @@
                 </script>
                 <base target="_parent"/>
                 <t t-call-assets="project.webclient"/>
+                <t t-call-assets="web.assets_backend" t-js="false"/>
             </t>
             <t t-set="head" t-value="head_project_sharing + (head or '')"/>
             <t t-set="body_classname" t-value="'o_web_client o_project_sharing'"/>


### PR DESCRIPTION
**Problem**:
When a portal user tries to edit a task's description by adding a checklist, the checkboxes do not appear as they do in the Odoo backend (e.g., in the To-Do app).

This occurs because the editor is rendered in an `iframe` without loading the required CSS classes.

**Solution**:
Load `web.assets_backend` to include all necessary CSS for the editor.

**Steps to Reproduce**:
1. Share a project with **"Edit"** permission for a portal user.
2. Log in as the portal user.
3. Go to any task inside the project.
4. In the description, add a checklist using `/checklist` command.
   - **Issue**: No checkboxes appear.
   - **Issue**: Other styles, like the editable border, are missing.

opw-4481993

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
