### PR TITLE
[FIX] spreadsheet: Add title to FilterValue

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -46,4 +46,5 @@ FilterValue.components = { RecordsSelector, DateFilterValue };
 FilterValue.props = {
     filter: Object,
     model: Object,
+    showTitle: { type: Boolean, optional: true },
 };

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -2,9 +2,8 @@
 <templates>
     <t t-name="spreadsheet_edition.FilterValue"
         owl="1">
-        <div class="o-filter-value d-flex align-items-start w-100">
-            <t t-set="filter"
-                t-value="props.filter"/>
+        <t t-set="filter" t-value="props.filter"/>
+        <div class="o-filter-value d-flex align-items-start w-100" t-att-title="props.showTitle and filter.label">
             <t t-set="filterValue"
                 t-value="getters.getGlobalFilterValue(filter.id)"/>
             <div t-if="filter.type === 'text'" class="w-100">

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -11,6 +11,7 @@
                     t-as="filter"
                     t-foreach="filters"
                     t-key="filter.id"
+                    showTitle="true"
                 />
             </t>
         </ControlPanel>


### PR DESCRIPTION
Currently, the date filters do not have their title displayed in the `FilteValue` component which is an issue in dashboards where one could have multiple date filters defined and could not differentiate them.

This revision adds the fiter label as a title such that users can identify the right filter given that they gave it an appropriate label.

task-4606670

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
