### PR TITLE
[FIX] hr: fix resource calendar access

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -672,7 +672,7 @@ class HrEmployee(models.Model):
         """
         if not dt:
             calendars = self._get_calendars()
-            return {emp_id: calendar.tz for emp_id, calendar in calendars.items()}
+            return {emp_id: calendar.sudo().tz for emp_id, calendar in calendars.items()}
 
         employees_by_tz = self.grouped(lambda emp: emp._get_tz())
 
@@ -680,7 +680,7 @@ class HrEmployee(models.Model):
         for tz, employee_ids in employees_by_tz.items():
             date_at = timezone(tz).localize(dt).date()
             calendars = self._get_calendars(date_at)
-            employee_timezones |= {emp_id: cal.tz for emp_id, cal in calendars.items()}
+            employee_timezones |= {emp_id: cal.sudo().tz for emp_id, cal in calendars.items()}
         return employee_timezones
 
     def _employee_attendance_intervals(self, start, stop, lunch=False):


### PR DESCRIPTION
-- Context and behavior before the fix
When we want to check in an employee in attendance kiosk mode, a call is made to a function to get the employee's calendar timezone. However, since we are logged out, an access error occurs.

-- How to reproduce
Install hr_attendance and hr_contract. Set up an employee with a valid working contract. Enter the kiosk mode and try to check in

-- Fix
To fix the issue, we use a sudo version of the calendar record to get the timezone. This is valid security-wise as the timezone is not a record.

task-4599567
