### PR TITLE
[FIX] sale_project: handle `any` operator in task_ids search method

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -6,8 +6,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models, _, Command
 from odoo.exceptions import UserError
-from odoo.tools.safe_eval import safe_eval
-from odoo.osv.expression import AND
+from odoo.osv.expression import AND, NEGATIVE_TERM_OPERATORS, TERM_OPERATORS_NEGATION, ANY_IN
 
 
 class SaleOrder(models.Model):
@@ -54,21 +53,18 @@ class SaleOrder(models.Model):
             order.show_create_project_button = is_project_manager and order.id in show_button_ids and not order.project_count and order.order_line.product_template_id.filtered(lambda x: x.service_policy in ['delivered_timesheet', 'delivered_milestones'])
 
     def _search_tasks_ids(self, operator, value):
-        is_name_search = operator in ['=', '!=', 'like', '=like', 'ilike', '=ilike'] and isinstance(value, str)
-        is_id_eq_search = operator in ['=', '!='] and isinstance(value, int)
-        is_id_in_search = operator in ['in', 'not in'] and isinstance(value, list) and all(isinstance(item, int) for item in value)
-        if not (is_name_search or is_id_eq_search or is_id_in_search):
-            raise NotImplementedError(_('Operation not supported'))
-
-        if is_name_search:
-            tasks_ids = self.env['project.task']._name_search(value, operator=operator, limit=None)
-        elif is_id_eq_search:
-            tasks_ids = value if operator == '=' else self.env['project.task']._search([('id', '!=', value)], order='id')
-        else:  # is_id_in_search
-            tasks_ids = self.env['project.task']._search([('id', operator, value)], order='id')
-
-        tasks = self.env['project.task'].browse(tasks_ids)
-        return [('id', 'in', tasks.sale_order_id.ids)]
+        if operator in NEGATIVE_TERM_OPERATORS:
+            positive_operator = TERM_OPERATORS_NEGATION[operator]
+        else:
+            positive_operator = operator
+        if operator in ANY_IN:
+            new_operator = ANY_IN[operator]
+            task_domain = AND([value, [('sale_order_id', '!=', False)]])
+        else:
+            new_operator = 'in' if positive_operator == operator else 'not in'
+            task_domain = [('display_name' if isinstance(value, str) else 'id', positive_operator, value), ('sale_order_id', '!=', False)]
+        query = self.env['project.task']._search(task_domain)
+        return [('id', new_operator, query.subselect('sale_order_id'))]
 
     @api.depends('order_line.product_id.project_id')
     def _compute_tasks_ids(self):

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -140,6 +140,11 @@ class TestSaleProject(TestSaleProjectCommon):
         self.assertFalse(so_line_order_only_project.task_id, "Task should not be created")
         self.assertTrue(so_line_order_only_project.project_id, "Sales order line should be linked to newly created project")
 
+        self.assertEqual(self.env['sale.order'].search([('tasks_ids', 'in', so_line_order_new_task_new_project.task_id.ids)]), sale_order)
+        self.assertEqual(self.env['sale.order'].search([('tasks_ids', '=', so_line_order_new_task_new_project.task_id.id)]), sale_order)
+        self.assertEqual(self.env['sale.order'].search([('tasks_ids', 'any', [('project_id', '=', so_line_order_new_task_new_project.project_id.id)])]), sale_order)
+        self.assertEqual(self.env['sale.order'].search([('tasks_ids.project_id', '=', so_line_order_new_task_new_project.project_id.id)]), sale_order)
+
         self.assertEqual(self.project_global._get_sale_order_items(), self.project_global.sale_line_id | self.project_global.tasks.sale_line_id, 'The _get_sale_order_items should returns all the SOLs linked to the project and its active tasks.')
 
         sale_order_2 = SaleOrder.create({


### PR DESCRIPTION
Before this commit, when the user creates a custom filter in SO model to
select the SO in which there is at least one task linked to a specific
project, he got an error saying the domain is invalid.

This commit fixes the issue by improving the search method implementing
for the `task_ids` field to make sure the search view supports a query
contained inside `value` parameter.

Steps to reproduce the issue:
----------------------------

0. Install `sale_timesheet` module with demo data
1. Go to Sales app
2. Creates a custom filter and select `Tasks associated to this sale >
   Project` as left part, `=` as operator (second field in the custom
   filter) and `After sales-service` as project (right part, last field
   in the custom filter).
3. Apply the custom filter

Expected behavior:
-----------------

The custom filter should be applied without any issue.

Current behavior:
----------------

The user has an error saying the domain is invalid when he tries to
save/apply his custom filter.
