### PR TITLE
[FIX] mail: no failure ".o-mail-ChatHub-compact" with text "1"

### DIFF
--- a/addons/mail/static/tests/mail_test_helpers_contains.js
+++ b/addons/mail/static/tests/mail_test_helpers_contains.js
@@ -1,7 +1,7 @@
 /** @odoo-module alias=@web/../tests/utils default=false */
 
 import { __debug__, after, afterEach, expect, getFixture } from "@odoo/hoot";
-import { queryAll, queryFirst } from "@odoo/hoot-dom";
+import { getActiveElement, queryAll, queryFirst } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, tick } from "@odoo/hoot-mock";
 import { isMacOS } from "@web/core/browser/feature_detection";
 import { isVisible } from "@web/core/utils/ui";
@@ -233,10 +233,15 @@ function _triggerEvents(el, selector, eventDefs, options = {}) {
 function _click(
     el,
     selector,
-    { mouseEventInit = {}, skipDisabledCheck = false, skipVisibilityCheck = false } = {}
+    { mouseEventInit = {}, skipDisabledCheck = false, skipVisibilityCheck = false, target } = {}
 ) {
     if (!skipDisabledCheck && el.disabled) {
         throw new Error("Can't click on a disabled button");
+    }
+    const previousEl = getActiveElement(target);
+    const nextEl = findElement(el, selector);
+    if (previousEl !== nextEl) {
+        _triggerEvents(previousEl, undefined, ["focusout"], { skipVisibilityCheck });
     }
     return _triggerEvents(
         el,
@@ -719,6 +724,7 @@ class Contains {
                 mouseEventInit: this.options.click,
                 skipDisabledCheck: true,
                 skipVisibilityCheck: true,
+                target: this.options.target,
             });
         }
         if (this.options.dragenterFiles) {


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/199828

PR above added a new test that resulted in frequent runbot failures:

```
Failed assertions:

1. [toBe] Failed to find 1 of ".o-mail-ChatHub-compact" with text "1" (Timeout of 3 seconds). Found 0 instead.
> Expected: true
> Received: false

2. [errors] 1 unverified error(s)

Error during test:

Failed to find 1 of ".o-mail-ChatHub-compact" with text "1" (Timeout of 3 seconds). Found 0 instead.
```

This happens because the test had a chat window open, enabled the compact mode of chat hub, then posts a message and assert there's a counter on the chathub compact button.

Everything works fine when a human do these interactions. However the test failed because there was no counter. This comes from chat window modeling that was thinking the composer was still focused, therefore it was marking the conversation as read, leading to consuming the "1" counter. Composer was kept in "focused" state because when programmatically simulating a `click`, the detection of loss of focus is made with a `focusout` event that is triggered normally on the previously focused element. In HOOT, the `@mail` click test helper was not triggering `focusout` on the previous element.

This commit fixes the issue by triggering `"focusout"` on the previously active element in the `click` helper of `@mail` when the previous element is not the same as the next.

runbot-159692

https://runbot.odoo.com/runbot/build/76027155