### PR TITLE
[FIX] web: fix reference field style

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -162,7 +162,7 @@
                     width: auto!important;
                 }
             }
-            .o_field_many2one_selection {
+            .o_many2one {
                 width: 100% !important;
             }
         }


### PR DESCRIPTION
Since the commit [1]: the template of many2one has changed and caused a style issue in the reference field. This commit fixes the style.

[1]: bcaa9e9b23d637edfe05baff83aea2ac18d9f4b2

task-4623402