### PR TITLE
[FIX] web_editor:  fix clicking on a snippet with an open mega menu

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -5110,38 +5110,42 @@ class SnippetsMenu extends Component {
                 dropZoneEls = [...dropZoneEls].filter(dropzoneEl => {
                     return !dropzoneEl.closest("[data-snippet]:not(.s_popup), #website_cookies_bar");
                 });
-                hookEl = this._getClosestDropzone(dropZoneEls)
-                    || dropZoneEls[dropZoneEls.length - 1];
-                hookEl.classList.add("o_hook_drop_zone");
+                if (dropZoneEls?.length) {
+                    hookEl = this._getClosestDropzone(dropZoneEls)
+                        || dropZoneEls[dropZoneEls.length - 1];
+                    hookEl.classList.add("o_hook_drop_zone");
+                }
             } else {
                 hookEl = initialSnippetEl;
             }
 
-            const hookParentEl = hookEl.parentNode;
-            // Excludes snippets that cannot be placed at the target location.
-            [...this.snippets.values()].forEach((snippet) => {
-                if (snippet.disabled) {
-                    snippet.excluded = true;
-                } else {
-                    const $snippetSelectorChildren =
-                            this._getSelectors($(snippet.baseBody)).$selectorChildren;
-                    const hasSelectorChild = [...$snippetSelectorChildren].some(snippetSelectorChild => {
-                        return snippetSelectorChild === hookParentEl;
-                    });
-                    const forbidSanitize = snippet.data.oeForbidSanitize;
-                    let isForbidden = false;
-                    if (forbidSanitize === "form") {
-                        isForbidden = hookEl.closest('[data-oe-sanitize]:not([data-oe-sanitize="allow_form"])');
-                    } else if (forbidSanitize) {
-                        isForbidden = hookEl.closest("[data-oe-sanitize]");
+            if (hookEl) {
+                const hookParentEl = hookEl.parentNode;
+                // Excludes snippets that cannot be placed at the target location.
+                [...this.snippets.values()].forEach((snippet) => {
+                    if (snippet.disabled) {
+                        snippet.excluded = true;
+                    } else {
+                        const $snippetSelectorChildren =
+                                this._getSelectors($(snippet.baseBody)).$selectorChildren;
+                        const hasSelectorChild = [...$snippetSelectorChildren].some(snippetSelectorChild => {
+                            return snippetSelectorChild === hookParentEl;
+                        });
+                        const forbidSanitize = snippet.data.oeForbidSanitize;
+                        let isForbidden = false;
+                        if (forbidSanitize === "form") {
+                            isForbidden = hookEl.closest('[data-oe-sanitize]:not([data-oe-sanitize="allow_form"])');
+                        } else if (forbidSanitize) {
+                            isForbidden = hookEl.closest("[data-oe-sanitize]");
+                        }
+                        snippet.excluded = !hasSelectorChild || isForbidden;
                     }
-                    snippet.excluded = !hasSelectorChild || isForbidden;
-                }
-            });
+                });
+            }
 
             const hasIncludedSnippet = [...this.snippets.values()].some(snippet => snippet.excluded === false);
-            if (!hasIncludedSnippet) {
-                if (dropZoneEls) {
+            if (!hasIncludedSnippet || !hookEl) {
+                if (dropZoneEls?.length) {
                     dropZoneEls.forEach(dropZoneEl => dropZoneEl.remove());
                 }
                 this.options.wysiwyg.odooEditor.historyUnpauseSteps();


### PR DESCRIPTION
Steps to reproduce:

- Add a mega menu to the menu.
- Enter edit mode.
- Open the mega menu.
- Click on a snippet category.
- Bug: A traceback occurs.

This was due to the absence of drop zones on the page for non-inline snippets when a mega menu was open. After this commit, we ensure that drop zones are present when clicking.