### PR TITLE
[FIX] l10n_es_edi_tbai: Correct DesgloseFactura for Bizkaia

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -356,7 +356,7 @@ class AccountEdiFormat(models.Model):
             if invoice.is_sale_document():
                 # Customer invoices
 
-                if com_partner.country_id.code in ('ES', False) and not (com_partner.vat or '').startswith("ESN"):
+                if (com_partner.country_id.code in ('ES', False) and not (com_partner.vat or '').startswith("ESN")) or is_simplified:
                     tax_details_info_vals = self._l10n_es_edi_get_invoices_tax_details_info(invoice)
                     invoice_node['TipoDesglose'] = {'DesgloseFactura': tax_details_info_vals['tax_details_info']}
 

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -432,7 +432,8 @@ class AccountEdiFormat(models.Model):
     def _l10n_es_tbai_get_importe_desglose(self, invoice):
         com_partner = invoice.commercial_partner_id
         sign = -1 if invoice.move_type in ('out_refund', 'in_refund') else 1
-        if com_partner.country_id.code in ('ES', False) and not (com_partner.vat or '').startswith("ESN"):
+        if (com_partner.country_id.code in ('ES', False) and not (com_partner.vat or '').startswith("ESN")) \
+                or invoice._is_l10n_es_tbai_simplified():
             tax_details_info_vals = self._l10n_es_edi_get_invoices_tax_details_info(invoice)
             tax_amount_retention = tax_details_info_vals['tax_amount_retention']
             desglose = {'DesgloseFactura': tax_details_info_vals['tax_details_info']}


### PR DESCRIPTION
An error occurs when a simplified invoice contains an OSS with a non-Spanish partner, and the Bizkaia tax agency is selected. This causes the B4_2000027 error to be returned by Bizkaia.

Steps to reproduce:
- Install l10n_es_edi_tbai and l10n_eu_oss
- Set the Tax Agency to Bizkaia
- Create a simplified invoice
    - Set fiscal position to OSS B2C - Poland
    - Use a Polish partner
    - Add a product
    - Validate the invoice
- Attempt to send to Bizkaia

The error raised is:
`B4_1000002: Todos los registros incluidos en la petición son incorrectos.
B4_2000027: La factura contiene un Tipo de desglose incorrecto. Ha de ser a nivel de operación cuando la factura es completa y, además, existe destinatario extranjero (tipo IDOtro o que sea NIF que empiece por N) o la Clave de IVA es 02.`

After investigation, it appears this issue occurs only with Bizkaia. This fix ensures that `DesgloseFactura` is used instead of `DesgloseTipoOperacion` for this specific case.

Reference:
https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G417/FicherosSuministros/V_1_1/SII_Descripcion_ServicioWeb_v1.1_en_gb.pdf?utm_source=chatgpt.com

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4464223)
opw-4464223