### PR TITLE
[REV] mail: allow to keep a reference to Message-Id

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -487,7 +487,7 @@ class MailMail(models.Model):
                     email_list.append(values)
 
                 # headers
-                headers = {'X-Odoo-Message-Id': mail.message_id}
+                headers = {}
                 ICP = self.env['ir.config_parameter'].sudo()
                 bounce_alias = ICP.get_param("mail.bounce.alias")
                 catchall_domain = ICP.get_param("mail.catchall.domain")

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1276,17 +1276,10 @@ class MailThread(models.AbstractModel):
         if strip_attachments:
             msg_dict.pop('attachments', None)
 
-        message_ids = [msg_dict['message_id']]
-        if msg_dict.get('x_odoo_message_id'):
-            message_ids.append(msg_dict['x_odoo_message_id'])
-        existing_msg_ids = self.env['mail.message'].search([('message_id', 'in', message_ids)], limit=1)
+        existing_msg_ids = self.env['mail.message'].search([('message_id', '=', msg_dict['message_id'])], limit=1)
         if existing_msg_ids:
-            if msg_dict.get('x_odoo_message_id'):
-                _logger.info('Ignored mail from %s to %s with Message-Id %s / Context Message-Id %s: found duplicated Message-Id during processing',
-                             msg_dict.get('email_from'), msg_dict.get('to'), msg_dict.get('message_id'), msg_dict.get('x_odoo_message_id'))
-            else:
-                _logger.info('Ignored mail from %s to %s with Message-Id %s: found duplicated Message-Id during processing',
-                             msg_dict.get('email_from'), msg_dict.get('to'), msg_dict.get('message_id'))
+            _logger.info('Ignored mail from %s to %s with Message-Id %s: found duplicated Message-Id during processing',
+                         msg_dict.get('email_from'), msg_dict.get('to'), msg_dict.get('message_id'))
             return False
 
         if self._detect_loop_headers(msg_dict):
@@ -1586,7 +1579,6 @@ class MailThread(models.AbstractModel):
             # Very unusual situation, be we should be fault-tolerant here
             message_id = "<%s@localhost>" % time.time()
             _logger.debug('Parsing Message without message-id, generating a random one: %s', message_id)
-        msg_dict['x_odoo_message_id'] = (message.get('X-Odoo-Message-Id') or '').strip()
         msg_dict['message_id'] = message_id.strip()
 
         if message.get('Subject'):

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -334,8 +334,6 @@ class MailGatewayCommon(TestMailCommon):
         self.assertEqual(len(self._mails), 1)
         mail = self._mails[0]
         extra = f'References: {mail["references"]}'
-        if mail["headers"].get("X-Odoo-Message-Id"):
-            extra += f'\nX-Odoo-Message-Id: {mail["headers"]["X-Odoo-Message-Id"]}'
         with self.mock_mail_gateway(), self.mock_mail_app():
             self.format_and_process(
                 MAIL_TEMPLATE, mail['email_from'], ','.join(mail['email_to']),
@@ -2130,7 +2128,6 @@ class TestMailGatewayLoops(MailGatewayCommon):
                 body='Answer',
                 partner_ids=self.alias_partner.ids,
             )
-        last_mail = self._mails  # save to reuse
         self.assertSentEmail(self.user_employee.email_formatted, [self.alias_partner.email_formatted])
 
         # simulate this email coming back to the same Odoo server -> msg_id is
@@ -2142,17 +2139,6 @@ class TestMailGatewayLoops(MailGatewayCommon):
         self.assertFalse(capture_gateway.records)
         self.assertNotSentEmail()
         self.assertFalse(bool(self._new_msgs))
-
-        # simulate stupid email providers that rewrites msg_id -> thanks to
-        # a custom header, it is rejected as already managed by mailgateway
-        self._mails = last_mail
-        with RecordCapturer(self.env['mail.test.ticket'], []) as capture_ticket, \
-             RecordCapturer(self.env['mail.test.gateway'], []) as capture_gateway:
-            self._reinject(force_msg_id='123donotnamemailjet456')
-        self.assertFalse(capture_ticket.records)
-        self.assertFalse(capture_gateway.records)
-        self.assertFalse(bool(self._new_msgs))
-        self.assertNotSentEmail()
 
     @mute_logger('odoo.addons.mail.models.mail_thread')
     def test_routing_loop_forward_catchall(self):

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -790,25 +790,6 @@ class TestMailMail(TestMailCommon):
             [['test.cc.1@test.example.com', 'test.cc.2@test.example.com']] * 3,
         )
 
-    def test_mail_mail_values_headers(self):
-        """ Test headers content, notably X-Odoo-Message-Id added to keep context
-        when going through exotic mail providers that change our message IDs. """
-        mail = self.env['mail.mail'].create({
-            'body_html': '<p>Test</p>',
-            'email_to': 'test.😊@example.com',
-        })
-        message_id = mail.message_id
-        with self.mock_mail_gateway():
-            mail.send()
-        self.assertEqual(len(self._mails), 1)
-        self.assertDictEqual(
-            self._mails[0]['headers'],
-            {
-                'Return-Path': f'{self.alias_bounce}@{self.alias_domain}',
-                'X-Odoo-Message-Id': message_id,
-            }
-        )
-
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_mail_mail_values_email_unicode(self):
         """ Unicode should be fine. """


### PR DESCRIPTION
This reverts commit 43041dfd66e984978ad743c4f720e580f82bd1aa.

It looks like Google and Microsoft flag custom headers as Spam.

opw-4439329
opw-4458057
opw-4471333
opw-4492740
opw-4501103
opw-4503823
opw-4507802
opw-4517232
opw-4523135
opw-4529415
opw-4547995
opw-4556927
opw-4557754

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
