### PR TITLE
[IMP] mail,im_livechat: add date on notification messages

### DIFF
--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -8,7 +8,7 @@ describe.current.tags("desktop");
 defineLivechatModels();
 
 test("Can invite a partner to a livechat channel", async () => {
-    mockDate("2023-01-03 12:00:00");
+    mockDate("2023-01-03 12:00:00", +1);
     const pyEnv = await startServer();
     const langIds = pyEnv["res.lang"].create([
         { code: "en", name: "English" },
@@ -55,7 +55,7 @@ test("Can invite a partner to a livechat channel", async () => {
     );
     await click("button:enabled", { text: "Invite" });
     await contains(".o-mail-NotificationMessage", {
-        text: "Mitch (FR) invited James to the channel",
+        text: "Mitch (FR) invited James to the channelToday at 1:00 PM",
     });
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await click("button[title='Members']");

--- a/addons/mail/static/src/core/common/notification_message.xml
+++ b/addons/mail/static/src/core/common/notification_message.xml
@@ -4,11 +4,12 @@
         <div class="o-mail-NotificationMessage text-break mx-auto px-3 text-center smaller" t-on-click="onClickNotificationMessage" t-ref="root">
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1 text-muted opacity-75"/>
             <t t-if="message.notificationType === 'call'">
-                <span class="text-muted opacity-75" t-esc="callInformation"/> <span class="o-mail-Message-date o-xsmaller" t-esc="message.dateSimpleWithDay"/>
+                <span class="text-muted opacity-75" t-esc="callInformation"/>
             </t>
             <t t-else="">
                 <span class="o-mail-NotificationMessage-author d-inline text-muted opacity-75" t-if="message.authorName and !message.richBody.includes(escape(message.authorName))" t-esc="message.authorName"/> <span class="text-muted opacity-75" t-out="message.richBody"/>
             </t>
+            <span class="o-mail-Message-date o-xsmaller ms-1" t-esc="message.dateSimpleWithDay"/>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -9,6 +9,7 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
+import { mockDate } from "@odoo/hoot-mock";
 import { Command, getService, serverState, withUser } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
@@ -36,6 +37,7 @@ test("should display the channel invitation form after clicking on the invite bu
 });
 
 test("can invite users in channel from chat window", async () => {
+    mockDate("2025-01-01 12:00:00", +1);
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         email: "testpartner@odoo.com",
@@ -57,7 +59,7 @@ test("can invite users in channel from chat window", async () => {
     await click("[title='Invite to Channel']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await contains(".o-mail-Thread .o-mail-NotificationMessage", {
-        text: "Mitchell Admin invited TestPartner to the channel",
+        text: "Mitchell Admin invited TestPartner to the channelToday at 1:00 PM",
     });
 });
 

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -9,7 +9,7 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
-import { Deferred, animationFrame } from "@odoo/hoot-mock";
+import { Deferred, mockDate, animationFrame } from "@odoo/hoot-mock";
 import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
 import { rpc } from "@web/core/network/rpc";
 
@@ -17,6 +17,7 @@ describe.current.tags("desktop");
 defineMailModels();
 
 test("navigate to sub channel", async () => {
+    mockDate("2025-01-01 12:00:00", +1);
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
@@ -36,7 +37,7 @@ test("navigate to sub channel", async () => {
     await click(".o-mail-DiscussSidebarChannel", { name: "General" });
     await contains(".o-mail-Discuss-threadName", { value: "New Thread" });
     await contains(".o-mail-NotificationMessage", {
-        text: `${serverState.partnerName} started a thread: New Thread. See all threads.`,
+        text: `${serverState.partnerName} started a thread: New Thread. See all threads.Today at 1:00 PM`,
     });
     await click(".o-mail-NotificationMessage a", { text: "New Thread" });
     await contains(".o-mail-Discuss-threadName", { value: "New Thread" });
@@ -59,6 +60,7 @@ test("can manually unpin a sub-thread", async () => {
 });
 
 test("open sub channel menu from notification", async () => {
+    mockDate("2025-01-01 12:00:00", +1);
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
@@ -69,7 +71,7 @@ test("open sub channel menu from notification", async () => {
     await contains(".o-mail-Discuss-threadName", { value: "New Thread" });
     await click(".o-mail-DiscussSidebarChannel", { name: "General" });
     await contains(".o-mail-NotificationMessage", {
-        text: `${serverState.partnerName} started a thread: New Thread. See all threads.`,
+        text: `${serverState.partnerName} started a thread: New Thread. See all threads.Today at 1:00 PM`,
     });
     await click(".o-mail-NotificationMessage a", { text: "See all threads" });
     await contains(".o-mail-SubChannelList");


### PR DESCRIPTION
Purpose of this commit is to add the posting date of notification type message beside the message body.
Before:
![image](https://github.com/user-attachments/assets/f006c04a-86f0-40c6-bafa-39da2f82ad89)
After:
![image](https://github.com/user-attachments/assets/7d1b5c9c-294f-4e90-bf30-43d9fe962c58)


task-4606885
