### PR TITLE
[FIX] l10n_sa_pos: correct receipt printing for paid orders

### DIFF
--- a/addons/l10n_sa_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_sa_pos/static/src/overrides/models/pos_store.js
@@ -6,7 +6,7 @@ patch(PosStore.prototype, {
         const result = super.getReceiptHeaderData(...arguments);
         const company = this.company;
         if (order && company?.country_id?.code === "SA") {
-            result.is_settlement = this.get_order().is_settlement();
+            result.is_settlement = order.is_settlement();
             if (!result.is_settlement) {
                 const codeWriter = new window.ZXing.BrowserQRCodeSvgWriter();
                 const qr_values = order.compute_sa_qr_code(


### PR DESCRIPTION
Prior to this commit, attempting to print a receipt for a paid order in the PoS restaurant with l10n_sa_pos installed resulted in an error. In later versions, the process would fail silently. This error occurred because the getReceiptHeaderData method in the PoS restaurant used ‘this.get_order()’ to retrieve the order, which is not applicable for paid orders.

The order is now passed as an argument to the getReceiptHeaderData function, allowing it to be used when assigning the is_settlement field.

This was actually resolved in PR: #145252 but was accidentally reverted during this PR: #142566

Current behavior before PR - 
In saas-17.4, we get a traceback for the is_settlement field
In 18.0+ it will silently fail

Desired behavior after PR:
Print the order

Steps to reproduce:
1.) Install
point_of_sale;
pos_restaurant;
l10n_sa_pos;
2.) This should have created a company 'SA Company' with the country code of 'SA', currency of 'SAR', country_id of Saudi Arabia. If not create one and activate it.
3.) Create a Restaurant point of sale shop
4.) Create a sale > validate so we had orders in the 'Paid' state
5.) Ensure no table is selected
6.) Navigate to orders > filter 'Paid'
7.) Select a paid order and 'Print Receipt'

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
