### PR TITLE
[FIX] spreadsheet: Add title to filter value

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
-    <t t-name="spreadsheet_edition.FilterValue"
-       >
-        <div class="o-filter-value d-flex align-items-start w-100">
+    <t t-name="spreadsheet_edition.FilterValue">
+        <div class="o-filter-value d-flex align-items-start w-100" t-att-title="filter.label">
             <div t-if="filter.type === 'text'" class="w-100">
                 <TextFilterValue
                     value="filterValue"

--- a/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, expect, test, getFixture } from "@odoo/hoot";
 import { click, queryAllTexts, queryAllValues } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
@@ -107,4 +107,17 @@ test("relational filter with a contextual domain", async function () {
     await click(".o_multi_record_selector input");
     await animationFrame();
     expect.verifySteps(["name_search"]);
+});
+
+test("Filters have a title", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "text",
+        label: "Text Filter",
+    });
+    await mountFilterValueComponent({ model, filter: model.getters.getGlobalFilter("42") });
+    const fixture = getFixture();
+    expect(fixture.querySelector(".o-filter-value").title).toBe("Text Filter");
 });


### PR DESCRIPTION
Currently, the date filters do not have their title displayed in the `FilteValue` component which is an issue in dashboards where one could have multiple date filters defined and could not differentiate them.

This revision adds the fiter label as a title such that users can identify the right filter given that they gave it an appropriate label.

task-4606670

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
