### PR TITLE
 [FIX] im_livechat: do not show new session button with hide button rule

### DIFF
--- a/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
@@ -26,7 +26,7 @@
         </div>
         <div class="d-flex gap-2 justify-content-center">
             <button class="btn btn-outline-secondary" t-on-click="props.onClickClose">Close</button>
-            <button class="btn btn-outline-secondary" t-on-click="props.onClickNewSession">New Session</button>
+            <button t-if="livechatService.rule?.action !== 'hide_button'" class="btn btn-outline-secondary" t-on-click="props.onClickNewSession">New Session</button>
         </div>
     </div>
 </div>

--- a/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
@@ -1,0 +1,65 @@
+import { registry } from "@web/core/registry";
+import { contains, click } from "@web/../tests/utils";
+
+const sendFirstMessageSteps = [
+    {
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+        run: "edit Hello, I need help!",
+    },
+    {
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+        run: "press Enter",
+    },
+    {
+        trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello, I need help!')",
+    },
+];
+registry.category("web_tour.tours").add("website_livechat_no_session_with_hide_rule", {
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        ...sendFirstMessageSteps,
+        {
+            trigger: ".o-livechat-root:shadow [title='Close Chat Window (ESC)']",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button:contains('Yes, leave conversation')",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow p:contains('Did we correctly answer your question?')",
+            async run() {
+                // Use contains instead of click action to ensure negative
+                // assertion is based on the correct parameters below.
+                await click("button", { target: this.anchor.getRootNode(), text: "New Session" });
+            },
+        },
+        ...sendFirstMessageSteps,
+        {
+            trigger: "body",
+            run: () => (window.location = "/"),
+        },
+        {
+            trigger: ".o-livechat-root:shadow [title='Close Chat Window (ESC)']",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button:contains('Yes, leave conversation')",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow p:contains('Did we correctly answer your question?')",
+            async run() {
+                await contains("button", { target: this.anchor.getRootNode(), text: "Close" });
+                await contains("button", {
+                    target: this.anchor.getRootNode(),
+                    text: "New Session",
+                    count: 0,
+                });
+            },
+        },
+    ],
+});

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -150,6 +150,24 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
     def test_user_known_after_reload(self):
         self.start_tour('/', 'website_livechat_user_known_after_reload')
 
+    def test_no_new_session_with_hide_button_rule(self):
+        self.livechat_channel.rule_ids = self.env["im_livechat.channel.rule"].create(
+            [
+                {
+                    "channel_id": self.livechat_channel.id,
+                    "regex_url": "/livechat_url",
+                    "sequence": 1,
+                },
+                {
+                    "channel_id": self.livechat_channel.id,
+                    "action": "hide_button",
+                    "regex_url": "/",
+                    "sequence": 2,
+                },
+            ]
+        )
+        self.start_tour("/livechat_url", "website_livechat_no_session_with_hide_rule")
+
 
 @tests.tagged('post_install', '-at_install')
 class TestLivechatBasicFlowHttpCaseMobile(HttpCaseWithUserDemo, TestLivechatCommon):


### PR DESCRIPTION
Before this PR, it was possible to start a new live chat while the rule for the page was "hide_button". The intent of this action is clear: prevent users from creating new chat on this page so we should not allow it throught the feedback panel.

Steps to reproduce:
- Setup a live chat rule ("/", "hide").
- Start a chat from the contactus page.
- Go to another page.
- Close the chat: a "new session" button is available while it should not.

This PR ensures this button is not shown with the "hide_button" rule.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
