### PR TITLE
[FIX] point_of_sale: prevent showing not available data

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -2185,6 +2185,11 @@ export class PosStore extends Reactive {
     get showSaveOrderButton() {
         return this.isOpenOrderShareable();
     }
+
+    get availableCategories() {
+        const { limit_categories, iface_available_categ_ids } = this.config;
+        return limit_categories && iface_available_categ_ids;
+    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};


### PR DESCRIPTION
Before this commit, when limited categories were enabled and a limited pricelist was selected, loading the paid orders caused unavailable categories, pricelists, and products to appear in the PoS interface. This commit filters out these non-available items even if they are loaded, ensuring that only valid data is shown.

opw-4629843

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
