### PR TITLE
[FIX] website: theme selector in website creator translated

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -460,9 +460,136 @@ class ThemeSelectionScreen extends ApplyConfiguratorScreen {
 
         onMounted(() => {
             this.state.themes.forEach((theme, idx) => {
-                $(this.themeSVGPreviews[idx].el).append(theme.svg);
+                const translatedSvg = this.translateSVG(theme.svg);
+                $(this.themeSVGPreviews[idx].el).append(translatedSvg);
             });
         });
+    }
+
+    translateSVG(svg) {
+        const domParser = new DOMParser();
+        const doc = domParser.parseFromString(svg, "image/svg+xml");
+        doc.querySelectorAll("text").forEach((elem) => {
+            const sanitizedTextContent = elem.textContent
+                .trim()
+                .split("\n")
+                .map((word) => word.trim());
+            var translatedTextContent = sanitizedTextContent.join(" ");
+            switch (translatedTextContent) {
+                case "Welcome":
+                    translatedTextContent = _t("Welcome");
+                    break;
+                case "Welcome Message":
+                    translatedTextContent = _t("Welcome Message");
+                    break;
+                case "A Welcome Message":
+                    translatedTextContent = _t("A Welcome Message");
+                    break;
+                case "A Welcoming Message":
+                    translatedTextContent = _t("A Welcoming Message");
+                    break;
+                case "Discover":
+                    translatedTextContent = _t("Discover");
+                    break;
+                case "Section Title":
+                    translatedTextContent = _t("Section Title");
+                    break;
+                case "Entry Title":
+                    translatedTextContent = _t("Entry Title");
+                    break;
+                case "Team Member":
+                    translatedTextContent = _t("Team Member");
+                    break;
+                case "A Section Title":
+                    translatedTextContent = _t("A Section Title");
+                    break;
+                case "A Very Long Title":
+                    translatedTextContent = _t("A Very Long Title");
+                    break;
+                case "A Big Title":
+                    translatedTextContent = _t("A Big Title");
+                    break;
+                case "A Very Long Subtitle":
+                    translatedTextContent = _t("A Very Long Subtitle");
+                    break;
+                case "Block Title":
+                    translatedTextContent = _t("Block Title");
+                    break;
+                case "BLOCK":
+                    translatedTextContent = _t("BLOCK");
+                    break;
+                case "TITLE":
+                    translatedTextContent = _t("TITLE");
+                    break;
+                case "Feature #01":
+                    translatedTextContent = _t("Feature") + " #01";
+                    break;
+                case "Feature #02":
+                    translatedTextContent = _t("Feature") + " #02";
+                    break;
+                case "Feature #03":
+                    translatedTextContent = _t("Feature") + " #03";
+                    break;
+                case "Section Entry":
+                    translatedTextContent = _t("Section Entry");
+                    break;
+                case "Contact Us":
+                    translatedTextContent = _t("Contact Us");
+                    break;
+                case "Contact":
+                    translatedTextContent = _t("Contact");
+                    break;
+                case "Card Title":
+                    translatedTextContent = _t("Card Title");
+                    break;
+                case "Call-To-Action Title":
+                    translatedTextContent = _t("Call-To-Action Title");
+                    break;
+                case "Subtitle #01":
+                    translatedTextContent = _t("Subtitle") + " #01";
+                    break;
+                case "Subtitle #02":
+                    translatedTextContent = _t("Subtitle") + " #02";
+                    break;
+            }
+
+            /*
+             * This code handles translating multiline phrases into languages
+             * whose corresponding phrases have more words, while keeping the
+             * same amount of lines
+             *
+             * Example: translating     Welcome     into    Messaggio di
+             *                          Message             Benvenuto
+             *
+             * starting phrase = 2 lines, 2 words
+             * translated phrase = 2 lines, 3 words
+             */
+            if (sanitizedTextContent.length > 1) {
+                const distributedTranslatedTextContent = [];
+                const splitTranslatedTextContent = translatedTextContent.split(/\s/);
+                const wordsPerLine = Math.ceil(
+                    splitTranslatedTextContent.length / sanitizedTextContent.length
+                );
+
+                for (let i = 0; i < splitTranslatedTextContent.length; i += wordsPerLine) {
+                    distributedTranslatedTextContent.push(
+                        splitTranslatedTextContent.slice(i, i + wordsPerLine).join(" ")
+                    );
+                }
+
+                distributedTranslatedTextContent.forEach((word, index) => {
+                    elem.querySelectorAll("tspan")[index].textContent = word;
+                });
+            } else {
+                const tspanEl = elem.querySelector("tspan");
+                if (tspanEl) {
+                    tspanEl.textContent = translatedTextContent;
+                } else {
+                    elem.textContent = translatedTextContent;
+                }
+            }
+        });
+        return doc.getElementsByTagNameNS("http://www.w3.org/2000/svg", "svg").item(0);
     }
 
     async chooseTheme(themeName) {


### PR DESCRIPTION
When a website is created, the theme selector's three sample themes SVGs are in english, even if the website is in another language.

Steps to reproduce:

- Install another language in the settings
- Create a website using a language other than english
- Proceed throught the website creation steps until the theme selection is reached
- The three sample themes are in english even though the website is in another language

After the change the sample themes are correctly translated in the chosen language.

design-themes PR: https://github.com/odoo/design-themes/pull/1052

task-3415840
