### PR TITLE
[IMP] packaging: replace scripts with console_scripts entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,11 @@ setup(
     author_email=author_email,
     classifiers=[c for c in classifiers.split('\n') if c],
     license=license,
-    scripts=['setup/odoo'],
+    entry_points={
+        'console_scripts': [
+            'odoo = odoo.cli:main',
+        ],
+    },
     packages=find_packages(),
     package_dir={'%s' % lib_name: 'odoo'},
     include_package_data=True,

--- a/setup/odoo
+++ b/setup/odoo
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-# set server timezone in UTC before time module imported
-__import__('os').environ['TZ'] = 'UTC'
-import odoo
-
-if __name__ == "__main__":
-    odoo.cli.main()


### PR DESCRIPTION
console_scripts entry points is the standardized approach to declare scripts, and works better with a variety of installers.

In particular, setuptools' `scripts` keyword has a bug with standardized editable installs which prevents Odoo to be installed with uv in editable mode. See https://github.com/pypa/setuptools/issues/4863 for more information.

`__import__('os').environ['TZ'] = 'UTC'` that is in the script we replace is already done in `odoo/__init__.py` so the result will be equivalent, i.e. invoking `odoo.cli.main()`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
