### PR TITLE
[FIX] account: uneditable readonly section / note lines

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -55,6 +55,7 @@
                         <input
                             class="o_input text-wrap border-0 fst-italic"
                             placeholder="Enter a description"
+                            readonly="1"
                             type="text"
                             t-att-class="sectionAndNoteClasses"
                             t-att-value="label"
@@ -66,6 +67,7 @@
                         <textarea
                             class="o_input d-print-none border-0 fst-italic"
                             placeholder="Enter a description"
+                            readonly="1"
                             rows="1"
                             type="text"
                             t-att-class="sectionAndNoteClasses"


### PR DESCRIPTION
Currently one can still edit section / note lines on posted moves (but not save the move).

This commit makes the section / notes lines readonly when they should be.

task: none
