### PR TITLE
[FIX] account: fix demo Coa not being loaded for main company

### DIFF
--- a/addons/account/demo/account_demo.xml
+++ b/addons/account/demo/account_demo.xml
@@ -28,13 +28,6 @@
             <value model="res.company" search="[('chart_template', '!=', False)]"/>
         </function>
 
-        <function model="account.chart.template" name="try_loading">
-            <value eval="[]"/>
-            <value>generic_coa</value>
-            <value model="res.company" search="[('partner_id.country_id.code', 'in', ['US', False])]"/>
-            <value name="install_demo" eval="True"/>
-        </function>
-
         <!-- Payment Terms -->
 
         <record id="account_payment_term_advance" model="account.payment.term">

--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -79,6 +79,7 @@ class IrModuleModule(models.Model):
                 env['account.chart.template'].try_loading(
                     guessed,
                     env.company,
+                    install_demo=self.demo,
                 )
             self.env.registry._auto_install_template = try_loading
         return res


### PR DESCRIPTION
If the country of the main company was switched to another value, the previous code was simply not loading the generic CoA. This would break the loading of demo data of account_accountant (expecting a journal to populate journal entries), until it eventually simply crashed at the installation of account_loans (because it was expecting to be able to load demo if the demo of account was loaded, that would require more fixing as well to make the code more robust)

How to reproduce:
* in addons/base/data/res_users_demo.xml, change country of main company to anything else but US
* install fresh DB with account_accountant
* observe in the logs that account_accountant is not able to load the account.move demo 'deferred_invoice'
* try to install account_loans => traceback






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
