### PR TITLE
[IMP] base,web: new `aggregate` attribute on calendar archs

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -9,7 +9,6 @@ const FIELD_ATTRIBUTE_NAMES = [
     "date_delay",
     "date_stop",
     "all_day",
-    "recurrence_update",
     "create_name_field",
     "color",
 ];
@@ -30,6 +29,7 @@ export class CalendarArchParser {
         let canCreate = true;
         let canDelete = true;
         let canEdit = true;
+        let aggregate;
         let quickCreate = true;
         let quickCreateViewId = null;
         let hasEditDialog = false;
@@ -59,6 +59,10 @@ export class CalendarArchParser {
                             fieldNames.add(fieldName);
                             fieldMapping[fieldAttrName] = fieldName;
                         }
+                    }
+                    if (node.hasAttribute("aggregate")) {
+                        aggregate = node.getAttribute("aggregate");
+                        fieldNames.add(aggregate.split(":")[0]);
                     }
 
                     if (node.hasAttribute("event_limit")) {
@@ -182,6 +186,7 @@ export class CalendarArchParser {
         });
 
         return {
+            aggregate,
             canCreate,
             canDelete,
             canEdit,

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -13,8 +13,11 @@ import { Model } from "@web/model/model";
 import { extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
 import { browser } from "@web/core/browser/browser";
 import { makeContext } from "@web/core/context";
+import { groupBy } from "@web/core/utils/arrays";
 import { Cache } from "@web/core/utils/cache";
+import { formatFloat } from "@web/core/utils/numbers";
 import { useDebounced } from "@web/core/utils/timing";
+import { computeAggregatedValue } from "@web/views/utils";
 
 export class CalendarModel extends Model {
     static DEBOUNCED_LOAD_DELAY = 600;
@@ -34,6 +37,10 @@ export class CalendarModel extends Model {
             firstDayOfWeek: (localization.weekStart || 0) % 7,
             formViewId: params.formViewId || formViewIdFromConfig,
         };
+        if (this.meta.aggregate?.split(":").length === 1) {
+            const aggregator = this.fields[this.meta.aggregate].aggregator || "sum";
+            this.meta.aggregate = `${this.meta.aggregate}:${aggregator}`;
+        }
         this.meta.scale = this.getLocalStorageScale();
         this.data = {
             filterSections: {},
@@ -73,6 +80,9 @@ export class CalendarModel extends Model {
     // Public
     //--------------------------------------------------------------------------
 
+    get aggregate() {
+        return this.meta.aggregate;
+    }
     get date() {
         return this.meta.date;
     }
@@ -366,6 +376,16 @@ export class CalendarModel extends Model {
         }
 
         await unusualDaysProm;
+
+        // Compute aggregate values
+        if (this.aggregate) {
+            for (const [fieldName, { filters }] of Object.entries(data.filterSections)) {
+                const aggregates = this.computeAggregatedValues(fieldName, data);
+                for (const filter of filters) {
+                    filter.aggregatedValue = aggregates[filter.value] || 0;
+                }
+            }
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -399,6 +419,29 @@ export class CalendarModel extends Model {
 
     //--------------------------------------------------------------------------
 
+    /**
+     * @param {string} fieldName
+     * @param {Object} [data=this.data]
+     * @returns Object
+     */
+    computeAggregatedValues(fieldName, data = this.data) {
+        const records = Object.values(data.records);
+        const fieldType = this.meta.fields[fieldName].type;
+        const groups = groupBy(records, ({ rawRecord }) => {
+            const rawValue = rawRecord[fieldName];
+            // FIXME: many2many not supported, but not support for filters either
+            return fieldType === "many2one" ? rawValue?.[0] || false : rawValue;
+        });
+        const aggregates = {};
+        const [aggregateField, aggregator] = this.aggregate.split(":");
+        for (const group in groups) {
+            const values = groups[group].map(({ rawRecord }) => rawRecord[aggregateField]);
+            aggregates[group] = formatFloat(computeAggregatedValue(values, aggregator), {
+                trailingZeros: false,
+            });
+        }
+        return aggregates;
+    }
     /**
      * @protected
      */

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -87,6 +87,7 @@
                     class="o_cw_filter_title flex-grow-1 text-truncate lh-base"
                     t-esc="filter.label"
                 />
+                <span t-if="filter.aggregatedValue" t-esc="filter.aggregatedValue"/>
             </label>
             <t t-if="filter.canRemove">
                 <button

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -11,12 +11,15 @@ import { useSortable } from "@web/core/utils/sortable_owl";
 import { getTabableElements } from "@web/core/utils/ui";
 import { Field, getPropertyFieldInfo } from "@web/views/fields/field";
 import { getTooltipInfo } from "@web/views/fields/field_tooltip";
-import { getClassNameFromDecoration } from "@web/views/utils";
+import {
+    computeAggregatedValue,
+    getClassNameFromDecoration,
+    getFormattedValue,
+} from "@web/views/utils";
 import { combineModifiers } from "@web/model/relational_model/utils";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { useBounceButton } from "@web/views/view_hook";
 import { Widget } from "@web/views/widgets/widget";
-import { getFormattedValue } from "../utils";
 import { localization } from "@web/core/l10n/localization";
 import { useMagicColumnWidths } from "./column_width_hook";
 
@@ -614,18 +617,7 @@ export class ListRenderer extends Component {
                 }
             }
             if (func) {
-                let aggregateValue = 0;
-                if (func === "max") {
-                    aggregateValue = Math.max(-Infinity, ...fieldValues);
-                } else if (func === "min") {
-                    aggregateValue = Math.min(Infinity, ...fieldValues);
-                } else if (func === "avg") {
-                    aggregateValue =
-                        fieldValues.reduce((acc, val) => acc + val) / fieldValues.length;
-                } else if (func === "sum") {
-                    aggregateValue = fieldValues.reduce((acc, val) => acc + val);
-                }
-
+                const aggregatedValue = computeAggregatedValue(fieldValues, func);
                 const formatter = formatters.get(widget, false) || formatters.get(type, false);
                 const formatOptions = {
                     digits: attrs.digits ? JSON.parse(attrs.digits) : undefined,
@@ -636,7 +628,7 @@ export class ListRenderer extends Component {
                 }
                 aggregates[fieldName] = {
                     help: attrs[func],
-                    value: formatter ? formatter(aggregateValue, formatOptions) : aggregateValue,
+                    value: formatter ? formatter(aggregatedValue, formatOptions) : aggregatedValue,
                 };
             }
         }

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -1,5 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { unique } from "@web/core/utils/arrays";
 import { exprToBoolean } from "@web/core/utils/strings";
 import { combineModifiers } from "@web/model/relational_model/utils";
 
@@ -294,4 +295,30 @@ export function uuid() {
     window.crypto.getRandomValues(array);
     // Uint8Array to hex
     return [...array].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Given an array of values and an aggregator function, returns the aggregated
+ * value.
+ *
+ * @param {number[]} values
+ * @param {'sum'|'avg'|'min'|'max'|'count'|'count_distinct'} aggregator
+ * @returns number
+ * @throws {Error} if the aggregator function given isn't supported
+ */
+export function computeAggregatedValue(values, aggregator) {
+    if (aggregator === "sum") {
+        return values.reduce((acc, v) => v + acc, 0);
+    } else if (aggregator === "avg") {
+        return values.reduce((acc, v) => v + acc, 0) / values.length;
+    } else if (aggregator === "min") {
+        return Math.min(Infinity, ...values);
+    } else if (aggregator === "max") {
+        return Math.max(-Infinity, ...values);
+    } else if (aggregator === "count") {
+        return values.length;
+    } else if (aggregator === "count_distinct") {
+        return unique(values).length;
+    }
+    throw new Error(`Invalid aggregator '${aggregator}'`);
 }

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
@@ -7,6 +7,7 @@ describe.current.tags("headless");
 
 const parser = new CalendarArchParser();
 const DEFAULT_ARCH_RESULTS = {
+    aggregate: undefined,
     canCreate: true,
     canDelete: true,
     canEdit: true,

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -5609,3 +5609,44 @@ test(`calendar renderer is rendered once after search refresh`, async () => {
     await validateSearch();
     expect.verifySteps(["rendered"]);
 });
+
+test.tags("desktop");
+test(`calendar with filters and count aggregate`, async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop" aggregate="id:count">
+                <field name="attendee_ids" write_model="filter.partner" write_field="partner_id" filter_field="is_checked"/>
+            </calendar>
+        `,
+    });
+
+    expect(queryAllTexts(".o_calendar_filter_item span")).toEqual(["partner 1", "2", "partner 2"]);
+});
+
+test.tags("desktop");
+test(`calendar with dynamic filters and sum aggregate`, async () => {
+    Event._fields.revenue = fields.Float();
+    Event._records[0].revenue = 1200;
+    Event._records[1].revenue = 350;
+    Event._records[2].revenue = 800;
+    Event._records[3].revenue = 3000;
+    Event._records[4].revenue = 1900;
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop" aggregate="revenue:sum">
+                <field name="partner_id" filters="1"/>
+            </calendar>
+        `,
+    });
+
+    expect(queryAllTexts(".o_calendar_filter_item span")).toEqual([
+        "partner 1",
+        "4,550",
+        "partner 4",
+        "2,700",
+    ]);
+});

--- a/addons/web/static/tests/views/view_utils.test.js
+++ b/addons/web/static/tests/views/view_utils.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "@odoo/hoot";
+
+import { computeAggregatedValue } from "@web/views/utils";
+
+describe.current.tags("headless");
+
+describe("computeAggregatedValue", () => {
+    test("sum", () => {
+        expect(computeAggregatedValue([], "sum")).toBe(0);
+        expect(computeAggregatedValue([7], "sum")).toBe(7);
+        expect(computeAggregatedValue([7, 3], "sum")).toBe(10);
+        expect(computeAggregatedValue([7.23, 3.1], "sum")).toBe(10.33);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "sum")).toBe(35);
+    });
+
+    test("min", () => {
+        expect(computeAggregatedValue([], "min")).toBe(Infinity);
+        expect(computeAggregatedValue([7], "min")).toBe(7);
+        expect(computeAggregatedValue([7, 3], "min")).toBe(3);
+        expect(computeAggregatedValue([7.23, 3.1], "min")).toBe(3.1);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "min")).toBe(-5);
+    });
+
+    test("max", () => {
+        expect(computeAggregatedValue([], "max")).toBe(-Infinity);
+        expect(computeAggregatedValue([7], "max")).toBe(7);
+        expect(computeAggregatedValue([7, 3], "max")).toBe(7);
+        expect(computeAggregatedValue([7.23, 3.1], "max")).toBe(7.23);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "max")).toBe(27);
+    });
+
+    test("avg", () => {
+        expect(computeAggregatedValue([], "avg")).toBe(NaN);
+        expect(computeAggregatedValue([7], "avg")).toBe(7);
+        expect(computeAggregatedValue([7, 3], "avg")).toBe(5);
+        expect(computeAggregatedValue([7.23, 3.1], "avg")).toBe(5.165);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "avg")).toBe(5);
+    });
+
+    test("count", () => {
+        expect(computeAggregatedValue([], "count")).toBe(0);
+        expect(computeAggregatedValue([7], "count")).toBe(1);
+        expect(computeAggregatedValue([7, 3], "count")).toBe(2);
+        expect(computeAggregatedValue([7.23, 3.1], "count")).toBe(2);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "count")).toBe(7);
+    });
+
+    test("count_distinct", () => {
+        expect(computeAggregatedValue([], "count_distinct")).toBe(0);
+        expect(computeAggregatedValue([7], "count_distinct")).toBe(1);
+        expect(computeAggregatedValue([7, 3], "count_distinct")).toBe(2);
+        expect(computeAggregatedValue([7.23, 3.1], "count_distinct")).toBe(2);
+        expect(computeAggregatedValue([10, 2, -3, 2, -5, 27, 2], "count_distinct")).toBe(5);
+    });
+
+    test("invalid aggregator", () => {
+        expect(() => computeAggregatedValue([])).toThrow("Invalid aggregator 'undefined'");
+        expect(() => computeAggregatedValue([], "oups")).toThrow("Invalid aggregator 'oups'");
+    });
+});

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1279,8 +1279,10 @@ actual arch.
     #------------------------------------------------------
     def _postprocess_tag_calendar(self, node, name_manager, node_info):
         for additional_field in ('date_start', 'date_delay', 'date_stop', 'color', 'all_day'):
-            if fnames := node.get(additional_field):
-                name_manager.has_field(node, fnames.split('.', 1)[0], node_info)
+            if fname := node.get(additional_field):
+                name_manager.has_field(node, fname, node_info)
+        if fname := node.get('aggregate'):
+            name_manager.has_field(node, fname.split(':')[0], node_info)
         for f in node:
             if f.tag == 'filter':
                 name_manager.has_field(node, f.get('name'), node_info)

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -13,6 +13,7 @@
             <rng:optional><rng:attribute name="date_stop" /></rng:optional>
             <rng:optional><rng:attribute name="date_delay" /></rng:optional>
             <rng:optional><rng:attribute name="all_day" /></rng:optional>
+            <rng:optional><rng:attribute name="aggregate" /></rng:optional>
             <rng:optional><rng:attribute name="form_view_id" /></rng:optional>
             <rng:optional><rng:attribute name="event_limit" /></rng:optional>
             <rng:optional><rng:attribute name="create_name_field" /></rng:optional>


### PR DESCRIPTION
This new attribute allows to specify a field, and optionally an aggregator (if not given, the default aggregator of the field is used), e.g. `aggregate="expected_revenue:sum"`. Aggregated values are then displayed next to filter values, in the calendar filter panel.

Part of task-4510549

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
