### PR TITLE
[IMP] im_livechat: allow live chat users see configs of other users

### DIFF
--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -77,11 +77,12 @@ class ResUsers(models.Model):
         When any user doesn't have its setting from ResUsersSettings defined, fallback to Default User Template's.
         """
         fallback_default_privacy = 'public'
-        if any(not user.res_users_settings_id.calendar_default_privacy for user in self):
+        # sudo: any user has access to other users calendar_default_privacy setting
+        if any(not user.sudo().res_users_settings_id.calendar_default_privacy for user in self):
             fallback_default_privacy = self._default_user_calendar_default_privacy()
 
         for user in self:
-            user.calendar_default_privacy = user.res_users_settings_id.calendar_default_privacy or fallback_default_privacy
+            user.calendar_default_privacy = user.sudo().res_users_settings_id.calendar_default_privacy or fallback_default_privacy
 
     def _inverse_calendar_res_users_settings(self):
         """

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_channel.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_channel.xml
@@ -8,6 +8,9 @@
         <record id="base.default_user_group" model="res.groups">
             <field name="implied_ids" eval="[(4, ref('im_livechat.im_livechat_group_manager'))]"/>
         </record>
+        <record id="base.user_admin" model="res.users">
+            <field name="livechat_username">Mitchou Pitchou</field>
+        </record>
     </data>
     <data>
         <record id="im_livechat_channel_rule_demo" model="im_livechat.channel.rule">

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -10,11 +10,25 @@ class ResUsers(models.Model):
     """
     _inherit = 'res.users'
 
-    livechat_username = fields.Char(string='Livechat Username', compute='_compute_livechat_username', inverse='_inverse_livechat_username', store=False)
-    livechat_lang_ids = fields.Many2many('res.lang', string='Livechat Languages', compute='_compute_livechat_lang_ids', inverse='_inverse_livechat_lang_ids', store=False)
+    livechat_username = fields.Char(
+        string="Livechat Username",
+        groups="im_livechat.im_livechat_group_user,base.group_erp_manager",
+        compute="_compute_livechat_username",
+        inverse="_inverse_livechat_username",
+        store=False,
+    )
+    livechat_lang_ids = fields.Many2many(
+        "res.lang",
+        string="Livechat Languages",
+        groups="im_livechat.im_livechat_group_user,base.group_erp_manager",
+        compute="_compute_livechat_lang_ids",
+        inverse="_inverse_livechat_lang_ids",
+        store=False,
+    )
     livechat_expertise_ids = fields.Many2many(
         "im_livechat.expertise",
         string="Live Chat Expertise",
+        groups="im_livechat.im_livechat_group_user,base.group_erp_manager",
         compute="_compute_livechat_expertise_ids",
         inverse="_inverse_livechat_expertise_ids",
         store=False,
@@ -43,7 +57,8 @@ class ResUsers(models.Model):
     @api.depends('res_users_settings_id.livechat_username')
     def _compute_livechat_username(self):
         for user in self:
-            user.livechat_username = user.res_users_settings_id.livechat_username
+            # sudo: livechat user can see the livechat username of any other user
+            user.livechat_username = user.sudo().res_users_settings_id.livechat_username
 
     def _inverse_livechat_username(self):
         for user in self:
@@ -53,7 +68,8 @@ class ResUsers(models.Model):
     @api.depends('res_users_settings_id.livechat_lang_ids')
     def _compute_livechat_lang_ids(self):
         for user in self:
-            user.livechat_lang_ids = user.res_users_settings_id.livechat_lang_ids
+            # sudo: livechat user can see the livechat languages of any other user
+            user.livechat_lang_ids = user.sudo().res_users_settings_id.livechat_lang_ids
 
     def _inverse_livechat_lang_ids(self):
         for user in self:
@@ -63,7 +79,8 @@ class ResUsers(models.Model):
     @api.depends("res_users_settings_id.livechat_expertise_ids")
     def _compute_livechat_expertise_ids(self):
         for user in self:
-            user.livechat_expertise_ids = user.res_users_settings_id.livechat_expertise_ids
+            # sudo: livechat user can see the livechat expertise of any other user
+            user.livechat_expertise_ids = user.sudo().res_users_settings_id.livechat_expertise_ids
 
     def _inverse_livechat_expertise_ids(self):
         for user in self:

--- a/addons/im_livechat/views/res_users_views.xml
+++ b/addons/im_livechat/views/res_users_views.xml
@@ -30,8 +30,7 @@
             <field name="arch" type="xml">
                     <xpath expr="//group[@name='messaging']" position="after">
                         <field name="has_access_livechat" invisible="1"/>
-                        <group name="livechat" string="Livechat"
-                            invisible="not has_access_livechat">
+                        <group name="livechat" string="Livechat" invisible="not has_access_livechat" groups="im_livechat.im_livechat_group_user,base.group_erp_manager">
                             <field name="livechat_username"/>
                             <field name="livechat_lang_ids" string="Online Chat Language"
                                 options="{'no_create': True, 'no_edit': True, 'no_quick_create': True}"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This  PR allows a bypass on the settings of users to read the configuration of any user by any user of the livechat.

It was done this way to prevent giving access to the full user settings model and is therefore a more secure way to do this.

Current behavior before PR:
A non-admin user could not see the configuration in the preferences of any other user in the user form>preferences>live chat

Desired behavior after PR is merged:
Now they should see the livechat preferences of any user


We introduce here a fix on the calendar module to avoid clashes in the fetch of the settings due to a non-sudo access to the settings of the user. This means that the calendar default policy is shown to all users like the other settings.

task-4600054



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
