### PR TITLE
[FIX] hr_holidays: fix allocation/leave's image without hr right

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -382,7 +382,7 @@
                         <div class="oe_kanban_global_click container">
                             <div class="row g-0">
                                 <div class="col-3">
-                                    <img t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)"
+                                    <img t-att-src="kanban_image('hr.employee.public', 'avatar_128', record.employee_id.raw_value)"
                                         t-att-title="record.employee_id.value"
                                         t-att-alt="record.employee_id.value"
                                         class="o_image_64_cover float-start mr4"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -181,7 +181,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('o_leave_kanban_info')]" position='before'>
                 <div class="col-3">
-                    <img t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)"
+                    <img t-att-src="kanban_image('hr.employee.public', 'avatar_128', record.employee_id.raw_value)"
                         t-att-title="record.employee_id.value"
                         t-att-alt="record.employee_id.value"
                         class="o_image_64_cover float-start mr4"/>


### PR DESCRIPTION
- Fetch photo from `hr.employee.public` to be avail for users without no hr rights

Task: 4626795



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
