### PR TITLE
[FIX] project: open form view in main view in mobile for subtasks

### DIFF
--- a/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_one2many_field.js
+++ b/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_one2many_field.js
@@ -10,6 +10,14 @@ export class NotebookTaskOne2ManyField extends X2ManyField {
         ...X2ManyField.components,
         ListRenderer: NotebookTaskListRenderer,
     };
+
+    get rendererProps() {
+        const rendererProps = super.rendererProps;
+        if (this.props.viewMode === "kanban") {
+            rendererProps.openRecord = this.switchToForm.bind(this);
+        }
+        return rendererProps;
+    }
 }
 
 export const notebookTaskOne2ManyField = {

--- a/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
@@ -10,6 +10,14 @@ export class SubtaskOne2ManyField extends X2ManyField {
         ...X2ManyField.components,
         ListRenderer: SubtaskListRenderer,
     };
+
+    get rendererProps() {
+        const rendererProps = super.rendererProps;
+        if (this.props.viewMode === "kanban") {
+            rendererProps.openRecord = this.switchToForm.bind(this);
+        }
+        return rendererProps;
+    }
 }
 
 export const subtaskOne2ManyField = {

--- a/addons/project/static/tests/project_notebook_task_list_mobile.test.js
+++ b/addons/project/static/tests/project_notebook_task_list_mobile.test.js
@@ -1,0 +1,178 @@
+import { beforeEach, expect, describe, test } from "@odoo/hoot";
+import { animationFrame, click } from "@odoo/hoot-dom";
+import { getService, mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { WebClient } from "@web/webclient/webclient";
+
+import { defineProjectModels, ProjectProject, ProjectTask } from "./project_models";
+
+defineProjectModels();
+
+describe.current.tags("mobile");
+
+beforeEach(() => {
+    ProjectProject._records = [
+        {
+            id: 5,
+            name: "Project One",
+        },
+    ];
+
+    ProjectTask._records = [
+        {
+            id: 1,
+            name: "task one",
+            project_id: 5,
+            closed_subtask_count: 1,
+            closed_depend_on_count: 1,
+            subtask_count: 4,
+            child_ids: [2, 3, 4, 7],
+            depend_on_ids: [5, 6],
+            state: "04_waiting_normal",
+        },
+        {
+            id: 2,
+            name: "task two",
+            project_id: 5,
+            parent_id: 1,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: "03_approved",
+        },
+        {
+            id: 3,
+            name: "task three",
+            project_id: 5,
+            parent_id: 1,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: "02_changes_requested",
+        },
+        {
+            id: 4,
+            name: "task four",
+            project_id: 5,
+            parent_id: 1,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: "1_done",
+        },
+        {
+            id: 5,
+            name: "task five",
+            project_id: 5,
+            closed_subtask_count: 0,
+            subtask_count: 1,
+            child_ids: [6],
+            depend_on_ids: [],
+            state: "03_approved",
+        },
+        {
+            id: 6,
+            name: "task six",
+            project_id: 5,
+            parent_id: 5,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: "1_canceled",
+        },
+        {
+            id: 7,
+            name: "task seven",
+            project_id: 5,
+            parent_id: 1,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: "01_in_progress",
+        },
+    ];
+
+    ProjectTask._views = {
+        form: `
+            <form>
+                <field name="name"/>
+                <field name="child_ids" widget="subtasks_one2many">
+                    <kanban>
+                        <templates>
+                            <t t-name="card">
+                                <main>
+                                    <field name="name" class="fw-bold fs-5"/>
+                                    <field name="project_id" widget="project"/>
+                                    <field name="state"/>
+                                </main>
+                            </t>
+                        </templates>
+                    </kanban>
+                </field>
+                <field name="depend_on_ids" widget="notebook_task_one2many">
+                    <kanban>
+                        <templates>
+                            <t t-name="card">
+                                <main>
+                                    <field name="name" class="fw-bold fs-5"/>
+                                    <field name="project_id" widget="project"/>
+                                    <field name="state"/>
+                                </main>
+                            </t>
+                        </templates>
+                    </kanban>
+                </field>
+            </form>
+        `,
+        search: `<search/>`,
+    };
+});
+
+test("test open subtask in form view instead of form view dialog", async () => {
+    await mountWithCleanup(WebClient);
+
+    await getService("action").doAction({
+        name: "Tasks",
+        res_model: "project.task",
+        type: "ir.actions.act_window",
+        res_id: 1,
+        views: [[false, "form"]],
+    });
+
+    expect("div[name='name'] input").toHaveValue("task one");
+    expect("div[name='child_ids'] .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(4, {
+        message:
+            "The subtasks list should display all subtasks by default, thus we are looking for 4 in total",
+    });
+
+    await click("div[name='child_ids'] .o_kanban_record:first-child");
+    await animationFrame();
+    expect(document.body).not.toHaveClass("modal-open");
+    expect("div[name='name'] input").toHaveValue("task two");
+});
+
+test("test open task dependencies in form view instead of form view dialog", async () => {
+    await mountWithCleanup(WebClient);
+
+    await getService("action").doAction({
+        name: "Tasks",
+        res_model: "project.task",
+        type: "ir.actions.act_window",
+        res_id: 1,
+        views: [[false, "form"]],
+    });
+
+    expect("div[name='name'] input").toHaveValue("task one");
+    expect("div[name='depend_on_ids'] .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(2, {
+        message:
+            "The depend on tasks list should display all blocking tasks by default, thus we are looking for 2 in total",
+    });
+    await click("div[name='depend_on_ids'] .o_kanban_record:first-child");
+    await animationFrame();
+    expect(document.body).not.toHaveClass("modal-open");
+    expect("div[name='name'] input").toHaveValue("task five");
+});


### PR DESCRIPTION
Before this commit, when the user is in mobile view and go to a task with subtasks and selects a subtask, the form view of that subtask is opened inside a dialog form view instead of opening the record in the main view. Because of that, the chatter for that subtask is not displayed.

This commit opens the form view in the main view instead of opening it inside a form view dialog to be able to display the chatter of the subtask selected.

Steps to reproduce the issue:
----------------------------

1. Install project and go to project app.
2. Create a project A.
3. Add a task inside the project A
4. Add a subtask inside the new task created in step 3
5. Open the form view of the task created in step 3 in mobile
6. Click on the kanban record contained the subtask created in step 4

Expected behavior:
-----------------

The chatter should be displayed in the form view of that subtask to be able to communicate with the customer.

Current behavior:
----------------

Since the form view of the subtask selected is opened inside a form view dialog the chatter for that subtask is not displayed.

task-4278273
