### PR TITLE
[PERF] stock: prevent unecessary writes

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -454,13 +454,13 @@ class StockMoveLine(models.Model):
                     # Only need to unlink the package level if it's empty. Otherwise will unlink it to still valid move lines.
                     if not package_level.move_line_ids:
                         package_level.unlink()
-        # When we try to write on a reserved move line any fields from `triggers` or directly
-        # `reserved_uom_qty` (the actual reserved quantity), we need to make sure the associated
+        # When we try to write on a reserved move line any fields from `triggers`, result_package_id excepted,
+        # or directly reserved_uom_qty` (the actual reserved quantity), we need to make sure the associated
         # quants are correctly updated in order to not make them out of sync (i.e. the sum of the
         # move lines `reserved_uom_qty` should always be equal to the sum of `reserved_quantity` on
         # the quants). If the new charateristics are not available on the quants, we chose to
         # reserve the maximum possible.
-        if updates or 'quantity' in vals:
+        if (updates and {'result_package_id'}.difference(updates.keys())) or 'quantity' in vals:
             for ml in self:
                 if not ml.product_id.is_storable or ml.state == 'done':
                     continue

--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -155,7 +155,7 @@ class StockPackageLevel(models.Model):
     def create(self, vals_list):
         package_levels = super().create(vals_list)
         for package_level, vals in zip(package_levels, vals_list):
-            if vals.get('location_dest_id'):
+            if vals.get('location_dest_id') and not self.env.context.get('from_put_in_pack'):
                 package_level.move_line_ids.write({'location_dest_id': vals['location_dest_id']})
                 package_level.move_ids.write({'location_dest_id': vals['location_dest_id']})
         return package_levels

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1782,7 +1782,7 @@ class Picking(models.Model):
             'result_package_id': package.id,
         })
         if len(self) == 1:
-            self.env['stock.package_level'].create({
+            self.env['stock.package_level'].with_context(from_put_in_pack=True).create({
                 'package_id': package.id,
                 'picking_id': self.id,
                 'location_id': False,


### PR DESCRIPTION
When putting products in pack from the picking FormView `picking._put_in_pack` is eventually called. This method does a few things, amongst those is a write on picking.move_line_ids and another is the creation of a new package level. Both
of these can be a bit slow when the picking's number of move_lines gets bigger. This can happen for SN tracked products for instance. In a database with 1800 move_lines, each _put_in_pack call takes around 1.5s, which can become cumbersome when customers are using multiple packages.

Most of this slowness is coming from two things. The first one is stock.quants synchronization when writing on move.lines. The propose solution in this commit is to skip this synchronization when the only value in the vals dict is `result_package_id`. We can do that because this value is not used in the first quants synchronization of the write method.

The second one is a write of `location_dest_id` on the picking's move_ids and move_line_ids in `package_level.create`. Since the package_level.location_dest_id value is coming from the `move_line_ids` value in `_put_in_pack`, this commit adds a context key to skip this write in case we're coming from `picking._put_in_pack`

#### speedup

In a 17.4 customer database, putting in pack for a picking with 1800 move_lines: 1.5s -> 90ms


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
