### PR TITLE
[FIX] pos_restaurant: grid is not visible on grey background color

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.scss
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.scss
@@ -18,8 +18,8 @@
 }
 
 .floor-grid {
-    background-image: linear-gradient(0, $o-gray-300 14%, transparent 14%),
-    linear-gradient(90deg, transparent 90%, $o-gray-300 70%);
+    background-image: linear-gradient(0, rgba($o-gray-400, 0.5) 14%, transparent 14%),
+    linear-gradient(90deg, transparent 90%, rgba($o-gray-400, 0.5) 70%);
     background-size: 10px 10px;
 }
 


### PR DESCRIPTION
Steps to produce :
====
- Install pos_restaurant
- Create a new POS restaurant.
- Click on Edit Plan from the sidebar.
- Create the first floor, the background grid is visible.
- Create second floor.

Issue :
====
- Due to default grey color,the background grid is no longer visible.

Fix :
====
- The floor-grid css was not applied properly, opacity and little darker
solves the issue as floor has default grey backgorund color.

task-4619115
