### PR TITLE
[FIX] website_sale: prevent combo item access error

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -445,7 +445,8 @@ class ProductTemplate(models.Model):
             and website.show_line_subtotals_tax_selection == 'tax_included'
             and not all(
                 tax.price_include
-                for tax in product_or_template.combo_ids.combo_item_ids.product_id.taxes_id
+                for tax
+                in product_or_template.combo_ids.sudo().combo_item_ids.product_id.taxes_id
             )
         ):
             combination_info['tax_disclaimer'] = _(


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Set website to display prices tax included;
2. have a combo item published;
3. open product's eCommerce page as public user.

Issue
-----
Access Error.

Cause
-----
Commit 4ec8d2198a1a0 added a disclaimer for combo items products tax calculations. It checks the `taxes_id` fields of the `combo_item_ids`. Issue is that the `product.combo` model isn't accessible for public users (unlike `product.product` and `product.template`.

Solution
--------
Use `sudo` on the combo product.

opw-4608719