### PR TITLE
[FIX] web: save a dirty record without changes

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -997,6 +997,12 @@ export class Record extends DataPoint {
         const changes = this._getChanges();
         delete changes.id; // id never changes, and should not be written
         if (!creation && !Object.keys(changes).length) {
+            if (nextId) {
+                return this.model.load({ resId: nextId });
+            }
+            this._changes = markRaw({});
+            this.data = { ...this._values };
+            this.dirty = false;
             return true;
         }
         if (this.model._urgentSave && this.model.useSendBeaconToSaveUrgently) {


### PR DESCRIPTION
- Open a record (e.g., a project task);
- Add a tag to a `many2many_tags` field;
- Remove the previously added tag;
- The record should be dirty (the save icon should be visible);
- Click on the save icon/or click to pager next.

Before this commit, the UI does nothing. It doesn't save, or it doesn't go to
the next record if you click on the pager next. This is because even if the
record is considered dirty, because some changes have been made (adding and
removing tags), there are no changes. And a condition prevents to call the
`web_save` RPC from being called if there are no changes. If the `web_save`
RPC is not called, we do nothing.

In this commit, we change this condition so that if the `web_save` RPC is not
called, we mark the record as not dirty. When we move to another record (pager
next), we do not need to mark the current record as not dirty, but the next
record is loaded.
