### PR TITLE
[FIX] mail,test_event_full: translate registration email body

### DIFF
--- a/addons/mail/models/mail_composer_mixin.py
+++ b/addons/mail/models/mail_composer_mixin.py
@@ -66,8 +66,21 @@ class MailComposerMixin(models.AbstractModel):
         for composer_mixin in self:
             if not tools.is_html_empty(composer_mixin.body) and composer_mixin.template_id:
                 template_value = composer_mixin.template_id.body_html
-                sanitized_template_value = tools.html_sanitize(template_value)
-                composer_mixin.body_has_template_value = composer_mixin.body in (template_value, sanitized_template_value)
+                # matching email_outgoing sanitize level
+                sanitize_vals = {
+                    'output_method': 'xml',
+                    'sanitize_attributes': False,
+                    'sanitize_conditional_comments': False,
+                    'sanitize_form': True,
+                    'sanitize_style': True,
+                    'sanitize_tags': False,
+                    'silent': True,
+                    'strip_classes': False,
+                    'strip_style': False,
+                }
+                sanitized_template_value = tools.html_sanitize(template_value, **sanitize_vals)
+                composer_mixin.body_has_template_value = composer_mixin.body in (template_value,
+                    sanitized_template_value)
             else:
                 composer_mixin.body_has_template_value = False
 

--- a/addons/test_event_full/tests/test_event_mail.py
+++ b/addons/test_event_full/tests/test_event_mail.py
@@ -327,3 +327,15 @@ class TestEventSaleMail(TestEventFullCommon):
                 "email_from": self.test_event.organizer_id.email_formatted,
             },
         )
+
+    def test_registration_template_body_translation(self):
+        self.env['res.lang']._activate_lang('fr_BE')
+        test_event = self.test_event
+        self.partners[0].lang = 'fr_BE'
+        self.env.ref('event.event_subscription').with_context(lang='fr_BE').body_html = 'Bonjour'
+        with self.mock_mail_gateway(mail_unlink_sent=False):
+            self.env['event.registration'].create({
+            'event_id': test_event.id,
+            'partner_id': self.partners[0].id
+            })
+        self.assertEqual(self._new_mails[0].body_html, "<p>Bonjour</p>")


### PR DESCRIPTION
Steps to reproduce:

- Install Discuss, events and contacts app
- Set a partner langage to another langage
- Open the event app and select an event
- Select 'Attendees' in the smart buttons and click on New
-  In the 'Booked by' field, select the partner with the foreign langage
- Save

Current Behavior:
A registration email is created but the body of the email is not translated to the language of the partner

Expected Behavior:
The body of the registration email should be translated in the language of the partner

Cause of the issue:

In order for the translation to happen inside _render_field() the variable 'equality' has to be True
Link 1: https://github.com/odoo/odoo/blob/40b819ded20f769b0a63b73abfefebbdaca390df/addons/mail/models/mail_composer_mixin.py#L180

Because field is equal to 'body' the value of equality is the value of self.body_has_template_value
Link 2:https://github.com/odoo/odoo/blob/40b819ded20f769b0a63b73abfefebbdaca390df/addons/mail/models/mail_composer_mixin.py#L168

self.body_has_template_value is computed by checking if the 'body' attribute of self (self is an instance of mail.compose.message)
is either equal to self.template_id.body_html or tools.html_sanitize(self.template_id.body_html)
Link3: https://github.com/odoo/odoo/blob/40b819ded20f769b0a63b73abfefebbdaca390df/addons/mail/models/mail_composer_mixin.py#L70

In this case, self.body has been computed using html_sanitize(self.template_id_html)
Link4: https://github.com/odoo/odoo/blob/40b819ded20f769b0a63b73abfefebbdaca390df/odoo/fields.py#L2231
so self.body_has_template_value shoud be True

The reason it's False is that when computing the value of self.body (Link4) the method html_sanitize is used with an argument (**sanitize_vals)
which is not the case when comparing self.body to html_sanitize(self.template_id.body_html) (Link3)

As a result self.body and html_sanitize(self.template_id.body_html) are not equal
which makes self.body_has_template_value be False
which makes equality be equal to False
which makes the translation not happening

Fix :

Inside _compute_body_has_template_value() I made the method also return True if
self.body is equal to html_sanitize(self.template_id.body_html,**sanitize_vals)
with santize_vals having the same value as when self.body is computed

opw-4349122
