### PR TITLE
[FIX] base: allow the creation of manual company dep fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1276,6 +1276,7 @@ class IrModelFields(models.Model):
             'required': bool(field_data['required']),
             'readonly': bool(field_data['readonly']),
             'store': bool(field_data['store']),
+            'company_dependent': bool(field_data['company_dependent']),
         }
         if field_data['ttype'] in ('char', 'text', 'html'):
             attrs['translate'] = bool(field_data['translate'])


### PR DESCRIPTION
The field attribute `company_dependent` is not passed when instanciating manual fields so they do not get created as jsonb columns and lose the company dependent property.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
