### PR TITLE
[IMP] mail: emoji shortcodes on hover for better clarity

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -169,9 +169,9 @@ export class Message extends Component {
                     const bodyEl = createElementWithContent(
                         "span",
                         this.state.showTranslation
-                            ? this.message.translationValue
-                            : this.props.messageSearch?.highlight(this.message.body) ??
-                                  this.message.body
+                            ? this.message.richTranslationValue
+                            : this.props.messageSearch?.highlight(this.message.richBody) ??
+                                  this.message.richBody
                     );
                     this.prepareMessageBody(bodyEl);
                     this.shadowRoot.appendChild(bodyEl);
@@ -182,9 +182,9 @@ export class Message extends Component {
             },
             () => [
                 this.state.showTranslation,
-                this.message.translationValue,
+                this.message.richTranslationValue,
                 this.props.messageSearch?.searchTerm,
-                this.message.body,
+                this.message.richBody,
             ]
         );
         useEffect(
@@ -193,7 +193,7 @@ export class Message extends Component {
                     this.prepareMessageBody(this.messageBody.el);
                 }
             },
-            () => [this.state.isEditing, this.message.body]
+            () => [this.state.isEditing, this.message.richBody]
         );
     }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -59,7 +59,7 @@
                         >
                             <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
                                 <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
-                                    <t t-if="message.message_type === 'notification' and message.body" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
+                                    <t t-if="message.message_type === 'notification' and message.richBody" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
                                     <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited))">
                                         <MessageLinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" messageLinkPreviews="message.message_link_preview_ids"/>
                                         <t t-else="">
@@ -85,8 +85,8 @@
                                                     <t t-else="">
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
-                                                        <t t-elif="state.showTranslation" t-out="message.translationValue"/>
-                                                        <t t-elif="message.body" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
+                                                        <t t-elif="state.showTranslation" t-out="message.richTranslationValue"/>
+                                                        <t t-elif="message.richBody" t-out="props.messageSearch?.highlight(message.richBody) ?? message.richBody"/>
                                                         <em t-if="message.edited" class="smaller fw-bold text-500"> (edited)</em>
                                                         <p class="fst-italic text-muted small" t-if="state.showTranslation">
                                                             <t t-if="message.translationSource" t-esc="translatedFromText"/>
@@ -201,7 +201,7 @@
 
 <t t-name="mail.Message.bodyAsNotification">
     <div class="o-mail-Message-body text-break mb-0 w-100" t-att-class="{'o-note': message.message_type == 'notification'}">
-        <t t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
+        <t t-out="props.messageSearch?.highlight(message.richBody) ?? message.richBody"/>
     </div>
 </t>
 

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -13,7 +13,7 @@
                         <b><t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
                         <span class="o-mail-MessageInReply-message ms-1 text-break">
                             <t t-if="!props.message.parentMessage.isBodyEmpty">
-                                <t t-out="props.message.parentMessage.body"/>
+                                <t t-out="props.message.parentMessage.richBody"/>
                                 <em t-if="props.message.parentMessage.edited" class="smaller fw-bold text-500"> (edited)</em>
                             </t>
                             <t t-elif="props.message.parentMessage.attachment_ids.length > 0">

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -4,11 +4,13 @@ import {
     convertBrToLineBreak,
     htmlToTextContentInline,
     prettifyMessageContent,
+    wrapEmojisWithTitles,
 } from "@mail/utils/common/format";
 import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
 import { browser } from "@web/core/browser/browser";
 import { stateToUrl } from "@web/core/browser/router";
+import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
@@ -32,6 +34,22 @@ export class Message extends Record {
     attachment_ids = Record.many("ir.attachment", { inverse: "message" });
     author = Record.one("Persona");
     body = Record.attr("", { html: true });
+    richBody = Record.attr("", {
+        compute() {
+            if (!this.store.emojiLoader.loaded) {
+                loadEmoji();
+            }
+            return wrapEmojisWithTitles(this.body) ?? "";
+        },
+    });
+    richTranslationValue = Record.attr("", {
+        compute() {
+            if (!this.store.emojiLoader.loaded) {
+                loadEmoji();
+            }
+            return wrapEmojisWithTitles(this.translationValue) ?? "";
+        },
+    });
     composer = Record.one("Composer", { inverse: "message", onDelete: (r) => r.delete() });
     /** @type {DateTime} */
     date = Record.attr(undefined, { type: "datetime" });

--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -1,8 +1,8 @@
 import { useHover } from "@mail/utils/common/hooks";
-import { Component, onMounted, onPatched, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { loadEmoji, loader } from "@web/core/emoji_picker/emoji_picker";
+import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
@@ -23,19 +23,13 @@ export class MessageReactionList extends Component {
             onAway: () => (this.preview.isOpen = false),
             stateObserver: () => [this.preview?.isOpen],
         });
-        this.state = useState({ emojiLoaded: Boolean(loader.loaded) });
-        if (!loader.loaded) {
-            loader.onEmojiLoaded(() => (this.state.emojiLoaded = true));
-        }
-        onMounted(() => void this.state.emojiLoaded);
-        onPatched(() => void this.state.emojiLoaded);
     }
 
     /** @param {import("models").MessageReactions} reaction */
     previewText(reaction) {
         const { count, content: emoji } = reaction;
         const personNames = reaction.personas.slice(0, 3).map((persona) => persona.name);
-        const shortcode = loader.loaded?.emojiValueToShortcode?.[emoji] ?? "?";
+        const shortcode = this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[emoji][0] ?? "?";
         switch (count) {
             case 1:
                 return _t("%(emoji)s reacted by %(person)s", {

--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -1,15 +1,7 @@
-import { loadEmoji, loader } from "@web/core/emoji_picker/emoji_picker";
+import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
 import { onExternalClick } from "@mail/utils/common/hooks";
 
-import {
-    Component,
-    onMounted,
-    onPatched,
-    useEffect,
-    useExternalListener,
-    useRef,
-    useState,
-} from "@odoo/owl";
+import { Component, onMounted, useEffect, useExternalListener, useRef, useState } from "@odoo/owl";
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
@@ -25,7 +17,6 @@ export class MessageReactionMenu extends Component {
         this.store = useService("mail.store");
         this.ui = useService("ui");
         this.state = useState({
-            emojiLoaded: Boolean(loader.loaded),
             reaction: this.props.initialReaction
                 ? this.props.initialReaction
                 : this.props.message.reactions[0],
@@ -45,16 +36,11 @@ export class MessageReactionMenu extends Component {
             },
             () => [this.props.message.reactions.length]
         );
-        if (!loader.loaded) {
-            loader.onEmojiLoaded(() => (this.state.emojiLoaded = true));
-        }
         onMounted(() => {
-            void this.state.emojiLoaded;
-            if (!loader.loaded) {
+            if (!this.store.emojiLoader.loaded) {
                 loadEmoji();
             }
         });
-        onPatched(() => void this.state.emojiLoaded);
     }
 
     onKeydown(ev) {
@@ -71,6 +57,6 @@ export class MessageReactionMenu extends Component {
     }
 
     getEmojiShortcode(reaction) {
-        return loader.loaded?.emojiValueToShortcode?.[reaction.content] ?? "?";
+        return this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[reaction.content][0] ?? "?";
     }
 }

--- a/addons/mail/static/src/core/common/notification_message.xml
+++ b/addons/mail/static/src/core/common/notification_message.xml
@@ -7,7 +7,7 @@
                 <span class="text-muted opacity-75" t-esc="callInformation"/> <span class="o-mail-Message-date o-xsmaller" t-esc="message.dateSimpleWithDay"/>
             </t>
             <t t-else="">
-                <span class="o-mail-NotificationMessage-author d-inline text-muted opacity-75" t-if="message.authorName and !message.body.includes(escape(message.authorName))" t-esc="message.authorName"/> <span class="text-muted opacity-75" t-out="message.body"/>
+                <span class="o-mail-NotificationMessage-author d-inline text-muted opacity-75" t-if="message.authorName and !message.richBody.includes(escape(message.authorName))" t-esc="message.authorName"/> <span class="text-muted opacity-75" t-out="message.richBody"/>
             </t>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -1,7 +1,7 @@
-import { Component, onMounted, onPatched, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { loadEmoji, loader, useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
+import { loadEmoji, useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { useService } from "@web/core/utils/hooks";
 
 /**
@@ -50,17 +50,6 @@ export class QuickReactionMenu extends Component {
             })
         );
         this.frequentEmojiService = useService("web.frequent.emoji");
-        this.state = useState({ emojiLoaded: Boolean(loader.loaded) });
-        if (!loader.loaded) {
-            loader.onEmojiLoaded(() => (this.state.emojiLoaded = true));
-        }
-        onMounted(() => {
-            void this.state.emojiLoaded;
-            if (!loader.loaded) {
-                loadEmoji();
-            }
-        });
-        onPatched(() => void this.state.emojiLoaded);
         useExternalListener(window, "keydown", async (ev) => {
             if (
                 !this.dropdown.isOpen ||
@@ -83,10 +72,13 @@ export class QuickReactionMenu extends Component {
     }
 
     getEmojiShortcode(emoji) {
-        return loader.loaded?.emojiValueToShortcode?.[emoji] ?? "?";
+        return this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[emoji][0] ?? "?";
     }
 
     onClick() {
+        if (!this.store.emojiLoader.isLoaded) {
+            loadEmoji();
+        }
         this.picker.close();
         if (this.dropdown.isOpen) {
             this.dropdown.close();

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -12,6 +12,7 @@ import { Deferred, Mutex } from "@web/core/utils/concurrency";
 import { debounce } from "@web/core/utils/timing";
 import { session } from "@web/session";
 import { browser } from "@web/core/browser/browser";
+import { loader } from "@web/core/emoji_picker/emoji_picker";
 
 /**
  * @typedef {{isSpecial: boolean, channel_types: string[], label: string, displayName: string, description: string}} SpecialMention
@@ -82,6 +83,7 @@ export class Store extends BaseStore {
     });
     settings = Record.one("Settings");
     openInviteThread = Record.one("Thread");
+    emojiLoader = loader;
 
     fetchDeferred = new Deferred();
     /** @type {[string | [string, any]]} */

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -21,7 +21,7 @@
                             </t>
                         </ul>
                     </t>
-                    <div t-if="!message.isEmpty and message.body" t-call="mail.Message.bodyAsNotification" t-ref="body"/>
+                    <div t-if="!message.isEmpty and message.richBody" t-call="mail.Message.bodyAsNotification" t-ref="body"/>
                 </div>
             </t>
             <t t-else="">$0</t>

--- a/addons/mail/static/src/utils/common/html.js
+++ b/addons/mail/static/src/utils/common/html.js
@@ -31,12 +31,41 @@ export function htmlJoin(...args) {
  * @returns {ReturnType<markup>}
  */
 export function htmlReplace(content, search, replacement) {
+    if (search instanceof RegExp && !(replacement instanceof Function)) {
+        throw new Error("htmlReplace: replacement must be a function when search is a RegExp.");
+    }
     content = htmlEscape(content);
     if (typeof search === "string" || search instanceof String) {
         search = htmlEscape(search);
     }
-    replacement = htmlEscape(replacement);
-    return markup(content.replace(search, replacement));
+    const safeReplacement =
+        replacement instanceof Function
+            ? (...args) => htmlEscape(replacement(...args))
+            : htmlEscape(replacement);
+    return markup(content.replace(search, safeReplacement));
+}
+
+/**
+ * Applies string replaceAll on content and returns a markup result built for HTML.
+ *
+ * @param {string|ReturnType<markup>} content
+ * @param {string | RegExp} search
+ * @param {string|(match: string) => string|ReturnType<markup>} replacement
+ * @returns {ReturnType<markup>}
+ */
+export function htmlReplaceAll(content, search, replacement) {
+    if (search instanceof RegExp && !(replacement instanceof Function)) {
+        throw new Error("htmlReplaceAll: replacement must be a function when search is a RegExp.");
+    }
+    content = htmlEscape(content);
+    if (typeof search === "string" || search instanceof String) {
+        search = htmlEscape(search);
+    }
+    const safeReplacement =
+        replacement instanceof Function
+            ? (...args) => htmlEscape(replacement(...args))
+            : htmlEscape(replacement);
+    return markup(content.replaceAll(search, safeReplacement));
 }
 
 /**

--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -1,4 +1,4 @@
-import { patchTranslations, preloadBundle } from "@web/../tests/web_test_helpers";
+import { patchTranslations, preloadBundle, serverState } from "@web/../tests/web_test_helpers";
 
 import {
     click,
@@ -215,4 +215,20 @@ test("selecting an emoji while holding down the Shift key prevents the emoji pic
     await contains(".o-EmojiPicker-navbar [title='Frequently used']");
     await contains(".o-EmojiPicker");
     await contains(".o-mail-Composer-input", { value: "👺" });
+});
+
+test("shortcodes shown in emoji title in message", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "" });
+    pyEnv["mail.message"].create({
+        res_id: channelId,
+        model: "discuss.channel",
+        body: "💑😇",
+        author_id: serverState.partnerId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", { text: "💑😇" });
+    await contains(".o-mail-Message span[title=':couple_with_heart:']", { text: "💑" });
+    await contains(".o-mail-Message span[title=':innocent: :halo:']", { text: "😇" });
 });

--- a/addons/mail/static/tests/utils/html.test.js
+++ b/addons/mail/static/tests/utils/html.test.js
@@ -2,6 +2,7 @@ import {
     createDocumentFragmentFromContent,
     htmlJoin,
     htmlReplace,
+    htmlReplaceAll,
     htmlTrim,
 } from "@mail/utils/common/html";
 
@@ -29,27 +30,45 @@ test("htmlJoin keeps html markup and escapes text", () => {
 });
 
 test("htmlReplace with text/text/text replaces with escaped text", () => {
-    const res = htmlReplace("<p>test</p>", "<p>test</p>", "<span>test</span>");
+    let res = htmlReplace("<p>test</p>", "<p>test</p>", "<span>test</span>");
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplace("<p>test</p>", "<p>test</p>", () => "<span>test</span>");
     expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
 test("htmlReplace with text/text/html replaces with html markup", () => {
-    const res = htmlReplace("<p>test</p>", "<p>test</p>", markup("<span>test</span>"));
+    let res = htmlReplace("<p>test</p>", "<p>test</p>", markup("<span>test</span>"));
+    expect(res.toString()).toBe("<span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplace("<p>test</p>", "<p>test</p>", () => markup("<span>test</span>"));
     expect(res.toString()).toBe("<span>test</span>");
     expect(res).toBeInstanceOf(Markup);
 });
 
 test("htmlReplace with text/html does not find", () => {
-    const res = htmlReplace("<p>test</p>", markup("<p>test</p>"), "never found");
+    let res = htmlReplace("<p>test</p>", markup("<p>test</p>"), "never found");
+    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplace("<p>test</p>", () => markup("<p>test</p>"), "never found");
     expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
 test("htmlReplace with html/html/html replaces with html markup", () => {
-    const res = htmlReplace(
+    let res = htmlReplace(
         markup("<p>test</p>"),
         markup("<p>test</p>"),
+        markup("<span>test</span>")
+    );
+    expect(res.toString()).toBe("<span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplace(markup("<p>test</p>"), markup("<p>test</p>"), () =>
         markup("<span>test</span>")
     );
     expect(res.toString()).toBe("<span>test</span>");
@@ -57,15 +76,108 @@ test("htmlReplace with html/html/html replaces with html markup", () => {
 });
 
 test("htmlReplace with html/html/text replaces with escaped text", () => {
-    const res = htmlReplace(markup("<p>test</p>"), markup("<p>test</p>"), "<span>test</span>");
+    let res = htmlReplace(markup("<p>test</p>"), markup("<p>test</p>"), "<span>test</span>");
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplace(markup("<p>test</p>"), markup("<p>test</p>"), () => "<span>test</span>");
     expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
 test("htmlReplace with html/text does not find", () => {
-    const res = htmlReplace(markup("<p>test</p>"), "<p>test</p>", "never found");
+    let res = htmlReplace(markup("<p>test</p>"), "<p>test</p>", "never found");
     expect(res.toString()).toBe("<p>test</p>");
     expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplace(markup("<p>test</p>"), () => "<p>test</p>", "never found");
+    expect(res.toString()).toBe("<p>test</p>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplaceAll with text/text/text replaces all with escaped text", () => {
+    let res = htmlReplaceAll("<p>test</p> <p>test</p>", "<p>test</p>", "<span>test</span>");
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; &lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplaceAll("<p>test</p> <p>test</p>", "<p>test</p>", () => "<span>test</span>");
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; &lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplaceAll with text/text/html replaces all with html markup", () => {
+    let res = htmlReplaceAll("<p>test</p> <p>test</p>", "<p>test</p>", markup("<span>test</span>"));
+    expect(res.toString()).toBe("<span>test</span> <span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplaceAll("<p>test</p> <p>test</p>", "<p>test</p>", () =>
+        markup("<span>test</span>")
+    );
+    expect(res.toString()).toBe("<span>test</span> <span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplaceAll with text/html does not find, escapes all", () => {
+    let res = htmlReplaceAll("<p>test</p> <p>test</p>", markup`<p>test</p>`, "never found");
+    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt; &lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplaceAll("<p>test</p> <p>test</p>", markup`<p>test</p>`, () => "never found");
+    expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt; &lt;p&gt;test&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplaceAll with html/html/html replaces all with html markup", () => {
+    let res = htmlReplaceAll(
+        markup("<p>test</p> <p>test</p>"),
+        markup("<p>test</p>"),
+        markup("<span>test</span>")
+    );
+    expect(res.toString()).toBe("<span>test</span> <span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplaceAll(markup("<p>test</p> <p>test</p>"), markup("<p>test</p>"), () =>
+        markup("<span>test</span>")
+    );
+    expect(res.toString()).toBe("<span>test</span> <span>test</span>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplaceAll with html/html/text replaces all with escaped text", () => {
+    let res = htmlReplaceAll(
+        markup("<p>test</p> <p>test</p>"),
+        markup("<p>test</p>"),
+        "<span>test</span>"
+    );
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; &lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplaceAll(
+        markup("<p>test</p> <p>test</p>"),
+        markup("<p>test</p>"),
+        () => "<span>test</span>"
+    );
+    expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; &lt;span&gt;test&lt;/span&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplaceAll with html/text does not find, keeps all", () => {
+    let res = htmlReplaceAll(markup("<p>test</p> <p>test</p>"), "<p>test</p>", "never found");
+    expect(res.toString()).toBe("<p>test</p> <p>test</p>");
+    expect(res).toBeInstanceOf(Markup);
+
+    res = htmlReplaceAll(markup("<p>test</p> <p>test</p>"), "<p>test</p>", () => "never found");
+    expect(res.toString()).toBe("<p>test</p> <p>test</p>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlReplace/htmlReplaceAll only accept functions replacement when search is a RegExp", () => {
+    expect(() => htmlReplace("test", /test/, "$1")).toThrow(
+        "htmlReplace: replacement must be a function when search is a RegExp."
+    );
+    expect(() => htmlReplaceAll("test", /test/, "$1")).toThrow(
+        "htmlReplaceAll: replacement must be a function when search is a RegExp."
+    );
 });
 
 test("htmlTrim escapes text", () => {

--- a/addons/mail/static/tests/utils/wrap_emoji_title.test.js
+++ b/addons/mail/static/tests/utils/wrap_emoji_title.test.js
@@ -1,0 +1,30 @@
+import { wrapEmojisWithTitles } from "@mail/utils/common/format";
+import { expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
+import { makeMockEnv } from "@web/../tests/web_test_helpers";
+import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
+const Markup = markup().constructor;
+
+test("emojis in text content are wrapped with title and marked up", async () => {
+    await makeMockEnv();
+    await loadEmoji();
+    const result = wrapEmojisWithTitles("😇");
+    expect(result).toBeInstanceOf(Markup);
+    expect(result.toString()).toEqual('<span title=":innocent: :halo:">😇</span>');
+});
+
+test("emojis in attributes are not wrapped with title", async () => {
+    await makeMockEnv();
+    await loadEmoji();
+    const result = wrapEmojisWithTitles(markup("<span title='😇'>test</span>"));
+    expect(result.toString()).toEqual('<span title="😇">test</span>');
+});
+
+test("unsafe content is escaped when wrapping emojis with title", async () => {
+    await makeMockEnv();
+    await loadEmoji();
+    const result = wrapEmojisWithTitles("<img src='javascript:alert(\"xss\")'/>😇");
+    expect(result.toString()).toEqual(
+        '&lt;img src=\'javascript:alert("xss")\'/&gt;<span title=":innocent: :halo:">😇</span>'
+    );
+});

--- a/addons/web/static/src/core/utils/html.js
+++ b/addons/web/static/src/core/utils/html.js
@@ -1,6 +1,7 @@
 import { markup } from "@odoo/owl";
 
 import { escape } from "@web/core/utils/strings";
+import { formatList } from "../l10n/utils";
 
 const Markup = markup().constructor;
 
@@ -26,6 +27,25 @@ export function createElementWithContent(elementName, content) {
  */
 export function htmlEscape(content) {
     return content instanceof Markup ? content : markup(escape(content));
+}
+
+/**
+ * Same behavior as formatList, but produces safe HTML. If the values are flagged as safe HTML using
+ * `markup()` they are set as it is. Otherwise they are escaped.
+ *
+ * @param {Array<string|ReturnType<markup>>} list The array of values to format into a list.
+ * @param {Object} [param0]
+ * @param {string} [param0.localeCode] The locale to use (e.g. en-US).
+ * @param {"standard"|"standard-short"|"or"|"or-short"|"unit"|"unit-short"|"unit-narrow"} [param0.style="standard"] The style to format the list with.
+ * @returns {ReturnType<markup>} The formatted list.
+ */
+export function htmlFormatList(list, ...args) {
+    return markup(
+        formatList(
+            Array.from(list, (val) => htmlEscape(val).toString()),
+            ...args
+        )
+    );
 }
 
 /**

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -6,6 +6,7 @@ import { describe, expect, test } from "@odoo/hoot";
 import {
     createElementWithContent,
     htmlEscape,
+    htmlFormatList,
     isHtmlEmpty,
     setElementContent,
 } from "@web/core/utils/html";
@@ -52,4 +53,13 @@ test("setElementContent keeps html markup", () => {
     const div = document.createElement("div");
     setElementContent(div, markup("<p>test</p>"));
     expect(div.innerHTML).toBe("<p>test</p>");
+});
+
+test("htmlFormatList", () => {
+    const list = ["<p>test 1</p>", markup("<p>test 2</p>"), "&lt;p&gt;test 3&lt;/p&gt;"];
+    const res = htmlFormatList(list, { localeCode: "fr-FR" });
+    expect(res.toString()).toBe(
+        "&lt;p&gt;test 1&lt;/p&gt;, <p>test 2</p> et &amp;lt;p&amp;gt;test 3&amp;lt;/p&amp;gt;"
+    );
+    expect(res).toBeInstanceOf(Markup);
 });


### PR DESCRIPTION
Understanding the meaning of emojis in messages can sometimes be challenging. This update enhances readability by displaying emoji shortcodes on hover, making communication easier.

![image](https://github.com/user-attachments/assets/4396b62c-3646-4146-96a0-0807f08daece)

