### PR TITLE
[FIX] pos_sale: prevent horizontal scroll bar for down payment receipts

### DIFF
--- a/addons/pos_sale/static/src/overrides/components/orderline/orderline.scss
+++ b/addons/pos_sale/static/src/overrides/components/orderline/orderline.scss
@@ -1,0 +1,4 @@
+.sale-order-info td {
+    padding: 2px 8px;
+    white-space: normal;
+}

--- a/addons/pos_sale/static/src/overrides/components/orderline/orderline.xml
+++ b/addons/pos_sale/static/src/overrides/components/orderline/orderline.xml
@@ -10,8 +10,7 @@
                 <table t-if="line.details" class="sale-order-info">
                     <tr t-foreach="line.details" t-as="soLine" t-key="soLine_index">
                         <td class="text-truncate"><t t-esc="soLine.product_uom_qty"/>x</td>
-                        <td class="text-truncate" style="max-width: 275px;"
-                            t-esc="soLine.product_name" />
+                        <td class="text-truncate" t-esc="soLine.product_name" />
                         <td class="text-truncate">: </td>
                         <td t-if="!props.basic_receipt" class="text-truncate"><t t-esc="soLine.total" /> (tax incl.)</td>
                     </tr>


### PR DESCRIPTION
Before this commit, making a down payment for a sale order with a product that has a long name would cause a horizontal scroll bar to appear in the receipt.

Before:
<img width="259" alt="image" src="https://github.com/user-attachments/assets/3db17ad0-e1a7-4653-9e50-edd9dd8c4e9e" />

After:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/faa0c3ea-c400-4cb6-96ed-2b496236710f" />


opw-4604797

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
