### PR TITLE
[IMP] stock*: allow selection of 'Dropship' operation type in rules

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -28,13 +28,10 @@ class StockRule(models.Model):
         return message_dict
 
     def _compute_picking_type_code_domain(self):
-        remaining = self.browse()
+        super()._compute_picking_type_code_domain()
         for rule in self:
             if rule.action == 'manufacture':
-                rule.picking_type_code_domain = 'mrp_operation'
-            else:
-                remaining |= rule
-        super(StockRule, remaining)._compute_picking_type_code_domain()
+                rule.picking_type_code_domain = rule.picking_type_code_domain or [] + ['mrp_operation']
 
     def _should_auto_confirm_procurement_mo(self, p):
         return (not p.orderpoint_id and p.move_raw_ids) or (p.move_dest_ids.procure_method != 'make_to_order' and not p.move_raw_ids and not p.workorder_ids)

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -32,13 +32,10 @@ class StockRule(models.Model):
 
     @api.depends('action')
     def _compute_picking_type_code_domain(self):
-        remaining = self.browse()
+        super()._compute_picking_type_code_domain()
         for rule in self:
             if rule.action == 'buy':
-                rule.picking_type_code_domain = 'incoming'
-            else:
-                remaining |= rule
-        super(StockRule, remaining)._compute_picking_type_code_domain()
+                rule.picking_type_code_domain = rule.picking_type_code_domain or [] + ['incoming']
 
     @api.onchange('action')
     def _onchange_action(self):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -80,8 +80,8 @@ class StockRule(models.Model):
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type',
         required=True, check_company=True,
-        domain="[('code', '=?', picking_type_code_domain)]")
-    picking_type_code_domain = fields.Char(compute='_compute_picking_type_code_domain')
+        domain="[('code', 'in', picking_type_code_domain)] if picking_type_code_domain else []")
+    picking_type_code_domain = fields.Json(compute='_compute_picking_type_code_domain')
     delay = fields.Integer('Lead Time', default=0, help="The expected date of the created transfer will be computed based on this lead time.")
     partner_address_id = fields.Many2one(
         'res.partner', 'Partner Address',
@@ -203,7 +203,7 @@ class StockRule(models.Model):
 
     @api.depends('action')
     def _compute_picking_type_code_domain(self):
-        self.picking_type_code_domain = False
+        self.picking_type_code_domain = []
 
     def _run_push(self, move):
         """ Apply a push rule on a move.

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -21,6 +21,12 @@ class StockRule(models.Model):
             return False
         return super()._get_partner_id(values, rule)
 
+    def _compute_picking_type_code_domain(self):
+        super()._compute_picking_type_code_domain()
+        for rule in self:
+            if rule.action == 'buy':
+                rule.picking_type_code_domain += ['dropship']
+
 
 class ProcurementGroup(models.Model):
     _inherit = "procurement.group"


### PR DESCRIPTION
*: stock_dropshipping

With this commit
========================

Previously, only 'Receipt' operation types could be selected for rules
with the 'Buy' action. However, with a dedicated 'Dropship' operation type,
it's now possible to distinguish between standard receipts and dropship flows.

This commit enhances the route rule configuration by allowing both
'Receipt' and 'Dropship' operation types to be selectable for 'Buy' actions.
Now that 'Dropship' is an operation type, allowing it for 'Buy' rules ensures
correct flow setup for dropshipping scenarios.


task-4353843
