### PR TITLE
[FIX] partner_autocomplete: fix error on loading data

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
@@ -152,7 +152,7 @@ export function usePartnerAutocomplete() {
     function getCreateData(company) {
         const removeUselessFields = (company) => {
             // Delete attribute to avoid "Field_changed" errors
-            const fields = ['label', 'description', 'domain', 'logo', 'legal_name', 'ignored', 'email', 'bank_ids', 'classList', 'skip_enrich'];
+            const fields = ['label', 'description', 'domain', 'logo', 'legal_name', 'ignored', 'email', 'bank_ids', 'classList', 'skip_enrich', 'mobile'];
             fields.forEach((field) => {
                 delete company[field];
             });

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -154,6 +154,7 @@ QUnit.module('partner_autocomplete', {
                         'id': 1,
                         'display_name': "California (US)",
                     },
+                    "mobile": false,
                 });
             }
             else if (route.startsWith("https://autocomplete.clearbit.com/v1/companies/suggest")) {


### PR DESCRIPTION
How to reproduce:
================

Create a trial database on 'odoo.com', go to Contacts and click on new, then add a company name by clicking on one option from the autocompletion's selection.You get a Client Error (UncaughtPromiseError > TypeError).

Reason:
======

The error is linked to the recent deletion of the 'mobile' field on the 'res_partner' model (see odoo/odoo#189739). It occurs on the trial database (and not on the runbot dbs) because it has free credits for testing the api, which returns all company information (including the mobile key,value/field).

Solution:
========

As modifying the api would involve a new api version, we make it so the Client discards the 'mobile' key/value from the api (enrich_company) result, before the related record is updated.

task-4620000
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
