### PR TITLE
[FIX] im_livechat: no duplicate t-key in channel invite

### DIFF
--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -1,4 +1,8 @@
 declare module "models" {
+    export interface Persona {
+        livechat_languages: String[],
+        livechat_expertise: String[],
+    }
     export interface Thread {
         livechat_operator_id: Persona,
     }

--- a/addons/im_livechat/static/src/core/common/persona_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/persona_model_patch.js
@@ -1,0 +1,13 @@
+import { Persona } from "@mail/core/common/persona_model";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Persona} */
+const personaPatch = {
+    setup() {
+        super.setup();
+        this.livechat_languages = [];
+        this.livechat_expertise = [];
+    },
+};
+patch(Persona.prototype, personaPatch);

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
@@ -9,13 +9,13 @@
                     <span class="d-flex text-start fs-6 gap-1">
                         <i class="fa fa-fw fa-comment-o" title="Language"/>
                         <span class="badge rounded text-bg-primary" t-esc="selectablePartner.lang_name"/>
-                        <t t-foreach="selectablePartner.livechat_languages" t-as="language" t-key="index">
+                        <t t-foreach="selectablePartner.livechat_languages" t-as="language" t-key="language_index">
                             <span class="badge rounded text-bg-primary" t-esc="language"/>
                         </t>
                     </span>
                     <span class="d-flex text-start fs-6 gap-1">
                         <i t-if="selectablePartner.livechat_expertise.length" class="fa fa-fw fa-graduation-cap" title="Expertise"/>
-                        <t t-foreach="selectablePartner.livechat_expertise" t-as="expertise" t-key="index">
+                        <t t-foreach="selectablePartner.livechat_expertise" t-as="expertise" t-key="expertise_index">
                             <span class="badge rounded text-bg-info bg-opacity-75 o-text-white" t-esc="expertise"/>
                         </t>
                     </span>

--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -10,9 +10,23 @@ defineLivechatModels();
 test("Can invite a partner to a livechat channel", async () => {
     mockDate("2023-01-03 12:00:00");
     const pyEnv = await startServer();
+    const langIds = pyEnv["res.lang"].create([
+        { code: "en", name: "English" },
+        { code: "fr", name: "French" },
+        { code: "de", name: "German" },
+    ]);
+    const expertiseIds = pyEnv["im_livechat.expertise"].create([
+        { name: "pricing" },
+        { name: "events" },
+    ]);
     pyEnv["res.partner"].write([serverState.partnerId], { user_livechat_username: "Mitch (FR)" });
-    const userId = pyEnv["res.users"].create({ name: "James" });
+    const userId = pyEnv["res.users"].create({
+        name: "James",
+        livechat_lang_ids: langIds,
+        livechat_expertise_ids: expertiseIds,
+    });
     pyEnv["res.partner"].create({
+        lang: "en",
         name: "James",
         user_ids: [userId],
     });
@@ -36,6 +50,9 @@ test("Can invite a partner to a livechat channel", async () => {
     await click("input", {
         parent: [".o-discuss-ChannelInvitation-selectable", { text: "James" }],
     });
+    await contains(
+        ".o-discuss-ChannelInvitation-selectable:contains('James\nEnglish\nFrench\nGerman\npricing\nevents')"
+    );
     await click("button:enabled", { text: "Invite" });
     await contains(".o-mail-NotificationMessage", {
         text: "Mitch (FR) invited James to the channel",

--- a/addons/im_livechat/static/tests/livechat_test_helpers.js
+++ b/addons/im_livechat/static/tests/livechat_test_helpers.js
@@ -9,6 +9,7 @@ import {
 import { DiscussChannel } from "./mock_server/mock_models/discuss_channel";
 import { DiscussChannelMember } from "./mock_server/mock_models/discuss_channel_member";
 import { LivechatChannel } from "./mock_server/mock_models/im_livechat_channel";
+import { Im_LivechatExpertise } from "./mock_server/mock_models/im_livechat_expertise";
 import { ResGroups } from "./mock_server/mock_models/res_groups";
 import { ResLang } from "./mock_server/mock_models/res_lang";
 import { ResPartner } from "./mock_server/mock_models/res_partner";
@@ -24,6 +25,7 @@ export const livechatModels = {
     DiscussChannel,
     DiscussChannelMember,
     LivechatChannel,
+    Im_LivechatExpertise,
     RatingRating,
     ResLang,
     ResPartner,

--- a/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_expertise.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_expertise.js
@@ -1,0 +1,5 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+export class Im_LivechatExpertise extends models.ServerModel {
+    _name = "im_livechat.expertise";
+}

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
@@ -14,6 +14,8 @@ export class ResPartner extends mailModels.ResPartner {
         const DiscussChannelMember = this.env["discuss.channel.member"];
         /** @type {import("mock_models").LivechatChannel} */
         const LivechatChannel = this.env["im_livechat.channel"];
+        /** @type {import("mock_models").Im_LivechatExpertise} */
+        const Im_LivechatExpertise = this.env["im_livechat.expertise"];
         /** @type {import("mock_models").ResLang} */
         const ResLang = this.env["res.lang"];
         /** @type {import("mock_models").ResPartner} */
@@ -40,6 +42,18 @@ export class ResPartner extends mailModels.ResPartner {
             };
             if (partner.lang) {
                 data.lang_name = ResLang.search_read([["code", "=", partner.lang]])[0].name;
+            }
+            if (partner.user_ids.length) {
+                const [user] = ResUsers.browse(partner.user_ids[0]);
+                if (user) {
+                    const userLangs = user.livechat_lang_ids
+                        .map((langId) => ResLang.browse(langId)[0])
+                        .filter((lang) => lang.name !== data.lang_name);
+                    data.livechat_languages = userLangs.map((lang) => lang.name);
+                    data.livechat_expertise = user.livechat_expertise_ids.map(
+                        (expId) => Im_LivechatExpertise.browse(expId)[0].name
+                    );
+                }
             }
             store.add(this.browse(partner.id), data);
         }


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/198093

PR above improved channel invitation UI to show livechat operator languages and expertise, whereas it was only showing the main language.

This PR introduced the following crash by mistake:

```
OwlError: Got duplicate key in t-foreach: undefined
```

This happens because the keys were defined as `index`, which is `undefined` thus an operator with at least 3 languages or 2 expertise items made it crash.

The intend of `t-key` was to use the index of item in the respective list, so the `t-value` variable with `_index`, e.g. `language_index`, which this commit fixes.