### PR TITLE
[FIX] project: make the customer field readonly in portal view

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -40,12 +40,12 @@ PROJECT_TASK_READABLE_FIELDS = {
     'message_is_follower',
     'recurring_task',
     'closed_subtask_count',
+    'partner_id',
 }
 
 PROJECT_TASK_WRITABLE_FIELDS = {
     'name',
     'description',
-    'partner_id',
     'date_deadline',
     'date_last_stage_update',
     'tag_ids',

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -183,7 +183,7 @@
                             <field name="parent_id" invisible="1" />
                             <field name="company_id" invisible="1" />
                             <field name="state" invisible="1" />
-                            <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" invisible="not project_id"/>
+                            <field name="partner_id" readonly="1" options="{'no_open': True, 'no_create': True, 'no_edit': True}" invisible="not project_id"/>
                             <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" decoration-danger="date_deadline &lt; current_date"/>
                         </group>
                     </group>


### PR DESCRIPTION
Since the user can only set himself as customer for task in the portal view, we removed this option in order to avoid issues on the customer side. E.A. setting the customer to False, then save, and being unable to put back the original customer.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
