### PR TITLE
[FIX] l10n_cz: prevent cz taxable supply date in bank rec

### DIFF
--- a/addons/l10n_cz/models/account_move.py
+++ b/addons/l10n_cz/models/account_move.py
@@ -11,7 +11,7 @@ class AccountMove(models.Model):
     def _compute_date(self):
         super()._compute_date()
         for move in self:
-            if move.country_code == 'CZ' and move.taxable_supply_date and move.state == 'draft':
+            if move.country_code == 'CZ' and move.taxable_supply_date and move.state == 'draft' and not move.statement_line_id:
                 move.date = move.taxable_supply_date
 
     @api.depends('taxable_supply_date')

--- a/addons/l10n_cz/tests/test_moves.py
+++ b/addons/l10n_cz/tests/test_moves.py
@@ -40,3 +40,17 @@ class TestAccountCZ(AccountTestInvoicingCommon):
         self.assertEqual(self.invoice_a.date, fields.Date.to_date('2024-05-31'))
         self.assertEqual(self.invoice_a.invoice_currency_rate, 0.042799058421)
         self.assertEqual(self.invoice_a.invoice_line_ids[0].currency_rate, 0.042799058421)
+
+    def test_cz_bank_rec_no_taxable_supply_date(self):
+        """
+        Test that when creating a new bank reconciliation, the taxable payable date is not set automatically.
+        """
+        st_line = self.env['account.bank.statement.line'].create({
+            'amount': 100,
+            'date': '2024-12-31',
+        })
+        wizard = self.env['bank.rec.widget'].with_context(default_st_line_id=st_line.id).new({})
+        wizard._action_validate()
+
+        inv_line = self.env['account.move'].search([('statement_line_id', '=', st_line.id)])
+        self.assertNotEqual(inv_line.taxable_supply_date, st_line.date)


### PR DESCRIPTION
- Install l10n_cz and switch to a cz company.

- In bank reconciliation, create a new bank transaction and set its date to a past or future date (not today)

The date of the newly created bank transaction is automatically set to today.

In the Czech Republic, it is required to use the taxable supply date as the accounting date. This functionality was introduced by 184c1e65a9992e890af81bb60eeeb7b8b825ab54. However, it also sets the taxable supply date for bank transactions, which is incorrect.

opw-4544305




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
