### PR TITLE
[FIX] mrp_subcontracting_dropshipping: Prevent partner_id overwrite

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/models/stock_orderpoint.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_orderpoint.py
@@ -9,7 +9,6 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _prepare_procurement_values(self, date=False, group=False):
         vals = super()._prepare_procurement_values(date, group)
-        if not vals.get('partner_id') and self.location_id.is_subcontracting_location:
-            subcontractors = self.location_id.subcontractor_ids
-            vals['partner_id'] = subcontractors.id if len(subcontractors) == 1 else False
+        if not vals.get('partner_id') and self.location_id.is_subcontracting_location and len(self.location_id.subcontractor_ids) == 1:
+            vals['partner_id'] = self.location_id.subcontractor_ids.id
         return vals

--- a/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
@@ -462,3 +462,34 @@ class TestSubcontractingDropshippingFlows(TestMrpSubcontractingCommon):
         self.assertEqual(component_lines[0]['route_name'], 'Buy', 'Outside of the subcontracted context, it should try to resupply stock.')
         self.assertEqual(component_lines[1]['product_id'], compo_rr.id)
         self.assertEqual(component_lines[1]['route_name'], 'Buy')
+
+    def test_partner_id_no_overwrite(self):
+        subcontract_location = self.env.company.subcontracting_location_id
+        p1, p2 = self.env['res.partner'].create([
+            {'name': 'partner 1', 'property_stock_subcontractor': subcontract_location.id},
+            {'name': 'partner 2', 'property_stock_subcontractor': subcontract_location.id},
+        ])
+        route_resupply = self.env['stock.route'].create({
+            'name': 'Resupply Subcontractor',
+            'rule_ids': [(0, False, {
+                'name': 'Stock -> Subcontractor',
+                'location_src_id': self.env.ref('stock.stock_location_stock').id,
+                'location_dest_id': subcontract_location.id,
+                'company_id': self.env.company.id,
+                'action': 'pull',
+                'auto': 'manual',
+                'picking_type_id': self.env.ref('stock.picking_type_out').id,
+                'partner_address_id': p1.id,
+            })],
+        })
+        self.env['stock.warehouse.orderpoint'].create({
+            'name': 'Resupply Subcontractor',
+            'location_id': subcontract_location.id,
+            'route_id': route_resupply.id,
+            'product_id': self.comp1.id,
+            'product_min_qty': 2,
+            'product_max_qty': 2,
+        })
+        self.env['procurement.group'].run_scheduler()
+        delivery = self.env["stock.move"].search([("product_id", "=", self.comp1.id)]).picking_id
+        self.assertEqual(delivery.partner_id, p1)


### PR DESCRIPTION
When there are none or more than 1 partner that have the same subcontracting location setup, then any procurement made to this subcontracting location will be removed, even if another configuration is applicable.


## How to reproduce:
https://drive.google.com/file/d/1jvT1pmCqY0JNAinvqmbonX0CDYYysoJz/view?usp=sharing

- Activate Routes, Subcontracting, Dropshipping
- Create custom subcontracting location
- Create partners "Partner 1" & "Partner 2", with custom sub loc setup
- Create custom route 'Resupply Subcontractor', with rule:
  - action: Pull From
  - operation: delivery
  - source: Stock
  - dest: custom sub loc
  - method: take from stock
  - Partner Address: Partner 1
- Create product with reordering rule:
  - manual, min 0, max 0, custom sub loc, custom route
- In Replenishment -> Find custom reordering rule -> set Order Qty to 1 -> Order Once
  - Created Transfer does not have any partner address
- Cancel created transfer
- Remove subcontracting loc for "Partner 2"
- In Replenishment -> Find custom reordering rule -> set Order Qty to 1 -> Order Once
  - Created Transfer has the partner address

OPW-4576260

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
