### PR TITLE
[FIX] hr_timesheet: add percentage formatter for project_task_progressbar

### DIFF
--- a/addons/hr_timesheet/static/src/components/progress_bar/project_task_progress_bar_field.js
+++ b/addons/hr_timesheet/static/src/components/progress_bar/project_task_progress_bar_field.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
+import { formatPercentage } from "@web/views/fields/formatters";
 import { progressBarField, ProgressBarField } from "@web/views/fields/progress_bar/progress_bar_field";
 
 export class ProjectTaskProgressBarField extends ProgressBarField {
@@ -23,3 +24,4 @@ export const projectTaskProgressBarField = {
 };
 
 registry.category("fields").add("project_task_progressbar", projectTaskProgressBarField);
+registry.category("formatters").add("project_task_progressbar", formatPercentage);


### PR DESCRIPTION
Before this commit, the total for each group or the grand total displayed in the list view of task for the progress field is formatted as a float instead of a percentage. The reason is because the framework does not find the formatter associated to that widget and so we will take the default formatter for float field.

This commit adds a formatter for the widget to be sure the framework formats the total displayed in the list view in percentage.

