### PR TITLE
[FIX] web: center today red dot in calendars

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -448,8 +448,8 @@
                         content: "";
                         z-index: -1;
                         display: none;
-                        @include o_position-absolute($top: 0%, $left: 50%);
-                        transform: translateX(-50%);
+                        @include o_position-absolute($top: 50%, $left: 50%);
+                        transform: translate(-50%, -50%);
                         aspect-ratio: 1/1;
                         height: 100%;
                         border-radius: 100%;
@@ -537,6 +537,10 @@
                                 display: block;
                             }
                         }
+
+                        .fc-daygrid-day-number:before {
+                            height: 120%;
+                        }
                     }
                 }
             }
@@ -584,7 +588,10 @@
 
                     .fc-daygrid-body tr {
                         .fc-daygrid-day-frame {
+                            display: flex;
+                            place-content: center;
                             min-height: 2rem;
+                            line-height: 1;
                         }
 
                         .o-fc-week {


### PR DESCRIPTION
This commit fixes vertical misalignment of today indicator in back-end calendars.

task-4617623

| Before | After |
|--------|--------|
| <img width="1115" alt="Screenshot 2025-03-04 at 16 55 25" src="https://github.com/user-attachments/assets/b879fcb1-c416-44ea-956d-ce9c4c8328f2" /> | <img width="1095" alt="Screenshot 2025-03-04 at 14 17 45" src="https://github.com/user-attachments/assets/47e64b96-2ca2-4ec5-83ab-d3d8e133175d" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
