### PR TITLE
[IMP] account: support sequence_override_regex not matching every string

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -132,8 +132,12 @@ class SequenceMixin(models.AbstractModel):
             # make the seq the only matching group
             regex = self._make_regex_non_capturing(record._sequence_fixed_regex.replace(r"?P<seq>", ""))
             matching = re.match(regex, sequence)
-            record.sequence_prefix = sequence[:matching.start(1)]
-            record.sequence_number = int(matching.group(1) or 0)
+            if matching:
+                record.sequence_prefix = sequence[:matching.start(1)]
+                record.sequence_number = int(matching.group(1) or 0)
+            else:
+                record.sequence_prefix = ''
+                record.sequence_number = int(0)
 
     @api.model
     def _deduce_sequence_number_reset(self, name):


### PR DESCRIPTION
Before this commit
------------------
If sequence_override_regex is set to a regex that does not match an empty string, an error occurs when adding a new move.

After this commit:
------------------
Sequence is correctly validated, even if the override regex doesn't match an empty string.

Advantage of relaxing the requirements for sequence_override_regex
------------------------------------------------------------------ 
Writing a regex that should only match the desired sequence format and not every other string too, is easier to write AND easier to read. Note that also the default _sequence_monthly_regex and _sequence_yearly_regex do not match an empty string.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
