### PR TITLE
[FIX] web_editor: prevent null errors using optional chaining

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4214,7 +4214,7 @@ export class OdooEditor extends EventTarget {
     _onKeyDown(ev) {
         delete this._isNavigatingByMouse;
         const selection = this.document.getSelection();
-        if (selection.anchorNode && isProtected(selection.anchorNode)) {
+        if ((!selection?.anchorNode) || (isProtected(selection.anchorNode))) {
             return;
         }
         if (this.document.querySelector(".transfo-container")) {
@@ -4273,13 +4273,13 @@ export class OdooEditor extends EventTarget {
             const sel = this.document.getSelection();
             const closestUnbreakable = closestElement(sel.anchorNode, isUnbreakable);
             const closestTableOrLi = closestElement(sel.anchorNode, 'table, li');
-            const closestUnbreakableOrLi = closestElement(sel.anchorNode, ["li", closestUnbreakable.nodeName].join(","));
+            const closestUnbreakableOrLi = closestElement(sel.anchorNode, ["li", closestUnbreakable?.nodeName].join(","));
             if (closestTableOrLi && closestTableOrLi.nodeName === 'TABLE') {
                 this._onTabulationInTable(ev);
             } else if (
                 !ev.shiftKey &&
                 sel.isCollapsed &&
-                closestUnbreakableOrLi.nodeName !== 'LI'
+                closestUnbreakableOrLi?.nodeName !== 'LI'
             ) {
                 // Indent text (collapsed selection).
                 this.execCommand('insert', parseHTML(this.document, tabHtml));


### PR DESCRIPTION
This PR fixes traceback issue:

Steps to Reproduce for 1st traceback:
1. Go to Website in edit mode.
2. Click on the menu in the header such a way that the cursor is not placed inside.
3. Press the tab key.
4. You will receive the traceback.

Issue:
When the selection is null, the anchorNode also becomes null, resulting in closestUnbreakable being null. Therefore, we should avoid accessing nodeName on a null element to prevent errors.

Fix:
Safely access elements using optional chaining to prevent errors when elements are not found.

task-4577864