### PR TITLE
[FIX] analytic: enable proper search on analytic distribution

### DIFF
--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, fields, api, _
-from odoo.tools import SQL
+from odoo.tools import SQL, unique
 from odoo.tools.float_utils import float_round, float_compare
 from odoo.tools.misc import flatten
 from odoo.exceptions import UserError, ValidationError
@@ -22,6 +22,11 @@ class AnalyticMixin(models.AbstractModel):
     analytic_precision = fields.Integer(
         store=False,
         default=lambda self: self.env['decimal.precision'].precision_get("Percentage Analytic"),
+    )
+    distribution_analytic_account_ids = fields.Many2many(
+        comodel_name='account.analytic.account',
+        compute='_compute_distribution_analytic_account_ids',
+        search='_search_analytic_distribution',
     )
 
     def init(self):
@@ -48,6 +53,14 @@ class AnalyticMixin(models.AbstractModel):
 
     def _compute_analytic_distribution(self):
         pass
+
+    @api.depends('analytic_distribution')
+    def _compute_distribution_analytic_account_ids(self):
+        all_ids = {int(_id) for rec in self for key in (rec.analytic_distribution or {}) for _id in key.split(',')}
+        existing_accounts_ids = set(self.env['account.analytic.account'].browse(all_ids).exists().ids)
+        for rec in self:
+            ids = list(unique(int(_id) for key in (rec.analytic_distribution or {}) for _id in key.split(',') if int(_id) in existing_accounts_ids))
+            rec.distribution_analytic_account_ids = self.env['account.analytic.account'].browse(ids)
 
     def _search_analytic_distribution(self, operator, value):
         if operator == 'in' and isinstance(value, (tuple, list)):


### PR DESCRIPTION
Currently, in models with the analytic mixin, users are not able to filter records by analytic distribution.

Steps to reproduce:
- Enable analytic accounting
- Create a Purchase order, having analytic distribution set on a line
- In list view filter by [Add Custom Filter] for Order Lines > Analytic Distribution

Issue: Mentioned filter cannot be found. It was removed in https://github.com/odoo/odoo/pull/195765
Now users have no way to filter records by analytic distribution.

This commit backport the `distribution_analytic_account_ids` field introduced in 18.0 [1] in order to properly search analytic accounts

[1] https://github.com/odoo/odoo/commit/381f201d49626bdd22c1f0b10d7050df0d264714

opw-4620169