### PR TITLE
[IMP] website, *: stop forcing redirection when reaching the website app

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { session } from "@web/session";
 import * as OdooEditorLib from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
 import { _t } from "@web/core/l10n/translation";
 import { isVisible } from "@web/core/utils/ui";
@@ -273,6 +274,37 @@ export class Link extends Component {
      */
     _doStripDomain() {}
     /**
+     * Checks if the given URL is using the domain where the content being
+     * edited is reachable, i.e. if this URL should be stripped of its domain
+     * part and converted to a relative URL if put as a link in the content.
+     *
+     * @private
+     * @returns {boolean}
+     */
+    _isAbsoluteURLInCurrentDomain(url) {
+        // First check if it is a relative URL: if it is, we don't want to check
+        // further as we will always leave those untouched.
+        let hasProtocol;
+        try {
+            hasProtocol = !!(new URL(url).protocol);
+        } catch {
+            hasProtocol = false;
+        }
+        if (!hasProtocol) {
+            return false;
+        }
+
+        const urlObj = new URL(url, window.location.origin);
+        return urlObj.origin === window.location.origin
+            // Chosen heuristic to detect someone trying to enter a link using
+            // its Odoo instance domain. We just suppose it should be a relative
+            // URL (if unexpected behavior, the user can just not enter its Odoo
+            // instance domain but its real domain, or opt-out from the domain
+            // stripping). Mentioning an .odoo.com domain, especially its own
+            // one, is always a bad practice anyway.
+            || new RegExp(`^https?://${session.db}\\.odoo\\.com(/.*)?$`).test(urlObj.origin);
+    }
+    /**
      * Get the link's data (url, content and styles).
      *
      * @private
@@ -307,12 +339,15 @@ export class Link extends Component {
         var isNewWindow = this._isNewWindow(url);
         var doStripDomain = this._doStripDomain();
         let urlWithoutDomain = this.state.url;
-        if (this.state.url.indexOf(location.origin) === 0) {
-            urlWithoutDomain = this.state.url.slice(location.origin.length);
+        if (this._isAbsoluteURLInCurrentDomain(this.state.url)) {
+            const urlObj = new URL(this.state.url, window.location.origin);
+            // Not necessarily equal to window.location.origin
+            // (see _isAbsoluteURLInCurrentDomain)
+            urlWithoutDomain = this.state.url.replace(urlObj.origin, '');
             if (doStripDomain) {
                 this.state.url = urlWithoutDomain;
             }
-        } else if (url.indexOf(location.origin) === 0 && !doStripDomain) {
+        } else if (this._isAbsoluteURLInCurrentDomain(url) && !doStripDomain) {
             this.state.url = url;
         }
         var allWhitespace = /\s+/gi;
@@ -323,8 +358,8 @@ export class Link extends Component {
         if (urlWithoutDomain && urlWithoutDomain.startsWith("/web/content/")) {
             isDocument = !this.isLastAttachmentUrl;
             directDownload = urlWithoutDomain.includes("&download=true");
-        } 
-        
+        }
+
         return {
             content: content,
             url: this._correctLink(this.state.url),
@@ -686,10 +721,11 @@ export class Link extends Component {
      */
     _onURLInput() {
         var $linkUrlInput = this.$el.find('#o_link_dialog_url_input');
-        let value = $linkUrlInput.val();
+        const value = $linkUrlInput.val() || '';
         let isLink = !EMAIL_REGEX.test(value) && !PHONE_REGEX.test(value);
         this._getIsNewWindowFormRow().toggleClass('d-none', !isLink);
-        this.$el.find('.o_strip_domain').toggleClass('d-none', value.indexOf(window.location.origin) !== 0);
+        this.$el.find('.o_strip_domain')
+            .toggleClass('d-none', !this._isAbsoluteURLInCurrentDomain(value));
     }
     /**
      * @private

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -81,6 +81,18 @@ export class WebsitePreview extends Component {
 
             const encodedPath = encodeURIComponent(this.path);
             if (!session.website_bypass_domain_redirect // Used by the Odoo support (bugs to be expected)
+                    // As a stable fix, we chose to never redirect to the right
+                    // domain anymore in this case. We still do when using the
+                    // website switcher, but not when reaching the "default"
+                    // website. The goal is to better support users typing
+                    // mysupercompany.odoo.com explicitly to enter their
+                    // backend instead of mysupercompany.be.
+                    // Bugs are to be expected while editing/using the website
+                    // mysupercompany.be from mysupercompany.odoo.com though,
+                    // but it should be the case only in specific/advanced
+                    // situations.
+                    // TODO remove this code properly in master.
+                    && 1 === 0
                     && this.websiteDomain
                     && !wUtils.isHTTPSorNakedDomainRedirection(this.websiteDomain, window.location.origin)) {
                 // The website domain might be the naked one while the naked one

--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -2,6 +2,7 @@
 
 import { LinkTools } from '@web_editor/js/wysiwyg/widgets/link_tools';
 import { patch } from "@web/core/utils/patch";
+import { useService } from "@web/core/utils/hooks";
 
 import { onWillStart, status, useEffect } from '@odoo/owl';
 import wUtils from "@website/js/utils";
@@ -24,6 +25,9 @@ patch(LinkTools.prototype, {
 
     setup() {
         super.setup();
+
+        this.websiteService = useService("website");
+
         onWillStart(() => {
             this._adaptPageAnchor = debounce(this._adaptPageAnchor, LINK_DEBOUNCE);
         });
@@ -84,6 +88,33 @@ patch(LinkTools.prototype, {
             }
         }
         $selectMenu.data("anchor-for", urlInputValue);
+    },
+    /**
+     * @override
+     */
+    _isAbsoluteURLInCurrentDomain(url) {
+        const res = super._isAbsoluteURLInCurrentDomain(url);
+        if (res) {
+            return true;
+        }
+
+        const w = this.websiteService.currentWebsite;
+        if (!w) {
+            return false;
+        }
+
+        // Make sure that while being on abc.odoo.com, if you edit a link and
+        // enter an absolute URL using your real domain, it is still considered
+        // to be added as relative, preferably.
+        // In the past, you could not edit your website from abc.odoo.com if you
+        // properly configured your real domain already.
+        let origin;
+        try { // Needed: "http:" would crash
+            origin = new URL(url, window.location.origin).origin;
+        } catch {
+            return false;
+        }
+        return `${origin}/`.startsWith(w.domain);
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
*: web_editor

Before this commit, there was two cases where we forced the backend to reload using a website domain:

1. When trying to enter the website app, and reaching the default website's preview. Ensuring edition of that website is made while being on the right website domain.

2. When switching website using the website switcher (multi-websites case).

This commit removes the redirection in the first case. It might lead to unexpected behavior in some specific/advanced cases, but it was decided it was worth the risk, to improve the QoL of users reaching their backend by explicitly typing their `<database>`.odoo.com URL. Even though this is not supposed the case anymore as soon as their website is properly configured.

At the same time, this commit strengthens (hopefully) link edition. In the past, we suggested users to automatically strip the domain part of the URL they added in their website if it matches the current domain used while being in edit mode. Now we still do that and two more checks:

- If the added URL is using `<dbname>`.odoo.com, suggest to strip the domain too. It might not be right, but it's a good guess. And the user can still opt-out.

- If the added URL uses the website domain, suggest to strip the domain.

Related to task-4069779
