### PR TITLE
[IMP] fleet: vehicle quick create view

### DIFF
--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -266,12 +266,24 @@
         </field>
     </record>
 
+    <record id="fleet_vehicle_view_form_quick_create" model="ir.ui.view">
+        <field name="name">fleet.vehicle.form.quick.create</field>
+        <field name="model">fleet.vehicle</field>
+        <field name="priority">1000</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="model_id" placeholder="e.g. Model S"/>
+                </group>
+            </form>
+        </field>
+    </record>
 
     <record id='fleet_vehicle_view_kanban' model='ir.ui.view'>
         <field name="name">fleet.vehicle.kanban</field>
         <field name="model">fleet.vehicle</field>
         <field name="arch" type="xml">
-            <kanban default_group_by="state_id" sample="1">
+            <kanban default_group_by="state_id" sample="1" quick_create_view="fleet.fleet_vehicle_view_form_quick_create">
                 <field name="contract_renewal_due_soon" />
                 <field name="contract_renewal_overdue" />
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On the kanban view of Fleet Vehicles, add a view to the quick create button.

Current behavior before PR:
Default view shows the title field which is not relevant in our case.

Desired behavior after PR is merged:
Add field model_id, the only required field, to the view

task-4614230

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
