### PR TITLE
[FIX] iot_box_image: missing python3-libcamera package

### DIFF
--- a/addons/iot_box_image/configuration/packages.txt
+++ b/addons/iot_box_image/configuration/packages.txt
@@ -30,6 +30,7 @@ python3-docutils
 python3-geoip2
 python3-jinja2
 python3-ldap
+python3-libcamera
 python3-libsass
 python3-lxml
 python3-mako


### PR DESCRIPTION
In odoo/odoo#192999, the fw port missed the `python3-libcamera` package add. 
This commit adds it.
