### PR TITLE
[FIX] l10n_es_edi_tbai: Non deductibility of tax ignored in tbai xml

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
+++ b/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
@@ -127,7 +127,7 @@
                                 <BaseImponible t-out="format_float(tax['base'])"/>
                                 <TipoImpositivo t-out="tax['rec'].amount"/>
                                 <CuotaIVASoportada t-out="format_float(tax['tax'])"/>
-                                <CuotaIVADeducible t-out="format_float(tax['tax'])"/>
+                                <CuotaIVADeducible t-out="format_float(tax['tax']) if tax['rec'].l10n_es_type != 'no_deducible' else '0.00'"/>
                             </DetalleIVA>
                         </IVA>
                     </t>

--- a/addons/l10n_es_edi_tbai/tests/common.py
+++ b/addons/l10n_es_edi_tbai/tests/common.py
@@ -265,6 +265,57 @@ class TestEsEdiTbaiCommon(AccountEdiTestCommon):
     </FacturasRecibidas>
 </lrpjframp:LROEPJ240FacturasRecibidasAltaModifPeticion>"""
 
+    L10N_ES_TBAI_SAMPLE_XML_POST_IN_ND = """
+<lrpjframp:LROEPJ240FacturasRecibidasAltaModifPeticion xmlns:lrpjframp="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_2_FacturasRecibidas_AltaModifPeticion_V1_0_1.xsd">
+    <Cabecera>
+        <Modelo>240</Modelo>
+        <Capitulo>2</Capitulo>
+        <Operacion>A00</Operacion>
+        <Version>1.0</Version>
+        <Ejercicio>2022</Ejercicio>
+        <ObligadoTributario>
+            <NIF>09760433S</NIF>
+            <ApellidosNombreRazonSocial>EUS Company</ApellidosNombreRazonSocial>
+        </ObligadoTributario>
+    </Cabecera>
+    <FacturasRecibidas>
+        <FacturaRecibida>
+                <EmisorFacturaRecibida>
+                    <IDOtro>
+                        <IDType>02</IDType>
+                        <ID>BE0477472701</ID>
+                    </IDOtro>
+                    <ApellidosNombreRazonSocial>&amp;@àÁ$£€èêÈÊöÔÇç¡⅛™³</ApellidosNombreRazonSocial>
+                </EmisorFacturaRecibida>
+                <CabeceraFactura>
+                    <SerieFactura>TEST</SerieFactura>
+                    <NumFactura>INV/5234</NumFactura>
+                    <FechaExpedicionFactura>01-01-2022</FechaExpedicionFactura>
+                    <FechaRecepcion>01-01-2022</FechaRecepcion>
+                    <TipoFactura>F1</TipoFactura>
+                </CabeceraFactura>
+                <DatosFactura>
+                    <DescripcionOperacion>INV/5234</DescripcionOperacion>
+                    <Claves>
+                        <IDClave>
+                            <ClaveRegimenIvaOpTrascendencia>01</ClaveRegimenIvaOpTrascendencia>
+                        </IDClave>
+                    </Claves>
+                    <ImporteTotalFactura>1100.00</ImporteTotalFactura>
+                </DatosFactura>
+                <IVA>
+                    <DetalleIVA>
+                        <CompraBienesCorrientesGastosBienesInversion>C</CompraBienesCorrientesGastosBienesInversion>
+                        <InversionSujetoPasivo>N</InversionSujetoPasivo>
+                        <BaseImponible>1000.00</BaseImponible>
+                        <TipoImpositivo>10.0</TipoImpositivo>
+                        <CuotaIVASoportada>100.00</CuotaIVASoportada>
+                        <CuotaIVADeducible>0.00</CuotaIVADeducible>
+                    </DetalleIVA>
+                </IVA>
+        </FacturaRecibida>
+    </FacturasRecibidas>
+</lrpjframp:LROEPJ240FacturasRecibidasAltaModifPeticion>"""
 
     L10N_ES_TBAI_SAMPLE_XML_POST_IN_IC = """
 <lrpjframp:LROEPJ240FacturasRecibidasAltaModifPeticion xmlns:lrpjframp="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_2_FacturasRecibidas_AltaModifPeticion_V1_0_1.xsd">

--- a/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
@@ -164,6 +164,26 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
             xml_expected = etree.fromstring(super().L10N_ES_TBAI_SAMPLE_XML_POST_IN)
             self.assertXmlTreeEqual(xml_doc, xml_expected)
 
+    def test_xml_tree_no_deducible_tax(self):
+        """Test XML of vendor bill with non deductible tax"""
+        with freeze_time(self.frozen_today):
+            self.in_invoice = self.env['account.move'].create({
+                'name': 'INV/01',
+                'move_type': 'in_invoice',
+                'ref': 'INV/5234',
+                'invoice_date': datetime.now(),
+                'partner_id': self.partner_a.id,
+                'invoice_line_ids': [(0, 0, {
+                    'product_id': self.product_a.id,
+                    'price_unit': 1000.0,
+                    'quantity': 1,
+                    'tax_ids': [(6, 0, self._get_tax_by_xml_id('p_iva10_nd').ids)],
+                })],
+            })
+            xml_doc = etree.fromstring(self.edi_format._l10n_es_tbai_get_invoice_content_edi(self.in_invoice))
+            xml_expected = etree.fromstring(super().L10N_ES_TBAI_SAMPLE_XML_POST_IN_ND)
+            self.assertXmlTreeEqual(xml_doc, xml_expected)
+
     def test_xml_tree_in_ic_post(self):
         """Test XML of vendor bill for LROE Batuz intra-community"""
         with freeze_time(self.frozen_today):


### PR DESCRIPTION
Steps to reproduce:
- Create a Vendor Bill with 10% ND tax
- Post
- In 'Edi Documents' tab download e-invoice

Issue: `CuotaIVADeducible` element show the full tax amount, 
even if the tax has been set to non deductible

opw-4582712