### PR TITLE
[FIX] account: show invoice_sending_methods label only if necessary

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -252,11 +252,13 @@
 
     <template id="portal_my_details_fields" inherit_id="portal.portal_my_details_fields">
         <xpath expr="//select[@name='country_id']/.." position="after">
-            <div class="col-12 d-none d-xl-block">
-                <small class="form-text text-muted">
-                    You can choose how you want us to send your invoices, and with which electronic format.
-                </small>
-            </div>
+            <t t-if="len(invoice_sending_methods) > 1 and invoice_edi_format">
+                <div class="col-12 d-none d-xl-block">
+                    <small class="form-text text-muted">
+                        You can choose how you want us to send your invoices, and with which electronic format.
+                    </small>
+                </div>
+            </t>
             <div class="row m-0 p-0" t-if="len(invoice_sending_methods) > 1">
                 <div class="col-xl-6">
                     <label class="col-form-label" for="invoice_sending_method">Receive invoices</label>


### PR DESCRIPTION
Currently, there is no validation in place to determine when the labe related to invoice_sending_methods should be added to the portal_my_details_fields template in the inheritance made in [1].
    
This results in the following:
    
For invoice_sending_methods, the label/message: 'You can choose how yo want us to send your invoices, and with which electronic format.' is always displayed, even if the <select> to define the method is not visible.
    
Now, a validation has been added to display this label only when necessary, in order to avoid user confusion.

[1]: https://github.com/odoo/odoo/commit/de567b6

Before:
![200261_before](https://github.com/user-attachments/assets/658210fa-a4d8-44ab-a72a-472c1fb22e43)


After:
![200261_after](https://github.com/user-attachments/assets/13010255-e315-4b30-b046-274c4be9dea0)

