### PR TITLE
[FIX] payment: disabled post-processing cron on update

### DIFF
--- a/addons/payment/data/payment_cron.xml
+++ b/addons/payment/data/payment_cron.xml
@@ -13,4 +13,6 @@
         <field name="active" eval="False"/>
     </record>
 
+    <function model="payment.provider" name="_toggle_post_processing_cron"/>
+
 </odoo>

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -397,6 +397,7 @@ class PaymentProvider(models.Model):
                 _("The following fields must be filled: %s", ", ".join(field_names))
             )
 
+    @api.model
     def _toggle_post_processing_cron(self):
         """ Enable the post-processing cron if some providers are enabled; disable it otherwise.
 


### PR DESCRIPTION
The post processing cron has been recently changed to be disabled by default (ecc5711f002180d7ccf37654d5c3ea5b057b3a17) but this change wasn't properly tested on module updates, which did disable the cron regardless of the providers states.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
