### PR TITLE
[IMP] project: make list view of task editable

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -718,7 +718,7 @@
             <field name="name">project.task.view.list.main.base</field>
             <field name="model">project.task</field>
             <field name="arch" type="xml">
-                <list string="Tasks" sample="1" default_order="priority desc, sequence, state, date_deadline asc, id desc">
+                <list string="Tasks" editable="bottom" open_form_view="True" sample="1" default_order="priority desc, sequence, state, date_deadline asc, id desc">
                     <field name="sequence" readonly="1" column_invisible="True"/>
                     <field name="allow_milestones" column_invisible="True"/>
                     <field name="subtask_count" column_invisible="True"/>


### PR DESCRIPTION
Before this commit, the list view of task was in readonly but the list view could also be a good opportunity for the user to quickly update some fields or to quickly create some tasks without writing anything on the description field.

This commit makes the list view of task editable to let the user edits the tasks or create some tasks in the list view without having to open the form view.

task-4624574