### PR TITLE
[FIX] web: hide pager when sample data is displayed

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -57,7 +57,7 @@ export class KanbanController extends Component {
         usePager(() => {
             const root = this.model.root;
             const { count, hasLimitedCount, isGrouped, limit, offset } = root;
-            if (!isGrouped) {
+            if (!isGrouped && !this.model.useSampleModel) {
                 return {
                     offset: offset,
                     limit: limit,

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -142,6 +142,9 @@ export class ListController extends Component {
         usePager(() => {
             const list = this.model.root;
             const { count, hasLimitedCount, isGrouped, limit, offset } = list;
+            if (this.model.useSampleModel) {
+                return;
+            }
             return {
                 offset: offset,
                 limit: limit,

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -13645,4 +13645,28 @@ QUnit.module("Views", (hooks) => {
             assert.containsN(target, ".o_kanban_group", 3);
         }
     );
+
+    QUnit.test("hide pager in the kanban view with sample data", async (assert) => {
+        serverData.models.partner.records = [];
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban sample="1">
+                    <field name="product_id"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div>
+                                <field name="int_field"/>
+                                <field name="category_ids" widget="many2many_tags"/>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>`,
+        });
+
+        assert.hasClass(target.querySelector(".o_content"), "o_view_sample_data");
+        assert.isNotVisible(target.querySelector(".o_cp_pager"));
+    });
 });

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -18004,4 +18004,20 @@ QUnit.module("Views", (hooks) => {
 
         await clickSave(target);
     });
+
+    QUnit.test("hide pager in the list view with sample data", async (assert) => {
+        await makeView({
+            type: "list",
+            arch: `
+                <tree sample="1">
+                    <field name="date"/>
+                </tree>`,
+            serverData,
+            domain: Domain.FALSE.toList(),
+            resModel: "foo",
+        });
+
+        assert.hasClass(target.querySelector(".o_content"), "o_view_sample_data");
+        assert.isNotVisible(target.querySelector(".o_cp_pager"));
+    });
 });


### PR DESCRIPTION
Before this commit:
When sample data was visible in the view, the pager was also displayed, showing
a record count, which could be misleading.

After this commit:
Now, when sample data is visible, the pager is hidden.

Task-4489033

