### PR TITLE
[FIX] mrp: ensure automatic conversion to a unique name for manufactu…

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -49,7 +49,7 @@ class MrpProduction(models.Model):
     def _get_default_is_locked(self):
         return not self.user_has_groups('mrp.group_unlocked_by_default')
 
-    name = fields.Char('Reference', default='New', copy=False, readonly=True)
+    name = fields.Char('Reference', default=lambda self: _('New'), copy=False, readonly=True)
     priority = fields.Selection(
         PROCUREMENT_PRIORITIES, string='Priority', default='0',
         help="Components will be reserved first for the MO with the highest priorities.")


### PR DESCRIPTION
…ring orders

**Issue:**
When using a language other than English and setting the Manufacturing Order name field to read-only via Studio, the name is not automatically converted into a unique value. As a result, after saving the first order (which defaults to "New"), any subsequent order creation fails with an error, stating that the name must be unique.

**Steps to Reproduce:**
1. Install the Manufacturing app.
2. Install the Studio app.
3. Change the language to one other than English.
4. Navigate to Manufacturing > Operations > Manufacturing Orders.
5. Create a new Manufacturing Order.
6. Open Studio and set the name field to read-only.
7. Save the first Manufacturing Order with the default name ("New").
8. Attempt to create another Manufacturing Order.
9. Error: The system prevents saving due to a duplicate name.

Expected Behavior: The Manufacturing Order name should be automatically updated to a unique value upon saving, regardless of the selected language.

Actual Behavior: The name remains "New", but it is not translated when using a different language. Since the name field is set to read-only, the system does not trigger the automatic conversion to a unique name. As a result, when attempting to create another order, the system detects a duplicate and prevents saving due to a name conflict.

**Root Cause**
The system always sets the default name to "New" in English. However, the automatic name conversion process expects a translated name before updating it to a unique value. Because "New" remains untranslated, the system does not recognize it as a placeholder and fails to convert it.

**Fix**
Modify the default value of the name field to use a localized translation like it’s done for the sale order https://github.com/odoo/odoo/blob/7bc38562f1988ba15525c04168e30c06a8f1d33c/addons/sale/models/sale_order.py#L55. This ensures that the default name is translated according to the user's language, allowing the system to properly detect and replace it with a unique value when saving.

Opw-4553109

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
