### PR TITLE
[FIX] sale: remove down payment tax setting on wizard

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -50,9 +50,6 @@
                         options="{'no_create': True}"
                         invisible="product_id"
                         groups="account.group_account_manager"/>
-                    <field name="deposit_taxes_id"
-                        widget="many2many_tags"
-                        invisible="product_id"/>
                 </group>
                 <group invisible="not has_down_payments">
                     <field name="amount_invoiced"/>


### PR DESCRIPTION
When creating a down payment from a SO, the first time the wizard is opened, the down payment product does not exists yet. This trigger the display of the `deposit_taxes_id` field to define a tax for the display product. But this tax has no use anymore since https://github.com/odoo/odoo/commit/a11f402d6b949fdef8a86b532642287609ea74bc.
This commit removes `deposit_taxes_id` from the view (leaving it in the wizard model because of stable policy).