### PR TITLE
[FIX] crm: give priority to leads with high probabilty

### DIFF
--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -461,6 +461,58 @@ class TestLeadAssign(TestLeadAssignCommon):
         self.assertMemberAssign(test_sales_team_m2, 3)
         self.assertMemberAssign(test_sales_team_m3, 3)
 
+    def test_assign_preferred_and_probability(self):
+        random.seed(1914)
+        preferred_tag = self.env['crm.tag'].create({'name': 'preferred'})
+        leads = self._create_leads_batch(
+            lead_type='lead',
+            user_ids=[False],
+            count=10,
+        )
+        for proba, lead in enumerate(leads[:5]):
+            lead.write({
+                'tag_ids': [(6, 0, preferred_tag.ids)],
+                'probability': proba,
+            })
+
+        for proba, lead in enumerate(leads[5:]):
+            lead.write({
+                'probability': proba,
+            })
+            proba += 1
+
+        leads.flush_recordset()
+
+        test_sales_team = self.env['crm.team'].create({
+            'name': 'Sales Team 5',
+            'sequence': 15,
+            'alias_name': False,
+            'use_leads': True,
+            'use_opportunities': True,
+            'company_id': False,
+            'user_id': False,
+        })
+        test_sales_team_m1 = self.env['crm.team.member'].create({
+            'user_id': self.user_sales_manager.id,
+            'crm_team_id': test_sales_team.id,
+            'assignment_max': 180,
+            'assignment_domain': False,
+            'assignment_domain_preferred': "[('tag_ids', 'in', %s)]" % preferred_tag.ids,
+        })
+
+        test_sales_team._action_assign_leads()
+
+        member_leads = self.env['crm.lead'].search([
+            ('user_id', '=', test_sales_team_m1.user_id.id),
+            ('team_id', '=', test_sales_team_m1.crm_team_id.id),
+            ('date_open', '>=', Datetime.now() - timedelta(hours=24)),
+        ])
+        self.assertEqual(
+                len(member_leads.filtered_domain(literal_eval(test_sales_team_m1.assignment_domain_preferred))),
+                3
+            )
+        self.assertMemberAssign(test_sales_team_m1, 6)
+
     def test_assign_quota(self):
         """ Test quota computation """
         self.assertInitialData()


### PR DESCRIPTION
Since we've added the preferred domain field, the leads are firstly
assigned to members matching the preffered domain. The issue with this
behavor is that a memeber with prefered domain can get a lot of leads
with low probability because they match his preferred domain.

So we process the leads in the order of probabilities and if it match a
preferred domain, it'll be assigned to the member, and if not we choose
one without the matching preferred domain.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
