### PR TITLE
[IMP] web: allow duplicating record when explicitly specified

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -492,7 +492,7 @@ export class FormController extends Component {
                 callback: () => this.model.root.unarchive(),
             },
             duplicate: {
-                isAvailable: () => activeActions.create && activeActions.duplicate,
+                isAvailable: () => activeActions.duplicate,
                 sequence: 30,
                 icon: "fa fa-clone",
                 description: _t("Duplicate"),

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -161,7 +161,7 @@ export function getActiveActions(rootNode) {
         delete: exprToBoolean(rootNode.getAttribute("delete"), true),
     };
     activeActions.duplicate =
-        activeActions.create && exprToBoolean(rootNode.getAttribute("duplicate"), true);
+        exprToBoolean(rootNode.getAttribute("duplicate"), activeActions.create);
     return activeActions;
 }
 


### PR DESCRIPTION
**Description of the feature this PR addresses:**

- Allows duplicating records when `create='false'` and `duplicate='true'`

**Current behavior before PR:**

- Setting `create='false'` in an XML view automatically removes both the New and Duplicate actions.
- There is no way to hide only the New button while keeping Duplicate visible.
- To retain the Duplicate action, we must create a custom view, adding unnecessary complexity.

**Desired behavior after PR is merged:**

- Setting `create='false'` will still hide both the New and Duplicate actions by default.
- However, if `duplicate='true'` is explicitly set, the Duplicate action will remain visible, while the New button stays hidden.
- The change is fully backward-compatible and does not break any existing test cases.

This feature is useful when we don't want the user to create a new record and use an existing one by duplicating. (eg. Payment providers)

Affected Version: _master_
task-[4523394](https://www.odoo.com/odoo/project/4106/tasks/4523394)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
