### PR TITLE
[FIX] html_editor: apply font size on outdented blocks

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -333,6 +333,11 @@ export class ListPlugin extends Plugin {
         const list = insertListAfter(this.document, baseContainer, mode, [
             childNodes(baseContainer),
         ]);
+        if (baseContainer.style.getPropertyValue("padding")) {
+            // Prevent copying padding from baseContainer to ensure
+            // the ::marker of the list is displayed correctly.
+            baseContainer.style.removeProperty("padding");
+        }
         this.dependencies.dom.copyAttributes(baseContainer, list);
         baseContainer.remove();
         cursors.remapNode(baseContainer, list.firstChild).restore();

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -637,6 +637,9 @@ export class ListPlugin extends Plugin {
             if (textAlign && !block.style.getPropertyValue("text-align")) {
                 block.style.setProperty("text-align", textAlign);
             }
+            if (ul.style.getPropertyValue("font-size")) {
+                block.style.setProperty("font-size", ul.style.getPropertyValue("font-size"));
+            }
             cursors.update(callbacksForCursorUpdate.after(ul, block));
             ul.after(block);
         }

--- a/addons/html_editor/static/tests/list/outdent.test.js
+++ b/addons/html_editor/static/tests/list/outdent.test.js
@@ -497,6 +497,23 @@ describe("with selection collapsed", () => {
                 <h2>c</h2>`),
         });
     });
+    test("should preserve `ul` fontSize if exists", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <ul style="font-size: 12px;">
+                    <li>a</li>
+                    <li>
+                        []b
+                    </li>
+                </ul>`),
+            stepFunction: keydownShiftTab,
+            contentAfter: unformat(`
+                <ul style="font-size: 12px;">
+                    <li>a</li>
+                </ul>
+                <p style="font-size: 12px;">[]b</p>`),
+        });
+    });
     test("should not crash when outdenting a list item with empty nodes", async () => {
         const { el, editor } = await setupEditor(
             unformat(`

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -23,6 +23,14 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should not copy padding of base container", async () => {
+            await testEditor({
+                contentBefore: `<p style="padding: 0px">ab[]cd</p>`,
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>ab[]cd</li></ol>",
+            });
+        });
+
         test("should turn a unordered list into a ordered list", async () => {
             await testEditor({
                 contentBefore: "<ul><li>ab[]cd</li></ul>",


### PR DESCRIPTION
**Problem**:
When forcing a font size on blocks, creating a bullet list applies the font size to the `ul` element. However, when outdenting, the font size is not applied to the newly created blocks, causing them to lose the forced font size.

**Solution**:
When outdenting a `ul` with a `font-size` style, apply the same font size to the newly created blocks to maintain consistency.

**Steps to Reproduce**:
1. Open **Sale Order**.
2. Click **Send email** button.
   - The popup contains an editable area with predefined content.
3. Add a new paragraph.
4. Run `/bulletlist` command to create a bullet list.
5. Press **Backspace** to remove the bullet list.
6. Add text:
   - **Issue**: The forced font size is no longer applied.

**opw-4636426**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
