### PR TITLE
[FIX] base: add properties definition field automatically in views

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1304,6 +1304,8 @@ actual arch.
                 if isinstance(domain, str):
                     vnames = get_expression_field_names(domain)
                     name_manager.must_have_fields(node, vnames, node_info, ('domain', domain))
+            if field.type == 'properties':
+                name_manager.must_have_fields(node, [field.definition_record], node_info, ('fieldname', field.name))
             context = node.get('context')
             if context:
                 vnames = get_expression_field_names(context)

--- a/odoo/addons/test_new_api/tests/test_views.py
+++ b/odoo/addons/test_new_api/tests/test_views.py
@@ -204,3 +204,21 @@ class TestViewGroups(ViewCase):
             form.bar = 1  # should make 'name' readonly by onchange modifying sub_bar
             with self.assertRaisesRegex(AssertionError, "can't write on readonly field 'name'"):
                 form.name = 'toto'
+
+    def test_add_properties_definition_field(self):
+        view = self.env['ir.ui.view'].create({
+            'name': 'stuff',
+            'model': 'test_new_api.message',
+            'arch': """
+                <form>
+                    <field name="attributes"/>
+                </form>
+            """,
+        })
+        views = self.env['test_new_api.message'].get_views([(view.id, 'form')])
+        arch = views['views']['form']['arch']
+        form = etree.fromstring(arch)
+        discussion_node = form.find("field[@name='discussion']")
+        self.assertIsNotNone(discussion_node, "the properties definition field `discussion` should be added automatically")
+        self.assertEqual(discussion_node.get("invisible"), "True")
+        self.assertEqual(discussion_node.get("data-used-by"), "fieldname='attributes' (field,attributes)")


### PR DESCRIPTION
Steps to reproduce
==================

- Install repair,web_studio
- Go to repair
- Open any record
- Open studio
- Switch to the misceallaneous tab
- Click on the Operation Type field
- Add the "Technical / Receive notifications in Odoo" group in "Allow visibility to groups"

```
TypeError: Cannot read properties of undefined (reading '0')
  at PropertiesField._getSeparatorFoldKey
```

Cause of the issue
==================

Since the user doesn't have that group, the field `picking_type_id` will no be available.

```py
repair_properties = fields.Properties(
    'Properties',
    definition='picking_type_id.repair_properties_definition'
)
```

That field is needed as it's the definition field for the repair_properties field.

Solution
========

When postprocessing views, we already add some fields that are needed by others. We can do the same for properties fields.

opw-4594796