### PR TITLE
[FIX] website: sitemap method ok with redirect 308


### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+import functools
 import hashlib
 import inspect
 import json
@@ -1173,9 +1174,12 @@ class Website(models.Model):
 
         for rule in router.iter_rules():
             if 'sitemap' in rule.endpoint.routing and rule.endpoint.routing['sitemap'] is not True:
-                if rule.endpoint.func.__func__ in sitemap_endpoint_done:
+                endpoint_func = rule.endpoint.func
+                if isinstance(endpoint_func, functools.partial): # follow partial in case of redirect
+                    endpoint_func = endpoint_func.func
+                if endpoint_func.__func__ in sitemap_endpoint_done:
                     continue
-                sitemap_endpoint_done.add(rule.endpoint.func.__func__)
+                sitemap_endpoint_done.add(endpoint_func.__func__)
 
                 func = rule.endpoint.routing['sitemap']
                 if func is False:

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -23,6 +23,7 @@ from . import test_page
 from . import test_page_manager
 from . import test_performance
 from . import test_qweb
+from . import test_redirect
 from . import test_res_users
 from . import test_snippets
 from . import test_theme

--- a/addons/website/tests/test_redirect.py
+++ b/addons/website/tests/test_redirect.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website.tools import MockRequest
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestWebsiteRedirect(TransactionCase):
+    def test_sitemap_with_redirect(self):
+        self.env['website.rewrite'].create({
+            'name': 'Test Website Redirect',
+            'redirect_type': '308',
+            'url_from': '/website/info',
+            'url_to': '/test',
+        })
+        website = self.env.ref('website.default_website')
+        with MockRequest(self.env, website=website):
+            pages = self.env.ref('website.default_website')._enumerate_pages()
+            urls = [url['loc'] for url in pages]
+            self.assertIn('/website/info', urls)
+            self.assertNotIn('/test', urls)


### PR DESCRIPTION
Scenario:

- create a redirect 308 from route with a sitemap method
(eg.  /website/version)
- go to /sitemap.xml (you might need to delete sitemap in attachment
before)

Result: you get a 500 error, with this traceback in server logs:

```
…
File "/Users/odoo/src/odoo/17.0/addons/website/models/website.py", line 1333, in _enumerate_pages
if rule.endpoint.func.__func__ in sitemap_endpoint_done:
AttributeError: 'functools.partial' object has no attribute '__func__'. Did you mean: '__doc__'?
```

Fix: take a second level of partial (from the redirection and not the
route) when handling duplicates routes.

opw-4594629
opw-4614216
opw-4628703
