### PR TITLE
[FIX] l10n_br_website_sale: check Brazil is selected in address form

### DIFF
--- a/addons/l10n_br_website_sale/static/src/js/address.js
+++ b/addons/l10n_br_website_sale/static/src/js/address.js
@@ -53,13 +53,18 @@ websiteSaleAddress.include({
         }
     },
 
+    _selectedCountryCode: function() {
+        const countryOption = this.addressForm.country_id;
+        return countryOption.selectedOptions[0].getAttribute("code");
+    },
+
     _selectState: function (id) {
         this.addressForm.querySelector(`select[name="state_id"] > option[value="${id}"]`).selected =
             "selected";
     },
 
     _onChangeZip: function () {
-        if (this.countryCode !== "BR") {
+        if (this.countryCode !== "BR" || this._selectedCountryCode() !== "BR") {
             return;
         }
 
@@ -91,7 +96,7 @@ websiteSaleAddress.include({
     },
 
     _onChangeBrazilianCity: function () {
-        if (this.countryCode !== "BR") {
+        if (this.countryCode !== "BR" || this._selectedCountryCode() !== "BR") {
             return;
         }
 
@@ -128,12 +133,7 @@ websiteSaleAddress.include({
             return res;
         }
 
-        const countryOption = this.addressForm.country_id;
-        const selectedCountryCode = countryOption.value
-            ? countryOption.selectedOptions[0].getAttribute("code")
-            : "";
-
-        if (selectedCountryCode === "BR") {
+        if (this._selectedCountryCode() === "BR") {
             this._setVisibility(".o_standard_address", false); // hide
             this._setVisibility(".o_extended_address", true); // show
             this._onChangeZip();


### PR DESCRIPTION
Versions
--------
- saas-18.1+

Steps
-----
1. Enable Brazilian localization;
2. assign eCommerce website to Brazilian company;
3. as a non-Brazilian user, add a product to the cart;
4. during checkout, edit your address;
5. ensure Brazil is not selected in the country selector;
6. change your zip code.

Issue
-----
Oops! Something went wrong... `UncaughtClientError > TypeError`

Cause
-----
Commit 08e1857b36cdc introduced a select menu for Brazilian cities on checkout. In order to decide whether to run the custom event handlers, it does a check on `this.countryCode`, which returns the company's country, but not on the country selected in the address form.

The error occurs trying to select a Brazilian state regardless of the selected country.

Solution
--------
Add a check on the country selected in the address form to make sure it's Brazil before attempting to select a Brazilian state.

opw-4542781