### PR TITLE
[IMP] base: do not aggregate interval, priority in ir.cron

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -59,7 +59,7 @@ class ir_cron(models.Model):
     cron_name = fields.Char('Name', related='ir_actions_server_id.name', store=True, readonly=False)
     user_id = fields.Many2one('res.users', string='Scheduler User', default=lambda self: self.env.user, required=True)
     active = fields.Boolean(default=True)
-    interval_number = fields.Integer(default=1, help="Repeat every x.")
+    interval_number = fields.Integer(default=1, group_operator=None, help="Repeat every x.")
     interval_type = fields.Selection([('minutes', 'Minutes'),
                                       ('hours', 'Hours'),
                                       ('days', 'Days'),
@@ -69,7 +69,7 @@ class ir_cron(models.Model):
     doall = fields.Boolean(string='Repeat Missed', help="Specify if missed occurrences should be executed when the server restarts.")
     nextcall = fields.Datetime(string='Next Execution Date', required=True, default=fields.Datetime.now, help="Next planned execution date for this job.")
     lastcall = fields.Datetime(string='Last Execution Date', help="Previous time the cron ran successfully, provided to the job through the context on the `lastcall` key")
-    priority = fields.Integer(default=5, help='The priority of the job, as an integer: 0 means higher priority, 10 means lower priority.')
+    priority = fields.Integer(default=5, group_operator=None, help='The priority of the job, as an integer: 0 means higher priority, 10 means lower priority.')
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Sets aggregator=None on ir.cron's priority field since aggregating this by summing it up (sum is the default aggregator on Integer fields) gives us no useful information. Removing it has a very minimal performance improvement and would partly address the issue where this field's aggregated value clips over the grouped by field

Prior to https://github.com/odoo/odoo/commit/3d9a6ac the width of the first column would be increased in case of grouping list views. This would make the label of the grouped field visible by expanding the first column. However after the mentioned commit, we restrict the min and max widths of the columns which leads to the value of this grouped by field getting clipped by the aggregated column's value.

Although the issue primarily exists in 17.4, prior stable versions (16.0 and up) could also benefit from this.


**Current behavior before PR:**

In 17.4 onwards, the grouped field's table row is clipped by the priority field that gets aggregated

![image](https://github.com/user-attachments/assets/014208c5-74ad-4fb1-af9e-fc0f9ef007a1)
![image](https://github.com/user-attachments/assets/06d90eeb-7961-4e60-b4e8-ca823d2e23a7)

**Desired behavior after PR is merged:**

The priority field in `ir.cron` is no longer aggregated thus it does not clip the grouped field.

![image](https://github.com/user-attachments/assets/cd763f22-3e29-4bc6-9ae7-319b114dc7c1)



opw-4536133

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
