### PR TITLE
[IMP] l10n_it_edi: register demo proxy user by default

### DIFF
--- a/addons/l10n_it_edi/models/res_company.py
+++ b/addons/l10n_it_edi/models/res_company.py
@@ -126,10 +126,19 @@ class ResCompany(models.Model):
             if not record.l10n_it_tax_representative_partner_id.country_id:
                 raise ValidationError(_("Your tax representative partner must have a country."))
 
-    @api.depends("account_edi_proxy_client_ids")
+    @api.depends("account_edi_proxy_client_ids", "l10n_it_codice_fiscale")
     def _compute_l10n_it_edi_proxy_user_id(self):
         for company in self:
             company.l10n_it_edi_proxy_user_id = company.account_edi_proxy_client_ids.filtered(lambda x: x.proxy_type == 'l10n_it_edi')
+
+            # If we can't find any proxy user, create a new demo proxy user for this italian company.
+            # They must have the Codice Fiscale field filled for the registration process to work.
+            if not company.l10n_it_edi_proxy_user_id and company.l10n_it_codice_fiscale:
+                company.l10n_it_edi_proxy_user_id = self.env['account_edi_proxy_client.user']._register_proxy_user(
+                    company=company,
+                    proxy_type='l10n_it_edi',
+                    edi_mode='demo',
+                )
 
     @api.depends('country_code')
     def _compute_l10n_it_edi_purchase_journal_id(self):

--- a/addons/l10n_it_edi/models/res_config_settings.py
+++ b/addons/l10n_it_edi/models/res_config_settings.py
@@ -50,4 +50,13 @@ class ResConfigSettings(models.TransientModel):
             elif config.l10n_it_edi_register and not proxy_user:
                 # Create a new proxy user
                 edi_mode = self.env['ir.config_parameter'].sudo().get_param('l10n_it_edi.proxy_user_edi_mode') or 'prod'
-                self._create_proxy_user(config.company_id, edi_mode)
+                proxy_user = self._create_proxy_user(config.company_id, edi_mode)
+
+            if proxy_user:
+                # Delete any previously created demo proxy user
+                self.env['account_edi_proxy_client.user'].search([
+                    ('company_id', '=', config.company_id.id),
+                    ('proxy_type', '=', 'l10n_it_edi'),
+                    ('edi_mode', '=', 'demo'),
+                    ('id', '!=', proxy_user.id),
+                ]).sudo().unlink()


### PR DESCRIPTION
Until the checkbox for FatturaPA is checked, the proxy state of italian companies should the demo one.

To achieve this, we will automatically create a demo proxy user if no proxy user is found for italian companies, but only when the Codice Fiscale field of the company has been filled (because we need it for registering new proxy user).

Task [link](https://www.odoo.com/odoo/project.task/4636273)
task-id: 4636273