### PR TITLE
[IMP] repair: UX cleanup, overview removal

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -196,6 +196,15 @@ class RepairOrder(models.Model):
     reserve_visible = fields.Boolean(
         'Allowed to Reserve Production', compute='_compute_unreserve_visible',
         help='Technical field to check when we can reserve quantities')
+    picking_type_visible = fields.Boolean(compute='_compute_picking_type_visible')
+
+    def _compute_picking_type_visible(self):
+        repair_type_by_company = dict(self.env['stock.picking.type']._read_group([
+                ('code', '=', 'repair_operation'),
+                ('company_id', 'in', self.company_id.ids)
+            ], groupby=['company_id'], aggregates=['__count']))
+        for ro in self:
+            ro.picking_type_visible = repair_type_by_company.get(ro.company_id, 0) > 1
 
     @api.depends('product_id', 'picking_id', 'lot_id')
     def _compute_product_qty(self):

--- a/addons/repair/models/stock_picking.py
+++ b/addons/repair/models/stock_picking.py
@@ -183,12 +183,6 @@ class StockPickingType(models.Model):
         repair_records = [(i, d, _('Confirmed')) for i, d in picking_type_id_to_dates.items()]
         return records + repair_records
 
-    def action_repair_overview(self):
-        routing_count = self.env['stock.picking.type'].search_count([('code', '=', 'repair_operation')])
-        if routing_count == 1:
-            return self.env['ir.actions.actions']._for_xml_id('repair.action_repair_order_tree')
-        return self.env['ir.actions.actions']._for_xml_id('repair.action_repair_picking_type_kanban')
-
 
 class StockPicking(models.Model):
     _inherit = 'stock.picking'

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -130,6 +130,7 @@
                                 decoration-success="parts_availability_state == 'available'"
                                 decoration-warning="parts_availability_state == 'expected'"
                                 decoration-danger="parts_availability_state == 'late'"/>
+                            <field name="picking_type_id" options="{'no_create': True}" readonly="state in ('done', 'cancel')" invisible="not picking_type_visible"/>
                         </group>
                         <field name="repair_properties" nolabel="1" columns="2" hideAddButton="1"/>
                     </group>
@@ -187,15 +188,6 @@
                     </page>
                     <page string="Repair Notes" name="repair_notes">
                         <field name="internal_notes" placeholder="Add internal notes."/>
-                    </page>
-                    <page string="Miscellaneous" name="page_miscellaneous">
-                        <group>
-                            <field name="picking_type_id" options="{'no_create': True}" readonly="state in ('done', 'cancel')"/>
-                        </group>
-                        <group string="Locations" groups="stock.group_stock_multi_locations" name="locations">
-                            <field name="product_location_src_id" readonly="state != 'draft'" options="{'no_create': True}"/>
-                            <field name="location_id" readonly="state != 'draft'" options="{'no_create': True}"/>
-                        </group>
                     </page>
                 </notebook>
                 </sheet>
@@ -321,13 +313,14 @@
         </record>
 
         <record id="action_repair_order_graph" model="ir.actions.act_window">
-            <field name="name">Repair Orders</field>
+            <field name="name">Repair Orders Analysis</field>
             <field name="context">{
                 'search_default_product': 1,
                 'search_default_createDate': 1,
             }
             </field>
             <field name="res_model">repair.order</field>
+            <field name="path">repair-orders-analysis</field>
             <field name="view_mode">list,kanban,graph,pivot,form</field>
             <field name="view_id" ref="view_repair_graph"/>
         </record>
@@ -354,26 +347,13 @@
             <field name="context">{'search_default_filter_confirmed': 1}</field>
         </record>
 
-        <record id="view_repair_tag_form" model="ir.ui.view">
-            <field name="name">repair.tag.form</field>
-            <field name="model">repair.tags</field>
-            <field name="arch" type="xml">
-                <form string="Repair Tags">
-                    <sheet>
-                        <group>
-                            <field name="name"/>
-                        </group>
-                    </sheet>
-                </form>
-            </field>
-        </record>
-
         <record id="view_repair_tag_tree" model="ir.ui.view">
             <field name="name">repair.tag.list</field>
             <field name="model">repair.tags</field>
             <field name="arch" type="xml">
                 <list string="Tags" editable="bottom">
                     <field name="name"/>
+                    <field name="color" widget="color_picker"/>
                 </list>
             </field>
         </record>
@@ -398,36 +378,8 @@
             </field>
         </record>
 
-        <record id="action_repair_picking_type_kanban" model="ir.actions.act_window">
-            <field name="name">Repair Overview</field>
-            <field name="path">repair-types</field>
-            <field name="res_model">stock.picking.type</field>
-            <field name="view_mode">kanban,form</field>
-            <field name="domain">[('code', '=', 'repair_operation')]</field>
-            <field name="view_id" ref="stock.stock_picking_type_kanban"/>
-        </record>
-
-        <record id="action_repair_overview" model="ir.actions.server">
-            <field name="name">stock.repair.type.overview</field>
-            <field name="model_id" ref="model_stock_picking_type"/>
-            <field name="group_ids" eval="[(4, ref('stock.group_stock_user'))]"/>
-            <field name="state">code</field>
-            <field name="code">
-                action = model.action_repair_overview()
-            </field>
-        </record>
-
         <menuitem id="menu_repair_order" groups="stock.group_stock_user" name="Repairs" sequence="165"
                   web_icon="repair,static/description/icon.png"/>
-
-        <menuitem
-            id="repair_picking_type_menu"
-            name="Overview"
-            action="action_repair_overview"
-            groups="stock.group_stock_user"
-            parent="menu_repair_order"
-            sequence="0"
-        />
 
         <menuitem id="repair_order_menu" name="Orders" action="action_repair_order_tree" groups="stock.group_stock_user"
                   parent="menu_repair_order" sequence="10"/>
@@ -438,10 +390,11 @@
 
         <menuitem id="repair_menu_config" name="Configuration" parent="menu_repair_order" groups="stock.group_stock_manager" sequence="20"/>
 
-        <menuitem id="repair_menu_tag" name="Repair Orders Tags" parent="repair_menu_config" action="action_repair_order_tag" sequence="1"/>
         <menuitem id="repair_menu_product_template" name="Products" action="stock.product_template_action_product"
             parent="repair_menu_config" sequence="2"/>
         <menuitem id="repair_menu_product_product" name="Product Variants" action="stock.stock_product_normal_action"
             parent="repair_menu_config" sequence="3" groups="product.group_product_variant"/>
+        <menuitem id="repair_menu_tag" name="Repair Orders Tags" parent="repair_menu_config"
+            action="action_repair_order_tag" sequence="1000" groups="base.group_no_one"/>
     </data>
 </odoo>


### PR DESCRIPTION
- Moved "Operation Type" to the main form view, using the existing field to reflect the behavior of the "Overview" menu. This removes the need for a separate menu, making navigation clearer by showing relevant options directly within the form.
- Simplified the repair order form by removing the "Miscellaneous" tab, as "Locations" was redundant — hidden in draft state and readonly afterward — providing no added value.
- Renamed "Repair Orders" to "Repair Orders Analysis" with a pretty URL (/repair-orders-analysis) for clearer navigation.
- Removed the "Repair Order Tags" menu item, reducing clutter.

task-4557792