### PR TITLE
[FIX] website_sale: latest viewed products in random order

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -111,7 +111,16 @@ class WebsiteSnippetFilter(models.Model):
                     domain,
                     [('id', 'in', products_ids)],
                 ])
-                products = self.env['product.product'].with_context(display_default_code=False, add2cart_rerender=True).search(domain, limit=limit)
+                filtered_ids = set(self.env['product.product'].with_context(
+                    display_default_code=False,
+                    add2cart_rerender=True,
+                )._search(domain, limit=limit))
+                # `search` will not keep the order of tracked products; however, we want to keep
+                # that order (latest viewed first).
+                products = self.env['product.product'].browse(
+                    [product_id for product_id in products_ids if product_id in filtered_ids]
+                )
+
         return products
 
     def _get_products_recently_sold_with(self, website, limit, domain, context):


### PR DESCRIPTION
Before this commit:
The product snippet with filter "Latest Viewed Product" selected showed products in a random order. This was caused by a
`search([('id', 'in', ids)])` which does not enforce the order of `ids` in the returned set.

After this commit:
The order returned follows the intended "Last Viewed Product" order.

task-3916458

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
