### PR TITLE
[IMP] pos*: delete cash moves before closing

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -113,7 +113,7 @@ export class Navbar extends Component {
         return this.pos.config.customer_display_type !== "none" && !isMobileOS();
     }
     get showCashMoveButton() {
-        return Boolean(this.pos.config.cash_control && this.pos.session._has_cash_move_perm);
+        return this.pos.showCashMoveButton;
     }
     getOrderTabs() {
         return this.pos.getOpenOrders().filter((order) => !order.table_id);

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.js
@@ -1,0 +1,47 @@
+import { useService } from "@web/core/utils/hooks";
+import { Component } from "@odoo/owl";
+import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
+import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+import { Dialog } from "@web/core/dialog/dialog";
+import { _t } from "@web/core/l10n/translation";
+
+export class CashMoveListPopup extends Component {
+    static template = "point_of_sale.CashMoveListPopup";
+    static components = { Dialog };
+    static props = {
+        close: { type: Function },
+        cashMoves: { type: Array },
+        partnerId: { type: Number },
+    };
+    async setup() {
+        super.setup();
+        this.pos = usePos();
+        this.ui = useService("ui");
+        this.callbacks = this.props.cashMoves.reduce(
+            (acc, cm) => ({
+                ...acc,
+                [cm.id]: useTrackedAsync(() => this.onDeleteCm(cm)),
+            }),
+            {}
+        );
+    }
+
+    getStatus(cm) {
+        return cm.amount < 0 ? _t("Out") : _t("In");
+    }
+
+    getAmount(cm) {
+        return this.env.utils.formatCurrency(Math.abs(cm.amount));
+    }
+
+    async onDeleteCm(cm) {
+        await this.pos.data.call(
+            "pos.session",
+            "delete_cash_in_out",
+            [[this.pos.session.id], cm.id, this.props.partnerId],
+            {},
+            true
+        );
+        this.props.cashMoves = this.props.cashMoves.filter((cashMove) => cashMove.id !== cm.id);
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="point_of_sale.CashMoveListPopup">
+        <Dialog title.translate="Cash move details" size="'md'" footer="false">
+            <div class="cash-move-list overflow-y-auto flex-grow-1 rounded-bottom-3 bg-view">
+                <t t-if="props.cashMoves.length !== 0">
+                    <table t-if="!ui.isSmall"  class="table table-striped table-hover">
+                        <tbody>
+                            <t t-foreach="props.cashMoves" t-as="cm" t-key="cm.id">
+                                <tr class="cash-move-row" >
+                                    <td>
+                                        <div class="fs-6 fw-bolder"><t t-esc="this.pos.getDate(cm.date)"></t></div>
+                                        <div class="small text-muted"><t t-esc="this.pos.getTime(cm.date)"></t></div>
+                                    </td>
+                                    <td>
+                                        <t t-if="cm.cashier_name" t-esc="cm.cashier_name"/>
+                                    </td>
+                                    <td class="align-middle text-end">
+                                        <t t-set="status" t-value="getStatus(cm)" />
+                                        <div t-attf-class="w-50 text-center badge rounded fs-6 text-bg-{{status === 'In' ? 'success' : 'danger'}}">
+                                            <t t-esc="status"></t>
+                                        </div>
+                                    </td>
+                                    
+                                    <td class="align-middle">
+                                        <div class="fw-bolder"><t t-esc="getAmount(cm)"></t></div>
+                                    </td>
+                                    
+                                    <td class="text-end delete-row">
+                                        <button t-on-click.stop="callbacks[cm.id].call" class="btn btn-link btn-lg text-danger">
+                                            <i t-if="callbacks[cm.id].status != 'loading'" class="fa fa-trash" aria-hidden="true"/>
+                                            <i t-else="" class="fa fa-spin fa-circle-o-notch" aria-hidden="true" />
+                                        </button>
+                                    </td>
+                                </tr>
+                            </t>
+                        </tbody>
+
+                    </table>
+                    <t t-if="ui.isSmall" t-foreach="props.cashMoves" t-as="cm" t-key="cm.id">
+                        <div class="container">
+                            <div class="cash-move-row row">
+                                <div class="col-2 align-self-center">
+                                        <div class="fw-bolder"><t t-esc="this.pos.getDate(cm.date)"></t></div>
+                                        <div class="small text-muted"><t t-esc="this.pos.getTime(cm.date)"></t></div>
+                                </div>
+                                <div class="col-3 align-self-center">
+                                    <t t-if="cm.cashier_name" t-esc="cm.cashier_name"/>
+                                </div>
+                                <t t-set="status" t-value="getStatus(cm)" />
+                                <div t-attf-class="col-1 align-self-center fs-6 px-0 badge rounded text-bg-{{status === 'In' ? 'success' : 'danger'}}">
+                                    <t t-esc="status"></t>
+                                </div>
+                                <div class="col-4 align-self-center fw-bolder"><t t-esc="getAmount(cm)"></t></div>
+                                <div class="col-2 align-self-center delete-row">
+                                    <div class="d-flex align-items-center justify-content-center h-100" name="delete" t-on-click.stop="callbacks[cm.id].call">
+                                        <div class="btn btn-danger btn-lg">
+                                            <i t-if="callbacks[cm.id].status != 'loading'" class="fa fa-trash" aria-hidden="true"/>
+                                            <i t-else="" class="fa fa-spin fa-circle-o-notch" aria-hidden="true" />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </t>
+                <div t-else="" class="d-flex justify-content-center">
+                    <span class="fs-4">No cash move found</span>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-secondary" t-on-click="props.close">Discard</button>
+            </t>
+        </Dialog>
+    </t>
+
+</templates>

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.xml
@@ -26,14 +26,24 @@
                 <label for="reason">Reason</label>
             </div>
             <t t-set-slot="footer">
-                <button class="button confirm btn btn-lg lh-lg btn-primary"
-                    t-on-click="confirm"
-                    t-att-disabled="!isValidCashMove()">
-                    Confirm
-                </button>
-                <button class="button cancel btn btn-lg lh-lg btn-secondary" t-on-click="props.close">
-                    Discard
-                </button>
+                <div class="w-100 d-flex flex-wrap justify-content-between gap-2">
+                    <!-- First line of buttons -->
+                    <div class="d-flex gap-2">
+                        <button class="button confirm btn btn-lg lh-lg btn-primary"
+                            t-on-click="confirm"
+                            t-att-disabled="!isValidCashMove()">
+                            Confirm
+                        </button>
+                        <button class="button cancel btn btn-lg lh-lg btn-secondary" t-on-click="props.close">
+                            Discard
+                        </button>
+                    </div>
+
+                    <!-- Second line of buttons -->
+                    <div class=" d-flex gap-2">
+                        <button class="button btn btn-secondary btn-lg" t-on-click="() => this.openDetails()">Details</button>
+                    </div>
+                </div>
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -45,6 +45,15 @@ export class ClosePosPopup extends Component {
             this.env.utils.formatCurrency(count, false);
         this.setManualCashInput(count);
     }
+    autoFillPMCount(paymentId) {
+        const pm = this.props.non_cash_payment_methods.find((pm) => pm.id === paymentId);
+        if (pm) {
+            this.state.payments[paymentId].counted = this.env.utils.formatCurrency(
+                pm.amount,
+                false
+            );
+        }
+    }
     get cashMoveData() {
         const { total, moves } = this.props.default_cash_details.moves.reduce(
             (acc, move, i) => {

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.xml
@@ -72,8 +72,11 @@
                     <t t-set="_showDiff" t-value="pm.type === 'bank' and pm.number !== 0" />
                     <t t-if="_showDiff">
                         <span><t t-esc="pm.name" /> Count</span>
-                        <Input tModel="[state.payments[pm.id], 'counted']"
-                            isValid.bind="env.utils.isValidFloat" />
+                        <div class="d-flex w-100 gap-2 mt-1">
+                            <Input tModel="[state.payments[pm.id], 'counted']"
+                                isValid.bind="env.utils.isValidFloat" class="'w-100'" />
+                            <button class="icon fa fa-clone btn btn-secondary" t-on-click="() => this.autoFillPMCount(pm.id)" />
+                        </div>
                     </t>
                 </div>
                 <div class="notes-container d-flex flex-column flex-sm-row gap-3 pt-3">
@@ -104,7 +107,7 @@
 
                     <!-- Second line of buttons -->
                     <div t-att-class="{'col-12 col-md-6 p-0': this.ui.isSmall}" class=" d-flex gap-2">
-                        <button class="button btn btn-secondary" t-att-class="this.ui.isSmall ? 'w-100' : 'btn-lg'" t-on-click="() => this.cashMove()">Cash In/Out</button>
+                        <button t-if="pos.showCashMoveButton" class="button btn btn-secondary" t-att-class="this.ui.isSmall ? 'w-100' : 'btn-lg'" t-on-click="() => this.cashMove()">Cash In/Out</button>
                         <button class="button icon btn btn-secondary"
                             t-on-click="downloadSalesReport"
                             t-att-class="this.ui.isSmall ? 'w-100' : 'btn-lg ms-auto'"

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -1,6 +1,6 @@
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { formatDate, parseDateTime } from "@web/core/l10n/dates";
+import { parseDateTime } from "@web/core/l10n/dates";
 import { parseFloat } from "@web/views/fields/parsers";
 import { _t } from "@web/core/l10n/translation";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -29,7 +29,6 @@ import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/n
 import { ConnectionLostError } from "@web/core/network/rpc";
 
 const NBR_BY_PAGE = 30;
-const { DateTime } = luxon;
 
 export class TicketScreen extends Component {
     static storeOnOrder = false;
@@ -445,17 +444,6 @@ export class TicketScreen extends Component {
                 this.state.page * this.state.nbrByPage
             );
         }
-    }
-    getDate(order) {
-        const todayTs = DateTime.now().startOf("day").ts;
-        if (order.date_order.startOf("day").ts === todayTs) {
-            return _t("Today");
-        } else {
-            return formatDate(order.date_order);
-        }
-    }
-    getTime(order) {
-        return order.date_order.toFormat("hh:mm");
     }
     getTotal(order) {
         return this.env.utils.formatCurrency(order.getTotalWithTax());

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -40,8 +40,8 @@
                                         <tr class="order-row" t-attf-class="{{ isHighlighted(order) ? 'highlight active': '' }}"
                                             t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => order.uiState.locked ? ()=>{} : this._setOrder(order)" >
                                             <td>
-                                                <div class="fs-6 fw-bolder"><t t-esc="getDate(order)"></t></div>
-                                                <div class="small text-muted"><t t-esc="getTime(order)"></t></div>
+                                                <div class="fs-6 fw-bolder"><t t-esc="this.pos.getDate(order.date_order)"></t></div>
+                                                <div class="small text-muted"><t t-esc="this.pos.getTime(order.date_order)"></t></div>
                                             </td>
                                             <td>
                                                 <div class="fw-bolder"><t t-esc="order.getName()"></t></div>
@@ -88,8 +88,8 @@
                                 <div class="mobileOrderList order-row d-flex flex-row ps-1" t-attf-class="{{ isHighlighted(order) ? 'highlight': '' }}"
                                     t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() =>  order.uiState.locked ? ()=>{} : this._setOrder(order)" >
                                     <div class="p-2">
-                                            <div class="fw-bolder"><t t-esc="getDate(order)"></t></div>
-                                            <div class="small text-muted"><t t-esc="getTime(order)"></t></div>
+                                            <div class="fw-bolder"><t t-esc="this.pos.getDate(order.date_order)"></t></div>
+                                            <div class="small text-muted"><t t-esc="this.pos.getTime(order.date_order)"></t></div>
                                     </div>
                                     <div class="p-2 d-flex flex-column flex-grow-1 justify-content-center align-items-start">
                                         <div class="fw-bolder"><t t-esc="order.getName()"></t></div>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -37,7 +37,7 @@ import { unaccent } from "@web/core/utils/strings";
 import { WithLazyGetterTrap } from "@point_of_sale/lazy_getter";
 import { debounce } from "@web/core/utils/timing";
 import DevicesSynchronisation from "../utils/devices_synchronisation";
-import { deserializeDateTime } from "@web/core/l10n/dates";
+import { deserializeDateTime, formatDate } from "@web/core/l10n/dates";
 import { openCustomerDisplay } from "@point_of_sale/customer_display/utils";
 
 const { DateTime } = luxon;
@@ -1007,6 +1007,9 @@ export class PosStore extends WithLazyGetterTrap {
     }
     cashierHasPriceControlRights() {
         return !this.config.restrict_price_control || this.getCashier()._role == "manager";
+    }
+    get showCashMoveButton() {
+        return Boolean(this.config.cash_control && this.session._has_cash_move_perm);
     }
     createNewOrder(data = {}) {
         const fiscalPosition = this.models["account.fiscal.position"].find(
@@ -2243,6 +2246,17 @@ export class PosStore extends WithLazyGetterTrap {
         } else {
             return `${pm.name} (${fmtAmount})`;
         }
+    }
+    getDate(date) {
+        const todayTs = DateTime.now().startOf("day").ts;
+        if (date.startOf("day").ts === todayTs) {
+            return _t("Today");
+        } else {
+            return formatDate(date);
+        }
+    }
+    getTime(date) {
+        return date.toFormat("hh:mm");
     }
 }
 

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -1,6 +1,7 @@
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as CashMoveList from "@point_of_sale/../tests/pos/tours/utils/cash_move_list_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
@@ -184,5 +185,25 @@ registry.category("web_tour.tours").add("test_reload_page_before_payment_with_cu
             PaymentScreen.clickValidate(),
             ReceiptScreen.clickNextOrder(),
             ProductScreen.isShown(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_cash_in_out", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Chrome.doCashMove("10", "MOBT in"),
+            Chrome.doCashMove("5", "MOBT out"),
+            Chrome.clickMenuOption("Close Register"),
+            Utils.selectButton("Cash In/Out"),
+            Utils.selectButton("Details"),
+            CashMoveList.checkNumberOfRows(2),
+            CashMoveList.checkCashMoveShown("10"),
+            CashMoveList.checkCashMoveShown("5"),
+            CashMoveList.deleteCashMove("10"),
+            CashMoveList.checkNumberOfRows(1),
+            CashMoveList.checkCashMoveShown("5"),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/cash_move_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/cash_move_list_util.js
@@ -1,0 +1,30 @@
+import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
+
+export function checkCashMoveShown(amount) {
+    return {
+        content: `Check has cash move with amount ${amount}`,
+        trigger: `.cash-move-list .cash-move-row:contains(${amount})`,
+    };
+}
+export function deleteCashMove(amount) {
+    return [
+        {
+            content: `Delete cash move with amount ${amount}`,
+            trigger: `.cash-move-list .cash-move-row:contains(${amount}) .delete-row .btn`,
+            run: "click",
+        },
+        negateStep(checkCashMoveShown(amount)),
+    ];
+}
+export function checkNumberOfRows(number) {
+    return {
+        content: "check number of cash moves",
+        trigger: ".cash-move-list .cash-move-row",
+        run: () => {
+            const cashMoveRows = document.querySelectorAll(".cash-move-list .cash-move-row").length;
+            if (cashMoveRows !== number) {
+                throw new Error(`Expected ${number} cash moves, found ${cashMoveRows}`);
+            }
+        },
+    };
+}

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -30,6 +30,17 @@ export function isCashMoveButtonHidden() {
         },
     ];
 }
+export function doCashMove(amount, reason) {
+    return [
+        ...clickMenuOption("Cash In/Out"),
+        fillTextArea(".cash-reason", reason),
+        {
+            trigger: ".modal .input-amount input",
+            run: "edit " + amount,
+        },
+        Dialog.confirm(),
+    ];
+}
 export function endTour() {
     return {
         content: "Last tour step that avoids error mentioned in commit 443c209",

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1755,6 +1755,19 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductCardUoMPrecision', login="pos_user")
 
+    def test_cash_in_out(self):
+        self.pos_user.write({
+            'group_ids': [
+                (4, self.env.ref('account.group_account_basic').id),
+            ]
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_cash_in_out', login="pos_user")
+
+        self.assertEqual(len(self.main_pos_config.current_session_id.statement_line_ids), 1, "There should be one cash in/out statement line")
+        self.assertEqual(self.main_pos_config.current_session_id.statement_line_ids[0].amount, -5, "The cash in/out amount should be -5")
+
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'

--- a/addons/pos_hr/models/pos_session.py
+++ b/addons/pos_hr/models/pos_session.py
@@ -87,8 +87,17 @@ class PosSession(models.Model):
 
         return data
 
-    def _prepare_account_bank_statement_line_vals(self, session, sign, amount, reason, extras):
-        vals = super()._prepare_account_bank_statement_line_vals(session, sign, amount, reason, extras)
+    def _prepare_account_bank_statement_line_vals(self, session, sign, amount, reason, partner_id, extras):
+        vals = super()._prepare_account_bank_statement_line_vals(session, sign, amount, reason, partner_id, extras)
         if extras.get('employee_id'):
             vals['employee_id'] = extras['employee_id']
         return vals
+
+    def get_cash_in_out_list(self):
+        cash_in_out_list = super().get_cash_in_out_list()
+        if self.config_id.module_pos_hr:
+            for cash_in_out in cash_in_out_list:
+                cash_move = self.env['account.bank.statement.line'].browse(cash_in_out['id'])
+                if cash_move.employee_id:
+                    cash_in_out['cashier_name'] = cash_move.partner_id.name
+        return cash_in_out_list

--- a/addons/pos_hr/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/pos_hr/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -10,4 +10,9 @@ patch(CashMovePopup.prototype, {
         }
         return result;
     },
+    get partnerId() {
+        return this.pos.config.module_pos_hr
+            ? this.pos.cashier.work_contact_id?.id
+            : super.partnerId;
+    },
 });


### PR DESCRIPTION
This commit adds the possibility to delete cash moves before closing the session. Before, if a user made a mistake an input a wrong cash move, he had to make the math to ensure to reverse it.

task-id: 4630290

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
