### PR TITLE
[FIX] account: default_account_id removal from context when reversing analytic distribution

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1249,10 +1249,7 @@ class AccountMoveLine(models.Model):
             line.id for line in self if line.parent_state == "posted"
         ])
         lines_to_modify.analytic_line_ids.unlink()
-
-        context = dict(self.env.context)
-        context.pop('default_account_id', None)
-        lines_to_modify.with_context(context)._create_analytic_lines()
+        lines_to_modify._create_analytic_lines()
 
     @api.onchange('account_id')
     def _inverse_account_id(self):
@@ -3092,7 +3089,9 @@ class AccountMoveLine(models.Model):
         for line in self:
             analytic_line_vals.extend(line._prepare_analytic_lines())
 
-        self.env['account.analytic.line'].create(analytic_line_vals)
+        context = dict(self.env.context)
+        context.pop('default_account_id', None)
+        self.env['account.analytic.line'].with_context(context).create(analytic_line_vals)
 
     def _prepare_analytic_lines(self):
         self.ensure_one()


### PR DESCRIPTION
[FIX] account: default_account_id removal from context when reversing analytic distribution

When accessing journal items from a report, the context often includes default_account_id. When changing the account of a journal item, new analytic items are created, inheriting an account_id field. If account_id is False, it is automatically populated from default_account_id, which is sourced from account.account instead of account.analytic.account. This mismatch leads to the error: 
```The operation cannot be completed: another model requires the record being deleted. If possible, archive it instead.```

This fix moves when we remove the default_account_id from context to ensure it is removed despite the call stack not including the function _inverse_analytic_distribution

opw-4443816

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
