### PR TITLE
[FIX] discuss: prevent track race condition in calls

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -705,8 +705,8 @@ export class Rtc extends Record {
                     return;
                 }
                 for (const [id, info] of Object.entries(payload)) {
-                    const session = this.store.RtcSession.get(Number(id));
-                    if (!session) {
+                    const session = await this.store.RtcSession.getWhenReady(Number(id));
+                    if (!session || !this.state.channel) {
                         return;
                     }
                     // `isRaisingHand` is turned into the Date `raisingHand`
@@ -718,8 +718,8 @@ export class Rtc extends Record {
             case "track":
                 {
                     const { sessionId, type, track, active } = payload;
-                    const session = this.store.RtcSession.get(sessionId);
-                    if (!session) {
+                    const session = await this.store.RtcSession.getWhenReady(sessionId);
+                    if (!session || !this.state.channel) {
                         this.log(
                             this.selfSession,
                             `track received for unknown session ${sessionId} (${this.state.connectionType})`


### PR DESCRIPTION
Before this commit, we could get events for a RtcSession that is
not yet available. This can happen when network information (SFU/p2p)
races Odoo server information (bus). As RtcSessions' source of truth
is the Odoo server, information obtained from the call network are
only acknowledged if we have the record from Odoo.

This commit fixes this issue by awaiting sessions
for which events are obtained.

Fetching should not be necessary as:
- if the event is for a session that exists, the client will eventually
obtain it (from the bus message that is sent when a new is created,
or by the `rtc_service.ping()` which periodically fetches sessions).
- if the event is for a session that does not exist, fetching does not
make sense.