### PR TITLE
[FIX] mrp{_account}: round values before summing

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -291,7 +291,7 @@ class ReportMoOverview(models.AbstractModel):
             })
             total_expected_time += workorder.duration_expected
             total_current_time += wo_duration if is_workorder_started else workorder.duration_expected
-            total_expected_cost += mo_cost
+            total_expected_cost += self.env.company.currency_id.round(mo_cost)
             total_real_cost += real_cost
 
         return {

--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -121,7 +121,7 @@ class MrpProduction(models.Model):
             workorders = defaultdict(self.env['mrp.workorder'].browse)
             for wo in mo.workorder_ids:
                 account = wo.workcenter_id.expense_account_id or product_accounts['expense']
-                labour_amounts[account] += wo._cal_cost()
+                labour_amounts[account] += self.env.company.currency_id.round(wo._cal_cost())
                 workorders[account] |= wo
             workcenter_cost = sum(labour_amounts.values())
 


### PR DESCRIPTION
Rounding issue can occurs when validating MO under certain conditions.

Steps to reproduce:
- Create three work centers with different expense accounts:
    - First: hourly cost of 4.11
    - Second: hourly cost of 4.23
    - Third: hourly cost of 2.25
- Create an MO for a product with real-time valuation and 3 work orders (one per work center).
    - Each work order has an expected duration of 2790:00
- Attempt to click on "Produce All" button.

This leads to an unbalanced move error.
This fix rounds the values before summing them to prevent rounding issues and unbalanced moves. It also corrects the displayed value in the Manufacturing Order overview.

opw-4631409