### PR TITLE
[FIX] account: do not print note / section line placeholders

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -151,14 +151,14 @@
                                         </t>
                                         <t t-elif="line.display_type == 'line_section'">
                                             <td colspan="99">
-                                                <span t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
+                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
                                             </td>
                                             <t t-set="current_section" t-value="line"/>
                                             <t t-set="current_subtotal" t-value="0"/>
                                         </t>
                                         <t t-elif="line.display_type == 'line_note'">
                                             <td colspan="99">
-                                                <span t-field="line.name" t-options="{'widget': 'text'}">A note, whose content usually applies to the section or product above.</span>
+                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A note, whose content usually applies to the section or product above.</span>
                                             </td>
                                         </t>
                                     </tr>


### PR DESCRIPTION
It is possible to add note / section lines with empty label (`name`). Currenlty we then print placeholder values:
  * section: `A section title`
  * note: `A note, whose content usually applies to the section or product above.` (They were added to be displayed in studio; see commit 2fbf17d235fb7c92914f0a3b6a3ce954c27f3032.)

After this commit the placeholders will not be printed on PDFs anymore. (But they will still be shown in studio.)

task: none
