### PR TITLE
[FIX] product: hide darkmode image background in catalog

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -676,7 +676,15 @@ action = {
                                         groups="product.group_product_variant"
                                         options="{'color_field': 'color'}"/>
                             </div>
-                            <field name="image_128" widget="image" alt="Product" invisible="not image_128" class="ms-auto" options="{'size': [55, 55]}"/>
+                            <field
+                                name="image_128"
+                                widget="image"
+                                alt="Product"
+                                invisible="not image_128"
+                                class="ms-auto"
+                                options="{'size': [55, 55]}"
+                                style="max-height: 55px;"
+                            />
                         </div>
                     </t>
                 </templates>


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Enable dark mode (requires `web_enterprise`);
2. create a quotation;
3. open product catalog.

Issue
-----
There's a weird rectangle visible below the images.

Cause
-----
Commit 5234fad374c9c adapted Odoo for darkmode. As part of it, it added a background color for image fields, which defaults to `#E4E4E4`. There is no background color defined for image fields in light mode.

Commit e8836b42200e3 changed the catalog kanban to use cards instead of boxes. As a consequence, the background color for image fields now gets used on the `div` containing the image.

Normally this background color is invisible, as the image overlaps the `div`, but because the catalog resizes images to 55px, the `div` is now taller than the image, revealing the element's background color.

Solution
--------
Add a `style="max-height: 55px;` attribute to the element to ensure its height corresponds to the image's.

opw-4499252