### PR TITLE
[IMP] point_of_sale,tests: allow running parallel tours

### DIFF
--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -269,7 +269,13 @@ class TestFrontend(TestFrontendCommon):
 
     def test_06_split_bill_screen(self):
         self.pos_config.with_user(self.pos_user).open_ui()
-        self.start_pos_tour('SplitBillScreenTour2')
+        self.run_parallel_tours(
+            "pos_user",
+            [
+                self.prepare_pos_tour('SplitBillScreenTour2'),
+                self.prepare_pos_tour('RefundStayCurrentTableTour'),
+            ]
+        )
 
     def test_07_split_bill_screen(self):
         # disable kitchen printer to avoid printing errors


### PR DESCRIPTION
This PR aims to add a way to run multiple tours in parallel in order to
test the synchronization feature in the `pos_restaurant` module.

The introduced `run_parallel_tours` method runs the given prepared tours
in different threads. But in order to do this, we need to make changes
around:

- the SIGXCPU signal handling, and,
- the authentication

For simplicity, we kept the authentication behavior such that it only
works for one user. So in this implementation, all the opened browsers
share the same user and session.

As for the SIGXCPU signal handling, setting the signal handler can only
be done in the main thread. So we introduced a context manager that
sets the custom SIGXCPU handler when starting the tours and restores
the previous signal handler when the tours are finished.