### PR TITLE
[IMP] payment_mercado_pago: Add platform-id header for certification

### DIFF
--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -55,7 +55,10 @@ class Paymentprovider(models.Model):
         self.ensure_one()
 
         url = urls.url_join('https://api.mercadopago.com', endpoint)
-        headers = {'Authorization': f'Bearer {self.mercado_pago_access_token}'}
+        headers = {
+            'Authorization': f'Bearer {self.mercado_pago_access_token}',
+            'X-Platform-Id': 'dev_cdf1cfac242111ef9fdebe8d845d0987',
+        }
         try:
             if method == 'GET':
                 response = requests.get(url, params=payload, headers=headers, timeout=10)


### PR DESCRIPTION
Mercado Pago requires the X-platform-id header to be passed in all requests to their platform to keep track of the amount of odoo customers that exist.

This key is not secret and perfectly fine to be committed in this repo without worry.

task-4628319