### PR TITLE
[FIX] sales_team: archive team member when user is archived

### DIFF
--- a/addons/sales_team/models/res_users.py
+++ b/addons/sales_team/models/res_users.py
@@ -33,3 +33,7 @@ class ResUsers(models.Model):
             else:
                 sorted_memberships = user.crm_team_member_ids  # sorted by create date
                 user.sale_team_id = sorted_memberships[0].crm_team_id if sorted_memberships else False
+
+    def action_archive(self):
+        self.env['crm.team.member'].search([('user_id', 'in', self.ids)]).action_archive()
+        return super().action_archive()

--- a/addons/sales_team/tests/test_sales_team_membership.py
+++ b/addons/sales_team/tests/test_sales_team_membership.py
@@ -19,6 +19,12 @@ class TestMembership(TestSalesCommon):
         })
         cls.env['ir.config_parameter'].set_param('sales_team.membership_multi', True)
 
+    def test_archive_user_archives_team_member(self):
+        """Test that archiving a user also archives their linked team member."""
+        self.assertTrue(self.sales_team_1_m1.active)
+        self.user_sales_leads.action_archive()
+        self.assertFalse(self.sales_team_1_m1.active)
+
     @users('user_sales_manager')
     def test_fields(self):
         self.assertTrue(self.sales_team_1.with_user(self.env.user).is_membership_multi)


### PR DESCRIPTION
**How to reproduce:**
- Create a user, assign it to a team (in multi-team, or not)
- Archive this user
- Open the list of members (CRM>Configuration in debug mode)
- The team member has not been archived

**Technical Reason:**
When user is archived, its respective record in crm_team_member is not updated.

**After this PR:**
When user is archived, their linked sales team member will also be archived.

Task-4617779