### PR TITLE
[FIX] l10n_id: prevent error when getting QR code from PoS

### DIFF
--- a/addons/l10n_id/models/res_bank.py
+++ b/addons/l10n_id/models/res_bank.py
@@ -87,7 +87,7 @@ class ResBank(models.Model):
                 "do": "create-invoice",
                 "apikey": self.l10n_id_qris_api_key,
                 "mID": self.l10n_id_qris_mid,
-                "cliTrxNumber": structured_communication,
+                "cliTrxNumber": free_communication or structured_communication,
                 "cliTrxAmount": int(amount)
             }
             response = _l10n_id_make_qris_request('show_qris.php', params)

--- a/addons/l10n_id_pos/tests/test_qris_pos.py
+++ b/addons/l10n_id_pos/tests/test_qris_pos.py
@@ -136,6 +136,7 @@ class TestPosQris(AccountTestInvoicingHttpCommon):
 
         def _patched_make_qris_request(endpoint, params):
             if endpoint == 'show_qris.php':
+                self.assertTrue(params['cliTrxNumber'])
                 return {
                     "status": "success",
                     "data": {


### PR DESCRIPTION
Before this commit, retrieving the QR code from the PoS interface would result in an error due to a missing `cliTrxNumber` in the request. This issue occurs because the `structured_communication` is empty when sending from PoS.

opw-4599402

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
