### PR TITLE
[FIX] website: mock request compatibility with geoip2 5.0

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -72,7 +72,10 @@ def MockRequest(
     if website:
         request.website_routing = website.id
     if country_code:
-        request.geoip._city_record = odoo.http.geoip2.models.City({'country': {'iso_code': country_code}})
+        try:
+            request.geoip._city_record = odoo.http.geoip2.models.City(['en'], country={'iso_code': country_code})
+        except TypeError:
+            request.geoip._city_record = odoo.http.geoip2.models.City({'country': {'iso_code': country_code}})
 
     # The following code mocks match() to return a fake rule with a fake
     # 'routing' attribute (routing=True) or to raise a NotFound


### PR DESCRIPTION
maxmind decided to remove support for `raw_response` and chhange the API of Country/City to take all the raw_response components by keywords instead
(maxmind/GeoIP2-python@4518919151e1b39bd544df653b41cd155dc2f708). This leads to location mocking not working anymore, which leads to the failure of `:TestWebsiteSaleCart.test_cart_new_fpos_from_geoip` when using geoip2 5.0.

When mocking the request with a country code set, just try the new API then fallback on the old one (note: the commit also removes the `locales` default fallback, so make that explicit).
