### PR TITLE
[IMP] tests: allow to run/disable specific js tests

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -3,6 +3,7 @@
 
 import re
 import odoo.tests
+from werkzeug.urls import url_quote_plus
 
 RE_ONLY = re.compile(r'QUnit\.(only|debug)\(')
 
@@ -22,12 +23,72 @@ def qunit_error_checker(message):
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-class WebSuite(odoo.tests.HttpCase):
+class WebsuiteCommon(odoo.tests.HttpCase):
+    def get_filter(self, test_params):
+        positive = []
+        negative = []
+        for sign, param in test_params:
+            filters = param.split(',')
+            for filter in filters:
+                filter = filter.strip()
+                if not filter:
+                    continue
+                negate = sign == '-'
+                if filter.startswith('-'):
+                    negate = not negate
+                    filter = filter[1:]
+                if negate:
+                    negative.append(f'({re.escape(filter)}.*)')
+                else:
+                    positive.append(f'({re.escape(filter)}.*)')
+        filter = ''
+        if positive or negative:
+            positive_re = '|'.join(positive) or '.*'
+            negative_re = '|'.join(negative)
+            negative_re = f'(?!{negative_re})' if negative_re else ''
+            filter = f'^({negative_re})({positive_re})$'
+        return filter
+
+    def test_get_filter(self):
+        f1 = self.get_filter([('+', 'utils,mail,-utils > bl1,-utils > bl2')])
+        f2 = self.get_filter([('+', 'utils'), ('-', 'utils > bl1,utils > bl2'), ('+', 'mail')])
+        for f in (f1, f2):
+            self.assertRegex('utils', f)
+            self.assertRegex('mail', f)
+            self.assertRegex('utils > something', f)
+
+            self.assertNotRegex('utils > bl1', f)
+            self.assertNotRegex('utils > bl2', f)
+            self.assertNotRegex('web', f)
+
+        f2 = self.get_filter([('+', '-utils > bl1,-utils > bl2')])
+        f3 = self.get_filter([('-', 'utils > bl1,utils > bl2')])
+        for f in (f2, f3):
+            self.assertRegex('utils', f)
+            self.assertRegex('mail', f)
+            self.assertRegex('utils > something', f)
+            self.assertRegex('web', f)
+
+            self.assertNotRegex('utils > bl1', f)
+            self.assertNotRegex('utils > bl2', f)
+
+    def get_filter_param(self):
+        filter_param = ''
+        filter = self.get_filter(self._test_params)
+        if filter:
+            url_filter = url_quote_plus(filter)
+            filter_param = f'&filter=/{url_filter}/'
+        return filter_param
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class WebSuite(WebsuiteCommon):
 
     @odoo.tests.no_retry
     def test_js(self):
+        filter_param = self.get_filter_param()
         # webclient desktop test suite
-        self.browser_js('/web/tests?mod=web', "", "", login='admin', timeout=1800, error_checker=qunit_error_checker)
+        self.browser_js('/web/tests?mod=web%s' % filter_param, "", "", login='admin', timeout=1800, error_checker=qunit_error_checker)
 
     def test_check_suite(self):
         # verify no js test is using `QUnit.only` as it forbid any other test to be executed
@@ -53,10 +114,11 @@ class WebSuite(odoo.tests.HttpCase):
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-class MobileWebSuite(odoo.tests.HttpCase):
+class MobileWebSuite(WebsuiteCommon):
     browser_size = '375x667'
     touch_enabled = True
 
     def test_mobile_js(self):
+        filter_param = self.get_filter_param()
         # webclient mobile test suite
-        self.browser_js('/web/tests/mobile?mod=web', "", "", login='admin', timeout=1800, error_checker=qunit_error_checker)
+        self.browser_js('/web/tests/mobile?mod=web%s' % filter_param, "", "", login='admin', timeout=1800, error_checker=qunit_error_checker)

--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -355,6 +355,45 @@ class TestSelectorSelection(TransactionCase):
         position = TagsSelector('post_install')
         self.assertTrue(tags.check(post_install_obj) and position.check(post_install_obj))
 
+    def test_selector_parser_parameters(self):
+        tags = ','.join([
+            '/base:FakeClassA[failfast=0,filter=-livechat]',
+            #'/base:FakeClassA[filter=[-barecode,-stock_x]]',
+            '/other[notForThisClass]',
+            '-/base:FakeClassA[arg1,arg2]',
+        ])
+        tags = TagsSelector(tags)
+        class FakeClassA(TransactionCase):
+            pass
+
+        fc = FakeClassA()
+        tags.check(fc)
+        self.assertEqual(fc._test_params, [('+', 'failfast=0,filter=-livechat'), ('-', 'arg1,arg2')])
+
+    def test_negative_parameters_translate(self):
+        tags = TagsSelector('.test_negative_parameters_translate')
+        self.assertTrue(tags.check(self), "Sanity check")
+        self.assertEqual(self._test_params, [])
+
+        tags = TagsSelector('/other_module,-.test_negative_parameters_translate[someparam]')
+        self.assertFalse(tags.check(self), "we don't expect a negative parameter to enable the test if not enabled in other tags")
+        self.assertEqual(self._test_params, [])
+
+        tags = TagsSelector('/base,-.test_negative_parameters_translate[someparam]')
+        self.assertTrue(tags.check(self), "A negative parametric tag should not disable the test")
+        self.assertEqual(self._test_params, [('-', 'someparam')])
+
+        tags = TagsSelector('-.test_negative_parameters_translate[someparam]')
+        self.assertTrue(tags.check(self), "we don't expect a single negative parameter to disable the test that should run by edfault")
+        self.assertEqual(self._test_params, [('-', 'someparam')])
+
+        tags = TagsSelector('/base,-.test_negative_parameters_translate')
+        self.assertFalse(tags.check(self), "Sanity check, a negative parametric tag without params still disable the test")
+        self.assertEqual(self._test_params, [])
+
+        tags = TagsSelector('.test_negative_parameters_translate[-someparam]')
+        self.assertTrue(tags.check(self), "A parametric tag should enable test")
+        self.assertEqual(self._test_params, [('+', '-someparam')])
 
 class TestTestClass(BaseCase):
     def test_canonical_tag(self):

--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -1,18 +1,30 @@
 import re
 import logging
 
+from odoo.tools.misc import OrderedSet
+
 _logger = logging.getLogger(__name__)
 
 
 class TagsSelector(object):
     """ Test selector based on tags. """
-    filter_spec_re = re.compile(r'^([+-]?)(\*|\w*)(?:\/([\w\/]*(?:.py)?))?(?::(\w*))?(?:\.(\w*))?$')  # [-][tag][/module][:class][.method]
+    filter_spec_re = re.compile(r'''
+                                ^
+                                ([+-]?)                     # operator_re
+                                (\*|\w*)                    # tag_re
+                                (?:\/([\w\/]*(?:.py)?))?    # module_re
+                                (?::(\w*))?                 # test_class_re
+                                (?:\.(\w*))?                # test_method_re
+                                (?:\[(.*)\])?               # parameters
+                                $''', re.VERBOSE)  # [-][tag][/module][:class][.method][[params]]
 
     def __init__(self, spec):
         """ Parse the spec to determine tags to include and exclude. """
-        filter_specs = {t.strip() for t in spec.split(',') if t.strip()}
+        parts = re.split(r',(?![^\[]*\])', spec)  # split on all comma not inside [] (not followed by ])
+        filter_specs = [t.strip() for t in parts if t.strip()]
         self.exclude = set()
         self.include = set()
+        self.parameters = OrderedSet()
 
         for filter_spec in filter_specs:
             match = self.filter_spec_re.match(filter_spec)
@@ -20,8 +32,9 @@ class TagsSelector(object):
                 _logger.error('Invalid tag %s', filter_spec)
                 continue
 
-            sign, tag, module, klass, method = match.groups()
+            sign, tag, module, klass, method, parameters = match.groups()
             is_include = sign != '-'
+            is_exclude = not is_include
 
             if not tag and is_include:
                 # including /module:class.method implicitly requires 'standard'
@@ -33,14 +46,20 @@ class TagsSelector(object):
             if module and (module.endswith('.py')):
                 module_path = module[:-3].replace('/', '.')
                 module = None
+
             test_filter = (tag, module, klass, method, module_path)
+
+            if parameters:
+                # we could check here that test supports negated parameters
+                self.parameters.add((test_filter, ('-' if is_exclude else '+', parameters)))
+                is_exclude = False
 
             if is_include:
                 self.include.add(test_filter)
-            else:
+            if is_exclude:
                 self.exclude.add(test_filter)
 
-        if self.exclude and not self.include:
+        if (self.exclude or self.parameters) and not self.include:
             self.include.add(('standard', None, None, None, None))
 
     def check(self, test):
@@ -55,6 +74,8 @@ class TagsSelector(object):
         test_class = getattr(test, 'test_class', None)
         test_tags = test.test_tags | {test_module}  # module as test_tags deprecated, keep for retrocompatibility,
         test_method = getattr(test, '_testMethodName', None)
+
+        test._test_params = []
 
         def _is_matching(test_filter):
             (tag, module, klass, method, module_path) = test_filter
@@ -73,7 +94,11 @@ class TagsSelector(object):
         if any(_is_matching(test_filter) for test_filter in self.exclude):
             return False
 
-        if any(_is_matching(test_filter) for test_filter in self.include):
-            return True
+        if not any(_is_matching(test_filter) for test_filter in self.include):
+            return False
+        
+        for test_filter, parameter in self.parameters:
+            if _is_matching(test_filter):
+                test._test_params.append(parameter)
 
-        return False
+        return True

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -174,7 +174,7 @@ class configmanager(object):
                          help="Enable unit tests.")
         group.add_option("--test-tags", dest="test_tags",
                          help="Comma-separated list of specs to filter which tests to execute. Enable unit tests if set. "
-                         "A filter spec has the format: [-][tag][/module][:class][.method] "
+                         "A filter spec has the format: [-][tag][/module][:class][.method][[params]] "
                          "The '-' specifies if we want to include or exclude tests matching this spec. "
                          "The tag will match tags added on a class with a @tagged decorator "
                          "(all Test classes have 'standard' and 'at_install' tags "
@@ -184,6 +184,9 @@ class configmanager(object):
                          "If tag is omitted on exclude mode, its value is '*'. "
                          "The module, class, and method will respectively match the module name, test class name and test method name. "
                          "Example: --test-tags :TestClass.test_func,/test_module,external "
+                         "It is also possible to provide parameters to a test method that supports them"
+                         "Example: --test-tags /web.test_js[mail]"
+                         "If negated, a test-tag with parameter will negate the parameter when passing it to the test"
 
                          "Filtering and executing the tests happens twice: right "
                          "after each module installation/update and at the end "


### PR DESCRIPTION
## Summary

1. `--test-tags ".test_js[mail > widgets]"` will start all test_js starting with "mail > widgets"
2. `--test-tags "/web,-.test_js[Components > CheckBox]"` will start all web test, but skip Components > CheckBox qunit
3. ` --test-tags ".test_js[utils,-utils > Hooks,-utils > Patch]"` start all test_js utils tests except the Hooks and Patch ones
4. `--test-tags "-.test_js[Components > CheckBox]"` will start **all** tests, but skip Components > CheckBox qunit

## Motivation

Tags are used by runbot to *disable* randomly failing tests without the need to commit changes.
They can precisely target a python test method, class or module.

They can also be used by developer to run a *specific* test.

The problem is that the qunit is a special case, a js test suite inside the test_suite. It is only possible to disable all of them, or none of them.
Adding the possibility to enable/disable some of them was requested for a long time.

 ## Using test tags

The solution to use test-tags as multiple pros:
    - avoid a new command line argument
    - runbot already manages test-tags for errors meaning that this solution would imply minimal changes on this side
    - passing arguments to a specific tests, without regard of the qunit needs looks like a decent solution. This is a generic solution that could lead to other posibilities (profiling, test mode, ...)

Test tags are not aware of the purpose of the parameters, they will only be passed to the test. The tests has the responsibility to parse them.

 ## Chosen syntax and behavior

The main need is to be enable/disable some qunit. This means that we may want to support having parameters using comma `,` Unfortunately this may conflict with comma used to split tags if the syntax is not well defined.

The main idea to solve this issue was that it would be intuitive to give parameters as a function call would, between parentheses.
The opening and closing of the parentheses would allow to identify if a comma is part of the parameters or a tag separator. But using parenthesis is not a good idea in a command line since it could be interpreted by the shell.

The chosen alternative was to use `[]` to have a opening and closing symbol. Depending on how the parameters are interpreted, it can also be quite intuitive to understand: we select a specific element.
`.test_js[mail,stock]`

to run only js tests concerning mail and stock.
The idea to disable some qunit would be to specify a negative filter as for tags:

`.test_js[-some_module]`

Multiple matching tags may be given, in this case all parameters are given to the test. This is why test_parameters are a list of strings.

`.test_js[-m1,-m2],.test_js[-m3]` will be given to the test as `['-m1,-m2', '-m3']`

 ## Splitting the tags

The idea to support nested [] in params was considered but this would complexify a lot the parsing
`.test_method[filters=[mail,crm],failfast=0]`
This is NOT supported even if it could be. 

Parsing such tags would need a more complex parser (to split the , )
The final decision was made to keep it simple for now since it wouldn't be a problem to add this in the future if needed.

## Negating a parametric tag

A test tag can be negated to disable a test `-.test_js` (no op if test_js was not expected to run)
The question is, what is the expected behaviour of `-.test_js[mail]`.

### 1. Forbid this form
Simple solution, consider it as disabling a test, so passing the parameters would be usellesss and we should just don't allow that. But forbidding this form may force to make some complex development in runbot, since the current logic to disable a test is to add a '-' in front of the tag extected to run the test. 

### 2. Transform it to negate the parameter
It could be as simple as transforming `-.test_js[mail]` to `.test_js[-(mail)]`, or to manage the case when we could have already negated arguments (and multiple ones), tansform it to `.test_js[-mail-]`
The only cons of this solution is that adding the tag -.test_js[mail] would actually enable the test_js even if it is not the case, and be more equivalent to `.test_js,.test_js[-mail]`

### 3. Consider them apart: negated but not including. 
With this last solution, it is not possible to translate it as a tag, it would mean `.test_js[-mail]` if test_js is already enabled. This is whats looks to be the most robust solution. Adding a negated test-tag should not enable a test that wouldn't if not present

### 4. Always considered as parameters
`.test_js[mail]` would not enable test_js, but pass mail as parameter to test_js if another test enables it.
This means that to start the mail js test, we would use --test-tags .test_js,.test_js[mail]
This could make sence but would be less practical.

Since the main goal  is to be able to disable a specific qunit from the runbot, 2, 3 and 4 could work in most cases
but 2 could be problematic in edge cases, and for odoosh were we may want to use autotags but only enable test from one module. /my_module,.test_js[-some_test] would enable the test_js.
3 and 4 are equivalent for negation, but the automatic generation of config wouldn't work with 4. 

The current chosen solution is 3 since it looks to be the more practical.
