### PR TITLE
[FIX] website: fix search function for `website_published` field

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -278,12 +278,12 @@ class WebsitePublishedMultiMixin(WebsitePublishedMixin):
             value = not value
 
         current_website_id = self._context.get('website_id')
-        is_published = [('is_published', '=', value)]
         if current_website_id:
+            is_published = [('is_published', '=', True)]
             on_current_website = self.env['website'].website_domain(current_website_id)
-            return (['!'] if value is False else []) + expression.AND([is_published, on_current_website])
+            return ([] if value else ['!']) + expression.AND([is_published, on_current_website])
         else:  # should be in the backend, return things that are published anywhere
-            return is_published
+            return [('is_published', '=', value)]
 
     def open_website_url(self):
         website_id = False


### PR DESCRIPTION
The search function was correctly evaluating `[('website_published', '=', True)]` to
`['&', ('is_published', '=', True), ('website_id', 'in', (False, current_website_id))]`,
but it was incorrectly evaluating `[('website_published', '=', False)]` to
`['|', ('is_published', '=', True), ('website_id', 'not in', (False, current_website_id))]`.

Indeed, the condition on `is_published` should be the same as on `website_published`.