### PR TITLE
[FIX] l10n_es_edi_tbai_multi_refund: remove view redundancy

### DIFF
--- a/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
+++ b/addons/l10n_es_edi_tbai_multi_refund/views/account_move_view.xml
@@ -5,7 +5,7 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
-            <field name="l10n_es_tbai_refund_reason" position='after'>
+            <field name="l10n_es_tbai_reversed_ids" position='replace'>
                 <field name="l10n_es_tbai_reversed_ids" invisible="move_type not in ('in_refund', 'out_refund')" widget="many2many_tags" options="{'no_create': True}" />
             </field>
         </field>


### PR DESCRIPTION
The module is added in https://github.com/odoo/odoo/pull/191303 as a backport to https://github.com/odoo/odoo/pull/166533 in `saas-17.3`. In `saas-17.4` this module adds similar functionality from `l10n_es_edi_tbai`. The view is modified to avoid displaying the [same field](https://github.com/odoo/odoo/blob/6140fa87601af7a75b6cf1bd93132ebc471f9181/addons/l10n_es_edi_tbai/views/account_move_view.xml#L16) twice. The module will be merged in the upgrade to `18.0`.

upgrade https://github.com/odoo/upgrade/pull/7341



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
