### PR TITLE
[FIX] html_editor: remove outline only on `contenteditable=true`

### DIFF
--- a/addons/html_editor/static/src/styles.scss
+++ b/addons/html_editor/static/src/styles.scss
@@ -1,3 +1,3 @@
-*[contenteditable] {
+*[contenteditable="true"] {
     outline: none;
 }


### PR DESCRIPTION
**Problem**:
The outline is removed for all elements with `contenteditable`, including those with `contenteditable=false`, which is incorrect.

**Solution**:
Restrict outline removal to elements with `contenteditable=true` only.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
