### PR TITLE
[IMP] web: Tree Editor: restore virtual operators in sub trees

### DIFF
--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -42,7 +42,7 @@ import { toPyValue } from "@web/core/py_js/py_utils";
 
 /**
  * @typedef {Object} Options
- * @property {(value: Value) => (null|Object)} [getFieldDef]
+ * @property {(value: Value | Couple) => (null|Object)} [getFieldDef]
  * @property {boolean} [distributeNot]
  */
 
@@ -79,6 +79,13 @@ const EXCHANGE = {
 };
 
 const COMPARATORS = ["<", "<=", ">", ">=", "in", "not in", "==", "is", "!=", "is not"];
+
+export class Couple {
+    constructor(x, y) {
+        this.fst = x;
+        this.snd = y;
+    }
+}
 
 export class Expression {
     constructor(ast) {
@@ -251,21 +258,21 @@ function normalizeCondition(condition) {
 
 /**
  * @param {AST[]} ASTs
- * @param {boolean} distributeNot
+ * @param {Options} [options={}]
  * @param {boolean} [negate=false]
  * @returns {{ tree: Tree, remaimingASTs: AST[] }}
  */
-function _construcTree(ASTs, distributeNot, negate = false) {
+function _construcTree(ASTs, options = {}, negate = false) {
     const [firstAST, ...tailASTs] = ASTs;
 
     if (firstAST.type === 1 && firstAST.value === "!") {
-        return _construcTree(tailASTs, distributeNot, !negate);
+        return _construcTree(tailASTs, options, !negate);
     }
 
     const tree = { type: firstAST.type === 1 ? "connector" : "condition" };
     if (tree.type === "connector") {
         tree.value = firstAST.value;
-        if (distributeNot && negate) {
+        if (options.distributeNot && negate) {
             tree.value = tree.value === "&" ? "|" : "&";
             tree.negate = false;
         } else {
@@ -280,7 +287,10 @@ function _construcTree(ASTs, distributeNot, negate = false) {
         tree.value = toValue(valueAST);
         if (["any", "not any"].includes(tree.operator)) {
             try {
-                tree.value = treeFromDomain(formatAST(valueAST));
+                tree.value = treeFromDomain(formatAST(valueAST), {
+                    ...options,
+                    getFieldDef: (p) => options.getFieldDef?.(new Couple(tree.path, p)) || null,
+                });
             } catch {
                 tree.value = Array.isArray(tree.value) ? tree.value : [tree.value];
             }
@@ -292,8 +302,8 @@ function _construcTree(ASTs, distributeNot, negate = false) {
         for (let i = 0; i < 2; i++) {
             const { tree: child, remaimingASTs: otherASTs } = _construcTree(
                 remaimingASTs,
-                distributeNot,
-                distributeNot && negate
+                options,
+                options.distributeNot && negate
             );
             remaimingASTs = otherASTs;
             addChild(tree, child);
@@ -304,15 +314,14 @@ function _construcTree(ASTs, distributeNot, negate = false) {
 
 /**
  * @param {AST[]} initialASTs
- * @param {Object} options
- * @param {boolean} [options.distributeNot=false]
+ * @param {Options} [options={}]
  * @returns {Tree}
  */
-function construcTree(initialASTs, options) {
+function construcTree(initialASTs, options = {}) {
     if (!initialASTs.length) {
         return connector("&");
     }
-    const { tree } = _construcTree(initialASTs, options.distributeNot);
+    const { tree } = _construcTree(initialASTs, options);
     return tree;
 }
 

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -6,6 +6,7 @@ import {
     createVirtualOperators,
     normalizeValue,
     isTree,
+    Couple,
 } from "@web/core/tree_editor/condition_tree";
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
@@ -82,26 +83,45 @@ export function useMakeGetFieldDef(fieldService) {
     fieldService ||= useService("field");
     const loadFieldInfo = useLoadFieldInfo(fieldService);
     return async (resModel, tree, additionalsPath = []) => {
-        const pathsInTree = getPathsInTree(tree);
+        const pathsInTree = getPathsInTree(tree, true);
         const paths = new Set([...pathsInTree, ...additionalsPath]);
         const promises = [];
         const fieldDefs = {};
-        for (const path of paths) {
-            if (typeof path === "string") {
-                promises.push(
-                    loadFieldInfo(resModel, path).then(({ fieldDef }) => {
-                        fieldDefs[path] = fieldDef;
-                    })
-                );
+        const loadFieldInfoFromMultiplePaths = async (resModel, fieldDefs, path) => {
+            if (typeof path === "string" && !(path in fieldDefs)) {
+                const prom = loadFieldInfo(resModel, path).then(({ fieldDef }) => {
+                    fieldDefs[path].fieldDef = fieldDef;
+                    return fieldDef?.relation || null;
+                });
+                fieldDefs[path] = { prom, pathFieldDefs: {}, fieldDef: null };
+                return prom;
             }
-        }
-        await Promise.all(promises);
-        return (path) => {
-            if (typeof path === "string") {
-                return fieldDefs[path];
+            if (path instanceof Couple && typeof path.fst === "string" && path.fst in fieldDefs) {
+                const resModel = await fieldDefs[path.fst].prom;
+                if (resModel) {
+                    return loadFieldInfoFromMultiplePaths(
+                        resModel,
+                        fieldDefs[path.fst].pathFieldDefs,
+                        path.snd
+                    );
+                }
             }
             return null;
         };
+        for (const path of paths) {
+            promises.push(loadFieldInfoFromMultiplePaths(resModel, fieldDefs, path));
+        }
+        await Promise.all(promises);
+        const _getFieldDef = (path, fieldDefs) => {
+            if (typeof path === "string") {
+                return fieldDefs[path].fieldDef;
+            }
+            if (path instanceof Couple && typeof path.fst === "string" && path.fst in fieldDefs) {
+                return _getFieldDef(path.snd, fieldDefs[path.fst].pathFieldDefs);
+            }
+            return null;
+        };
+        return (path) => _getFieldDef(path, fieldDefs);
     };
 }
 
@@ -291,14 +311,20 @@ function _extractIdsRecursive(tree, getFieldDef, idsByModel) {
     return idsByModel;
 }
 
-export function getPathsInTree(tree) {
+export function getPathsInTree(tree, lookInSubTrees = false) {
     const paths = [];
     if (tree.type === "condition") {
         paths.push(tree.path);
+        if (lookInSubTrees && isTree(tree.value)) {
+            const subTreePaths = getPathsInTree(tree.value, lookInSubTrees);
+            for (const p of subTreePaths) {
+                paths.push(new Couple(tree.path, p));
+            }
+        }
     }
     if (tree.type === "connector" && tree.children) {
         for (const child of tree.children) {
-            paths.push(...getPathsInTree(child));
+            paths.push(...getPathsInTree(child, lookInSubTrees));
         }
     }
     return unique(paths);


### PR DESCRIPTION
In order to be created, virtual operators like "is", "not_set" need field definitions to be known. It turns out that in sub trees corresponding to sub domains for any/not_any operators), the virtual operators are not created because:
- the option getFieldDef is not passed when constructing sub trees
- the getFieldDef function does not collect info on paths in sub trees.

Here we solve each problem so that when modifying the tree in some way all virtual operators are restored correctly. For instance if a condition involving a boolean field like "Active is not set" is found in a sub tree, and a condition is added/removed elsewhere, the above condition will remain the same and not become "Active = False".