### PR TITLE
[FIX] point_of_sale: remove old BaseData id reference when the id is updated

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -697,8 +697,10 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
         }
         _update(record, vals, opts = {}) {
             const ownFields = getFields(this.name);
-            Object.assign(baseData[this.name][record.id], vals);
-
+            const recordBaseData = baseData[this.name][record.id];
+            if (recordBaseData) {
+                Object.assign(recordBaseData, vals);
+            }
             for (const name in vals) {
                 if (!(name in ownFields) && name !== "id") {
                     continue;
@@ -827,6 +829,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
             const key = database[this.name]?.key || "id";
             this.triggerEvents("delete", { key: record[key] });
             this.records[this.name].delete(id);
+            delete baseData[this.name][id];
             for (const key of indexes[this.name] || []) {
                 const keyVal = record.raw[key];
                 if (Array.isArray(keyVal)) {

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -500,8 +500,11 @@ export class PosData extends Reactive {
                 const results = this.models.loadData(data);
                 result = results[model];
             } else if (type === "write") {
-                const baseData = Object.assign(this.baseData[model][ids[0]], values);
-                this.synchronizeServerDataInIndexedDB({ [model]: [baseData] });
+                const recordBaseData = this.baseData[model][ids[0]];
+                if (recordBaseData) {
+                    Object.assign(recordBaseData, values);
+                    this.synchronizeServerDataInIndexedDB({ [model]: [recordBaseData] });
+                }
             }
 
             return result;

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -5,6 +5,7 @@ import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Utils from "@point_of_sale/../tests/pos/tours/utils/common";
+import { refresh } from "@point_of_sale/../tests/generic_helpers/utils";
 import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 
@@ -164,5 +165,24 @@ registry.category("web_tour.tours").add("test_tracking_number_closing_session", 
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_reload_page_before_payment_with_customer_account", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.0"),
+            refresh(),
+            ProductScreen.productIsDisplayed("Desk Organizer"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Partner Test 1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Customer Account"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.isShown(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/unit/related_models.test.js
+++ b/addons/point_of_sale/static/tests/unit/related_models.test.js
@@ -712,3 +712,44 @@ describe("models without backlinks", () => {
         });
     });
 });
+
+describe("Base data", () => {
+    test("baseData is updated when the record id is updated", () => {
+        const { models, baseData } = createRelatedModels(
+            {
+                "pos.order": { name: { type: "char" }, uuid: { name: "uuid", type: "char" } },
+            },
+            {},
+            {
+                dynamicModels: ["pos.order"],
+                databaseIndex: {
+                    "pos.order": ["uuid"],
+                },
+                databaseTable: {
+                    "pos.order": { key: "uuid" },
+                },
+            }
+        );
+
+        const order1 = models["pos.order"].create({ name: "Order 1" });
+        expect(baseData["pos.order"][order1.id].id).toBe(order1.id);
+        const oldId = order1.id;
+
+        // Update
+        models.loadData({
+            "pos.order": [
+                {
+                    id: 22,
+                    uuid: order1.uuid,
+                    name: "Order 1",
+                },
+            ],
+        });
+
+        const updatedOrder = models["pos.order"].get(22);
+        expect(updatedOrder).not.toBe(undefined);
+
+        expect(baseData["pos.order"][oldId]).toBeEmpty(); // Old Basedata is deleted
+        expect(baseData["pos.order"][updatedOrder.id].id).toBe(updatedOrder.id);
+    });
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1725,6 +1725,18 @@ class TestUi(TestPointOfSaleHttpCommon):
         for order in self.env['pos.order'].search([]):
             self.assertEqual(int(order.tracking_number) % 100, 1)
 
+    def test_reload_page_before_payment_with_customer_account(self):
+        self.customer_account_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Customer Account',
+            'split_transactions': True,
+        })
+        self.main_pos_config.write({'payment_method_ids': [(6, 0, self.customer_account_payment_method.ids)]})
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            f'/pos/ui?config_id={self.main_pos_config.id}',
+            'test_reload_page_before_payment_with_customer_account',
+            login='pos_user'
+        )
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Ensure that BaseData references tied to the old ID are correctly removed when the ID is updated. Failing to update properly can lead to errors in some scenarios:

Steps to reproduce:
- Select a product
- Refresh the interface
- Add a customer to the order
- Pay using “Customer Account”
- Click on “New Order”
- An error is displayed (the old BaseData is reused)