### PR TITLE
[FIX] website: page's can publish must default to super

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -93,9 +93,11 @@ class Page(models.Model):
 
     @api.depends_context('uid')
     def _compute_can_publish(self):
-        is_designer = self.env.user.has_group('website.group_website_designer')
-        for record in self:
-            record.can_publish = is_designer
+        if self.env.user.has_group('website.group_website_designer'):
+            for record in self:
+                record.can_publish = True
+        else:
+            super()._compute_can_publish()
 
     def _get_most_specific_pages(self):
         ''' Returns the most specific pages in self. '''


### PR DESCRIPTION
Since [1] when can publish rights were adapted, the overload for pages did only handle the website designer users, but did not call super for other users.

This commit calls super if the user is not a website designer.

[1]: https://github.com/odoo/odoo/commit/1a83b2508b9383e2b7df192f8641751f71f852da

task-3175890
