### PR TITLE
[FIX] pos_restaurant: fix placement of course btn

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.ActionpadWidget" t-inherit="point_of_sale.ActionpadWidget" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('actionpad')]/div/button[last()]" position="before">
+        <xpath expr="//div[hasclass('actionpad')]//button[hasclass('mobile-more-button')]" position="before">
             <button t-if="pos.config.module_pos_restaurant and !this.currentOrder._isRefundOrder()"
                     class="btn btn-secondary btn-lg flex-shrink-0 border-0" t-on-click="()=>this.pos.addCourse()">
                 <span>Course</span>


### PR DESCRIPTION
- Before this fix the `Course` button was displayed 2 times on desktop and not displayed on mobile.
- To fix this I've updated the target `xpath` for the Course button on mobile.

task-id: 4619395

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
