### PR TITLE
[FIX] stock: raise warning when superuser-created order point is snoozed

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -9109,6 +9109,14 @@ msgstr ""
 
 #. module: stock
 #. odoo-python
+#: code:addons/stock/wizard/stock_orderpoint_snooze.py:0
+msgid ""
+"This order point has been created automatically.\n"
+"snoozing it will not affect future ones created for the same product."
+msgstr ""
+
+#. module: stock
+#. odoo-python
 #: code:addons/stock/models/product.py:0
 msgid ""
 "This product has been used in at least one inventory movement. It is not "

--- a/addons/stock/wizard/stock_orderpoint_snooze.py
+++ b/addons/stock/wizard/stock_orderpoint_snooze.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.tools.date_utils import add
 
 
@@ -32,3 +32,15 @@ class StockOrderpointSnooze(models.TransientModel):
         self.orderpoint_ids.write({
             'snoozed_until': self.snoozed_until
         })
+        if self.orderpoint_ids.create_uid._is_superuser():
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'warning',
+                    'sticky': False,
+                    'message': _("This order point has been created automatically.\n"
+                                "snoozing it will not affect future ones created for the same product."),
+                    'next': {'type': 'ir.actions.act_window_close'},
+                }
+            }


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”
- Go to Operations > Replenishment:
    - An orderpoint is created for “P1”
- Click on the Snooze button:
    - Snooze for 1 day
    - Snooze date: today
- The orderpoint for "P1" becomes invisible thanks to the “Snooze” filter
- Refresh the page

Problem:
The snooze filter is correctly applied, but an orderpoint for "P1" is still visible. This happens because the old snoozed orderpoint was unlinked, and a new one was created without the snoozed_until field set.

https://github.com/odoo/odoo/blob/18.0/addons/stock/models/stock_orderpoint.py#L596-L599

opw-4628611
