### PR TITLE
[FIX] website_livechat: test_chatbot_fw_operator_matching_lang lang

### DIFF
--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
@@ -2,18 +2,30 @@
 
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang", {
+const commonSteps = [
+    { trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello! I'm a bot!')" },
+    {
+        trigger: ".o-livechat-root:shadow button:contains(I want to speak with an operator)",
+        run: "click",
+    },
+];
+
+registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang_en", {
     steps: () => [
-        {
-            trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello! I'm a bot!')",
-        },
-        {
-            trigger: ".o-livechat-root:shadow button:contains(I want to speak with an operator)",
-            run: "click",
-        },
+        ...commonSteps,
         {
             trigger:
                 ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(joined the channel)",
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang_fr", {
+    steps: () => [
+        ...commonSteps,
+        {
+            trigger:
+                ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(a rejoint le canal)", // FIXME: lang is on behalf of who triggers the notification
         },
     ],
 });

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -211,12 +211,12 @@ class TestLivechatChatbotUI(TestGetOperatorCommon, TestWebsiteLivechatCommon, Ch
         )
         self.livechat_channel.user_ids = fr_op + en_op
         self.env["discuss.channel"].search([("livechat_channel_id", "=", self.livechat_channel.id)]).unlink()
-        self.start_tour("/fr", "chatbot_fw_operator_matching_lang")
+        self.start_tour("/fr", "chatbot_fw_operator_matching_lang_fr")
         channel = self.livechat_channel.channel_ids[0]
         self.assertIn(channel.channel_member_ids.partner_id.user_ids, fr_op)
         self.assertNotIn(channel.channel_member_ids.partner_id.user_ids, en_op)
         self.env["discuss.channel"].search([("livechat_channel_id", "=", self.livechat_channel.id)]).unlink()
-        self.start_tour("/en", "chatbot_fw_operator_matching_lang")
+        self.start_tour("/en", "chatbot_fw_operator_matching_lang_en")
         channel = self.livechat_channel.channel_ids[0]
         self.assertIn(channel.channel_member_ids.partner_id.user_ids, en_op)
         self.assertNotIn(channel.channel_member_ids.partner_id.user_ids, fr_op)


### PR DESCRIPTION
Before this commit, the test `test_chatbot_fw_operator_matching_lang` failed at the following step:

```
  "trigger": ".o-livechat-root:shadow .o-mail-Message:contains('Hello! I'm a bot!')"
},
{
  "trigger": ".o-livechat-root:shadow button:contains(I want to speak with an operator)",
  "run": "click"
},
---------- FAILED: [3/3] Tour chatbot_fw_operator_matching_lang → Step .o-livechat-root:shadow .o-mail-NotificationMessage:contains(joined the channel) ----------
{
  "trigger": ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(joined the channel)"
},
------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

This happens because when the chatbot forward to operator, the message notification "Operator joined the channel" uses the language of the operator. This is not ideal but this is a technical limitation that cannot change in stable.

The test was asserting "joined the channel" message notification when the chatbot forwards to a French operator. However in practice this is actually shown as "a rejoint le channel", because this uses the operator language which is French.

The test was passing due to french translations not being updated, thus it was still relying on the English version. When translations have been updated, this test failed as expected.

This commit fixes the issue by assertion presence of message notification like before but it takes into account the language of the operator.

Note that this is definitely not ideal: the message notification should actually adapt the language on the viewer. We plan to improve this, but this needs non-trivial changes to message notifications to make this work.

runbot-159895