### PR TITLE
[FIX] hr_holidays: fix search on leave name

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -102,12 +102,12 @@ class LeaveReportCalendar(models.Model):
             leave.name += f": {leave.sudo().leave_id.duration_display}"
 
     def _search_name(self, operator, value):
-        query = self.env['hr.leave'].sudo()._search([('duration_display', operator, value)])
-        domain = ['|', ('employee_id.name', operator, value), ('leave_id', 'in', query)]
+        query = self.env['hr.leave.report.calendar'].sudo()._search([('leave_id.duration_display', operator, value)])
+        domain = ['|', ('employee_id.name', operator, value), ('id', 'in', query)]
         if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
             domain = expression.OR([domain , [('leave_id.holiday_status_id.name', operator, value)]])
         return domain
-    
+
     @api.depends('leave_manager_id')
     def _compute_is_manager(self):
         for leave in self:


### PR DESCRIPTION
Before this commit, making a search on name in the overview of the Time Off application without Time Off rights would give an access error.

To reproduce:
- Connect with a user without Time Off rights (Marc Demo for example)
- Go on Time Off > Overview
- Make a search on the name
- An access error is raised while it shouldn't

This commit changes the _search_name method by removing the explicit call to `leave_id` in the domain part not restricted to officers.