### PR TITLE
[FIX] web: fix extractProps not executing in list widget

### DIFF
--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -138,6 +138,7 @@ export class ListArchParser {
                     // can decode it later...
                     node: encodeObjectForTemplate({ attrs: widgetInfo.attrs }).slice(1, -1),
                     className: node.getAttribute("class") || "",
+                    widgetInfo,
                 };
                 columns.push({
                     ...widgetInfo,

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -4607,15 +4607,13 @@ test(`fields are translatable in list view`, async () => {
         fr_BE: "Frenglish",
     });
 
-    onRpc("/web/dataset/call_kw/foo/get_field_translations", () => {
-        return [
-            [
-                { lang: "en_US", source: "yop", value: "yop" },
-                { lang: "fr_BE", source: "yop", value: "valeur français" },
-            ],
-            { translation_type: "char", translation_show_source: false },
-        ];
-    });
+    onRpc("/web/dataset/call_kw/foo/get_field_translations", () => [
+        [
+            { lang: "en_US", source: "yop", value: "yop" },
+            { lang: "fr_BE", source: "yop", value: "valeur français" },
+        ],
+        { translation_type: "char", translation_show_source: false },
+    ]);
 
     await mountView({
         resModel: "foo",
@@ -15063,6 +15061,30 @@ test(`view widgets are rendered in list view`, async () => {
         message: "there should be one widget (inside td) per record",
     });
     expect(queryAllTexts`.test_widget`).toEqual(["true", "true", "true", "false"]);
+});
+
+test(`view widget with options in list view`, async () => {
+    class TestWidget extends Component {
+        static template = xml`<div class="test_widget" t-esc="props.x"/>`;
+        static props = ["*"];
+    }
+    registry.category("view_widgets").add("test_widget", {
+        component: TestWidget,
+        extractProps: ({ options }) => ({
+            x: options.x,
+        }),
+    });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <widget name="test_widget" options="{'x': 'y'}"/>
+            </list>
+        `,
+    });
+    expect(queryAllTexts`.test_widget`).toEqual(["y", "y", "y", "y"]);
 });
 
 test(`edit a record then select another record with a throw error when saving`, async () => {

--- a/doc/cla/individual/tanzv.md
+++ b/doc/cla/individual/tanzv.md
@@ -1,0 +1,11 @@
+China, 2025-01-25
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Sudhir Arya zkind@foxmail.com https://github.com/tanzv


### PR DESCRIPTION
Before this fix, the list widget's extractProps function was never called due to an incorrect method reference in the web module. This caused issues when rendering dynamic props or customizing the list view behavior.

After the fix:
- The extractProps function is properly invoked.
- The list widget can now retrieve props values as expected.

Closes #200296

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
