### PR TITLE
[IMP] web: allow middle-click on x2many_field

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -228,7 +228,7 @@ export class X2ManyField extends Component {
         return evaluateBooleanExpr(invisible, this.list.evalContext);
     }
 
-    async switchToForm(record) {
+    async switchToForm(record, options) {
         await this.props.record.save();
         this.action.doAction(
             {
@@ -239,6 +239,7 @@ export class X2ManyField extends Component {
             },
             {
                 props: { resIds: this.list.resIds },
+                newWindow: options.newWindow,
             }
         );
     }

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -4,6 +4,7 @@ import {
     click,
     hover,
     manuallyDispatchProgrammaticEvent,
+    middleClick,
     press,
     queryAll,
     queryAllAttributes,
@@ -9323,6 +9324,39 @@ test(`Can switch to form view on inline tree`, async () => {
 
     await contains(`td.o_list_record_open_form_view`).click();
     expect.verifySteps(["doAction"]);
+});
+
+test(`x2many field, open form view in new window`, async () => {
+    mockService("action", {
+        doAction(params, options) {
+            if (options?.newWindow) {
+                expect.step("opened in a new window");
+                return;
+            }
+            super.doAction(params);
+        },
+        loadState() {},
+    });
+    Partner._records[0].child_ids = [2];
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <field name="child_ids">
+                    <list editable="top" open_form_view="1">
+                        <field name="foo"/>
+                    </list>
+                </field>
+            </form>
+        `,
+        resId: 1,
+    });
+    expect(`td.o_list_record_open_form_view`).toHaveCount(1);
+
+    await middleClick("td.o_list_record_open_form_view");
+    await animationFrame();
+    expect.verifySteps(["opened in a new window"]);
 });
 
 test(`can toggle column in x2many in sub form view`, async () => {


### PR DESCRIPTION
This commit adds the ability to use a middle click/ctrl click to open a record in a new window/new tab on a x2many_field.

task-id 4600027
