### PR TITLE
[IMP] web: base.group_allow_export to session_info

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -131,7 +131,9 @@ class IrHttp(models.AbstractModel):
             },
             'test_mode': config['test_enable'],
             'view_info': self.env['ir.ui.view'].get_view_info(),
-            'groups': {},
+            'groups': {
+                'base.group_allow_export': user.has_group('base.group_allow_export') if session_uid else False,
+            },
         }
         if request.session.debug:
             session_info['bundle_params']['debug'] = request.session.debug

--- a/addons/web/tests/test_session_info.py
+++ b/addons/web/tests/test_session_info.py
@@ -72,7 +72,9 @@ class TestSessionInfo(common.HttpCase):
             'allowed_companies': expected_allowed_companies,
             'disallowed_ancestor_companies': expected_disallowed_ancestor_companies,
         }
-        self.assertEqual(result["groups"], {})
+        self.assertEqual(result["groups"], {
+            'base.group_allow_export': self.user.has_group('base.group_allow_export')
+        })
         self.assertEqual(
             result['user_companies'],
             expected_user_companies,


### PR DESCRIPTION
Since the `base.group_allow_export` group is now always used by the default view list (desktop) and kanban (mobile) [1]. It made sense to add it inside the session_info `groups` key.

[1] https://github.com/odoo/odoo/commit/1e4e40cf78fe8151dffdcb19df2688787084732c

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
