### PR TITLE
[FIX] core: environments got mixed in /web/database/create

### DIFF
--- a/addons/web/controllers/database.py
+++ b/addons/web/controllers/database.py
@@ -83,7 +83,7 @@ class Database(http.Controller):
             with odoo.modules.registry.Registry(name).cursor() as cr:
                 env = odoo.api.Environment(cr, None, {})
                 request.session.authenticate(env, credential)
-                request._save_session()
+                request._save_session(env)
                 request.session.db = name
             return request.redirect('/odoo')
         except Exception as e:

--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -50,11 +50,9 @@ class Session(http.Controller):
                 return {'uid': None}
 
             request.session.db = db
-            # `request.session.authenticate` sets the env on the request, hence the ability to call `_save_session`
-            # even when the request was initially without db or env.
-            request._save_session()
+            request._save_session(env)
 
-            return request.env['ir.http'].session_info()
+            return env['ir.http'].with_user(request.session.uid).session_info()
 
     @http.route('/web/session/get_lang_list', type='jsonrpc', auth="none")
     def get_lang_list(self):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1106,7 +1106,7 @@ class Session(collections.abc.MutableMapping):
         if auth_info.get('mfa') == 'skip' or not user._mfa_url():
             self.finalize(env)
 
-        if request and request.session is self:
+        if request and request.session is self and request.db == env.registry.db_name:
             request.env = env(user=self.uid, context=self.context)
             request.update_context(lang=get_lang(request.env(user=pre_uid)).code)
 
@@ -1842,21 +1842,34 @@ class Request:
         threading.current_thread().url = httprequest.url
         self.httprequest = httprequest
 
-    def _save_session(self):
-        """ Save a modified session on disk. """
+    def _save_session(self, env=None):
+        """
+        Save a modified session on disk.
+
+        :param env: an environment to compute the session token.
+            MUST be left ``None`` (in which case it uses the request's
+            env) UNLESS the database changed.
+        """
         sess = self.session
+        if env is None:
+            env = self.env
 
         if not sess.can_save:
             return
 
         if sess.should_rotate:
-            root.session_store.rotate(sess, self.env)  # it saves
+            root.session_store.rotate(sess, env)  # it saves
         elif sess.is_dirty:
             root.session_store.save(sess)
 
         cookie_sid = self.cookies.get('session_id')
         if sess.is_dirty or cookie_sid != sess.sid:
-            self.future_response.set_cookie('session_id', sess.sid, max_age=get_session_max_inactivity(self.env), httponly=True)
+            self.future_response.set_cookie(
+                'session_id',
+                sess.sid,
+                max_age=get_session_max_inactivity(env),
+                httponly=True
+            )
 
     def _set_request_dispatcher(self, rule):
         routing = rule.endpoint.routing


### PR DESCRIPTION
Login in a database where utm is installed, so you get a session in that database. Now go to /web/database/manager and create a new empty db, the installation completes but you get an Internal Server Error message, in the logs a traceback: UTM is not installed.

The problem is that once the new database has been created, the user automatically gets a new logged-in session inside that new database, but the environment of the original request got (wrongly) updated too, so later on when the request wraps up, we are no longer using the same environment/registry as at the begining of the request and the http stack fails.

Solution: only update the request env if the new env is on the same database.

Btw, the original implementation with httpocalypse got that part right, but when we did f63c0f4 a few years later we couldn't remember why the `if request.db == dbname` was needed and we decided to remove it, turns out it is indeed needed.