### PR TITLE
[FIX] mail : display the full name on hover in channel member list

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -41,7 +41,7 @@
                 <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
             </div>
             <div t-ref="displayName" class="d-flex overflow-hidden flex-column">
-                <span class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name"/>
+                <span class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name" t-att-title="member.name"/>
             </div>
             <span class="ms-auto">
                 <span t-if="member.in(props.thread.invitedMembers)" class="p-1 fa fa-user-plus opacity-75"/>


### PR DESCRIPTION
Purpose:

to  display the full name on hover  in channel member list.

task-4630148
after PR:
![image](https://github.com/user-attachments/assets/79b414c4-545e-45e2-b918-2dacb513af8e)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
