### PR TITLE
[FIX] html_editor: add missing checklist styles in `html_editor`

### DIFF
--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -1,3 +1,32 @@
 li p {
     margin-bottom: 0px;
 }
+
+// Checklist
+ul.o_checklist {
+    > li {
+        list-style: none;
+        position: relative;
+        margin-left: 20px;
+
+        &:not(.oe-nested):before {
+            content: '';
+            position: absolute;
+            left: -20px;
+            display: block;
+            height: 14px;
+            width: 14px;
+            top: 1px;
+            border: 1px solid;
+            cursor: pointer;
+        }
+        &.o_checked:after {
+            content: "✓";
+            transition: opacity .5s;
+            position: absolute;
+            left: -18px;
+            top: -1px;
+            opacity: 1;
+        }
+    }
+}

--- a/addons/html_editor/static/src/styles.scss
+++ b/addons/html_editor/static/src/styles.scss
@@ -1,0 +1,3 @@
+*[contenteditable] {
+    outline: none;
+}


### PR DESCRIPTION
**Problem**:
When a portal user edits a task's description and adds a checklist, the checkboxes do not appear as they do in the Odoo backend (e.g., in the To-Do app).

This occurs because the editor is rendered in an `iframe` with only `html_editor` loaded, while checklist styles are in `web_editor`.

**Solution**:
Add checklist styles to `html_editor`.

**Steps to Reproduce**:
1. Share a project with **"Edit"** permission for a portal user.
2. Log in as the portal user.
3. Go to any task inside the project.
4. In the description, add a checklist using `/checklist` command.
   - **Issue**: No checkboxes appear.

opw-4481993

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
