### PR TITLE
[FIX] auth_password_policy_signup: input padding

### DIFF
--- a/addons/auth_password_policy_signup/static/src/public/scss/signup_policy.scss
+++ b/addons/auth_password_policy_signup/static/src/public/scss/signup_policy.scss
@@ -1,6 +1,18 @@
 .field-password {
-  position: relative;
-  meter.o_password_meter {
-    bottom: calc(#{$input-height} / 2 - 7px);
-  }
+    --PasswordMeter-width: 4rem;
+
+    position: relative;
+
+    meter.o_password_meter {
+        right: $input-padding-x;
+        // We can't use $input-height-sm because it relies on em units
+        // and the font size is defined in the input.
+        bottom: ($input-line-height * $input-font-size-sm) / 2 + $input-padding-y-sm + o-to-rem($border-width);
+        transform: translateY(50%);
+        inline-size: var(--PasswordMeter-width);
+    }
+
+    #password {
+        padding-right: calc(#{$input-padding-x * 2} + var(--PasswordMeter-width));
+    }
 }


### PR DESCRIPTION
Due to the pasword security meter on the right of the input, the content of the input can overflow behind the security meter.

Note: I seized the opportunity to reindent this file according to our coding guidelines

task-4630394

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
