### PR TITLE
[IMP] sale,website_sale: product_configurator pre_compute values

### DIFF
--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -54,6 +54,7 @@ export class ComboConfiguratorDialog extends Component {
         this._initSelectedComboItems();
         this.getPriceUrl = '/sale/combo_configurator/get_price';
         useSubEnv({ currency: { id: this.props.currency_id } });
+        this.product_configurator_url = '/sale/product_configurator/get_values'
     }
 
     /**
@@ -68,14 +69,31 @@ export class ComboConfiguratorDialog extends Component {
         comboItem = this.getSelectedOrProvidedComboItem(comboId, comboItem);
         let product = comboItem.product;
         if (comboItem.is_configurable) {
+            const productConfiguratorValues = await rpc(this.product_configurator_url,
+                {
+                    product_template_id: product.product_tmpl_id,
+                    quantity: 1,
+                    currency_id: this.props.currency_id,
+                    so_date: this.props.date,
+                    company_id: this.props.company_id,
+                    pricelist_id: this.props.pricelist_id,
+                    ptav_ids: product.selectedPtavIds,
+                    force_dialog: true,
+                    show_main_product: true,
+                    show_optional_product: true,
+                    ...this._getAdditionalRpcParams(),
+                }
+            )
             this.dialog.add(ProductConfiguratorDialog, {
+                products: productConfiguratorValues['products'],
+                optionalProducts: productConfiguratorValues['optional_products'],
                 productTemplateId: product.product_tmpl_id,
                 ptavIds: product.selectedPtavIds,
                 customPtavs: product.selectedCustomPtavs,
                 quantity: 1,
                 companyId: this.props.company_id,
                 pricelistId: this.props.pricelist_id,
-                currencyId: this.props.currency_id,
+                currency_id: productConfiguratorValues['currency_id'],
                 soDate: this.props.date,
                 edit: true, // Hide the optional products, if any.
                 options: { canChangeVariant: false, showQuantity: false, showPrice: false },

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -8,6 +8,8 @@ export class ProductConfiguratorDialog extends Component {
     static components = { Dialog, ProductList};
     static template = 'sale.ProductConfiguratorDialog';
     static props = {
+        products: {type: Array, element: Object},
+        optionalProducts: {type: Array, element: Object},
         productTemplateId: Number,
         ptavIds: { type: Array, element: Number },
         customPtavs: {
@@ -52,7 +54,6 @@ export class ProductConfiguratorDialog extends Component {
         // Nest the currency id in an object so that it stays up to date in the `env`, even if we
         // modify it in `onWillStart` afterwards.
         this.currency = { id: this.props.currencyId };
-        this.getValuesUrl = '/sale/product_configurator/get_values';
         this.createProductUrl = '/sale/product_configurator/create_product';
         this.updateCombinationUrl = '/sale/product_configurator/update_combination';
         this.getOptionalProductsUrl = '/sale/product_configurator/get_optional_products';
@@ -72,13 +73,8 @@ export class ProductConfiguratorDialog extends Component {
         });
 
         onWillStart(async () => {
-            const {
-                products,
-                optional_products,
-                currency_id,
-            } = await this._loadData(this.props.edit);
-            this.state.products = products;
-            this.state.optionalProducts = optional_products;
+            this.state.products = this.props.products;
+            this.state.optionalProducts = this.props.optionalProducts;
             for (const customPtav of this.props.customPtavs) {
                 this._updatePTAVCustomValue(
                     this.env.mainProductTmplId,
@@ -88,28 +84,13 @@ export class ProductConfiguratorDialog extends Component {
             }
             this._checkExclusions(this.state.products[0]);
             // Use the currency id retrieved from the server if none was provided in the props.
-            this.currency.id ??= currency_id;
+            this.currency.id ??= this.props.currencyId;
         });
     }
 
     //--------------------------------------------------------------------------
     // Data Exchanges
     //--------------------------------------------------------------------------
-
-    async _loadData(onlyMainProduct) {
-        return rpc(this.getValuesUrl, {
-            product_template_id: this.props.productTemplateId,
-            quantity: this.props.quantity,
-            currency_id: this.currency.id,
-            so_date: this.props.soDate,
-            product_uom_id: this.props.productUOMId,
-            company_id: this.props.companyId,
-            pricelist_id: this.props.pricelistId,
-            ptav_ids: this.props.ptavIds,
-            only_main_product: onlyMainProduct,
-            ...this._getAdditionalRpcParams(),
-        });
-    }
 
     async _createProduct(product) {
         return rpc(this.createProductUrl, {

--- a/addons/sale/static/tests/sale_product_field.test.js
+++ b/addons/sale/static/tests/sale_product_field.test.js
@@ -18,12 +18,17 @@ class SaleOrder extends models.Model {
         relation: "sale.order.line",
         relation_field: "order_id",
     });
+    company_id = fields.Many2one({
+        string: 'company',
+        relation: "res.company",
+    });
 
     _records = [
         {
             id: 1,
             name: "first record",
             order_line: [],
+            company_id: 1,
         },
     ];
 }
@@ -89,7 +94,15 @@ class Product extends models.Model {
     _records = [{ id: 14, name: "desk" }];
 }
 
-defineModels([SaleOrder, SaleOrderLine, ProductTemplate, ProductTemplateAttributeValue, Product]);
+class Company extends models.Model {
+    _name = "res.company";
+
+    name = fields.Char();
+
+    _records = [{ id: 1, name: "test company" }];
+}
+
+defineModels([Company, SaleOrder, SaleOrderLine, ProductTemplate, ProductTemplateAttributeValue, Product]);
 defineMailModels();
 
 test.tags`desktop`;
@@ -97,12 +110,16 @@ test("pressing tab with incomplete text will create a product", async () => {
     onRpc(({ method }) => {
         expect.step(method);
     });
+    onRpc('/sale/product/get_values', ()=>{
+        return {dialog: 'false'}
+    })
     await mountView({
         type: "form",
         resModel: "sale.order",
         arch: `
                 <form>
                     <sheet>
+                        <field name="company_id"/>
                         <field name="order_line">
                             <list editable="bottom">
                                 <field name="product_template_id" widget="sol_product_many2one"/>
@@ -125,6 +142,5 @@ test("pressing tab with incomplete text will create a product", async () => {
         "onchange",
         "web_name_search",
         "name_create",
-        "get_single_product_variant",
     ]);
 });

--- a/addons/sale/tests/test_product_configurator_data.py
+++ b/addons/sale/tests/test_product_configurator_data.py
@@ -28,7 +28,8 @@ class TestProductConfiguratorData(HttpCaseWithUserDemo, ProductVariantsCommon, S
                     'company_id': None,
                     'pricelist_id': None,
                     'ptav_ids': ptav_ids,
-                    'only_main_product': False,
+                    'show_main_product': True,
+                    'show_optional_product': True,
                 },
             }
         )

--- a/addons/sale_product_matrix/models/product_template.py
+++ b/addons/sale_product_matrix/models/product_template.py
@@ -16,10 +16,7 @@ class ProductTemplate(models.Model):
         help="Configurator: choose attribute values to add the matching product variant to the order."
              "\nGrid: add several variants at once from the grid of attribute values")
 
-    def get_single_product_variant(self):
-        res = super().get_single_product_variant()
-        if self.has_configurable_attributes:
-            res['mode'] = self.product_add_mode
-        else:
-            res['mode'] = 'configurator'
-        return res
+    def _get_dialog_type(self):
+        if self.product_add_mode == 'matrix':
+            return 'matrix'
+        return super()._get_dialog_type()

--- a/addons/sale_product_matrix/static/src/js/sale_product_field.js
+++ b/addons/sale_product_matrix/static/src/js/sale_product_field.js
@@ -12,11 +12,11 @@ patch(SaleOrderLineProductField.prototype, {
         return this.matrixConfigurator.open(this.props.record, edit);
     },
 
-    async _openProductConfigurator(edit=false) {
+    async _openProductConfigurator(show_main_product, show_optional_product, edit=false) {
         if (edit && this.props.record.data.product_add_mode == 'matrix') {
             this._openGridConfigurator(true);
         } else {
-            return super._openProductConfigurator(edit);
+            return super._openProductConfigurator(show_main_product, show_optional_product, edit);
         }
     },
 });

--- a/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -24,6 +24,7 @@ patch(ComboConfiguratorDialog.prototype, {
 
         if (this.props.isFrontend) {
             this.getPriceUrl = '/website_sale/combo_configurator/get_price';
+            this.product_configurator_url = '/website_sale/product_configurator/get_values'
         }
     },
 

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -25,7 +25,6 @@ patch(ProductConfiguratorDialog.prototype, {
         super.setup(...arguments);
 
         if (this.props.isFrontend) {
-            this.getValuesUrl = '/website_sale/product_configurator/get_values';
             this.createProductUrl = '/website_sale/product_configurator/create_product';
             this.updateCombinationUrl = '/website_sale/product_configurator/update_combination';
             this.getOptionalProductsUrl = '/website_sale/product_configurator/get_optional_products';

--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -163,11 +163,12 @@ class TestWebsiteSaleProductConfigurator(
         main_product = self.env['product.template'].create({
             'name': "Main product", 'website_published': True
         })
-
         with MockRequest(self.env, website=self.website):
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
-            )
+            show_configurator = self.pc_controller.website_sale_product_get_values(
+                product_template_id=main_product.id,
+                is_product_configured=False,
+                force_dialog=True,
+            )['dialog']
 
         self.assertTrue(show_configurator)
 
@@ -183,9 +184,10 @@ class TestWebsiteSaleProductConfigurator(
         })
 
         with MockRequest(self.env, website=self.website):
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
-            )
+            show_configurator = self.pc_controller.website_sale_product_get_values(
+                product_template_id=main_product.id,
+                is_product_configured=False,
+            )['dialog']
 
         self.assertTrue(show_configurator)
 
@@ -207,9 +209,10 @@ class TestWebsiteSaleProductConfigurator(
         })
 
         with MockRequest(self.env, website=self.website):
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
-            )
+            show_configurator = self.pc_controller.website_sale_product_get_values(
+                product_template_id=main_product.id,
+                is_product_configured=False,
+            )['dialog']
 
         self.assertFalse(show_configurator)
 
@@ -238,9 +241,10 @@ class TestWebsiteSaleProductConfigurator(
         })
 
         with MockRequest(self.env, website=self.website):
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, ptav_ids=[], is_product_configured=True
-            )
+            show_configurator = self.pc_controller.website_sale_product_get_values(
+                product_template_id=main_product.id,
+                is_product_configured=True,
+            )['dialog']
 
         self.assertFalse(show_configurator)
 
@@ -268,9 +272,10 @@ class TestWebsiteSaleProductConfigurator(
         })
 
         with MockRequest(self.env, website=self.website):
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
-            )
+            show_configurator = self.pc_controller.website_sale_product_get_values(
+                product_template_id=main_product.id,
+                is_product_configured=False,
+            )['dialog']
 
         self.assertTrue(show_configurator)
 
@@ -298,9 +303,10 @@ class TestWebsiteSaleProductConfigurator(
         })
 
         with MockRequest(self.env, website=self.website):
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
-            )
+            show_configurator = self.pc_controller.website_sale_product_get_values(
+                product_template_id=main_product.id,
+                is_product_configured=False,
+            )['dialog']
 
         self.assertTrue(show_configurator)
 
@@ -329,9 +335,10 @@ class TestWebsiteSaleProductConfigurator(
         })
 
         with MockRequest(self.env, website=self.website):
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
-            )
+            show_configurator = self.pc_controller.website_sale_product_get_values(
+                product_template_id=main_product.id,
+                is_product_configured=False,
+            )['dialog']
 
         self.assertTrue(show_configurator)
 
@@ -349,18 +356,17 @@ class TestWebsiteSaleProductConfigurator(
         })
 
         with MockRequest(self.env, website=self.website):
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, ptav_ids=[], is_product_configured=False
+            product_values = self.pc_controller.website_sale_product_get_values(
+                product_template_id=main_product.id,
             )
             configurator_values = self.pc_controller.website_sale_product_configurator_get_values(
                 product_template_id=main_product.id,
                 quantity=1,
+                so_date=datetime(2000, 1, 1).strftime('%Y-%m-%d'),
                 currency_id=self.currency.id,
-                so_date='2000-01-01',
-                pricelist_id=self.pricelist.id,
             )
 
-        self.assertFalse(show_configurator)
+        self.assertFalse(product_values['dialog'])
         self.assertListEqual(configurator_values['optional_products'], [])
 
     def test_product_configurator_extra_price_taxes(self):


### PR DESCRIPTION
Prior this commit:
- Currently, we perform some computations to know whether the product configurator should be shown. If it should be shown, we perform some additional computations to populate it

Post this commit:
- Pre-compute product configurator values in advance before opening it to avoid overlapping computations

task - 3891049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
