### PR TITLE
[FIX] html_editor: unwrap base container during paste

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -191,7 +191,11 @@ export class DomPlugin extends Plugin {
         // In case the html inserted is all contained in a single root <p> or <li>
         // tag, we take the all content of the <p> or <li> and avoid inserting the
         // <p> or <li>.
-        if (container.childElementCount === 1 && shouldUnwrap(container.firstChild)) {
+        if (
+            container.childElementCount === 1 &&
+            (this.dependencies.baseContainer.isCandidateForBaseContainer(container.firstChild) ||
+                shouldUnwrap(container.firstChild))
+        ) {
             const nodeToUnwrap = container.firstElementChild;
             container.replaceChildren(...childNodes(nodeToUnwrap));
         } else if (container.childElementCount > 1) {

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -1003,6 +1003,42 @@ describe("Unwrapping html element", () => {
             contentAfter: "<p>a</p><p><br></p><p><br></p><p>[]<br></p>",
         });
     });
+    test("should unwrap base container node when pasting on different empty node", async () => {
+        await testEditor({
+            contentBefore: "<h1>[]<br></h1>",
+            stepFunction: async (editor) => {
+                pasteHtml(editor, "<p>abc</p>");
+            },
+            contentAfter: "<h1>abc[]</h1>",
+        });
+        await testEditor({
+            contentBefore: "<h1>[]<br></h1>",
+            stepFunction: async (editor) => {
+                pasteHtml(editor, '<div class="o-paragraph">abc</div>');
+            },
+            contentAfter: "<h1>abc[]</h1>",
+        });
+        await testEditor({
+            contentBefore: "<h1>[]<br></h1>",
+            stepFunction: async (editor) => {
+                pasteOdooEditorHtml(
+                    editor,
+                    '<p><font style="background-color: rgb(255, 0, 0);">abc</font></p>'
+                );
+            },
+            contentAfter: '<h1><font style="background-color: rgb(255, 0, 0);">abc</font>[]</h1>',
+        });
+        await testEditor({
+            contentBefore: "<h1>[]<br></h1>",
+            stepFunction: async (editor) => {
+                pasteOdooEditorHtml(
+                    editor,
+                    '<div class="o-paragraph"><font style="background-color: rgb(255, 0, 0);">abc</font></div>'
+                );
+            },
+            contentAfter: '<h1><font style="background-color: rgb(255, 0, 0);">abc</font>[]</h1>',
+        });
+    });
 });
 
 describe("Complex html span", () => {


### PR DESCRIPTION
**Current behavior before PR:**

- Before commit [1], when pasting a single paragraph node, only its content was
  inserted, and the paragraph tag was omitted. However, due to these changes,
  the entire paragraph node is now inserted instead of just its content, causing
  the target node to be replaced by the paragraph node.

**Desired behavior after PR is merged:**

- When pasting a single base container, only its content will be inserted.
  As a result,the base container will no longer replace the target block format.

[1]: https://github.com/odoo/odoo/commit/fef32b42beb80eb27bd3c2cfa8c4c2f3c86ad12d

task: 4585788