### PR TITLE
[FIX] l10n_nz: change GST Only Imports tags

### DIFF
--- a/addons/l10n_nz/__manifest__.py
+++ b/addons/l10n_nz/__manifest__.py
@@ -3,7 +3,7 @@
     'name': 'New Zealand - Accounting',
     'icon': '/account/static/description/l10n.png',
     'countries': ['nz'],
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 New Zealand Accounting Module

--- a/addons/l10n_nz/data/account_tax_report_data.xml
+++ b/addons/l10n_nz/data/account_tax_report_data.xml
@@ -93,11 +93,35 @@
                         <field name="name">[BOX 13] Credit adjustments from your calculation sheet</field>
                         <field name="code">NZBOX13</field>
                         <field name="expression_ids">
-                            <record id="tax_report_box13_formula" model="account.report.expression">
+                            <record id="tax_report_box13_aggregation" model="account.report.expression">
                                 <field name="label">balance</field>
-                                <field name="engine">external</field>
-                                <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">NZBOX13_tags.balance + NZBOX13_manual.balance</field>
+                            </record>
+                        </field>
+                        <field name="children_ids">
+                            <record id="tax_report_box13_tags" model="account.report.line">
+                                <field name="name">[BOX 13] Amount computed from tax tags</field>
+                                <field name="code">NZBOX13_tags</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_box13_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">BOX 13</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_box13_manual" model="account.report.line">
+                                <field name="name">[BOX 13] Manual adjustments</field>
+                                <field name="code">NZBOX13_manual</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_box13_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                </field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_nz/data/template/account.tax-nz.csv
+++ b/addons/l10n_nz/data/template/account.tax-nz.csv
@@ -28,6 +28,6 @@
 "","","","","","","","","","","base","refund","",""
 "","","","","","","","","","","tax","refund","",""
 "nz_tax_purchase_gst_only","100% ONLY","5","GST Only - Imports","GST Only on Imports","purchase","division","100.0","True","tax_group_100","base","invoice","",""
-"","","","","","","","","","","tax","invoice","+BOX 11","nz_21330"
+"","","","","","","","","","","tax","invoice","+BOX 13","nz_21330"
 "","","","","","","","","","","base","refund","",""
-"","","","","","","","","","","tax","refund","-BOX 11","nz_21330"
+"","","","","","","","","","","tax","refund","-BOX 13","nz_21330"

--- a/addons/l10n_nz/migrations/1.2/post-migrate.py
+++ b/addons/l10n_nz/migrations/1.2/post-migrate.py
@@ -1,0 +1,10 @@
+def migrate(cr, version):
+    cr.execute("""
+        UPDATE account_report_expression e
+           SET label = 'balance'
+          FROM ir_model_data d
+         WHERE e.id = d.res_id
+           AND d.module = 'l10n_nz'
+           AND d.name = 'tax_report_box13_formula'
+           AND e.label = '_upg_1.2balance'
+    """)

--- a/addons/l10n_nz/migrations/1.2/pre-migrate.py
+++ b/addons/l10n_nz/migrations/1.2/pre-migrate.py
@@ -1,0 +1,10 @@
+def migrate(cr, version):
+    cr.execute("""
+        UPDATE account_report_expression e
+           SET label = '_upg_1.2balance'
+          FROM ir_model_data d
+         WHERE e.id = d.res_id
+           AND d.module = 'l10n_nz'
+           AND d.name = 'tax_report_box13_formula'
+           AND e.label = 'balance'
+    """)


### PR DESCRIPTION
Current set up under the tax concerned is "BOX 11" which is incorrect as according to the IRD GST report, BOX 11 excludes the amount of imported goods. The tax in consideration is used when the NZ Customs bills the user only for the GST amount based on the purchase value of the goods. Therefore, the tax grids for this tax need to changed to "BOX 13".

Backport of 6d70452299cb06ad65bb745218fedfcbdb8f2c8e
PR backport: #202382
    
task-3926151