### PR TITLE
[FIX] mail: no failure ".o-mail-ChatHub-compact" with text "1"

### DIFF
--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -13,6 +13,7 @@ import {
     setupChatHub,
     start,
     startServer,
+    triggerEvents,
     triggerHotkey,
 } from "../mail_test_helpers";
 
@@ -399,6 +400,7 @@ test("Open chat window from messaging menu with chat hub compact", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", { text: "John" });
     await contains(".o-mail-ChatWindow", { text: "John" });
+    await triggerEvents(".o-mail-Composer-input", ["blur", "focusout"]); // FIXME: click fold doesn't focusout/blur the composer, thus marks as read
     await click(".o-mail-ChatWindow-command[title='Fold']");
     await contains(".o-mail-ChatWindow", { count: 0 });
     await withUser(johnId, () =>


### PR DESCRIPTION
Follow-up of odoo#199828

PR above added a new test that resulted in frequent runbot failures:

```
Failed assertions:

1. [toBe] Failed to find 1 of ".o-mail-ChatHub-compact" with text "1" (Timeout of 3 seconds). Found 0 instead.
> Expected: true
> Received: false

2. [errors] 1 unverified error(s)

Error during test:

Failed to find 1 of ".o-mail-ChatHub-compact" with text "1" (Timeout of 3 seconds). Found 0 instead.
```

This happens because the test had a chat window open, enabled the compact mode of chat hub, then posts a message and assert there's a counter on the chathub compact button.

Everything works fine when a human do these interactions. However the test failed because there was no counter. This comes from chat window modeling that was thinking the composer was still focused, therefore it was marking the conversation as read, leading to consuming the "1" counter. Composer was kept in "focused" state because when programmatically simulating a `click`, the detection of loss of focus is made with a `focusout` event that is triggered normally on the previously focused element. In HOOT, the `@mail` click test helper was not triggering `focusout` on the previous element.

Some attempts were made to programmatically trigger the "focusout", including some reliance of tests that do `mousedown.prevent` that are expected to not change focus on click, but tests keep failing. As this is important to make runbot green as soon as possible, this commit fixes the issue by helping the problematic test to blur/focusout the composer.

Note that the `contains().click` from `web_test_helpers` seem to properly managed the focusous and the `mousedown.prevent`, but there are a lot of occurrences of mail `await click()` to change, and this without taking into account some issues in converting to `contains.click()` at the moment:
- timeout of click is 200ms, which is too short for discuss tests
- mail `click` feature uses `text` to make exact comparison of textnode, compared to `:contains()`. This is probably not a big issue as with `value` where asserting composer is empty asynchronously is very important for discuss

The plan is to use web test helpers for mail tests, but this requires more time than the urgency to fix this test now.

runbot-159692