### PR TITLE
[FIX] mail: hide isTalking when self-deafened

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -117,7 +117,12 @@ export class CallParticipantCard extends Component {
     }
 
     get isTalking() {
-        return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isMute);
+        return Boolean(
+            this.rtcSession &&
+                this.rtcSession.isTalking &&
+                !this.rtcSession.isMute &&
+                !this.rtc.state.selfSession?.isDeaf
+        );
     }
 
     get hasRaisingHand() {


### PR DESCRIPTION
Current behavior before PR:

`isTalking` status displayed who was talking even
when the user had deafened themselves.

Desired behavior after PR is merged:

`isTalking` status no longer shows who is talking
if the user has deafened themselves.

Task-id:[4609755](https://www.odoo.com/odoo/project.task/4609755)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
