### PR TITLE
[FIX] pos_loyalty: fix history for gift cards

### DIFF
--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -56,9 +56,9 @@ class PosOrder(models.Model):
         id_mapping = {item['old_id']: int(item['id']) for item in coupon_updates}
         history_lines_create_vals = []
         for coupon in coupon_data:
-            if int(coupon['card_id']) not in id_mapping:
+            card_id = id_mapping.get(int(coupon['card_id'], False)) or int(coupon['card_id'])
+            if not self.env['loyalty.card'].browse(card_id).exists():
                 continue
-            card_id = id_mapping[int(coupon['card_id'])]
             issued = coupon['won']
             cost = coupon['spent']
             if (issued or cost) and card_id > 0:

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -498,6 +498,8 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_pos_tour("GiftCardProgramTour2")
         # Check that gift cards are used
         self.assertEqual(gift_card_program.coupon_ids.points, 46.8)
+        loyalty_history = self.env['loyalty.history'].search([('card_id','=',gift_card_program.coupon_ids.id)])
+        self.assertEqual(loyalty_history.used, 3.2)
 
     def test_ewallet_program(self):
         """


### PR DESCRIPTION
Loyalty history for gift cards was not working properly. The history was not being updated when a gift card was used in a POS order.

Steps to reproduce:
-------------------
* Create some gift cards
* Use one in the PoS to make an order
> Observation: The history is not updated accordingly

Why the fix:
------------
Instead of relying only on `coupon_updates` we check that card id provided exist before creating the history record.

opw-4546985-1