### PR TITLE
[IMP] website_sale_stock: Prevent user from editing an address (`res_partner`) that is linked to pending stock operations.

### DIFF
--- a/addons/website_sale_stock/controllers/__init__.py
+++ b/addons/website_sale_stock/controllers/__init__.py
@@ -4,3 +4,4 @@ from . import main
 from . import reorder
 from . import variant
 from . import website_sale
+from . import portal

--- a/addons/website_sale_stock/controllers/portal.py
+++ b/addons/website_sale_stock/controllers/portal.py
@@ -1,0 +1,31 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _
+from odoo.addons.portal.controllers.portal import CustomerPortal
+
+
+class WebsiteSaleStockCustomerPortal(CustomerPortal):
+
+    def _validate_address_values(self, address_values, partner_sudo, address_type, *args, **kwargs):
+        """
+            Extends address validation to prevent modifications
+            if the partner has delivery notes in certain states.
+
+            Args:
+                address_values (dict): Address values.
+                partner_sudo (recordset): Partner with elevated permissions.
+                address_type (str): Address type.
+                *args, **kwargs: Additional arguments.
+
+            Returns:
+                tuple: (invalid_fields, missing_fields, error_messages).
+        """
+        invalid_fields, missing_fields, error_messages = super()._validate_address_values(
+            address_values, partner_sudo, address_type, *args, **kwargs
+        )
+
+        if partner_sudo and not partner_sudo._can_edit_address():
+            error_messages.append(_('Address cannot be edited because there are pending stock operations. '
+                                    'Please contact us directly for this operation.'))
+
+        return invalid_fields, missing_fields, error_messages

--- a/addons/website_sale_stock/models/__init__.py
+++ b/addons/website_sale_stock/models/__init__.py
@@ -8,3 +8,4 @@ from . import res_config_settings
 from . import sale_order
 from . import sale_order_line
 from . import stock_picking
+from . import res_partner

--- a/addons/website_sale_stock/models/res_partner.py
+++ b/addons/website_sale_stock/models/res_partner.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, api
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    def _get_stock_picking_search_domain(self):
+        """
+            Defines the search domain for delivery notes (stock.picking)
+            associated with this partner.
+
+            Returns:
+            list: A search domain that filters delivery notes according to the
+            current partner and the statuses 'waiting', 'confirmed' or 'assigned'.
+        """
+        return [('partner_id', '=', self.id),
+                ('state', 'in', ['waiting', 'confirmed', 'assigned'])]
+
+    def _can_edit_address(self):
+        """
+            Checks if the partner's address can be edited.
+
+            The address cannot be edited if the partner has delivery notes in the status
+            'waiting', 'confirmed' or 'assigned'.
+
+            Returns:
+            bool: True if the address can be edited, False otherwise.
+        """
+        self.ensure_one()
+        picking_ids = self.env['stock.picking'].sudo().search(self._get_stock_picking_search_domain())
+        if picking_ids:
+            return False
+        return True

--- a/addons/website_sale_stock/models/res_partner.py
+++ b/addons/website_sale_stock/models/res_partner.py
@@ -31,6 +31,6 @@ class ResPartner(models.Model):
         """
         self.ensure_one()
         picking_ids = self.env['stock.picking'].sudo().search(self._get_stock_picking_search_domain())
-        if picking_ids:
+        if picking_ids and self.type == 'delivery':
             return False
         return True


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Extends address validation to prevent modifications when a `delivery` type `res_partner` has pending stock operations. This ensures data consistency and prevents inadvertent address changes that may affect deliveries.

Current behavior before PR:
Addresses can be modified even if the `delivery` type `res_partner` has pending stock operations, which could cause logistical problems.

Desired behavior after PR is merged:
If a `delivery` type `res_partner` has pending stock operations, an error message will be displayed preventing the address from being modified. The user will be informed that address changes must be managed internally.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
