### PR TITLE
[FIX] base: update imports or translate

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1,26 +1,24 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import odoo
-from odoo import api, fields, models, tools, _, Command
-from odoo.exceptions import MissingError, ValidationError, AccessError, UserError
-from odoo.fields import Domain
-from odoo.tools import frozendict
+import base64
+import contextlib
+import json
+import logging
+import re
+from collections import defaultdict
+from functools import reduce
+from operator import getitem
+
+import requests
+from pytz import timezone
+
+from odoo import api, fields, models, tools
+from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
+from odoo.fields import Command, Domain
+from odoo.tools import _, frozendict
+from odoo.tools.float_utils import float_compare
 from odoo.tools.misc import unquote
 from odoo.tools.safe_eval import safe_eval, test_python_expr
-from odoo.tools.float_utils import float_compare
-from odoo.http import request
-import base64
-from collections import defaultdict
-from functools import partial, reduce
-import logging
-from operator import getitem
-import requests
-import json
-import re
-import contextlib
-
-from pytz import timezone
 
 _logger = logging.getLogger(__name__)
 _server_action_logger = _logger.getChild("server_action_safe_eval")
@@ -1003,7 +1001,7 @@ class IrActionsServer(models.Model):
             'env': self.env,
             'model': model,
             # Exceptions
-            'UserError': odoo.exceptions.UserError,
+            'UserError': UserError,
             # record
             'record': record,
             'records': records,

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import relativedelta
 
 import odoo
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.exceptions import LockError, UserError
 from odoo.modules.registry import Registry
 from odoo.tools import SQL
@@ -132,7 +132,7 @@ class IrCron(models.Model):
         cron_cr = self.env.cr
         job = self._acquire_one_job(cron_cr, self.id, include_not_ready=True)
         if not job:
-            raise UserError(_("Job '%s' already executing", self.name))
+            raise UserError(self.env._("Job '%s' already executing", self.name))
         self._process_job(cron_cr, job)
         return True
 
@@ -521,7 +521,7 @@ class IrCron(models.Model):
                 failure_count = 0
                 first_failure_date = None
                 active = False
-                self._notify_admin(_(
+                self._notify_admin(self.env._(
                     "Cron job %(name)s (%(id)s) has been deactivated after failing %(count)s times. "
                     "More information can be found in the server logs around %(time)s.",
                     name=repr(job['cron_name']),

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -15,12 +15,12 @@ from lxml.etree import LxmlError
 from lxml.builder import E
 from markupsafe import Markup
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools
 from odoo.exceptions import ValidationError, AccessError, UserError
 from odoo.http import request
 from odoo.modules.module import get_resource_from_path
 from odoo.service.model import get_public_method
-from odoo.tools import config, lazy_property, frozendict, SQL
+from odoo.tools import _, config, lazy_property, frozendict, SQL
 from odoo.tools.convert import _fix_multiple_roots
 from odoo.tools.misc import file_path, get_diff, ConstantMapping
 from odoo.tools.template_inheritance import apply_inheritance_specs, locate_node


### PR DESCRIPTION
Use the translation function from the env or import it from `odoo.tools` in order to avoid directly referencing the monkey-patched `odoo._`. Using it may create warnings when generating the documentation.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
