### PR TITLE
[PERF] hr_timesheet: Add missing index on `parent_task_id`

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -63,7 +63,7 @@ class AccountAnalyticLine(models.Model):
         'project.task', 'Task', index='btree_not_null',
         compute='_compute_task_id', store=True, readonly=False,
         domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id)]")
-    parent_task_id = fields.Many2one('project.task', related='task_id.parent_id', store=True)
+    parent_task_id = fields.Many2one('project.task', related='task_id.parent_id', store=True, index='btree_not_null')
     project_id = fields.Many2one(
         'project.project', 'Project', domain=_domain_project_id, index=True,
         compute='_compute_project_id', store=True, readonly=False)


### PR DESCRIPTION
Improve deletion performance for `project.task` with numerous `account.analytic.line` records by adding a missing index on the `parent_task_id` foreign key, which Postgres checks during the `DELETE` operation.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
