### PR TITLE
[IMP] point_of_sale: add complete_name to pos_category model

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -13,6 +13,7 @@ class PosCategory(models.Model):
     _description = "Point of Sale Category"
     _inherit = ['pos.load.mixin']
     _order = "sequence, name"
+    _rec_name = 'complete_name'
 
     @api.constrains('parent_id')
     def _check_category_recursion(self):
@@ -23,6 +24,9 @@ class PosCategory(models.Model):
         return random.randint(0, 10)
 
     name = fields.Char(string='Category Name', required=True, translate=True)
+    complete_name = fields.Char(
+        'Complete Name', compute='_compute_complete_name', recursive=True, translate=True,
+        store=True)
     parent_id = fields.Many2one('pos.category', string='Parent Category', index=True)
     child_ids = fields.One2many('pos.category', 'parent_id', string='Children Categories')
     sequence = fields.Integer(help="Gives the sequence order when displaying a list of product categories.")
@@ -34,6 +38,18 @@ class PosCategory(models.Model):
     # During loading of data, the image is not loaded so we expose a lighter
     # field to determine whether a pos.category has an image or not.
     has_image = fields.Boolean(compute='_compute_has_image')
+
+    @api.depends('name', 'parent_id.complete_name')
+    def _compute_complete_name(self):
+        languages = self.env['res.lang'].search([('active', '=', True)])
+        for lang in languages:
+            for category in self:
+                if category.parent_id:
+                    category.with_context(lang=lang.code).complete_name = '%s / %s' % (
+                    category.with_context(lang=lang.code).parent_id.complete_name,
+                    category.with_context(lang=lang.code).name)
+                else:
+                    category.with_context(lang=lang.code).complete_name = category.with_context(lang=lang.code).name
 
     @api.model
     def _load_pos_data_domain(self, data):
@@ -49,15 +65,10 @@ class PosCategory(models.Model):
     def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'parent_id', 'child_ids', 'write_date', 'has_image', 'color', 'sequence', 'hour_until', 'hour_after']
 
-    def _get_hierarchy(self) -> List[str]:
-        """ Returns a list representing the hierarchy of the categories. """
-        self.ensure_one()
-        return (self.parent_id._get_hierarchy() if self.parent_id else []) + [(self.name or '')]
-
     @api.depends('parent_id')
     def _compute_display_name(self):
         for cat in self:
-            cat.display_name = " / ".join(cat._get_hierarchy())
+            cat.display_name = cat.complete_name
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_session_open(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Adding new field for `_rec_name` (`complete_name`) which will be computed by hierarchy

Current behavior before PR:
Currently we cannot import product's POS category if it's nested.
Odoo will show error because the POS category is not found

Desired behavior after PR is merged:
Will be able to import nested POS category



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
