### PR TITLE
[FIX] stock_dropshipping,sale_stock: handle return of intercompany dropship

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -316,8 +316,11 @@ class SaleOrderLine(models.Model):
             moves = moves.filtered(lambda r: fields.Date.context_today(r, r.date) <= self._context['accrual_entry_date'])
 
         for move in moves:
-            if (strict and move.location_dest_id._is_outgoing()) or \
-               (not strict and move.rule_id.id in triggering_rule_ids and (move.location_final_id or move.location_dest_id)._is_outgoing()):
+            if not move._is_dropshipped_returned() and (
+                (strict and move.location_dest_id._is_outgoing()) or (
+                not strict and move.rule_id.id in triggering_rule_ids and
+                (move.location_final_id or move.location_dest_id)._is_outgoing()
+            )):
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
                     outgoing_moves_ids.add(move.id)
             elif move.location_id._is_outgoing() and move.to_refund:


### PR DESCRIPTION
**Current behavior:**
Returning an intercompany dropship (product vendor is another
`res.company`) increases the original sale order line's
delivered qty.

**Expected behavior:**
The delivered qty should decrease once the return is completed.

**Steps to reproduce:**
1. Create two companies, enable all the inter-company
synchronization rules

2. Create a product with the dropship route and set the other
company as the vendor

3. Create a sale order for the dropship product, confirm

4. Confirm the corresponding purchase order -> validate the
dropship picking

5. Return the dropship picking

6. See the sale order line's delievered qty is wrong

**Cause of the issue:**
The dropship return move(s) are incorrectly flagged as outgoing.

**Fix:**
Use the `_is_dropshipped_returned()` method to filter these
moves from being considered outgoing.

Also added on to an existing dropshipping test so that there is
now coverage for this use-case when the vendor is not another
company, as this was previously not covered.

opw-4526750