### PR TITLE
l10n_bg: add delivery date on invoice

### DIFF
--- a/addons/l10n_bg/models/__init__.py
+++ b/addons/l10n_bg/models/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_bg
+from . import account_move

--- a/addons/l10n_bg/models/account_move.py
+++ b/addons/l10n_bg/models/account_move.py
@@ -1,0 +1,19 @@
+from odoo import models, api
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.depends('invoice_date')
+    def _compute_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_delivery_date()
+        for move in self:
+            if move.invoice_date and move.country_code == 'BG' and not move.delivery_date:
+                move.delivery_date = move.invoice_date
+
+    @api.depends('country_code', 'move_type')
+    def _post(self, soft=True):
+        for move in self:
+            if move.country_code == 'BG' and move.is_sale_document() and not move.delivery_date:
+                move.delivery_date = move.invoice_date
+        return super()._post(soft)

--- a/doc/cla/corporate/iaxus.md
+++ b/doc/cla/corporate/iaxus.md
@@ -1,0 +1,13 @@
+Bulgaria, 2025-03-06
+
+Iaxus agrees to the terms of the Odoo Corporate Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Iaxus denev@iaxus.com https://github.com/mic1983
+
+List of contributors:
+
+Mihail Denev denev@iaxus.com https://github.com/mic1983


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Delivery dates on invoices are a legal requirement on Bulgaria. It needs to be
displayed on the header of the form view and will be displayed on the printed
invoices.

Current behavior before PR:
Delivery date is not required and it is possible to not have value.

Desired behavior after PR is merged:
If delivery date is empty it copy the value of invoice date field in delivery date field



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
