### PR TITLE
[FIX] l10n_ro_edi_stock: conditionally checking if the module is installed

### DIFF
--- a/addons/l10n_ro_edi_stock/tests/common.py
+++ b/addons/l10n_ro_edi_stock/tests/common.py
@@ -11,10 +11,10 @@ class TestL10nRoEdiStockCommon(ValuationReconciliationTestCommon):
         cls.warehouse = cls.company_data['default_warehouse']
         cls.customer_location = cls.env.ref('stock.stock_location_customers').id
         cls.stock_location = cls.warehouse.lot_stock_id.id
-
-        # Disable auto-batching
-        cls.warehouse.out_type_id.auto_batch = False
-        cls.warehouse.in_type_id.auto_batch = False
+        if cls.env['ir.module.module']._get('stock_picking_batch').state == 'installed':
+            # Disable auto-batching
+            cls.warehouse.out_type_id.auto_batch = False
+            cls.warehouse.in_type_id.auto_batch = False
 
     @classmethod
     def create_stock_picking(cls, partner, name=False, location_id=None, location_dest_id=None, picking_type=None, product_data=None):


### PR DESCRIPTION
…lled in the test

The test was failing when the module was not installed because it was trying to access the auto_batch field but AttributeError: 'stock.picking.type' object has no attribute 'auto_batch' , because we need to install the module to have the field available which is stock_picking_batch module. 

so I conditionally check if stock_picking_batch module is installed

build_error-115361

