### PR TITLE
[IMP] im_livechat: live chat operators can read all lc conversations

### DIFF
--- a/addons/im_livechat/security/im_livechat_channel_security.xml
+++ b/addons/im_livechat/security/im_livechat_channel_security.xml
@@ -22,20 +22,20 @@
         </record>
 
     <data noupdate="1">
-        <record id="ir_rule_discuss_channel_group_im_livechat_group_manager" model="ir.rule">
-            <field name="name">discuss.channel: livechat manager can read all livechat channels</field>
+        <record id="ir_rule_discuss_channel_im_livechat_group_user" model="ir.rule">
+            <field name="name">discuss.channel: livechat users can read all livechat channels</field>
             <field name="model_id" ref="mail.model_discuss_channel"/>
-            <field name="groups" eval="[(4, ref('im_livechat_group_manager'))]"/>
+            <field name="groups" eval="[(4, ref('im_livechat_group_user'))]"/>
             <field name="domain_force">[('channel_type', '=', 'livechat')]</field>
             <field name="perm_create" eval="False"/>
             <field name="perm_write" eval="False"/>
             <field name="perm_unlink" eval="False"/>
         </record>
 
-        <record id="ir_rule_discuss_channel_member_group_im_livechat_group_manager" model="ir.rule">
-            <field name="name">discuss.channel.member: livechat manager can read all livechat channel members and can invite anyone</field>
+        <record id="ir_rule_discuss_channel_member_im_livechat_group_user" model="ir.rule">
+            <field name="name">discuss.channel.member: livechat users can read all livechat channel members and can invite anyone</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>
-            <field name="groups" eval="[(4, ref('im_livechat_group_manager'))]"/>
+            <field name="groups" eval="[(4, ref('im_livechat_group_user'))]"/>
             <field name="domain_force">[('channel_id.channel_type', '=', 'livechat')]</field>
             <field name="perm_write" eval="False"/>
             <field name="perm_unlink" eval="False"/>

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -346,3 +346,26 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             partner_ids=self.operators[0].partner_id.ids
         )
         self.assertEqual(self_member.partner_id, self.operators[0].partner_id)
+
+    def test_livechat_operator_can_see_all_livechat_conversations_and_members(self):
+        bob_user = new_test_user(
+            self.env, "bob_user", groups="base.group_user,im_livechat.im_livechat_group_user"
+        )
+        livechat_session = self.env["discuss.channel"].create(
+            {
+                "channel_type": "livechat",
+                "livechat_operator_id": self.operators[0].partner_id.id,
+                "name": "test",
+            }
+        )
+        livechat_session.with_user(self.operators[0]).add_members(
+            partner_ids=self.operators[1].partner_id.ids
+        )
+        self.assertEqual(
+            self.env["discuss.channel"].with_user(bob_user).search([("id", "=", livechat_session.id)]),
+            livechat_session
+        )
+        self.assertEqual(
+            self.env["discuss.channel.member"].with_user(bob_user).search([("channel_id", "=", livechat_session.id)]),
+            livechat_session.channel_member_ids
+        )


### PR DESCRIPTION
This commit lets live chat operators read the live chat conversations of other operators.

task-4603688
