### PR TITLE
[PERF] stock: CASE in JOIN on dest/final_id

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -57,10 +57,8 @@ WITH
         FROM stock_move m
         LEFT JOIN warehouse_cte source ON source.sl_id = m.location_id
         LEFT JOIN warehouse_cte dest ON
-            CASE
-                WHEN m.state != 'done' THEN dest.sl_id = COALESCE(m.location_final_id, m.location_dest_id)
-                WHEN m.state = 'done' THEN dest.sl_id = m.location_dest_id
-            END
+            (m.state != 'done' AND dest.sl_id = COALESCE(m.location_final_id, m.location_dest_id)) OR
+            (m.state = 'done' AND dest.sl_id = m.location_dest_id)
         LEFT JOIN product_product pp on pp.id=m.product_id
         LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
         WHERE pt.is_storable = true AND


### PR DESCRIPTION
We need to use either location_dest_id or location_final_id in the stock quantity report. Commit e16b3bc adds the logic for this but implements it using a CASE in the JOIN which the planner selects a nested loop based plan to accomplish (quadratic time).

Change it here to a boolean expression which can be better optimized by the query planner.