### PR TITLE
[FIX] purchase: float repr. updated received qty notifcation

### DIFF
--- a/addons/purchase/data/mail_templates.xml
+++ b/addons/purchase/data/mail_templates.xml
@@ -20,7 +20,7 @@
             <strong>The received quantity has been updated.</strong>
             <ul>
                 <li><t t-esc="line.product_id.display_name"/>:</li>
-                Received Quantity: <t t-esc="line.qty_received" /> -&gt; <t t-esc="float(qty_received)"/><br/>
+                Received Quantity: <t t-esc="line.qty_received" /> -&gt; <t t-esc="str_qty_received"/><br/>
             </ul>
         </div>
     </template>

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -10,7 +10,7 @@ from werkzeug.urls import url_encode
 from odoo import api, fields, models, _
 from odoo.osv import expression
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, format_amount, format_date, formatLang, get_lang, groupby
-from odoo.tools.float_utils import float_compare, float_is_zero, float_round
+from odoo.tools.float_utils import float_compare, float_is_zero, float_repr, float_round
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -1491,9 +1491,11 @@ class PurchaseOrderLine(models.Model):
         if  self.env.context.get('accrual_entry_date'):
             return
         if new_qty != self.qty_received and self.order_id.state == 'purchase':
+            precision_digits = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+            str_qty_received = float_repr(new_qty, precision_digits)
             self.order_id.message_post_with_view(
                 'purchase.track_po_line_qty_received_template',
-                values={'line': self, 'qty_received': new_qty},
+                values={'line': self, 'qty_received': new_qty, 'str_qty_received': str_qty_received},
                 subtype_id=self.env.ref('mail.mt_note').id
             )
 


### PR DESCRIPTION
**Current behavior:**
Updating the received qty on a purchase order line will generate a notification in the record chatter, but the new qty value can have an unrounded/untruncated value.

**Expected behavior:**
Order qty adheres to decimal precision value for product uom.

**Steps to reproduce:**
1. Create a purchase order, add a product line, confirm

2. Add `qty_received` to the order line embed view, change it to `6.1` -> shows in chatter as `6.100...5`

**Cause of the issue:**
Quantity given to template is neither rounded nor truncated.

**Fix:**
Use the float repr. (string)  instead of actual numerical value.

opw-4508642