### PR TITLE
[FIX] tests: addapt tag_sector for upgrade tests

### DIFF
--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -55,7 +55,10 @@ class TagsSelector(object):
         test_class = test.test_class
         test_tags = test.test_tags | {test_module}  # module as test_tags deprecated, keep for retrocompatibility,
         test_method = test._testMethodName
-        test_module_path = test.__module__.removeprefix('odoo.addons').replace('.', '/') + '.py'
+        test_module_path = test.__module__
+        for prefix in ('odoo.addons', 'odoo.upgrade'):
+            test_module = test_module.removeprefix(prefix)
+        test_module_path = test_module_path.replace('.', '/') + '.py'
 
         def _is_matching(test_filter):
             (tag, module, klass, method, file_path) = test_filter


### PR DESCRIPTION
For upgrade tests, the test modules can be imported from odoo.upgrade.

The current solution is not correct since `test_module_path` would be `odoo/upgrade/module/tests/test_file.py`  and so the condition `test_module_path.endswith(file_path):` would match `/upgrade/module/tests/test_file.py` (but not `/odoo/upgrade/module/tests/test_file.py`) whitch is not really expected. 

The problem is even more problematic in master with #195929 because the tag  `/module/tests/test_file.py` won't match  `odoo/upgrade/module/tests/test_file.py`
