### PR TITLE
[FIX] account: Keep fiscal position when switching an invoice to a credit note

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3733,6 +3733,7 @@ class AccountMove(models.Model):
                 'move_type': new_move_type,
                 'partner_bank_id': False,
                 'currency_id': move.currency_id.id,
+                'fiscal_position_id': move.fiscal_position_id.id,
             })
             if move.amount_total < 0:
                 move.write({


### PR DESCRIPTION
Back port of PR https://github.com/odoo/odoo/pull/196673

Issue
When converting an invoice into a credit note, the fiscal position is lost while other fields are retained.

Steps to Reproduce:

Go to Customer Invoices and create a new invoice.
Fill in all the necessary details, including the Fiscal Position.
Click on Switch into Invoice/Credit Note to convert the invoice into a credit note.
Observe that all data is transferred except for the Fiscal Position, which is missing.
Expected behavior: The Fiscal Position should be retained when converting an invoice to a credit note.
Actual behavior: all data is transferred except for the Fiscal Position, which is lost.

Root Cause

The issue occurs in the action_switch_move_type method. When switching move_type, the method does not explicitly retain fiscal_position_id. Unlike static fields such as incoterm_id, the fiscal position is often recomputed dynamically. Writing changes to move_type likely triggers onchange methods that reset the fiscal position, leading to its removal.

Fix
Explicitly preserving fiscal_position_id when updating move_type prevents Odoo’s automatic recomputation from clearing the field. This ensures that fiscal positions are consistently retained, maintaining expected accounting behavior.

opw-4497662






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
