### PR TITLE
[FIX] html_editor: ignore same textContent change mutations in Firefox

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -299,8 +299,19 @@ export class HistoryPlugin extends Plugin {
     setIdOnRecords(records) {
         for (const record of records) {
             if (record.type === "childList" && record.addedNodes.length) {
-                for (const node of record.addedNodes) {
-                    this.setNodeId(node);
+                const { addedNodes, removedNodes } = record;
+                if (this.isSameTextContentMutation(record)) {
+                    const oldId = this.nodeToIdMap.get(removedNodes[0]);
+                    if (oldId) {
+                        this.nodeToIdMap.delete(removedNodes[0]);
+                        this.idToNodeMap.delete(oldId);
+                        this.nodeToIdMap.set(addedNodes[0], oldId);
+                        this.idToNodeMap.set(oldId, addedNodes[0]);
+                    }
+                } else {
+                    for (const node of addedNodes) {
+                        this.setNodeId(node);
+                    }
                 }
             }
         }
@@ -366,11 +377,32 @@ export class HistoryPlugin extends Plugin {
                 if (!attributeCache.get(record.target)[record.attributeName]) {
                     continue;
                 }
+            } else if (record.type === "childList" && this.isSameTextContentMutation(record)) {
+                continue;
             }
             filteredRecords.push(record);
         }
         // @todo @phoenix allow an option to filter mutation records.
         return filteredRecords;
+    }
+
+    /**
+     * Check if a mutation consists of removing and adding a single text node
+     * with the same text content, which occurs in Firefox but is optimized
+     * away in Chrome.
+     *
+     * @param { MutationRecord } record
+     */
+    isSameTextContentMutation(record) {
+        const { addedNodes, removedNodes } = record;
+        return (
+            record.type === "childList" &&
+            addedNodes.length === 1 &&
+            removedNodes.length === 1 &&
+            addedNodes[0].nodeType === Node.TEXT_NODE &&
+            removedNodes[0].nodeType === Node.TEXT_NODE &&
+            addedNodes[0].textContent === removedNodes[0].textContent
+        );
     }
 
     /**


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

Firefox triggered a mutation when setting `textContent` to the same value, causing unnecessary dirty state updates in the editor.

Desired behavior after PR is merged:

Such mutations are now detected and ignored to prevent false positives.

task-4629669

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
