### PR TITLE
[FIX] im_livechat: do not end conversation when forwarding operator

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -12,10 +12,17 @@ export class Chatbot extends Record {
     static MULTILINE_STEP_DEBOUNCE_DELAY = 10000;
     static MULTILINE_STEP_DEBOUNCE_DELAY_TOUR = 500;
 
+    forwarded;
     isTyping = false;
     isProcessingAnswer = false;
     script = Record.one("chatbot.script");
-    currentStep = Record.one("ChatbotStep");
+    currentStep = Record.one("ChatbotStep", {
+        onUpdate() {
+            if (this.currentStep?.operatorFound) {
+                this.forwarded = true;
+            }
+        },
+    });
     steps = Record.many("ChatbotStep");
     thread = Record.one("Thread", {
         inverse: "chatbot",

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -31,6 +31,9 @@ export class ChatBotService {
         this.store = services["mail.store"];
         this.livechatService.onStateChange(SESSION_STATE.NONE, () => this.stop());
         this.bus.addEventListener("MESSAGE_POST", async ({ detail: message }) => {
+            if (this.chatbot?.forwarded) {
+                return;
+            }
             await this.chatbot?.processAnswer(message);
             if (this.chatbot?.currentStep.completed) {
                 this._triggerNextStep();

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -98,7 +98,11 @@ patch(Thread.prototype, {
     },
     /** @returns {Promise<import("models").Message} */
     async post(body, postData, extraData = {}) {
-        if (this.chatbot && this.chatbot.currentStep?.type !== "free_input_multi") {
+        if (
+            this.chatbot &&
+            !this.chatbot.forwarded &&
+            this.chatbot.currentStep?.type !== "free_input_multi"
+        ) {
             this.chatbot.isProcessingAnswer = true;
         }
         if (this.channel_type === "livechat" && this.isTransient) {
@@ -143,6 +147,9 @@ patch(Thread.prototype, {
 
     get composerDisabled() {
         const step = this.chatbot?.currentStep;
+        if (this.chatbot?.forwarded && this.livechat_active) {
+            return false;
+        }
         return (
             super.composerDisabled ||
             this.chatbot?.isProcessingAnswer ||

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
@@ -22,5 +22,19 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_forward", {
         {
             trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
         },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            run: "edit Hello, I need help!",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            run: "press Enter",
+        },
+        {
+            trigger: messagesContain("Hello, I need help!"),
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
+        },
     ],
 });


### PR DESCRIPTION
In [1], the composer was blocked when the chat bot is processing an answer and unlocked on the next step. However, we should not block it once the conversation is completed. It's especially problematic when an operator was forwarded as there is no more answer to process thus locking the composer forever.

[1]: https://github.com/odoo/odoo/pull/199920

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
