### PR TITLE
[FIX] l10n_es_edi_tbai: correct usage of LazyTransalte

### DIFF
--- a/addons/l10n_es_edi_tbai/models/res_company.py
+++ b/addons/l10n_es_edi_tbai/models/res_company.py
@@ -134,7 +134,8 @@ class ResCompany(models.Model):
                 license_key = self.l10n_es_tbai_tax_agency
             else:  # production env: only one license
                 license_key = 'production'
-            return L10N_ES_TBAI_LICENSE_DICT[license_key]
+            license = L10N_ES_TBAI_LICENSE_DICT[license_key]
+            return dict(license, license_name=str(license["license_name"]))  # force translation
         else:
             return {}
 


### PR DESCRIPTION
LazyTranslate objects cannot be used directly in the `Markup.format()` function as it won't be able to find the lang to use.

We have to explicitly use `self.env._()`.

Runbot build error: https://runbot.odoo.com/odoo/runbot.build.error/98431

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
