### PR TITLE
[FIX] l10n_eg_edi: Send line label to ETA

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -301,7 +301,7 @@ class AccountEdiFormat(models.Model):
             discount_amount = self._l10n_eg_edi_round(price_subtotal_before_discount - abs(line.balance))
             item_code = line.product_id.l10n_eg_eta_code or line.product_id.barcode
             lines.append({
-                'description': line.product_id.display_name or line.name,
+                'description': line.name,
                 'itemType': item_code.startswith('EG') and 'EGS' or 'GS1',
                 'itemCode': item_code,
                 'unitType': line.product_uom_id.l10n_eg_unit_code_id.code,


### PR DESCRIPTION
purpose of this commit:
In version 17.3, a change was introduced to send the product display name instead of the line label. which meant unsupporting some valid use cases. This commit reverts the change back to sending the line label

ticket-id: 4602920

Description of the issue/feature this PR addresses:
modified labels are not sent to the ETA
Current behavior before PR:
-> change an invoice line label
-> post the invoice
-> send to ETA
-> only product name is sent to the ETA
Desired behavior after PR is merged:
-> change an invoice line label
-> post the invoice
-> send to ETA
-> line label is sent to the ETA



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
