### PR TITLE
[FIX] point_of_sale: Put trusted pos back

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -216,6 +216,14 @@ class PosConfig(models.Model):
             'records': records
         })
 
+        for config in self.trusted_config_ids:
+            config._notify('SYNCHRONISATION', {
+                'static_records': static_records,
+                'session_id': config.current_session_id.id,
+                'login_number': 0,
+                'records': records
+            })
+
     def read_config_open_orders(self, domain, record_ids):
         all_domain = expression.OR([domain, [('id', 'in', record_ids.get('pos.order')), ('config_id', '=', self.id)]])
         all_orders = self.env['pos.order'].search(all_domain)

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -7,6 +7,9 @@
                 <BackButton t-if="!props.showActionButton and pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>
                 <t t-if="props.onClickMore">
                     <SelectPartnerButton partner="props.partner"/>
+                    <button t-if="this.pos.showSaveOrderButton" t-att-disabled="this.pos.get_order().is_empty()" class="btn btn-light btn-lg" t-on-click="() => this.pos.clickSaveOrder()">
+                        <i class="fa fa-upload"/>
+                    </button>
                     <button class="button mobile-more-button btn btn-light btn-lg flex-fill" t-on-click="props.onClickMore">
                         <span>Actions</span>
                     </button>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -41,7 +41,7 @@ export class ControlButtons extends Component {
                 item: "none",
             },
         ];
-        for (const fiscalPos of this.pos.models["account.fiscal.position"].getAll()) {
+        for (const fiscalPos of this.pos.config.fiscal_position_ids) {
             fiscalPosList.push({
                 id: fiscalPos.id,
                 label: fiscalPos.name,
@@ -79,7 +79,7 @@ export class ControlButtons extends Component {
      * @returns {Array}
      */
     getPricelistList() {
-        const selectionList = this.pos.models["product.pricelist"].map((pricelist) => ({
+        const selectionList = this.pos.config.available_pricelist_ids.map((pricelist) => ({
             id: pricelist.id,
             label: pricelist.name,
             isSelected:

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -10,7 +10,10 @@
                 class="buttonClass"
                 setter="(orderline, note) => orderline.setNote(note)" />
         </t>
-        <button class="more-btn btn btn-light btn-lg flex-shrink-0 ms-auto" t-if="!props.showRemainingButtons and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
+        <button t-if="!props.showRemainingButtons and !ui.isSmall and this.pos.showSaveOrderButton" t-att-disabled="this.pos.get_order().is_empty()" t-attf-class="{{ buttonClass }}" t-att-class="{'ms-auto': !props.showRemainingButtons}" t-on-click="() => this.pos.clickSaveOrder()">
+            <i class="fa fa-upload"/>
+        </button>
+        <button class="more-btn btn btn-light btn-lg flex-shrink-0" t-att-class="{'ms-auto': !this.pos.showSaveOrderButton}" t-if="!props.showRemainingButtons and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
             Actions
         </button>
         <!-- All these buttons will only be displayed in a dialog -->

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -124,9 +124,12 @@ export class ProductScreen extends Component {
     }
 
     getCategoriesAndSub() {
-        const rootCategories = this.pos.models["pos.category"].filter(
-            (category) => !category.parent_id
-        );
+        const { limit_categories, iface_available_categ_ids } = this.pos.config;
+        let rootCategories = this.pos.models["pos.category"].getAll();
+        if (limit_categories) {
+            rootCategories = iface_available_categ_ids;
+        }
+        rootCategories = rootCategories.filter((category) => !category.parent_id);
         const selected = this.pos.selectedCategory ? [this.pos.selectedCategory] : [];
         const allParents = selected.concat(this.pos.selectedCategory?.allParents || []).reverse();
         return this.getCategoriesList(rootCategories, allParents, 0)
@@ -338,6 +341,19 @@ export class ProductScreen extends Component {
     }
 
     get products() {
+        const { limit_categories, iface_available_categ_ids } = this.pos.config;
+        if (limit_categories) {
+            const productIds = new Set([]);
+            for (const categ of iface_available_categ_ids) {
+                for (const p of this.pos.models["product.product"].getBy(
+                    "pos_categ_ids",
+                    categ.id
+                )) {
+                    productIds.add(p.id);
+                }
+            }
+            return this.pos.models["product.product"].filter((p) => productIds.has(p.id));
+        }
         return this.pos.models["product.product"].getAll();
     }
 

--- a/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
@@ -171,7 +171,18 @@ export default class DevicesSynchronisation {
         const localIds = serverOpenOrders.map((o) => o.id);
         let domain = new Domain(["&", ["state", "=", "draft"], ["id", "not in", localIds]]);
         domain = Domain.or([domain, ...localDomain]);
-        domain = Domain.and([domain, new Domain([["config_id", "=", odoo.pos_config_id]])]);
+        domain = Domain.and([
+            domain,
+            new Domain([
+                "|",
+                ["config_id", "=", odoo.pos_config_id],
+                [
+                    "config_id",
+                    "in",
+                    this.models["pos.config"].get(odoo.pos_config_id).raw.trusted_config_ids,
+                ],
+            ]),
+        ]);
         return domain.toList();
     }
 

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -2239,6 +2239,28 @@ export class PosStore extends Reactive {
             return `${pm.name} (${fmtAmount})`;
         }
     }
+
+    clickSaveOrder() {
+        this.syncAllOrders({ orders: [this.get_order()] });
+        this.notification.add(_t("Order saved for later"), { type: "success" });
+        this.selectEmptyOrder();
+        this.mobile_pane = "right";
+    }
+
+    selectEmptyOrder() {
+        const emptyOrders = this.models["pos.order"].filter(
+            (order) => order.is_empty() && !order.finalized
+        );
+        if (emptyOrders.length > 0) {
+            this.set_order(emptyOrders[0]);
+            return;
+        }
+        this.add_new_order();
+    }
+
+    get showSaveOrderButton() {
+        return this.isOpenOrderShareable();
+    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -361,4 +361,7 @@ patch(PosStore.prototype, {
     _shouldLoadOrders() {
         return super._shouldLoadOrders() || this.config.module_pos_restaurant;
     },
+    get showSaveOrderButton() {
+        return super.showSaveOrderButton && !this.config.module_pos_restaurant;
+    },
 });


### PR DESCRIPTION
The button save and all the logic about trusted orders were removed. This commit puts it back.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
