### PR TITLE
[FIX] website_event: add turnstile on modal shown

### DIFF
--- a/addons/website_event/static/src/js/website_event.js
+++ b/addons/website_event/static/src/js/website_event.js
@@ -91,7 +91,6 @@ var EventRegistrationForm = publicWidget.Widget.extend({
         }
         const modalEl = new DOMParser().parseFromString(modal, "text/html").body.firstChild;
         const form = modalEl.querySelector("form#attendee_registration");
-        this._addTurnstile(form);
         const _onClick = () => {
             buttonEl.disabled = false;
             modalEl.querySelector(".js_goto_event").removeEventListener("click", _onClick);
@@ -106,6 +105,11 @@ var EventRegistrationForm = publicWidget.Widget.extend({
             tokenInput.setAttribute("type", "hidden");
             tokenInput.setAttribute("value", recaptchaToken.token);
             ev.currentTarget.appendChild(tokenInput);
+        });
+        // the turnstile container needs to be already appended to the dom before rendering
+        // see modal.js for events
+        modalEl.addEventListener("shown.bs.modal", () => {
+            this._addTurnstile(form);
         });
         const formModal = Modal.getOrCreateInstance(modalEl, {
             backdrop: "static",


### PR DESCRIPTION
[1] migrates jquery for event form modal display
for the more standard modal.js component.

This means the modal is not yet added to the document when `_addTurnstile` is added which makes rendering fail.

We now wait for the modal to be shown before adding turnstile.

[1]: 8510021c1b5395fb2cb134bbeab93ecd536ba5a6

task-4335141