### PR TITLE
[IMP] html_editor: introduce keyboard shortcuts

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -102,6 +102,7 @@ export class FormatPlugin extends Plugin {
             { hotkey: "control+i", commandId: "formatItalic" },
             { hotkey: "control+u", commandId: "formatUnderline" },
             { hotkey: "control+5", commandId: "formatStrikethrough" },
+            { hotkey: "control+space", commandId: "removeFormat" },
         ],
         toolbar_groups: withSequence(20, { id: "decoration" }),
         toolbar_items: [

--- a/addons/html_editor/static/src/main/align/align_plugin.js
+++ b/addons/html_editor/static/src/main/align/align_plugin.js
@@ -35,6 +35,12 @@ export class AlignPlugin extends Plugin {
                 run: () => this.setAlignment("justify"),
             },
         ],
+        shortcuts: [
+            { hotkey: "control+shift+l", commandId: "alignLeft" },
+            { hotkey: "control+shift+e", commandId: "alignCenter" },
+            { hotkey: "control+shift+r", commandId: "alignRight" },
+            { hotkey: "control+shift+j", commandId: "justify" },
+        ],
         toolbar_groups: withSequence(29, { id: "alignment" }),
         toolbar_items: [
             {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -70,6 +70,11 @@ export class ListPlugin extends Plugin {
                 run: () => this.toggleListCommand({ mode: "CL" }),
             },
         ],
+        shortcuts: [
+            { hotkey: "control+shift+7", commandId: "toggleListOL" },
+            { hotkey: "control+shift+8", commandId: "toggleListUL" },
+            { hotkey: "control+shift+9", commandId: "toggleListCL" },
+        ],
         toolbar_groups: withSequence(30, { id: "list" }),
         toolbar_items: [
             {

--- a/addons/html_editor/static/tests/align.test.js
+++ b/addons/html_editor/static/tests/align.test.js
@@ -1,4 +1,5 @@
 import { describe, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
 import { testEditor } from "./_helpers/editor";
 import { alignCenter, justify, alignLeft, alignRight } from "./_helpers/user_actions";
 
@@ -84,6 +85,15 @@ describe("left", () => {
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: left;">a[]b</h1></div>',
         });
     });
+
+    test("should left align a container with shortcut", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: center;"><p>a[]b</p></div>',
+            stepFunction: () => press(["ctrl", "shift", "l"]),
+            contentAfter:
+                '<div style="text-align: center;"><p style="text-align: left;">a[]b</p></div>',
+        });
+    });
 });
 
 describe("center", () => {
@@ -157,6 +167,15 @@ describe("center", () => {
             stepFunction: alignCenter,
             contentAfter:
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: center;">a[]b</h1></div>',
+        });
+    });
+
+    test("should center align a container with shortcut", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: left;"><p>a[]b</p></div>',
+            stepFunction: () => press(["ctrl", "shift", "e"]),
+            contentAfter:
+                '<div style="text-align: left;"><p style="text-align: center;">a[]b</p></div>',
         });
     });
 });
@@ -234,6 +253,14 @@ describe("right", () => {
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: right;">a[]b</h1></div>',
         });
     });
+    test("should right align a container with shortcut", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: left;"><p>a[]b</p></div>',
+            stepFunction: () => press(["ctrl", "shift", "r"]),
+            contentAfter:
+                '<div style="text-align: left;"><p style="text-align: right;">a[]b</p></div>',
+        });
+    });
 });
 
 describe("justify", () => {
@@ -307,6 +334,15 @@ describe("justify", () => {
             stepFunction: justify,
             contentAfter:
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: justify;">a[]b</h1></div>',
+        });
+    });
+
+    test("should justify align a container with shortcut", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: right;"><p>a[]b</p></div>',
+            stepFunction: () => press(["ctrl", "shift", "j"]),
+            contentAfter:
+                '<div style="text-align: right;"><p style="text-align: justify;">a[]b</p></div>',
         });
     });
 });

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent } from "../_helpers/selection";
-import { click, queryAll, waitFor } from "@odoo/hoot-dom";
+import { click, press, queryAll, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { execCommand } from "../_helpers/userCommands";
 
@@ -132,6 +132,13 @@ test("should remove bold format (14)", async () => {
         contentAfter: "<div>a<strong>b</strong>[cd]<strong>e</strong>f</div>",
     });
 });
+test("should remove bold format with shortcut", async () => {
+    await testEditor({
+        contentBefore: "<div>ab<b>[cd]</b>ef</div>",
+        stepFunction: () => press(["control", "Space"]),
+        contentAfter: "<div>ab[cd]ef</div>",
+    });
+});
 test("should remove italic format (1)", async () => {
     await testEditor({
         contentBefore: "<div>ab<i>[cd]</i>ef</div>",
@@ -194,6 +201,13 @@ test("should remove italic format (9)", async () => {
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter:
             '<div>a<font style="font-style: italic">b</font>[cd]<font style="font-style: italic">e</font>f</div>',
+    });
+});
+test("should remove italic format with shortcut", async () => {
+    await testEditor({
+        contentBefore: "<div>ab<i>[cd]</i>ef</div>",
+        stepFunction: () => press(["control", "Space"]),
+        contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove underline format (1)", async () => {
@@ -266,6 +280,13 @@ test("should remove underline format (10)", async () => {
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter:
             '<div>a<font style="text-decoration-line: underline">b</font>[cd]<font style="text-decoration-line: underline">e</font>f</div>',
+    });
+});
+test("should remove underline format with shortcut", async () => {
+    await testEditor({
+        contentBefore: "<div>ab<u>[cd]</u>ef</div>",
+        stepFunction: () => press(["control", "Space"]),
+        contentAfter: "<div>ab[cd]ef</div>",
     });
 });
 test("should remove striketrough format (1)", async () => {
@@ -401,6 +422,13 @@ test("should remove text color (8)", async () => {
             '<div>a<font class="text-o-color-1">b</font>[cd]<font class="text-o-color-1">e</font>f</div>',
     });
 });
+test("should remove text color with shortcut", async () => {
+    await testEditor({
+        contentBefore: '<div>ab<font style="color: rgb(255, 0, 0);">[cd]</font>ef</div>',
+        stepFunction: () => press(["control", "Space"]),
+        contentAfter: "<div>ab[cd]ef</div>",
+    });
+});
 test("should remove background color (1)", async () => {
     await testEditor({
         contentBefore: '<div>ab<font style="background: rgb(0, 0, 255);">[cd]</font>ef</div>',
@@ -476,11 +504,26 @@ test("should remove background color (10)", async () => {
             '<div>a<font class="bg-o-color-1">b</font>[cd]<font class="bg-o-color-1">e</font>f</div>',
     });
 });
+test("should remove background color with shortcut", async () => {
+    await testEditor({
+        contentBefore: '<div>ab<font style="background: rgb(0, 0, 255);">[cd]</font>ef</div>',
+        stepFunction: () => press(["control", "Space"]),
+        contentAfter: "<div>ab[cd]ef</div>",
+    });
+});
 test("should remove the background image when clear the format", async () => {
     await testEditor({
         contentBefore:
             '<div><p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%);">[ab]</font></p></div>',
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<div><p>[ab]</p></div>",
+    });
+});
+test("should remove the background image when clear the format with shortcut", async () => {
+    await testEditor({
+        contentBefore:
+            '<div><p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%);">[ab]</font></p></div>',
+        stepFunction: () => press(["control", "Space"]),
         contentAfter: "<div><p>[ab]</p></div>",
     });
 });
@@ -498,6 +541,13 @@ test("should remove all the colors for the text separated by Shift+Enter when us
         contentAfter: `<div><h1>[ab<br>cd<br><font style="color: red">]ef</font></h1></div>`,
     });
 });
+test("should remove all the colors for the text separated by Shift+Enter when using removeFormat button with shortcut", async () => {
+    await testEditor({
+        contentBefore: `<div><h1><font style="color: red">[ab</font><br><font style="color: red">cd</font><br><font style="color: red">ef]</font></h1></div>`,
+        stepFunction: () => press(["control", "Space"]),
+        contentAfter: `<div><h1>[ab<br>cd<br>ef]</h1></div>`,
+    });
+});
 test("should remove all the colors for the text separated by Enter when using removeFormat button", async () => {
     await testEditor({
         contentBefore: `<div><h1><font style="background-color: red">[ab</font></h1><h1><font style="background-color: red">cd</font></h1><h1><font style="background-color: red">ef]</font></h1></div>`,
@@ -507,6 +557,18 @@ test("should remove all the colors for the text separated by Enter when using re
     await testEditor({
         contentBefore: `<div><h1><font style="color: red">[ab</font></h1><h1><font style="color: red">cd</font></h1><h1><font style="color: red">ef]</font></h1></div>`,
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: `<div><h1>[ab</h1><h1>cd</h1><h1>ef]</h1></div>`,
+    });
+});
+test("should remove all the colors for the text separated by Enter with shortcut", async () => {
+    await testEditor({
+        contentBefore: `<div><h1><font style="background-color: red">[ab</font></h1><h1><font style="background-color: red">cd</font></h1><h1><font style="background-color: red">ef]</font></h1></div>`,
+        stepFunction: () => press(["control", "Space"]),
+        contentAfter: `<div><h1>[ab</h1><h1>cd</h1><h1>ef]</h1></div>`,
+    });
+    await testEditor({
+        contentBefore: `<div><h1><font style="color: red">[ab</font></h1><h1><font style="color: red">cd</font></h1><h1><font style="color: red">ef]</font></h1></div>`,
+        stepFunction: () => press(["control", "Space"]),
         contentAfter: `<div><h1>[ab</h1><h1>cd</h1><h1>ef]</h1></div>`,
     });
 });
@@ -528,6 +590,13 @@ test("should remove multiple format (3)", async () => {
     await testEditor({
         contentBefore: "<div><p><b>a[bc</b></p><p>de<br>fg<br></p><p><i>ij</i>sd]fsf</p></div>",
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<div><p><b>a</b>[bc</p><p>de<br>fg<br></p><p>ijsd]fsf</p></div>",
+    });
+});
+test("should remove multiple format with shortcut", async () => {
+    await testEditor({
+        contentBefore: "<div><p><b>a[bc</b></p><p>de<br>fg<br></p><p><i>ij</i>sd]fsf</p></div>",
+        stepFunction: () => press(["control", "Space"]),
         contentAfter: "<div><p><b>a</b>[bc</p><p>de<br>fg<br></p><p>ijsd]fsf</p></div>",
     });
 });
@@ -588,6 +657,14 @@ test.todo("should remove multiple color (6)", async () => {
             '<div>ab<font style="background: blue">c</font>[de]<font class="bg-o-color-1">f</font>gh</div>',
     });
 });
+test("should remove multiple color with shortcut", async () => {
+    await testEditor({
+        contentBefore:
+            '<div>ab<font style="background: blue">c[d<font class="bg-o-color-1">ef]</font></font>gh</div>',
+        stepFunction: () => press(["control", "Space"]),
+        contentAfter: '<div>ab<font style="background: blue">c</font>[def]gh</div>',
+    });
+});
 test("undo remove format should return the element to it's original state", async () => {
     await testEditor({
         contentBefore:
@@ -638,6 +715,14 @@ test("should remove font-size style from multiple formatted selected text", asyn
     await testEditor({
         contentBefore: '<p>a<strong>bc<span style="font-size: 10px;">[de]</span>fg</strong>h</p>',
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>a<strong>bc</strong>[de]<strong>fg</strong>h</p>",
+    });
+});
+
+test("should remove font-size style from multiple formatted selected text with shortcut", async () => {
+    await testEditor({
+        contentBefore: '<p>a<strong>bc<span style="font-size: 10px;">[de]</span>fg</strong>h</p>',
+        stepFunction: () => press(["control", "Space"]),
         contentAfter: "<p>a<strong>bc</strong>[de]<strong>fg</strong>h</p>",
     });
 });

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
@@ -11,6 +12,14 @@ describe("Range collapsed", () => {
             await testEditor({
                 contentBefore: "<p>[]<br></p>",
                 stepFunction: toggleCheckList,
+                contentAfter: '<ul class="o_checklist"><li>[]<br></li></ul>',
+            });
+        });
+
+        test("should turn an empty paragraph into a checklist with shortcut", async () => {
+            await testEditor({
+                contentBefore: "<p>[]<br></p>",
+                stepFunction: () => press(["control", "shift", "9"]),
                 contentAfter: '<ul class="o_checklist"><li>[]<br></li></ul>',
             });
         });
@@ -417,6 +426,14 @@ describe("Range not collapsed", () => {
                 contentBefore: "<p>ab</p><p>cd[ef]gh</p>",
                 stepFunction: toggleCheckList,
                 contentAfter: '<p>ab</p><ul class="o_checklist"><li>cd[ef]gh</li></ul>',
+            });
+        });
+
+        test("should turn a paragraph into a checklist with shortcut", async () => {
+            await testEditor({
+                contentBefore: "<p>[abc]</p>",
+                stepFunction: () => press(["control", "shift", "9"]),
+                contentAfter: '<ul class="o_checklist"><li>[abc]</li></ul>',
             });
         });
 

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -1,4 +1,5 @@
 import { describe, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { toggleOrderedList } from "../_helpers/user_actions";
@@ -11,6 +12,14 @@ describe("Range collapsed", () => {
                 contentBeforeEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 stepFunction: toggleOrderedList,
                 contentAfterEdit: `<ol><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ol>`,
+                contentAfter: "<ol><li>[]<br></li></ol>",
+            });
+        });
+
+        test("should turn an empty paragraph into a list with shortcut", async () => {
+            await testEditor({
+                contentBefore: "<p>[]<br></p>",
+                stepFunction: () => press(["control", "shift", "7"]),
                 contentAfter: "<ol><li>[]<br></li></ol>",
             });
         });
@@ -258,6 +267,14 @@ describe("Range not collapsed", () => {
                 contentBefore: "<p>ab</p><p>cd[ef]gh</p>",
                 stepFunction: toggleOrderedList,
                 contentAfter: "<p>ab</p><ol><li>cd[ef]gh</li></ol>",
+            });
+        });
+
+        test("should turn a paragraph into a list with shortcut", async () => {
+            await testEditor({
+                contentBefore: "<p>[abc]</p>",
+                stepFunction: () => press(["control", "shift", "7"]),
+                contentAfter: "<ol><li>[abc]</li></ol>",
             });
         });
 

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -1,4 +1,5 @@
 import { describe, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { toggleUnorderedList } from "../_helpers/user_actions";
@@ -11,6 +12,14 @@ describe("Range collapsed", () => {
                 contentBeforeEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 stepFunction: toggleUnorderedList,
                 contentAfterEdit: `<ul><li o-we-hint-text="List" class="o-we-hint">[]<br></li></ul>`,
+                contentAfter: "<ul><li>[]<br></li></ul>",
+            });
+        });
+
+        test("should turn an empty paragraph into a list with shortcut", async () => {
+            await testEditor({
+                contentBefore: "<p>[]<br></p>",
+                stepFunction: () => press(["control", "shift", "8"]),
                 contentAfter: "<ul><li>[]<br></li></ul>",
             });
         });
@@ -324,6 +333,14 @@ describe("Range not collapsed", () => {
                 contentBefore: "<p>ab</p><p>cd[ef]gh</p>",
                 stepFunction: toggleUnorderedList,
                 contentAfter: "<p>ab</p><ul><li>cd[ef]gh</li></ul>",
+            });
+        });
+
+        test("should turn a paragraph into a list with shortcut", async () => {
+            await testEditor({
+                contentBefore: "<p>[abc]</p>",
+                stepFunction: () => press(["control", "shift", "8"]),
+                contentAfter: "<ul><li>[abc]</li></ul>",
             });
         });
 


### PR DESCRIPTION
### Purpose of this PR:

This commit introduces new keyboard shortcuts for text formatting, alignment, and list creation to improve the editing experience.

### Formatting:
Remove format → `Ctrl + Space`

### Text alignment:
Left → `Ctrl + Shift + L`
Center → `Ctrl + Shift + E`
Right → `Ctrl + Shift + R`
Justify → `Ctrl + Shift + J`

### Lists:
Numbered list → `Ctrl + Shift + 7`
Bullet list → `Ctrl + Shift + 8`
Checkbox list → `Ctrl + Shift + 9`

task-4595308

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
