### PR TITLE
[FIX] point_of_sale: prevent session Id gap

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1665,6 +1665,8 @@ class PosSession(models.Model):
         return self.config_id.open_ui()
 
     def set_opening_control(self, cashbox_value: int, notes: str):
+        if self.state != 'opening_control':
+            return
         self.state = 'opened'
         self.start_at = fields.Datetime.now()
         if not self.rescue:

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -856,9 +856,8 @@ class TestPoSBasicConfig(TestPoSCommon):
 
         def open_and_check(pos_data):
             self.config = pos_data['config']
-            self.open_new_session()
+            self.open_new_session(pos_data['amount_paid'])
             session = self.pos_session
-            session.set_opening_control(pos_data['amount_paid'], False)
             self.assertEqual(session.cash_register_balance_start, pos_data['amount_paid'])
 
         pos01_config = self.config


### PR DESCRIPTION
Before this commit, if a session was opened on two devices concurrently, both devices could set the opening control. This resulted in duplicate opening cash setting and a gap in the session ID sequence. This fix ensures that opening control is set only once, maintaining correct session tracking.

opw-4627585

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
