### PR TITLE
[FIX] account: forbid modifying a tax used in posted document

### DIFF
--- a/addons/account/tests/test_account_tax.py
+++ b/addons/account/tests/test_account_tax.py
@@ -28,3 +28,25 @@ class TestAccountTax(AccountTestInvoicingCommon):
 
         with self.assertRaises(UserError), self.cr.savepoint():
             self.company_data['default_tax_sale'].company_id = self.company_data_2['company']
+
+    def test_changing_tax_values(self):
+        ''' Ensure you can't change the fields impacting the computation of tax if there are some journal entries '''
+
+        # Avoid duplicate key value violates unique constraint "account_tax_name_company_uniq".
+        self.company_data['default_tax_sale'].name = 'test_changing_tax_values'
+
+        self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_line_ids': [
+                (0, 0, {
+                    'name': 'invoice_line',
+                    'quantity': 1.0,
+                    'price_unit': 100.0,
+                    'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],
+                }),
+            ],
+        })
+
+        with self.assertRaises(UserError), self.cr.savepoint():
+            self.company_data['default_tax_sale'].amount = 20.0


### PR DESCRIPTION
Currently it is possible to modify the percent amount of a tax used in a posted document.
This is an issue when the tax is price included, as the untaxes total shown in the invoice will differ after changing the tax percent amount

Steps to reproduce:
- Have a price included tax [TAX]
- Make an invoice using [TAX], post it, take note of tax totals
- Edit [TAX] record with a different percent amount
- Check again the invoice tax totals

Issue: Tax totals widget shows updated values

This occurs because when recomputing the tax totals, we rely on the existing lines to provide the tax amount, but in case of price included taxes, the untaxed total will be recomputed with the updated values, causing a difference.

opw-4473523