### PR TITLE
[FIX] account_edi_proxy_client: fix key name

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -152,7 +152,10 @@ class AccountEdiProxyClientUser(models.Model):
 
         :param company: the company of the user.
         '''
-        private_key_sudo = self.env['certificate.key'].sudo()._generate_rsa_private_key(company, name=f"{self.id_client}_{self.edi_identification}.key")
+        private_key_sudo = self.env['certificate.key'].sudo()._generate_rsa_private_key(
+            company,
+            name=f"{proxy_type}_{edi_mode}_{company.id}.key",
+        )
         edi_identification = self._get_proxy_identification(company, proxy_type)
         if edi_mode == 'demo':
             # simulate registration


### PR DESCRIPTION
In most cases, at this time of the process the edi_identification and the client_id are not known and the key's name end up to be `False_False.key`, which is not very descriptive.

task-no

**Before:**
![image](https://github.com/user-attachments/assets/103c5f2b-da98-41d9-aeeb-5c61bdacdecc)

**After:**
![image](https://github.com/user-attachments/assets/b68c69d7-20c0-4452-83c9-f6d3ec8d587d)
