### PR TITLE
[FIX] im_livechat: fix ellipsis overlap with leave warning on mobile

### DIFF
--- a/addons/im_livechat/static/src/embed/common/close_confirmation.scss
+++ b/addons/im_livechat/static/src/embed/common/close_confirmation.scss
@@ -1,0 +1,3 @@
+.o-livechat-CloseConfirmation{
+    z-index: $o-mail-NavigableList-zIndex - 1;
+}

--- a/addons/im_livechat/static/src/embed/common/close_confirmation.xml
+++ b/addons/im_livechat/static/src/embed/common/close_confirmation.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.CloseConfirmation">
         <div
-            class="o-livechat-CloseConfirmation z-1 bg-black-50 position-absolute w-100 h-100 d-flex justify-content-center align-items-center"
+            class="o-livechat-CloseConfirmation bg-black-50 position-absolute w-100 h-100 d-flex justify-content-center align-items-center"
             t-on-keydown.capture.stop="onKeydown"
             t-on-click.stop="() => this.props.onCloseConfirmationDialog()"
             t-ref="root"


### PR DESCRIPTION
**Current behavior before PR:**

prior to this PR ellipsis was overlapping the leave warning dialog-box.

**Desired behavior after PR is merged:**

now issue was resolved by adding z-index to dialog-box higher then ellipsis.

task-4630702

before PR:
![image](https://github.com/user-attachments/assets/ded40f91-c563-4280-bc70-2f58e23514da)
after PR:
![image](https://github.com/user-attachments/assets/eb346aab-a47e-497c-86b8-6214e8915bc0)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
