### PR TITLE
[FIX] web: date picker today on last row create a scrollbar

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -67,19 +67,7 @@
     }
 
     .o_today span {
-        position: relative;
-
-        &::after {
-            content: "";
-            position: absolute;
-            left: 50%;
-            bottom: $spacer * -0.25;
-            transform: translateX(-50%);
-            width: 0.95em;
-            height: 0.2em;
-            border-radius: $border-radius-pill;
-            background: $danger;
-        }
+        border-bottom: 0.2em solid $danger;
     }
 
     // Grids

--- a/addons/web/static/src/views/calendar/calendar_controller.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller.scss
@@ -49,10 +49,7 @@ $o-cw-filter-avatar-size: 20px;
         width: 230px;
 
         .o_datetime_picker {
-            --DateTimePicker__Cell-size-md: 1.8rem;
-            @include media-breakpoint-up(xl){
-                --DateTimePicker__Cell-size-md: 1.5rem;
-            }
+            --DateTimePicker__Cell-size-md: 1.5rem;
             padding-right: 0 !important;
             padding-left: 0 !important;
 


### PR DESCRIPTION
THis commit fixes the style of the date picker when the today day on the last row as before its creates an overflow and so a scrollbar too.

task-4607085

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
