### PR TITLE
 [FIX] web: avoid saving _original_action on the saved current_action

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -392,6 +392,7 @@ export function makeActionManager(env, router = _router) {
      */
     function _preprocessAction(action, context = {}) {
         try {
+            delete action._originalAction;
             action._originalAction = JSON.stringify(action);
         } catch {
             // do nothing, the action might simply not be serializable


### PR DESCRIPTION
- Open a lazy load client action (e.g. dashboard spreadsheet);
- Reload (F5) repeatedly.

Before this commit, a `QuotaExceededError` was thrown. This error occurs
because:
 - The action is processed, and an `_original_action` (a string copy of the
    action) is added;
 - The action is executed (a client action), in this case is a lazy load client
    action function.
 - The function returns, the same action to be re-executed (this time with the
    lazily loaded component client action);
 - The action returned by the function (which already has an
    `_original_action`), is processed, and an `_original_action` is added (a
    string copy of the action, that already contains a string copy of the
    action);
- Doing this multiple times on each reload will add a new layer of string copy
    of the action, until there is a memory error.

This problem was introduced by [1], prior to this commit, the saved actions
were only used if it was a dynamic multi-record action.

[1]: https://github.com/odoo/odoo/commit/c0ae72b25e935790c6e3b1fd805aadbd2fff75c7

opw-4619396
