### PR TITLE
[IMP] hr_contract: improve contract validation dialog

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -161,7 +161,7 @@ class HrContract(models.Model):
 
             domain = expression.AND([domain, start_domain, end_domain])
             if self.search_count(domain):
-                raise ValidationError(
+                raise HrContractValidationError(
                     _(
                         'An employee can only have one contract at the same time. (Excluding Draft and Cancelled contracts).\n\nEmployee: %(employee_name)s',
                         employee_name=contract.employee_id.name
@@ -402,3 +402,11 @@ class HrContract(models.Model):
                       'views':  [[False, 'list'], [False, 'kanban'], [False, 'activity'], [False, 'form']],
                        'context': {'default_employee_id': self.employee_id.id}})
         return action
+
+
+class HrContractValidationError(ValidationError):
+    """
+        Custom exception class for hr.contract validation errors.
+        This class is used to reset the contract state when a constraint violation occurs.
+    """
+    pass

--- a/addons/hr_contract/static/src/errors/contract_validation_error.js
+++ b/addons/hr_contract/static/src/errors/contract_validation_error.js
@@ -1,0 +1,34 @@
+import { Component } from "@odoo/owl";
+
+import { Dialog } from "@web/core/dialog/dialog";
+import { standardErrorDialogProps } from "@web/core/errors/error_dialogs";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+
+export class HrContractValidationDialog extends Component {
+    static template = "hr_contract.contract_validation_dialog";
+    static components = { Dialog };
+    static props = {
+        ...standardErrorDialogProps,
+    };
+
+    setup() {
+        const { data, message } = this.props;
+        this.title = _t("Odoo Validation");
+        if (data?.arguments) {
+            this.message = data.arguments[0];
+        } else {
+            this.message = message;
+        }
+    }
+    async onClose() {
+        const { record } = this.props.data
+        if (record) {
+            record.update({ state: record._values.state });
+        }
+        this.props.close();
+    }
+}
+
+registry.category("error_dialogs")
+        .add("odoo.addons.hr_contract.models.hr_contract.HrContractValidationError", HrContractValidationDialog);

--- a/addons/hr_contract/static/src/errors/contract_validation_error.xml
+++ b/addons/hr_contract/static/src/errors/contract_validation_error.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="hr_contract.contract_validation_dialog">
+        <Dialog size="'xl'" contentClass="'o_error_dialog'">
+            <t t-set-slot="header">
+                <h4 class="modal-title text-break flex-grow-1">
+                    <t t-out="title"/>
+                </h4>
+                <button type="button" class="btn-close" aria-label="Close" tabindex="-1" t-on-click="onClose"></button>
+            </t>
+            <div role="alert">
+                <p t-out="message" class="text-prewrap"/>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary o-default-button" t-on-click="onClose">Close</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/hr_contract/static/src/widgets/contract_statusbar_field.js
+++ b/addons/hr_contract/static/src/widgets/contract_statusbar_field.js
@@ -1,0 +1,26 @@
+import { registry } from "@web/core/registry";
+import { statusBarField, StatusBarField } from "@web/views/fields/statusbar/statusbar_field";
+
+export class HrContractStatusBarField extends StatusBarField {
+    
+    async selectItem(item) {
+        const { record } = this.props;
+        if (record.resModel != 'hr.contract') {
+            super.selectItem(item);
+        }
+        try {
+            await super.selectItem(item);
+        } catch (e) {
+            e.data.record = record;
+            throw e
+        }
+    }
+}
+
+export const hrContractStatusBarField = {
+    ...statusBarField,
+    component: HrContractStatusBarField,
+    additionalClasses: ["o_field_statusbar"],
+};
+
+registry.category("fields").add("hr_contract_statusbar", hrContractStatusBarField);

--- a/addons/hr_contract/tests/test_contract.py
+++ b/addons/hr_contract/tests/test_contract.py
@@ -4,7 +4,7 @@ from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
-from odoo.exceptions import ValidationError
+from odoo.addons.hr_contract.models.hr_contract import HrContractValidationError
 from odoo.addons.hr_contract.tests.common import TestContractCommon
 from odoo.tests import tagged
 
@@ -49,7 +49,7 @@ class TestHrContracts(TestContractCommon):
         self.create_contract('open', 'normal', start, end)
 
         # Incoming contract
-        with self.assertRaises(ValidationError, msg="It should not create two contract in state open or incoming"):
+        with self.assertRaises(HrContractValidationError, msg="It should not create two contract in state open or incoming"):
             start = datetime.strptime('2015-11-15', '%Y-%m-%d').date()
             end = datetime.strptime('2015-12-30', '%Y-%m-%d').date()
             self.create_contract('draft', 'done', start, end)
@@ -60,7 +60,7 @@ class TestHrContracts(TestContractCommon):
         self.create_contract('open', 'normal', start, end)
 
         # Pending contract
-        with self.assertRaises(ValidationError, msg="It should not create two contract in state open or pending"):
+        with self.assertRaises(HrContractValidationError, msg="It should not create two contract in state open or pending"):
             start = datetime.strptime('2015-11-15', '%Y-%m-%d').date()
             end = datetime.strptime('2015-12-30', '%Y-%m-%d').date()
             self.create_contract('open', 'blocked', start, end)
@@ -85,7 +85,7 @@ class TestHrContracts(TestContractCommon):
         # No end date
         self.create_contract('open', 'normal', datetime.strptime('2015-11-01', '%Y-%m-%d').date())
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(HrContractValidationError):
             start = datetime.strptime('2015-11-15', '%Y-%m-%d').date()
             end = datetime.strptime('2015-12-30', '%Y-%m-%d').date()
             self.create_contract('draft', 'done', start, end)
@@ -96,7 +96,7 @@ class TestHrContracts(TestContractCommon):
         end = datetime.strptime('2015-12-30', '%Y-%m-%d').date()
         self.create_contract('open', 'normal', start, end)
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(HrContractValidationError):
             # No end
             self.create_contract('draft', 'done', datetime.strptime('2015-01-01', '%Y-%m-%d').date())
 

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -149,8 +149,8 @@
                 <form string="Current Contract">
                     <field name="contracts_count" invisible="1"/>
                     <header invisible="not id">
-                        <field name="state" groups="!hr_contract.group_hr_contract_manager" widget="statusbar"/>
-                        <field name="state" groups="hr_contract.group_hr_contract_manager" widget="statusbar" options="{'clickable': '1'}"/>
+                        <field name="state" groups="!hr_contract.group_hr_contract_manager" widget="hr_contract_statusbar"/>
+                        <field name="state" groups="hr_contract.group_hr_contract_manager" widget="hr_contract_statusbar" options="{'clickable': '1'}"/>
                     </header>
                     <sheet>
                         <field name="state" invisible="1"/>


### PR DESCRIPTION
This PR improves the contract validation error dialog box. When an employee has multiple contracts and one of the contracts is changed to the running state, a validation error occurs. Upon closing the dialog, the contract state will automatically reset.

task-4405417