### PR TITLE
[FIX] hr_holidays: prevent crashing when openning Time off

### DIFF
--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -91,3 +91,18 @@ registry.category("web_tour.tours").add('hr_holidays_tour', {
         isCheck: true,
     }
 ]});
+
+registry.category("web_tour.tours").add('hr_holidays_launch', {
+    url: '/web',
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="hr_holidays.menu_hr_holidays_root"]',
+            run: "click",
+        },
+        {
+            trigger: '.o_calendar_container',
+            run: ()=>{},
+        },
+    ]
+});

--- a/addons/hr_holidays/static/src/views/hooks.js
+++ b/addons/hr_holidays/static/src/views/hooks.js
@@ -4,9 +4,11 @@ import { _t } from "@web/core/l10n/translation";
 import { useService, useOwnedDialogs } from "@web/core/utils/hooks";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { useComponent } from "@odoo/owl";
+import { pyToJsLocale } from "@web/core/l10n/utils";
 
 export function formatNumber(lang, number, maxDecimals = 2) {
-    const userLang = lang.split("_").join("-");
+    const userLang = pyToJsLocale(lang);
+
     const numberFormat = new Intl.NumberFormat(userLang, { maximumFractionDigits: maxDecimals });
     return numberFormat.format(number);
 }

--- a/addons/hr_holidays/tests/test_hr_holidays_tour.py
+++ b/addons/hr_holidays/tests/test_hr_holidays_tour.py
@@ -43,3 +43,9 @@ class TestHrHolidaysTour(HttpCase):
         })
 
         self.start_tour('/web', 'hr_holidays_tour', login="admin")
+
+    def test_hr_holidays_launch(self):
+        admin_user = self.env.ref("base.user_admin")
+        self.env.ref("base.lang_sr@latin").active = True
+        admin_user.lang = "sr@latin"
+        self.start_tour("/web", "hr_holidays_launch", login="admin")


### PR DESCRIPTION
Crash with traceback when openning Time Off in Serbian (latin)

Steps to reproduce:
-------------------
*Change user language to Serbian (Latin)
*Open Time Off app
> Observation:
Traceback

Why the fix:
------------
Intl.NumberFormat only accept dash-case format. @ in sr@latin is not supported.

opw-4583287

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
