### PR TITLE
[FIX] pos*: post OXP bug fix

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1413,6 +1413,7 @@ class PosOrderLine(models.Model):
     is_edited = fields.Boolean('Edited', default=False)
     # Technical field holding custom data for the taxes computation engine.
     extra_tax_data = fields.Json()
+    is_extra_combo_line = fields.Boolean('Is Extra Combo Line', default=False)
 
     @api.model
     def _load_pos_data_domain(self, data):
@@ -1423,7 +1424,7 @@ class PosOrderLine(models.Model):
         return [
             'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type',
             'product_id', 'discount', 'tax_ids', 'pack_lot_ids', 'customer_note', 'refunded_qty', 'price_extra', 'full_product_name', 'refunded_orderline_id', 'combo_parent_id', 'combo_line_ids', 'combo_item_id', 'refund_orderline_ids',
-            'extra_tax_data',
+            'extra_tax_data', 'is_extra_combo_line',
         ]
 
     @api.model

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -153,9 +153,6 @@ export class OrderSummary extends Component {
                         val,
                         Boolean(selectedLine.combo_line_ids?.length)
                     );
-                    for (const line of selectedLine.combo_line_ids) {
-                        line.setQuantity(val, true);
-                    }
                     if (result !== true) {
                         this.dialog.add(AlertDialog, result);
                         this.numberBuffer.reset();

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -130,14 +130,18 @@ export class ProductScreen extends Component {
             {
                 value: "discount",
                 text: _t("%"),
-                disabled: !this.pos.config.manual_discount || this.pos.cashier._role === "minimal",
+                disabled:
+                    !this.pos.config.manual_discount ||
+                    this.pos.cashier._role === "minimal" ||
+                    Boolean(this.currentOrder?.getSelectedOrderline()?.combo_parent_id),
             },
             {
                 value: "price",
                 text: _t("Price"),
                 disabled:
                     !this.pos.cashierHasPriceControlRights() ||
-                    this.pos.cashier._role === "minimal",
+                    this.pos.cashier._role === "minimal" ||
+                    Boolean(this.currentOrder?.getSelectedOrderline()?.combo_parent_id),
             },
             BACKSPACE,
         ]).map((button) => ({

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
@@ -140,6 +140,9 @@ export class SplitBillScreen extends Component {
         const lineToDel = [];
         const newCourses = new Map();
         for (const line of originalOrder.lines) {
+            if (this.parentCombo && !line.combo_parent_id) {
+                this.parentCombo = false;
+            }
             if (this.qtyTracker[line.uuid]) {
                 let newCourse;
                 if (line.course_id) {
@@ -156,8 +159,15 @@ export class SplitBillScreen extends Component {
                     }
                 }
                 const data = { ...line.raw };
+                if (this.parentCombo) {
+                    data.combo_parent_id = this.parentCombo;
+                }
                 delete data.uuid;
                 delete data.id;
+                if (data.combo_line_ids.length > 0) {
+                    delete data.combo_line_ids;
+                    this.parentCombo = true;
+                }
                 const newLine = this.pos.models["pos.order.line"].create(
                     {
                         ...data,
@@ -168,6 +178,9 @@ export class SplitBillScreen extends Component {
                     false,
                     true
                 );
+                if (this.parentCombo === true) {
+                    this.parentCombo = newLine.id;
+                }
 
                 if (line.getQuantity() === this.qtyTracker[line.uuid]) {
                     lineToDel.push(line);

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -90,7 +90,7 @@ class PosSelfOrderController(http.Controller):
 
             fiscal_pos = preset_id.fiscal_position_id or pos_config.default_fiscal_position_id if preset_id else pos_config.default_fiscal_position_id
             if len(line.combo_line_ids) > 0:
-                original_total = sum(line.combo_line_ids.mapped("combo_item_id").combo_id.mapped("base_price"))
+                original_total = sum(line.combo_line_ids.combo_item_id.combo_id.mapped("base_price"))
                 remaining_total = lst_price
                 factor = lst_price / original_total if original_total > 0 else 1
 

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -10,26 +10,6 @@ class PosOrderLine(models.Model):
 
     combo_id = fields.Many2one('product.combo', string='Combo reference')
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            if (vals.get('combo_parent_uuid')):
-                vals.update([
-                    ('combo_parent_id', self.search([('uuid', '=', vals.get('combo_parent_uuid'))]).id)
-                ])
-            if 'combo_parent_uuid' in vals:
-                del vals['combo_parent_uuid']
-        return super().create(vals_list)
-
-    def write(self, vals):
-        if (vals.get('combo_parent_uuid')):
-            vals.update([
-                ('combo_parent_id', self.search([('uuid', '=', vals.get('combo_parent_uuid'))]).id)
-            ])
-        if 'combo_parent_uuid' in vals:
-            del vals['combo_parent_uuid']
-        return super().write(vals)
-
 
 class PosOrder(models.Model):
     _inherit = "pos.order"

--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
@@ -68,7 +68,9 @@ export class OrderWidget extends Component {
             (acc, [key, value]) => {
                 if (value.qty && value.qty > 0) {
                     const line = this.selfOrder.models["pos.order.line"].getBy("uuid", key);
-                    acc.count += value.qty;
+                    if (!value.part_of_combo) {
+                        acc.count += value.qty;
+                    }
                     acc.price += line.getDisplayPrice();
                 }
                 return acc;

--- a/addons/pos_self_order/static/src/app/models/pos_order_line.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order_line.js
@@ -15,6 +15,7 @@ patch(PosOrderline.prototype, {
                 custom_attribute_value_ids: JSON.stringify(
                     this.custom_attribute_value_ids.map((a) => a.id).sort()
                 ),
+                part_of_combo: Boolean(this.combo_parent_id),
             };
         }
 
@@ -32,6 +33,7 @@ patch(PosOrderline.prototype, {
                 change.custom_attribute_value_ids
                     ? change.custom_attribute_value_ids
                     : false,
+            part_of_combo: Boolean(this.combo_parent_id),
         };
         return diff;
     },

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -207,11 +207,16 @@ export class CartPage extends Component {
         await this._changeQuantity(line, increase);
     }
 
+    canClickOnLine(line) {
+        const order = this.selfOrder.currentOrder;
+        return order.state === "draft" && !order.uiState.lineChanges[line.uuid];
+    }
+
     clickOnLine(line) {
         const order = this.selfOrder.currentOrder;
         this.selfOrder.editedLine = line;
 
-        if (order.state === "draft" && !order.lastChangesSent[line.uuid]) {
+        if (this.canClickOnLine(line)) {
             this.selfOrder.selectedOrderUuid = order.uuid;
 
             if (line.combo_line_ids.length > 0) {

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -17,7 +17,7 @@
                                 </div>
                                 <div t-if="line.attribute_value_ids?.length > 0 || line.combo_line_ids.length > 0" class="d-flex align-items-start gap-2 gap-md-3 my-2">
                                     <button
-                                        t-if="Object.keys(selfOrder.currentOrder.changes).length === 0"
+                                        t-if="Object.keys(selfOrder.currentOrder.changes).length === 0 and this.canClickOnLine(line)"
                                         type="button"
                                         t-on-click="() => this.clickOnLine(line)"
                                         class="btn btn-secondary"> <i class="fa fa-pencil"></i></button>

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -47,7 +47,7 @@ export class ComboPage extends Component {
         return !(
             this.selfOrder.editedLine &&
             this.selfOrder.editedLine.uuid &&
-            order.lastChangesSent[this.selfOrder.editedLine.uuid]
+            order.uiState.lineChanges[this.selfOrder.editedLine.uuid]
         );
     }
 

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -46,7 +46,7 @@ export class ProductPage extends Component {
         return !(
             this.selfOrder.editedLine &&
             this.selfOrder.editedLine.uuid &&
-            order.lastChangesSent[this.selfOrder.editedLine.uuid]
+            order.uiState.lineChanges[this.selfOrder.editedLine.uuid]
         );
     }
 

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -281,7 +281,7 @@ export class SelfOrder extends Reactive {
                     combo_item_id: comboItem.combo_item_id,
                     price_unit: comboItem.price_unit,
                     order_id: this.currentOrder,
-                    qty: values.qty,
+                    qty: qty,
                     attribute_value_ids: comboItem.attribute_value_ids?.map((attr) => [
                         "link",
                         attr,
@@ -812,7 +812,7 @@ export class SelfOrder extends Reactive {
     verifyCart() {
         let result = true;
         for (const line of this.currentOrder.unsentLines) {
-            if (line.combo_parent_id?.uuid) {
+            if (line.combo_parent_id) {
                 continue;
             }
 


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant, pos_self_order

This is a compilation of bug fix mostly about combos.

1. make pos combo groupable in pos
2. changing discount price or discount does not work
3. should not be able to set the price on a combo line
4. changing price on combo parent should adapt price
5. in self, remove clickOnLine button when it is unusable
6. when splitting an order with a combo with quantity more than 1, the user was not able to select the quantity he wanted for the combo. It was always 0 or the whole quantity.
7.adding multiple combo at the same time was not working in self
8. when opening a table on two different device, adding lines on one of them and going to the floor screen, a traceback was shown on the other.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
