### PR TITLE
[FIX] im_livechat, mail: show live chat user name on channel invitation

### DIFF
--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -59,3 +59,8 @@ class DiscussChannelMember(models.Model):
                 ]
             )
         return domain
+
+    def _get_html_link_title(self):
+        if self.channel_id.channel_type == "livechat" and self.partner_id.user_livechat_username:
+            return self.partner_id.user_livechat_username
+        return super()._get_html_link_title()

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -15,3 +15,4 @@ from . import test_message
 from . import test_upload_attachment
 from . import test_res_users
 from . import test_session_history
+from . import test_user_livechat_username

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -1,0 +1,27 @@
+from odoo.tests.common import tagged, new_test_user
+from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
+
+
+@tagged("post_install", "-at_install")
+class TestUserLivechatUsername(TestGetOperatorCommon):
+    def test_user_livechat_username_channel_invite_notification(self):
+        john = self._create_operator("fr_FR")
+        bob = self._create_operator("fr_FR")
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {
+                "name": "Livechat Channel",
+                "user_ids": [bob.id],
+            }
+        )
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Visitor",
+                "channel_id": livechat_channel.id,
+                "persisted": True,
+            },
+        )
+        john.partner_id.user_livechat_username = "ELOPERADOR"
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
+        channel.add_members(partner_ids=john.partner_id.ids)
+        self.assertEqual(channel.message_ids[-1].body, f"<div class=\"o_mail_notification\">invited <a href=\"#\" data-oe-model=\"res.partner\" data-oe-id=\"{john.partner_id.id}\">@ELOPERADOR</a> to the channel</div>")

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -566,9 +566,12 @@ class DiscussChannelMember(models.Model):
             ],
         )
 
+    def _get_html_link_title(self):
+        return self.partner_id.name if self.partner_id else self.guest_id.name
+
     def _get_html_link(self, *args, for_persona=False, **kwargs):
         if not for_persona:
             return self._get_html_link(*args, **kwargs)
         if self.partner_id:
-            return self.partner_id._get_html_link(title=f"@{self.partner_id.name}")
+            return self.partner_id._get_html_link(title=f"@{self._get_html_link_title()}")
         return Markup("<strong>%s</strong>") % self.guest_id.name


### PR DESCRIPTION
Before this PR, the real live chat operator name was shown on the channel join notification. The issue is that the name is stored in the message in database, which does not allow configuration according to who's seing the message.

A decent solution is to always store the live chat user name if any, which comes with some downsides such as not being able to update the messages afterwards. However, live chat conversations are short lived which mitigates the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
