### PR TITLE
[IMP] mail: Main Page menu added to discuss app

### DIFF
--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -8,10 +8,17 @@
         sequence="5"
     />
     <menuitem
+        id="mail.main_menu_discuss"
+        name="Conversations"
+        parent="mail.menu_root_discuss"
+        action="action_discuss"
+        sequence="1"
+    />
+    <menuitem
         id="mail.menu_configuration"
         name="Configuration"
         parent="mail.menu_root_discuss"
-        sequence="1"
+        sequence="2"
     />
     <menuitem name="Notifications"
         id="mail.menu_notification_settings"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The purpose is to allow a user to come back to the initial discuss page from other pages (e.g. you cannot come back to the initial discuss page from the canned responses view)

This feature avoids that the user goes out and back into the discuss app while he could have stayed in the app.

**Current behavior before PR:**

**Desired behavior after PR is merged:**


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
