### PR TITLE
[FIX] crm: fix crm_tour input

### DIFF
--- a/addons/crm/i18n/crm.pot
+++ b/addons/crm/i18n/crm.pot
@@ -98,6 +98,18 @@ msgid "<b>Write a few letters</b> to look for a company, or create a new one."
 msgstr ""
 
 #. module: crm
+#. odoo-javascript
+#: code:addons/crm/static/src/js/tours/crm.js:0
+msgid "<b>Click</b> to look for, or create, a company."
+msgstr ""
+
+#. module: crm
+#. odoo-javascript
+#: code:addons/crm/static/src/js/tours/crm.js:0
+msgid "<b>Select</b> a company."
+msgstr ""
+
+#. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_lead_view_form
 msgid ""
 "<i class=\"fa fa-gear\" role=\"img\" title=\"Switch to automatic "

--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -34,14 +34,16 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "click",
 }, {
     trigger: ".o_kanban_quick_create .o_field_widget[name='partner_id'] input",
-    content: markup(_t('<b>Write a few letters</b> to look for a company, or create a new one.')),
+    content: markup(_t('<b>Click</b> to look for, or create, a company.')),
     position: "top",
-    run: "edit Brandon Freeman",
-}, {
-    isActive: ["auto"],
-    trigger: ".ui-menu-item > a",
-    in_modal: false,
     run: "click",
+}, {
+    trigger: ".ui-menu-item > a",
+    content: markup(_t('<b>Select</b> a company.')),
+    position: "right",
+    run: "click",
+}, {
+    trigger: ".o_kanban_quick_create .o_field_widget[name='partner_id'] .o_external_button", // Wait for other fields to update
 }, {
     trigger: ".o_kanban_quick_create .o_kanban_add",
     content: markup(_t("Now, <b>add your Opportunity</b> to your Pipeline.")),


### PR DESCRIPTION
Purpose
=======
Fix the crm_tour which was stuck on the "Write a few letters
to look for a company" step in the quick create.

Specification
=============
This step requires the user to enter an actual character in the input.
Clicking on the input and selecting a record in the dropdown isn't enough.
=> Making so that a click on the field is enough to get going.
=> Adding a step to make sure the user correctly selects a value in the dropdown
and doesn't come out of the field.

related PR: https://github.com/odoo/odoo/pull/158055

Task-4624497

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
