### PR TITLE
[FIX] l10n_it_edi_withholding: fix edi import with enasarco lines

### DIFF
--- a/addons/l10n_it_edi_withholding/tests/test_withholding.py
+++ b/addons/l10n_it_edi_withholding/tests/test_withholding.py
@@ -296,12 +296,15 @@ class TestWithholdingAndPensionFundTaxes(TestItEdi):
             self.assertEqual(self.withholding_purchase_tax_23, line.tax_ids.filtered(lambda x: x.l10n_it_withholding_reason == 'ZO'))
 
     def test_enasarco_tax_import_global(self):
-        """Test that if we have a ENASARCO line with a price of 0.0,
-        the pension fund contribution will be applied on the total
-        amount of the invoice instead of the line amount.
+        """Test that if we have a unique ENASARCO line with a price of 0.0,
+        the pension fund contribution will be applied on the total amount of
+        the invoice instead of the line amount because it's considered as global.
         """
         applied_xml = """
-            <xpath expr="//AltriDatiGestionali[RiferimentoNumero=29.75]" position="replace"/>
+            <xpath expr="//DettaglioLinee[NumeroLinea=1]/AltriDatiGestionali" position="replace"/>
+            <xpath expr="//DettaglioLinee[NumeroLinea=2]/AltriDatiGestionali" position="replace"/>
+            <xpath expr="//DettaglioLinee[NumeroLinea=3]/AltriDatiGestionali" position="replace"/>
+            <xpath expr="//DettaglioLinee[NumeroLinea=4]/AltriDatiGestionali" position="replace"/>
 
             <xpath expr="//DettaglioLinee[NumeroLinea=4]" position="after">
                 <DettaglioLinee>


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_it_edi_withholding
- Switch to an Italian company (e.g. IT Company)
- Import an electronic Italian invoice (XML) containing an element like:

```xml
<DettaglioLinee>
    <NumeroLinea>2</NumeroLinea>
    <Descrizione>Contributo ENASARCO</Descrizione>
    <PrezzoUnitario>0.00</PrezzoUnitario>
    <PrezzoTotale>0.00</PrezzoTotale>
    <AliquotaIVA>22.00</AliquotaIVA>
    <AltriDatiGestionali>
        <TipoDato>CASSA-PREV</TipoDato>
        <RiferimentoTesto>TC07 - ENASARCO</RiferimentoTesto>
        <RiferimentoNumero>10.03</RiferimentoNumero>
    </AltriDatiGestionali>
</DettaglioLinee>
```

**Issue:**
1) When the above ENASARCO element is present and its unit price is 0, we consider that the ENASARCO tax should be applied to each line. We try to retrieve the percentage of the ENASARCO tax used by computing it from the amount from <RiferimentoNumero> element and the untaxed amount of the invoice.
Then the ENASARCO tax is applied on all the current move lines. However, it is possible that all the move lines have not been imported yet and the tax will not be applied on all the lines.

2) If a ENASARCO tax has been set on a particular move line with a unit price of 0, the tax is applied to all the move lines, but it shouldn't.

3) When a global ENASARCO element is found in a move line, this move line is deleted, which can cause an error if the ENASARCO tax cannot be found in the database because a message is logged with the move line name.

**Solution:**
1-2. In "_l10n_it_edi_import_line" method, we had the ENASARCO tax to the current line by computing the tax rate with the unit price of the line if it is not 0.
Then, in "_l10n_it_edi_import_invoice" method, we parse the XML to check if there was a unique ENASARCO element with an amount and without unit price.
If it is the case, we considered the ENASARCO tax as global. Instead of using the untaxed amount of the invoice to compute the rate of the ENASARCO tax used, we should be able to retrieve the real taxable amount in a <DatiRiepilogo> element.

There should be an element like:

```xml
<DatiRiepilogo>
    <AliquotaIVA>22.00</AliquotaIVA>
    <ImponibileImporto>117.97</ImponibileImporto>
    <Imposta>25.95</Imposta>
    <EsigibilitaIVA>I</EsigibilitaIVA>
</DatiRiepilogo>
```
from which we sum all the "ImponibileImporto" values.

3) Only remove the line if the ENASARCO tax is global and can be found in the database.

Ref old fix: https://github.com/odoo/odoo/pull/197456

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4555966)
opw-4555966
