### PR TITLE
[FIX] web: fix extractProps not executing in list widget

### DIFF
--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -138,6 +138,7 @@ export class ListArchParser {
                     // can decode it later...
                     node: encodeObjectForTemplate({ attrs: widgetInfo.attrs }).slice(1, -1),
                     className: node.getAttribute("class") || "",
+                    widgetInfo
                 };
                 columns.push({
                     ...widgetInfo,

--- a/doc/cla/individual/tanzv.md
+++ b/doc/cla/individual/tanzv.md
@@ -1,0 +1,11 @@
+China, 2025-01-25
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Sudhir Arya zkind@foxmail.com https://github.com/tanzv


### PR DESCRIPTION
Before this fix, the list widget's extractProps function was never called due to an incorrect method reference in the web module. This caused issues when rendering dynamic props or customizing the list view behavior.

After the fix:
- The extractProps function is properly invoked.
- The list widget can now retrieve props values as expected.

Description of the issue/feature this PR addresses:

Current behavior before PR: widget extractProps do not execute correctly

Desired behavior after PR is merged:  widget extractProps execute correctly, and props are passed correctly




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
