### PR TITLE
[FIX] point_of_sale: fix error when printing sales details report

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/sale_details_button/sales_detail_report.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/sale_details_button/sales_detail_report.xml
@@ -11,7 +11,7 @@
                 SOLD:
             </div>
 
-            <t t-set="ProductUnit" t-as="pos.models['decimal.precision'].find((dp) => dp.name === 'Product Unit')" />
+            <t t-set="ProductUnit" t-value="pos.models['decimal.precision'].find((dp) => dp.name === 'Product Unit')" />
 
             <div class="orderlines">
                 <t t-foreach="products" t-as="category" t-key="category['name']">


### PR DESCRIPTION
Before this commit:
==========
- Attempting to print the sales details report from the POS resulted in an error due to the round being accessed from an undefined source.

After this commit:
==========
- The sales details report prints correctly without errors.

task-4639074