### PR TITLE
[FIX] point_of_sale: deselect customer at any point

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -71,13 +71,11 @@ class PosOrder(models.Model):
         if pos_session.state == 'closing_control' or pos_session.state == 'closed':
             order['session_id'] = self._get_valid_session(order).id
 
-        if order.get('partner_id'):
-            partner_id = self.env['res.partner'].browse(order['partner_id'])
-            if not partner_id.exists():
-                order.update({
-                    "partner_id": False,
-                    "to_invoice": False,
-                })
+        if not (order.get('partner_id') and self.env['res.partner'].browse(order['partner_id']).exists()):
+            order.update({
+                "partner_id": False,
+                "to_invoice": False,
+            })
 
         pos_order = False
         record_uuid_mapping = order.pop('relations_uuid_mapping', {})


### PR DESCRIPTION
Steps to reproduce:
--------------------------
- Open session in point_of_sale.
- Order something with any customer selected.
- Now remove the customer and pay.

Issue:
--------
- The order still have that customer in the backend.

Cause:
----------
- When we remove the partner and pay or do any operation which sync order It will have no partner in  the order_dict to be written instead of false. So it won't write the partner as the key not found.

Fix:
-----
- We should have partner_id to be written as false if not there.

Task: 4619078
