### PR TITLE
[IMP] hr_work_entry_contract: created is_work field

### DIFF
--- a/addons/hr_work_entry_contract/models/hr_work_entry.py
+++ b/addons/hr_work_entry_contract/models/hr_work_entry.py
@@ -186,3 +186,15 @@ class HrWorkEntryType(models.Model):
 
     is_leave = fields.Boolean(
         default=False, string="Time Off", help="Allow the work entry type to be linked with time off types.")
+    is_work = fields.Boolean(
+        compute='_compute_is_work', inverse='_inverse_is_work', string="Working Time", readonly=False,
+        help="If checked, the work entry is counted as work time in the working schedule")
+
+    @api.depends('is_leave')
+    def _compute_is_work(self):
+        for record in self:
+            record.is_work = not record.is_leave
+
+    def _inverse_is_work(self):
+        for record in self:
+            record.is_leave = not record.is_work

--- a/addons/hr_work_entry_contract/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry_contract/views/hr_work_entry_views.xml
@@ -26,15 +26,4 @@
         </field>
     </record>
 
-    <record id="hr_work_entry_contract_type_view_form_inherit" model="ir.ui.view">
-        <field name="name">hr.work.entry.type.contract.view.form.inherit</field>
-        <field name="model">hr.work.entry.type</field>
-        <field name="inherit_id" ref="hr_work_entry.hr_work_entry_type_view_form"/>
-        <field name="arch" type="xml">
-            <group name="time_off" position="inside">
-                <field name="is_leave"/>
-            </group>
-        </field>
-    </record>
-
 </odoo>


### PR DESCRIPTION
In this PR,

A new field named 'is_work' is created, which is the opposite of 'is_leave'
This field will be used in the views instead of 'is_leave'

Task-4199423
