### PR TITLE
[FIX] mass_mailing_themes: ensure unsubscribe link displays

### DIFF
--- a/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
+++ b/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
@@ -1631,7 +1631,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="o_mail_footer_links">
+                    <div class="col-lg o_mail_footer_links">
                         <a role="button" href="/unsubscribe_from_list" class="btn btn-link o_default_snippet_text">Unsubscribe</a>
                     </div>
                 </div>


### PR DESCRIPTION
### Steps to reproduce

* install `mass_mailing`
* send an email with the "Training" template

You will see that the "unsubscribe" link does not appear in the email that is sent

opw-4615170