### PR TITLE
[FIX] spreadsheet: don't truncate odoo chart tooltips

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
@@ -15,7 +15,6 @@ const {
     getBarChartLegend,
     getChartShowValues,
     getTrendDatasetForBarChart,
-    truncateLabel,
 } = chartHelpers;
 
 export class OdooBarChart extends OdooChart {
@@ -72,7 +71,7 @@ function createOdooChartRuntime(chart, getters) {
     const config = {
         type: "bar",
         data: {
-            labels: chartData.labels.map(truncateLabel),
+            labels: chartData.labels,
             datasets: getBarChartDatasets(definition, chartData),
         },
         options: {

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_combo_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_combo_chart.js
@@ -15,7 +15,6 @@ const {
     getComboChartLegend,
     getChartShowValues,
     getTrendDatasetForBarChart,
-    truncateLabel,
 } = chartHelpers;
 
 export class OdooComboChart extends OdooChart {
@@ -76,7 +75,7 @@ function createOdooChartRuntime(chart, getters) {
     const config = {
         type: "bar",
         data: {
-            labels: chartData.labels.map(truncateLabel),
+            labels: chartData.labels,
             datasets: getComboChartDatasets(definition, chartData),
         },
         options: {

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
@@ -15,7 +15,6 @@ const {
     getLineChartLegend,
     getChartShowValues,
     getTrendDatasetForLineChart,
-    truncateLabel,
 } = chartHelpers;
 
 export class OdooLineChart extends OdooChart {
@@ -77,7 +76,7 @@ function createOdooChartRuntime(chart, getters) {
     const config = {
         type: "line",
         data: {
-            labels: chartData.labels.map(truncateLabel),
+            labels: chartData.labels,
             datasets: chartJsDatasets,
         },
         options: {

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pie_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pie_chart.js
@@ -13,7 +13,6 @@ const {
     getChartTitle,
     getPieChartLegend,
     getChartShowValues,
-    truncateLabel,
 } = chartHelpers;
 
 export class OdooPieChart extends OdooChart {
@@ -56,7 +55,7 @@ function createOdooChartRuntime(chart, getters) {
     const config = {
         type: definition.isDoughnut ? "doughnut" : "pie",
         data: {
-            labels: chartData.labels.map(truncateLabel),
+            labels: chartData.labels,
             datasets: getPieChartDatasets(definition, chartData),
         },
         options: {

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pyramid_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pyramid_chart.js
@@ -14,7 +14,6 @@ const {
     getPyramidChartScales,
     getBarChartLegend,
     getPyramidChartTooltip,
-    truncateLabel,
 } = chartHelpers;
 
 export class OdooPyramidChart extends OdooChart {
@@ -72,7 +71,7 @@ function createOdooChartRuntime(chart, getters) {
     const config = {
         type: "bar",
         data: {
-            labels: chartData.labels.map(truncateLabel),
+            labels: chartData.labels,
             datasets: getBarChartDatasets(definition, chartData),
         },
         options: {

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_radar_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_radar_chart.js
@@ -14,7 +14,6 @@ const {
     getRadarChartScales,
     getRadarChartLegend,
     getRadarChartTooltip,
-    truncateLabel,
 } = chartHelpers;
 
 export class OdooRadarChart extends OdooChart {
@@ -58,7 +57,7 @@ function createOdooChartRuntime(chart, getters) {
     const config = {
         type: "radar",
         data: {
-            labels: chartData.labels.map(truncateLabel),
+            labels: chartData.labels,
             datasets: getRadarChartDatasets(definition, chartData),
         },
         options: {

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_scatter_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_scatter_chart.js
@@ -15,7 +15,6 @@ const {
     getScatterChartLegend,
     getChartShowValues,
     getTrendDatasetForLineChart,
-    truncateLabel,
 } = chartHelpers;
 
 export class OdooScatterChart extends OdooChart {
@@ -71,7 +70,7 @@ function createOdooChartRuntime(chart, getters) {
     const config = {
         type: "line",
         data: {
-            labels: chartData.labels.map(truncateLabel),
+            labels: chartData.labels,
             datasets: getScatterChartDatasets(definition, chartData),
         },
         options: {


### PR DESCRIPTION
The labels given to chartJS were truncated to not bee too long. But that also means that they were truncated in the tooltip where it wasn't necessary. This commit removes the truncation in the tooltip, only truncating inside the legend/scale callbacks.

Task: [4626006](https://www.odoo.com/web#id=4626006&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
