### PR TITLE
[IMP] mail: indicate last edited date on hover

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4607,7 +4607,7 @@ class MailThread(models.AbstractModel):
         if body is not None:
             msg_values["body"] = (
                 # keep html if already Markup, otherwise escape
-                escape(body) + Markup("<span class='o-mail-Message-edited'/>")
+                escape(body) + Markup("<span class='o-mail-Message-edited' data-oe-expression='%s'/>") % fields.Datetime.to_string(fields.Datetime.now())
                 if body or not message._filter_empty()
                 else ""
             )

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -389,7 +389,9 @@ export class Message extends Component {
             return;
         }
         const editedEl = bodyEl.querySelector(".o-mail-Message-edited");
-        editedEl?.replaceChildren(renderToElement("mail.Message.edited"));
+        editedEl?.replaceChildren(
+            renderToElement("mail.Message.edited", { message: this.message })
+        );
         const linkEls = bodyEl.querySelectorAll(".o_channel_redirect");
         for (const linkEl of linkEls) {
             const text = linkEl.textContent.substring(1); // remove '#' prefix

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -23,6 +23,10 @@
     opacity: 35%;
 }
 
+.o-mail-Message-edited {
+    opacity: 50%;
+}
+
 .o-mail-Message-sidebar {
     flex-basis: $o-mail-Message-sidebarWidth;
     max-width: $o-mail-Message-sidebarWidth;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -20,7 +20,7 @@
                         </div>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>
                         <t t-elif="!message.is_transient">
-                            <small t-if="isActive and props.showDates" class="o-mail-Message-date o-xsmaller mt-2 text-center lh-1" t-att-title="message.datetimeShort">
+                            <small t-if="isActive and props.showDates" class="o-mail-Message-date o-xsmaller mt-2 text-center lh-1" t-att-title="message.datetimeMedium">
                                 <t t-esc="message.dateSimple"/>
                             </small>
                         </t>
@@ -31,7 +31,7 @@
                                 <strong class="me-1" t-esc="message.authorName"/>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
-                            <small t-if="!message.is_transient" class="o-mail-Message-date o-xsmaller" t-att-title="message.datetimeShort">
+                            <small t-if="!message.is_transient" class="o-mail-Message-date o-xsmaller" t-att-title="message.datetimeMedium">
                                 <t t-if="message.isPending" t-call="mail.Message.pendingStatus"/>
                                 <t t-else="" t-out="message.dateSimpleWithDay"/>
                             </small>
@@ -122,7 +122,7 @@
     </t>
 
 <t t-name="mail.Message.edited">
-    <em class="smaller fw-bold text-500"> (edited)</em>
+    <span class="o-xsmaller fw-bold" t-att-title="message.editedDatetimeMedium"> (edited)</span>
 </t>
 
 <t t-name="mail.Message.actions">

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -31,6 +31,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { getOrigin, url } from "@web/core/utils/urls";
+import { user } from "@web/core/user";
 
 const { DateTime } = luxon;
 
@@ -349,6 +350,7 @@ test("Do not stop edition on click away when clicking on emoji", async () => {
 });
 
 test("Edit and click save", async () => {
+    mockDate("2025-01-01 12:00:00", +1);
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "general",
@@ -367,6 +369,7 @@ test("Edit and click save", async () => {
     await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-body", { text: "Goodbye World (edited)" });
+    await contains("span[title='Jan 1, 2025, 1:00 PM']:contains('(edited)')");
 });
 
 test("Do not call server on save if no changes", async () => {
@@ -800,7 +803,7 @@ test("basic rendering of message", async () => {
     await contains(
         `.o-mail-Message .o-mail-Message-header .o-mail-Message-date[title='${deserializeDateTime(
             "2019-04-20 10:00:00"
-        ).toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS)}']`
+        ).toLocaleString({ ...DateTime.DATETIME_MED }, { locale: user.lang })}']`
     );
 });
 

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -673,7 +673,9 @@ async function mail_message_update_content(request) {
     const [message] = MailMessage.browse(message_id);
     const msg_values = {};
     if (body !== null) {
-        const edit_label = "<span class='o-mail-Message-edited'/>";
+        const edit_label = `<span class='o-mail-Message-edited' data-oe-expression="${serializeDateTime(
+            DateTime.now()
+        )}"/>`;
         msg_values.body = body === "" && attachment_ids.length === 0 ? "" : body + edit_label;
     }
     if (attachment_ids.length === 0) {

--- a/addons/mail/tests/common_controllers.py
+++ b/addons/mail/tests/common_controllers.py
@@ -1,5 +1,6 @@
 import json
 
+from freezegun import freeze_time
 from markupsafe import Markup
 from requests.exceptions import HTTPError
 
@@ -267,9 +268,10 @@ class MailControllerUpdateCommon(MailControllerCommon):
             user, guest = self._authenticate_pseudo_user(data_user)
             with self.subTest(user=user.name, guest=guest.name, route_kw=route_kw):
                 if allowed:
-                    self._update_content(message.id, self.alter_message_body, route_kw)
+                    with freeze_time('2025-04-08 12:00:00'):
+                        self._update_content(message.id, self.alter_message_body, route_kw)
                     self.assertEqual(message.body,
-                                     Markup('<p>Altered message body<span class="o-mail-Message-edited"></span></p>'))
+                                     Markup('<p>Altered message body<span class="o-mail-Message-edited" data-oe-expression="2025-04-08 12:00:00"></span></p>'))
                 else:
                     with self.assertRaises(
                         JsonRpcException,

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo import fields
@@ -805,6 +806,7 @@ class TestChannelRTC(MailCommon):
             channel_member_test_guest._rtc_leave_call()
 
     @users('employee')
+    @freeze_time('2025-04-08 12:00:00')
     @mute_logger('odoo.models.unlink')
     def test_25_lone_call_participant_leaving_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
@@ -934,7 +936,7 @@ class TestChannelRTC(MailCommon):
                                 "attachment_ids": [],
                                 "body": [
                                     "markup",
-                                    '<div data-oe-type="call" class="o_mail_notification"></div><span class="o-mail-Message-edited"></span>',
+                                    '<div data-oe-type="call" class="o_mail_notification"></div><span class="o-mail-Message-edited" data-oe-expression="2025-04-08 12:00:00"></span>',
                                 ],
                                 "id": channel.last_call_message_id.id,
                                 "pinned_at": False,
@@ -1156,6 +1158,7 @@ class TestChannelRTC(MailCommon):
         self.assertEqual(self._new_bus_notifs, found_bus_notifs)
 
     @users('employee')
+    @freeze_time('2025-04-08 12:00:00')
     @mute_logger('odoo.models.unlink')
     def test_40_leave_call_should_remove_existing_sessions_of_user_in_channel_and_return_data(self):
         channel = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
@@ -1195,7 +1198,7 @@ class TestChannelRTC(MailCommon):
                                 "attachment_ids": [],
                                 "body": [
                                     "markup",
-                                    '<div data-oe-type="call" class="o_mail_notification"></div><span class="o-mail-Message-edited"></span>',
+                                    '<div data-oe-type="call" class="o_mail_notification"></div><span class="o-mail-Message-edited" data-oe-expression="2025-04-08 12:00:05"></span>',
                                 ],
                                 "id": channel.last_call_message_id.id,
                                 "pinned_at": False,

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1,3 +1,4 @@
+from freezegun import freeze_time
 from markupsafe import Markup
 from unittest.mock import patch
 from unittest.mock import DEFAULT
@@ -179,8 +180,9 @@ class TestAPI(MailCommon, TestRecipients):
             partner_ids=self.partner_1.ids,
         )
         self.assertEqual(message.body, expected)
-        ticket_record._message_update_content(message, "Hello <R&D/>")
-        self.assertEqual(message.body, Markup('<p>Hello &lt;R&amp;D/&gt;<span class="o-mail-Message-edited"></span></p>'))
+        with freeze_time('2025-04-08 10:00:00'):
+            ticket_record._message_update_content(message, "Hello <R&D/>")
+        self.assertEqual(message.body, Markup('<p>Hello &lt;R&amp;D/&gt;<span class="o-mail-Message-edited" data-oe-expression="2025-04-08 10:00:00"></span></p>'))
 
     @users('employee')
     def test_mail_partner_find_from_emails(self):
@@ -922,30 +924,33 @@ class TestAPI(MailCommon, TestRecipients):
         self.assertEqual(message.subtype_id, self.env.ref('mail.mt_note'))
 
         # clear the content when having attachments should show edit label
-        ticket_record._message_update_content(message, "",)
+        with freeze_time('2025-04-08 10:00:00'):
+            ticket_record._message_update_content(message, "")
         self.assertEqual(message.attachment_ids, attachments)
-        self.assertEqual(message.body, Markup('<span class="o-mail-Message-edited"></span>'))
+        self.assertEqual(message.body, Markup('<span class="o-mail-Message-edited" data-oe-expression="2025-04-08 10:00:00"></span>'))
         # update the content with new attachments
         new_attachments = self.env['ir.attachment'].create(
             self._generate_attachments_data(2, 'mail.compose.message', 0)
         )
-        ticket_record._message_update_content(
-            message, Markup("<p>New Body</p>"),
-            attachment_ids=new_attachments.ids
-        )
+        with freeze_time('2025-04-08 12:00:00'):
+            ticket_record._message_update_content(
+                message, Markup("<p>New Body</p>"),
+                attachment_ids=new_attachments.ids
+            )
         self.assertEqual(message.attachment_ids, attachments + new_attachments)
         self.assertEqual(set(message.mapped('attachment_ids.res_id')), set(ticket_record.ids))
         self.assertEqual(set(message.mapped('attachment_ids.res_model')), set([ticket_record._name]))
-        self.assertEqual(message.body, Markup('<p>New Body</p><span class="o-mail-Message-edited"></span>'))
+        self.assertEqual(message.body, Markup('<p>New Body</p><span class="o-mail-Message-edited" data-oe-expression="2025-04-08 12:00:00"></span>'))
 
         # void attachments
-        ticket_record._message_update_content(
-            message, Markup("<p>Another Body, void attachments</p>"),
-            attachment_ids=[]
-        )
+        with freeze_time('2025-04-08 13:00:00'):
+            ticket_record._message_update_content(
+                message, Markup("<p>Another Body, void attachments</p>"),
+                attachment_ids=[]
+            )
         self.assertFalse(message.attachment_ids)
         self.assertFalse((attachments + new_attachments).exists())
-        self.assertEqual(message.body, Markup('<p>Another Body, void attachments</p><span class="o-mail-Message-edited"></span>'))
+        self.assertEqual(message.body, Markup('<p>Another Body, void attachments</p><span class="o-mail-Message-edited" data-oe-expression="2025-04-08 13:00:00"></span>'))
 
     @mute_logger('openerp.addons.mail.models.mail_mail')
     @users('employee')


### PR DESCRIPTION
Purpose:

previously, there was no indication of when a message was last edited. now, hovering over the '(edited)' text will display the last edited date and time.

This commit also changes the style of "edited" to be more different from text content.

task-4614516

![Screenshot 2025-04-08 at 15 44 55](https://github.com/user-attachments/assets/a035c791-6086-472e-85f1-ff99e8fa40f2)
![Screenshot 2025-04-08 at 15 46 59](https://github.com/user-attachments/assets/156ab7d4-3c73-4082-a8aa-299fd4f347e6)

