### PR TITLE
[FIX] l10n_fr: Remove duplicate XPath entries

### DIFF
--- a/addons/l10n_fr_account/views/report_invoice.xml
+++ b/addons/l10n_fr_account/views/report_invoice.xml
@@ -18,18 +18,15 @@
         </xpath>
 
         <xpath expr="//div[@id='informations']" position="inside">
-            <t t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id != o.partner_id and o.move_type.startswith('out_')">
-                <t t-set="partner" t-value="o.partner_id.commercial_partner_id"/>
-                <div name="customer_address" class='col'>
-                    <strong>Customer Address</strong>
-                    <br/>
-                    <address t-field="partner.self" class="m-0" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True}"/>
-                </div>
-            </t>
-        </xpath>
-
-        <xpath expr="//div[@id='informations']" position="inside">
             <t t-if="o.l10n_fr_is_company_french and o.move_type.startswith('out_')">
+                <t t-if="o.partner_id.commercial_partner_id != o.partner_id">
+                    <t t-set="partner" t-value="o.partner_id.commercial_partner_id"/>
+                    <div name="customer_address" class='col'>
+                        <strong>Customer Address:</strong>
+                        <br/>
+                        <address t-field="partner.self" class="m-0" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True}"/>
+                    </div>
+                </t>
                 <t t-set="tax_scopes" t-value="o.invoice_line_ids.mapped('tax_ids.tax_scope')"/>
                 <t t-set="has_service" t-value="'service' in tax_scopes"/>
                 <t t-set="has_consu" t-value="'consu' in tax_scopes"/>


### PR DESCRIPTION
The commit https://github.com/odoo/odoo/pull/171340 introduced duplicate XPath expressions targeting the same location, leading to redundancy in l10n_fr. This commit cleans up the duplicate XPath to maintain a cleaner and more maintainable module structure.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
