### PR TITLE
[IMP] account_peppol: webhook event notifications

### DIFF
--- a/addons/account_peppol/controllers/__init__.py
+++ b/addons/account_peppol/controllers/__init__.py
@@ -1,1 +1,2 @@
 from . import portal
+from . import webhooks

--- a/addons/account_peppol/controllers/webhooks.py
+++ b/addons/account_peppol/controllers/webhooks.py
@@ -1,0 +1,62 @@
+from odoo import http
+from odoo.http import request
+
+
+class PeppolWebhookController(http.Controller):
+
+    @http.route(
+        '/peppol/webhook/new-message',
+        type='http',
+        auth='public',
+        methods=['POST'],
+        csrf=False,
+    )
+    def webhook_new_message(self, token):
+        edi_client = request.env['account_edi_proxy_client.user']._get_user_from_token(token, url=request.httprequest.url)
+
+        cron = request.env.ref(
+            'account_peppol.ir_cron_peppol_get_new_documents',
+            raise_if_not_found=False,
+        )
+        if edi_client and cron:
+            cron.sudo()._trigger()
+
+        return http.Response(status=204)
+
+    @http.route(
+        '/peppol/webhook/message-state-update',
+        type='http',
+        auth='public',
+        methods=['POST'],
+        csrf=False,
+    )
+    def webhook_message_update(self, token):
+        edi_client = request.env['account_edi_proxy_client.user']._get_user_from_token(token, url=request.httprequest.url)
+
+        cron = request.env.ref(
+            'account_peppol.ir_cron_peppol_get_message_status',
+            raise_if_not_found=False,
+        )
+        if edi_client and cron:
+            cron.sudo()._trigger()
+
+        return http.Response(status=204)
+
+    @http.route(
+        '/peppol/webhook/user-state-update',
+        type='http',
+        auth='public',
+        methods=['POST'],
+        csrf=False,
+    )
+    def webhook_user_update(self, token):
+        edi_client = request.env['account_edi_proxy_client.user']._get_user_from_token(token, url=request.httprequest.url)
+
+        cron = request.env.ref(
+            'account_peppol.ir_cron_peppol_get_participant_status',
+            raise_if_not_found=False,
+        )
+        if edi_client and cron:
+            cron.sudo()._trigger()
+
+        return http.Response(status=204)

--- a/addons/account_peppol/data/cron.xml
+++ b/addons/account_peppol/data/cron.xml
@@ -26,4 +26,13 @@
         <field name="code">model._cron_peppol_get_participant_status()</field>
         <field name="state">code</field>
     </record>
+
+    <record id="ir_cron_peppol_webhook_keepalive" model="ir.cron">
+        <field name="name">PEPPOL: webhook keep alive</field>
+        <field name="interval_number">2</field>
+        <field name="interval_type">weeks</field>
+        <field name="model_id" ref="model_account_edi_proxy_client_user"/>
+        <field name="code">model._cron_peppol_webhook_keepalive()</field>
+        <field name="state">code</field>
+    </record>
 </odoo>

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -5,6 +5,7 @@ import re
 import requests
 from lxml import etree
 from stdnum import get_cc_module, ean
+from urllib.parse import urljoin
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -275,6 +276,10 @@ class ResCompany(models.Model):
         # by design, we can only have zero or one proxy user per company with type Peppol
         peppol_user = self.sudo().account_edi_proxy_client_ids.filtered(lambda u: u.proxy_type == 'peppol')
         return peppol_user.edi_mode or config_param or 'prod'
+
+    def _get_peppol_webhook_endpoint(self):
+        self.ensure_one()
+        return urljoin(self.get_base_url(), '/peppol/webhook')
 
     def _get_company_info_on_peppol(self, edi_identification):
 


### PR DESCRIPTION
Up until now odoo clients using peppol were updating local state by polling data (e.g. fetching new invoices once every couple of hours). This had multiple not so great side-effects.
For example:
- A sales demonstrating odoo to a client would not even be able to show reception on the same business day because of cron polling interval set too high
- Accountants not receiving new invoices very often

This commit, together with https://github.com/odoo/iap-apps/pull/1008 adds support for peppol webhooks, but only for saas and odoosh users. The decision of not supporting on-prem instances has the following reasonning:
- It would require to implement a black-list based SSRF protection which is very hard to do well and usually pretty easy to bypass.
- On-prem users can easily increase the velocity of their polling crons when they need to, which is not something we want to do on saas.

Thus only webhooks with netloc mathcing the followung pattern would work: `<subdomain>.odoo.com[/ignored/path]` and would send the webhook to `POST <netloc>/peppol/webhook/<peppol_user_uuid>/<event>`

task-4582273