### PR TITLE
[IMP] project,*: add task templates

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -61,7 +61,7 @@ class AccountAnalyticLine(models.Model):
     task_id = fields.Many2one(
         'project.task', 'Task', index='btree_not_null',
         compute='_compute_task_id', store=True, readonly=False,
-        domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id)]")
+        domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('has_template_ancestor', '=', False)]")
     parent_task_id = fields.Many2one('project.task', related='task_id.parent_id', store=True, index='btree_not_null')
     project_id = fields.Many2one(
         'project.project', 'Project', domain=_domain_project_id, index=True,

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -37,7 +37,7 @@
                     <t groups="hr_timesheet.group_hr_timesheet_user">
                         <field name="analytic_account_active" invisible="1"/>
                     </t>
-                    <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
+                    <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets or has_template_ancestor" groups="hr_timesheet.group_hr_timesheet_user">
                     <field name="timesheet_ids" mode="list,kanban" readonly="not analytic_account_active" context="{'default_project_id': project_id, 'default_name': ''}">
                         <list editable="top" string="Timesheet Activities" decoration-muted="readonly_timesheet == True">
                             <field name="readonly_timesheet" column_invisible="True"/>

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -69,6 +69,7 @@
             'project/static/src/css/project.css',
             'project/static/src/core/web/**/*',
             'project/static/src/utils/**/*',
+            'project/static/src/actions/client_actions.js',
             'project/static/src/components/**/*',
             'project/static/src/views/**/*',
             'project/static/src/js/tours/project.js',

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -776,6 +776,58 @@
             <field name="parent_id" ref="project.project_1_task_16"/>
             <field name="stage_id" ref="project_stage_2"/>
         </record>
+        <record id="project_1_task_18" model="project.task">
+            <field name="name">[Room Name] Layout Planning</field>
+            <field name="description">
+                <![CDATA[
+                <div>
+                    Plan and finalize the furniture and equipment layout for the [Room Name]. 
+                    Include seating arrangements, lighting needs, power outlets, and accessibility considerations.
+                </div>
+                <h3><br/>Checklist</h3>
+                <ul class="o_checklist">
+                    <li>Measure room dimensions</li>
+                    <li>Identify purpose and capacity</li>
+                    <li>Select furniture and equipment</li>
+                    <li>Create layout draft</li>
+                    <li>Review with design team</li>
+                    <li>Get approval from stakeholders</li>
+                    <li>Finalize and upload blueprint</li>
+                </ul>
+                ]]>
+            </field>
+            <field name="project_id" ref="project.project_project_1"/>
+            <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
+            <field name="tag_ids" eval="[Command.set([ref('project_tags_08')])]"/>
+            <field name="is_template">True</field>
+        </record>
+        <record id="project_1_task_19" model="project.task">
+            <field name="name">[Vendor Name] Furniture Coordination</field>
+            <field name="description">
+                <![CDATA[
+                <div>Coordinate delivery, quality check, and installation with [Vendor Name] for selected furniture items. Ensure schedule alignment and site readiness.</div>
+                ]]>
+            </field>
+            <field name="project_id" ref="project.project_project_1"/>
+            <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
+            <field name="tag_ids" eval="[Command.set([ref('project_tags_05'), ref('project_tags_09')])]"/>
+            <field name="is_template">True</field>
+        </record>
+        <record id="project_1_task_19_subtask_1" model="project.task">
+            <field name="name">Confirm Order and Delivery Date</field>
+            <field name="project_id" ref="project.project_project_1"/>
+            <field name="parent_id" ref="project_1_task_19"/>
+        </record>
+        <record id="project_1_task_19_subtask_2" model="project.task">
+            <field name="name">Prepare Site for Delivery</field>
+            <field name="project_id" ref="project.project_project_1"/>
+            <field name="parent_id" ref="project_1_task_19"/>
+        </record>
+        <record id="project_1_task_19_subtask_3" model="project.task">
+            <field name="name">Log Delivery and Report Issues</field>
+            <field name="project_id" ref="project.project_project_1"/>
+            <field name="parent_id" ref="project_1_task_19"/>
+        </record>
 
         <!-- Project 2 Tasks-->
         <record id="project_2_task_1" model="project.task">

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -65,6 +65,8 @@ class ReportProjectTaskUser(models.Model):
         column2='task_id', string='Block', readonly=True,
         domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
     description = fields.Text(readonly=True)
+    # We exclude template tasks, but we still need the field for the views
+    is_template = fields.Boolean(readonly=True)
 
     def _select(self):
         return """
@@ -96,7 +98,8 @@ class ReportProjectTaskUser(models.Model):
                 NULLIF(t.working_hours_open, 0) as working_hours_open,
                 NULLIF(t.working_hours_close, 0) as working_hours_close,
                 (extract('epoch' from (t.date_deadline-(now() at time zone 'UTC'))))/(3600*24) as delay_endings_days,
-                COUNT(td.task_id) as dependent_ids_count
+                COUNT(td.task_id) as dependent_ids_count,
+                t.is_template
         """
 
     def _group_by(self):
@@ -141,6 +144,7 @@ class ReportProjectTaskUser(models.Model):
     def _where(self):
         return """
                 t.project_id IS NOT NULL
+                AND t.is_template IS NOT TRUE
         """
 
     def init(self):

--- a/addons/project/static/src/actions/client_actions.js
+++ b/addons/project/static/src/actions/client_actions.js
@@ -1,0 +1,58 @@
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+
+export function displayTemplateNotificationAction(env, action) {
+    const params = action.params || {};
+    const taskId = params.task_id;
+    const removeNotification = env.services.notification.add(_t("Task converted to template"), {
+        type: "success",
+        buttons: [
+            {
+                name: "Undo",
+                icon: "fa-undo",
+                onClick: async () => {
+                    const res = await env.services.orm.call(
+                        "project.task",
+                        "action_undo_convert_to_template",
+                        [taskId]
+                    );
+                    if (res) {
+                        env.services.action.doAction(res);
+                    }
+                    removeNotification();
+                },
+            },
+        ],
+    });
+    return params.next;
+}
+
+registry
+    .category("actions")
+    .add("project_show_template_notification", displayTemplateNotificationAction);
+
+export function displayTemplateUndoConfirmationDialog(env, action) {
+    const params = action.params || {};
+    const taskId = params.task_id;
+    env.services.dialog.add(ConfirmationDialog, {
+        body: _t(
+            "This task is already a template. Do you want to convert it back to a regular task?"
+        ),
+        confirmLabel: _t("Convert to Task"),
+        confirm: async () => {
+            await env.services.action.doAction(
+                await env.services.orm.call("project.task", "action_undo_convert_to_template", [
+                    taskId,
+                ])
+            );
+        },
+        cancelLabel: _t("Discard"),
+        cancel: () => {},
+    });
+    return params.next;
+}
+
+registry
+    .category("actions")
+    .add("project_show_template_undo_confirmation_dialog", displayTemplateUndoConfirmationDialog);

--- a/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { pick } from "@web/core/utils/objects";
 import { X2ManyField, x2ManyField } from '@web/views/fields/x2many/x2many_field';
 
 import { SubtaskListRenderer } from './subtask_list_renderer';
@@ -8,6 +9,28 @@ export class SubtaskOne2ManyField extends X2ManyField {
         ...X2ManyField.components,
         ListRenderer: SubtaskListRenderer,
     };
+
+    async switchToForm(record, options) {
+        await this.props.record.save();
+        this.action.doAction(
+            {
+                type: "ir.actions.act_window",
+                views: [[false, "form"]],
+                res_id: record.resId,
+                res_model: this.list.resModel,
+                context: pick(
+                    this.props.context,
+                    "active_test",
+                    "default_project_id",
+                    "propagate_not_active"
+                ),
+            },
+            {
+                props: { resIds: this.list.resIds },
+                newWindow: options.newWindow,
+            }
+        );
+    }
 }
 
 export const subtaskOne2ManyField = {

--- a/addons/project/static/src/views/components/project_task_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.js
@@ -1,0 +1,62 @@
+import { Component, onWillStart } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+export class ProjectTaskTemplateDropdown extends Component {
+    static template = "project.TemplateDropdown";
+
+    static props = {
+        hotkey: {
+            type: String,
+            optional: true,
+        },
+        newButtonClasses: String,
+        onCreate: Function,
+        // Can be a number, false (in to-do) or undefined
+        projectId: {
+            type: [Number, Boolean],
+            optional: true,
+        },
+        context: Object,
+        getAdditionalContext: {
+            type: Function,
+            optional: true,
+        },
+    };
+    static defaultProps = {
+        hotkey: "r",
+        projectId: null,
+    };
+
+    setup() {
+        this.action = useService("action");
+        this.orm = useService("orm");
+        onWillStart(this.onWillStart);
+        this.taskTemplates = [];
+    }
+
+    async onWillStart() {
+        if (this.props.projectId) {
+            this.taskTemplates = await this.orm.call("project.project", "get_template_tasks", [
+                this.props.projectId,
+            ]);
+        }
+    }
+
+    async createTaskFromTemplate(templateId) {
+        const context = { ...this.props.context };
+        if (this.props.getAdditionalContext) {
+            Object.assign(context, this.props.getAdditionalContext());
+        }
+        this.action.switchView("form", {
+            resId: await this.orm.call(
+                "project.task",
+                "action_create_from_template",
+                [templateId],
+                {
+                    context: context,
+                }
+            ),
+            focusTitle: true,
+        });
+    }
+}

--- a/addons/project/static/src/views/components/project_task_template_dropdown.xml
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="project.TemplateDropdown">
+        <button t-if="!taskTemplates.length" type="button" t-att-class="props.newButtonClasses" t-att-data-hotkey="props.hotkey" t-on-click.stop="props.onCreate" data-bounce-button="">New</button>
+        <t t-else="">
+            <a t-attf-class="{{ props.newButtonClasses }} dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" t-att-data-hotkey="props.hotkey" data-bounce-button="">
+                New
+            </a>
+            <ul class="dropdown-menu o-project-form-dropdown-menu">
+                <button type="button" class="btn btn-link dropdown-item o-dropdown-item" t-on-click="props.onCreate">
+                    New Task
+                </button>
+                <div class="dropdown-divider"/>
+                <div class="dropdown-header" style="padding-left: 20px;">Task Templates</div>
+                <t t-foreach="taskTemplates" t-as="template" t-key="template.id">
+                    <button type="button" class="btn btn-link o-dropdown-item dropdown-item" style="padding-left: 32px;" t-on-click="() =&gt; this.createTaskFromTemplate(template.id)" t-out="template.name"/>
+                </t>
+            </ul>
+        </t>
+    </t>
+</templates>

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.js
@@ -2,9 +2,11 @@ import { _t } from "@web/core/l10n/translation";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { HistoryDialog } from "@html_editor/components/history_dialog/history_dialog";
 import { useService } from '@web/core/utils/hooks';
-import { markup } from '@odoo/owl';
+import { markup, useEffect } from "@odoo/owl";
 import { escape } from '@web/core/utils/strings';
 import { FormControllerWithHTMLExpander } from '@resource/views/form_with_html_expander/form_controller_with_html_expander';
+
+import { ProjectTaskTemplateDropdown } from "../components/project_task_template_dropdown";
 
 export const subTaskDeleteConfirmationMessage = _t(
     `Deleting a task will also delete its associated sub-tasks. \
@@ -14,9 +16,41 @@ Are you sure you want to proceed?`
 );
 
 export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
+    static template = "project.ProjectTaskFormView";
+    static components = {
+        ...FormControllerWithHTMLExpander.components,
+        ProjectTaskTemplateDropdown,
+    };
+
+    static props = {
+        ...FormControllerWithHTMLExpander.props,
+        focusTitle: {
+            type: Boolean,
+            optional: true,
+        },
+    };
+    static defaultProps = {
+        ...FormControllerWithHTMLExpander.defaultProps,
+        focusTitle: false,
+    };
+
     setup() {
         super.setup();
         this.notifications = useService("notification");
+
+        if (this.props.focusTitle) {
+            useEffect(
+                () => {
+                    if (this.rootRef) {
+                        const title = this.rootRef.el.querySelector("#name_0");
+                        if (title) {
+                            title.focus();
+                        }
+                    }
+                },
+                () => []
+            );
+        }
     }
 
     /**

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.xml
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.ProjectTaskFormView" t-inherit="resource.FormViewWithHtmlExpander" t-inherit-mode="primary">
+        <button class="btn btn-outline-primary o_form_button_create" position="replace">
+            <ProjectTaskTemplateDropdown
+                projectId="props.context.default_project_id"
+                onCreate="() =&gt; this.create()"
+                newButtonClasses="'btn btn-outline-primary o_form_button_create'"
+                context="props.context"
+            />
+        </button>
+    </t>
+</templates>

--- a/addons/project/static/src/views/project_task_form/project_task_form_view.scss
+++ b/addons/project/static/src/views/project_task_form/project_task_form_view.scss
@@ -21,3 +21,7 @@
         margin-bottom: 0;
     }
 }
+
+.o-project-form-dropdown-menu {
+    z-index: 1030 !important;
+}

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.js
@@ -1,0 +1,16 @@
+import { KanbanController } from "@web/views/kanban/kanban_controller";
+
+import { ProjectTaskTemplateDropdown } from "../components/project_task_template_dropdown";
+
+export class ProjectTaskKanbanController extends KanbanController {
+    static template = "project.ProjectTaskKanbanView";
+    static components = {
+        ...KanbanController.components,
+        ProjectTaskTemplateDropdown,
+    };
+
+    setup() {
+        super.setup();
+        this.hideGhostColumns = this.props.context.hide_kanban_ghost_columns;
+    }
+}

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.ProjectTaskKanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
+        <button class="btn btn-primary o-kanban-button-new" position="replace">
+            <ProjectTaskTemplateDropdown
+                projectId="props.context.default_project_id"
+                onCreate="() =&gt; this.createRecord()"
+                newButtonClasses="'btn btn-primary o-kanban-button-new'"
+                context="props.context"
+            />
+        </button>
+        <t t-component="props.Renderer" position="attributes">
+            <attribute name="hideGhostColumns">hideGhostColumns</attribute>
+        </t>
+    </t>
+</templates>

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
@@ -6,11 +6,14 @@ import { onWillStart } from "@odoo/owl";
 import { user } from "@web/core/user";
 
 export class ProjectTaskKanbanRenderer extends KanbanRenderer {
+    static template = "project.ProjectTaskKanbanRenderer";
     static components = {
         ...KanbanRenderer.components,
         KanbanRecord: ProjectTaskKanbanRecord,
         KanbanHeader: ProjectTaskKanbanHeader,
     };
+
+    static props = [...KanbanRenderer.props, "hideGhostColumns?"];
 
     setup() {
         super.setup();

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.xml
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.ProjectTaskKanbanRenderer" t-inherit="web.KanbanRenderer" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_kanban_example_background_container')]" position="attributes">
+            <attribute name="t-if">props.list.groups.length === 0 &amp;&amp; !props.hideGhostColumns</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.js
@@ -1,5 +1,6 @@
 import { registry } from "@web/core/registry";
 import { kanbanView } from '@web/views/kanban/kanban_view';
+import { ProjectTaskKanbanController } from "./project_task_kanban_controller";
 import { ProjectTaskKanbanModel } from "./project_task_kanban_model";
 import { ProjectTaskKanbanRenderer } from './project_task_kanban_renderer';
 
@@ -7,6 +8,7 @@ export const projectTaskKanbanView = {
     ...kanbanView,
     Model: ProjectTaskKanbanModel,
     Renderer: ProjectTaskKanbanRenderer,
+    Controller: ProjectTaskKanbanController,
 };
 
 registry.category('views').add('project_task_kanban', projectTaskKanbanView);

--- a/addons/project/static/src/views/project_task_list/project_task_list_controller.js
+++ b/addons/project/static/src/views/project_task_list/project_task_list_controller.js
@@ -1,7 +1,14 @@
 import { ListController } from "@web/views/list/list_controller";
 import { subTaskDeleteConfirmationMessage } from "@project/views/project_task_form/project_task_form_controller";
 
+import { ProjectTaskTemplateDropdown } from "../components/project_task_template_dropdown";
+
 export class ProjectTaskListController extends ListController {
+    static template = "project.ProjectTaskListView";
+    static components = {
+        ...ListController.components,
+        ProjectTaskTemplateDropdown,
+    };
 
     get deleteConfirmationDialogProps() {
         const deleteConfirmationDialogProps = super.deleteConfirmationDialogProps;

--- a/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
+++ b/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.ProjectTaskListView" t-inherit="web.ListView" t-inherit-mode="primary">
+        <button class="btn btn-primary o_list_button_add" position="replace">
+            <ProjectTaskTemplateDropdown 
+                projectId="props.context.default_project_id"
+                onCreate="() =&gt; this.onClickCreate()"
+                newButtonClasses="'btn btn-primary o_list_button_add'"
+                context="props.context"
+            />
+        </button>
+    </t>
+</templates>

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -30,7 +30,17 @@ export class ProjectProject extends models.Model {
 
     check_access_rights() {
         return Promise.resolve(true);
-    };
+    }
+
+    get_template_tasks(projectId) {
+        return this.env["project.task"].search_read(
+            [
+                ["project_id", "=", projectId],
+                ["is_template", "=", true],
+            ],
+            ["id", "name"]
+        );
+    }
 }
 
 export class ProjectProjectStage extends models.Model {
@@ -91,6 +101,7 @@ export class ProjectTask extends models.Model {
     depend_on_ids = fields.Many2many({ relation: "project.task" });
     closed_depend_on_count = fields.Integer();
     is_closed = fields.Boolean();
+    is_template = fields.Boolean({ string: "Is Template", default: false });
 
     _records = [
         {

--- a/addons/project/static/tests/project_task_template_dropdown.test.js
+++ b/addons/project/static/tests/project_task_template_dropdown.test.js
@@ -1,0 +1,116 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { contains, mountView } from "@web/../tests/web_test_helpers";
+
+import { defineProjectModels, ProjectTask } from "./project_models";
+
+defineProjectModels();
+
+function addTemplateTasks() {
+    ProjectTask._records.push(
+        {
+            id: 4,
+            name: "Template Task 1",
+            project_id: 1,
+            stage_id: 1,
+            state: "01_in_progress",
+            is_template: true,
+        },
+        {
+            id: 5,
+            name: "Template Task 2",
+            project_id: 1,
+            stage_id: 1,
+            state: "01_in_progress",
+            is_template: true,
+        }
+    );
+}
+
+beforeEach(() => {
+    ProjectTask._views = {
+        form: `
+            <form js_class="project_task_form">
+                <field name="name"/>
+            </form>
+        `,
+        kanban: `
+            <kanban js_class="project_task_kanban">
+                <templates>
+                    <t t-name="card">
+                        <field name="name"/>
+                    </t>
+                </templates>
+            </kanban>
+        `,
+        list: `
+            <list js_class="project_task_list">
+                <field name="name"/>
+            </list>
+        `,
+    };
+});
+
+for (const [viewType, newButtonClass] of [
+    ["form", ".o_form_button_create"],
+    ["kanban", ".o-kanban-button-new"],
+    ["list", ".o_list_button_add"],
+]) {
+    test(`template dropdown in ${viewType} view of a project with no template`, async () => {
+        await mountView({
+            resModel: "project.task",
+            resId: 1,
+            type: viewType,
+            context: {
+                default_project_id: 1,
+            },
+        });
+        expect(newButtonClass).toHaveCount(1, {
+            message: "The “New” button should be displayed",
+        });
+        expect(newButtonClass).not.toHaveClass("dropdown-toggle", {
+            message: "The “New” button should not be a dropdown since there is no template",
+        });
+
+        // Test that we can create a new record without errors
+        await contains(`${newButtonClass}`).click();
+    });
+
+    test(`template dropdown in ${viewType} view of a project with one template`, async () => {
+        addTemplateTasks();
+        await mountView({
+            resModel: "project.task",
+            resId: 1,
+            type: viewType,
+            context: {
+                default_project_id: 1,
+            },
+        });
+        expect(newButtonClass).toHaveCount(1, {
+            message: "The “New” button should be displayed",
+        });
+        expect(newButtonClass).toHaveClass("dropdown-toggle", {
+            message: "The “New” button should be a dropdown since there is a template",
+        });
+
+        await contains(newButtonClass).click();
+        expect("button.dropdown-item:contains('New Task')").toHaveCount(1, {
+            message: "The “New Task” button should be in the dropdown",
+        });
+        expect("button.dropdown-item:contains('Template Task 1')").toHaveCount(1, {
+            message: "There should be a button named after the task template",
+        });
+    });
+}
+
+test("template dropdown should not appear when not in the context of a specific project", async () => {
+    addTemplateTasks();
+    await mountView({
+        resModel: "project.task",
+        type: "kanban",
+    });
+
+    expect(".o-kanban-button-new").not.toHaveClass("dropdown-toggle", {
+        message:
+            "The “New” button should not be a dropdown since there is no project in the context",
+    });
+});

--- a/addons/project/static/tests/tours/project_task_templates_tour.js
+++ b/addons/project/static/tests/tours/project_task_templates_tour.js
@@ -1,0 +1,47 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("project_task_templates_tour", {
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
+            run: "click",
+        },
+        {
+            trigger: '.o_kanban_record span:contains("Project with Task Template")',
+            run: "click",
+            content: "Navigate to the project with a task template",
+        },
+        {
+            trigger: 'div.o_last_breadcrumb_item span:contains("Project with Task Template")',
+            content: "Wit for the kanban view to load",
+        },
+        {
+            trigger: "a.o-kanban-button-new",
+            run: "click",
+        },
+        {
+            trigger: 'ul.dropdown-menu button.dropdown-item:contains("Template")',
+            run: "click",
+            content: "Create a task with the template",
+        },
+        {
+            trigger: 'div[name="name"] .o_input',
+            run: "edit Task",
+        },
+        {
+            trigger: "button.o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
+        {
+            trigger: 'div.note-editable.odoo-editor-editable:contains("Template description")',
+            content: "Check that the created task has copied the description of the template",
+        },
+    ],
+});

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -26,6 +26,8 @@ from . import test_multicompany
 from . import test_personal_stages
 from . import test_task_dependencies
 from . import test_task_follow
+from . import test_task_templates
+from . import test_task_templates_ui
 from . import test_task_tracking
 from . import test_project_report
 from . import test_project_task_quick_create

--- a/addons/project/tests/test_task_templates.py
+++ b/addons/project/tests/test_task_templates.py
@@ -1,0 +1,96 @@
+from odoo.addons.project.tests.test_project_base import TestProjectCommon
+
+
+class TestTaskTemplates(TestProjectCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project_with_templates = cls.env["project.project"].create({
+            "name": "Project with Task Template",
+        })
+        cls.template_task = cls.env["project.task"].create({
+            "name": "Template",
+            "project_id": cls.project_with_templates.id,
+            "is_template": True,
+            "description": "Template description",
+            "partner_id": cls.partner_1.id,
+        })
+        cls.child_task = cls.env["project.task"].create({
+            "name": "Child Task",
+            "parent_id": cls.template_task.id,
+            "description": "Child description",
+            "partner_id": cls.partner_2.id,
+        })
+
+    def test_create_from_template(self):
+        """
+        Creating a task through the action should result in a non template copy, with no partner_id
+        """
+        task_id = self.template_task.action_create_from_template()
+        task = self.env["project.task"].browse(task_id)
+        self.assertFalse(task.is_template, "The created task should be a normal task and not a template.")
+        self.assertFalse(task.partner_id, "The created task should not have a partner.")
+
+        self.assertEqual(len(task.child_ids), 1, "The child of the template should be copied too.")
+        child_task = task.child_ids
+        self.assertFalse(child_task.is_template, "The child task should still not be a template.")
+        self.assertFalse(child_task.partner_id, "The child task should also not have a partner.")
+
+        # With a partner set on the project, new tasks should get the partner too, even if created from a template
+        self.project_with_templates.partner_id = self.partner_3
+
+        task_id = self.template_task.action_create_from_template()
+        task = self.env["project.task"].browse(task_id)
+        self.assertEqual(task.partner_id, self.partner_3, "The created task should have the same partner as the project.")
+        child_task = task.child_ids
+        self.assertEqual(child_task.partner_id, self.partner_3, "The child of the created task should have the same partner as the project.")
+
+    def test_copy_template(self):
+        """
+        A copy of a template should be a template
+        """
+        copied_template = self.template_task.copy()
+        self.assertTrue(copied_template.is_template, "The copy of the template should also be a template.")
+        self.assertEqual(len(copied_template.child_ids), 1, "The child of the template should be copied too.")
+        copied_template_child_task = copied_template.child_ids
+        self.assertFalse(copied_template_child_task.is_template, "The child of the copy should still not be a template.")
+
+    def test_copy_project_with_templates(self):
+        """
+        Copying a project should also copy its task templates
+        """
+        copied_project = self.project_with_templates.copy()
+        task = self.env["project.task"].search([("project_id", "=", copied_project.id)], order="id asc", limit=1)
+        self.assertTrue(task, "The copied project should contain a copy of the template.")
+        self.assertTrue(task.is_template, "The copied template should still be a template.")
+
+    def test_has_template_ancestor(self):
+        self.assertTrue(self.template_task.has_template_ancestor, "The template is a template.")
+        self.assertTrue(self.child_task.has_template_ancestor, "The child of the template has a template ancestor.")
+
+        task = self.env["project.task"].create({
+            "name": "Task",
+            "project_id": self.project_with_templates.id,
+        })
+        self.assertFalse(task.has_template_ancestor, "The task does not have ancestors and is not a template.")
+
+        child = self.env["project.task"].create({
+            "name": "Child",
+            "parent_id": task.id,
+        })
+        self.assertFalse(child.has_template_ancestor, "The task has ancestors, but none of them are templates.")
+
+        self.assertCountEqual(
+            self.env["project.task"].search(
+                [('project_id', '=', self.project_with_templates.id), ('has_template_ancestor', '=', True)],
+            ),
+            self.template_task | self.child_task,
+            "The search should find the template and its child",
+        )
+        self.assertCountEqual(
+            self.env["project.task"].search(
+                [('project_id', '=', self.project_with_templates.id), ('has_template_ancestor', '=', False)],
+            ),
+            task | child,
+            "The search should find the non template task and its child",
+        )

--- a/addons/project/tests/test_task_templates_ui.py
+++ b/addons/project/tests/test_task_templates_ui.py
@@ -1,0 +1,23 @@
+from odoo import Command
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestTaskTemplatesTour(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project_with_templates = cls.env["project.project"].create({
+            "name": "Project with Task Template",
+            "type_ids": [Command.link(cls.env.ref("project.project_project_stage_0").id)],
+        })
+        cls.template_task = cls.env["project.task"].create({
+            "name": "Template",
+            "project_id": cls.project_with_templates.id,
+            "is_template": True,
+            "description": "Template description",
+            "stage_id": cls.env.ref("project.project_project_stage_0").id,
+        })
+
+    def test_task_templates_tour(self):
+        self.start_tour("/odoo", "project_task_templates_tour", login="admin")

--- a/addons/project/views/project_menus.xml
+++ b/addons/project/views/project_menus.xml
@@ -104,6 +104,11 @@
                 action="project_tags_action"
             />
             <menuitem
+                name="Task Templates"
+                id="project_menu_config_task_templates"
+                action="project_task_templates_action"
+            />
+            <menuitem
                 name="Activity Types"
                 id="project_menu_config_activity_type"
                 action="mail_activity_type_action_config_project_types"

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -203,7 +203,7 @@
             <field name="path">tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
-            <field name="domain">[('project_id', '=', active_id)]</field>
+            <field name="domain">[('project_id', '=', active_id), ('has_template_ancestor', '=', False)]</field>
             <field name="context">{
                 'default_project_id': active_id,
                 'show_project_update': True,
@@ -330,6 +330,7 @@
                     <field name="depend_on_count" invisible="1"/>
                     <field name="closed_depend_on_count" invisible="1"/>
                     <field name="html_field_history_metadata" invisible="1"/>
+                    <field name="is_template" invisible="1"/>
                     <header>
                         <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not project_id and not stage_id"/>
                         <field name="state" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="1"/>
@@ -346,7 +347,7 @@
                         <span id="start_rating_buttons" invisible="1"/>
                         <field name="rating_avg" invisible="1"/>
                         <field name="rating_active" invisible="1"/>
-                        <button name="action_open_ratings" type="object" invisible="rating_count == 0 or not rating_active" class="oe_stat_button" groups="project.group_project_rating">
+                        <button name="action_open_ratings" type="object" invisible="rating_count == 0 or not rating_active or has_template_ancestor" class="oe_stat_button" groups="project.group_project_rating">
                             <i class="fa fa-fw o_button_icon fa-smile-o text-success" invisible="rating_avg &lt; 3.66" title="Happy"/>
                             <i class="fa fa-fw o_button_icon fa-meh-o text-warning" invisible="rating_avg &lt; 2.33 or rating_avg &gt;= 3.66" title="Neutral"/>
                             <i class="fa fa-fw o_button_icon fa-frown-o text-danger" invisible="rating_avg &gt;= 2.33" title="Unhappy"/>
@@ -388,15 +389,16 @@
                         <!-- Dummy tag used to organize buttons -->
                         <span id="end_button_box" invisible="1"/>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or is_template"/>
+                    <widget name="web_ribbon" title="Template" bg_color="text-bg-info" invisible="not is_template"/>
                     <h1 class="d-flex justify-content-between align-items-center">
                         <div class="d-flex w-100">
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
                         </div>
-                        <div class="d-flex justify-content-end o_state_container" invisible="not active">
+                        <div class="d-flex justify-content-end o_state_container" invisible="not active or is_template">
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>
-                        <div class="d-flex justify-content-start o_state_container w-100 w-md-50 w-lg-25" invisible="active">
+                        <div class="d-flex justify-content-start o_state_container w-100 w-md-50 w-lg-25" invisible="active and not is_template">
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>
                     </h1>
@@ -404,7 +406,7 @@
                         <group>
                             <field name="project_id"
                                 domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
-                                required="parent_id or child_ids"
+                                required="parent_id or child_ids or is_template"
                                 widget="project"/>
                             <field name="milestone_id"
                                 placeholder="e.g. Product Launch"
@@ -419,7 +421,7 @@
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
-                            <field name="partner_id" nolabel="0" widget="res_partner_many2one" class="o_task_customer_field" invisible="not project_id"/>
+                            <field name="partner_id" nolabel="0" widget="res_partner_many2one" class="o_task_customer_field" invisible="not project_id or has_template_ancestor"/>
                             <label for="date_deadline"/>
                             <div id="date_deadline_and_recurring_task" class="d-inline-flex w-100">
                                 <field name="date_deadline" nolabel="1" decoration-danger="date_deadline and date_deadline &lt; current_date and state not in ['1_done', '1_canceled']"/>
@@ -457,11 +459,14 @@
                                         'default_parent_id': id,
                                         'default_partner_id': partner_id,
                                         'default_milestone_id': allow_milestones and milestone_id,
+                                        'default_is_template': False,
                                         'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
                                         'closed_X2M_count': closed_subtask_count,
                                    }"
                                    widget="subtasks_one2many">
                                 <list editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
+                                    <field name="active" column_invisible="True"/>
+                                    <field name="is_template" column_invisible="True"/>
                                     <field name="allow_milestones" column_invisible="True"/>
                                     <field name="display_in_project" column_invisible="True" force_save="1"/>
                                     <field name="sequence" widget="handle"/>
@@ -478,7 +483,7 @@
                                         context="{'default_project_id': project_id}"
                                         column_invisible="not parent.allow_milestones"
                                         invisible="not allow_milestones"/>
-                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id"/>
+                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="parent.has_template_ancestor"/>
                                     <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
                                     <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                                     <field name="company_id" column_invisible="True"/>
@@ -522,7 +527,7 @@
                                         context="{'default_project_id': project_id}"
                                         column_invisible="not parent.allow_milestones"
                                         invisible="not allow_milestones"/>
-                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id"/>
+                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="has_template_ancestor"/>
                                     <field name="parent_id" optional="hide" groups="base.group_no_one"/>
                                     <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
                                     <field name="company_id" optional="hide" groups="base.group_multi_company" />
@@ -592,6 +597,7 @@
                                placeholder="Private"
                                class="o_project_task_project_field"
                                domain="[('type_ids', 'in', context['default_stage_id'])] if context.get('default_stage_id') else []"
+                               required="is_template"
                         />
                         <field name="user_ids" options="{'no_open': True, 'no_quick_create': True}"
                             widget="many2many_avatar_user"/>
@@ -858,7 +864,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
             <field name="context">{'search_default_my_tasks': 1}</field>
-            <field name="domain">[('project_id', '!=', False)]</field>
+            <field name="domain">[('project_id', '!=', False), ('has_template_ancestor', '=', False)]</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
@@ -1009,7 +1015,7 @@
                 'default_user_ids': [(4, uid)],
             }</field>
             <field name="search_view_id" ref="view_task_search_form"/>
-            <field name="domain">[('user_ids', 'in', uid)]</field>
+            <field name="domain">[('user_ids', 'in', uid), ('has_template_ancestor', '=', False)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No tasks found. Let's create one!
@@ -1059,7 +1065,7 @@
             <field name="res_model">project.task</field>
             <field name="path">all-tasks</field>
             <field name="view_mode">list,kanban,form,calendar,activity,pivot,graph</field>
-            <field name="domain">[]</field>
+            <field name="domain">[('has_template_ancestor', '=', False)]</field>
             <field name="context">{'search_default_open_tasks': 1, 'default_user_ids': [(4, uid)]}</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
@@ -1115,6 +1121,18 @@
             </field>
         </record>
 
+        <record id="action_server_convert_to_template" model="ir.actions.server">
+            <field name="name">Convert to Template</field>
+            <field name="model_id" ref="project.model_project_task"/>
+            <field name="binding_model_id" ref="project.model_project_task"/>
+            <field name="binding_view_types">form</field>
+            <field name="group_ids" eval="[Command.link(ref('project.group_project_manager'))]"/>
+            <field name="state">code</field>
+            <field name="code">
+                action = record.action_convert_to_template()
+            </field>
+        </record>
+
         <!-- Views for 'Tasks' stat button via Contact form -->
         <record id="view_task_form_res_partner" model="ir.ui.view">
             <field name="name">project.task.form.res.partner</field>
@@ -1158,6 +1176,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">list,kanban,form,calendar,pivot,graph,activity</field>
             <field name="search_view_id" ref="view_task_search_form"/>
+            <field name="domain">[('has_template_ancestor', '=', False)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No tasks found. Let's create one!
@@ -1197,7 +1216,7 @@
             <field name="name">Overpassed Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">list,form,calendar,graph,kanban</field>
-            <field name="domain">[('is_closed', '=', False), ('date_deadline','&lt;',time.strftime('%Y-%m-%d')), ('project_id', '!=', False)]</field>
+            <field name="domain">[('is_closed', '=', False), ('date_deadline','&lt;',time.strftime('%Y-%m-%d')), ('project_id', '!=', False), ('has_template_ancestor', '=', False)]</field>
             <field name="filter" eval="True"/>
             <field name="search_view_id" ref="view_task_search_form"/>
         </record>
@@ -1207,7 +1226,7 @@
             <field name="res_model">project.task</field>
             <field name="name">Project's tasks</field>
             <field name="view_mode">list,form,calendar,graph,kanban</field>
-            <field name="domain">[('project_id', '=', active_id)]</field>
+            <field name="domain">[('project_id', '=', active_id), ('has_template_ancestor', '=', False)]</field>
             <field name="context">{'project_id':active_id}</field>
         </record>
 
@@ -1243,6 +1262,7 @@
             <field name="name">Tasks.test</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
+            <field name="domain">[('has_template_ancestor', '=', False)]</field>
             <field name="context">{'default_project_id': active_id}</field>
         </record>
 
@@ -1279,6 +1299,75 @@
             <field name="sequence" eval="70"/>
             <field name="view_mode">graph</field>
             <field name="view_id" ref="project_task_graph_view_project_milestone"/>
+        </record>
+
+        <record id="project_task_templates_list" model="ir.ui.view">
+            <field name="name">project.task.templates.list</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="project_task_view_tree_base"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <field name="project_id" position="attributes">
+                    <attribute name="readonly">False</attribute>
+                    <attribute name="required">is_template</attribute>
+                </field>
+                <field name="partner_id" position="replace"/>
+            </field>
+        </record>
+
+        <record id="project_task_templates_kanban" model="ir.ui.view">
+            <field name="name">project.task.templates.list</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="view_task_kanban"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <kanban position="attributes">
+                    <attribute name="default_group_by">project_id</attribute>
+                </kanban>
+                <xpath expr="//templates//field[@name='partner_id']" position="replace"/>
+            </field>
+        </record>
+
+        <record id="view_task_template_search_form" model="ir.ui.view">
+            <field name="name">project.task.search.form</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="view_task_search_form"></field>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <filter name="private_tasks" position="replace"/>
+                <filter name="closed_on" position="replace"/>
+                <filter name="customer" position="replace"/>
+            </field>
+        </record>
+
+        <record id="project_task_templates_action" model="ir.actions.act_window">
+            <field name="name">Task Templates</field>
+            <field name="res_model">project.task</field>
+            <field name="view_mode">list,kanban,form</field>
+            <field name="domain">[('is_template', '=', True)]</field>
+            <field name="context">{'default_is_template': True, 'hide_kanban_ghost_columns': True}</field>
+            <field name="search_view_id" ref="view_task_template_search_form"/>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No task templates found. Let's create one!
+                </p>
+                <p>
+                    Save time by using task templates with pre-filled details.<br/>
+                    Standardize workflows and ensure consistency across tasks.
+                </p>
+            </field>
+        </record>
+
+        <record id="project_task_templates_action_list" model="ir.actions.act_window.view">
+            <field name="act_window_id" ref="project_task_templates_action"/>
+            <field name="view_mode">list</field>
+            <field name="view_id" ref="project.project_task_templates_list"/>
+        </record>
+
+        <record id="project_task_templates_action_kanban" model="ir.actions.act_window.view">
+            <field name="act_window_id" ref="project_task_templates_action"/>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="project.project_task_templates_kanban"/>
         </record>
 
 </odoo>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -748,6 +748,7 @@
             <field name="arch" type="xml">
                 <list position="attributes">
                     <attribute name="multi_edit">1</attribute>
+                    <attribute name="js_class">project_task_list</attribute>
                 </list>
                 <field name="date_deadline" position="after">
                     <field name="activity_ids" string="Next Activity" widget="list_activity" optional="show"/>
@@ -780,7 +781,6 @@
             <field name="priority">2</field>
             <field name="arch" type="xml">
                 <list position="attributes">
-                    <attribute name="js_class">project_task_list</attribute>
                     <attribute name="default_group_by">stage_id</attribute>
                 </list>
             </field>

--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -11,7 +11,7 @@ class AccountAnalyticLine(models.Model):
 
     holiday_id = fields.Many2one("hr.leave", string='Time Off Request', copy=False, index='btree_not_null', export_string_translation=False)
     global_leave_id = fields.Many2one("resource.calendar.leaves", string="Global Time Off", index='btree_not_null', ondelete='cascade', export_string_translation=False)
-    task_id = fields.Many2one(domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('is_timeoff_task', '=', False)]")
+    task_id = fields.Many2one(domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('has_template_ancestor', '=', False), ('is_timeoff_task', '=', False)]")
 
     def _get_redirect_action(self):
         leave_form_view_id = self.env.ref('hr_holidays.hr_leave_view_form').id

--- a/addons/project_timesheet_holidays/models/res_config_settings.py
+++ b/addons/project_timesheet_holidays/models/res_config_settings.py
@@ -14,7 +14,7 @@ class ResConfigSettings(models.TransientModel):
              " You can specify another project on each time off type individually.")
     leave_timesheet_task_id = fields.Many2one(
         related='company_id.leave_timesheet_task_id', string="Time Off Task", readonly=False,
-        domain="[('company_id', '=', company_id), ('project_id', '=?', internal_project_id)]",
+        domain="[('company_id', '=', company_id), ('project_id', '=?', internal_project_id), ('has_template_ancestor', '=', False)]",
         help="The default task used when automatically generating timesheets via time off requests."
              " You can specify another task on each time off type individually.")
 

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -166,7 +166,7 @@
             <xpath expr="//span[@id='start_rating_buttons']" position="before">
                 <button class="oe_stat_button"
                         type="object" name="action_view_so" icon="fa-dollar"
-                        invisible="not sale_order_id"
+                        invisible="not sale_order_id or has_template_ancestor"
                         groups="sales_team.group_sale_salesman">
                         <div class="o_stat_info">
                             <span class="o_stat_text">Sales Order</span>
@@ -177,16 +177,16 @@
                 <attribute name="context">{'default_project_id': context.get('default_project_id'), 'default_sale_line_id': sale_line_id}</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
-                <attribute name="invisible">not allow_billable</attribute>
+                <attribute name="invisible">not allow_billable or has_template_ancestor</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="project_sale_order_id" invisible="1"/>
                 <field name="sale_order_id" invisible="True" groups="sales_team.group_sale_salesman"/>
-                <label for="sale_line_id" invisible="not allow_billable or not project_id or not partner_id"/>
+                <label for="sale_line_id" invisible="not allow_billable or not project_id or not partner_id or has_template_ancestor"/>
                 <div 
                     name="sale_line_div"
                     class="o_row"
-                    invisible="not allow_billable or not project_id or not partner_id">
+                    invisible="not allow_billable or not project_id or not partner_id or has_template_ancestor">
                     <field name="sale_line_id"
                         groups="!sales_team.group_sale_salesman"
                         string="Sales Order Item"
@@ -221,8 +221,9 @@
                        context="{'create': False, 'edit': False, 'delete': False, 'with_price_unit': True}"
                        placeholder="Non-billable"
                        groups="sales_team.group_sale_salesman"
-                       invisible="not allow_billable"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman"/>
+                       invisible="not allow_billable"
+                       column_invisible="parent.has_template_ancestor"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor"/>
                 <field name="allow_billable" column_invisible="True"/>
             </xpath>
             <xpath expr="//field[@name='child_ids']/list/field[@name='partner_id']" position="attributes">
@@ -230,8 +231,8 @@
                 <attribute name="invisible">not allow_billable</attribute>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/list/field[@name='partner_id']" position="after">
-                <field name="sale_line_id" optional="hide" readonly="1" groups="sales_team.group_sale_salesman"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman"/>
+                <field name="sale_line_id" optional="hide" readonly="1" groups="sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor"/>
                 <field name="allow_billable" column_invisible="True"/>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/list/field[@name='partner_id']" position="attributes">


### PR DESCRIPTION
*=hr_timesheet,sale_project

Purpose
-------

This PR introduces task templates in the Project app, allowing tasks to be marked as reusable templates within a project. Templates can then be selected when creating new tasks, enabling faster task creation with consistent content and structure. This feature is intended to support common workflows and reduce repetitive task setup.

Details
-------
- Tasks can now be marked as template through a server action.
	- This action is only visible to Project admins.
	- Templates are specific to their project.
	- As such, private tasks can't be converted to templates, and a project is required on template tasks.
	- Attempting to convert a task that is already a template will prompt the user to revert it to a normal task.
	- After converting a task to a template, a notification appears briefly that allows the user to undo that action
- Templates are hidden from all projects action, except a new action created specifically for them in the project settings.
	- This action is only visible to Project admins.
- Some features are hidden on template tasks: many stat buttons, some buttons and some fields that are not relevant for a template.
- If a project contains at least one template, the "New" button in its Form, List, Kanban and Gantt views turn into a dropdown, from which the user can select a template to create a task from, or just create a task as normal.
	- Clicking on the name of a template creates a copy of that template and opens it in a form view.
	- The Customer field is excluded from this copy.
- Added some task templates for the "Office Design" project in demo data.

---

Enterprise: https://github.com/odoo/enterprise/pull/81519

Task-4614548