### PR TITLE
[FIX] base: use all_group_ids instead of group_ids in the embedded action compute method

### DIFF
--- a/odoo/addons/base/models/ir_embedded_actions.py
+++ b/odoo/addons/base/models/ir_embedded_actions.py
@@ -75,7 +75,7 @@ class IrEmbeddedActions(models.Model):
             active_model_record = self.env[parent_res_model].search(domain_id, order='id')
             for record in records:
                 action_groups = record.groups_ids
-                if not action_groups or (action_groups & self.env.user.group_ids):
+                if not action_groups or (action_groups & self.env.user.all_group_ids):
                     domain_model = literal_eval(record.domain or '[]')
                     record.is_visible = (
                         record.parent_res_id in (False, self.env.context.get('active_id', False))


### PR DESCRIPTION
**Steps to Reproduce:**
- Open the project_purchase.
- Click on any project in the Kanban view.
- Click on the embedded action dropdown.


**Cause:**

Before merging PR https://github.com/odoo/odoo/pull/179354, there was only one field that included both assigned and implied groups.

**Example:**

The Admin has been granted access to the Purchase Manager (Administrator) role, which automatically assigns the Purchase User access.

In group_ids, only the Purchase Manager group is present, and the Purchase User group does not exist.

The project_embedded_action_purchase_orders embedded action includes the Purchase User group.

**FIX:**
    Therefore, in this commit, we used all_group_ids instead of group_ids.

task-4623903
