### PR TITLE
[IMP] hr_holidays, hr_work_entry_holidays: improve time off type form

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -163,6 +163,14 @@ class HrLeaveType(models.Model):
 
         return [('id', operator, leave_types.ids)]
 
+    @api.constrains('company_id', 'country_id')
+    def _check_company_country_id(self):
+        for leave_type in self:
+            if leave_type.is_used:
+                raise ValidationError(_("The company/country field cannot be edited for this time off type, as it is "
+                    "currently linked to existing time off or allocation requests.\nTo modify this field, please "
+                    "archive or delete the associated requests, or consider creating a new time off type."))
+
     @api.constrains('include_public_holidays_in_duration')
     def _check_overlapping_public_holidays(self):
         # checking for the current user's company too

--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -772,7 +772,6 @@ class TestMultiCompany(TestHrHolidaysCommon):
     @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
     def test_leave_access_no_company_user(self):
         self.employee_emp.company_id = self.user_employee.company_id
-        self.leave_type.write({'company_id': False})
         employee_leave = self.employee_leave.with_user(self.user_employee)
 
         employee_leave.name

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -70,8 +70,8 @@
                                     invisible="leave_validation_type in ['no_validation', 'manager'] and (requires_allocation == 'no' or allocation_validation_type not in ['hr', 'both'])"/>
                         </group>
                         <group>
-                            <field name="company_id" groups="base.group_multi_company" readonly="is_used" placeholder="Visible to all"/>
-                            <field name="country_id" groups="base.group_multi_company" readonly="company_id or is_used"/>
+                            <field name="company_id" groups="base.group_multi_company" placeholder="Visible to all"/>
+                            <field name="country_id" groups="base.group_multi_company" readonly="company_id" placeholder="Visible to all"/>
                             <field name="country_id" invisible="1"/>
                         </group>
                     </group>
@@ -154,8 +154,8 @@
                 <field name="allocation_validation_type" string="Allocation Approval"/>
                 <field name="employee_requests" optional="hide"/>
                 <field name="color" widget="color_picker" optional="hide"/>
-                <field name="company_id" groups="base.group_multi_company" optional="show" readonly="is_used"/>
-                <field name="country_id" groups="base.group_multi_company" optional="show" readonly="company_id or is_used"/>
+                <field name="company_id" groups="base.group_multi_company" optional="show"/>
+                <field name="country_id" groups="base.group_multi_company" optional="show" readonly="company_id"/>
             </list>
         </field>
     </record>

--- a/addons/hr_work_entry_holidays/views/hr_leave_views.xml
+++ b/addons/hr_work_entry_holidays/views/hr_leave_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='negative_cap']" position="after">
                     <group name="payroll" string="Payroll" colspan="2">
-                        <field name="work_entry_type_id"/>
+                        <field name="work_entry_type_id" placeholder="Not linked to a work entry type"/>
                     </group>
             </xpath>
         </field>


### PR DESCRIPTION
- Added a placeholder for the Country and Work Entry Type fields in the Time Off Type form.
- Added a constraint to prevent editing the Company and Country fields if the Time Off Type has been used in allocation or leave requests.

task-4603964

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
