### PR TITLE
[FIX] point_of_sale: don't equalitate a date and a datetime

### DIFF
--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -986,7 +986,7 @@ class TestPoSBasicConfig(TestPoSCommon):
             # Check the credit note
             self.assertTrue(return_to_invoice.account_move, 'Invoice should be created.')
             self.assertEqual(return_to_invoice.account_move.move_type, 'out_refund', 'Invoice should be a credit note.')
-            self.assertEqual(return_to_invoice.account_move.invoice_date, new_session_date, 'Invoice date should be the same as the session it is created in.')
+            self.assertEqual(return_to_invoice.account_move.invoice_date, new_session_date.date(), 'Invoice date should be the same as the session it is created in.')
             self.assertRecordValues(return_to_invoice.account_move, [{
                 'amount_untaxed': 30,
                 'amount_tax': 0,


### PR DESCRIPTION
Normally a `date` and a `datetime` compare `False`. For some reason however a `datetime` and a `freezegun.api.FakeDate` compare equal as long as the datetime's date part matches the fakedate's... until Python 3.13, when it stop working.

I've no idea why it ever worked, but it's completely unnecessary, we can just get the reference datetime's `date()` part and compare that to the date.

upstream issue: spulec/freezegun#568
