### PR TITLE
[FIX] account_edi_ubl_cii: ensure compliance with PEPPOL-COMMON-R042

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -51,7 +51,7 @@ EAS_MAPPING = {
     'CY': {'9928': 'vat'},
     'CZ': {'9929': 'vat'},
     'DE': {'9930': 'vat'},
-    'DK': {'0184': 'company_registry', '0198': 'vat'},
+    'DK': {'0184': 'vat', '0198': 'vat'},
     'EE': {'9931': 'vat'},
     'ES': {'9920': 'vat'},
     'FI': {'0216': None},


### PR DESCRIPTION
Based on PEPPOL-COMMON-R042 (https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-peppol/PEPPOL-COMMON-R042/) when using the 0184 scheme the VAT number should be used (CVR number prefixed by the country code)

This is a backport of already merged PR https://github.com/odoo/odoo/pull/190952

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
