### PR TITLE
[IMP] web: py_js: add new keyword before NotSupportedError

### DIFF
--- a/addons/web/static/src/core/py_js/py_date.js
+++ b/addons/web/static/src/core/py_js/py_date.js
@@ -308,7 +308,7 @@ export class PyDate {
         if (other instanceof PyDate) {
             return PyTimeDelta.create(this.toordinal() - other.toordinal());
         }
-        throw NotSupportedError();
+        throw new NotSupportedError();
     }
 
     /**
@@ -489,7 +489,14 @@ export class PyDateTime {
      * @returns {PyDateTime}
      */
     to_utc() {
-        const d = new Date(this.year, this.month -1, this.day, this.hour, this.minute, this.second);
+        const d = new Date(
+            this.year,
+            this.month - 1,
+            this.day,
+            this.hour,
+            this.minute,
+            this.second
+        );
         const timedelta = PyTimeDelta.create({ minutes: d.getTimezoneOffset() });
         return this.add(timedelta);
     }
@@ -561,9 +568,8 @@ const PERIODS = ["year", "month", "day", ...TIME_PERIODS];
 const RELATIVE_KEYS = "years months weeks days hours minutes seconds microseconds leapdays".split(
     " "
 );
-const ABSOLUTE_KEYS = "year month day hour minute second microsecond weekday nlyearday yearday".split(
-    " "
-);
+const ABSOLUTE_KEYS =
+    "year month day hour minute second microsecond weekday nlyearday yearday".split(" ");
 
 const argsSpec = ["dt1", "dt2"]; // all other arguments are kwargs
 export class PyRelativeDelta {
@@ -625,7 +631,7 @@ export class PyRelativeDelta {
      */
     static add(date, delta) {
         if (!(date instanceof PyDate || date instanceof PyDateTime)) {
-            throw NotSupportedError();
+            throw new NotSupportedError();
         }
 
         // First pass: we want to determine which is our target year and if we will apply leap days

--- a/addons/web/static/src/core/py_js/py_interpreter.js
+++ b/addons/web/static/src/core/py_js/py_interpreter.js
@@ -166,14 +166,14 @@ function applyBinaryOp(ast, context) {
                 if (right instanceof PyDate || right instanceof PyDateTime) {
                     return right.add(left);
                 } else {
-                    throw NotSupportedError();
+                    throw new NotSupportedError();
                 }
             }
             if (timeDeltaOnRight) {
                 if (left instanceof PyDate || left instanceof PyDateTime) {
                     return left.add(right);
                 } else {
-                    throw NotSupportedError();
+                    throw new NotSupportedError();
                 }
             }
 
@@ -192,7 +192,7 @@ function applyBinaryOp(ast, context) {
                 } else if (left instanceof PyDate || left instanceof PyDateTime) {
                     return left.substract(right);
                 } else {
-                    throw NotSupportedError();
+                    throw new NotSupportedError();
                 }
             }
 


### PR DESCRIPTION
We call NotSupportedError with the keyword "new" in order to avoid this kind of errors in py_js:

UncaughtPromiseError > TypeError
Uncaught Promise > Class constructor NotSupportedError cannot be invoked without 'new'
...