### PR TITLE
[FIX] html_editor: text color test based on default color

### DIFF
--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -112,7 +112,8 @@ test("should not apply color on an uneditable element", async () => {
 });
 
 test("should apply color with default text color on block when applying background color", async () => {
-    const defaultTextColor = "color: rgb(55, 65, 81);";
+    const defaultTextColor = "color: rgb(1, 10, 100);";
+    const styleContent = `* {${defaultTextColor}}`;
     await testEditor({
         contentBefore: unformat(`
                 <table><tbody>
@@ -127,11 +128,13 @@ test("should apply color with default text color on block when applying backgrou
                     <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">cd]</td></tr>
                 </tbody></table>
             `),
+        styleContent,
     });
 });
 
 test("should remove color from block when removing background color", async () => {
-    const defaultTextColor = "color: rgb(55, 65, 81);";
+    const defaultTextColor = "color: rgb(1, 10, 100);";
+    const styleContent = `* {${defaultTextColor}}`;
     await testEditor({
         contentBefore: unformat(`
             <table><tbody>
@@ -146,11 +149,13 @@ test("should remove color from block when removing background color", async () =
                 <tr><td>cd]</td></tr>
             </tbody></table>
         `),
+        styleContent,
     });
 });
 
 test("should not apply background color on an uneditable selected cell in a table", async () => {
-    const defaultTextColor = "color: rgb(55, 65, 81);";
+    const defaultTextColor = "color: rgb(1, 10, 100);";
+    const styleContent = `* {${defaultTextColor};}`;
     await testEditor({
         contentBefore: unformat(`
                 <table><tbody>
@@ -167,6 +172,7 @@ test("should not apply background color on an uneditable selected cell in a tabl
                     <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}">ef]</td></tr>
                 </tbody></table>
             `),
+        styleContent,
     });
 });
 

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -168,7 +168,9 @@ test("select hex color and apply it", async () => {
 });
 
 test("always show the current custom color", async () => {
-    const { el } = await setupEditor(`<p>[test]</p>`);
+    const defaultTextColor = "rgb(1, 10, 100)";
+    const styleContent = `* {color: ${defaultTextColor};}`;
+    await setupEditor(`<p>[test]</p>`, { styleContent });
     await waitFor(".o-we-toolbar");
     await click(".o-we-toolbar .o-select-color-foreground");
     await animationFrame();
@@ -178,7 +180,6 @@ test("always show the current custom color", async () => {
     await click(".o_hex_input");
     await animationFrame();
     expect(".o_colorpicker_section:nth-of-type(1) button").toHaveCount(1);
-    const defaultTextColor = getComputedStyle(el.querySelector("p")).color;
     expect(queryOne(".o_colorpicker_section:nth-of-type(1) button").style.backgroundColor).toBe(
         defaultTextColor,
         { message: "backgroundColor is the default black" }
@@ -282,10 +283,13 @@ test("selected text color is shown in the toolbar and update when clicking", asy
     expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgb(255, 0, 255)" });
 });
 test("selected text color is not shown in the toolbar after removeFormat", async () => {
+    const defaultTextColor = "rgb(1, 10, 100)";
+    const styleContent = `* {color: ${defaultTextColor};}`;
     const { el } = await setupEditor(
         `<p>
             <font style="color: rgb(255, 0, 0);">t[es]t</font>
-        </p>`
+        </p>`,
+        { styleContent }
     );
 
     await waitFor(".o-we-toolbar");
@@ -297,8 +301,7 @@ test("selected text color is not shown in the toolbar after removeFormat", async
             <font style="color: rgb(255, 0, 0);">t</font>[es]<font style="color: rgb(255, 0, 0);">t</font>
         </p>`);
     await animationFrame();
-    const defaultBodyColor = window.getComputedStyle(document.body)["color"];
-    expect("i.fa-font").toHaveStyle({ borderBottomColor: defaultBodyColor });
+    expect("i.fa-font").toHaveStyle({ borderBottomColor: defaultTextColor });
 });
 
 test("collapsed selection color is shown in the permanent toolbar", async () => {
@@ -508,8 +511,10 @@ describe("color preview", () => {
     });
 
     test("should preview color in table on hover in solid tab", async () => {
-        const defaultTextColor = "color: rgb(55, 65, 81);";
-        const { el } = await setupEditor(`
+        const defaultTextColor = "color: rgb(1, 10, 100);";
+        const styleContent = `* {${defaultTextColor}}`;
+        const { el } = await setupEditor(
+            `
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr>
@@ -524,7 +529,9 @@ describe("color preview", () => {
                     </tr>
                 </tbody>
             </table>
-        `);
+        `,
+            { styleContent }
+        );
         await waitFor(".o-we-toolbar");
         await animationFrame();
         await click(".o-select-color-background");
@@ -570,8 +577,10 @@ describe("color preview", () => {
     });
 
     test("should preview color in table on hover in custom tab", async () => {
-        const defaultTextColor = "color: rgb(55, 65, 81);";
-        const { el } = await setupEditor(`
+        const defaultTextColor = "color: rgb(1, 10, 100);";
+        const styleContent = `* {${defaultTextColor}}`;
+        const { el } = await setupEditor(
+            `
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr>
@@ -586,7 +595,9 @@ describe("color preview", () => {
                     </tr>
                 </tbody>
             </table>
-        `);
+        `,
+            { styleContent }
+        );
         await waitFor(".o-we-toolbar");
         await animationFrame();
         await click(".o-select-color-background");


### PR DESCRIPTION
Before this commit, some tests based on the default text color only worked if the tests were run with enterprise because the default text color was hard-coded based on the style of enterprise.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
