### PR TITLE
[FIX] base: fix test_create_res_partner nightly test

### DIFF
--- a/odoo/addons/base/tests/test_form_create.py
+++ b/odoo/addons/base/tests/test_form_create.py
@@ -16,10 +16,10 @@ class TestFormCreate(TransactionCase):
         if hasattr(self.env['res.partner'], 'property_account_payable_id'):
             # Required for `property_account_payable_id`, `property_account_receivable_id` to be visible in the view
             # By default, it's the `group` `group_account_readonly` which is required to see it, in the `account` module
-            # But once `account_accountant` gets installed, it becomes `account.group_account_manager`
-            # https://github.com/odoo/enterprise/blob/bfa643278028da0bfabded2f87ccb7e323d697c1/account_accountant/views/product_views.xml#L9
+            # But once `account_accountant` gets installed, it becomes `account.group_account_user`
+            # https://github.com/odoo/enterprise/commit/68f6c1f9fd3ff6762c98e1a405ade035129efce0
             self.env.user.groups_id += self.env.ref('account.group_account_readonly')
-            self.env.user.groups_id += self.env.ref('account.group_account_manager')
+            self.env.user.groups_id += self.env.ref('account.group_account_user')
         partner_form = Form(self.env['res.partner'])
         partner_form.name = 'a partner'
         # YTI: Clean that brol


### PR DESCRIPTION
This https://github.com/odoo/enterprise/commit/68f6c1f9fd3ff6762c98e1a405ade035129efce0 caused the `test_create_res_partner` test to fail.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
