### PR TITLE
[FIX] l10n_in: prevent error when configure an indian intergration

### DIFF
--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -99,8 +99,18 @@ class ResCompany(models.Model):
                 ]
                 self._activate_l10n_in_taxes(gst_group_refs, company)
                 # Set sale and purchase tax accounts when user registered under GST.
-                company.account_sale_tax_id = self.env['account.chart.template'].with_company(company).ref('sgst_sale_5').id
-                company.account_purchase_tax_id = self.env['account.chart.template'].with_company(company).ref('sgst_purchase_5').id
+                if (
+                    account_sale_tax := self.env["account.chart.template"]
+                    .with_company(company)
+                    .ref("sgst_sale_5", raise_if_not_found=False)
+                ):
+                    company.account_sale_tax_id = account_sale_tax.id
+                if (
+                    account_purchase_tax := self.env["account.chart.template"]
+                    .with_company(company)
+                    .ref("sgst_purchase_5", raise_if_not_found=False)
+                ):
+                    company.account_purchase_tax_id = account_purchase_tax.id
 
     @api.depends('parent_id.l10n_in_tds_feature', 'parent_id.l10n_in_tcs_feature', 'parent_id.l10n_in_is_gst_registered')
     def _compute_l10n_in_parent_based_features(self):
@@ -112,9 +122,11 @@ class ResCompany(models.Model):
 
     def _activate_l10n_in_taxes(self, group_refs, company):
         for group_ref in group_refs:
-            tax_group_id = self.env['account.chart.template'].with_company(company).ref(group_ref).id
+            tax_group_id = self.env['account.chart.template'].with_company(company).ref(group_ref, raise_if_not_found=False)
+            if not tax_group_id:
+                continue
             taxes = self.env['account.tax'].with_company(company).with_context(active_test=False).search([
-                ('tax_group_id', '=', tax_group_id),
+                ('tax_group_id', '=', tax_group_id.id),
             ])
             taxes.write({'active': True})
 


### PR DESCRIPTION
This error occurs when a user selects `Fiscal Country` to `India` and attempts to configure any `Indian Integration`.

Steps to reproduce :
1. Install module `l10n_in`.
2. Create a new company `without assigning a country` and switch on it.
3. In Accounting settings :
  - Set Fiscal Country to India and Save.
  - Enable Registered Under GST, enter the GST Number, and Save.

ValueError: External ID not found in the system: account.1_sgst_group.

This error occurs when the `Fiscal Country` is set to `India` and due to recent merge in module at `[1]` allows users to fill in sgst_group even when the `Fiscal Localization Package` is not set. As a result, the system cannot find the required sgst_groupID, which is created dynamically when the Fiscal Localization Package is set to India.

This commit ensures that if the id does not exist, the function will return None instead of raising an exception.

Link [1] : https://github.com/odoo/odoo/pull/190265

sentry: 6362946694

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
