### PR TITLE
[FIX] pos_self_order: fix blank screen

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -186,22 +186,7 @@ export class PosData extends Reactive {
             }
         }
 
-        if (results && results["pos.order"]) {
-            const ids = results["pos.order"]
-                .map((o) => o.id)
-                .filter((id) => typeof id === "number");
-
-            if (ids.length) {
-                const result = await this.read("pos.order", ids);
-                const serverIds = result.map((r) => r.id);
-
-                for (const id of ids) {
-                    if (!serverIds.includes(id)) {
-                        this.localDeleteCascade(this.models["pos.order"].get(id));
-                    }
-                }
-            }
-        }
+        await this.checkAndDeleteMissingOrders(results);
 
         return results;
     }
@@ -643,6 +628,25 @@ export class PosData extends Reactive {
         });
 
         this.syncInProgress = false;
+    }
+
+    async checkAndDeleteMissingOrders(results) {
+        if (results && results["pos.order"]) {
+            const ids = results["pos.order"]
+                .map((o) => o.id)
+                .filter((id) => typeof id === "number");
+
+            if (ids.length) {
+                const result = await this.read("pos.order", ids);
+                const serverIds = result.map((r) => r.id);
+
+                for (const id of ids) {
+                    if (!serverIds.includes(id)) {
+                        this.localDeleteCascade(this.models["pos.order"].get(id));
+                    }
+                }
+            }
+        }
     }
 
     write(model, ids, vals) {

--- a/addons/pos_self_order/static/src/app/services/data_service.js
+++ b/addons/pos_self_order/static/src/app/services/data_service.js
@@ -46,4 +46,5 @@ patch(PosData.prototype, {
     async missingRecursive(recordMap) {
         return recordMap;
     },
+    async checkAndDeleteMissingOrders(results) {},
 });


### PR DESCRIPTION
- This PR fix a blank screen appearing when trying to pay an order from the self order. This error was appearing when we when using the self order with a public user (in a browser where we're not logged as a odoo user) and that we try to access the ORM (`const result = await this.read("pos.order", ids);`).
- To fix this issue, we don't execute this part of code in self order.

task-id: 4610893

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
