### PR TITLE
[FIX] spreadsheet: fetch currency display name

### DIFF
--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -86,6 +86,7 @@ export class ListDataSource extends OdooViewsDataSource {
                     spec[field.currency_field] = {
                         fields: {
                             ...spec[field.currency_field]?.fields,
+                            display_name: {},
                             name: {}, // currency code
                             symbol: {},
                             decimal_places: {},

--- a/addons/spreadsheet/static/tests/lists/list_plugin_test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin_test.js
@@ -542,6 +542,7 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
                     assert.strictEqual(Object.keys(spec).length, 2);
                     assert.deepEqual(spec.currency_id, {
                         fields: {
+                            display_name: {},
                             name: {},
                             symbol: {},
                             decimal_places: {},
@@ -581,6 +582,16 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
             assert.strictEqual(getEvaluatedCell(model, "A2").value, "EUR");
         }
     );
+
+    QUnit.test("add currency field after the list has been loaded", async function (assert) {
+        const { model } = await createSpreadsheetWithList({
+            columns: ["pognon"],
+        });
+        setCellContent(model, "A1", '=ODOO.LIST(1, 1, "pognon")');
+        await waitForDataSourcesLoaded(model);
+        setCellContent(model, "A2", '=ODOO.LIST(1, 1, "currency_id")');
+        assert.strictEqual(getEvaluatedCell(model, "A2").value, "EUR");
+    });
 
     QUnit.test("Spec of web_search_read is minimal", async function (assert) {
         const spreadsheetData = {


### PR DESCRIPTION
Steps to reproduce:

- Go to Accounting > Customers > Invoices
- Insert the list into a spreadsheet
- in any cell, type `=ODOO.LIST(1,1,"company_currency_id")`

=> the currency is not displayed.

The reason is that the `company_currency_id` is fetched as part of a monetary field. When the new `=ODOO.LIST(1,1,"company_currency_id")` is typed, the list data source thinks it has the data, but actually the `dislay_name` is missing.

Task: 4633078

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
