### PR TITLE
[IMP] l10n_ro_edi: Allow default VAT for the customer

### DIFF
--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
@@ -66,14 +66,14 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:CompanyID>1234567897</cbc:CompanyID>
+        <cbc:CompanyID>0000000000000</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:ID>NOT_EU_VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Roasted Romanian Roller</cbc:RegistrationName>
-        <cbc:CompanyID>1234567897</cbc:CompanyID>
+        <cbc:CompanyID>0000000000000</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>Roasted Romanian Roller</cbc:Name>

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -99,28 +99,26 @@ class TestUBLRO(TestUBLCommon):
 
     def test_export_invoice_without_country_code_prefix_in_vat(self):
         self.company_data['company'].write({'vat': '1234567897'})
-        self.partner_a.write({'vat': '1234567897'})
+        self.partner_a.write({'vat': False})
         invoice = self.create_move("out_invoice")
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_no_prefix_vat.xml')
 
     def test_export_no_vat_but_have_company_registry(self):
         self.company_data['company'].write({'vat': False, 'company_registry': 'RO1234567897'})
-        self.partner_a.write({'vat': False, 'company_registry': 'RO1234567897'})
         invoice = self.create_move("out_invoice")
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice.xml')
 
     def test_export_no_vat_but_have_company_registry_without_prefix(self):
         self.company_data['company'].write({'vat': False, 'company_registry': '1234567897'})
-        self.partner_a.write({'vat': False, 'company_registry': '1234567897'})
+        self.partner_a.write({'vat': False})
         invoice = self.create_move("out_invoice")
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_no_prefix_vat.xml')
 
     def test_export_no_vat_and_no_company_registry_raises_error(self):
         self.company_data['company'].write({'vat': False, 'company_registry': False})
-        self.partner_a.write({'vat': False, 'company_registry': False})
         invoice = self.create_move("out_invoice", send=False)
         with self.assertRaisesRegex(UserError, "doesn't have a VAT nor Company ID"):
             invoice._generate_pdf_and_send_invoice(self.move_template, allow_fallback_pdf=False)


### PR DESCRIPTION
Problem
---------
As of Jan 01, 2025 the Romanian tax authority will accept blank tax IDs for recipient individuals of an e-invoice in the form "0000000000000".  However, in Odoo a blank tax id number for an individual contact is denoted as '/'.

Objective
---------
When creating the Invoice XML, if the res.partner has an empty Tax ID, or a tax ID that is "/" or <2 characters, replace the value by  0000000000000 in the produced XML.

task-4610149

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
