### PR TITLE
[FIX] spreadsheet: download button in topbar menu of shared spreadsheet

### DIFF
--- a/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
+++ b/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
@@ -16,6 +16,7 @@ registries.topbarMenuRegistry.addChild("download_public_excel", ["file"], {
     execute: (env) => env.downloadExcel(),
     isReadonlyAllowed: true,
     icon: "o-spreadsheet-Icon.DOWNLOAD",
+    isVisible: (env) => env.canDownloadExcel(),
 });
 
 export class PublicReadonlySpreadsheet extends Component {
@@ -23,7 +24,7 @@ export class PublicReadonlySpreadsheet extends Component {
     static components = { Spreadsheet };
     static props = {
         dataUrl: String,
-        downloadExcelUrl: String,
+        downloadExcelUrl: { type: [String, Boolean], optional: true },
         mode: { type: String, optional: true },
     };
 
@@ -39,6 +40,7 @@ export class PublicReadonlySpreadsheet extends Component {
                     url: this.props.downloadExcelUrl,
                     data: {},
                 }),
+            canDownloadExcel: () => Boolean(this.props.downloadExcelUrl),
         });
         useSpreadsheetPrint(() => this.model);
         onWillStart(this.createModel.bind(this));

--- a/addons/spreadsheet/static/tests/helpers/ui.js
+++ b/addons/spreadsheet/static/tests/helpers/ui.js
@@ -42,11 +42,11 @@ export async function mountSpreadsheet(model) {
  * Mount public spreadsheet component with the given data
  * @returns {Promise<HTMLElement>}
  */
-export async function mountPublicSpreadsheet(dataUrl, mode) {
+export async function mountPublicSpreadsheet(dataUrl, mode, downloadExcelUrl = "downloadUrl") {
     mountWithCleanup(PublicReadonlySpreadsheet, {
         props: {
             dataUrl,
-            downloadExcelUrl: "downloadUrl",
+            downloadExcelUrl,
             mode,
         },
         noMainContainer: true,

--- a/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet.test.js
@@ -66,3 +66,11 @@ test("click close button in filter panel will close the panel", async function (
     expect(fixture.querySelector(".o-public-spreadsheet-filter-button")).toBeVisible();
     expect(fixture.querySelector(".o-public-spreadsheet-filters")).toBe(null);
 });
+
+test("Hides the download button when the downloadExcelUrl is not provided", async function () {
+    const model = await createModelWithDataSource();
+    data = await freezeOdooData(model);
+    const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet", false);
+    await contains(".o-topbar-menu[data-id='file']").click();
+    expect(fixture.querySelector(".o-menu-item[data-name='download_public_excel']")).toBe(null);
+});


### PR DESCRIPTION
### Description:

In PR #192349, we hide the download button in the live shared spreadsheet, but it remained visible in the topbar menu.

This commit ensures the button is also hidden in the topbar menu when no pre-generated spreadsheet is available.

Task: 4625077




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
