### PR TITLE
[FIX] website: allow to edit menu groups


### DIFF
--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -108,8 +108,10 @@ class WebsiteMenu(models.Model):
     def write(self, values):
         self.env.registry.clear_cache('templates')
         res = super().write(values)
-        if 'group_ids' in values:
-            self.filtered('group_ids').group_ids += self.env.ref('website.group_website_designer')
+        if 'group_ids' in values and not self.env.context.get("adding_designer_group_to_menu"):
+            self.filtered("group_ids").with_context(
+                adding_designer_group_to_menu=True
+            ).group_ids += self.env.ref("website.group_website_designer")
         return res
 
     def unlink(self):

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -236,6 +236,19 @@ class TestMenu(common.TransactionCase):
         submenu.url = '/sub/slug-3'
         test_full_case(submenu)
 
+    def test_menu_group_ids(self):
+        Menu = self.env['website.menu']
+        menu = Menu.create({
+            'name': 'Test',
+        })
+        self.assertEqual(menu.group_ids, self.env['res.groups'])
+        menu.group_ids = self.env.ref('base.group_user')
+        self.assertEqual(
+            menu.group_ids,
+            self.env.ref('base.group_user') +
+            self.env.ref('website.group_website_designer')
+        )
+
 
 class TestMenuHttp(common.HttpCase):
     def setUp(self):


### PR DESCRIPTION

Scenario: add a group to a website menu from backend

Result: traceback error with "RecursionError: maximum recursion depth
exceeded while calling a Python object".

Issue: refactoring cb400ceb7f518815036d985165ebe416bbb0b5eb introduces a
recursive loop writing on website.menu().group_ids field.

Fix: use context key to avoid the loop.

opw-4591357
