### PR TITLE
[FIX] account: log more explicit error on import

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -14411,6 +14411,13 @@ msgid "This Quarter"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "This specific error occurred during the import:"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_report__default_opening_date_filter__this_tax_period
 msgid "This Tax Period"
 msgstr ""

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3233,10 +3233,16 @@ class AccountMove(models.Model):
 
                 except RedirectWarning:
                     raise
-                except Exception:
+                except Exception as e:
                     message = _("Error importing attachment '%s' as invoice (decoder=%s)", file_data['filename'], decoder.__name__)
-                    current_invoice.sudo().message_post(body=message)
                     _logger.exception(message)
+                    if isinstance(e, UserError):
+                        message = Markup("%s<br/><br/>%s<br/>%s") % (
+                            message,
+                            _("This specific error occurred during the import:"),
+                            str(e),
+                        )
+                    current_invoice.sudo().message_post(body=message)
 
             passed_file_data_list.append(file_data)
             close_file(file_data)


### PR DESCRIPTION
When importing an xml invoice, we display a generic
error in case of Exception. This is useful from a technical point
of view but this is obscur for the user.
With this commit, in case of a UserError, we add the
error message in the chatter.

Let's assume a wrong configuration and steps like this:

- Belgian demo company, `account_peppol` installed and activated
- Make sure there are no moves in `Vendor Bills` journal
- On the account 600000, set `Allowed Journals` to be any journal
  different from `Vendor Bills`
- From the journal dashboard, vendor bills journal, click on
  `Fetch from peppol`, then go to the bil that has been created
-> In the chatter you will see the error message:
	"Error importing attachment '2_demo_vendor_bill' as invoice (decoder=_import_invoice_ubl_cii)"

This is because we raise the constrains
`account_move_line._check_constrains_account_id_journal_id`, but the
user will never know until we display the UserRrror message in the
chatter.

opw-4513344
