### PR TITLE
[FIX] sale: display correct tip in wizard

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -26,7 +26,8 @@
                     invisible="advance_payment_method not in ('fixed', 'percentage')">
                     <field name="company_id" invisible="1"/>
                     <field name="product_id" invisible="1"/>
-                    <label for="amount"/>
+                    <label for="fixed_amount" invisible="advance_payment_method != 'fixed'"/>
+                    <label for="amount" invisible="advance_payment_method != 'percentage'"/>
                     <div id="payment_method_details">
                         <field name="currency_id" invisible="1"/>
                         <field name="display_invoice_amount_warning" invisible="1"/>


### PR DESCRIPTION
On the amount field, the tip for percentage amount was always displayed, whether the percentage or fixed amount option was selected.

Fwd port of https://github.com/odoo/odoo/commit/c63f6c2308ab9d0c7216b592c7873a6db24f0378

16.0 PR : https://github.com/odoo/odoo/pull/200919
