### PR TITLE
[FIX] sale: display correct tip in wizard

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -30,7 +30,8 @@
                     attrs="{'invisible': [('advance_payment_method', 'not in', ('fixed', 'percentage'))]}">
                     <field name="company_id" invisible="1"/>
                     <field name="product_id" invisible="1"/>
-                    <label for="amount"/>
+                    <label for="fixed_amount" attrs="{'invisible': [('advance_payment_method', '!=', 'fixed')]}"/>
+                    <label for="amount" attrs="{'invisible': [('advance_payment_method', '!=', 'percentage')]}"/>
                     <div id="payment_method_details">
                         <field name="currency_id" invisible="1"/>
                         <field name="fixed_amount"


### PR DESCRIPTION
On the amount field, the tip for percentage amount was always displayed, whether the percentage or fixed amount option was selected.

17.0 PR https://github.com/odoo/odoo/pull/200928