### PR TITLE
[17.0] [FIX] web, base: Reload on usable view when switch company gives AccessError

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -33,7 +33,14 @@ import { FormCompiler } from "./form_compiler";
 import { FormErrorDialog } from "./form_error_dialog/form_error_dialog";
 import { FormStatusIndicator } from "./form_status_indicator/form_status_indicator";
 
-import { Component, onRendered, useEffect, useRef, useState } from "@odoo/owl";
+import {
+    Component,
+    onError,
+    onRendered,
+    useEffect,
+    useRef,
+    useState,
+} from "@odoo/owl";
 
 const viewRegistry = registry.category("views");
 
@@ -122,6 +129,7 @@ export class FormController extends Component {
         this.user = useService("user");
         this.viewService = useService("view");
         this.ui = useService("ui");
+        this.companyService = useService("company");
         useBus(this.ui.bus, "resize", this.render);
 
         this.archInfo = this.props.archInfo;
@@ -164,6 +172,17 @@ export class FormController extends Component {
         useEffect(() => {
             if (!this.env.inDialog) {
                 this.updateURL();
+            }
+        });
+
+        onError((error) => {
+            const suggestedCompany = error.cause?.data?.context?.suggested_company;
+            if (error.cause?.data?.name === "odoo.exceptions.AccessError" && suggestedCompany) {
+                const activeCompanyIds = this.companyService.activeCompanyIds;
+                activeCompanyIds.push(suggestedCompany.id);
+                this.companyService.setCompanies(activeCompanyIds, true);
+            } else {
+                throw error;
             }
         });
 

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -238,20 +238,33 @@ class IrRule(models.Model):
                 return f'{description}, {rec.display_name} ({model}: {rec.id}, company={rec.company_id.display_name})'
             return f'{description}, {rec.display_name} ({model}: {rec.id})'
 
-        failing_records = '\n '.join(f'- {get_record_description(rec)}' for rec in records_sudo)
-
-        rules_description = '\n'.join(f'- {rule.name}' for rule in rules)
-        failing_rules = _("Blame the following rules:\n%s", rules_description)
-
+        context = None
         if company_related:
-            failing_rules += "\n\n" + _('Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!')
+            suggested_companies = records_sudo._get_redirect_suggested_company()
+            if suggested_companies and len(suggested_companies) != 1:
+                resolution_info += "\n\n" + _('Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!')
+            elif suggested_companies and suggested_companies in self.env.user.company_ids:
+                context = {'suggested_company': {'id': suggested_companies.id, 'display_name': suggested_companies.display_name}}
+                resolution_info += "\n\n" + _('This seems to be a multi-company issue, you might be able to access the record by switching to the company: %s.', suggested_companies.display_name)
+            elif suggested_companies:
+                resolution_info += "\n\n" + _('This seems to be a multi-company issue, but you do not have access to the proper company to access the record anyhow.')
+
+        if not self.env.user.has_group('base.group_no_one') or not self.env.user._is_internal():
+            msg = f"{operation_error}\n{failing_model}\n\n{resolution_info}"
+        else:
+            # This extended AccessError is only displayed in debug mode.
+            failing_records = '\n'.join(f'- {get_record_description(rec)}' for rec in records_sudo)
+            rules_description = '\n'.join(f'- {rule.name}' for rule in rules)
+            failing_rules = _("Blame the following rules:\n%s", rules_description)
+            msg = f"{operation_error}\n{failing_records}\n\n{failing_rules}\n\n{resolution_info}"
 
         # clean up the cache of records prefetched with display_name above
         records_sudo.invalidate_recordset()
 
-        msg = f"{operation_error}\n{failing_records}\n\n{failing_rules}\n\n{resolution_info}"
-        return AccessError(msg)
-
+        exception = AccessError(msg)
+        if context:
+            exception.context = context
+        return exception
 
 #
 # Hack for field 'global': this field cannot be defined like others, because

--- a/odoo/addons/test_access_rights/tests/test_feedback.py
+++ b/odoo/addons/test_access_rights/tests/test_feedback.py
@@ -343,8 +343,6 @@ Sorry, %s (id=%s) doesn't have 'write' access to:
 Blame the following rules:
 - rule 0
 
-Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!
-
 If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies."""
         % (self.user.name, self.user.id, self.record._description, self.record.display_name, self.record._name, self.record.id))
 
@@ -377,8 +375,6 @@ Sorry, %s (id=%s) doesn't have 'read' access to:
 Blame the following rules:
 - rule 0
 
-Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!
-
 If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies."""
         % (self.user.name, self.user.id, child_record._description, child_record.display_name, child_record._name, child_record.id))
 
@@ -402,10 +398,11 @@ Sorry, %s (id=%s) doesn't have 'read' access to:
 Blame the following rules:
 - rule 0
 
-Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!
+If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.
 
-If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies."""
-        % (self.user.name, self.user.id, self.record._description, self.record.display_name, self.record._name, self.record.id, self.record.sudo().company_id.display_name))
+This seems to be a multi-company issue, you might be able to access the record by switching to the company: %s."""
+        % (self.user.name, self.user.id, self.record._description, self.record.display_name, self.record._name, self.record.id, self.record.sudo().company_id.display_name,
+        self.record.sudo().company_id.display_name))
         p = self.env['test_access_right.inherits'].create({'some_id': self.record.id})
         self.env.flush_all()
         self.env.invalidate_all()
@@ -414,6 +411,42 @@ If you really, really need access, perhaps you can win over your friendly admini
             r"Implicitly accessed through 'Object for testing related access rights' \(test_access_right.inherits\)\.",
         ):
             p.with_user(self.user).val
+
+    def test_warn_company_access_multi_record(self):
+        """ Test that AccessError handle correctly several companies """
+        company_1 = self.env['res.company'].create([
+            {'name': 'Brosse Inc.'},
+        ])
+
+        company_2 = self.env['res.company'].create([
+            {'name': 'Brosse Inc. 2'},
+        ])
+
+        records = self.env["test_access_right.some_obj"].create([
+            {"val": 1, "company_id": company_1.id},
+            {"val": 2, "company_id": company_2.id},
+        ])
+        record_1, record_2 = records
+        self.user.sudo().company_ids = [Command.link(company_1.id), Command.link(company_2.id)]
+        self._make_rule('rule 0', "[('company_id', '=', False)]", attr='read')
+        self.env.invalidate_all()
+        with self.debug_mode(), self.assertRaises(AccessError) as ctx:
+            _ = records.with_user(self.user).read(["val"])
+        self.assertEqual(
+            ctx.exception.args[0],
+            f"""Uh-oh! Looks like you have stumbled upon some top-secret records.
+
+Sorry, {self.user.name} (id={self.user.id}) doesn't have 'read' access to:
+- {record_1._description}, {record_1.display_name} ({record_1._name}: {record_1.id}, company={record_1.company_id.display_name})
+- {record_2._description}, {record_2.display_name} ({record_2._name}: {record_2.id}, company={record_2.company_id.display_name})
+
+Blame the following rules:
+- rule 0
+
+If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.
+
+Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!""")
+
 
 class TestFieldGroupFeedback(Feedback):
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5810,6 +5810,22 @@ class BaseModel(metaclass=MetaModel):
     def _unregister_hook(self):
         """ Clean up what `~._register_hook` has done. """
 
+    def _get_redirect_suggested_company(self):
+        """Return the suggested company to be set on the context
+        in case of a URL redirection to the record. To avoid multi
+        company issues when clicking on a shared link, this
+        could be called to try setting the most suited company on
+        the allowed_company_ids in the context. This method can be
+        overridden, for example on the hr.leave model, where the
+        most suited company is the company of the leave type, as
+        specified by the ir.rule.
+        """
+        if 'company_id' in self:
+            return self.company_id
+        elif 'company_ids' in self:
+            return (self.company_ids & self.env.user.company_ids)[:1]
+        return False
+
     #
     # Instance creation
     #


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

This error only exists in the 17.0 version
- In the 16.0 version, it doesn’t select other companies in the navigation bar and doesn’t give an access error as well
- In the 17.4 and 18.0 versions, it selects other companies in the navigation bar and doesn’t give an access error as well

I backported the fix from the below-attached PRs:
- https://github.com/odoo/odoo/pull/157399/files#diff-706c5300f0b758ed43a362c85fa84a655c8bae12339bd882e98dc419623facc2R207
- https://github.com/odoo/odoo/pull/160730/files#diff-c28b3e2d6bbe6f94bf95e9cbbe228f61664ca6e1d9a4048f951d8769e2d22752L124

### Steps to reproduce the bug:
1) Create 2 companies: Company A and Company B
2) Assign Company A to the company_id field on the contact form for Company A. 
3) Assign Company B to the company_id field on the contact form for Company B. 
4) Create a user and add both companies to the allowed companies in the user record. 
5) In the navigation bar, select only one company (e.g., Company A). 
6) Attempt to open the user record from the user form, it will give an access error.

### Current Behavior before PR:
An AccessError is raised when attempting to open the user record after selecting only one company in the navigation bar.

### Desired behavior after PR is merged:
When navigating to a user record after selecting only one company in the navigation bar, the system should:
1) Automatically select the other company [similar to the behavior in version 18] 
2) Reload the page before redirecting to the specific user record 
3) Open the user record page without giving any access error.

opw-4449964



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
