### PR TITLE
[FIX] website_slides: resolve traceback while archiving the content

### DIFF
--- a/addons/website_slides/static/src/interactions/slide_archive.js
+++ b/addons/website_slides/static/src/interactions/slide_archive.js
@@ -27,7 +27,7 @@ export class SlideArchive extends Interaction {
                 if (isArchived) {
                     this.el.closest(".o_wslides_slides_list_slide")?.remove();
                     const categories = document.querySelectorAll(".o_wslides_slide_list_category");
-                    for (const category in categories) {
+                    for (const category of categories) {
                         const categoryHeaderEl = category.querySelector(".o_wslides_slide_list_category_header");
                         const categorySlideCountEl = category.querySelector(".o_wslides_slides_list_slide:not(.o_not_editable)").length;
                         const emptyFlagContainerEl = categoryHeaderEl.querySelector(".o_wslides_slides_list_drag");


### PR DESCRIPTION
Steps to reproduce
==================
- Open any course on the front-end side.
- Click on the delete button of any content to open the confirmation dialog.
- Click on the Archive button of the dialog.

Technical
============
Here https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba#diff-42aed129bdbb169fcea12a40c91754f8d556fa11d3b2c1989a442760a101d031 we changed the public widgets into the interactions where we used for...in loop.

- We were using a for...in loop, which iterates over the keys/indices of an array, not the values. which caused the issue.
- To fix the issue, we replaced the for...in loop with a for...of loop, which correctly iterates over the elements of the array.

Task-4625895
