### PR TITLE
[FIX] product: prevent error if product category is not given in product

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -476,7 +476,7 @@ class ProductPricelistItem(models.Model):
             res = False
 
         elif self.applied_on == "2_product_category":
-            if (
+            if not product.categ_id or (
                 product.categ_id != self.categ_id
                 and not product.categ_id.parent_path.startswith(self.categ_id.parent_path)
             ):


### PR DESCRIPTION
Currently, an exception is raised when the user clicks on the catalog in a quotation if a product has no assigned category.

Steps to Reproduce:

1. Install the sale_management module.
2. Navigate to Sales -> Configuration -> Settings.
3. Enable the Pricelists.
4. Open a new Pricelists -> Add a Price Rules with Apply To `Category`, select a category, and save.
5. Go to Products -> Products.
6. Open an existing product and remove its product category.
7. Go to Sales -> Orders -> New Quotation.
8. Select the created Pricelists, and click on Catalog.
9. An error occurs.

Error:
`AttributeError
'bool' object has no attribute 'startswith'
`

This issue [1] occurs because when the user tries to access product category, the product category is not provided, as it is not a required field.

[1] -
https://github.com/odoo/odoo/blob/4bf8fc4c43ab7d8fd923aaaea8c6423c9a16e428/addons/product/models/product_pricelist_item.py#L481

This fix resolves the issue by ensuring that the product category exists before trying to access it.

sentry-6320016916

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
