### PR TITLE
[FIX] base: add confirmation labels to view validator

### DIFF
--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -330,6 +330,8 @@
             <rng:optional><rng:attribute name="readonly"/></rng:optional>
             <rng:optional><rng:attribute name="context"/></rng:optional>
             <rng:optional><rng:attribute name="confirm"/></rng:optional>
+            <rng:optional><rng:attribute name="confirm-label"/></rng:optional>
+            <rng:optional><rng:attribute name="cancel-label"/></rng:optional>
             <rng:optional><rng:attribute name="help"/></rng:optional>
             <rng:optional><rng:attribute name="class"/></rng:optional>
             <rng:optional><rng:attribute name="default_focus"/></rng:optional>

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -158,7 +158,7 @@ TRANSLATED_ELEMENTS = {
 TRANSLATED_ATTRS = dict.fromkeys({
     'string', 'add-label', 'help', 'sum', 'avg', 'confirm', 'placeholder', 'alt', 'title', 'aria-label',
     'aria-keyshortcuts', 'aria-placeholder', 'aria-roledescription', 'aria-valuetext',
-    'value_label', 'data-tooltip', 'label',
+    'value_label', 'data-tooltip', 'label', 'confirm-label', 'cancel-label'
 }, lambda e: True)
 
 def translate_attrib_value(node):


### PR DESCRIPTION
We had the option to rename the buttons on the confirmation dialog using the attributes "confirm-label" and "cancel-label", but it was not part of the view grammar. This caused an "Invalid view" error upon using these attributes in a list view and re-starting the database.

Blocking: [PR Enterprise #77824](https://github.com/odoo/enterprise/pull/77824)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
