### PR TITLE
[FIX] website: rely on _check_user_can_modify to determine can_publish

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -232,8 +232,7 @@ class WebsitePublishedMixin(models.AbstractModel):
                 # to be rendered by a template even if they were not supposed
                 # to be accessible
                 plain_record = record.sudo(flag=False) if self._context.get('can_publish_unsudo_main_object', False) else record
-                plain_record.check_access_rights('write')
-                plain_record.check_access_rule('write')
+                self.env['website'].get_current_website()._check_user_can_modify(plain_record)
                 record.can_publish = True
             except AccessError:
                 record.can_publish = False

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -94,9 +94,10 @@ class Page(models.Model):
 
     @api.depends_context('uid')
     def _compute_can_publish(self):
+        super()._compute_can_publish()
         is_designer = self.env.user.has_group('website.group_website_designer')
         for record in self:
-            record.can_publish = is_designer
+            record.can_publish = record.can_publish or is_designer
 
     def _get_most_specific_pages(self):
         ''' Returns the most specific pages in self. '''


### PR DESCRIPTION
In [1] when forward-porting the adaptation of the right to publish, the check was done with strict access rules instead of relying on the customization-friendly `_check_user_can_modify`.

This commit delegates those checks to that method.

[1]: https://github.com/odoo/odoo/commit/b77fbc8467352800f63cfb5cd9a1982612746dfa

task-3175890
