### PR TITLE
[FIX] repair: added group check on copying a product

### DIFF
--- a/addons/repair/models/product.py
+++ b/addons/repair/models/product.py
@@ -29,3 +29,8 @@ class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     create_repair = fields.Boolean('Create Repair', help="Create a linked Repair Order on Sale Order confirmation of this product.", groups='stock.group_stock_user')
+
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        default['create_repair'] = (self.env.user.has_group('stock.group_stock_user') or self.env.is_superuser()) and default.get('create_repair', self.create_repair)
+        return super().copy_data(default)

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError
 from odoo.tests import tagged, common, Form
 from odoo.tools import float_compare, float_is_zero
 
@@ -826,3 +826,29 @@ class TestRepair(common.TransactionCase):
             'quantity': 1.0,
         })]
         self.assertEqual(repair_order.lot_id, sn_1)
+
+    def test_copy_repair_product_with_different_groups(self):
+        """
+            This test checks if the product can be copied with users that don't have access on the Inventory app
+        """
+        product_templ = self.env['product.template'].create({
+            'name': "Repair Consumable",
+            'type': 'consu',
+            'create_repair': True,
+        })
+        mitchell_user = self.env['res.users'].create({
+            'name': "Mitchell not Admin",
+            'login': "m_user",
+            'email': "m@user.com",
+            'groups_id': [Command.set(self.env.ref('sales_team.group_sale_manager').ids)],
+        })
+        product_templ.invalidate_recordset(['create_repair'])
+        with self.assertRaises(AccessError):
+            product_templ.with_user(mitchell_user).create_repair
+        copied_without_access = product_templ.with_user(mitchell_user).copy()
+        mitchell_user.write({
+            'groups_id': [Command.link(self.env.ref('stock.group_stock_user').id)]
+        })
+        self.assertFalse(copied_without_access.create_repair)
+        copied_with_access = product_templ.copy().with_user(mitchell_user)
+        self.assertTrue(copied_with_access.create_repair)


### PR DESCRIPTION
Steps to reproduce the bug:
- install Inventory app
- remove any access rights from the logged in user to the inventory app
- copy any product

Traceback is thrown that the user doesn't have any access on the field create_repair on the product.template model. The user still can create a product normally, but he can't copy it anymore. The field has group scope to stock.group_stock_user so the user can't set the field on creating a product, but with default copy=True on the field, the copy operation fails.

opw-4563733

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
