### PR TITLE
[FIX] stock, mrp: don’t clean reservations for Kit products

### DIFF
--- a/addons/mrp/models/stock_quant.py
+++ b/addons/mrp/models/stock_quant.py
@@ -9,3 +9,6 @@ class StockQuant(models.Model):
     def _check_kits(self):
         if self.sudo().product_id.filtered("is_kits"):
             raise UserError(_('You should update the components quantity instead of directly updating the quantity of the kit product.'))
+
+    def _should_bypass_product(self, product=False, location=False, reserved_quantity=0, lot_id=False, package_id=False, owner_id=False):
+        return super()._should_bypass_product(product, location, reserved_quantity, lot_id, package_id, owner_id) or (product and product.is_kits)

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1162,7 +1162,8 @@ class StockQuant(models.Model):
                 del reserved_move_lines[(product, location, lot, package, owner)]
 
         for (product, location, lot, package, owner), reserved_quantity in reserved_move_lines.items():
-            if location.should_bypass_reservation():
+            if location.should_bypass_reservation() or\
+                self.env['stock.quant']._should_bypass_product(product, location, reserved_quantity, lot, package, owner):
                 continue
             else:
                 self.env['stock.quant']._update_reserved_quantity(product, location, reserved_quantity, lot_id=lot, package_id=package, owner_id=owner)
@@ -1556,6 +1557,9 @@ class StockQuant(models.Model):
                 result_package_id))
         moves = self.env['stock.move'].create(move_vals)
         moves._action_done()
+
+    def _should_bypass_product(self, product=False, location=False, reserved_quantity=0, lot_id=False, package_id=False, owner_id=False):
+        return False
 
 
 class QuantPackage(models.Model):


### PR DESCRIPTION
Since this commit: https://github.com/odoo/odoo/pull/188201/commits/766ec99dbc2701a237f082f3fb124793d9dfe596

We try to clean reservations because, for some reason, there could be a discrepancy between the sum of “stock.move.line” and the quantity/reserved quantity on “stock.quant”.

However, there are cases where a user creates a storable product, updates its quantity, and then uses it in a “stock.move.line”, confirms it, and later changes the product type to a kit. So, when trying to clean the reservations for these “stock.move.line”, a user error occurs because the system attempts to create a quant for a kit-type product: 

https://github.com/odoo/odoo/blob/c07778bbce4311c142bd8e2ce3013998d4f126ae/addons/mrp/models/stock_quant.py#L6-L11

As a result, each time users try to access the quant list, clean_reservation is triggered, causing a user error that prevents them from modifying the quantity of any quant.

Solution:
For kits, we can skip cleaning their quant to avoid unnecessary errors.

opw-4625002
opw-4624008
opw-4621175
opw-4625465
opw-4621504
opw-4623523
opw-4621508
opw-4623329
opw-4629386
