### PR TITLE
[IMP] hw_{drivers,posbox_homepage}: move password generation to database

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -13,7 +13,7 @@ from itertools import groupby
 from pathlib import Path
 
 from odoo import http
-from odoo.addons.hw_drivers.tools import helpers, wifi
+from odoo.addons.hw_drivers.tools import helpers, route, wifi
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.connection_manager import connection_manager
 from odoo.tools.misc import file_path
@@ -188,12 +188,6 @@ class IotBoxOwlHomePage(http.Controller):
             'availableWiFi': wifi.get_available_ssids(),
         })
 
-    @http.route('/hw_posbox_homepage/generate_password', auth="none", type="http", cors='*')
-    def generate_password(self):
-        return json.dumps({
-            'password': helpers.generate_password(),
-        })
-
     @http.route('/hw_posbox_homepage/version_info', auth="none", type="http", cors='*')
     def get_version_info(self):
         git = ["git", "--work-tree=/home/pi/odoo/", "--git-dir=/home/pi/odoo/.git"]
@@ -302,6 +296,13 @@ class IotBoxOwlHomePage(http.Controller):
             }
 
         return res_payload
+
+    @route.protect
+    @http.route('/hw_posbox_homepage/generate_password', auth="none", type="jsonrpc", methods=["POST"], cors='*')
+    def generate_password(self):
+        return {
+            'password': helpers.generate_password(),
+        }
 
     @http.route('/hw_posbox_homepage/enable_ngrok', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def enable_remote_connection(self, auth_token):

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/RemoteDebugDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/RemoteDebugDialog.js
@@ -26,6 +26,7 @@ export class RemoteDebugDialog extends Component {
 
             const data = await this.store.rpc({
                 url: "/hw_posbox_homepage/generate_password",
+                method: "POST",
             });
 
             this.state.password = data.password;
@@ -73,7 +74,7 @@ export class RemoteDebugDialog extends Component {
                     This allows someone who give a ngrok authtoken to gain remote access to your IoT Box,
                     and thus your entire local network. Only enable this for someone you trust.
                 </div>
-                <div class="d-flex flex-row gap-2 mb-4">
+                <div t-if="!store.base.server_status" class="d-flex flex-row gap-2 mb-4">
                     <input placeholder="Password" t-att-value="this.state.password" class="form-control" readonly="readonly" />
                     <button class="btn btn-primary btn-sm" t-on-click="generatePassword">
                         <div t-if="this.state.loading" class="spinner-border spinner-border-sm" role="status">


### PR DESCRIPTION
Since database-to-IoT Box network requests are now signed, we can move the ssh password reset from the IoT Box homepage to the connected database as we can now ensure that the request is performed by an authorized member.

If no database is connected, the password can still be generated from the IoT Box homepage.

Enterprise PR: [https://github.com/odoo/enterprise/pull/80877](https://github.com/odoo/enterprise/pull/80877)
Task: 4383920