### PR TITLE
[IMP] l10n_in: automate LUT Detection in Fiscal Position

### DIFF
--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -41,6 +41,7 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'data/l10n_in.section.alert.csv',
         'data/account_tax_report_tcs_data.xml',
         'data/account_tax_report_tds_data.xml',
+        'data/ir_cron.xml',
         'wizard/l10n_in_withhold_wizard.xml',
         'views/l10n_in_section_alert_views.xml',
         'views/account_account_views.xml',

--- a/addons/l10n_in/data/ir_cron.xml
+++ b/addons/l10n_in/data/ir_cron.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_cron_update_lut_status" model="ir.cron">
+        <field name="name">Indian Accounting: Update LUT Status</field>
+        <field name="model_id" ref="model_res_company"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_update_lut_status()</field>
+        <field name="interval_number">9999</field>
+        <field name="interval_type">months</field>
+    </record>
+</odoo>

--- a/addons/l10n_in/demo/demo_company.xml
+++ b/addons/l10n_in/demo/demo_company.xml
@@ -18,6 +18,7 @@
     <record id="base.demo_company_in" model="res.company" forcecreate="1">
         <field name="name">IN Company</field>
         <field name="partner_id" ref="base.partner_demo_company_in"/>
+        <field name="l10n_in_iec_number">12345678</field>
     </record>
 
     <function model="res.company" name="_onchange_country_id">

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -1,5 +1,6 @@
 import pytz
 from stdnum.in_ import pan, gstin
+from datetime import timedelta, datetime, time
 
 from odoo import _, api, fields, models 
 from odoo.exceptions import ValidationError
@@ -38,6 +39,9 @@ class ResCompany(models.Model):
     )
     l10n_in_pan_type = fields.Char(string="PAN Type", compute="_compute_l10n_in_pan_type")
     l10n_in_gst_state_warning = fields.Char(related="partner_id.l10n_in_gst_state_warning")
+    l10n_in_iec_number = fields.Char(string="IEC No.")
+    l10n_in_lut_number = fields.Char(string="LUT No.")
+    l10n_in_lut_expiration_date = fields.Date(string="LUT valid up to", help="Date until which the LUT is valid.")
 
     # TDS/TCS settings
     l10n_in_tds_feature = fields.Boolean(
@@ -141,11 +145,37 @@ class ResCompany(models.Model):
     def onchange_vat(self):
         self.partner_id.onchange_vat()
 
+    def _update_l10n_in_export_sez_fiscal_position(self):
+        """Update fiscal positions based on LUT and IEC numbers."""
+        for company in self:
+            ChartTemplate = self.env['account.chart.template'].with_company(company)
+            lut_sez_fp = ChartTemplate.ref('fiscal_position_in_lut_sez')
+            export_sez_fp = ChartTemplate.ref('fiscal_position_in_export_sez_in')
+            if company.l10n_in_iec_number and not export_sez_fp.auto_apply and not company.l10n_in_lut_number:
+                export_sez_fp.write({'auto_apply': True})
+            elif export_sez_fp.auto_apply:
+                export_sez_fp.write({'auto_apply': False})
+
+            if company.l10n_in_lut_number and company.l10n_in_lut_expiration_date:
+                if not lut_sez_fp.auto_apply:
+                    lut_sez_fp.write({'auto_apply': True})
+                    export_sez_fp.write({'auto_apply': False})
+                user_tz = pytz.timezone(self.env.user.tz)
+                lut_cron_trigger_datetime = user_tz.localize(datetime.combine(company.l10n_in_lut_expiration_date + timedelta(days=1), time.min))
+                self.env.ref('l10n_in.ir_cron_update_lut_status')._trigger((lut_cron_trigger_datetime.astimezone(pytz.utc)).replace(tzinfo=None))
+            elif lut_sez_fp.auto_apply:
+                lut_sez_fp.write({'auto_apply': False})
+
     @api.constrains('l10n_in_pan')
     def _check_l10n_in_pan(self):
         for record in self:
             if record.l10n_in_pan and not pan.is_valid(record.l10n_in_pan):
                 raise ValidationError(_('The entered PAN seems invalid. Please enter a valid PAN.'))
+
+    @api.constrains('l10n_in_lut_expiration_date')
+    def _check_l10n_in_lut_expiration_date(self):
+        if self.l10n_in_lut_expiration_date and self.l10n_in_lut_expiration_date < fields.Date.today():
+            raise ValidationError(_('Please enter a valid LUT Expiration Date.'))
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -162,6 +192,8 @@ class ResCompany(models.Model):
         if (vals.get('state_id') or vals.get('country_id')) and not self.env.context.get('delay_account_group_sync'):
             # Update Fiscal Positions for companies setting up state for the first time
             self._update_l10n_in_fiscal_position()
+        if 'l10n_in_iec_number' in vals or 'l10n_in_lut_number' in vals or vals.get('l10n_in_lut_expiration_date'):
+            self._update_l10n_in_export_sez_fiscal_position()
         return res
 
     def _update_l10n_in_fiscal_position(self):
@@ -179,3 +211,15 @@ class ResCompany(models.Model):
     def action_update_state_as_per_gstin(self):
         self.ensure_one()
         self.partner_id.action_update_state_as_per_gstin()
+
+    def _cron_update_lut_status(self):
+        """Schedule the cron job to deactivate LUT after expiration."""
+        tz = pytz.timezone("Asia/Kolkata")
+        today_date = fields.Datetime.now().astimezone(tz).replace(tzinfo=None).date()
+        companies = self.search([
+            ('l10n_in_lut_number', '!=', False),
+            ('l10n_in_lut_expiration_date', '<', today_date),
+        ])
+        for company in companies:
+            company.write({'l10n_in_lut_number': False, 'l10n_in_lut_expiration_date': False})
+            company._update_l10n_in_export_sez_fiscal_position()

--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -59,6 +59,20 @@ class ResConfigSettings(models.TransientModel):
     l10n_in_fetch_vendor_edi_feature = fields.Boolean(string="Fetch Vendor E-Invoiced Document")
     l10n_in_enet_vendor_batch_payment_feature = fields.Boolean(string="ENet Vendor Batch Payment")
 
+    # Import/Export settings
+    l10n_in_iec_number = fields.Char(
+        related='company_id.l10n_in_iec_number',
+        readonly=False
+    )
+    l10n_in_lut_number = fields.Char(
+        related='company_id.l10n_in_lut_number',
+        readonly=False
+    )
+    l10n_in_lut_expiration_date = fields.Date(
+        related='company_id.l10n_in_lut_expiration_date',
+        readonly=False
+    )
+
     module_l10n_in_reports = fields.Boolean("GST E-Filing & Matching")
     module_l10n_in_edi = fields.Boolean("Indian Electronic Invoicing")
     module_l10n_in_ewaybill = fields.Boolean("Indian Electronic Waybill")

--- a/addons/l10n_in/models/template_in.py
+++ b/addons/l10n_in/models/template_in.py
@@ -76,7 +76,6 @@ class AccountChartTemplate(models.AbstractModel):
             'fiscal_position_in_export_sez_in': {
                 'name': _('Export/SEZ'),
                 'sequence': 3,
-                'auto_apply': True,
                 'note': _('SUPPLY MEANT FOR EXPORT/SUPPLY TO SEZ UNIT OR SEZ DEVELOPER FOR AUTHORISED OPERATIONS ON PAYMENT OF INTEGRATED TAX.'),
                 'tax_ids': (
                     self._get_l10n_in_fiscal_tax_vals(trailing_id='_sez_exp')
@@ -118,3 +117,4 @@ class AccountChartTemplate(models.AbstractModel):
         if template_code == 'in':
             company = company or self.env.company
             company._update_l10n_in_is_gst_registered()
+            company._update_l10n_in_export_sez_fiscal_position()

--- a/addons/l10n_in/views/res_company_views.xml
+++ b/addons/l10n_in/views/res_company_views.xml
@@ -16,6 +16,9 @@
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
                 <field name="l10n_in_pan" invisible="country_code != 'IN'"/>
+                <field name="l10n_in_iec_number" invisible="country_code != 'IN'" required="l10n_in_lut_number"/>
+                <field name="l10n_in_lut_number" invisible="country_code != 'IN'" required="l10n_in_lut_expiration_date"/>
+                <field name="l10n_in_lut_expiration_date" invisible="country_code != 'IN'" required="l10n_in_lut_number"/>
             </xpath>
             <xpath expr="//sheet" position="before">
                 <div class="alert alert-warning mt-1 mb-1" role="alert" invisible="not l10n_in_gst_state_warning or country_code != 'IN'">

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -38,6 +38,17 @@
                                 </div>
                             </div>
                         </setting>
+                        <setting string="Import/Export"
+                                 company_dependent="1">
+                            <div id="india_export" class="row">
+                                <label string="IEC Number" for="l10n_in_iec_number" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_in_iec_number" required="l10n_in_lut_number"/>
+                                <label string="LUT Number" for="l10n_in_lut_number" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_in_lut_number" required="l10n_in_lut_expiration_date"/>
+                                <label string="LUT Valid up to" for="l10n_in_lut_expiration_date" class="col-lg-4 o_light_label"/>
+                                <field name="l10n_in_lut_expiration_date" required="l10n_in_lut_number"/>
+                            </div>
+                        </setting>
                         <t invisible="not l10n_in_is_gst_registered">
                             <setting name="india_production_setting"
                                      company_dependent="1"


### PR DESCRIPTION
Before this PR, companies with an LUT had to manually enable the "Detect Automatically" option in the fiscal position configuration for LUT.

With this PR:
-Two new fields `l10n_in_is_lut` and `l10n_in_lut_expiration_date` are added to the `res.company` form view.
-When a user selects LUT and enters a valid expiration date:
 "Detect Automatically" will be enabled for "LUT - Export/SEZ".
 "Detect Automatically" will be disabled for "Export/SEZ".
-A scheduled cron job will run the day after the expiration date, reversing the above settings.

**task**-4405282

