### PR TITLE
[FIX] base: Fixed DB getting broken on company deletion

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -288,6 +288,15 @@ class Company(models.Model):
         if any(company.child_ids for company in self):
             raise UserError(_("Companies that have associated branches cannot be deleted. Consider archiving them instead."))
 
+    def unlink(self):
+        """
+        Unlink the companies and clear the cache to make sure that
+        _get_company_ids of res.users gets only existing company ids.
+        """
+        res = super().unlink()
+        self.env.registry.clear_cache()
+        return res
+
     def write(self, values):
         invalidation_fields = self.cache_invalidation_fields()
         asset_invalidation_fields = {'font', 'primary_color', 'secondary_color', 'external_report_layout_id'}


### PR DESCRIPTION
Repro steps:
1. Create a new company.
2. Attempt to delete the newly created company.
3. The deletion is successful, but if the user tries to login again, they will keep getting this error `Record does not exist or has been deleted.`

Cause:
The cause was that the cache would have the id of the deleted company, and attempting to access this company was the bug cause.

Solution:
This commit solves this bug by clearing the cache on company deletion.

task-4438207



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
