### PR TITLE
[IMP] core: profile ormcache footprint

### DIFF
--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -38,7 +38,7 @@ from .utils import SUPERUSER_ID
 from . import model_classes
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Collection, Iterable, Iterator, MutableMapping
+    from collections.abc import Callable, Collection, Iterable, Iterator
     from odoo.fields import Field
     from odoo.models import BaseModel
     from odoo.sql_db import BaseCursor, Connection, Cursor
@@ -89,7 +89,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
     _saved_lock: threading.RLock | DummyRLock | None = None
 
     @lazy_classproperty
-    def registries(cls) -> MutableMapping[str, Registry]:
+    def registries(cls) -> LRU[str, Registry]:
         """ A mapping from database names to registries. """
         size = config.get('registry_lru_size', None)
         if not size:


### PR DESCRIPTION
Enhance ORMCache statistics log with memory footprint estimation with SIGUSR2

the log looks like below for SIGUSR1
<img width="893" alt="image" src="https://github.com/user-attachments/assets/760d3998-9c2d-416a-b5a3-28318e687212" />

the log looks like below for SIGUSR2
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/0e359056-49dc-4d89-a7a7-1895be52a47e" />


This commit also
1. avoid useing `logging` module in the signal handler
2. fix a bug the signal is called after a registry is poped in the `Registry.registries` LRU cache


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
