### PR TITLE
[FIX] website, test_website: fix edit button visibility

### DIFF
--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 import wTourUtils from '@website/js/tours/tour_utils';
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 /**
  * The purpose of these tours is to check the systray visibility:
@@ -134,7 +135,7 @@ const canEdit = () => [
     },
 ];
 
-const cannotEdit = () => [{
+const cannotEdit = () => [stepUtils.waitIframeIsReady(), {
     content: "Check Edit is not available",
     trigger: '.o_menu_systray:not(:has(.o_edit_website_container))',
 }];

--- a/addons/website/static/src/systray_items/edit_website.js
+++ b/addons/website/static/src/systray_items/edit_website.js
@@ -115,7 +115,7 @@ class EditWebsiteSystray extends Component {
 
 export const systrayItem = {
     Component: EditWebsiteSystray,
-    isDisplayed: (env) => env.services.website.currentWebsite.metadata.editable || env.services.website.currentWebsite.metadata.translatable,
+    isDisplayed: (env) => env.services.website.isRestrictedEditor && (env.services.website.currentWebsite.metadata.editable || env.services.website.currentWebsite.metadata.translatable),
 };
 
 registry.category("website_systray").add("EditWebsite", systrayItem, { sequence: 7 });


### PR DESCRIPTION
When the "can publish" right was forward ported to 17.4, the whole website systray became visible for non-website users. The condition was moved to individual items like the "+New" button and the mobile preview button. However it was not added on the "Edit" button.

This commit fixes this by requiring the user to be at least a restricted editor to display the "Edit" button.
The negative test failed to catch this because for a short period of time, the systray is displayed without the "Edit" button.

[1]: https://github.com/odoo/odoo/commit/dc3f497dcf8701881016791b78368773ba66f5d2

task-3175890
