### PR TITLE
[FIX] website: add missing class on `s_image_text_box`

### DIFF
--- a/addons/website/views/snippets/s_image_text_box.xml
+++ b/addons/website/views/snippets/s_image_text_box.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_image_text_box" name="Image Text Box">
-    <section class="s_image_text_box pt80 pb80" data-oe-shape-data="{'shape': 'web_editor/Connections/08'}">
+    <section class="s_image_text_box o_colored_level pt80 pb80" data-oe-shape-data="{'shape': 'web_editor/Connections/08'}">
         <div class="o_we_shape o_web_editor_Connections_08"/>
         <div class="container">
             <div class="row o_grid_mode" data-row-count="10" style="column-gap: 24px;">


### PR DESCRIPTION
This PR adds a missing `o_colored_level` class on the `s_image_text_box` snippet section.

With the themes revamp, we reviewed the design of a lot of snippets, which sometimes included colors adjustments using `o_cc o_cc*` classes.

These adjustments, which are often nested `o_cc` classes require a `o_colored_level` class on the section to ensure the different colors are correctly rendered in the snippet modal.

task-4255088
related to task-4177975

| Master | This PR |
|--------|--------|
| <img width="467" alt="image" src="https://github.com/user-attachments/assets/9498a409-608e-4efb-b333-396b572d124c"> | <img width="466" alt="image" src="https://github.com/user-attachments/assets/1f6a6632-0ef8-4188-912f-307897aeae6e"> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
