### PR TITLE
[IMP] mail: message edit action outside of drop down for author

### DIFF
--- a/addons/im_livechat/static/tests/embed/message_actions.test.js
+++ b/addons/im_livechat/static/tests/embed/message_actions.test.js
@@ -36,9 +36,9 @@ test("Only two quick actions are shown", async () => {
     await contains(".o-mail-MessageReaction", { text: "😅" });
     await contains(".o-mail-Message-actions i", { count: 3 });
     await contains("[title='Add a Reaction']");
-    await contains("[title='Reply']");
     await contains("[title='Expand']");
     await click("[title='Expand']");
+    await contains("[title='Reply']");
     await contains(".o-mail-Message-actions i, .o-mail-Message-moreMenu i", { count: 8 });
     await contains("[title='View Reactions']");
     await contains("[title='Mark as Unread']");

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -248,7 +248,7 @@ export class Message extends Component {
 
     /** Max amount of quick actions, including "..." */
     get quickActionCount() {
-        return this.env.inChatter ? 3 : this.env.inChatWindow ? 2 : 4;
+        return this.env.inChatWindow ? 2 : 4;
     }
 
     get showSubtypeDescription() {

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -58,7 +58,11 @@ messageActionsRegistry
                 thread.composer.replyToMessage = message;
             }
         },
-        sequence: (component) => (component.props.thread?.eq(component.store.inbox) ? 55 : 20),
+        sequence: (component) =>
+            component.props.thread?.eq(component.store.inbox) ||
+            component.props.message.isSelfAuthored
+                ? 55
+                : 20,
     })
     .add("toggle-star", {
         condition: (component) => component.props.message.canToggleStar,
@@ -99,7 +103,7 @@ messageActionsRegistry
             component.props.messageEdition.enterEditMode(component.props.message);
             component.optionsDropdown?.close();
         },
-        sequence: 80,
+        sequence: (component) => (component.props.message.isSelfAuthored ? 20 : 55),
     })
     .add("delete", {
         condition: (component) => component.props.message.editable,

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -728,6 +728,7 @@ test("Replying on a channel should focus composer initially", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer-input:focus");
 });
@@ -1147,7 +1148,8 @@ test("composer reply-to message is restored on thread change", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Reply']");
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message-moreMenu [title='Reply']");
     await contains(".o-mail-Composer:contains('Replying to')");
     await click(".o-mail-DiscussSidebar-item:contains('Inbox')");
     await contains(".o-mail-Message", { count: 0 });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -51,8 +51,7 @@ test("Start edition on click edit", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer-input", { value: "Hello world" });
     await click("a[role='button']", { text: "cancel" });
     await contains(".o-mail-Message .o-mail-Composer-input", { count: 0 });
@@ -79,11 +78,13 @@ test("Can only edit one message at a time", async () => {
     ]);
     await start();
     await openDiscuss(channelId);
-    await click("[title='Expand']", { parent: [".o-mail-Message", { text: "Goodbye!" }] });
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']", {
+        parent: [".o-mail-Message", { text: "Goodbye!" }],
+    });
     await contains(".o-mail-Composer-input", { value: "Goodbye!" });
-    await click("[title='Expand']", { parent: [".o-mail-Message", { text: "Hello!" }] });
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']", {
+        parent: [".o-mail-Message", { text: "Hello!" }],
+    });
     await contains(".o-mail-Message .o-mail-Composer-input", { count: 1 });
     await contains(".o-mail-Composer-input", { value: "Hello!" });
     await focus(".o-mail-Composer-input", { value: "" });
@@ -163,8 +164,7 @@ test("Editing message keeps the mentioned channels", async () => {
     await click(".o-mail-Composer-suggestion strong", { text: "other" });
     await press("Enter");
     await contains(".o_channel_redirect", { count: 1, text: "other" });
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "#other bye", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
@@ -185,13 +185,11 @@ test("Can edit message comment in chatter", async () => {
     });
     await start();
     await openFormView("res.partner", partnerId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-content", { text: "edited message (edited)" });
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message:contains('Escape to cancel, CTRL-Enter to save')");
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited again", { replace: true });
     await press("Enter");
@@ -236,8 +234,7 @@ test("Cursor is at end of composer input on edit", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     const textarea = queryFirst(".o-mail-Composer-input");
     const contentLength = textarea.value.length;
     expect(textarea.selectionStart).toBe(contentLength);
@@ -259,8 +256,7 @@ test("Stop edition on click cancel", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await click(".o-mail-Message a", { text: "cancel" });
     await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
@@ -280,8 +276,7 @@ test("Stop edition on press escape", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     triggerHotkey("Escape", false);
     await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
@@ -301,8 +296,7 @@ test("Stop edition on click save", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
@@ -322,8 +316,7 @@ test("Stop edition on press enter", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     triggerHotkey("Enter", false);
     await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
@@ -343,8 +336,7 @@ test("Do not stop edition on click away when clicking on emoji", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await click(".o-mail-Composer button[title='Add Emojis']");
     await click(".o-EmojiPicker-content :nth-child(1 of .o-Emoji)");
     await contains(".o-mail-Message.o-editing .o-mail-Composer");
@@ -365,8 +357,7 @@ test("Edit and click save", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-body", { text: "Goodbye World (edited)" });
@@ -388,8 +379,7 @@ test("Do not call server on save if no changes", async () => {
     onRpcBefore("/mail/message/update_content", () => asyncStep("update_content"));
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await click(".o-mail-Message a", { text: "save" });
     await waitForSteps([]);
 });
@@ -410,8 +400,7 @@ test("Update the link previews when a message is edited", async () => {
     onRpcBefore("/mail/link_preview$", (args) => asyncStep("link_preview"));
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "http://odoo.com", {
         replace: true,
     });
@@ -435,8 +424,7 @@ test("Scroll bar to the top when edit starts", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer-input");
     const textarea = document.querySelector(".o-mail-Message .o-mail-Composer-input");
     expect(textarea.scrollHeight).toBeGreaterThan(textarea.clientHeight);
@@ -459,8 +447,7 @@ test("mentions are kept when editing message", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Hi @Mitchell Admin", {
         replace: true,
     });
@@ -495,8 +482,7 @@ test("can add new mentions when editing message", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", " @");
     await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
     await contains(".o-mail-Composer-input", { value: "Hello @TestPartner " });
@@ -567,8 +553,7 @@ test("Updating the parent message of a reply also updates the visual of the repl
     });
     await start();
     await openDiscuss(channelId);
-    await click(":nth-child(1 of .o-mail-Message) [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(":nth-child(1 of .o-mail-Message) [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", {
         replace: true,
     });
@@ -590,7 +575,8 @@ test("Deleting parent message of a reply should adapt reply visual", async () =>
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Reply']");
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message-moreMenu [title='Reply']");
     await insertText(".o-mail-Composer-input", "FooBarFoo");
     triggerHotkey("Enter", false);
     await click(".o-mail-Message [title='Expand']");
@@ -613,8 +599,7 @@ test("Can open emoji picker after edit mode", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message", { text: "Hello world" });
     await click("[title='Add a Reaction']");
@@ -1035,8 +1020,7 @@ test("click on message edit button should open edit composer", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer");
 });
 
@@ -1155,8 +1139,7 @@ test("Editing a message to clear its composer opens message delete dialog.", asy
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message.o-editing .o-mail-Composer-input", "", { replace: true });
     triggerHotkey("Enter");
     await contains(".modal-body p", { text: "Are you sure you want to delete this message?" });
@@ -1180,8 +1163,7 @@ test("Clear message body should not open message delete dialog if it has attachm
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message.o-editing .o-mail-Composer-input", "", { replace: true });
     triggerHotkey("Enter");
     await contains(".o-mail-Message-textContent", { text: "" });
@@ -1704,8 +1686,8 @@ test("Can reply to chatter messages from history", async () => {
     });
     await start();
     await openDiscuss("mail.box_history");
-    await contains(".o-mail-Message [title='Reply']");
-    await click(".o-mail-Message [title='Reply']");
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message-moreMenu [title='Reply']");
     await click(".o-mail-Composer button[title='More Actions']");
     await contains(".dropdown-item:contains('Open Full Composer')");
 });
@@ -1865,8 +1847,7 @@ test("Can edit a message only containing an attachment", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message.o-editing .o-mail-Composer-input");
 });
 

--- a/addons/test_mail_full/static/tests/tours/message_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/message_actions_tour.js
@@ -4,11 +4,11 @@ registry.category("web_tour.tours").add("star_message_tour", {
     steps: () => [
         {
             trigger: "#chatterRoot:shadow .o-mail-Message:contains(Test Message)",
-            run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Mark as Todo'] i.fa-star-o",
+            run: "hover && click #chatterRoot:shadow [title='Mark as Todo'] i.fa-star-o",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message:contains(Test Message)",
-            run: "hover #chatterRoot:shadow .o-mail-Message [title='Mark as Todo'] i.fa-star.o-mail-Message-starred",
+            run: "hover #chatterRoot:shadow [title='Mark as Todo'] i.fa-star.o-mail-Message-starred",
         },
     ],
 });


### PR DESCRIPTION
**Current behavior before PR**:

message edit action was inside the drop down for all users including author

**Desired behavior after PR is merged**:

message `edit` action will be outside while `reply` will be inside  the drop down for author and will remain same as before for other users

**task-id**:[4625740](https://www.odoo.com/odoo/my-tasks/4625740)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr