### PR TITLE
[FIX] web: make image field div fit content

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.scss
+++ b/addons/web/static/src/views/fields/image/image_field.scss
@@ -1,10 +1,7 @@
 .o_field_image {
     background-color: var(--ImageField-background-color, transparent);
-
-    > div {
-        height: 100%;
-        width: 100%;
-    }
+    max-height: fit-content;
+    max-width: fit-content;
 
     button {
         transition: opacity ease 400ms;


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Enable dark mode (requires `web_enterprise`);
2. go to Sale;
3. create a quotation;
4. open product catalog.

Issue
-----
There's a weird rectangle visible below the product images: 
![image](https://github.com/user-attachments/assets/fbff9b8f-e07f-44ab-9b09-a23064186d78)


Cause
-----
Commit 5234fad374c9c adapted Odoo for darkmode. As part of it, it added a background color for image fields, which defaults to `#E4E4E4`. There is no background color defined for image fields in light mode.

Commit f601823a19231 added kanban cards to supersede kanban boxes. Part of this is to style `.o_field_image > div` elements to have 100% height and width, filling up as much space as possible.

Commit e8836b42200e3 changed the catalog kanban to use cards instead of boxes. As a consequence, the background color for image fields now gets used on the `div` containing the image, which is sized to fill up all of the available space.

Normally this background color is invisible if the image is allowed to fill up all the avaialble space as well, but for the catalog, they get restricted to 55 by 55 px. Hence the `img` element has its `max-height` set to 55px while its parent `div` element has `height` set to `100%`, filling up all available space with no regard for the image size.

Solution
--------
Rather than basing size on the parent element, have the `div` size be based on the containing image via `fit-content`. This ensures the image background doesn't leak out of its intended element.

opw-4499252