### PR TITLE
[FIX] rating: update rating date

### DIFF
--- a/addons/im_livechat/views/rating_rating_views.xml
+++ b/addons/im_livechat/views/rating_rating_views.xml
@@ -14,9 +14,9 @@
                 <filter string="Livechat Channel" name="groupby_livechat_channel" context="{'group_by': 'parent_res_name'}"/>
             </xpath>
             <xpath expr="/search" position="inside">
-                <filter string="This Week" name="creation_date_filter" domain="[
-                ('create_date', '>=', (datetime.datetime.combine(context_today() + relativedelta(weeks=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),
-                ('create_date', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
+                <filter string="This Week" name="rated_on_filter" domain="[
+                ('rated_on', '>=', (datetime.datetime.combine(context_today() + relativedelta(weeks=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),
+                ('rated_on', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
             </xpath>
         </field>
     </record>

--- a/addons/portal_rating/views/rating_rating_views.xml
+++ b/addons/portal_rating/views/rating_rating_views.xml
@@ -5,8 +5,16 @@
         <field name="model">rating.rating</field>
         <field name="inherit_id" ref="rating.rating_rating_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='rating_text']" position="after">
-                <field name="publisher_comment" string="Comment"/>
+            <xpath expr="//field[@name='rated_on']" position="after">
+                <label for="publisher_comment" string="Comment"/>
+                <div>
+                    <field name="publisher_comment"/>
+                    <br />
+                    <span class="oe_inline">by </span>
+                    <field name="publisher_id" class="oe_inline"/>
+                    <span class="oe_inline"> on </span>
+                    <field name="publisher_datetime" class="oe_inline"/>
+                </div>
             </xpath>
         </field>
     </record>

--- a/addons/project/views/rating_rating_views.xml
+++ b/addons/project/views/rating_rating_views.xml
@@ -48,13 +48,10 @@
             <field name="rated_partner_id" position="attributes">
                 <attribute name="string">Assigned to</attribute>
             </field>
-            <field name="create_date" position="replace">
-                <field name="write_date" readonly="1" string="Submitted On"/>
-            </field>
             <field name="feedback" position="attributes">
                 <attribute name="readonly">1</attribute>
             </field>
-            <field name="write_date" position="after">
+            <field name="rated_on" position="after">
                 <field name="partner_id" position="move"/>
             </field>
             <xpath expr="//field[@name='is_internal']" position="attributes">
@@ -70,7 +67,7 @@
         <field name="mode">primary</field>
         <field name="priority">64</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='create_date']" position="attributes">
+            <xpath expr="//field[@name='rated_on']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='rating']" position="attributes">
@@ -88,19 +85,6 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='rating']" position="attributes">
                 <attribute name="string">Rating (1-5)</attribute>
-            </xpath>
-        </field>
-    </record>
-
-    <record id="rating_rating_project_view_kanban" model="ir.ui.view">
-        <field name="name">rating.rating.kanban.project</field>
-        <field name="model">rating.rating</field>
-        <field name="inherit_id" ref="rating.rating_rating_view_kanban"/>
-        <field name="mode">primary</field>
-        <field name="priority">64</field>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='create_date']" position="replace">
-                <field name="write_date"/>
             </xpath>
         </field>
     </record>
@@ -137,15 +121,11 @@
             <xpath expr="//filter[@name='responsible']" position="attributes">
                 <attribute name="string">Assigned to</attribute>
             </xpath>
-            <xpath expr="//filter[@name='filter_create_date']" position="replace">
-                <filter name="filter_write_date" string="Submitted On" date="write_date" default_period="custom_write_date_last_30_days">
-                    <filter name="write_date_last_7_days" string="Last 7 Days" domain="[('write_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=7), datetime.time(23, 59, 59)).to_utc())]"/>
-                    <filter name="write_date_last_30_days" string="Last 30 Days" domain="[('write_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=30), datetime.time(23, 59, 59)).to_utc())]"/>
-                    <filter name="write_date_last_365_days" string="Last 365 Days" domain="[('write_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=365), datetime.time(23, 59, 59)).to_utc())]"/>
-                </filter>
+            <xpath expr="//filter[@name='filter_rated_on']" position="attributes">
+                <attribute name="default_period">custom_rated_on_last_30_days</attribute>
             </xpath>
             <xpath expr="//filter[@name='month']" position="attributes">
-                <attribute name="context">{'group_by':'write_date:month'}</attribute>
+                <attribute name="context">{'group_by':'rated_on:month'}</attribute>
             </xpath>
         </field>
     </record>
@@ -167,7 +147,7 @@
         <field name="sequence" eval="5"/>
         <field name="view_mode">kanban</field>
         <field name="act_window_id" ref="rating_rating_action_view_project_rating"/>
-        <field name="view_id" ref="rating_rating_project_view_kanban"/>
+        <field name="view_id" ref="rating.rating_rating_view_kanban"/>
     </record>
 
     <record id="rating_rating_action_view_project_rating_tree" model="ir.actions.act_window.view">
@@ -218,7 +198,7 @@
         <field name="sequence" eval="5"/>
         <field name="view_mode">kanban</field>
         <field name="act_window_id" ref="rating_rating_action_task"/>
-        <field name="view_id" ref="rating_rating_project_view_kanban"/>
+        <field name="view_id" ref="rating.rating_rating_view_kanban"/>
     </record>
 
     <record id="rating_rating_action_task_tree" model="ir.actions.act_window.view">
@@ -265,7 +245,7 @@
             </p>
         </field>
         <field name="context">{
-            'search_default_filter_write_date': 1,
+            'search_default_filter_rated_on': 1,
             'graph_groupbys': ['rated_partner_id'],
         }</field>
     </record>
@@ -274,7 +254,7 @@
         <field name="sequence" eval="5"/>
         <field name="view_mode">kanban</field>
         <field name="act_window_id" ref="rating_rating_action_project_report"/>
-        <field name="view_id" ref="rating_rating_project_view_kanban"/>
+        <field name="view_id" ref="rating.rating_rating_view_kanban"/>
     </record>
 
     <record id="rating_rating_action_project_report_tree" model="ir.actions.act_window.view">

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -52,6 +52,7 @@ class RatingRating(models.Model):
     is_internal = fields.Boolean('Visible Internally Only', readonly=False, related='message_id.is_internal', store=True)
     access_token = fields.Char('Security Token', default=_default_access_token)
     consumed = fields.Boolean(string="Filled Rating")
+    rated_on = fields.Datetime(string="Rated On")
 
     _rating_range = models.Constraint(
         'check(rating >= 0 and rating <= 5)',
@@ -123,11 +124,15 @@ class RatingRating(models.Model):
         for values in vals_list:
             if values.get('res_model_id') and values.get('res_id'):
                 values.update(self._find_parent_data(values))
+            if 'rating' in values or 'feedback' in values:
+                values['rated_on'] = fields.Datetime.now()
         return super().create(vals_list)
 
     def write(self, values):
         if values.get('res_model_id') and values.get('res_id'):
             values.update(self._find_parent_data(values))
+        if 'rating' in values or 'feedback' in values:
+            values['rated_on'] = fields.Datetime.now()
         return super().write(values)
 
     def unlink(self):

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -31,6 +31,7 @@
                                 <field name="rated_partner_id" widget="many2one_avatar"/>
                                 <field name="rating" invisible="1"/>
                                 <field name="is_internal"/>
+                                <field name="consumed" groups="base.group_no_one"/>
                             </group>
                             <group>
                                 <field name="partner_id"/>
@@ -40,7 +41,7 @@
                                         <strong><field name="rating_text"/></strong>
                                     </div>
                                 </div>
-                                <field name="create_date"/>
+                                <field name="rated_on"/>
                             </group>
                         </group>
                         <group class="mw-100" invisible="not feedback">
@@ -64,19 +65,6 @@
                         decoration-warning="rating_text == 'ok'"
                         decoration-success="rating_text == 'top'"
                         widget='badge'/>
-                </xpath>
-            </field>
-        </record>
-
-        <record id="rating_rating_view_form_complete" model="ir.ui.view">
-            <field name="name">rating.rating.view.form.complete</field>
-            <field name="model">rating.rating</field>
-            <field name="inherit_id" ref="rating.rating_rating_view_form"/>
-            <field name="priority">48</field>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='is_internal']" position="after">
-                    <field name="consumed" groups="base.group_no_one"/>
                 </xpath>
             </field>
         </record>
@@ -106,7 +94,7 @@
                                     </a>
                                 </span>
                                 <div>
-                                    on <field name="create_date" />
+                                    on <field name="rated_on" />
                                 </div>
                                 <span class="text-truncate" t-att-title="record.feedback.raw_value">
                                     <field name="feedback"/>
@@ -153,7 +141,7 @@
                                     <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
                                         <field name="res_name" />
                                     </a>
-                                    <div><i class="fa fa-clock-o me-2" aria-label="Create date"/> <field name="create_date" /></div>
+                                    <div><i class="fa fa-clock-o me-2" aria-label="Create date"/> <field name="rated_on" /></div>
                                     <field name="feedback" class="mt-2"/>
                                 </div>
                             </main>
@@ -169,7 +157,7 @@
             <field name="arch" type="xml">
                 <pivot string="Ratings" display_quantity="1" sample="1">
                     <field name="rated_partner_id" type="row"/>
-                    <field name="create_date" type="col"/>
+                    <field name="rated_on" type="col"/>
                     <field name="rating" type="measure" string="Rating (/5)"/>
                     <field name="parent_res_id" invisible="1"/>
                     <field name="res_id" invisible="1"/>
@@ -182,7 +170,7 @@
            <field name="model">rating.rating</field>
            <field name="arch" type="xml">
                 <graph string="Ratings" sample="1">
-                    <field name="create_date"/>
+                    <field name="rated_on"/>
                     <field name="rating" type="measure" string="Rating (/5)"/>
                     <field name="parent_res_id" invisible="1"/>
                     <field name="res_id" invisible="1"/>
@@ -207,17 +195,17 @@
                     <filter string="Okay" name="rating_okay" domain="[('rating_text', '=', 'ok')]"/>
                     <filter string="Dissatisfied" name="rating_unhappy" domain="[('rating_text', '=', 'ko')]"/>
                     <separator/>
-                    <filter name="filter_create_date" date="create_date">
-                        <filter name="create_date_last_7_days" string="Last 7 Days" domain="[('create_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=7), datetime.time(23, 59, 59)).to_utc())]"/>
-                        <filter name="create_date_last_30_days" string="Last 30 Days" domain="[('create_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=30), datetime.time(23, 59, 59)).to_utc())]"/>
-                        <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('create_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=365), datetime.time(23, 59, 59)).to_utc())]"/>
+                    <filter name="filter_rated_on" string="Rated On" date="rated_on">
+                        <filter name="rated_on_last_7_days" string="Last 7 Days" domain="[('rated_on', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=7), datetime.time(23, 59, 59)).to_utc())]"/>
+                        <filter name="rated_on_last_30_days" string="Last 30 Days" domain="[('rated_on', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=30), datetime.time(23, 59, 59)).to_utc())]"/>
+                        <filter name="rated_on_last_365_days" string="Last 365 Days" domain="[('rated_on', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=365), datetime.time(23, 59, 59)).to_utc())]"/>
                     </filter>
                     <group expand="0" string="Group By">
                         <filter string="Rated Operator" name="responsible" context="{'group_by':'rated_partner_id'}"/>
                         <filter string="Customer" name="customer" context="{'group_by':'partner_id'}"/>
                         <filter string="Rating" name="rating_text" context="{'group_by':'rating_text'}"/>
                         <filter string="Resource" name="resource" context="{'group_by':'res_name'}"/>
-                        <filter string="Submitted on" name="month" context="{'group_by': 'create_date:month'}"/>
+                        <filter string="Submitted on" name="month" context="{'group_by': 'rated_on:month'}"/>
                     </group>
                 </search>
             </field>
@@ -245,7 +233,7 @@
             <field name="act_window_id" ref="rating_rating_action"/>
             <field name="sequence">5</field>
             <field name="view_mode">form</field>
-            <field name="view_id" ref="rating_rating_view_form_complete"/>
+            <field name="view_id" ref="rating_rating_view_form"/>
         </record>
 
         <!-- Add menu entry in Technical/Discuss -->

--- a/addons/test_mail_full/models/test_mail_models_mail.py
+++ b/addons/test_mail_full/models/test_mail_models_mail.py
@@ -52,7 +52,7 @@ class MailTestRating(models.Model):
         'portal.mixin',
     ]
     _mailing_enabled = True
-    _order = 'name asc, id asc'
+    _order = 'id asc'
 
     name = fields.Char('Name')
     subject = fields.Char('Subject')

--- a/addons/website_slides/views/rating_rating_views.xml
+++ b/addons/website_slides/views/rating_rating_views.xml
@@ -10,8 +10,8 @@
             <xpath expr="//filter[@name='rating_text']" position="after">
                 <filter string="Course" name="groupby_course" context="{'group_by': 'res_name'}"/>
             </xpath>
-            <filter name="filter_create_date" position="attributes">
-                <attribute name="default_period">custom_create_date_last_30_days</attribute>
+            <filter name="filter_rated_on" position="attributes">
+                <attribute name="default_period">custom_rated_on_last_30_days</attribute>
             </filter>
             <xpath expr="//filter[@name='my_ratings']" position="replace"/>
             <xpath expr="//filter[@name='responsible']" position="replace"/>
@@ -52,7 +52,7 @@
         <field name="priority">64</field>
         <field name="arch" type="xml">
             <list create="0">
-                <field name="create_date" string="Review Date"/>
+                <field name="rated_on" string="Review Date"/>
                 <field name="partner_id"/>
                 <field name="res_name" string="Course"/>
                 <field name="rating" string="Score"/>
@@ -88,7 +88,7 @@
                         <group>
                             <field name="partner_id"/>
                             <field name="resource_ref" string="Course"/>
-                            <field name="create_date"/>
+                            <field name="rated_on"/>
                         </group>
                         <group>
                             <field name="rating"/>


### PR DESCRIPTION
Steps to reproduce
===================
1. Send a rating request for the task.
2.  Customer rates using email.
3.  After some time, rename the task ->The rating date is changed as we are showing write_date as rating_date.

After this commit
=================
Added a new field rated_on to store the recent date for the rating.

Task-4023246
