### PR TITLE
[IMP] cli: remove obsolete encoding declaration from templates

### DIFF
--- a/odoo/cli/templates/default/__init__.py.template
+++ b/odoo/cli/templates/default/__init__.py.template
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import controllers
 from . import models

--- a/odoo/cli/templates/default/__manifest__.py.template
+++ b/odoo/cli/templates/default/__manifest__.py.template
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 {
     'name': "{{ name }}",
 

--- a/odoo/cli/templates/default/controllers/__init__.py.template
+++ b/odoo/cli/templates/default/controllers/__init__.py.template
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import controllers

--- a/odoo/cli/templates/default/controllers/controllers.py.template
+++ b/odoo/cli/templates/default/controllers/controllers.py.template
@@ -1,7 +1,6 @@
 {%- set mod = name|snake -%}
 {%- set model = "%s.%s"|format(mod, mod) -%}
 {%- set root = "/%s/%s"|format(mod, mod) -%}
-# -*- coding: utf-8 -*-
 # from odoo import http
 
 

--- a/odoo/cli/templates/default/models/__init__.py.template
+++ b/odoo/cli/templates/default/models/__init__.py.template
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import models

--- a/odoo/cli/templates/default/models/models.py.template
+++ b/odoo/cli/templates/default/models/models.py.template
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # from odoo import models, fields, api
 
 


### PR DESCRIPTION
UTF-8 has been the default encoding since Python 3. Therefore, defining it at the top of a Python file is useless.

This commit removes the `# -*- coding: utf-8 -*-` comment from the scaffold default templates, so as not to perpetuate outdated practice.