### PR TITLE
[FIX] l10n_es: fix a few typos in the Modelo reports.

### DIFF
--- a/addons/l10n_es/data/mod303.xml
+++ b/addons/l10n_es/data/mod303.xml
@@ -409,7 +409,7 @@
                                         </field>
                                     </record>
                                     <record id="mod_303_casilla_24" model="account.report.line">
-                                        <field name="name">[24] Contributinos 5.2%</field>
+                                        <field name="name">[24] Contributions 5.2%</field>
                                         <field name="code">aeat_mod_303_24</field>
                                         <field name="groupby">account_id</field>
                                         <field name="foldable" eval="True"/>

--- a/addons/l10n_es/data/mod390/mod390_section2.xml
+++ b/addons/l10n_es/data/mod390/mod390_section2.xml
@@ -940,7 +940,7 @@
                                         </field>
                                     </record>
                                     <record id="mod_390_casilla_763" model="account.report.line">
-                                        <field name="name">[763] Base imponible 5%</field>
+                                        <field name="name">[763] Base imponible 7.5%</field>
                                         <field name="code">aeat_mod_390_763</field>
                                         <field name="expression_ids">
                                             <record id="mod_390_casilla_763_balance" model="account.report.expression">
@@ -951,7 +951,7 @@
                                         </field>
                                     </record>
                                     <record id="mod_390_casilla_764" model="account.report.line">
-                                        <field name="name">[764] Cuota 5%</field>
+                                        <field name="name">[764] Cuota 7.5%</field>
                                         <field name="code">aeat_mod_390_764</field>
                                         <field name="expression_ids">
                                             <record id="mod_390_casilla_764_balance" model="account.report.expression">

--- a/addons/l10n_es/i18n/es.po
+++ b/addons/l10n_es/i18n/es.po
@@ -1664,7 +1664,7 @@ msgstr "[24] Importe de los ingresos a cuenta"
 
 #. module: l10n_es
 #: model:account.report.line,name:l10n_es.mod_303_casilla_24
-msgid "[24] Contributinos 5.2%"
+msgid "[24] Contributions 5.2%"
 msgstr "[24] Cuota 5,2 %"
 
 #. module: l10n_es

--- a/addons/l10n_es/i18n/l10n_es.pot
+++ b/addons/l10n_es/i18n/l10n_es.pot
@@ -16,6 +16,81 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_p103
+msgid "+mod390[103]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_p104
+msgid "+mod390[104]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_p230
+msgid "+mod390[230]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_p232
+msgid "+mod390[232]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_p773
+msgid "+mod390[773]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_p774
+msgid "+mod390[774]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_p775
+msgid "+mod390[775]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_p776
+msgid "+mod390[776]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_m104
+msgid "-mod390[104]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_m230
+msgid "-mod390[230]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_m232
+msgid "-mod390[232]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_m773
+msgid "-mod390[773]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_m774
+msgid "-mod390[774]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_m775
+msgid "-mod390[775]"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.account.tag,name:l10n_es.account_tag_mod390_m776
+msgid "-mod390[776]"
+msgstr ""
+
+#. module: l10n_es
 #: model:ir.model,name:l10n_es.model_account_chart_template
 msgid "Account Chart Template"
 msgstr ""
@@ -1642,7 +1717,7 @@ msgstr ""
 
 #. module: l10n_es
 #: model:account.report.line,name:l10n_es.mod_303_casilla_24
-msgid "[24] Contributinos 5.2%"
+msgid "[24] Contributions 5.2%"
 msgstr ""
 
 #. module: l10n_es
@@ -2482,8 +2557,73 @@ msgid "[662] Cuotas pendientes de compensación al término del ejercicio"
 msgstr ""
 
 #. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_667
+msgid "[667] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_668
+msgid "[668] Cuota 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_669
+msgid "[669] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
 #: model:account.report.line,name:l10n_es.mod_303_casilla_66
 msgid "[66] Attributable to the State Administration"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_670
+msgid "[670] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_671
+msgid "[671] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_672
+msgid "[672] Cuota 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_673
+msgid "[673] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_674
+msgid "[674] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_675
+msgid "[675] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_676
+msgid "[676] Cuota 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_677
+msgid "[677] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_678
+msgid "[678] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_679
+msgid "[679] Base imponible 2%"
 msgstr ""
 
 #. module: l10n_es
@@ -2492,8 +2632,83 @@ msgid "[67] Contributions to be compensated from previous periods"
 msgstr ""
 
 #. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_680
+msgid "[680] Cuota 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_681
+msgid "[681] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_682
+msgid "[682] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_683
+msgid "[683] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_684
+msgid "[684] Cuota 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_685
+msgid "[685] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_686
+msgid "[686] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_687
+msgid "[687] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_688
+msgid "[688] Cuota 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_689
+msgid "[689] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
 #: model:account.report.line,name:l10n_es.mod_303_casilla_68
 msgid "[68] Result of the annual regularization"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_690
+msgid "[690] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_695
+msgid "[695] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_696
+msgid "[696] Cuota deducible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_697
+msgid "[697] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_698
+msgid "[698] Cuota 7.5%"
 msgstr ""
 
 #. module: l10n_es
@@ -2724,13 +2939,173 @@ msgid "[741] Cuota 5%"
 msgstr ""
 
 #. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_745
+msgid "[745] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_746
+msgid "[746] Cuota 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_747
+msgid "[747] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_748
+msgid "[748] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_749
+msgid "[749] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
 #: model:account.report.line,name:l10n_es.mod_303_casilla_74
 msgid "[74] Base taxable"
 msgstr ""
 
 #. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_750
+msgid "[750] Cuota deducible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_751
+msgid "[751] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_752
+msgid "[752] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_753
+msgid "[753] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_754
+msgid "[754] Cuota deducible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_755
+msgid "[755] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_756
+msgid "[756] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_757
+msgid "[757] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_758
+msgid "[758] Cuota deducible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_759
+msgid "[759] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
 #: model:account.report.line,name:l10n_es.mod_303_casilla_75
 msgid "[75] Contributions"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_760
+msgid "[760] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_761
+msgid "[761] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_762
+msgid "[762] Cuota deducible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_763
+msgid "[763] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_764
+msgid "[764] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_765
+msgid "[765] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_766
+msgid "[766] Cuota deducible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_767
+msgid "[767] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_768
+msgid "[768] Cuota 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_769
+msgid "[769] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_770
+msgid "[770] Cuota deducible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_771
+msgid "[771] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_772
+msgid "[772] Cuota deducible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_773
+msgid "[773] Base imponible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_774
+msgid "[774] Cuota deducible 2%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_775
+msgid "[775] Base imponible 7.5%"
+msgstr ""
+
+#. module: l10n_es
+#: model:account.report.line,name:l10n_es.mod_390_casilla_776
+msgid "[776] Cuota 7.5%"
 msgstr ""
 
 #. module: l10n_es


### PR DESCRIPTION
I spotted three mistakes in the naming of the lines in the Modelo 303 and 390 reports. This PR fixes them and updates the .po, .pot files accordingly.
