### PR TITLE
[FIX] event, website_event_sale: check event availability before payment

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -559,9 +559,11 @@ class EventEvent(models.Model):
         sold_out_events = []
         for event in self:
             if event.seats_limited and event.seats_max and event.seats_available < minimal_availability:
-                sold_out_events.append(
-                    (_('- "%(event_name)s": Missing %(nb_too_many)i seats.',
-                        event_name=event.name, nb_too_many=-event.seats_available)))
+                sold_out_events.append(_(
+                    '- "%(event_name)s": Missing %(nb_too_many)i seats.',
+                    event_name=event.name,
+                    nb_too_many=minimal_availability - event.seats_available,
+                ))
         if sold_out_events:
             raise ValidationError(_('There are not enough seats available for:')
                                   + '\n%s\n' % '\n'.join(sold_out_events))

--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -158,9 +158,12 @@ class EventTicket(models.Model):
         sold_out_tickets = []
         for ticket in self:
             if ticket.seats_max and ticket.seats_available < minimal_availability:
-                sold_out_tickets.append((_(
+                sold_out_tickets.append(_(
                     '- the ticket "%(ticket_name)s" (%(event_name)s): Missing %(nb_too_many)i seats.',
-                    ticket_name=ticket.name, event_name=ticket.event_id.name, nb_too_many=-ticket.seats_available)))
+                    ticket_name=ticket.name,
+                    event_name=ticket.event_id.name,
+                    nb_too_many=minimal_availability - ticket.seats_available,
+                ))
         if sold_out_tickets:
             raise ValidationError(_('There are not enough seats available for:')
                                   + '\n%s\n' % '\n'.join(sold_out_tickets))

--- a/addons/website_event_sale/controllers/payment.py
+++ b/addons/website_event_sale/controllers/payment.py
@@ -9,10 +9,17 @@ class PaymentPortalOnsite(PaymentPortal):
         Throws a ValidationError if the user tries to pay for a ticket which isn't available
         """
         super()._validate_transaction_for_order(transaction, sale_order_id)
-        sale_order = request.env['sale.order'].browse(sale_order_id).exists()
+
         count_per_ticket = request.env['event.registration'].sudo()._read_group(
-            [('sale_order_id', 'in', sale_order.ids), ('state', '!=', 'cancel'), ('event_ticket_id', '!=', False)],
+            [('sale_order_id', '=', sale_order_id), ('state', '!=', 'cancel'), ('event_ticket_id', '!=', False)],
             ['event_ticket_id'], ['__count']
         )
         for ticket, count in count_per_ticket:
             ticket._check_seats_availability(minimal_availability=count)
+
+        count_per_event = request.env['event.registration'].sudo()._read_group(
+            [('sale_order_id', '=', sale_order_id), ('state', '!=', 'cancel'), ('event_ticket_id', '!=', False)],
+            ['event_id'], ['__count']
+        )
+        for event, count in count_per_event:
+            event._check_seats_availability(minimal_availability=count)

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -2,6 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
+from odoo import Command
+from odoo.exceptions import ValidationError
+from odoo.tests import JsonRpcException
 
 from datetime import timedelta
 
@@ -126,70 +129,102 @@ class TestRoutes(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon, PaymentHttpCo
 
     @mute_logger('odoo.http')
     def test_check_seats_avail_before_purchase(self):
+        """Check that payments fails when there aren't enough seats available.
+        - First check payment fails due to exceeding the ticket's limit
+        - Then change to 2 unlimited tickets, which fails due to exceeding event limit
+        - Finally do a successful purchase of a single ticket without limit
+        """
         self.authenticate(None, None)
-
-        so_line_1, so_line_2 = self.env['sale.order.line'].create([
-            {
-                'event_id': self.event.id,
-                'event_ticket_id': self.ticket.id,
-                'name': self.event.name,
-                'order_id': self.so.id,
-                'product_id': self.ticket.product_id.id,
-                'product_uom_qty': 2,
-            },
-            {
-                'event_id': self.event_2.id,
-                'event_ticket_id': self.ticket_2.id,
-                'name': self.event_2.name,
-                'order_id': self.so.id,
-                'product_id': self.ticket_2.product_id.id,
-                'product_uom_qty': 2,
-            },
-        ])
-        self.so._cart_update(line_id=so_line_1.id, product_id=self.ticket.product_id.id, set_qty=1)
-        self.so._cart_update(line_id=so_line_2.id, product_id=self.ticket_2.product_id.id, set_qty=1)
-
-        url = self._build_url(f'/shop/payment/transaction/{self.so.id}')
-        self.assertEqual(self.event.seats_taken, 0)
-        self.assertEqual(self.event_2.seats_taken, 0)
-        self.env['event.registration'].create([
-            {
-                'event_id': self.event.id,
-                'name': 'reg1',
-                'state': 'done',
-            },
-            {
-                'event_id': self.event_2.id,
-                'name': 'reg2',
-                'state': 'done',
-            }
-        ])
-        self.assertEqual(self.event.seats_taken, 1)
-        self.assertEqual(self.event_2.seats_taken, 1)
-        self.ticket.write({
-            'seats_max': 2,
-            'seats_limited': True,
-        })
         self.ticket_2.write({
-            'seats_max': 2,
+            'name': "VIP",
+            'event_id': self.event.id,
+            'seats_max': 1,
             'seats_limited': True,
         })
-        self.env['event.registration'].create([
-            {'event_id': e.id, 'sale_order_id': self.so.id, 'partner_id': p.id, 'event_ticket_id': t.id}
-            for p in [(self.partner), (self.partner_admin)]
-            for e, t in [(self.event, self.ticket), (self.event_2, self.ticket_2)]
-        ])
+        self.event.write({
+            'seats_max': 3,
+            'seats_limited': True,
+        })
+        self.assertFalse(self.ticket.seats_limited)
+        self.assertEqual(self.ticket_2.seats_available, 1)
+        self.assertEqual(self.event.seats_available, 3)
+
+        # Add VIP ticket to cart & create draft registration
+        self.so.order_line = [Command.create({
+            'product_id': self.ticket.product_id.id,
+            'event_id': self.event.id,
+            'event_ticket_id': self.ticket_2.id,
+        })]
+        registration = self.env['event.registration'].create({
+            'state': 'draft',
+            'partner_id': self.so.partner_id.id,
+            'event_id': self.event.id,
+            'event_ticket_id': self.ticket_2.id,
+            'sale_order_id': self.so.id,
+        })
+        self.assertEqual(self.event.seats_taken, 0)
+        self.assertEqual(self.event.event_ticket_ids.mapped('seats_taken'), [0, 0])
+
+        # Sneaky Mitchell beats us to the punch
+        self.event.registration_ids = [Command.create({
+            'partner_id': self.partner_admin.id,
+            'event_ticket_id': self.ticket_2.id,
+            'state': 'done',
+        })]
+        self.assertEqual(self.event.seats_taken, 1)
+        self.assertEqual(self.event.seats_available, 2)
+
+        # Set up transaction values
+        url = self._build_url(f'/shop/payment/transaction/{self.so.id}')
         route_kwargs = {
             'provider_id': self.provider.id,
             'payment_method_id': self.payment_method.id,
             'token_id': None,
-            'amount': self.so.amount_total,
             'flow': 'direct',
             'tokenization_requested': False,
             'landing_route': '/shop/payment/validate',
-            'is_validation': False,
-            'csrf_token': odoo.http.Request.csrf_token(self),
             'access_token': self.so._portal_ensure_token(),
         }
-        with self.assertRaisesRegex(odoo.tests.JsonRpcException, 'odoo.exceptions.ValidationError'):
+
+        # Payment should fail due to exceeding the VIP ticket limit
+        with self.assertRaisesRegex(JsonRpcException, r'odoo\.exceptions\.ValidationError'):
             self.make_jsonrpc_request(url, route_kwargs)
+        # Double check that we hit the correct limit
+        with self.assertRaises(ValidationError):
+            self.ticket_2._check_seats_availability(minimal_availability=1)
+        self.event._check_seats_availability(minimal_availability=1)
+
+        # Replace VIP ticket with 2 regular tickets
+        self.so.order_line.write({
+            'product_id': self.ticket.product_id,
+            'product_uom_qty': 2,
+            'event_id': self.event.id,
+            'event_ticket_id': self.ticket.id,
+        })
+        registration.event_ticket_id = self.ticket.id
+        registration += registration.copy({'state': 'draft', 'sale_order_id': self.so.id})
+
+        # Sneaky Mitchell beats us to the punch again
+        self.event.registration_ids = [Command.create({
+            'partner_id': self.partner_admin.id,
+            'event_ticket_id': self.ticket.id,
+            'state': 'done',
+        })]
+        self.assertEqual(self.event.seats_taken, 2)
+        self.assertEqual(self.event.seats_available, 1)
+
+        # Payment should fail due to exceeding the event seat limit
+        with self.assertRaisesRegex(JsonRpcException, r'odoo\.exceptions\.ValidationError'):
+            self.make_jsonrpc_request(url, route_kwargs)
+        # Double check that we hit the correct limit
+        with self.assertRaises(ValidationError):
+            self.event._check_seats_availability(minimal_availability=2)
+        self.ticket._check_seats_availability(minimal_availability=1)
+
+        # Payment should succeed when buying only one ticket
+        self.so.order_line.product_uom_qty = 1
+        registration[1].unlink()
+        self.make_jsonrpc_request(url, route_kwargs)
+        registration.exists().write({'state': 'open'})
+        self.assertEqual(self.ticket.seats_taken, 2)
+        self.assertEqual(self.event.seats_taken, 3)


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Create an event with an attendee limit of 1;
2. publish the event;
3. add a ticket to you cart;
4. go through checkout until your reach the payment page;
5. open a incognito window or different browser;
6. add same ticket to cart;
7. go to the payment step;
8. click "Pay now" and wait for confirmation;
9. go to previous window, and click "Pay now".

Issue
-----
The payment gets confirmed, but you land on an internal server error due to a lack of available seats for the event.

Cause
-----
Commit ffc9026361beb added a check before payment to ensure the tickets still had seats available. The event itself however can have a separate seat limit that isn't currently being checked.

Solution
--------
Add a check on the event's seat availability to `_validate_transaction_for_order`.

Also, in case there's a lack of seats, display the correct number of lacking seats for the order instead of `-available_seats`.

opw-4453539