### PR TITLE
[FIX] stock: orderpoint `qty_to_order` search & selective unlink

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -339,7 +339,7 @@ class StockWarehouseOrderpoint(models.Model):
     def _search_qty_to_order(self, operator, value):
         records = self.search_fetch([('qty_to_order_manual', 'in', [0, False])], ['qty_to_order_computed'])
         matched_ids = records.filtered_domain([('qty_to_order_computed', operator, value)]).ids
-        return ['|',
+        return ['&',
                     ('qty_to_order_manual', operator, value),
                     ('id', 'in', matched_ids)
                 ]


### PR DESCRIPTION
**Current behavior:**
Everytime the Replenishment action is called we delete and
recreate lots of (default) orderpoints. Sometimes it's annoying
because manual values may have been set on them and in general
it is wasteful.

**Expected behavior:**
Don't delete an orderpoint if either it's product min/max qty
fields have non-default values, don't delete/create orderpoints
if not necessary.

**Steps to reproduce:**
1. Create a delivery for (storable) product

2. Open replenishment -> edit auto-gen orderpoint to have 5
min/max qty

3. Go to dashboard, re-open replenishment -> the edited record
was deleted and there is a new one with the default `0`
min/max qty

**Cause of the issue:**
`_search_qty_to_order` does not really respect a domain leaf
like:
`('qty_to_order', '<=', 0)`
because currently it satisfied by `qty_to_order_manual==0`,
irrespective of `qty_to_order_computed`.

**Fix:**
Make `_search_qty_to_order` stricter by taking the intersection
of searching `qty_to_order_manual` and `qty_to_order_computed`
instead of the union.

opw-4547116