### PR TITLE
[IMP] web: View more... in ir.filters

### DIFF
--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { PropertiesGroupByItem } from "@web/search/properties_group_by_item/properties_group_by_item";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -54,6 +54,7 @@ export class SearchBarMenu extends Component {
         }
         this.fields = sortBy(fields, "string");
         // Favorite
+        this.state = useState({ sharedFavoritesExpanded: false });
         useBus(this.env.searchModel, "update", this.render);
     }
 
@@ -138,9 +139,15 @@ export class SearchBarMenu extends Component {
     }
 
     get sharedFavorites() {
-        return this.env.searchModel.getSearchItems(
+        const sharedFavorites = this.env.searchModel.getSearchItems(
             (searchItem) => searchItem.type === "favorite" && searchItem.userId === false
         );
+        if (sharedFavorites.length <= 4 || this.state.sharedFavoritesExpanded) {
+            this.state.sharedFavoritesExpanded = true;
+        } else {
+            sharedFavorites.length = 3;
+        }
+        return sharedFavorites;
     }
 
     get otherItems() {

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.scss
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.scss
@@ -16,6 +16,10 @@ $o-search-bar-menu-max-width: calc(100vw - #{map-get($spacers, 3) * 2 });
         white-space: nowrap;
     }
 
+    .o_favorite_item:hover i {
+        display: block !important;
+    }
+
     @include media-breakpoint-up(lg) {
         .o_dropdown_container {
             max-width: calc(#{$o-search-bar-menu-max-width} / 6);

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -124,18 +124,10 @@
                         <t t-if="favoriteItems.length">
                             <div role="separator" class="dropdown-divider"/>
                         </t>
-                        <t t-if="sharedFavoritesItems.length > 10">
-                            <AccordionItem class="'o_shared_favorites text-truncate'" description.translate="Shared filters">
-                                <t t-foreach="sharedFavoritesItems" t-as="item" t-key="item.id">
-                                    <t t-call="web.SearchBarMenu.FavoriteItem" />
-                                </t>
-                            </AccordionItem>
+                        <t t-foreach="sharedFavoritesItems" t-as="item" t-key="item.id">
+                            <t t-call="web.SearchBarMenu.FavoriteItem" />
                         </t>
-                        <t t-else="">
-                            <t t-foreach="sharedFavoritesItems" t-as="item" t-key="item.id">
-                                <t t-call="web.SearchBarMenu.FavoriteItem" />
-                            </t>
-                        </t>
+                        <DropdownItem t-if="!this.state.sharedFavoritesExpanded" class="'o_menu_item o_expand_shared_favorites'" closingMode="'none'" onSelected.bind="() => this.state.sharedFavoritesExpanded = true">More...</DropdownItem>
                         <div t-if="sharedFavoritesItems.length" role="separator" class="dropdown-divider"/>
                         <t t-set="currentGroup" t-value="null"/>
                         <t t-foreach="otherItems" t-as="item" t-key="item.key">
@@ -154,14 +146,14 @@
 
     <t t-name="web.SearchBarMenu.FavoriteItem">
         <t t-set="item" t-value="item" />
-        <CheckboxItem class="{ 'o_menu_item text-truncate': true, selected: item.isActive }"
+        <CheckboxItem class="{ 'o_menu_item o_favorite_item text-truncate': true, selected: item.isActive }"
                             checked="item.isActive"
                             closingMode="'none'"
                             onSelected="() => this.onFavoriteSelected(item.id)"
         >
             <span class="d-flex p-0 align-items-center justify-content-between">
                 <span t-esc="item.description" t-att-title="item.description.length > 15 ? item.description : ''" class="text-truncate flex-grow-1"/>
-                <i class="ms-1 fa fa-pencil"
+                <i class="ms-1 fa fa-pencil d-none"
                     title="Edit favorite"
                     t-on-click.stop="() => this.editFavorite(item.id)"
                 />

--- a/addons/web/static/tests/_framework/search_test_helpers.js
+++ b/addons/web/static/tests/_framework/search_test_helpers.js
@@ -217,7 +217,9 @@ export async function toggleFavoriteMenu() {
  */
 export async function editFavorite(text) {
     await ensureSearchBarMenu();
-    await contains(`.o_favorite_menu .o_menu_item:contains(/^${text}$/) i.fa-pencil`).click();
+    await contains(`.o_favorite_menu .o_menu_item:contains(/^${text}$/) i.fa-pencil`, {
+        visible: false,
+    }).click();
 }
 
 export async function toggleSaveFavorite() {

--- a/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
@@ -5,15 +5,12 @@ import { editValue } from "@web/../tests/core/tree_editor/condition_tree_editor_
 import {
     contains,
     editFavorite,
-    editFavoriteName,
     getFacetTexts,
     isItemSelected,
     mockService,
     mountWithSearch,
     onRpc,
-    saveFavorite,
     toggleMenuItem,
-    toggleSaveFavorite,
     toggleSearchBarMenu,
 } from "@web/../tests/web_test_helpers";
 import { defineSearchBarModels } from "./models";
@@ -241,15 +238,9 @@ test("edit a favorite with a groupby", async () => {
     expect(`.o_group_by_menu .o_menu_item:not(.o_add_custom_group_menu)`).toHaveCount(0);
 });
 
-test("shared favorites are grouped under a dropdown if there are more than 10", async () => {
-    onRpc("create_or_replace", ({ args, route }) => {
-        expect.step(route);
-        const irFilter = args[0];
-        expect(irFilter.domain).toBe(`[]`);
-        return [10]; // fake serverSideId
-    });
+test("shared favorites are partially shown if there is more than 4", async () => {
     const irFilters = [];
-    for (let i = 1; i < 11; i++) {
+    for (let i = 1; i < 6; i++) {
         irFilters.push({
             context: "{}",
             domain: "[('foo', '=', 'a')]",
@@ -267,14 +258,9 @@ test("shared favorites are grouped under a dropdown if there are more than 10", 
         activateFavorite: false,
     });
     await toggleSearchBarMenu();
-    expect(".o_favorite_menu .o-dropdown-item").toHaveCount(10);
-    await toggleSaveFavorite();
-    await editFavoriteName("My favorite11");
-    await contains(".o-checkbox:eq(1)").click();
-    await saveFavorite();
-    expect.verifySteps(["/web/dataset/call_kw/ir.filters/create_or_replace"]);
-    expect(".o_favorite_menu .o-dropdown-item").toHaveCount(0);
-    expect(".o_favorite_menu .o_menu_item:contains(Shared filters)").toHaveCount(1);
-    await contains(".o_favorite_menu .o_menu_item:contains(Shared filters)").click();
-    expect(".o_favorite_menu .o-dropdown-item").toHaveCount(11);
+    expect(".o_favorite_menu .o_favorite_item").toHaveCount(3);
+    expect(".o_favorite_menu .o_expand_shared_favorites").toHaveCount(1);
+    await contains(".o_favorite_menu .o_expand_shared_favorites").click();
+    expect(".o_favorite_menu .o_expand_shared_favorites").toHaveCount(0);
+    expect(".o_favorite_menu .o_favorite_item").toHaveCount(5);
 });

--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -40,7 +40,7 @@ registry.category("web_tour.tours").add("test_favorite_management", {
             trigger: ".o_favorite_menu .o-dropdown-item:contains(Apps2)",
         },
         {
-            trigger: ".o_favorite_menu .o-dropdown-item:contains(Apps1) i",
+            trigger: ".o_favorite_menu .o-dropdown-item:contains(Apps1) i:not(:visible)",
             run: "click",
         },
         {
@@ -77,7 +77,7 @@ registry.category("web_tour.tours").add("test_favorite_management", {
             trigger: ".o_kanban_record:not(.o_kanban_ghost):only",
         },
         {
-            trigger: ".o_favorite_menu .o-dropdown-item:contains(Apps1) i",
+            trigger: ".o_favorite_menu .o-dropdown-item:contains(Apps1) i:not(:visible)",
             run: "click",
         },
         {


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/145019, shared favorites are hidden behind a dropdown when there are too many. This commit modifies that behavior by removing the dropdown and ensuring that at least three shared favorites are always visible. If there are more than four, the excess favorites are hidden behind a 'More...' button. Additionally, the edit button's style is updated to appear only on hover.

task-4610805
