### PR TITLE
[FIX] project: make re-install possible if project shared

### DIFF
--- a/addons/project/__init__.py
+++ b/addons/project/__init__.py
@@ -35,3 +35,9 @@ def _project_post_init(cr, registry):
         ['mail_message_id', 'old_value_integer'],
         where=f'field={project_task_stage_field_id}'
     )
+
+def _project_uninstall_hook(cr, registry):
+    """Since the m2m table for the project share wizard's `partner_ids` field is not dropped at uninstall, it is
+    necessary to ensure it is emptied, else re-installing the module will fail due to foreign keys constraints."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['project.share.wizard'].search([("partner_ids", "!=", False)]).partner_ids = False

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -56,6 +56,7 @@
     'installable': True,
     'application': True,
     'post_init_hook': '_project_post_init',
+    'uninstall_hook': '_project_uninstall_hook',
     'assets': {
         'web.assets_backend': [
             'project/static/src/css/project.css',


### PR DESCRIPTION
**Issue**
Re-installing Project is not possible if the Project Share Wizard has been used shortly before the module uninstallation.

**Cause**
The `project_share_wizard_res_partner_rel` table for the `partner_ids` field of the `project.share.wizard` is not dropped at uninstall (this is a known ORM limitation) and if it contains rows, restoring the foreign keys constraint for the `project_share_wizard_id` column will fail.

**Solution**
Ensure the table is empty after uninstall.

**Steps to reproduce**
- Project Kanban View > 3 dots > Share
- Add a recipient and Send: this should add a row to the `project_share_wizard_res_partner_rel` table.
- Uninstall Project shortly after (before the row is deleted by the auto-vacuum).
- Try to re-install Project:
```
The operation cannot be completed: another model requires the record being deleted. If possible, archive it instead.

Model: Unknown (unknown)
Constraint: project_share_wizard_res_partner_r_project_share_wizard_id_fkey
```

opw-4593125
