### PR TITLE
[FIX] mail: thread names should be displayed in muted when muted

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -143,6 +143,30 @@ export class DiscussSidebarChannel extends Component {
         return this.props.thread;
     }
 
+    get subChannels() {
+        return this.env.filteredThreads?.(this.thread.sub_channel_ids) ?? [];
+    }
+
+    showThread(sub) {
+        if (sub.eq(this.store.discuss.thread)) {
+            return true;
+        }
+        if (!this.thread.discussAppCategory.open) {
+            return false;
+        }
+        if (!this.thread.isMuted || sub.selfMember?.message_unread_counter > 0) {
+            return true;
+        }
+        return this.isSelfOrThreadActive && !(this.thread.isMuted && sub.isMuted);
+    }
+
+    get isSelfOrThreadActive() {
+        return (
+            this.thread.eq(this.store.discuss.thread) ||
+            this.store.discuss.thread?.in(this.subChannels)
+        );
+    }
+
     askConfirmation(body) {
         return new Promise((resolve) => {
             this.dialogService.add(ConfirmationDialog, {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -100,11 +100,9 @@
                     </t>
                 </Dropdown>
                 <t t-else="" t-call="mail.DiscussSidebarChannel.main"/>
-                <t t-set="subChannels" t-value="env.filteredThreads?.(thread.sub_channel_ids) ?? []"/>
-                <t t-set="isCategoryOpen" t-value="thread.discussAppCategory.open" />
-                <ul t-if="subChannels.length > 0" class="list-unstyled position-relative flex-grow-1" t-att-class="{ 'my-1 d-flex flex-column gap-1': store.discuss.isSidebarCompact, 'my-0 d-flex flex-column gap-1': !store.discuss.isSidebarCompact }">
+                <ul t-if="subChannels?.length > 0" class="list-unstyled position-relative flex-grow-1" t-att-class="{ 'my-1 d-flex flex-column gap-1': store.discuss.isSidebarCompact, 'my-0 d-flex flex-column gap-1': !store.discuss.isSidebarCompact }">
                     <t t-foreach="subChannels" t-as="sub" t-key="sub.localId">
-                        <DiscussSidebarSubchannel t-if="isCategoryOpen or sub.eq(store.discuss.thread)" thread="sub" isFirst="sub_first or !isCategoryOpen"/>
+                        <DiscussSidebarSubchannel t-if="showThread(sub)" thread="sub" isFirst="sub_first or !isCategoryOpen"/>
                     </t>
                 </ul>
             </t>
@@ -138,6 +136,7 @@
                 'px-1 py-2 mx-1 text-wrap word-break lh-1': store.discuss.isSidebarCompact,
                 'o-nonCompact me-1 p-0 ps-1': !store.discuss.isSidebarCompact,
                 'o-item-unread': thread.selfMember?.message_unread_counter > 0 and !thread.isMuted,
+                'opacity-50': thread.isMuted,
             }">
                 <span class="text-truncate" t-esc="thread.displayName" t-att-class="{
                     'fw-bolder': thread.selfMember?.message_unread_counter > 0,

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -10,7 +10,8 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
 import { Deferred, animationFrame } from "@odoo/hoot-mock";
-import { Command, serverState } from "@web/../tests/web_test_helpers";
+import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
+import { rpc } from "@web/core/network/rpc";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -191,4 +192,56 @@ test("mention suggestions in thread match channel restrictions", async () => {
     await contains(".o-mail-Composer-suggestion", { count: 2 });
     await contains(".o-mail-Composer-suggestion", { text: "Mitchell Admin" });
     await contains(".o-mail-Composer-suggestion", { text: "p1" });
+});
+
+test("sub-thread is visually muted when mute is active", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("button[title='Threads']");
+    await click("button[aria-label='Create Thread']");
+    await contains(".opacity-50.o-mail-DiscussSidebar-item:contains('New Thread')", { count: 0 });
+    await click(".o-mail-DiscussSidebar-item:contains('New Thread')");
+    await click("button[title='Notification Settings']");
+    await click("button:contains('Mute Conversation')");
+    await click("button:contains('Until I turn it back on')");
+    await contains(".opacity-50.o-mail-DiscussSidebar-item:contains('New Thread')");
+});
+
+test("muted channel hides sub-thread unless channel is selected or thread has unread messages", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const partnerId2 = pyEnv["res.partner"].create({ email: "p1@odoo.com", name: "p1" });
+    const userId2 = pyEnv["res.users"].create({ name: "User 2", partner_id: partnerId2 });
+    const partnerId = serverState.partnerId;
+    const subChannelId = pyEnv["discuss.channel"].create({
+        name: "New Thread",
+        parent_channel_id: channelId,
+        channel_member_ids: [
+            Command.create({ partner_id: partnerId }),
+            Command.create({ partner_id: partnerId2 }),
+        ],
+    });
+    pyEnv["discuss.channel"].create({ name: "Other" });
+    await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-DiscussSidebar-item:contains('General')");
+    await click("button[title='Notification Settings']");
+    await click("button:contains('Mute Conversation')");
+    await click("button:contains('Until I turn it back on')");
+    await click(".o-mail-DiscussSidebar-item:contains('Other')");
+    await contains(".o-mail-DiscussSidebar-item:contains('New Thread')", { count: 0 });
+    await click(".o-mail-DiscussSidebar-item:contains('General')");
+    await contains(".o-mail-DiscussSidebar-item:contains('New Thread')");
+    await click(".o-mail-DiscussSidebar-item:contains('Other')");
+    await contains(".o-mail-DiscussSidebar-item:contains('New Thread')", { count: 0 });
+    withUser(userId2, () =>
+        rpc("/mail/message/post", {
+            post_data: { body: "Some message", message_type: "comment" },
+            thread_id: subChannelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-DiscussSidebar-item:contains('New Thread')");
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The goals of the PR are multiple:
- The thread names in the discuss app are not muted when "mute all conversations" is enabled or when the specific thread is muted.
- The threads with no new messages are invisible when the parent thread is muted

Current behavior before PR:
see above

Desired behavior after PR is merged:
The thread opacity is set to 50 whenever the thread is muted (by any of the two ways)

task-4607160


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
