### PR TITLE
[IMP] web, base: move aggregated cols to end in grouped list view

### DIFF
--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -237,7 +237,7 @@ test(`width computation: with records, lot of fields, grouped`, async () => {
         groupBy: ["int_field"],
     });
     expect(`.o_resize`).toHaveCount(9);
-    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 89, 154, 114, 45]);
+    expect(getColumnWidths()).toEqual([40, 29, 89, 89, 89, 154, 34, 80, 102, 125]);
 });
 
 test(`width computation: with records, few fields`, async () => {

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -77,7 +77,7 @@ class ir_cron(models.Model):
                                       ('months', 'Months')], string='Interval Unit', default='months', required=True)
     nextcall = fields.Datetime(string='Next Execution Date', required=True, default=fields.Datetime.now, help="Next planned execution date for this job.")
     lastcall = fields.Datetime(string='Last Execution Date', help="Previous time the cron ran successfully, provided to the job through the context on the `lastcall` key")
-    priority = fields.Integer(default=5, help='The priority of the job, as an integer: 0 means higher priority, 10 means lower priority.')
+    priority = fields.Integer(default=5, aggregator=None, help='The priority of the job, as an integer: 0 means higher priority, 10 means lower priority.')
     failure_count = fields.Integer(default=0, help="The number of consecutive failures of this job. It is automatically reset on success.")
     first_failure_date = fields.Datetime(string='First Failure Date', help="The first time the cron failed. It is automatically reset on success.")
 


### PR DESCRIPTION
#### Description of the issue/feature this PR addresses:

This PR changes:
1. Sets `aggregator=None` on `ir.cron`'s `priority` field since aggregating this by summing it up (sum is the default aggregator on Integer fields) gives us no useful information. Removing it has a very minimal performance improvement and would partly address the issue where this field's aggregated value clips over the grouped by field
2. Moves the aggregated columns to the end in a list view that is grouped:
    a. New getter method: `aggregatedFieldNames` which gives us the names of fields that have an aggregator property. We cannot use the existing get aggregates method since that is undefined before we have rendered the list.
    b. In the `onWillRender` method of `list_renderer.js`, we check if the list is grouped, if yes then move all the aggregated columns to the end of the table. Thanks to @aab-odoo (author of the original refactor) for suggesting this idea.

#### Current behavior before PR:

Prior to https://github.com/odoo/odoo/commit/3d9a6ac the width of the first column would be increased in case of grouping list views. This would make the label of the grouped field visible by expanding the first column. However after the mentioned commit, we restrict the min and max widths of the columns which leads to the value of this grouped by field getting clipped by the aggregated column's value.

![image](https://github.com/user-attachments/assets/014208c5-74ad-4fb1-af9e-fc0f9ef007a1)
![image](https://github.com/user-attachments/assets/06d90eeb-7961-4e60-b4e8-ca823d2e23a7)


####Desired behavior after PR is merged:

Aggregated columns will be moved to the end of the table in the order of 

https://github.com/user-attachments/assets/9c50500d-578f-4f9d-bb70-b6368ef30ac2




opw-4536133

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
