### PR TITLE
[FIX] Show JSON error when the response return non JSON

### DIFF
--- a/doc/cla/individual/martinvelezf.md
+++ b/doc/cla/individual/martinvelezf.md
@@ -1,0 +1,11 @@
+Ecuador, 2025-03-09
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Martin Velez. martinvelezfalconi@outlook.com https://github.com/martinvelezf


### PR DESCRIPTION
Description of the issue/feature this PR addresses: The auth base module, do not show errors, when you add a wrong url that return HTML response

Current behavior before PR: Show a generic raise exception, hard to address issue
Desired behavior after PR is merged: Show error in logs what is the wrong URL





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
