### PR TITLE
[REF] requirements.txt: Install missing pycairo for reportlab 4.0+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ qrcode==7.3.1 ; python_version < '3.11'  # (jammy)
 qrcode==7.4.2 ; python_version >= '3.11'
 reportlab==3.6.8 ; python_version <= '3.10'
 reportlab==3.6.12 ; python_version > '3.10' and python_version < '3.12'
-reportlab==4.1.0 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
+reportlab[pycairo]==4.1.0 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package and reportlab 4.0+ needs pycairo https://docs.reportlab.com/install/ReportLab_Plus_version_installation/
 requests==2.25.1 ;  python_version < '3.11' # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
 requests==2.31.0 ; python_version >= '3.11' # (Noble)
 rjsmin==1.1.0 ; python_version < '3.11'  # (jammy)


### PR DESCRIPTION
Reportlab 4.0+ documentation installation says:
 - `If generating bitmaps make sure to add the PyCairo extension`
   - https://docs.reportlab.com/install/ReportLab_Plus_version_installation/

If your PDF report is using QR barcode (bitmaps) it will not be displayed if `pycairo` is not installed

After install this package the QR barcode is displayed correctly

This problem is not reproduced from docker odoo oficial image because it is already installed
  - docker run -it --rm odoo:18.0 pip freeze |grep -i pycairo

The output is:
 - pycairo==1.25.1
 - rlPyCairo==0.3.0

Same case for odoo-sh for odoo 18.0
 - `ssh YOUR_USER@YOUR_18_CUSTOMER.odoo.com "/bin/bash -c 'pip freeze'" |grep -i pycairo`

It is because the package `python3-renderpm`:
- apt-get install -y --no-install-recommends python3-renderpm
  - https://github.com/odoo/docker/blob/061cbb890fb7750146483717c32d9f533856468e/18.0/Dockerfile#L33

is installing the pycairo dependency for py3.12+

However, if you are using requirements.txt directly it is not auto-installed

In fact, if you try to install using:
 - `pip install pycairo`

You will get the following error:
 - `../cairo/meson.build:31:12: ERROR: Dependency "cairo" not found, tried pkgconfig`

It requires to have installed `libcairo2-dev` apk package:
 - `apt install -y libcairo2-dev`


Related to https://github.com/odoo/documentation/pull/12291

PDF report without `pycairo` installed:
 - ![image (12)](https://github.com/user-attachments/assets/32e8b685-84dc-44fd-b1a4-3f090ce6afb0)

Same report with `pycairo` installed:
 - ![image (11)](https://github.com/user-attachments/assets/deb70699-8986-4114-b971-dc7bd8acda8a)
