### PR TITLE
[FIX] project: compute display_in_project when project is computed

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -228,7 +228,7 @@ class ProjectTask(models.Model):
     # In the domain of displayed_image_id, we couln't use attachment_ids because a one2many is represented as a list of commands so we used res_model & res_id
     displayed_image_id = fields.Many2one('ir.attachment', domain="[('res_model', '=', 'project.task'), ('res_id', '=', id), ('mimetype', 'ilike', 'image')]", string='Cover Image')
 
-    parent_id = fields.Many2one('project.task', string='Parent Task', index=True, domain="['!', ('id', 'child_of', id)]", tracking=True)
+    parent_id = fields.Many2one('project.task', string='Parent Task', inverse="_inverse_parent_id", index=True, domain="['!', ('id', 'child_of', id)]", tracking=True)
     child_ids = fields.One2many('project.task', 'parent_id', string="Sub-tasks", domain="[('recurring_task', '=', False)]", export_string_translation=False)
     subtask_count = fields.Integer("Sub-task Count", compute='_compute_subtask_count', export_string_translation=False)
     closed_subtask_count = fields.Integer("Closed Sub-tasks Count", compute='_compute_subtask_count', export_string_translation=False)
@@ -348,6 +348,13 @@ class ProjectTask(models.Model):
             record.display_in_project = record.project_id and (
                 not record.parent_id or record.project_id != record.parent_id.project_id
             )
+
+    def _inverse_parent_id(self):
+        for task in self:
+            if not task.parent_id:
+                task.display_in_project = True
+            elif task.display_in_project and task.project_id == task.parent_id.project_id:
+                task.display_in_project = False
 
     @api.depends('stage_id', 'depend_on_ids.state', 'project_id.allow_task_dependencies')
     def _compute_state(self):
@@ -1280,8 +1287,6 @@ class ProjectTask(models.Model):
                         if not project_link:
                             project_link = link_per_project_id[task.project_id.id] = task.project_id._get_html_link(title=task.project_id.display_name)
                         project_link_per_task_id[task.id] = project_link
-        if vals.get('parent_id') is False:
-            vals['display_in_project'] = True
         result = super().write(vals)
         if portal_can_write:
             super(ProjectTask, self_no_sudo).write(vals_no_sudo)

--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -532,3 +532,38 @@ class TestProjectSubtasks(TestProjectCommon):
             subtask_form.parent_id = self.env['project.task']
 
         self.assertTrue(invisible_subtask.display_in_project)
+
+    def test_display_in_project_is_correctly_set_when_parent_task_changes(self):
+        task = self.env['project.task'].create({
+            'name': 'Parent task',
+            'project_id': self.project_goats.id,
+            'child_ids': [
+                Command.create({'name': 'Sub-task 1', 'project_id': self.project_goats.id}),
+                Command.create({'name': 'Sub-task 1', 'project_id': self.project_pigs.id}),
+            ],
+        })
+        subtask_1, subtask_2 = task.child_ids
+
+        self.assertFalse(subtask_1.display_in_project)
+        self.assertTrue(subtask_2.display_in_project)
+
+        form_view = self.env.ref("project.project_task_convert_to_subtask_view_form")
+        with Form(subtask_1, view=form_view) as subtask_form:
+            subtask_form.parent_id = self.env['project.task']
+
+        self.assertTrue(subtask_1.display_in_project)
+
+        with Form(subtask_1, view=form_view) as subtask_form:
+            subtask_form.parent_id = task
+
+        self.assertFalse(subtask_1.display_in_project)
+
+        with Form(subtask_2, view=form_view) as subtask_form:
+            subtask_form.parent_id = self.env['project.task']
+
+        self.assertTrue(subtask_2.display_in_project)
+
+        with Form(subtask_2, view=form_view) as subtask_form:
+            subtask_form.parent_id = task
+
+        self.assertTrue(subtask_2.display_in_project)


### PR DESCRIPTION
Before this commit, when the compute method of the project_id field in `project.task` model is triggered, the compute method of `display_in_project` field is not triggered and so when a user converts a sub-task to a task and convert again the task into a sub-task, the display_in_project for that sub-task stays at True instead of being falsy as expected.

This commit makes sure the compute of `display_in_project` field is triggered even if the one of the project_id is triggered since now the compute of project_id no longer depends on `display_in_project` field and so we will not have a dependency loop.

Steps to reproduce the issue:
----------------------------
0. Install Project app.
1. Create a project A
2. Create a task A on that project A
3. Create a sub-task B in task A
4. Go to the form view of sub-task B
5. Clear the parent_id field on that sub-task (to convert it into a task)
6. Set the task A as the parent task of sub-task B
7. Go back to the kanban view of tasks of Project A

Current behavior:
----------------

The sub-task B is displayed in the kanban view even if the filter `Show sub-task` is not enabled

Expected behavior:
-----------------

The sub-task B should not be displayed in the kanban view if the filter Show sub-task is not enabled.

opw-4597692
