### PR TITLE
[FIX] point_of_sale: prevent pricelist loading when fetching partners

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -477,6 +477,10 @@ export class PosData extends Reactive {
                     continue;
                 }
 
+                if (this.opts.prohibitedAutoLoadedFields[rel.model]?.includes(rel.name)) {
+                    continue;
+                }
+
                 const values = records.map((record) => record[rel.name]).flat();
                 const missing = values.filter((value) => {
                     if (!value || typeof value !== "number" || idsMap[rel.relation]?.has(value)) {

--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -91,4 +91,10 @@ export class DataServiceOptions {
             "pos.pack.operation.lot",
         ];
     }
+
+    get prohibitedAutoLoadedFields() {
+        return {
+            "res.partner": ["property_product_pricelist"],
+        };
+    }
 }


### PR DESCRIPTION
Before this commit, when a partner linked to a specific pricelist was searched and loaded in the PoS, the associated pricelist and its products could be unintentionally loaded, even if they were not available in the PoS.

opw-4615603

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
