### PR TITLE
[FIX] stock{,_barcode}: avoid extra moves and demand updates

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -210,6 +210,8 @@ class StockMove(models.Model):
         for move in self:
             if move.state == 'done' or any(ml.picked for ml in move.move_line_ids):
                 move.picked = True
+            elif move.move_line_ids:
+                move.picked = False
 
     def _inverse_picked(self):
         for move in self:


### PR DESCRIPTION
Issue: In Barcode, performing certain operations and then reverting your changes can drastically affect the state of records: "picked" status or the visual demand of the move.

### Steps to reproduce:

- Create a storable product tracked by SN. Put 2 SN in stock SN1 and SN2
- Create a delivery order for 2 units and mark as to do.
> The two SN's should be reserved on your delivery.
- Go to the barcode app, scan SN1.
- Edit edit the SN1 line to set the qty back to 0.
- Leave the barcode app and come back to the record.
#### > The subline related to SN1 displays now a demand of 0. A new barcode line has been created with a demand of 1 for SN1. In short an extra record was created unecessarily.

### Cause of the issue:

In the barcode app the demand of each line is measured by the quantity present on its move lines. In our set up, the move is related to 2 moves lines with a quantity of 1 that are not picked. Scanning SN1 will update the qty_done of its line to 1. As such, the move line quantity will be set from 1 to 1 and the move line will be picked:
https://github.com/odoo/enterprise/blob/e8c831a540c12019c560cc19abf7abe8785d0e0e/stock_barcode/models/stock_move_line.py#L58-L61 In turns, the picked state of the move will be set to picked: https://github.com/odoo/odoo/blob/7bc38562f1988ba15525c04168e30c06a8f1d33c/addons/stock/models/stock_move.py#L208-L212 Now, editing the qty done of the move once more from 1 to 0 to reset the reservation will not revert the process for 2 reasons:
1. The quantity of the move line will be reset form its current value to 0, altering the demand of the barcode line to 0.
2. Even if the move line was unpicked in this process, the picked compute method of the move will never reset the picked state as the compute method can only set a True value.

We therefore end up with a picked move without any picked move line and for which one of the picked move line has a quantity of 0. Now, leaving the barcode app will launch the split_uncompleted_moves method in order to not lose the changes made to the record and since the move is picked for the wrong reason, the move will be splitted in 2 instead of escaping the split process.
https://github.com/odoo/enterprise/blob/e8c831a540c12019c560cc19abf7abe8785d0e0e/stock_barcode/models/stock_move.py#L21-L22

Enterprise: https://github.com/odoo/enterprise/pull/80675

opw-4600565
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
