### PR TITLE
[IMP] point_of_sale: autocomplete partner pos

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'Sales/Point of Sale',
     'sequence': 40,
     'summary': 'Handle checkouts and payments for shops and restaurants.',
-    'depends': ['resource', 'stock_account', 'barcodes', 'web_editor', 'digest', 'phone_validation'],
+    'depends': ['resource', 'stock_account', 'barcodes', 'web_editor', 'digest', 'phone_validation', 'partner_autocomplete'],
     'uninstall_hook': 'uninstall_hook',
     'data': [
         'security/point_of_sale_security.xml',
@@ -200,6 +200,7 @@
             ('remove', 'web/static/src/webclient/actions/reports/layout_assets/**/*'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
             'point_of_sale/static/src/customer_display/customer_display_adapter.js',
+            'partner_autocomplete/static/src/**/*',
         ],
         'point_of_sale.base_tests': [
             "web/static/lib/hoot-dom/**/*",


### PR DESCRIPTION
This commit adds the possibility to autocomplete partner data created in the point of sale based on the partner name or TVA number. This is done by adding the widget field_partner_autocomplete to the point_of_sale assets module.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
