### PR TITLE
[FIX] point_of sale: Recalculate refund's total based on the refund lines

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1205,7 +1205,9 @@ class PosOrder(models.Model):
                 PosOrderLineLot = self.env['pos.pack.operation.lot']
                 for pack_lot in line.pack_lot_ids:
                     PosOrderLineLot += pack_lot.copy()
-                line.copy(line._prepare_refund_data(refund_order, PosOrderLineLot))
+                new_line = line.copy(line._prepare_refund_data(refund_order, PosOrderLineLot))
+                new_line._onchange_amount_line_all()
+            refund_order._compute_prices()
             refund_orders |= refund_order
         return refund_orders
 


### PR DESCRIPTION
# Two commit setup
During working on the actual fix it came out that there are tests that need to be fixed as a prerequisite.
Hence let us first fix existing test and then fix the actual refund issue.

## [FIX] point_of_sale: use onchange in test setup for (sub)total calculations

### Why was the previous test setup wrong?
The test setup used hardcoded price_subtotal and price_subtotal_incl. 
Since lines have taxes and price_subtotal excludes tax while price_subtotal_incl including
They can NOT be equal.


### HOW SHOULD TAX AND DISCOUNT BE APPLIED? (Case: Discount & Tax-Excluded)
Setup: 
A line with 3 products (`qty=3`), each priced at `price_unit=300`, discounted by 5%, with a 5% tax (not included in price_unit).
(This corresponds to the second line in our test case.)

Correct Calculation Approach:
Here, the situation is straightforward because the base price for tax calculation is the discounted price_unit.  
We correctly compute the subtotals step by step:
Step 1: Compute Discounted Price (Base Price for Tax)
```
	price_unit * (1-discount) * qty =  tax_base  = price_subtotal
	   300     *     0.95     *  3  =    855
```
Step 2: Compute Tax Amount
```
	tax_base *  tax  * = tax_amount
	   855   *  0.05 * =   42.75
```
Step 3: Compute Final Tax-Included Price (`price_subtotal_incl`)
```
	 price_subtotal +  tax_amount = price_subtotal_incl
	    855         +     42.75   =    897.75
```

### HOW SHOULD TAX AND DISCOUNT BE APPLIED? (Case: Discount & Tax-Included)
Setup: 
A line with 2 products (`qty=2`), each priced at `price_unit=450`, discounted by 5%, with a 10% tax (included in price_unit).
(This corresponds to the first line in our test case.)

Correct Calculation Approach:
This may seem confusing as the initial tax included into the price gets modified by the discount and the discount
is calculated from the price without tax.
Step 1: Compute price without tax (Base Price for the Discount)
```
	price_unit / (1+tax) * qty =  discount_base
	   300     /   1.1   *  2  =    818.18
```
Step 2: Apply the discount
```
	discount_base * (1-discount) =  tax_base  = price_subtotal
	   818.18     *     0.95     =   777.27
```
Step 3: Compute Tax Amount
```
	tax_base  *  tax * = tax_amount
	   777.27  * 0.1 * =   77.73
```
Step 4: Compute Final Tax-Included Price (`price_subtotal_incl`)
```
    price_subtotal +  tax_amount = price_subtotal_incl
	   777.27      +    77.73    =     855
```

related to 
opw-4565492






---

## [FIX] point_of_sale: Ensure refund totals reflect refunded quantities

Before this fix, multiple partial refunds in POS could lead to an incorrect total amount.
After the first partial refund, the refund quantity was correctly updated, but the total 
amount incorrectly reflected a full refund of all items instead of just the refunded ones.
It was caused because we first copyied the total amount from the orginal order using it as refund total,
copying individual likes later on. 

With this commit we recalculate totals after all the lines were assigned to the refund order

### Steps to Reproduce

1. Install `pos_sale`
2. Create a product P priced at $1
3. Open POS register, sell 3x P
4. In POS backend, refund the order:
   - Refund 1 out of 3 products → Total: -$1 (Correct)
   - Refund another 1 out of 2 remaining products → Total: -$3 (Incorrect)
Bug: The second refund sets the return quantity to -2, but still applies the total for -3 products.

### Why modify existing test `test_refund_multiple_payment_rounding` ?            
Recalculation of the total based on the actuall order exposed missing   
line in the test setup. Since unit_price is crutial to know the (sub)total,
we have to add it. Test purpose hasn't changed.

opw-4565492