### PR TITLE
[FIX] base_automation: remove write_date as trigger date id

### DIFF
--- a/addons/base_automation/i18n/base_automation.pot
+++ b/addons/base_automation/i18n/base_automation.pot
@@ -622,3 +622,10 @@ msgid ""
 "You cannot send an email, add followers or create an activity for a deleted "
 "record.  It simply does not work."
 msgstr ""
+
+#. module: base_automation
+#. odoo-python
+#: code:addons/base_automation/models/base_automation.py:0
+#, python-format
+msgid "You cannot set this field to last updated on."
+msgstr ""

--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -53,7 +53,7 @@ class BaseAutomation(models.Model):
         'ir.model.fields', string='Trigger Date',
         compute='_compute_trg_date_id',
         readonly=False, store=True,
-        domain="[('model_id', '=', model_id), ('ttype', 'in', ('date', 'datetime'))]",
+        domain="[('model_id', '=', model_id), ('ttype', 'in', ('date', 'datetime')), ('name', '!=', 'write_date')]",
         help="""When should the condition be triggered.
                 If present, will be checked by the scheduler. If empty, will be checked at creation and update.""")
     trg_date_range = fields.Integer(
@@ -117,6 +117,12 @@ class BaseAutomation(models.Model):
         )
         if invalid:
             invalid.trg_date_id = False
+
+    @api.constrains('trg_date_id')
+    def _check_field_name(self):
+        for record in self:
+            if record.trg_date_id and record.trg_date_id.name == 'write_date':
+                raise exceptions.ValidationError(_("You cannot set this field to last updated on."))
 
     @api.depends('trigger')
     def _compute_trg_date_range_data(self):

--- a/addons/base_automation/tests/test_automation.py
+++ b/addons/base_automation/tests/test_automation.py
@@ -42,7 +42,7 @@ class TestAutomation(TransactionCaseWithUserDemo):
                 "trigger_field_ids": [],
                 "trg_date_range": -60,
                 "trg_date_range_type": "minutes",
-                "trg_date_id": self.env.ref("base.field_res_partner__write_date").id,
+                "trg_date_id": self.env.ref("base.field_res_partner__create_date").id,
             },
             {
                 "name": "Bilbo time senstive reminder late",
@@ -51,7 +51,7 @@ class TestAutomation(TransactionCaseWithUserDemo):
                 "trigger_field_ids": [],
                 "trg_date_range": 60,
                 "trg_date_range_type": "minutes",
-                "trg_date_id": self.env.ref("base.field_res_partner__write_date").id,
+                "trg_date_id": self.env.ref("base.field_res_partner__create_date").id,
             }
             ])
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Time based automated actions used to trigger themselves due to empty writes on the domain records if the automated action is based on write date.

Current behavior before PR:

The automated action is tainting all records are changed by changing the write date.

Desired behavior after PR is merged:

write_date should not be used as the trigger date id as this would be essentially on_update which does not trigger itself again.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
