### PR TITLE
[FIX] html_editor: fix cropper issue with large images

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -42,6 +42,7 @@ export class ImageCrop extends Component {
         this.elRef = useRef("el");
         this.cropperWrapper = useRef("cropperWrapper");
         this.imageRef = useRef("imageRef");
+        this.cropperOpen = false;
 
         // We use capture so that the handler is called before other editor handlers
         // like save, such that we can restore the src before a save.
@@ -64,6 +65,9 @@ export class ImageCrop extends Component {
     }
 
     closeCropper() {
+        if (!this.cropperOpen) {
+            return;
+        }
         this.cropper?.destroy?.();
         this.media.setAttribute("src", this.initialSrc);
         if (
@@ -73,6 +77,7 @@ export class ImageCrop extends Component {
             this.media.classList.add("o_modified_image_to_save");
         }
         this.props?.onClose?.();
+        this.cropperOpen = false;
     }
 
     /**
@@ -90,6 +95,9 @@ export class ImageCrop extends Component {
     }
 
     async show() {
+        if (this.cropperOpen) {
+            return;
+        }
         // key: ratio identifier, label: displayed to user, value: used by cropper lib
         const src = this.media.getAttribute("src");
         const data = { ...this.media.dataset };
@@ -175,6 +183,7 @@ export class ImageCrop extends Component {
             this.aspectRatios[this.aspectRatio].value,
             this.media.dataset
         );
+        this.cropperOpen = true;
     }
     /**
      * Updates the DOM image with cropped data and associates required

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -16,7 +16,12 @@ import {
     waitForNone,
 } from "@odoo/hoot-dom";
 import { advanceTime, animationFrame, tick } from "@odoo/hoot-mock";
-import { contains, patchTranslations, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import {
+    contains,
+    onRpc,
+    patchTranslations,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
 import { fontItems, fontSizeItems } from "../src/main/font/font_plugin";
 import { Plugin } from "../src/plugin";
 import { MAIN_PLUGINS } from "../src/plugin_sets";
@@ -760,6 +765,51 @@ test("close the toolbar if the selection contains any nodes (traverseNode = [], 
     await tick(); // selectionChange
     await animationFrame();
     expect(".o-we-toolbar").toHaveCount(0);
+});
+
+test("should not close cropper while loading media", async () => {
+    onRpc("/html_editor/get_image_info", () => {
+        return {
+            original: {
+                image_src: "#",
+            },
+        };
+    });
+    onRpc("/web/image/__odoo__unknown__src__/", () => {
+        return {};
+    });
+
+    await setupEditor(`<p>[<img src="#">]</p>`);
+    await waitFor('div[name="image_transform"]');
+
+    await click('div[name="image_transform"] > .btn');
+    await animationFrame();
+
+    await click('.btn[name="image_crop"]');
+    await animationFrame();
+
+    await waitFor('.btn[title="Discard"]', { timeout: 1000 });
+    await click('.btn[title="Discard"]');
+    await animationFrame();
+
+    // cropper should not close as the cropper still loading the image.
+    expect('.btn[title="Discard"]').toHaveCount(1);
+    // debugger;
+    // once the image loaded we should be able to close
+    await waitFor("img.o_we_cropper_img", { timeout: 1000 });
+    await click('.btn[title="Discard"]');
+    await animationFrame();
+
+    await click("img");
+    await tick();
+    await animationFrame();
+
+    await click('div[name="image_transform"] > .btn');
+    await animationFrame();
+
+    await click('.btn[name="image_crop"]');
+    await animationFrame();
+    expect('.btn[title="Discard"]').toHaveCount(1);
 });
 
 describe.tags("desktop");


### PR DESCRIPTION
**Problem**:
Loading large images into the cropper takes time. Closing the cropper early causes `this.imageRef.el` to be `null` or `this.initialSrc` to be `undefined`, leading to a traceback.

**What happens**:
1. Add a large image.
2. Click "Crop".
   - This triggers `show`.
   - While `loadImage` is still unresolved due to image size.
3. Click "Discard" to close the cropper before image loads.
   - **Issue**: `this.imageRef.el` is `null` and `this.initialSrc` is `undefined` as the component is destroyed but `loadImage` has not resolved yet, when it is resolved a traceback will be appear.

**Solution**:
Add a lifecycle flag as full mounting of the cropper might take time.

**Steps to Reproduce**:
1. Add a large image.
2. Open cropper.
3. Close cropper before image loads.
   - **Issue**: Traceback.

opw-4607020

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
