### PR TITLE
[FIX] hr_work_entry_contract: fix work entries for fully flexible schedules

### DIFF
--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -192,6 +192,9 @@ class HrContract(models.Model):
             if contract.has_static_work_entries() or not leaves:
                 # Empty leaves means empty real_leaves
                 real_leaves = attendances - real_attendances
+            elif not calendar:
+                # If fully flexible working schedule is defined
+                real_leaves = leaves
             else:
                 # In the case of attendance based contracts use regular attendances to generate leave intervals
                 static_attendances = calendar._attendance_intervals_batch(


### PR DESCRIPTION
In case of fully flexible working schedules, the leaves must not be computed from the working schedule (as there is none).

The test for this bug is in the following related PR: https://github.com/odoo/enterprise/pull/80785

task-4623219
