### PR TITLE
[FIX] discuss: fix the visibility of participants in the call view

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -2,6 +2,7 @@ import { CallActionList } from "@mail/discuss/call/common/call_action_list";
 import { CallParticipantCard } from "@mail/discuss/call/common/call_participant_card";
 import { PttAdBanner } from "@mail/discuss/call/common/ptt_ad_banner";
 import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 import {
     Component,
@@ -44,6 +45,7 @@ export class Call extends Component {
         this.grid = useRef("grid");
         this.notification = useService("notification");
         this.rtc = useState(useService("discuss.rtc"));
+        this.isMobileOs = isMobileOS();
         this.state = useState({
             isFullscreen: false,
             sidebar: false,

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -5,7 +5,7 @@
         <PttAdBanner/>
         <div class="o-discuss-Call user-select-none d-flex position-relative" t-att-class="{
             'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen,
-            'o-compact': props.compact,
+            'o-compact': props.compact and !isMobileOs,
             'o-minimized': minimized,
             'position-relative': !state.isFullscreen,
         }">


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/175858,

the call view in mobile was too small to fit all of the call UI, this commit fixes this issue.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/86452883-f37c-4e18-961c-7bf2a2aceff6)  | ![image](https://github.com/user-attachments/assets/aa71c7c8-e8c0-4647-a261-6f496bed2dbb) | 



 
