### PR TITLE
[ADD] pos_update: add public_discription in ProductInfoPopup

### DIFF
--- a/addons/pos_update/__init__.py
+++ b/addons/pos_update/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/pos_update/__manifest__.py
+++ b/addons/pos_update/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': 'Point Of Sale Update',
+    'version': '1.0',
+    'description': 'Remove Barcode field if product type is "combo" (in point_of_sale)',
+    'depends': ['point_of_sale'],
+    'data': [
+        'views/product_views.xml',
+    ],
+    'assets': {
+    'point_of_sale._assets_pos': [
+        'pos_update/static/src/**/*'
+    ],
+    },
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/pos_update/models/__init__.py
+++ b/addons/pos_update/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_update_product

--- a/addons/pos_update/models/pos_update_product.py
+++ b/addons/pos_update/models/pos_update_product.py
@@ -1,0 +1,11 @@
+from odoo import api,models
+
+class ProductProduct(models.Model):
+
+    _inherit = "product.product"
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        fields = super()._load_pos_data_fields(config_id)
+        fields += ['public_description']
+        return fields

--- a/addons/pos_update/static/src/app/component/public_description/product_public_description.xml
+++ b/addons/pos_update/static/src/app/component/public_description/product_public_description.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template_id" xml:space="preserve">
+    <t t-name="template" t-inherit="point_of_sale.ProductInfoPopup" t-inherit-mode="extension">
+        <xpath expr="//ProductInfoBanner" position="after">
+                <t t-debug="pdb"/>
+                <h3 class="section-title">
+                    Description
+                </h3>
+                <t t-if="props.product.public_description">
+                    <span class="modal-body o_self_order_main_desc fs-3 p-4 ps-5 overflow-auto" t-out="props.product.public_description"/>
+                </t>
+                <t t-else="">
+                    <span class="modal-body o_self_order_main_desc fs-3 p-4 ps-5 overflow-auto">No description available</span>
+                </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_update/views/product_views.xml
+++ b/addons/pos_update/views/product_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- when product type is combo barcode field is invisible -->
+    <record id="product_product_view_form_normalized_pos_update" model="ir.ui.view">
+        <field name="name">product.product.view.form.normalized.pos_update.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_product_view_form_normalized" />
+        <field name="arch" type="xml">
+            <field name="barcode" position="attributes">
+                <attribute name="invisible">type == 'combo'</attribute>
+            </field>
+        </field>
+    </record>
+    <!-- public_description field visible in point_of_sale -->
+    <record id="product_template_form_view_pos_update" model="ir.ui.view">
+        <field name="name">product.template.form.pos_update.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='public_description']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
before this commit:

- public_description is not visible in point_of_sale
- barcode field is visible when product type is combo

after this commit:

- added public_description in ProductInfoPopup in point_of_sale
- [FIX] barcode field - now when product type is combo barcode field is not visible