### PR TITLE
[FIX] pos_self_order: revert svg qrcode download

### DIFF
--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import qrcode
-import qrcode.image.svg
 import zipfile
 from io import BytesIO
 
@@ -94,10 +93,7 @@ class ResConfigSettings(models.TransientModel):
         )
         qr.add_data(url)
         qr.make(fit=True)
-        return {
-            'png': qr.make_image(fill_color="black", back_color="transparent"),
-            'svg': qr.make_image(fill_color="black", back_color="transparent", image_factory=qrcode.image.svg.SvgImage)
-        }
+        return qr.make_image(fill_color="black", back_color="transparent")
 
     def generate_qr_codes_zip(self):
         if not self.pos_self_ordering_mode in ['mobile', 'consultation']:
@@ -113,12 +109,12 @@ class ResConfigSettings(models.TransientModel):
 
             for table in table_ids:
                 qr_images.append({
-                    'images': self._generate_single_qr_code(url_unquote(self.pos_config_id._get_self_order_url(table.id))),
+                    'image': self._generate_single_qr_code(url_unquote(self.pos_config_id._get_self_order_url(table.id))),
                     'name': f"{table.floor_id.name} - {table.table_number}",
                 })
         else:
             qr_images.append({
-                'images': self._generate_single_qr_code(url_unquote(self.pos_config_id._get_self_order_url())),
+                'image': self._generate_single_qr_code(url_unquote(self.pos_config_id._get_self_order_url())),
                 'name': "generic",
             })
 
@@ -127,9 +123,7 @@ class ResConfigSettings(models.TransientModel):
         with zipfile.ZipFile(zip_buffer, "w", 0) as zip_file:
             for index, qr_image in enumerate(qr_images):
                 with zip_file.open(f"{qr_image['name']} ({index + 1}).png", "w") as buf:
-                    qr_image['images']['png'].save(buf, format="PNG")
-                with zip_file.open(f"{qr_image['name']} ({index + 1}).svg", "w") as buf:
-                    qr_image['images']['svg'].save(buf)
+                    qr_image['image'].save(buf, format="PNG")
         zip_buffer.seek(0)
 
         # Delete previous attachments


### PR DESCRIPTION
This reverts commit 3d447856467e7ad72f0a89c71b643940b8ea5321.
This was incompatible with the lxml version we have on our server.
Revert for a quick fix until we have corrected the deployment (which will be slower)
Task-id 4575936 is a new feature that should not have targeted a stable version
