### PR TITLE
[FIX] account: demo data in python instead of xml

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -83,7 +83,7 @@ class AccountChartTemplate(models.AbstractModel):
 
         # the invoice_extract acts like a placeholder for the OCR to be ran and doesn't contain
         # any lines yet
-        for move in invoices:
+        for move in invoices.filtered(lambda m: m.state == 'draft'):
             try:
                 move.action_post()
             except (UserError, ValidationError):


### PR DESCRIPTION
Upgrading from 16 to 17 causes issues with demo data.
It happens when the main company has no chart template, because it won't find the correct `account.journal` for the moves (and `account.account` for the lines).

To reproduce:
- initialize an Odoo 16.0 database with `account_accountant` and NO demo data. (There will be no country_id set on the default company, so the `post_install` hook in `account` won't install `l10n_generic_coa`)
- install demo data (the `post_install` hook in `account` is then not fired, still no `l10n_generic_coa`)
- upgrade to Odoo 17.0

By creating the demo data in Python instead of the XML, we can put the condition to avoid creating the move if we do not have a chart template on the company.

Enterprise PR: odoo/enterprise#80812

opw-4781045