### PR TITLE
[FIX] pos*: fix pos synchro whole record

### DIFF
--- a/addons/l10n_ar_pos/models/pos_session.py
+++ b/addons/l10n_ar_pos/models/pos_session.py
@@ -12,8 +12,7 @@ class PosSession(models.Model):
             data += ['l10n_ar.afip.responsibility.type', 'l10n_latam.identification.type']
         return data
 
-    def _load_pos_data(self, data):
-        data = super()._load_pos_data(data)
+    def _post_read_pos_data(self, data):
         if self.env.company.country_id.code == 'AR':
             data[0]['_consumidor_final_anonimo_id'] = self.env.ref('l10n_ar.par_cfa').id
-        return data
+        return super()._post_read_pos_data(data)

--- a/addons/l10n_be_pos_sale/models/pos_session.py
+++ b/addons/l10n_be_pos_sale/models/pos_session.py
@@ -4,10 +4,9 @@ from odoo import models
 class PosSession(models.Model):
     _inherit = 'pos.session'
 
-    def _load_pos_data(self, data):
-        data = super()._load_pos_data(data)
+    def _post_read_pos_data(self, data):
         if self.env.company.country_code == 'BE':
             intracom_fpos = self.env["account.chart.template"].with_company(self.company_id).ref("fiscal_position_template_3", False)
             if intracom_fpos:
                 data[0]['_intracom_tax_ids'] = intracom_fpos.tax_ids.tax_dest_id.ids
-        return data
+        return super()._post_read_pos_data(data)

--- a/addons/l10n_pe_pos/models/pos_session.py
+++ b/addons/l10n_pe_pos/models/pos_session.py
@@ -12,9 +12,8 @@ class PosSession(models.Model):
             data += ['l10n_pe.res.city.district', 'l10n_latam.identification.type', 'res.city']
         return data
 
-    def _load_pos_data(self, data):
-        data = super()._load_pos_data(data)
+    def _post_read_pos_data(self, data):
         if self.env.company.country_id.code == "PE":
             data[0]['_default_l10n_latam_identification_type_id'] = self.env.ref('l10n_pe.it_DNI').id
             data[0]['_consumidor_final_anonimo_id'] = self.env.ref('l10n_pe_pos.partner_pe_cf').id
-        return data
+        return super()._post_read_pos_data(data)

--- a/addons/point_of_sale/models/ir_module_module.py
+++ b/addons/point_of_sale/models/ir_module_module.py
@@ -2,6 +2,7 @@ from odoo import api, models
 
 
 class IrModuleModule(models.Model):
+    _name = 'ir.module.module'
     _inherit = 'ir.module.module'
 
     @api.model
@@ -16,3 +17,10 @@ class IrModuleModule(models.Model):
         domain = self._load_pos_data_domain()
         fields = self._load_pos_data_fields(data['pos.config'][0]['id'])
         return self.search_read(domain, fields, load=False)
+
+    def _post_read_pos_data(self, data):
+        return data
+
+    def _read_pos_record(self, ids, config_id):
+        fields = self._load_pos_data_fields(self.id)
+        return self.browse(ids).read(fields, load=False)

--- a/addons/point_of_sale/models/pos_load_mixin.py
+++ b/addons/point_of_sale/models/pos_load_mixin.py
@@ -28,3 +28,10 @@ class PosLoadMixin(models.AbstractModel):
         if last_server_date and domain is not False and limited_loading:
             domain = AND([domain, [('write_date', '>', last_server_date)]])
         return domain
+
+    def _post_read_pos_data(self, data):
+        return data
+
+    def _read_pos_record(self, ids, config_id):
+        fields = self._load_pos_data_fields(self.id)
+        return self.with_context(config_id=config_id)._post_read_pos_data(self.browse(ids).read(fields, load=False))

--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -25,14 +25,13 @@ class ProductProduct(models.Model):
                     "Deleting a product available in a session would be like attempting to snatch a hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!",
                 ))
 
-    def _load_pos_data(self, data):
-        products = super()._load_pos_data(data)
-        config = self.env['pos.config'].browse(data['pos.config'][0]['id'])
+    def _post_read_pos_data(self, data):
+        config = self.env['pos.config'].browse(self.env.context.get('config_id'))
         different_currency = config.currency_id != self.env.company.currency_id
         if different_currency:
-            for product in products:
+            for product in data:
                 product['lst_price'] = self.env.company.currency_id._convert(product['lst_price'], config.currency_id, self.env.company, fields.Date.today())
-        return products
+        return super()._post_read_pos_data(data)
 
     def _can_return_content(self, field_name=None, access_token=None):
         if field_name == "image_128" and self.sudo().available_in_pos:

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -112,9 +112,12 @@ class ProductTemplate(models.Model):
             products += config.tip_product_id.product_tmpl_id
 
         fields = self._load_pos_data_fields(config.id)
-        available_products = products.read(fields, load=False)
-        self._process_pos_ui_product_product(available_products, config)
-        return available_products
+        return self.with_context(config_id=config.id)._post_read_pos_data(products.read(fields, load=False))
+
+    def _post_read_pos_data(self, data):
+        config = self.env['pos.config'].browse(self.env.context.get('config_id'))
+        self._process_pos_ui_product_product(data, config)
+        return super()._post_read_pos_data(data)
 
     def _load_product_with_domain(self, domain, load_archived=False):
         context = {**self.env.context, 'display_default_code': False, 'active_test': not load_archived}

--- a/addons/point_of_sale/models/product_uom.py
+++ b/addons/point_of_sale/models/product_uom.py
@@ -9,8 +9,3 @@ class ProductUom(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['id', 'barcode', 'product_id', 'uom_id']
-
-    def _load_pos_data(self, data):
-        domain = self._load_pos_data_domain(data)
-        fields = self._load_pos_data_fields(data['pos.config'][0]['id'])
-        return self.with_context({**self.env.context}).search_read(domain, fields, load=False)

--- a/addons/point_of_sale/models/res_users.py
+++ b/addons/point_of_sale/models/res_users.py
@@ -13,9 +13,9 @@ class ResUsers(models.Model):
     def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'partner_id', 'all_group_ids']
 
-    def _load_pos_data(self, data):
-        user = super()._load_pos_data(data)
-        if user:
-            user[0]['role'] = 'manager' if data['pos.config'][0]['group_pos_manager_id'] in user[0]['all_group_ids'] else 'cashier'
-            del user[0]['all_group_ids']
-        return user
+    def _post_read_pos_data(self, data):
+        config_id = self.env['pos.config'].browse(self.env.context.get('config_id'))
+        if data:
+            data[0]['role'] = 'manager' if config_id.group_pos_manager_id.id in data[0]['all_group_ids'] else 'cashier'
+            del data[0]['all_group_ids']
+        return super()._post_read_pos_data(data)

--- a/addons/point_of_sale/models/uom.py
+++ b/addons/point_of_sale/models/uom.py
@@ -10,8 +10,3 @@ class UomUom(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'factor', 'is_pos_groupable', 'parent_path', 'rounding']
-
-    def _load_pos_data(self, data):
-        domain = self._load_pos_data_domain(data)
-        fields = self._load_pos_data_fields(data['pos.config'][0]['id'])
-        return self.with_context({**self.env.context}).search_read(domain, fields, load=False)

--- a/addons/pos_discount/models/product_template.py
+++ b/addons/pos_discount/models/product_template.py
@@ -14,7 +14,6 @@ class ProductTemplate(models.Model):
             productModel = self.env['product.product'].with_context({**self.env.context, 'display_default_code': False})
             fields = self.env['product.template']._load_pos_data_fields(data['pos.config'][0]['id'])
             product = productModel.search_read([('id', '=', discount_product_id)], fields=fields, load=False)
-            self._process_pos_ui_product_product(product, config_id)
             res.extend(product)
 
         return res

--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -21,21 +21,19 @@ class HrEmployee(models.Model):
     def _load_pos_data_fields(self, config_id):
         return ['name', 'user_id', 'work_contact_id']
 
-    def _load_pos_data(self, data):
-        domain = self._load_pos_data_domain(data)
-        fields = self._load_pos_data_fields(data['pos.config'][0]['id'])
-
-        employees = self.search(domain)
-        manager_ids = employees.filtered(lambda emp: data['pos.config'][0]['group_pos_manager_id'] in emp.user_id.all_group_ids.ids).mapped('id')
+    def _post_read_pos_data(self, data):
+        employee_ids = [employee['id'] for employee in data]
+        employees = self.browse(employee_ids)
+        config_id = self.env['pos.config'].browse(self.env.context['config_id'])
+        manager_ids = employees.filtered(lambda emp: config_id.group_pos_manager_id.id in emp.user_id.all_group_ids.ids).mapped('id')
 
         employees_barcode_pin = employees.get_barcodes_and_pin_hashed()
         bp_per_employee_id = {bp_e['id']: bp_e for bp_e in employees_barcode_pin}
 
-        employees = employees.read(fields, load=False)
-        for employee in employees:
-            if employee['user_id'] and employee['user_id'] in manager_ids or employee['id'] in data['pos.config'][0]['advanced_employee_ids']:
+        for employee in data:
+            if (employee['user_id'] and employee['user_id'] in manager_ids) or employee['id'] in config_id.advanced_employee_ids.ids:
                 role = 'manager'
-            elif employee['id'] in data['pos.config'][0]['minimal_employee_ids']:
+            elif employee['id'] in config_id.minimal_employee_ids.ids:
                 role = 'minimal'
             else:
                 role = 'cashier'
@@ -44,7 +42,7 @@ class HrEmployee(models.Model):
             employee['_barcode'] = bp_per_employee_id[employee['id']]['barcode']
             employee['_pin'] = bp_per_employee_id[employee['id']]['pin']
 
-        return employees
+        return super()._post_read_pos_data(data)
 
     def get_barcodes_and_pin_hashed(self):
         if not self.env.user.has_group('point_of_sale.group_pos_user'):

--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -28,13 +28,10 @@ class LoyaltyReward(models.Model):
                 'discount_max_amount', 'discount_line_product_id', 'reward_product_id',
                 'multi_product', 'reward_product_ids', 'reward_product_qty', 'reward_product_uom_id', 'reward_product_domain']
 
-    def _load_pos_data(self, data):
-        domain = self._load_pos_data_domain(data)
-        fields = self._load_pos_data_fields(data['pos.config'][0]['id'])
-        rewards = self.search_read(domain, fields, load=False)
-        for reward in rewards:
+    def _post_read_pos_data(self, data):
+        for reward in data:
             reward['reward_product_domain'] = self._replace_ilike_with_in(reward['reward_product_domain'])
-        return rewards
+        return super()._post_read_pos_data(data)
 
     def _get_reward_product_domain_fields(self, config_id):
         fields = set()

--- a/addons/pos_loyalty/models/product_template.py
+++ b/addons/pos_loyalty/models/product_template.py
@@ -18,10 +18,7 @@ class ProductTemplate(models.Model):
         fields = self.env['product.template']._load_pos_data_fields(data['pos.config'][0]['id'])
 
         missing_product_templates = self.env['product.template'].browse(missing_product_tmpl_ids).read(fields=fields, load=False)
-        self._process_pos_ui_product_product(missing_product_templates, config_id)
-
         product_ids_to_hide = reward_products.product_tmpl_id - self.env['product.template'].browse(already_loaded_product_tmpl_ids)
-
         data['pos.session'][0]['_pos_special_products_ids'] += product_ids_to_hide.product_variant_id.ids
         res.extend(missing_product_templates)
 

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -276,7 +276,7 @@ class PosConfig(models.Model):
         # Classic data loading
         for model in self._load_self_data_models():
             try:
-                response[model] = self.env[model]._load_pos_self_data(response)
+                response[model] = self.env[model]._post_read_pos_self_data(self.env[model]._load_pos_self_data(response))
                 self.env['pos.session']._load_pos_data_relations(model, response)
             except AccessError:
                 response[model] = self.env[model]._load_pos_self_data_fields(self.id)

--- a/addons/pos_self_order/models/pos_load_mixin.py
+++ b/addons/pos_self_order/models/pos_load_mixin.py
@@ -17,3 +17,6 @@ class PosLoadMixin(models.AbstractModel):
         domain = self._load_pos_self_data_domain(data)
         fields = self._load_pos_self_data_fields(data['pos.config'][0]['id'])
         return self.search_read(domain, fields, load=False) if domain is not False else []
+
+    def _post_read_pos_self_data(self, data):
+        return data

--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -11,9 +11,8 @@ class PosSession(models.Model):
     def _load_pos_self_data_domain(self, data):
         return [('config_id', '=', data['pos.config'][0]['id']), ('state', '=', 'opened')]
 
-    def _load_pos_data(self, data):
-        sessions = super()._load_pos_data(data)
-        sessions[0]['_self_ordering'] = (
+    def _post_read_pos_data(self, data):
+        data[0]['_self_ordering'] = (
             self.env["pos.config"]
             .sudo()
             .search_count(
@@ -26,4 +25,4 @@ class PosSession(models.Model):
             )
             > 0
         )
-        return sessions
+        return super()._post_read_pos_data(data)

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -24,7 +24,7 @@ class ProductTemplate(models.Model):
 
         # Add custom fields for 'formula' taxes.
         fields = set(self._load_pos_self_data_fields(data['pos.config'][0]['id']))
-        taxes = self.env['account.tax'].search(self.env['account.tax']._load_pos_data_domain(data))
+        taxes = self.env['account.tax'].search(self.env['account.tax']._load_pos_self_data_domain(data))
         product_fields = taxes._eval_taxes_computation_prepare_product_fields()
         fields = list(fields.union(product_fields))
 
@@ -49,9 +49,12 @@ class ProductTemplate(models.Model):
 
         data['pos.config'][0]['_product_default_values'] = \
             self.env['account.tax']._eval_taxes_computation_prepare_product_default_values(product_fields)
-        self._process_pos_self_ui_products(products)
 
         return products
+
+    def _post_read_pos_self_data(self, data):
+        self._process_pos_self_ui_products(data)
+        return super()._post_read_pos_self_data(data)
 
     def _process_pos_self_ui_products(self, products):
         for product in products:


### PR DESCRIPTION
pos*: l10n_ar_pos, l10n_be_pos_sale, l10n_pe_pos, point_of_sale, pos_discount, pos_hr, pos_loyalty, pos_self_order

Before this commit, when wanting to synchronize a record from the server to a pos via websocket, we were only reading the record without post_processing it as we do when we load the data from the server at the opening of the pos. This would lead to error when synching the data as some data were lost when replacing old records with new ones.

Enterprise PR: odoo/enterprise#81052

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
