### PR TITLE
[IMP] web: add many2x typeahead

### DIFF
--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -386,7 +386,7 @@ QUnit.module('partner_autocomplete', {
         assert.containsN(
             autocompleteContainer,
             ".o-autocomplete--dropdown-item",
-            8,
+            9,
             "Clearbit and Odoo autocomplete options should be shown"
         );
     });

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -51,6 +51,7 @@ export class Many2ManyTagsField extends Component {
         context: { type: Object, optional: true },
         placeholder: { type: String, optional: true },
         nameCreateField: { type: String, optional: true },
+        searchThreshold: { type: Number, optional: true },
         string: { type: String, optional: true },
         noSearchMore: { type: Boolean, optional: true },
     };
@@ -233,6 +234,14 @@ export const many2ManyTagsField = {
             availableTypes: ["integer"],
             help: _t("Set an integer field to use colors with the tags."),
         },
+        {
+            label: _t("Typeahead search"),
+            name: "search_threshold",
+            type: "number",
+            help: _t(
+                "Defines the minimum number of characters to perform the search. If not set, the search is performed on focus."
+            ),
+        },
     ],
     supportedTypes: ["many2many", "one2many"],
     relatedFields: ({ options }) => {
@@ -258,6 +267,7 @@ export const many2ManyTagsField = {
             context: dynamicInfo.context,
             domain: dynamicInfo.domain,
             placeholder: attrs.placeholder,
+            searchThreshold: options.search_threshold,
             string,
         };
     },

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
@@ -24,6 +24,7 @@
                     nameCreateField="props.nameCreateField"
                     noSearchMore="props.noSearchMore"
                     getOptionClassnames.bind="getOptionClassnames"
+                    searchThreshold="props.searchThreshold"
                 />
             </div>
         </div>

--- a/addons/web/static/src/views/fields/many2one/many2one.js
+++ b/addons/web/static/src/views/fields/many2one/many2one.js
@@ -59,6 +59,7 @@ export function computeM2OProps(fieldProps) {
         placeholder: fieldProps.placeholder,
         readonly: fieldProps.readonly,
         relation: fieldProps.record.fields[fieldProps.name].relation,
+        searchThreshold: fieldProps.searchThreshold,
         string: fieldProps.string || fieldProps.record.fields[fieldProps.name].string || "",
         update: (value) => fieldProps.record.update({ [fieldProps.name]: value }),
         value: toRaw(fieldProps.record.data[fieldProps.name]),
@@ -95,6 +96,7 @@ export class Many2One extends Component {
         readonly: { type: Boolean, optional: true },
         relation: { type: String },
         searchMoreLabel: { type: String, optional: true },
+        searchThreshold: { type: Number, optional: true },
         slots: { type: Object, optional: true },
         specification: { type: Object, optional: true },
         string: { type: String, optional: true },
@@ -176,6 +178,7 @@ export class Many2One extends Component {
             quickCreate: this.props.canQuickCreate ? (name) => this.quickCreate(name) : null,
             resModel: this.props.relation,
             searchMoreLabel: this.props.searchMoreLabel,
+            searchThreshold: this.props.searchThreshold,
             setInputFloats: (isFloating) => {
                 this.state.isFloating = isFloating;
             },

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -36,6 +36,14 @@ export const m2oSupportedOptions = [
             "If checked, users will not be able to create records based through a popup form; they will still be able to create records based on the text input."
         ),
     },
+    {
+        label: _t("Typeahead search"),
+        name: "search_threshold",
+        type: "number",
+        help: _t(
+            "Defines the minimum number of characters to perform the search. If not set, the search is performed on focus."
+        ),
+    },
 ];
 /** @type {import("registries").FieldsRegistryItemShape["supportedTypes"]} */
 export const m2oSupportedTypes = ["many2one"];
@@ -73,6 +81,7 @@ export function extractM2OFieldProps(staticInfo, dynamicInfo) {
         nameCreateField: options.create_name_field,
         openActionContext: context || "{}",
         placeholder: attrs.placeholder,
+        searchThreshold: options.search_threshold,
         string,
     };
 }
@@ -95,6 +104,7 @@ export class Many2OneField extends Component {
         openActionContext: { type: String, optional: true },
         placeholder: { type: String, optional: true },
         searchLimit: { type: Number, optional: true },
+        searchThreshold: { type: Number, optional: true },
         string: { type: String, optional: true },
     };
 

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -927,7 +927,7 @@ test("empty many2one field", async () => {
     await contains(".o_field_many2one[name='trululu'] input").edit("abc", { confirm: false });
     await runAllTimers();
 
-    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(2);
+    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(3);
     expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(0);
 });
 
@@ -2571,8 +2571,10 @@ test("slow create on a many2one", async () => {
     });
     await contains(".o_field_many2one input").edit("new product", { confirm: false });
     await runAllTimers();
+    await press("arrowdown");
     await press("tab");
     await animationFrame();
+
 
     expect(".modal").toHaveCount(1);
     // cancel the many2one creation with Discard button
@@ -2583,6 +2585,7 @@ test("slow create on a many2one", async () => {
     // cancel the many2one creation with Close button
     await contains(".o_field_many2one input").edit("new product", { confirm: false });
     await runAllTimers();
+    await press("arrowdown");
     await press("tab");
     await animationFrame();
 
@@ -2598,6 +2601,7 @@ test("slow create on a many2one", async () => {
 
     await contains(".o_field_many2one input").edit("new product", { confirm: false });
     await runAllTimers();
+    await press("arrowdown");
     await press("tab");
     await animationFrame();
     expect(".modal").toHaveCount(1);
@@ -2608,6 +2612,7 @@ test("slow create on a many2one", async () => {
     // confirm the many2one creation
     await contains(".o_field_many2one input").edit("new product", { confirm: false });
     await runAllTimers();
+    await press("arrowdown");
     await press("tab");
     await animationFrame();
 
@@ -2647,6 +2652,7 @@ test("no_create option on a many2one", async () => {
 
     await contains(".o_field_many2one input").edit("new partner", { confirm: false });
     await runAllTimers();
+    await press("arrowdown");
     await press("tab");
 
     expect(".modal").toHaveCount(0);
@@ -2667,6 +2673,7 @@ test("no_create option on a many2one when can_create is absent", async () => {
     });
     await contains(".o_field_many2one input").edit("new partner", { confirm: false });
     await runAllTimers();
+    await press("arrowdown");
     await press("tab");
 
     expect(".modal").toHaveCount(0);
@@ -2687,8 +2694,11 @@ test("no_quick_create option on a many2one when can_create is absent", async () 
     });
     await contains(".o_field_many2one input").edit("new partner", { confirm: false });
     await runAllTimers();
-    expect(".ui-autocomplete .o_m2o_dropdown_option").toHaveCount(1);
-    expect(".ui-autocomplete .o_m2o_dropdown_option").toHaveClass(
+    expect(".ui-autocomplete .o_m2o_dropdown_option").toHaveCount(2);
+    expect(".ui-autocomplete .o_m2o_dropdown_option:eq(0)").toHaveClass(
+        "o_m2o_dropdown_option_search_more"
+    );
+    expect(".ui-autocomplete .o_m2o_dropdown_option:eq(1)").toHaveClass(
         "o_m2o_dropdown_option_create_edit"
     );
 });
@@ -2914,6 +2924,7 @@ test("pressing ENTER on a 'no_quick_create' many2one should open a M2ODialog", a
         confirm: false,
     });
     await runAllTimers();
+    await press("arrowdown");
     await press("Enter");
     await animationFrame();
     expect(".modal").toHaveCount(1);
@@ -3891,4 +3902,53 @@ test("many2one search with false as name", async () => {
     expect(".o_field_many2one[name='trululu'] .dropdown-menu a.dropdown-item:eq(0)").toHaveText(
         "Unnamed"
     );
+});
+
+test.tags("desktop");
+test("search typeahead", async () => {
+    onRpc("web_name_search", () => expect.step("web_name_search"));
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `<form><field name="trululu" options="{ 'search_threshold': 3 }"/></form>`,
+    });
+
+    await contains(".o_field_widget[name=trululu] input").click();
+    await runAllTimers();
+    expect.verifySteps([]);
+    expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
+        "Search More...",
+        "Start typing 3 characters",
+    ]);
+
+    await contains(".o_field_widget[name=trululu] input").edit("r", { confirm: false });
+    await runAllTimers();
+    expect.verifySteps([]);
+    expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
+        "Create \"r\"",
+        "Search More...",
+        "Create and edit...",
+        "Start typing 3 characters",
+    ]);
+
+    await contains(".o_field_widget[name=trululu] input").edit("re", { confirm: false });
+    await runAllTimers();
+    expect.verifySteps([]);
+    expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
+        "Create \"re\"",
+        "Search More...",
+        "Create and edit...",
+        "Start typing 3 characters",
+    ]);
+
+    await contains(".o_field_widget[name=trululu] input").edit("rec", { confirm: false });
+    await runAllTimers();
+    expect.verifySteps(["web_name_search"]);
+    expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
+        "first record",
+        "second record",
+        "Create \"rec\"",
+        "Search More...",
+        "Create and edit...",
+    ]);
 });

--- a/addons/web/static/tests/views/fields/reference_field.test.js
+++ b/addons/web/static/tests/views/fields/reference_field.test.js
@@ -169,10 +169,13 @@ test("ReferenceField respects no_quick_create", async () => {
     await click(".o_field_widget[name='reference'] input");
     await edit("new partner");
     await runAllTimers();
-    expect(".ui-autocomplete .o_m2o_dropdown_option").toHaveCount(1, {
-        message: "Dropdown should be opened and have only one item",
+    expect(".ui-autocomplete .o_m2o_dropdown_option").toHaveCount(2, {
+        message: "Dropdown should be opened and have two items",
     });
-    expect(".ui-autocomplete .o_m2o_dropdown_option").toHaveClass(
+    expect(".ui-autocomplete .o_m2o_dropdown_option:eq(0)").toHaveClass(
+        "o_m2o_dropdown_option_search_more"
+    );
+    expect(".ui-autocomplete .o_m2o_dropdown_option:eq(1)").toHaveClass(
         "o_m2o_dropdown_option_create_edit"
     );
 });


### PR DESCRIPTION
Currently, in M2O and M2M_tags, the name_search is performed after a short delay without typing. When it is performed on a large amount of data, this leads to a bad user experience because the page is "frozen". Moreover, it is not always relevant the perform a search on a few characters (serial numbers, products, contacts, barcodes, etc.).

After this commit, we can set a minimum character count to trigger the search on M2O and M2M_tags.

task-4369888