### PR TITLE
[FIX] mail, im_livechat: channel member name overflow in the member list.

### DIFF
--- a/addons/im_livechat/static/src/core/web/channel_member_list_patch.xml
+++ b/addons/im_livechat/static/src/core/web/channel_member_list_patch.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="discuss.channel_member" t-inherit-mode="extension">
-        <xpath expr="//*[@t-ref='displayName']" position="replace">
-            <div class="d-flex flex-column">
-                <t>$0</t>
+        <xpath expr="//*[@t-ref='displayName']" position="inside">
                 <div t-if="member.thread.channel_type === 'livechat'" class="ms-2 d-flex flex-wrap">
                     <span t-if="member.getLangName()" class="me-2">
                         <i class="fa fa-comment-o me-1" aria-label="Lang"/>
@@ -14,7 +12,6 @@
                         <t t-esc="member.persona?.country?.name ?? props.thread.anonymous_country.name"/>
                     </span>
                 </div>
-            </div>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -40,7 +40,9 @@
                 <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="member.persona.avatarUrl"/>
                 <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
             </div>
-            <span t-ref="displayName" class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name"/>
+            <div t-ref="displayName" class="d-flex overflow-hidden flex-column">
+                <span class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name"/>
+            </div>
             <span class="ms-auto">
                 <span t-if="member.in(props.thread.invitedMembers)" class="p-1 fa fa-user-plus opacity-75"/>
                 <span t-if="member.rtcSession?.isSelfMuted and !member.rtcSession?.isDeaf" class="p-1 fa fa-microphone-slash opacity-75"/>


### PR DESCRIPTION
**Purpose:**

to remove text overflow bug in the channel member name within the member list.
**before :** 
![image](https://github.com/user-attachments/assets/b9896bb3-629f-4b12-a935-dfb93f6ab07c)
**after:**
![image](https://github.com/user-attachments/assets/c2363d2a-f7a2-41ad-a82a-cd644b3d7921)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
