### PR TITLE
[FIX] pos_loyalty: remove fixed tax from discount on orders

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -1199,7 +1199,9 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
             if (!line.get_quantity()) {
                 continue;
             }
-            const taxKey = line.get_taxes().map((t) => t.id);
+            const taxKey = ['ewallet', 'gift_card'].includes(reward.program_id.program_type)
+                ? line.get_taxes().map((t) => t.id)
+                : line.get_taxes().filter((t) => t.amount_type !== 'fixed').map((t) => t.id);
             discountable += line.get_price_with_tax();
             if (!discountablePerTax[taxKey]) {
                 discountablePerTax[taxKey] = 0;

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
@@ -241,3 +241,12 @@ PosLoyalty.check.hasRewardLine("Free Product", "-10", "2.00");
 PosLoyalty.check.isRewardButtonHighlighted(false);
 
 Tour.register("PosLoyaltyRewardProductTag", { test: true, url: "/pos/web" }, getSteps());
+
+startSteps();
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickHomeCategory();
+ProductScreen.do.clickDisplayedProduct('Product A');
+PosLoyalty.do.enterCode('563412');
+PosLoyalty.check.hasRewardLine('10% on your order', '-1.50');
+
+Tour.register("test_loyalty_on_order_with_fixed_tax", { test: true, url: "/pos/web" }, getSteps());

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2148,3 +2148,33 @@ class TestUi(TestPointOfSaleHttpCommon):
             "PosLoyaltyRewardProductTag",
             login="accountman"
         )
+
+    def test_loyalty_on_order_with_fixed_tax(self):
+
+        self.env['loyalty.program'].search([('id', '!=', self.auto_promo_program_next.id)]).write({'active': False})
+        self.auto_promo_program_next.coupon_ids = [Command.create({
+            'code': '563412',
+            'points': 10
+        })]
+
+        fixed_tax = self.env['account.tax'].create({
+            'name': 'Fixed Tax',
+            'amount_type': 'fixed',
+            'amount': 50,
+        })
+        self.env["product.product"].create(
+            {
+                "name": "Product A",
+                "type": "product",
+                "list_price": 15,
+                "available_in_pos": True,
+                "taxes_id": [Command.link(fixed_tax.id)],
+            }
+        )
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "test_loyalty_on_order_with_fixed_tax",
+            login="accountman",
+        )


### PR DESCRIPTION
### Steps to reproduce the issue:

(Easier to reproduce with demo data)

1. Create a Fixed Tax and assign it to a Product
2. Open POS session, add Product to Order
3. Add a Coupon Code: "10pc"
    - This code should give a 10% Discount on the Order
4. The Discount Line includes the Fixed Tax amount and accounts for more than 10% of the Order Total

### Explanation:

During the creation of the reward line, the fixed taxes are not excluded from discounts. While it is logical for percentage taxes to be included, as they become part of the discount, fixed taxes are added to the amount.

### Fix reasoning:

The opposite issue was fixed in commit odoo/odoo@534de1e47ab882bfb1cc006bdf1fa00fc877c6c4, adapting the code to javascript.

opw-4506550