### PR TITLE
[FIX] web: show clipboard copy button only when field has data

### DIFF
--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.xml
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.xml
@@ -4,7 +4,7 @@
     <t t-name="web.CopyClipboardField">
         <div class="d-grid rounded-2 overflow-hidden">
             <Field t-props="fieldProps"/>
-            <CopyButton className="copyButtonClassName" content="props.record.data[props.name]" copyText="copyText" successText="successText"/>
+            <CopyButton t-if="props.record.data[props.name]" className="copyButtonClassName" content="props.record.data[props.name]" copyText="copyText" successText="successText"/>
         </div>
     </t>
 

--- a/addons/web/static/tests/views/fields/copy_clipboard_field_tests.js
+++ b/addons/web/static/tests/views/fields/copy_clipboard_field_tests.js
@@ -99,11 +99,11 @@ QUnit.module("Fields", (hooks) => {
             resId: 1,
         });
 
-        assert.containsOnce(
+        assert.containsNone(
             target,
             '.o_field_CopyClipboardChar[name="char_field"] .o_clipboard_button'
         );
-        assert.containsOnce(
+        assert.containsNone(
             target,
             '.o_field_CopyClipboardText[name="text_field"] .o_clipboard_button'
         );
@@ -128,7 +128,7 @@ QUnit.module("Fields", (hooks) => {
                     </form>`,
             });
 
-            assert.containsOnce(
+            assert.containsNone(
                 target,
                 '.o_field_CopyClipboardChar[name="display_name"] .o_clipboard_button'
             );


### PR DESCRIPTION
**Versions:** 
17.0

**Steps to Reproduce:**
1. Open the calendar app.
2. Create a new event.
3. Observe the clipboard copy button next to the Videocall URL.

**Issue:**
The clipboard copy button is visible even when the field is empty.

**Cause:**
The visibility of the copy button was not conditionally checked based on whether the field contains data.

**Solution:**
Add a condition to ensure the clipboard copy button is only visible when the field contains data.

