### PR TITLE
[FIX] website_sale: no access to reactions for public users in ecommerce

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -46,12 +46,15 @@ class PortalChatter(http.Controller):
         partner = request.env.user.partner_id
         if thread:
             mode = request.env[thread_model]._get_mail_message_access([thread_id], "create")
-            can_react = request.env[thread_model]._get_thread_with_access(thread_id, mode, **kwargs)
+            has_react_access = request.env[thread_model]._get_thread_with_access(thread_id, mode, **kwargs)
+            can_react = has_react_access
+            if request.env.user._is_public():
+                portal_partner = get_portal_partner(
+                    thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token")
+                )
+                can_react = has_react_access and portal_partner
+                partner = portal_partner or partner
             store.add(thread, {"can_react": bool(can_react)}, as_thread=True)
-            if request.env.user._is_public() and (portal_partner := get_portal_partner(
-                thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token")
-            )):
-                partner = portal_partner
         store.add({"self": Store.one(partner, fields=["active", "avatar_128", "name", "user"])})
         if request.env.user.has_group("website.group_website_restricted_editor"):
             store.add(partner, {"is_user_publisher": True})

--- a/addons/website_sale/static/tests/tours/website_sale_product_reviews_reactions_public.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_reviews_reactions_public.js
@@ -1,0 +1,30 @@
+import { registry } from "@web/core/registry";
+
+registry
+    .category('web_tour.tours')
+    .add('website_sale_product_reviews_reactions_public', {
+        url: '/shop?search=Storage Box Test',
+        steps: () => [
+            {
+                trigger: '.oe_product_cart a:contains("Storage Box Test")',
+                run: "click",
+            },
+            {
+                trigger: '.o_product_page_reviews_title',
+                run: "click",
+            },
+            {
+                trigger: "#chatterRoot:shadow .o-mail-Message-textContent:contains(Bad box!)",
+                run: "hover && click",
+            },
+            {
+                trigger: "#chatterRoot:shadow .o-mail-Message-actions",
+                run: async () => {
+                    const addReactionButton = document.querySelector('#chatterRoot').shadowRoot.querySelector("[title='Add a Reaction']")
+                    if (addReactionButton) {
+                        throw new Error("Non-authenticated user should not be able to add a reaction to a message");
+                    }
+                },
+            },
+        ],
+   });

--- a/addons/website_sale/tests/test_website_sale_product_page.py
+++ b/addons/website_sale/tests/test_website_sale_product_page.py
@@ -28,3 +28,26 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
         blue_sofa.product_template_attribute_value_ids.price_extra = 20
 
         self.start_tour(red_sofa.website_url, 'website_sale_contact_us_button')
+
+    def test_product_reviews_reactions_public(self):
+        """ Check that public users can not react to reviews """
+
+        self.env["ir.ui.view"].with_context(active_test=False).search([
+            ("key", "=", "website_sale.product_comment")
+        ]).write({"active": True})
+
+        self.product_product_7 = self.env["product.product"].create({
+            "name": "Storage Box Test",
+            "standard_price": 70.0,
+            "list_price": 79.0,
+            "website_published": True,
+            "invoice_policy": "delivery",
+        })
+        self.product_product_7.product_tmpl_id.message_post(
+            body="Bad box!",
+            message_type="comment",
+            rating_value="1",
+            subtype_xmlid="mail.mt_comment"
+        )
+
+        self.start_tour("/", "website_sale_product_reviews_reactions_public", login=None)

--- a/addons/website_slides/static/tests/tours/slides_course_reviews_reaction_public.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews_reaction_public.js
@@ -21,11 +21,11 @@ registry.category("web_tour.tours").add("course_reviews_reaction_public", {
             run: "hover && click",
         },
         {
-            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Message-actions",
+            trigger: "#chatterRoot:shadow .o-mail-Message-actions",
             run: async () => {
                 const addReactionButton = document.querySelector('#chatterRoot').shadowRoot.querySelector("[title='Add a Reaction']")
                 if (addReactionButton) {
-                    throw new Error("Public user is able to react");
+                    throw new Error("Non-authenticated user should not be able to add a reaction to a message");
                 }
             },
         },


### PR DESCRIPTION
This commit completes the fix https://github.com/odoo/odoo/pull/197508.
In this commit we make sure that the thread has the correct `can_react` value by also checking that the user has a valid portal_partner.
