### PR TITLE
[PERF] website_sale: speedup product search

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -159,7 +159,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             for srch in search.split(" "):
                 subdomains = [
                     Domain('name', 'ilike', srch),
-                    Domain('product_variant_ids.default_code', 'ilike', srch),
+                    Domain('variants_default_code', 'ilike', srch),
                 ]
                 if search_in_description:
                     subdomains.extend((

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -8,13 +8,25 @@ from odoo import _, api, fields, models
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools import float_is_zero, is_html_empty
+from odoo.tools.sql import create_column, column_exists, SQL
 from odoo.tools.translate import html_translate
 
 from odoo.addons.website.models import ir_http
 from odoo.addons.website.tools import text_from_html
 from odoo.addons.website_sale.const import SHOP_PATH
 
+# A delimiter that users aren't likely to search for in product codes.
+RARE_DELIMITER = '\u241E'
+
 _logger = logging.getLogger(__name__)
+
+
+def get_translated_field_gist_index(registry, column_name):
+    if not registry.has_trigram:
+        return ""
+    if registry.has_unaccent:
+        return f"USING GIST(unaccent((JSONB_PATH_QUERY_ARRAY({column_name}, '$.*'::jsonpath))::text) gist_trgm_ops)"
+    return f"USING GIST((JSONB_PATH_QUERY_ARRAY({column_name}, '$.*'::jsonpath)::text) gist_trgm_ops)"
 
 
 class ProductTemplate(models.Model):
@@ -53,6 +65,7 @@ class ProductTemplate(models.Model):
         sanitize_overridable=True,
         sanitize_attributes=False,
         sanitize_form=False,
+        index='trigram',
     )
     description_ecommerce = fields.Html(
         string="eCommerce Description",
@@ -143,6 +156,47 @@ class ProductTemplate(models.Model):
         help="Add a strikethrough price to your /shop and product pages for comparison purposes."
              "It will not be displayed if pricelists apply.",
     )
+    variants_default_code = fields.Char(
+        compute='_compute_variants_default_code',
+        store=True,
+        index='trigram',
+        help="Technical field to enhance performance when looking up default code of product"
+             "variants (LIKE/ILIKE)",
+    )
+    description = fields.Html(index='trigram')
+    description_sale = fields.Text(index='trigram')
+
+    # === INDEXES === #
+
+    # We need gist indexes for similarity check in ecommerce fuzzy search.
+    _name_gist_idx = models.Index(lambda registry: get_translated_field_gist_index(registry, "name"))
+    _description_gist_idx = models.Index(lambda registry: get_translated_field_gist_index(registry, "description"))
+    _description_sale_gist_idx = models.Index(lambda registry: get_translated_field_gist_index(registry, "description_sale"))
+    _default_code_gist_idx = models.Index(
+        lambda registry: 'USING GIST(unaccent(default_code) gist_trgm_ops)'
+        if registry.has_trigram and registry.has_unaccent
+        else ('USING GIST(default_code gist_trgm_ops)' if registry.has_trigram else '')
+    )
+
+    def _auto_init(self):
+        """Override _auto_init to prevent MemoryError on ecommerce installation in dbs with lots of products"""
+        if not column_exists(self.env.cr, 'product_template', 'variants_default_code'):
+            create_column(self.env.cr, 'product_template', 'variants_default_code', 'varchar')
+            self.env.cr.execute(SQL(
+                """
+                    UPDATE product_template
+                    SET variants_default_code = variants.default_codes
+                    FROM (
+                        SELECT pt.id AS template_id,
+                               STRING_AGG(pv.default_code, %s) AS default_codes
+                        FROM product_template pt
+                        JOIN product_product pv ON pv.product_tmpl_id = pt.id
+                        WHERE pv.default_code IS NOT NULL
+                        GROUP BY pt.id
+                    ) AS variants
+                    WHERE product_template.id = variants.template_id
+                """, RARE_DELIMITER))
+        return super()._auto_init()
 
     #=== COMPUTE METHODS ===#
 
@@ -192,6 +246,13 @@ class ProductTemplate(models.Model):
         for product in self:
             if product.id:
                 product.website_url = "/shop/%s" % self.env['ir.http']._slug(product)
+
+    @api.depends('product_variant_ids.default_code')
+    def _compute_variants_default_code(self):
+        for template in self:
+            template.variants_default_code = RARE_DELIMITER.join(
+                template.product_variant_ids.filtered('default_code').mapped('default_code')
+            )
 
     #=== CRUD METHODS ===#
 
@@ -802,7 +863,7 @@ class ProductTemplate(models.Model):
             domains.append([('list_price', '<=', max_price)])
         if attribute_value_dict:
             domains.extend(self._get_attribute_value_domain(attribute_value_dict))
-        search_fields = ['name', 'default_code', 'product_variant_ids.default_code']
+        search_fields = ['name', 'default_code', 'variants_default_code']
         fetch_fields = ['id', 'name', 'website_url']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},


### PR DESCRIPTION
Improve the website fuzzy_search performances by changing the generated query. Currently the query looks like this
```sql
SELECT id, GREATEST(word_similarity(*), ..)
FROM table
ORDER by 2 desc
LIMIT 1000
```

The lack of WHERE conditions leads to postgresql always going for a Seq Scan, which quickly becomes slow when the number of records in the database increases. In ecommerce, having 50 000 products leads to a search > 1s.

To improve this, this commit introduces conditions using the `<%` operator that filters rows based on word_similarity
using `pg_trgm.word_similarity_threshold` as the threshold. Postgresql can then use GIST indexes (GIN indexes don't work here) to speed up table scanning. Those GIST indexes are added in this commit for product_template on website_sale module installation. We also add GIN indexes for website_description, description and description_sale to speedup the search_exact queries. The new GIST indexes are not hit in this case because the ORM only generates
jsonb_path_query_array type conditions when the field is set with index=trigram.

Another pain point when searching for products in ecommerce is the subquery on product_product to check `product_variant_ids.default_code`. This subquery is an optimization fence and forces postgresql to go for
a seq scan when doing an exact search on product.template. To improve that, this commit introduces a new computed stored field `variants_default_code` that is the concatenation of product_variant_ids.default_code with an delimiter char. This field is then indexed with a GIN indexe to speedup LIKE/ILIKE searches on it.

#### speedup

website benchmark searching for a product on ecommerce.

| Number of products | Before PR | After PR   |
|:------------------:|:---------:|:----------:|
|        1000        |    140ms  |    96ms    |
|        10000       |    401ms  |    200ms   |
|        50000       |    1.23s  |    263ms   |
|        200000      |    4s     |    545ms   |
|        694272      |    12.5s  |    1.78s   |

Average speedup: 4.5x

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
