### PR TITLE
[FIX] sale: sudo check invoice state in wizard

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -133,7 +133,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
     @api.depends('sale_order_ids')
     def _compute_display_draft_invoice_warning(self):
         for wizard in self:
-            wizard.display_draft_invoice_warning = wizard.sale_order_ids.invoice_ids.filtered(lambda invoice: invoice.state == 'draft')
+            invoice_states = wizard.sale_order_ids._origin.sudo().invoice_ids.mapped('state')
+            wizard.display_draft_invoice_warning = 'draft' in invoice_states
 
     @api.depends('sale_order_ids')
     def _compute_invoice_amounts(self):


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Log in as admin;
2. have a user with access to Sales: Own Documents but not Invoicing;
3. assign them as a salesperson to a sales order;
4. create a draft invoice for the order;
5. assign admin as salesperson on the invoice;
6. log in as user;
7. create invoice for the sales order.

Issue
-----
- No existing draft warning is displayed.
- Trying to create a draft results in an access error.

Cause
-----
The wizards starts out as a `newId`. Consequently, its `sale_order_ids` field is also `newId` with the actual order id as its origin. When trying to read the `invoice_ids` of a pseudo-record, it will ignore any records you don't have access to. This is why you don't see an exisiting draft invoice warning.

Then when creating the invoice, the check is done again, but no longer as pseudo-records. Now it does get an invoice to check, and throws an error because it's assigned to a different user.

Solution
--------
Use `_origin.sudo()` to ensure access to the `state` field of the invoices.

opw-4554639