### PR TITLE
[FIX] core: handle usage of LazyTranslate in Markup.format calls

### DIFF
--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -162,6 +162,10 @@ class TestImport(common.TransactionCase):
         context = {'lang': 'fr_FR'}
         self.assertEqual(str(BOOLEAN_TRANSLATIONS[0]), 'oui')
 
+        # test lazy translation in `Markup.format()` calls
+        safe = Markup("<p>{}</p>").format(BOOLEAN_TRANSLATIONS[0])
+        self.assertEqual(safe, "<p>oui</p>")
+
     def test_import_from_csv_file(self):
         """Test the import from a single CSV file works"""
         with file_open('test_translation_import/i18n/dot.csv', 'rb') as f:

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -31,7 +31,7 @@ from tokenize import generate_tokens, STRING, NEWLINE, INDENT, DEDENT
 
 from babel.messages import extract
 from lxml import etree, html
-from markupsafe import escape, Markup
+from markupsafe import escape, Markup, __file__ as _MARKUPSAFE_LOC
 from psycopg2.extras import Json
 
 import odoo
@@ -593,6 +593,11 @@ def _get_translation_source(stack_level: int, module: str = '', lang: str = '', 
         frame = inspect.currentframe()
         for _index in range(stack_level + 1):
             frame = frame.f_back
+
+        # handle `Markup.format()` calls
+        if frame.f_back.f_code.co_filename == _MARKUPSAFE_LOC and frame.f_code.co_name == "format_field":
+            frame = frame.f_back.f_back.f_back.f_back.f_back
+
         lang = lang or _get_lang(frame, default_lang)
     if lang and lang != 'en_US':
         return get_translated_module(module or frame), lang


### PR DESCRIPTION
When formatting Markup object with LazyTranslate objects, we need to rewind a few frames back to find the lang to use.

Runbot build error: https://runbot.odoo.com/odoo/runbot.build.error/98431

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
