### PR TITLE
[IMP] website_sale_*: clean stock availability logic

### DIFF
--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -56,7 +56,7 @@ class TestSaleOrder(ClickAndCollectCommon):
         self.website.warehouse_id = self.warehouse_2
         so = self._create_in_store_delivery_order()
         so.warehouse_id = self.warehouse
-        _, free_qty = so._get_cart_and_free_qty(self.storable_product)
+        free_qty = so._get_free_qty(self.storable_product)
         self.assertEqual(free_qty, 10)
 
     def test_prevent_buying_out_of_stock_products(self):

--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, models
+from odoo import models
 from odoo.exceptions import ValidationError
 
 
@@ -22,9 +22,7 @@ class SaleOrder(models.Model):
         self.ensure_one()
         product = self.env['product.product'].browse(product_id)
         if product.is_storable and not product.allow_out_of_stock_order:
-            product_qty_in_cart, available_qty = self._get_cart_and_free_qty(
-                product, line=order_line
-            )
+            product_qty_in_cart, available_qty = self._get_cart_and_free_qty(product)
 
             old_qty = order_line.product_uom_qty if order_line else 0
             added_qty = new_qty - old_qty
@@ -35,86 +33,90 @@ class SaleOrder(models.Model):
                     if order_line:
                         order_line._set_shop_warning_stock(total_cart_qty, available_qty)
                     else:
-                        self._set_shop_warning_stock(total_cart_qty, available_qty)
+                        self.shop_warning = self.env._(
+                            "You ask for %(desired_qty)s products but only %(available_qty)s is"
+                            " available.",
+                            desired_qty=total_cart_qty, available_qty=available_qty
+                        )
                     returned_warning = order_line.shop_warning or self.shop_warning
-                else:  # 0 or negative allowed_qty
-                    # if existing line: it will be deleted
-                    # if no existing line: no line will be created
-                    if order_line:
-                        self.shop_warning = _(
-                            "Some products became unavailable and your cart has been updated. We're"
-                            " sorry for the inconvenience."
-                        )
-                        returned_warning = self.shop_warning
-                    else:
-                        returned_warning = _(
-                            "The item has not been added to your cart since it is not available."
-                        )
+                elif order_line:
+                    # Line will be deleted
+                    self.shop_warning = self.env._(
+                        "Some products became unavailable and your cart has been updated. We're"
+                        " sorry for the inconvenience."
+                    )
+                    returned_warning = self.shop_warning
+                else:
+                    returned_warning = self.env._(
+                        "The item has not been added to your cart since it is not available."
+                    )
                 return allowed_line_qty, returned_warning
         return super()._verify_updated_quantity(order_line, product_id, new_qty, **kwargs)
 
-    def _get_cart_and_free_qty(self, product, line=None):
-        """ Get cart quantity and free quantity for given product or line's product.
+    def _get_cart_and_free_qty(self, product):
+        """Get cart quantity and free quantity for given product.
 
         Note: self.ensure_one()
 
-        :param ProductProduct product: The product
-        :param SaleOrderLine line: The optional line
+        :param product: `product.product` record.
+        :returns: cart quantity and available quantity
+        :rtype: tuple
         """
         self.ensure_one()
-        if not line and not product:
-            return 0, 0
-        cart_qty = sum(self._get_common_product_lines(line, product).mapped('product_uom_qty'))
-        free_qty = (product or line.product_id).with_context(
-            warehouse_id=self.website_id.warehouse_id.id
-        ).free_qty
+        product.ensure_one()
 
-        return cart_qty, free_qty
+        return self._get_cart_qty(product.id), self._get_free_qty(product)
 
-    def _get_common_product_lines(self, line=None, product=None):
-        """ Get the lines with the same product or line's product
+    def _get_free_qty(self, product):
+        return product.with_context(warehouse_id=self._get_shop_warehouse_id()).free_qty
 
-        :param SaleOrderLine line: The optional line
-        :param ProductProduct product: The optional product
+    def _get_shop_warehouse_id(self):
+        """Return the warehouse to use for shop availability checks.
+
+        If no warehouse is specified on the website, all warehouses are considered,
+        regardless of the warehouse automatically assigned to the order.
+
+        Note: self.ensure_one()
+
+        :returns: `stock.warehouse` id
+        :rtype: int or False
         """
-        if not line and not product:
-            return self.env['sale.order.line']
-        product = product or line.product_id
-        return self.order_line.filtered(lambda l: l.product_id == product)
+        self.ensure_one()
+        return self.website_id.warehouse_id.id
+
+    def _get_cart_qty(self, product_id):
+        """Return the quantity of the given product in the current cart, if any.
+
+        :param int product_id: `product.product` id
+        :return: product quantity
+        :rtype: float
+        """
+        if not self:
+            return 0.0
+        return sum(self._get_common_product_lines(product_id).mapped('product_uom_qty'))
+
+    def _get_common_product_lines(self, product_id=None):
+        """Get all the lines of the current order with the given product."""
+        return self.order_line.filtered(lambda sol: sol.product_id.id == product_id)
 
     def _check_cart_is_ready_to_be_paid(self):
-        values = []
-        for line in self.order_line:
-            if line.product_id.is_storable and not line.product_id.allow_out_of_stock_order:
-                cart_qty, avl_qty = self._get_cart_and_free_qty(line.product_id, line=line)
-                if cart_qty > avl_qty:
-                    line._set_shop_warning_stock(cart_qty, max(avl_qty, 0))
-                    values.append(line.shop_warning)
+        values = [
+            line.shop_warning
+            for line in self.order_line
+            if not line._check_availability()
+        ]
         if values:
             raise ValidationError(' '.join(values))
         return super()._check_cart_is_ready_to_be_paid()
 
-    def _set_shop_warning_stock(self, desired_qty, new_qty):
-        self.ensure_one()
-        self.shop_warning = _(
-            'You ask for %(desired_qty)s products but only %(new_qty)s is available',
-            desired_qty=desired_qty, new_qty=new_qty
-        )
-        return self.shop_warning
-
     def _filter_can_send_abandoned_cart_mail(self):
-        """ Filter sale orders on their product availability. """
+        """Filter sale orders on their product availability."""
         return super()._filter_can_send_abandoned_cart_mail().filtered(
             lambda so: so._all_product_available()
         )
 
     def _all_product_available(self):
         self.ensure_one()
-        for line in self.order_line:
-            product = line.product_id
-            if not product.is_storable or product.allow_out_of_stock_order:
-                continue
-            free_qty = self.website_id._get_product_available_qty(product)
-            if free_qty == 0:
-                return False
-        return True
+        if not (lines := self.order_line):
+            return True
+        return not any(product._is_sold_out() for product in lines.product_id)

--- a/addons/website_sale_stock/models/sale_order_line.py
+++ b/addons/website_sale_stock/models/sale_order_line.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, models
+from odoo import models
 
 
 class SaleOrderLine(models.Model):
@@ -8,11 +8,21 @@ class SaleOrderLine(models.Model):
 
     def _set_shop_warning_stock(self, desired_qty, new_qty):
         self.ensure_one()
-        self.shop_warning = _(
-            'You ask for %(desired_qty)s %(product_name)s but only %(new_qty)s is available',
+        self.shop_warning = self.env._(
+            "You ask for %(desired_qty)s %(product_name)s but only %(new_qty)s is available",
             desired_qty=desired_qty, product_name=self.product_id.name, new_qty=new_qty
         )
-        return self.shop_warning
 
     def _get_max_available_qty(self):
-        return self.product_id.free_qty - self.product_id._get_cart_qty(order_sudo=self.order_id)
+        self.ensure_one()
+        cart_qty, free_qty = self.order_id._get_cart_and_free_qty(self.product_id)
+        return free_qty - cart_qty
+
+    def _check_availability(self):
+        self.ensure_one()
+        if self.product_id.is_storable and not self.product_id.allow_out_of_stock_order:
+            cart_qty, avl_qty = self.order_id._get_cart_and_free_qty(self.product_id)
+            if cart_qty > avl_qty:
+                self._set_shop_warning_stock(cart_qty, max(avl_qty, 0))
+                return False
+        return True

--- a/addons/website_sale_stock/models/website.py
+++ b/addons/website_sale_stock/models/website.py
@@ -9,4 +9,15 @@ class Website(models.Model):
     warehouse_id = fields.Many2one('stock.warehouse', string='Warehouse')
 
     def _get_product_available_qty(self, product, **kwargs):
+        """Give the available quantity of a given product.
+
+        NB: this method is only meant to be used on the shop before the checkout.
+        For checkout steps, please use `cart._get_free_qty` instead to consider
+        the chosen warehouse for delivery (website_sale_collect).
+
+        :param product: product.product record
+        :param dict kwargs: unused parameters, available for overrides
+        :return: available quantity
+        :rtype: float
+        """
         return product.with_context(warehouse_id=self.warehouse_id.id).free_qty

--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -5,7 +5,7 @@
         <div t-if="is_storable and !prevent_zero_price_sale" id="product_stock_availability">
             <div t-if="free_qty lte 0 and !cart_qty" t-attf-class="availability_message_#{product_template} mb-1">
                 <div id="out_of_stock_message">
-                    <t t-if='has_out_of_stock_message' t-out='out_of_stock_message'/>
+                    <t t-if="has_out_of_stock_message" t-out="out_of_stock_message"/>
                     <t t-elif="!allow_out_of_stock_order">
                         <div class="text-danger fw-bold">
                             <i class="fa fa-times me-1"/>
@@ -49,10 +49,10 @@
             </div>
 
             <div id="already_in_cart_message" t-if="!allow_out_of_stock_order and show_availability and cart_qty" t-attf-class="availability_message_#{product_template} text-warning mt8">
-                <t t-if='!free_qty'>
+                <t t-if="!free_qty">
                     You already added all the available product in your cart.
                 </t>
-                <t t-else=''>
+                <t t-else="">
                     You already added <t t-esc="cart_qty" /> <t t-esc="uom_name" /> in your cart.
                 </t>
             </div>


### PR DESCRIPTION
To prepare for an upcoming task aiming to handle UoM in the ecommerce, this commits tries to simplify the existing logic.

Stock availability methods were duplicated and not (always) coherent. This commit (and its enterprise counterpart) try to provide clear methods, simplify overrides, reduce entry points and duplicated code.

Also includes some linting changes:
* double quoted strings when displayed to the user
* remove deprecated _ uses
* ...

See also:
odoo/enterprise#80875


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
