### PR TITLE
[FIX] mail: check for existing followers when creating mail_thread

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -263,7 +263,7 @@ class MailThread(models.AbstractModel):
                 threads._name, threads.ids,
                 self.env.user.partner_id.ids, subtypes=None,
                 customer_ids=[],
-                check_existing=False
+                check_existing=True
             )
 
         # auto_subscribe: take values and defaults into account


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- currently, we do not check for existing followers, at the time creating a mail thread but there are few exception, if an activity is created (which in turn, will add follower) beforehand, then this code fails, raising a [validation error](https://github.com/odoo/odoo/blob/17.0/addons/mail/models/mail_followers.py#L70) due to violation of unique constraint

## steps to reproduce
- install `sale_subscription` 
- add a automation rule to create a new activity when a sale order is created.

![image](https://github.com/user-attachments/assets/d238766e-8be7-46d5-a451-83de9232d32f)
- try to create and confirm a sale order. 

## Current behavior before PR:
![image](https://github.com/user-attachments/assets/aa9bc65d-fc5c-4e44-9a4e-67153efead3b)


## Desired behavior after PR is merged:
- Sale order is confirmed and Automated action worked as intended.
- Note: This does create few extra computation, but will also increase usability of studio+other app

opw-4624667


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
