### PR TITLE
[FIX] point_of_sale: don't show orderlines empty state on receipts

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
@@ -48,7 +48,7 @@
             </div>
             <t t-slot="details"/>
         </t>
-        <t t-else="">
+        <t t-elif="props.mode !== 'receipt'">
             <div t-if="!props.slots?.emptyCart" class="d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded-3 gap-3">
                 <CenteredIcon icon="'fa-shopping-cart fa-4x'" text="emptyCartText()" class="'h-unset'"/>
                 <t t-slot="details"/>


### PR DESCRIPTION
When settling the user account from pos_settle_due, we show a receipt with no order (as expected), but with an empty state saying "Start adding products"!

Now we don't show the empty state on a receipt, since the user cannot edit a receipt anyway.

This bug has been reported while using the pos_settle_due module, however, the fix has been made generic and hence been implemented in the point_of_sale module.

(Note, this same bug has been fixed in 17.0 with https://github.com/odoo/odoo/pull/197256, and it was fixed in 17.2 till 18.0 with https://github.com/odoo/odoo/pull/184646)

opw-4430325