### PR TITLE
[FIX] portal: correct avatar ratio in portal chatter

### DIFF
--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -95,6 +95,7 @@ a dependency towards website editing and customization capabilities.""",
             "portal/static/src/chatter/scss/primary_variables.scss",  # to force interprise primary color
             ("include", "web._assets_bootstrap_backend"),
             "web/static/src/scss/mimetypes.scss",
+            'web/static/src/scss/ui.scss',
             "web/static/src/libs/fontawesome/css/font-awesome.css",
             "web/static/lib/odoo_ui_icons/style.css",
             "web/static/src/webclient/webclient.scss",


### PR DESCRIPTION
Before this commit, some messages in portal chatter may have avatar squished vertically or horizontally when the source image of avatar is not a square.

This happens because avatar are cropped to fit cover with `.o_object_fit_cover`, in order to give the right visual when the avatar doesn't fit in a square. The classname was present but the SCSS file defining this rule was missing from the ` "portal.assets_chatter_style"` bundle, which this commit fixes.

Before
![Screenshot 2025-03-04 at 18 32 58](https://github.com/user-attachments/assets/f718f870-1701-46a5-8794-c952fb932665)
After
![Screenshot 2025-03-04 at 18 33 22](https://github.com/user-attachments/assets/c43a9d75-630d-45a0-8b35-d41d8b4baafa)

