### PR TITLE
[FIX] account: cash basis move lines display_type fix

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -330,6 +330,7 @@ class AccountPartialReconcile(models.Model):
             'tax_ids': [Command.set(tax_ids.ids)],
             'tax_tag_ids': [Command.set(all_tags.ids)],
             'analytic_distribution': base_line.analytic_distribution,
+            'display_type': base_line.display_type,
         }
 
     @api.model
@@ -350,6 +351,7 @@ class AccountPartialReconcile(models.Model):
             'currency_id': cb_base_line_vals['currency_id'],
             'partner_id': cb_base_line_vals['partner_id'],
             'analytic_distribution': cb_base_line_vals['analytic_distribution'],
+            'display_type': cb_base_line_vals['display_type'],
         }
 
     @api.model
@@ -380,6 +382,7 @@ class AccountPartialReconcile(models.Model):
             'currency_id': tax_line.currency_id.id,
             'partner_id': tax_line.partner_id.id,
             'analytic_distribution': tax_line.analytic_distribution,
+            'display_type': tax_line.display_type,
             # No need to set tax_tag_invert as on the base line; it will be computed from the repartition line
         }
 
@@ -402,6 +405,7 @@ class AccountPartialReconcile(models.Model):
             'currency_id': cb_tax_line_vals['currency_id'],
             'partner_id': cb_tax_line_vals['partner_id'],
             'analytic_distribution': cb_tax_line_vals['analytic_distribution'],
+            'display_type': cb_tax_line_vals['display_type'],
         }
 
     @api.model


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Switch to a Mexican company (or any company with cash basis option enabled).
- Go to analytic plans and set at least one plan to mandatory.
- Create a vendor bill, with a line having a vat (16% for example), and confirm the bill.
- Click on credit note, try to confirm the credit note, it will show error.

Cause
-----
The cash basis entry created doesn't copy the display type of the original move lines, so the move lines of the taxes will get the default display type (product). And this affects the function that applies the mandatory analytic plans, as it filters out lines that have display_type != product.

Fix
---
Add lines to copy the display_type for the move lines of the cash basis.

opw-4579419
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr