### PR TITLE
[FIX] website_sale: hide ribbon element if there is no ribbon

### DIFF
--- a/addons/website_sale/models/product_ribbon.py
+++ b/addons/website_sale/models/product_ribbon.py
@@ -18,4 +18,6 @@ class ProductRibbon(models.Model):
     )
 
     def _get_position_class(self):
+        if not self:
+            return 'd-none'
         return 'o_ribbon_left' if self.position == 'left' else 'o_ribbon_right'


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
Unsure.

Issue
-----
The ribbon element is technically always visible, even if the product has no ribbon. This can lead to CSS shadow being applied to it, resulting in a white triangle in the top right corner of images: 
![image](https://github.com/user-attachments/assets/d301bd93-7d3e-49e2-848d-c1551b54e3cf)

Cause
-----
The `_get_position_class` method returns a position, even for empty recordsets, in which case it will return `o_ribbon_right`.

Solution
--------
If there is no record, return the `d-none` class to properly hide the element.

opw-4151902