### PR TITLE
[FIX] hw_drivers: remove useless logs on manual start

### DIFF
--- a/addons/hw_drivers/led_manager_L.py
+++ b/addons/hw_drivers/led_manager_L.py
@@ -32,8 +32,8 @@ class LedManager(Thread):
             time.sleep(STATUS_UPDATE_DELAY_SECONDS)
 
     def _disable_led_triggers(self):
-        subprocess.run(["sudo", "tee", "/sys/class/leds/ACT/trigger"], input="none", text=True)
-        subprocess.run(["sudo", "tee", "/sys/class/leds/PWR/trigger"], input="none", text=True)
+        subprocess.run(["sudo", "tee", "/sys/class/leds/ACT/trigger"], input=b"none", stdout=subprocess.DEVNULL)
+        subprocess.run(["sudo", "tee", "/sys/class/leds/PWR/trigger"], input=b"none", stdout=subprocess.DEVNULL)
 
     def _set_green_led(self, value):
         if self.green_led_on == value:
@@ -42,13 +42,17 @@ class LedManager(Thread):
         if helpers.raspberry_pi_model == 5:
             # 'ACT' LED is inverted on Raspberry Pi 5
             value = not value
-        subprocess.run(["sudo", "tee", "/sys/class/leds/ACT/brightness"], input="1" if value else "0", text=True)
+        subprocess.run(
+            ["sudo", "tee", "/sys/class/leds/ACT/brightness"], input=b"1" if value else b"0", stdout=subprocess.DEVNULL
+        )
 
     def _set_red_led(self, value):
         if self.red_led_on == value:
             return
         self.red_led_on = value
-        subprocess.run(["sudo", "tee", "/sys/class/leds/PWR/brightness"], input="1" if value else "0", text=True)
+        subprocess.run(
+            ["sudo", "tee", "/sys/class/leds/PWR/brightness"], input=b"1" if value else b"0", stdout=subprocess.DEVNULL
+        )
 
     def _blink_green_led(self):
         if not self.blinking:

--- a/addons/hw_drivers/tools/wifi.py
+++ b/addons/hw_drivers/tools/wifi.py
@@ -269,7 +269,7 @@ def is_access_point():
     :return: True if the device is in access point mode
     :rtype: bool
     """
-    return subprocess.run(['systemctl', 'is-active', 'hostapd']).returncode == 0
+    return subprocess.run(['systemctl', 'is-active', 'hostapd'], stdout=subprocess.DEVNULL).returncode == 0
 
 @cache
 def generate_qr_code_image(qr_code_data):

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -24,7 +24,7 @@ echo "export XAUTHORITY=/run/lightdm/pi/xauthority" >> /home/pi/.bashrc
 echo "export XAUTHORITY=/run/lightdm/root/:0" >> ~/.bashrc
 # Aliases
 echo  "alias ll='ls -al'" | tee -a ~/.bashrc /home/pi/.bashrc
-echo  "alias odoo='sudo systemctl stop odoo; sudo /usr/bin/python3 /home/pi/odoo/odoo-bin --config /home/pi/odoo.conf'" | tee -a ~/.bashrc /home/pi/.bashrc
+echo  "alias odoo='sudo systemctl stop odoo; sudo -u odoo /usr/bin/python3 /home/pi/odoo/odoo-bin --config /home/pi/odoo.conf'" | tee -a ~/.bashrc /home/pi/.bashrc
 echo  "alias odoo_logs='less +F /var/log/odoo/odoo-server.log'" | tee -a ~/.bashrc /home/pi/.bashrc
 echo  "alias write_mode='sudo mount -o remount,rw / && sudo mount -o remount,rw /root_bypass_ramdisks'" | tee -a ~/.bashrc /home/pi/.bashrc
 echo  "alias odoo_conf='cat /home/pi/odoo.conf'" | tee -a ~/.bashrc /home/pi/.bashrc


### PR DESCRIPTION
Logs when odoo was started manually were polluted by zeros and ones due to recurrent echos to the led configuration file.
