### PR TITLE
[FIX] l10n_mx: prevent error while creating an account through pos store

### DIFF
--- a/addons/l10n_mx/models/account_account.py
+++ b/addons/l10n_mx/models/account_account.py
@@ -9,8 +9,10 @@ class AccountAccount(models.Model):
         # EXTENDS account - ensure there is a tag on created MX accounts
         # The computation is a bit naive and might not be correct in all cases.
         accounts = super().create(vals_list)
-        debit_tag = self.env.ref('l10n_mx.tag_debit_balance_account')
-        credit_tag = self.env.ref('l10n_mx.tag_credit_balance_account')
+        debit_tag = self.env.ref('l10n_mx.tag_debit_balance_account', raise_if_not_found=False)
+        credit_tag = self.env.ref('l10n_mx.tag_credit_balance_account', raise_if_not_found=False)
+        if not debit_tag or not credit_tag:
+            return accounts
         mx_account_no_tags = accounts.filtered(lambda a: 'MX' in a.company_ids.mapped('country_code') and not a.tag_ids & (credit_tag + debit_tag))
         DEBIT_CODES = ['1', '5', '6', '7']  # all other codes are considered "credit"
         for account in mx_account_no_tags:


### PR DESCRIPTION
Currently, an error occurs when creating an account with a default tag `Debit Balance Account`, if it has been deleted.

**Steps to reproduce:**
- Install `l10n_mx`, `accountant`, `point_of_sale` modules without demo data.
- Change company country to `Mexico`.
- Delete the records `Debit Balance Account` of **account tag**, `Cash` of **journals** and  **chart of Accounts**  
 from `Accounting > Configuration `.
- Create a POS store.
- Observe the error.

**Error:**
`ValueError: External ID not found in the system: l10n_mx.tag_debit_balance_account`

The error occurs because the system attempts to fetch the tag `l10n_mx.tag_debit_balance_account` at [1], but it is unavailable as the user has already deleted it.

This commit ensures that if the tag does not exist, it proceeds without assigning it, preventing the error.

[1] - https://github.com/odoo/odoo/blob/63fc0d1cefaf8f59acd0743a225d1002425ff156/addons/l10n_mx/models/account_account.py#L12

sentry-6356695465

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
