### PR TITLE
[REF] iot_box_image: simplify image build

### DIFF
--- a/addons/iot_box_image/.gitignore
+++ b/addons/iot_box_image/.gitignore
@@ -1,3 +1,2 @@
 root_mount/
-iotbox.img
-raspios.img
+*.img

--- a/addons/iot_box_image/build_image.sh
+++ b/addons/iot_box_image/build_image.sh
@@ -4,156 +4,55 @@ set -o nounset
 set -o pipefail
 # set -o xtrace
 
-if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root" 
-   exit 1
-fi
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-file_exists() {
-    [[ -f $1 ]];
-}
+source ${__dir}/build_utils/methods.sh # Load useful functions
 
-require_command () {
-    type "$1" &> /dev/null || { echo "Command $1 is missing. Install it e.g. with 'apt-get install $1'. Aborting." >&2; exit 1; }
-}
+ensure_root # Check if script is run as root, exit if not
 
-require_command kpartx
+require_command losetup
 require_command qemu-arm-static
 require_command zerofree
-
-__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-__file="${__dir}/$(basename "${BASH_SOURCE[0]}")"
-__base="$(basename ${__file} .sh)"
 
 MOUNT_POINT="${__dir}/root_mount"
 OVERWRITE_FILES_BEFORE_INIT_DIR="${__dir}/overwrite_before_init"
 OVERWRITE_FILES_AFTER_INIT_DIR="${__dir}/overwrite_after_init"
+BUILD_UTILS_DIR="${__dir}/build_utils"
 VERSION_IOTBOX="$(date '+%y.%m')"
 
 if [[ "${1:-}" == "-c" || "${1:-}" == "--cleanup" ]]; then
     echo "Cleaning up..."
     umount -fv "${MOUNT_POINT}/boot/" > /dev/null 2>&1 || true
-    umount -lv "${MOUNT_POINT}/" > /dev/null 2>&1 || true
+    umount -lv "${MOUNT_POINT}" > /dev/null 2>&1 || true
     rm -rfv "${MOUNT_POINT}"
     rm -rf overwrite_before_init/usr
     rm -rf overwrite_before_init/home/pi/odoo
     rm -rfv iotbox.img
-    sudo kpartx -d /dev/loop1 > /dev/null 2>&1 || true
+    losetup -d /dev/loop0 > /dev/null 2>&1 || true
     losetup -d /dev/loop1 > /dev/null 2>&1 || true
     echo "Cleanup done."
     exit 0
 fi
 
-# ask user for the branch/version
-current_branch="$(git branch --show-current)"
-read -p "Enter dev branch [${current_branch}]: " VERSION
-VERSION=${VERSION:-$current_branch}
+# Download and extract Raspberry Pi OS, ngrok and clone Odoo repository
+source ${BUILD_UTILS_DIR}/download_requirements.sh "${__dir}"
 
-# ask user for the repository
-current_remote=$(git config branch.$current_branch.remote)
-current_repo="$(git remote get-url $current_remote | sed 's/.*github.com[\/:]//' | sed 's/\/odoo.git//')"
-read -p "Enter repo [${current_repo}]: " REPO
-REPO="https://github.com/${REPO:-$current_repo}/odoo.git"
-echo "Using repo: ${REPO}"
-
-if ! file_exists *raspios*.img ; then
-    wget "https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2024-11-19/2024-11-19-raspios-bookworm-armhf-lite.img.xz" -O raspios.img.xz
-    unxz --verbose raspios.img.xz
-fi
-
-RASPIOS=$(echo *raspios*.img)
+# Clone the Raspberry Pi OS image into the IoT Box image.
 rsync -avh --progress "${RASPIOS}" iotbox.img
 
-CLONE_DIR="${OVERWRITE_FILES_BEFORE_INIT_DIR}/home/pi/odoo"
+# Prepare the image for the IoT Box system: partition and format.
+# source to share variables
+source ${BUILD_UTILS_DIR}/partition_image.sh "iotbox.img"
 
-rm -rfv "${CLONE_DIR}"
-
-if [ ! -d $CLONE_DIR ]; then
-    echo "Clone Github repo"
-    mkdir -pv "${CLONE_DIR}"
-    git clone -b ${VERSION} --no-local --no-checkout --depth 1 ${REPO} "${CLONE_DIR}"
-    cd "${CLONE_DIR}"
-    git config core.sparsecheckout true
-    echo "addons/web
-addons/hw_*
-addons/iot_base
-addons/iot_box_image/configuration
-addons/point_of_sale/tools/posbox/configuration
-odoo/
-odoo-bin" | tee --append .git/info/sparse-checkout > /dev/null
-    git read-tree -mu HEAD
-    git remote set-url origin "https://github.com/odoo/odoo.git" # ensure remote is the original repo
-fi
-
-cd "${__dir}"
-USR_BIN="${OVERWRITE_FILES_BEFORE_INIT_DIR}/usr/bin/"
-mkdir -pv "${USR_BIN}"
-cd "/tmp"
-curl 'https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-arm.tgz' > ngrok.tgz
-tar xvzf ngrok.tgz -C "${USR_BIN}"
-rm -v ngrok.tgz
-cd "${__dir}"
-
-# zero pad the image to be around ~5 GiB, by default the image is only ~2.2 GiB
-echo "Enlarging the image..."
-dd if=/dev/zero bs=1M count=2560 status=progress >> iotbox.img
-
-# resize partition table
-echo "Fdisking"
-
-SECTORS_BOOT_START=$(sudo fdisk -l iotbox.img | tail -n 2 | awk 'NR==1 {print $2}')
-SECTORS_BOOT_END=$((SECTORS_BOOT_START + 1056767)) # sectors to have a partition of ~512Mo
-SECTORS_ROOT_START=$((SECTORS_BOOT_END + 1))
-
-(echo 'p';                          # print
- echo 'd';                          # delete
- echo '2';                          #    number 2
- echo 'd';                          # delete number 1 by default
- echo 'n';                          # create new partition
- echo 'p';                          #   primary
- echo '1';                          #   number 1
- echo "${SECTORS_BOOT_START}";      #   first sector
- echo "${SECTORS_BOOT_END}";        #   partition size
- echo 't';                          # change type of partition. 1 selected by default
- echo 'c';                          #   change to W95 FAT32 (LBA)
- echo 'n';                          # create new partition
- echo 'p';                          #   primary
- echo '2';                          #   number 2
- echo "${SECTORS_ROOT_START}";      #   starting at previous offset
- echo '';                           #   ending at default (fdisk should propose max)
- echo 'p';                          # print
- echo 'w') | fdisk iotbox.img       # write and quit
-
-LOOP_RASPIOS=$(kpartx -avs "${RASPIOS}")
-LOOP_RASPIOS_ROOT=$(echo "${LOOP_RASPIOS}" | tail -n 1 | awk '{print $3}')
-LOOP_RASPIOS_PATH="/dev/${LOOP_RASPIOS_ROOT::-2}"
-LOOP_RASPIOS_ROOT="/dev/mapper/${LOOP_RASPIOS_ROOT}"
-LOOP_RASPIOS_BOOT=$(echo "${LOOP_RASPIOS}" | head -n 1 | awk '{print $3}')
-LOOP_RASPIOS_BOOT="/dev/mapper/${LOOP_RASPIOS_BOOT}"
-
-LOOP_IOT=$(kpartx -avs iotbox.img)
-LOOP_IOT_ROOT=$(echo "${LOOP_IOT}" | tail -n 1 | awk '{print $3}')
-LOOP_IOT_PATH="/dev/${LOOP_IOT_ROOT::-2}"
-LOOP_IOT_ROOT="/dev/mapper/${LOOP_IOT_ROOT}"
-LOOP_IOT_BOOT=$(echo "${LOOP_IOT}" | head -n 1 | awk 'NR==1 {print $3}')
-LOOP_IOT_BOOT="/dev/mapper/${LOOP_IOT_BOOT}"
-
-mkfs.ext4 -v "${LOOP_IOT_ROOT}"
-
-dd if="${LOOP_RASPIOS_ROOT}" of="${LOOP_IOT_ROOT}" bs=4M status=progress
-
-# resize filesystem
-e2fsck -fvy "${LOOP_IOT_ROOT}" # resize2fs requires clean fs
-resize2fs "${LOOP_IOT_ROOT}"
-
-mkdir -pv "${MOUNT_POINT}" #-p: no error if existing
-mount -v "${LOOP_IOT_ROOT}" "${MOUNT_POINT}"
+# Mount system partition and customize the active system
+mkdir -pv "${MOUNT_POINT}"
+mount -v "${LOOP_IOT_SYS}" "${MOUNT_POINT}"
 mount -v "${LOOP_IOT_BOOT}" "${MOUNT_POINT}/boot/"
 
 QEMU_ARM_STATIC="/usr/bin/qemu-arm-static"
 cp -v "${QEMU_ARM_STATIC}" "${MOUNT_POINT}/usr/bin/"
 
-# 'overlay' the overwrite directory onto the mounted image filesystem
+# 'Overlay' the pre-init overwrite directory onto the mounted image filesystem.
 cp -av "${OVERWRITE_FILES_BEFORE_INIT_DIR}"/* "${MOUNT_POINT}"
 
 # Reload network manager is mandatory in order to apply DNS configurations:
@@ -161,29 +60,29 @@ cp -av "${OVERWRITE_FILES_BEFORE_INIT_DIR}"/* "${MOUNT_POINT}"
 # it needs to be performed in the classic filesystem, as 'systemctl' commands are not available in /root_bypass_ramdisks
 sudo systemctl reload NetworkManager
 
+# Run initialization script inside /mount_point (the mounted path of the image)
 chroot "${MOUNT_POINT}" /bin/bash -c "/etc/init_image.sh"
 
-# copy iotbox version
-mkdir -pv "${MOUNT_POINT}"/var/odoo/
-echo "${VERSION_IOTBOX}" > "${MOUNT_POINT}"/var/odoo/iotbox_version
+# Copy IoT Box version info.
+mkdir -pv "${MOUNT_POINT}/var/odoo/"
+echo "${VERSION_IOTBOX}" > "${MOUNT_POINT}/var/odoo/iotbox_version"
 
-# get rid of the git clone
-rm -rf "${CLONE_DIR}"
-# and the ngrok usr/bin
-rm -rf "${OVERWRITE_FILES_BEFORE_INIT_DIR}/usr"
+# 'Overlay' the post-init overwrite directory onto the mounted image filesystem.
 cp -a "${OVERWRITE_FILES_AFTER_INIT_DIR}"/* "${MOUNT_POINT}"
 
+# Unmount partitions: zerofree needs partitions to be unmounted (or mounted as read-only)
+umount -fv "${MOUNT_POINT}"/boot/
+umount -lv "${MOUNT_POINT}"/
+
 echo "Running zerofree..."
-zerofree -v "${LOOP_IOT_ROOT}" || true
+zerofree -v "${LOOP_IOT_SYS}" || true
 
 sleep 10
 
-# cleanup
-umount -fv "${MOUNT_POINT}"/boot/
-umount -lv "${MOUNT_POINT}"/
+# Final cleanup: unmount partitions and remove loop device mappings
+rm -rf "${CLONE_DIR}"
+rm -rf "${OVERWRITE_FILES_BEFORE_INIT_DIR}/usr"
 rm -rfv "${MOUNT_POINT}"
-kpartx -dv "${LOOP_RASPIOS_PATH}"
-kpartx -dv "${LOOP_IOT_PATH}"  # /dev/loop1
-losetup -d "${LOOP_IOT_PATH}"  # /dev/loop1
+losetup -d ${LOOP_IOT}
 
 echo "Image build finished."

--- a/addons/iot_box_image/build_utils/download_requirements.sh
+++ b/addons/iot_box_image/build_utils/download_requirements.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+require_command git
+require_command tar
+require_command unxz
+require_command unzip
+require_command wget
+
+__dir=$1
+
+# Ask user for branch/version and repository info
+current_branch="$(git branch --show-current)"
+read -p "Enter dev branch [${current_branch}]: " VERSION
+VERSION=${VERSION:-$current_branch}
+
+current_remote=$(git config branch.$current_branch.remote)
+current_repo="$(git remote get-url $current_remote | sed 's/.*github.com[\/:]//' | sed 's/\/odoo.git//')"
+read -p "Enter repo [${current_repo}]: " REPO
+REPO="https://github.com/${REPO:-$current_repo}/odoo.git"
+echo "Using repo: ${REPO}"
+
+CLONE_DIR="${OVERWRITE_FILES_BEFORE_INIT_DIR}/home/pi/odoo"
+if [ ! -d "$CLONE_DIR" ]; then
+    echo "Clone GitHub repo"
+    mkdir -pv "${CLONE_DIR}"
+    git clone -b ${VERSION} --no-local --no-checkout --depth=1 ${REPO} "${CLONE_DIR}"
+    cd "${CLONE_DIR}"
+    git config core.sparsecheckout true
+    tee -a .git/info/sparse-checkout < "${BUILD_UTILS_DIR}/sparse-checkout" > /dev/null
+    git read-tree -mu HEAD
+    git remote set-url origin "https://github.com/odoo/odoo.git" # ensure remote is the original repo
+fi
+cd "${__dir}"
+
+# Download and extract the Raspberry Pi OS image if not present.
+if ! file_exists *raspios*.img ; then
+    wget "https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2024-11-19/2024-11-19-raspios-bookworm-armhf-lite.img.xz" -O raspios.img.xz
+    unxz --verbose raspios.img.xz
+fi
+RASPIOS=$(echo *raspios*.img)
+
+# Download ngrok for ARM and place it in the overwrite directory.
+USR_BIN="${OVERWRITE_FILES_BEFORE_INIT_DIR}/usr/bin/"
+mkdir -pv "${USR_BIN}"
+if ! file_exists "${USR_BIN}/ngrok" ; then
+    wget -O /tmp/ngrok.tgz 'https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-arm.tgz'
+    tar xvzf /tmp/ngrok.tgz -C "${USR_BIN}" --remove-files
+fi

--- a/addons/iot_box_image/build_utils/methods.sh
+++ b/addons/iot_box_image/build_utils/methods.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ensure_root() {
+    if [[ $EUID -ne 0 ]]; then
+        echo "This script must be run as root"
+        exit 1
+    fi
+}
+
+file_exists() {
+    [[ -f $1 ]];
+}
+
+require_command() {
+    type "$1" &> /dev/null || {
+      echo "Command $1 is missing. Install it (e.g. with 'apt-get install $1'). Aborting." >&2;
+      exit 1;
+    }
+}

--- a/addons/iot_box_image/build_utils/partition_image.sh
+++ b/addons/iot_box_image/build_utils/partition_image.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ensure_root # Check if script is run as root, exit if not
+
+require_command fdisk
+require_command losetup
+require_command parted
+require_command e2fsck
+require_command resize2fs
+require_command e2label
+
+IOTBOX=$1
+
+# Enlarge the image (zero-pad). Sector size is 512 bytes (checked with: sudo fdisk -l raspios.img).
+# Note that we can dd using bigger sector size to speed up the process, but we need to be careful with the amount of sectors.
+#
+# We want to add 2.75GiB to the system partition to have enough space to install programs:
+# x (MiB) * 1024 * 1024 / 512 = y (sectors) <=> x (GiB) * 2048 = y (sectors)
+# e.g.  (2.75 * 1024) MiB * 2048 = 5.5M (sectors)
+echo "Enlarging the image..."
+SYSTEM_INCREASE_MiB=2816 # 2.75GiB * 1024 = 2816MiB, using MiB to avoid floating numbers
+SYSTEM_INCREASE_AMOUNT_SECTORS=$((SYSTEM_INCREASE_MiB * 2048)) # sectors
+dd if=/dev/zero of="./${IOTBOX}" bs=512 count=${SYSTEM_INCREASE_AMOUNT_SECTORS} status=progress conv=notrunc oflag=append
+
+# Map partitions from the IoT Box image to loop devices (/dev/loop1pX).
+LOOP_IOT=$(losetup -Pf --show ${IOTBOX})
+LOOP_IOT_BOOT="${LOOP_IOT}p1)" # /dev/loop1p1
+LOOP_IOT_SYS="${LOOP_IOT}p2" # /dev/loop1p2
+echo "Loop devices for ${IOTBOX}:"
+echo "  Boot: ${LOOP_IOT_BOOT}"
+echo "  System: ${LOOP_IOT_SYS}"
+
+# Resize the system partition to make it bigger:
+# We take the last sector of the raspbian image, and add the amount of sectors of the increase (gives us the end sector).
+SYSTEM_END_SECTOR=$(fdisk -l ${IOTBOX} | grep "${IOTBOX}2" | awk '{print $3}')
+NEW_END_SECTOR_SYSTEM=$((SYSTEM_END_SECTOR + SYSTEM_INCREASE_AMOUNT_SECTORS - 1))
+parted -s ${LOOP_IOT} resizepart 2 "${NEW_END_SECTOR_SYSTEM}s"
+
+# We need to remap the whole image to resize the filesystem taking changes into account.
+losetup -d ${LOOP_IOT}
+LOOP_IOT=$(losetup -Pf --show ${IOTBOX})
+LOOP_IOT_BOOT="${LOOP_IOT}p1" # /dev/loop1p1
+LOOP_IOT_SYS="${LOOP_IOT}p2" # /dev/loop1p2
+
+# Format and resize system partition filesystem.
+e2fsck -fvy ${LOOP_IOT_SYS}
+resize2fs ${LOOP_IOT_SYS}
+
+# Rename the system partition (optional but cool).
+e2label ${LOOP_IOT_SYS} iotboxfs

--- a/addons/iot_box_image/build_utils/sparse-checkout
+++ b/addons/iot_box_image/build_utils/sparse-checkout
@@ -1,0 +1,7 @@
+addons/web
+addons/hw_*
+addons/iot_base
+addons/iot_box_image/configuration
+addons/point_of_sale/tools/posbox/configuration
+odoo/
+odoo-bin

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -234,5 +234,6 @@ create_ramdisk_dir "/etc"
 create_ramdisk_dir "/tmp"
 mkdir -v /root_bypass_ramdisks
 
-echo "password"
-echo ${password}
+echo ""
+echo "--- DEFAULT PASSWORD: ${password} ---"
+echo ""


### PR DESCRIPTION
- Splitted the image builder into multiple files to ease readability and maintainability,
- simplified partitioning using `parted` tools,
- improved speed by copying partitions between raspbian and new image only once: resizing partition instead of re-creating it.
