### PR TITLE
[IMP] html_editor: make editor html migrations optional

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.xml
+++ b/addons/html_editor/static/src/fields/html_field.xml
@@ -2,7 +2,8 @@
     <t t-name="html_editor.HtmlField">
         <t t-if="this.displayReadonly">
             <HtmlViewer
-                config="getReadonlyConfig()"/>
+                config="getReadonlyConfig()"
+                migrateHTML="false"/>
         </t>
         <div t-else="" class="h-100" t-att-class="{'o_show_codeview': state.showCodeView, 'o_field_translate': isTranslatable}">
             <t t-if="state.showCodeView">

--- a/addons/html_editor/static/src/fields/html_viewer.js
+++ b/addons/html_editor/static/src/fields/html_viewer.js
@@ -19,9 +19,10 @@ export class HtmlViewer extends Component {
     static template = "html_editor.HtmlViewer";
     static props = {
         config: { type: Object },
+        migrateHTML: { type: Boolean, optional: true },
     };
     static defaultProps = {
-        hasFullHtml: false,
+        migrateHTML: true,
     };
 
     setup() {
@@ -107,12 +108,13 @@ export class HtmlViewer extends Component {
      * @returns { string | Markup }
      */
     formatValue(value) {
-        if (this.props.config.isFixedValue) {
-            return value;
+        let newVal = fixInvalidHTML(value);
+        if (this.props.migrateHTML) {
+            newVal = this.htmlUpgradeManager.processForUpgrade(newVal, {
+                containsComplexHTML: this.props.config.hasFullHtml,
+                env: this.env,
+            });
         }
-        const newVal = this.htmlUpgradeManager.processForUpgrade(fixInvalidHTML(value), {
-            env: this.env,
-        });
         if (instanceofMarkup(value)) {
             return markup(newVal);
         }

--- a/addons/html_editor/static/src/html_migrations/html_upgrade_manager.js
+++ b/addons/html_editor/static/src/html_migrations/html_upgrade_manager.js
@@ -14,13 +14,13 @@ import { fixInvalidHTML } from "@html_editor/utils/sanitize";
  * EmbeddedComponent counterparts, ...
  *
  * How to use:
- * - Create a file to export a `upgrade(element, env)` function which applies
+ * - Create a file to export a `migrate(element, env)` function which applies
  *   the necessary modifications inside `element` related to a specific version:
  *    - HTMLElement `element`: a container for the HtmlField value
  *    - Object `env`: the typical `owl` environment (can be used to check
  *      the current record data, use a service, ...).
  * !!!  ALWAYS assume that the `env` may not have the resource used in your
- *      upgrade function and adjust accordingly.
+ *      migrate function and adjust accordingly.
  * - Refer to that file in the `html_editor_upgrade` registry, in the version
  *   category related to your change: `major.minor` (bump major for an IMP,
  *   minor for a FIX), in a sub-category related to your module.
@@ -67,10 +67,11 @@ export class HtmlUpgradeManager {
             return this.value;
         }
         try {
-            const upgradeSequence = VERSIONS.filter((subVersion) => {
-                // skip already applied versions
-                return compareVersions(subVersion, version) > 0;
-            });
+            const upgradeSequence = VERSIONS.filter(
+                (subVersion) =>
+                    // skip already applied versions
+                    compareVersions(subVersion, version) > 0
+            );
             this.upgradedValue = this.upgrade(upgradeSequence);
         } catch {
             // If an upgrade fails, silently continue to use the raw value.
@@ -82,13 +83,13 @@ export class HtmlUpgradeManager {
         for (const version of upgradeSequence) {
             const modules = this.upgradeRegistry.category(version);
             for (const [key, module] of modules.getEntries()) {
-                const upgrade = odoo.loader.modules.get(module).upgrade;
-                if (!upgrade) {
+                const migrate = odoo.loader.modules.get(module).migrate;
+                if (!migrate) {
                     console.error(
-                        `An "${key}" upgrade function could not be found at "${module}" or it did not load.`
+                        `A "${key}" migrate function could not be found at "${module}" or it did not load.`
                     );
                 }
-                upgrade(this.element, this.env);
+                migrate(this.element, this.env);
             }
         }
         return this.element[this.containsComplexHTML ? "outerHTML" : "innerHTML"];

--- a/addons/html_editor/static/src/html_migrations/migration-1.1.js
+++ b/addons/html_editor/static/src/html_migrations/migration-1.1.js
@@ -4,7 +4,7 @@
  * @param {HTMLElement} container
  * @param {Object} env
  */
-export function upgrade(container) {
+export function migrate(container) {
     const excalidrawContainers = container.querySelectorAll("[data-embedded='draw']");
     for (const excalidrawContainer of excalidrawContainers) {
         const source = JSON.parse(excalidrawContainer.dataset.embeddedProps).source;

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -109,7 +109,6 @@ export const CORE_PLUGINS = [
     DeletePlugin,
     DialogPlugin,
     DomPlugin,
-    EditorVersionPlugin,
     FormatPlugin,
     HistoryPlugin,
     InputPlugin,
@@ -185,5 +184,6 @@ export const EXTRA_PLUGINS = [
     ...COLLABORATION_PLUGINS,
     ...MAIN_PLUGINS,
     ...EMBEDDED_COMPONENT_PLUGINS,
+    EditorVersionPlugin,
     QWebPlugin,
 ];


### PR DESCRIPTION
In preparation of `website` refactoring to use `html_editor`.

`website` already has its own migration features, which would make the
`EditorVersion` Plugin and editor html migrations through the
`HtmlUpgradeManager` redundant. That feature is therefore made optional:

Use the HtmlField option to prevent the migration if necessary.

`EditorVersion` Plugin is moved from `CORE_PLUGINS` to `EXTRA_PLUGINS` and won't
be packaged by default with the editor.

`upgrade` functions are renamed `migrate` to be more consistent with the
`migrate` function of the classic Odoo `upgrade` repository.