### PR TITLE
[FIX] html_editor: use default text color in tests

### DIFF
--- a/addons/html_editor/static/tests/_helpers/color.js
+++ b/addons/html_editor/static/tests/_helpers/color.js
@@ -1,0 +1,7 @@
+export const getDefaultTextColor = () => {
+    const tempElement = document.createElement("div");
+    document.body.appendChild(tempElement);
+    const computedColor = window.getComputedStyle(tempElement).color;
+    document.body.removeChild(tempElement);
+    return computedColor;
+};

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -2,6 +2,7 @@ import { test } from "@odoo/hoot";
 import { testEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
 import { setColor } from "./_helpers/user_actions";
+import { getDefaultTextColor } from "./_helpers/color";
 
 test("should apply a color to a slice of text in a span in a font", async () => {
     await testEditor({
@@ -112,7 +113,6 @@ test("should not apply color on an uneditable element", async () => {
 });
 
 test("should apply color with default text color on block when applying background color", async () => {
-    const defaultTextColor = "color: rgb(55, 65, 81);";
     await testEditor({
         contentBefore: unformat(`
                 <table><tbody>
@@ -123,20 +123,19 @@ test("should apply color with default text color on block when applying backgrou
         stepFunction: setColor("rgb(255, 0, 0)", "backgroundColor"),
         contentAfter: unformat(`
                 <table><tbody>
-                    <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">[ab</td></tr>
-                    <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">cd]</td></tr>
+                    <tr><td style="background-color: rgb(255, 0, 0); color: ${getDefaultTextColor()};">[ab</td></tr>
+                    <tr><td style="background-color: rgb(255, 0, 0); color: ${getDefaultTextColor()};">cd]</td></tr>
                 </tbody></table>
             `),
     });
 });
 
 test("should remove color from block when removing background color", async () => {
-    const defaultTextColor = "color: rgb(55, 65, 81);";
     await testEditor({
         contentBefore: unformat(`
             <table><tbody>
-                <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">[ab</td></tr>
-                <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">cd]</td></tr>
+                <tr><td style="background-color: rgb(255, 0, 0); color: ${getDefaultTextColor()};">[ab</td></tr>
+                <tr><td style="background-color: rgb(255, 0, 0); color: ${getDefaultTextColor()};">cd]</td></tr>
             </tbody></table>
         `),
         stepFunction: setColor("", "backgroundColor"),
@@ -150,7 +149,6 @@ test("should remove color from block when removing background color", async () =
 });
 
 test("should not apply background color on an uneditable selected cell in a table", async () => {
-    const defaultTextColor = "color: rgb(55, 65, 81);";
     await testEditor({
         contentBefore: unformat(`
                 <table><tbody>
@@ -162,9 +160,9 @@ test("should not apply background color on an uneditable selected cell in a tabl
         stepFunction: setColor("rgb(255, 0, 0)", "backgroundColor"),
         contentAfter: unformat(`
                 <table><tbody>
-                    <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">[ab</td></tr>
+                    <tr><td style="background-color: rgb(255, 0, 0); color: ${getDefaultTextColor()};">[ab</td></tr>
                     <tr><td contenteditable="false">cd</td></tr>
-                    <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">ef]</td></tr>
+                    <tr><td style="background-color: rgb(255, 0, 0); color: ${getDefaultTextColor()};">ef]</td></tr>
                 </tbody></table>
             `),
     });

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -15,6 +15,7 @@ import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { contains } from "@web/../tests/web_test_helpers";
 import { execCommand } from "./_helpers/userCommands";
+import { getDefaultTextColor } from "./_helpers/color";
 
 test("can set foreground color", async () => {
     const { el } = await setupEditor("<p>[test]</p>");
@@ -508,7 +509,6 @@ describe("color preview", () => {
     });
 
     test("should preview color in table on hover in solid tab", async () => {
-        const defaultTextColor = "color: rgb(55, 65, 81);";
         const { el } = await setupEditor(`
             <table class="table table-bordered o_table">
                 <tbody>
@@ -535,12 +535,12 @@ describe("color preview", () => {
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
-                        <td class="" style="background-color: rgb(206, 0, 0); ${defaultTextColor}">
+                        <td class="" style="background-color: rgb(206, 0, 0); color: ${getDefaultTextColor()};">
                             <p>[<br></p>
                         </td>
                     </tr>
                     <tr>
-                        <td class="" style="background-color: rgb(206, 0, 0); ${defaultTextColor}">
+                        <td class="" style="background-color: rgb(206, 0, 0); color: ${getDefaultTextColor()};">
                             <p>]<br></p>
                         </td>
                     </tr>
@@ -570,7 +570,6 @@ describe("color preview", () => {
     });
 
     test("should preview color in table on hover in custom tab", async () => {
-        const defaultTextColor = "color: rgb(55, 65, 81);";
         const { el } = await setupEditor(`
             <table class="table table-bordered o_table">
                 <tbody>
@@ -599,12 +598,12 @@ describe("color preview", () => {
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
-                        <td class="bg-black" style="${defaultTextColor}">
+                        <td class="bg-black" style="color: ${getDefaultTextColor()};">
                             <p>[<br></p>
                         </td>
                     </tr>
                     <tr>
-                        <td class="bg-black" style="${defaultTextColor}">
+                        <td class="bg-black" style="color: ${getDefaultTextColor()};">
                             <p>]<br></p>
                         </td>
                     </tr>


### PR DESCRIPTION
**Problem**:
Tests are failing due to hardcoded text color in this commit:
https://github.com/odoo/odoo/commit/443e1678e748ee2320c4d361d0d0538d862c5f68
Text color might change during tests, causing failures.

This issue affects only `td` elements since `color` is added to them
when their background is changed to ensure text visibility in
dark/light modes.

**Solution**:
Use the computed text color instead of hardcoded values in tests.

runbot-159850

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
