### PR TITLE
[FIX] pos_self_order: prevent adding to cart if option not selected

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -34,6 +34,7 @@ export class ComboPage extends Component {
             showQtyButtons: false,
             editMode: false,
             qty: 1,
+            selectedValues: this.env.selectedValues,
         });
 
         onWillUnmount(() => {
@@ -58,6 +59,17 @@ export class ComboPage extends Component {
         return this.selfOrder.models["product.template.attribute.value"].filter((c) =>
             attrValIds.includes(c.id)
         );
+    }
+
+    isEveryValueSelected() {
+        return Object.values(this.state.selectedValues).every((value) => value);
+    }
+
+    isArchivedCombination() {
+        const variantAttributeValueIds = Object.values(this.state.selectedValues)
+            .filter((attr) => typeof attr !== "object")
+            .map((attr) => Number(attr));
+        return this.props.product._isArchivedCombination(variantAttributeValueIds);
     }
 
     resetState() {

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -113,7 +113,7 @@
         <div
             t-if="state.showResume || (!state.showResume and showQtyButtons)"
             class="page-buttons d-flex justify-content-end gap-3 p-3 border-top bg-view">
-            <button t-if="!state.showResume and showQtyButtons" class="btn btn-primary btn-lg" t-on-click="next">Next</button>
+            <button t-if="!state.showResume and showQtyButtons" class="btn btn-primary btn-lg" t-on-click="next" t-att-disabled="!this.isEveryValueSelected() or isArchivedCombination()">Next</button>
             <button t-if="state.showResume and selfOrder.ordering" class="btn btn-primary btn-lg" t-on-click="addToCart">Add to cart</button>
         </div>
     </t>

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -86,7 +86,7 @@ export class ProductPage extends Component {
     }
 
     isEveryValueSelected() {
-        return Object.values(this.state.selectedValues).find((value) => !value) == false;
+        return Object.values(this.state.selectedValues).every((value) => value);
     }
 
     isArchivedCombination() {

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -51,13 +51,13 @@
 
             <div t-if="showQtyButtons and !props.onValidate" class="page-buttons d-flex p-3 gap-3 bg-view border-top"
                 t-att-class="(isArchivedCombination() ? 'justify-content-between': 'justify-content-end')">
-                <div t-if="isArchivedCombination() and !this.isEveryValueSelected()" class="alert alert-warning m-0">
+                <div t-if="isArchivedCombination() and this.isEveryValueSelected()" class="alert alert-warning m-0">
                     This combination does not exist.
                 </div>
                 <button
                     t-if="showQtyButtons and !props.onValidate and selfOrder.ordering"
                     class="btn btn-primary btn-lg"
-                    t-att-disabled="this.isEveryValueSelected() or isArchivedCombination()"
+                    t-att-disabled="!this.isEveryValueSelected() or isArchivedCombination()"
                     t-on-click="addToCart">
                     Add to cart
                 </button>

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -149,3 +149,19 @@ registry.category("web_tour.tours").add("self_order_language_changes", {
         Utils.checkLanguageIsAvailable("French"),
     ],
 });
+
+registry.category("web_tour.tours").add("test_self_order_kiosk_combo_sides", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Office Combo"),
+        ProductPage.clickProduct("Desk Organizer"),
+        {
+            trigger: `.page-buttons :disabled:contains("Next")`,
+        },
+        ...ProductPage.setupAttribute([
+            { name: "Size", value: "M" },
+            { name: "Fabric", value: "Leather" },
+        ]),
+        Utils.clickBtn("Add to cart"),
+    ],
+});

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -74,3 +74,37 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
         self.pos_config.with_user(self.pos_user).open_ui()
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "self_order_language_changes")
+
+    def test_self_order_kiosk_combo_sides(self):
+        combo = self.env["product.combo"].create(
+            {
+                "name": "Desk Accessories Combo",
+                "combo_item_ids": [
+                    Command.create({
+                        "product_id": self.desk_organizer.id,
+                        "extra_price": 0,
+                    }),
+                ],
+            }
+        )
+        self.env["product.product"].create(
+            {
+                "available_in_pos": True,
+                "list_price": 40,
+                "name": "Office Combo",
+                "type": "combo",
+                "combo_ids": [
+                    (6, 0, [combo.id])
+                ],
+            }
+        )
+        self.pos_config.write({
+            'takeaway': False,
+            'self_ordering_takeaway': False,
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_self_order_kiosk_combo_sides")


### PR DESCRIPTION
Currently, when ordering on kiosk a menu combo, if you do not select sides it will crash when adding it to the cart

Steps to reproduce:
-------------------
* Open kiosk
* Select burger Menu Combo
* Select Cheese burger
* DO NOT select sides
* Select Next button
* Add drink
* Add to cart
> Observation: White screen crashes

Why the fix:
------------
The crash is ultimately cause by a undefined `attribute_value_ids` https://github.com/odoo/odoo/blob/ea67d5ad5f81c7eae85cff352bcc75290053ba20/addons/pos_self_order/static/src/app/self_order_service.js#L263-L266

If we compare the behavior of the same product, outside a combo, we are not allowed to add the product to the cart if we did not select sides. We will now have a consistent behavior with/without combo.

opw-4516061