### PR TITLE
[FIX] point_of_sale: show cashier name on receipt if no preset

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -16,7 +16,7 @@
                 <div t-if="order.company.email" t-esc="order.company.email" />
                 <div t-if="order.company.website" t-esc="order.company.website" />
                 <div t-if="order.config.receipt_header" style="white-space:pre-line" t-esc="order.config.receipt_header" />
-                <div t-if="order?.getCashierName() and order.preset_id?.identification === 'name'" class="cashier">
+                <div t-if="order?.getCashierName() and (!order.preset_id or order.preset_id.identification === 'name')" class="cashier">
                     <div>--------------------------------</div>
                     <div>Served by: <t t-esc="order.getCashierName()" /></div>
                 </div>

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -27,6 +27,7 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             PaymentScreen.shippingLaterHighlighted(),
             PaymentScreen.clickValidate(),
             ReceiptScreen.receiptIsThere(),
+            ReceiptScreen.cashierNameExists("A simple PoS man!"),
             Dialog.confirm("Continue with limited functionality"),
             //receipt had expected delivery printed
             ReceiptScreen.shippingDateExists(),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -201,3 +201,12 @@ export function shippingDateIsToday() {
         },
     ];
 }
+
+export function cashierNameExists(name) {
+    return [
+        {
+            content: `Cashier ${name} exists on the receipt`,
+            trigger: `.pos-receipt-contact .cashier:contains(Served by):contains(${name})`,
+        },
+    ];
+}


### PR DESCRIPTION
Steps
------
- Normal PoS config (don't set a preset)
- Make an order and settle it

-> The cashier name is not show on the receipt as "Served by ...".

Reason
--------
Commit 3ff7270f7b349e88dc883ed27ecb44006bdbcd65 allowed showing the cashier name if there is a preset and it has 'name' as `identification`. However, it has mistakenly hidden the cashier name when a preset does not exist.

Fix
---
Account for the case of a non existing `order.preset_id`.

opw-4626268