### PR TITLE
[FIX] sale: remove empty line from SOL description

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -346,7 +346,7 @@ class SaleOrderLine(models.Model):
         if not self.product_custom_attribute_value_ids and not self.product_no_variant_attribute_value_ids:
             return ""
 
-        name = "\n"
+        name = ""
 
         custom_ptavs = self.product_custom_attribute_value_ids.custom_product_template_attribute_value_id
         no_variant_ptavs = self.product_no_variant_attribute_value_ids._origin

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -304,7 +304,7 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
         })
         sale_order.action_confirm()
         pol = sale_order._get_purchase_orders().order_line
-        self.assertEqual(pol.name, f"{self.service_purchase_1.display_name}\n\n{product_attribute.name}: {product_attribute_value.name}: {custom_value}")
+        self.assertEqual(pol.name, f"{self.service_purchase_1.display_name}\n{product_attribute.name}: {product_attribute_value.name}: {custom_value}")
 
     def test_service_to_purchase_multi_company(self):
         """Test the service to purchase in a multi-company environment

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -51,7 +51,7 @@ tour.register('sale_matrix_tour', {
     // wait for qty to be 1 => check the total to be sure all qties are set to 1
     extra_trigger: '.oe_subtotal_footer_separator:contains("248.40")',
 }, {
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
+    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\nPA4: PAV41")',
     extra_trigger: '.o_form_editable',
 }, {
     trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
@@ -80,7 +80,7 @@ tour.register('sale_matrix_tour', {
     // wait for qty to be 3 => check the total to be sure all qties are set to 3
     extra_trigger: '.oe_subtotal_footer_separator:contains("745.20")',
 }, {
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
+    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\nPA4: PAV41")',
     extra_trigger: '.o_form_editable',
 }, {
     trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
@@ -101,7 +101,7 @@ tour.register('sale_matrix_tour', {
 },
 // Open the matrix through the pencil button next to the product in line edit mode.
 {
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
+    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\nPA4: PAV41")',
     extra_trigger: '.o_form_status_indicator_buttons.invisible', // wait for save to be finished
 }, {
     trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix

--- a/addons/website_sale_product_configurator/tests/test_website_sale_configurator.py
+++ b/addons/website_sale_product_configurator/tests/test_website_sale_configurator.py
@@ -159,4 +159,4 @@ class TestWebsiteSaleProductConfigurator(TestProductConfiguratorCommon, HttpCase
         # Check the name of the created sale order line
         new_sale_order = self.env['sale.order'].search([]) - old_sale_order
         new_order_line = new_sale_order.order_line
-        self.assertEqual(new_order_line.name, 'Short (TEST) (M always, M dynamic)\n\nNever attribute size: M never\nNever attribute size custom: Yes never custom: TEST')
+        self.assertEqual(new_order_line.name, 'Short (TEST) (M always, M dynamic)\nNever attribute size: M never\nNever attribute size custom: Yes never custom: TEST')


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have a product with a "No variant" or customer attribute;
2. add product to a sales order.

Issue
-----
There is a blank line between the product name & attribute descriptor.

Cause
-----
The `_get_sale_order_line_multiline_description_variants` method returns either an empty string, or a string that starts with 2 newlines.

Solution
--------
Start with only 1 newline.

opw-4585174