### PR TITLE
[IMP] *: improve product page's component design

### DIFF
--- a/addons/portal_rating/static/src/scss/portal_rating.scss
+++ b/addons/portal_rating/static/src/scss/portal_rating.scss
@@ -1,7 +1,14 @@
 /* static stars */
+// portal_rating
 $o-w-rating-star-color: #FACC2E;
-.o_website_rating_static{
-    color: $o-w-rating-star-color;
+
+.o_website_rating_static {
+    color: var(--WebsiteRating__star-color,  #{$o-w-rating-star-color});
+}
+
+// website_sale
+#product_details {
+    --WebsiteRating__star-color: currentColor;
 }
 
 .o_website_rating_card_container {

--- a/addons/website_sale/const.py
+++ b/addons/website_sale/const.py
@@ -140,7 +140,7 @@ PRODUCT_PAGE_STYLE_MAPPING = {
             'disable': [
                 'website_sale.carousel_product_indicators_bottom',  # Layout/Thumbnails
                 'website_sale_comparison.product_add_to_compare',  # Comparison
-                'website_sale.product_custom_text',  # Terms and Conditions
+                'website_sale.product_terms_and_conditions',  # Terms and Conditions
             ],
         },
         'website_fields': {},  # Default
@@ -156,7 +156,7 @@ PRODUCT_PAGE_STYLE_MAPPING = {
                 'website_sale.product_picture_magnify_hover',
                 'website_sale.product_picture_magnify_both',
                 'website_sale_comparison.product_add_to_compare',  # Comparison
-                'website_sale.product_custom_text',  # Terms and Conditions
+                'website_sale.product_terms_and_conditions',  # Terms and Conditions
             ],
         },
         'website_fields': {
@@ -176,7 +176,7 @@ PRODUCT_PAGE_STYLE_MAPPING = {
                 'website_sale.products_carousel_16x9',
                 'website_sale.products_carousel_21x9',
                 'website_sale_comparison.product_add_to_compare',  # Comparison
-                'website_sale.product_custom_text',  # Terms and Conditions
+                'website_sale.product_terms_and_conditions',  # Terms and Conditions
             ],
         },
         'website_fields': {
@@ -194,7 +194,7 @@ PRODUCT_PAGE_STYLE_MAPPING = {
                 'website_sale.product_picture_magnify_hover',
                 'website_sale.product_picture_magnify_both',
                 'website_sale_comparison.product_add_to_compare',  # Comparison
-                'website_sale.product_custom_text',  # Terms and Conditions
+                'website_sale.product_terms_and_conditions',  # Terms and Conditions
             ],
         },
         'website_fields': {

--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -51,7 +51,7 @@
 
     <t t-name="website_sale.strikethrough_product_price">
         <h5
-            class="oe_striked_price text-muted small"
+            class="oe_striked_price text-muted small text-decoration-line-through text-nowrap"
             t-if="this.props.strikethrough_price"
             t-out="formattedStrikethroughPrice"
         />

--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -227,7 +227,10 @@ var VariantMixin = {
         $parent
             .find('option, input, label, .o_variant_pills')
             .removeClass('css_not_available')
-            .attr('title', function () { return $(this).data('value_name') || ''; })
+            .removeAttr('disabled')
+            .filter('option, input')
+            .closest('li')
+            .removeAttr('title')
             .data('excluded-by', '');
 
         // exclusion rules: array of ptav
@@ -326,15 +329,16 @@ var VariantMixin = {
     _disableInput: function ($parent, attributeValueId, excludedBy, attributeNames, productName) {
         var $input = $parent
             .find('option[value=' + attributeValueId + '], input[value=' + attributeValueId + ']');
-        $input.addClass('css_not_available');
+        $input.addClass('css_not_available').prop('disabled', true);
         $input.closest('label').addClass('css_not_available');
         $input.closest('.o_variant_pills').addClass('css_not_available');
 
+        const $li = $input.closest('li');
+
         if (excludedBy && attributeNames) {
-            var $target = $input.is('option') ? $input : $input.closest('label').add($input);
             var excludedByData = [];
-            if ($target.data('excluded-by')) {
-                excludedByData = JSON.parse($target.data('excluded-by'));
+            if ($li.data('excluded-by')) {
+                excludedByData = $li.data('excluded-by');
             }
 
             var excludedByName = attributeNames[excludedBy];
@@ -343,8 +347,8 @@ var VariantMixin = {
             }
             excludedByData.push(excludedByName);
 
-            $target.attr('title', _t('Not available with %s', excludedByData.join(', ')));
-            $target.data('excluded-by', JSON.stringify(excludedByData));
+            $li.attr('title', _t('Not available with %s', excludedByData.join(', ')));
+            $li.data('excluded-by', excludedByData);
         }
     },
     /**
@@ -433,7 +437,6 @@ var VariantMixin = {
                 combination.product_id,
                 combination.product_template_id,
                 combination.carousel,
-                isCombinationPossible
             );
             $parent
                 .find('.o_product_tags')
@@ -545,11 +548,16 @@ var VariantMixin = {
      * @param {MouseEvent} ev
      */
     _onChangeColorAttribute: function (ev) {
-        var $parent = $(ev.target).closest('.js_product');
+        let $eventTarget = $(ev.target);
+        var $parent = $eventTarget.closest('.js_product');
         $parent.find('.css_attribute_color')
             .removeClass("active")
             .filter(':has(input:checked)')
             .addClass("active");
+        let $attrValueEl = $eventTarget.closest('.variant_attribute').find('.attribute_value')[0];
+        if ($attrValueEl) {
+            $attrValueEl.innerText = $eventTarget.data('value_name');
+        }
     },
 
     _onChangePillsAttribute: function (ev) {
@@ -557,9 +565,9 @@ var VariantMixin = {
         radio.click();  // Trigger onChangeVariant.
         var $parent = $(ev.target).closest('.js_product');
         $parent.find('.o_variant_pills')
-            .removeClass("active")
+            .removeClass("active border-primary text-primary-emphasis bg-primary-subtle")
             .filter(':has(input:checked)')
-            .addClass("active");
+            .addClass("active border-primary text-primary-emphasis bg-primary-subtle");
     },
 
     /**

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -835,7 +835,7 @@ options.registry.WebsiteSaleProductPage = options.Class.extend({
         const isGrid = !!this.productDetailMain.querySelector('#o-grid-product');
         switch (widgetName) {
             case 'o_wsale_thumbnail_pos':
-                return Boolean(this.productPageCarousel) && hasImages;
+                return Boolean(this.productPageCarousel) && hasImages && multipleImages;
             case 'o_wsale_grid_spacing':
                 return isGrid && multipleImages;
             case 'o_wsale_grid_columns':

--- a/addons/website_sale/static/src/scss/product_configurator.scss
+++ b/addons/website_sale/static/src/scss/product_configurator.scss
@@ -1,31 +1,41 @@
 .css_attribute_color {
+    --o-wsale-css-attribute-color__height: 2rem;
+    --o-wsale-css-attribute-color__border-width: .25rem;
+
     position: relative;
     display: inline-block;
-    border: 5px solid $input-border-color;
+    height: calc(var(--o-wsale-css-attribute-color__height) - var(--o-wsale-css-attribute-color__border-width));
+    width: calc(var(--o-wsale-css-attribute-color__height) - var(--o-wsale-css-attribute-color__border-width));
+    border: var(--o-wsale-css-attribute-color__border-width) solid var(--body-bg);
     border-radius: 50%;
-    text-align: center;
     transition: $input-transition;
-
-    @include o-field-pointer();
-
-    &:before {
-        content: "";
-        display: block;
-        @include o-position-absolute(-3px, -3px, -3px, -3px);
-        border: 4px solid white;
-        border-radius: 50%;
-        box-shadow: inset 0 0 3px rgba(black, 0.3);
-    }
+    outline: $border-width solid $input-border-color;
+    box-shadow: inset 0 0 0 $border-width $border-color;
+    box-sizing: content-box;
 
     input {
-        margin: 8px;
-        height: 13px;
-        width: 13px;
         opacity: 0;
     }
 
+    &.active, &:hover {
+        border-color: var(--body-bg);
+        outline-color: map-get($theme-colors, 'primary');
+    }
+
+    &:has(input:focus-visible)::before {
+        @include o-position-absolute($top: 50%, $left: 50%);
+
+        content:" ";
+        width: 160%;
+        height: 160%;
+        border-radius: 100%;
+        z-index: -1;
+        background-color: $focus-ring-color;
+        transform: translate(-50%, -50%);
+    }
+
     &.active {
-        border: 5px solid map-get($theme-colors, 'primary');
+        outline-color: map-get($theme-colors, 'primary');
     }
 
     &.custom_value {
@@ -37,52 +47,49 @@
     }
 }
 
-.css_not_available_msg {
-    display: none;
-}
-
-.css_not_available.js_product {
-    .css_quantity {
-        display: none !important;
-    }
-
-    .css_not_available_msg {
-        display: block;
-    }
-
-    .availability_messages {
-        display: none;
-    }
-
-    .oe_price,
-    .oe_default_price {
-        display: none;
-    }
-}
-
 .css_quantity {
     width: initial; // We don't want the quantity form to be full-width
-
-    .btn, input {
-        border-color: $input-border-color;
-    }
+    border-radius: $btn-border-radius;
 
     input {
         // Needs !important because themes customize btns' padding direclty
         // rather than change '$input-btn-padding-X' (shared with inputs).
         height: auto !important;
-        max-width: 5ch;
+        max-width: 4ch;
     }
-}
 
-option.css_not_available {
-    color: #ccc;
+    &.input-group-lg {
+        &:not(.css_quantity_50) {
+            @include media-breakpoint-up(lg) {
+                width: 100%;
+            }
+
+            @include media-breakpoint-up(xl) {
+                width: auto;
+            }
+
+            input {
+                @include media-breakpoint-up(lg)  {
+                    max-width: 100%;
+                }
+
+                @include media-breakpoint-up(xl)  {
+                    max-width: 4ch;
+                }
+            }
+        }
+
+        .btn {
+            padding-top: $btn-padding-y-lg;
+            padding-bottom: $btn-padding-y-lg;
+        }
+    }
 }
 
 $-arrow-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='175' height='100' fill='#000'><polygon points='0,0 100,0 50,50'/></svg>");
 
 select.form-select.css_attribute_select {
-    max-width: 400px;
+    max-width: 26rem;
 
     &:not([multiple]):where(:not([size]), [size="1"]) {
         background-image: str-replace($-arrow-url, "#000", str-replace(#{$input-color}, "#", "%23"));
@@ -107,124 +114,33 @@ select.form-select.css_attribute_select {
     }
 }
 
-label, .o_variant_pills {
-    &.css_not_available {
-        opacity: 0.6;
+.variant_attribute {
+    .o_variant_pills {
+        border: $border-width solid $border-color;
+
+        &:has(input:focus-visible) {
+            box-shadow: $btn-focus-box-shadow;
+        }
+    }
+
+    label, .o_variant_pills {
+        &.css_not_available {
+            opacity: 0.6;
+            pointer-events: none;
+        }
     }
 }
 
 label.css_attribute_color.css_not_available {
-    opacity: 1;
-
     &:after {
         content: "";
-        @include o-position-absolute(-5px, -5px, -5px, -5px);
-        border: 2px solid map-get($theme-colors, 'danger');
-        border-radius: 50%;
-        background: str-replace(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='39' height='39'><line y2='0' x2='39' y1='39' x1='0' style='stroke:#{map-get($theme-colors, 'danger')};stroke-width:2'/><line y2='1' x2='40' y1='40' x1='1' style='stroke:rgb(255,255,255);stroke-width:1'/></svg>"), "#", "%23") ;
-        background-position: center;
-        background-repeat: no-repeat;
-    }
-}
-
-.variant_attribute {
-    padding-bottom: 1rem;
-
-    .attribute_name {
-        display: flex;
-        align-items: center;
-        @include font-size(0.9rem);
-        text-transform: uppercase;
-        padding-bottom: 0.5rem;
-
-        &:after {
-            content: '';
-            margin-left: $spacer;
-            flex-grow: 1;
-            border-bottom: 1px solid $border-color;
-        }
-    }
-
-    .radio_input_value {
-        font-weight: 400;
-
-        &:not(.o_variant_pills_input_value) {
-            margin-right: $spacer;
-
-            &, > span {
-                vertical-align: middle;
-            }
-        }
-        &.o_variant_pills_input_value {
-            .badge {
-                color: map-get($grays, '600');
-                background: white;
-                border: 1px solid map-get($theme-colors, 'primary');
-
-                &, > span {
-                    vertical-align: middle;
-                }
-
-                .sign_badge_price_extra {
-                    @include font-size(1.1rem);
-                }
-            }
-        }
-    }
-
-    .variant_custom_value {
-        margin-bottom: 0.7rem;
-
-        &.custom_value_radio {
-            display: inline-block;
-        }
-    }
-
-    select {
-        margin-bottom: 0.5rem;
-    }
-
-    ul.list-inline {
-        margin-left: 0;
-    }
-
-    .o_variant_pills {
-        padding: $spacer/2 $spacer;
-        margin-right: 0.2rem;
-        border: none;
-        cursor: default !important;
-
-        &.btn.active {
-            background-color: map-get($theme-colors, 'primary');
-        }
-        &:not(.active) {
-            color: map-get($grays, '600');
-            background-color: map-get($grays, '200');
-        }
-
-        input {
-            -moz-appearance: none;
-            -webkit-appearance: none;
-            appearance: none;
-            opacity: 0;
-        }
-    }
-
-    .radio_input_value, select, label {
-        .badge {
-            margin-left: 3px;
-            padding-left: 3px;
-        }
-
-        .sign_badge_price_extra {
-            display: inline-block;
-            width: 1rem;
-            height: 1rem;
-            color: map-get($theme-colors, 'primary');
-            background: white;
-            line-height: 1rem;
-            border-radius: 50%;
-        }
+        @include o-position-absolute($top: 50%, $left: 50%);
+        width: 2px;
+        height: 110%;
+        background-color: var(--body-bg);
+        rotate: 45deg;
+        transform: translate(-50%, -50%);
+        transform-origin: top;
     }
 }
 
@@ -277,9 +193,4 @@ label.css_attribute_color.css_not_available {
             width: 60px;
         }
     }
-}
-
-.oe_striked_price {
-    text-decoration: line-through;
-    white-space: nowrap;
 }

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -588,12 +588,6 @@ $input-border-color: $gray-400;
         font-weight: $font-weight-bold;
     }
 
-    // Extra price badge
-    .text-bg-light .variant_price_extra.text-muted {
-        // Needed to be visible on a dark <body> background.
-        color: adjust-color-to-background($text-muted, $light, mute-color($color-contrast-light), mute-color($color-contrast-dark)) !important;
-    }
-
     input.js_quantity {
         min-width: 48px;
         text-align: center;
@@ -1196,12 +1190,24 @@ a.no-decoration {
     }
 }
 
+#o_wsale_cta_wrapper {
+    &.o_wsale_cta_wrapper_boxed {
+        max-width: 26rem;
+    }
+
+    &.o_wsale_cta_wrapper_large .css_quantity {
+        border-radius: $btn-border-radius-lg;
+    }
+
+    &:not(.o_wsale_cta_wrapper_boxed) #product_option_block:has(button:only-child) {
+        @include media-breakpoint-up(lg) {
+            flex-grow: 0 !important;
+        }
+    }
+}
+
 #o-carousel-product {
     transition: top 200ms;
-
-    &.css_not_available {
-        opacity: 0.2;
-    }
 
     .carousel-inner {
         img {

--- a/addons/website_sale/static/src/website_builder/product_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/product_page_option.xml
@@ -3,7 +3,10 @@
 
 <t t-name="website_sale.ProductPageOption">
     <!-- Image config -->
-    <BuilderRow label.translate="Images Width">
+    <BuilderRow>
+        <h6 class="text-white">Product Images</h6>
+    </BuilderRow>
+    <BuilderRow label.translate="Width">
         <BuilderButtonGroup action="'productPageImageWidth'" applyTo="'#product_detail_main'">
             <BuilderButton title.translate="None" actionValue="'none'"
                 iconImg="'/website_sale/static/src/img/snippet_options/image-width-none.svg'"
@@ -28,7 +31,7 @@
 	    </BuilderRow>
     </t>
     <t t-if="!domState.isGrid and domState.multipleImages">
-	    <BuilderRow label.translate="Images Ratio" level="1">
+	    <BuilderRow label.translate="Ratio" level="1">
 	        <BuilderSelect action="'websiteConfig'" id="'o_wsale_image_ratio'">
 	            <BuilderSelectItem actionParam="{ views: [] }">Default (1x1)</BuilderSelectItem>
 	            <BuilderSelectItem actionParam="{ views: ['website_sale.products_carousel_4x3'] }">Landscape (4/3)</BuilderSelectItem>
@@ -39,7 +42,7 @@
 	    </BuilderRow>
     </t>
     <t t-if="domState.hasImages">
-	    <BuilderRow label.translate="Images Zoom" level="1">
+	    <BuilderRow label.translate="Zoom" level="1">
 	        <BuilderSelect action="'websiteConfig'" id="'o_wsale_zoom_mode'">
 	            <t t-foreach="props.getZoomLevels()" t-as="zoomLevel" t-key="zoomLevel.id">
 	                <t t-if="zoomLevel.visible">
@@ -84,7 +87,33 @@
 	        <BuilderButton id="'o_wsale_clear_extra_images'" type="'danger'" className="'flex-grow-1'" action="'productRemoveAllExtraImages'">Remove all</BuilderButton>
 	    </BuilderRow>
     </t>
-    <BuilderRow label.translate="Cart" id="'o_wsale_cart_opt'">
+    <hr/>
+    <BuilderRow>
+        <h6 class="text-white">Product Details</h6>
+    </BuilderRow>
+    <BuilderRow label.translate="Purchase Style">
+        <t
+            t-set="CtaLargeViews"
+            t-value="[
+                'website_sale.cta_wrapper_large',
+                'website_sale.product_buy_now_large',
+                'website_sale.product_quantity_large'
+            ]"
+        />
+        <t t-set="CtaBoxedViews" t-value="['website_sale.cta_wrapper_boxed']"/>
+        <BuilderSelect action="'websiteConfig'" id="'o_wsale_product_cta_style'">
+            <BuilderSelectItem id="cta_default_opt" actionParam="{ views: [] }">
+                Default
+            </BuilderSelectItem>
+            <BuilderSelectItem id="cta_boxed_opt" actionParam="{ views: CtaBoxedViews }">
+                Boxed
+            </BuilderSelectItem>
+            <BuilderSelectItem id="cta_large_opt" actionParam="{ views: CtaLargeViews }">
+                Large
+            </BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+    <BuilderRow label.translate="Purchase Options" id="'o_wsale_cart_opt'">
         <BuilderButton title.translate="Buy Now" className="'o_we_buy_now_btn'"
             action="'websiteConfig'"
             actionParam="{ views: ['website_sale.product_buy_now'] }"
@@ -102,17 +131,33 @@
     <BuilderRow id="'o_we_actions_opt'" label.translate="Actions">
         <!-- Filled by other modules -->
     </BuilderRow>
+    <BuilderRow label.translate="Separators">
+        <BuilderCheckbox
+            action="'websiteConfig'"
+            actionParam="{ views: ['website_sale.variants_separator', 'website_sale.cta_separator'] }"
+        />
+    </BuilderRow>
     <BuilderRow label.translate="Tax Indication">
         <BuilderCheckbox action="'websiteConfig'" actionParam="{ views: ['website_sale.tax_indication'] }"/>
     </BuilderRow>
-    <BuilderRow label.translate="Product Tags">
+    <BuilderRow label.translate="Tags">
         <BuilderCheckbox action="'websiteConfig'" actionParam="{ views: ['website_sale.product_tags'] }"/>
     </BuilderRow>
     <BuilderRow label.translate="Terms and Conditions">
-        <BuilderCheckbox action="'websiteConfig'" actionParam="{ views: ['website_sale.product_custom_text'] }"/>
+        <BuilderCheckbox
+            action="'websiteConfig'"
+            actionParam="{ views: ['website_sale.product_terms_and_conditions'] }"
+        />
     </BuilderRow>
     <BuilderRow label.translate="Reviews">
         <BuilderCheckbox action="'websiteConfig'" actionParam="{ views: ['website_sale.product_comment'] }"/>
+    </BuilderRow>
+    <hr/>
+    <BuilderRow label.translate="Search Bar">
+        <BuilderCheckbox
+            action="'websiteConfig'"
+            actionParam="{ views: ['website_sale.product_search'] }"
+        />
     </BuilderRow>
 </t>
 

--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -39,7 +39,7 @@ registry.category("web_tour.tours").add('google_analytics_view_item', {
     {
         content: 'select another variant',
         trigger:
-            "ul.js_add_cart_variants ul.list-inline li:has(label.active) + li:has(label) input:not(:visible)",
+            "ul.js_add_cart_variants ul.d-flex li:has(label.active) + li:has(label) input:not(:visible)",
         run: "click",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_preconfigured_variant_price.js
+++ b/addons/website_sale/static/tests/tours/website_sale_preconfigured_variant_price.js
@@ -4,7 +4,7 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add('website_sale_product_configurator_optional_products_tour', {
     steps: () => [
         {
-            trigger: 'ul.js_add_cart_variants span:contains("Aluminium") ~ span.badge:contains("50.40")',
+            trigger: 'ul.js_add_cart_variants span:contains("Aluminium") ~ span.small:contains("50.40")',
         },
         {
     content: 'Click Aluminium Option',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
@@ -30,34 +30,18 @@ registry.category("web_tour.tours").add('tour_shop_archived_variant_multi', {
         run: "click",
     },
     {
-        content: "Check that brand b is not available",
-        trigger: '.css_not_available',
+        content: "check that brand b is not clickable",
+        trigger: '.css_not_available input[disabled]',
     },
     {
-        content: "select brand b even though it's not available",
-        trigger: 'input[data-attribute_name="Brand"][data-value_name="Brand B"]',
-        run: "click",
-    },
-    {
-        content: "check combination is not possible",
-        trigger: '.js_main_product.css_not_available .css_not_available_msg:contains("This combination does not exist.")',
-    },
-    {
-        content: "check add to cart not possible",
-        trigger: '#add_to_cart.disabled',
-    },
-    {
-        content: "change second variant to remove warning",
+        content: "change second variant to make brand b available",
         trigger: 'input[data-attribute_name="Color"][data-value_name="White"]',
         run: "click",
     },
     {
-        content: "Check that brand b is not available",
-        trigger: '.css_not_available',
-    },
-    {
-        content: "Check that second variant is disabled",
-        trigger: '.css_not_available input[data-attribute_name="Color"][data-value_name="Black"]',
+        content: "check if brand b is clickable again",
+        trigger: 'input[data-attribute_name="Brand"][data-value_name="Brand B"]',
+        run: "click",
     },
 ]});
 

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
@@ -11,7 +11,7 @@ registry.category("web_tour.tours").add("a_shop_custom_attribute_value", {
         trigger: '.oe_product_cart a:contains("Customizable Desk (TEST)")',
         run: "click",
 }, {
-    trigger: 'a.js_add_cart_json:has(i.fa-plus)',
+    trigger: 'a.js_add_cart_json:has(i.oi-plus)',
     run: 'click',
 }, {
     trigger: 'span.oe_currency_value:contains(750)',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_deleted_archived_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_deleted_archived_variants.js
@@ -25,11 +25,6 @@ registry.category("web_tour.tours").add('tour_shop_deleted_archived_variants', {
         run: "click",
     },
     {
-        content: "check combination is not possible",
-        trigger: '.js_main_product.css_not_available .css_not_available_msg:contains("This combination does not exist.")',
-        run: "click",
-    },
-    {
         content: "click on the 3rd variant to reset the warning",
         trigger: 'input[data-attribute_name="My Attribute"][data-value_name="My Value 3"]',
         run: "click",
@@ -42,11 +37,6 @@ registry.category("web_tour.tours").add('tour_shop_deleted_archived_variants', {
     {
         content: "click on the first variant",
         trigger: 'input[data-attribute_name="My Attribute"][data-value_name="My Value 1"]',
-        run: "click",
-    },
-    {
-        content: "check combination is not possible",
-        trigger: '.js_main_product.css_not_available .css_not_available_msg:contains("This combination does not exist.")',
         run: "click",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
@@ -20,24 +20,8 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox', {
         run: "click",
     },
     {
-        content: 'click on the third option to select it',
-        trigger: 'input[data-attribute_name="Options"][data-value_name="Option 3"]',
-        run: "click",
-    },
-    {
-        content: 'check combination is not possible',
-        trigger: '.js_main_product.css_not_available .css_not_available_msg:contains("This combination does not exist.")',
-        timeout: 30000,
-        run: "click",
-    },
-    {
-        content: "check add to cart not possible",
-        trigger: '#add_to_cart.disabled',
-    },
-    {
-        content: 'click on the third option to unselect it',
-        trigger: 'input[data-attribute_name="Options"][data-value_name="Option 3"]',
-        run: "click",
+        content: 'check third option is not selectable',
+        trigger: 'input[data-attribute_name="Options"][data-value_name="Option 3"][disabled]',
     },
     {
         content: 'click on the second option to select it',

--- a/addons/website_sale/tests/test_website_sale_cart_notification.py
+++ b/addons/website_sale/tests/test_website_sale_cart_notification.py
@@ -35,4 +35,5 @@ class TestWebsiteSaleCartNotification(HttpCase, ProductVariantsCommon):
         })
 
     def test_website_sale_cart_notification(self):
+        self.env.ref('website_sale.product_search').active = True
         self.start_tour("/", 'website_sale_cart_notification')

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -501,7 +501,7 @@
             />
             <we-checkbox
                 string="Terms and Conditions"
-                data-customize-website-views="website_sale.product_custom_text"
+                data-customize-website-views="website_sale.product_terms_and_conditions"
                 data-no-preview="true"
                 data-reload="/"
             />

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1860,21 +1860,29 @@
         <t t-set="navClass" t-valuef="light"/>
 
         <t t-set="combination_info" t-value="product._get_combination_info()"/>
-        <t t-set="product_variant" t-value="product.env['product.product'].browse(combination_info['product_id'])"/>
+        <t
+            t-set="product_variant"
+            t-value="product.env['product.product'].browse(combination_info['product_id'])"
+        />
+        <t
+            t-set="is_fullwidth_content"
+            t-value="website.product_page_image_width in ['none', '100_pc']"
+        />
+        <t t-set="is_50_pc" t-value="website.product_page_image_width == '50_pc'"/>
 
         <t t-call="website.layout">
             <t t-set="additional_title" t-value="product.name" />
             <div id="wrap" class="js_sale o_wsale_product_page">
                 <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_product_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS"/>
                 <section id="product_detail"
-                         t-attf-class="oe_website_sale container my-3 my-lg-4 #{'discount'
+                         t-attf-class="oe_website_sale container mt-4 mb-5 #{'discount'
                             if combination_info['has_discounted_price'] else ''}"
                          t-att-data-view-track="view_track and '1' or '0'"
                          t-att-data-product-tracking-info="'product_tracking_info' in combination_info and json.dumps(combination_info['product_tracking_info'])"
                 >
-                    <div class="row align-items-center">
-                        <div class="col d-flex align-items-center order-1 order-lg-0">
-                            <ol class="o_wsale_breadcrumb breadcrumb p-0 mb-4 m-lg-0">
+                    <div class="d-flex flex-wrap align-items-center">
+                        <div class="d-flex align-items-center flex-grow-1 mb-4 m-lg-0">
+                            <ol class="o_wsale_breadcrumb breadcrumb m-0 p-0">
                                 <li class="o_not_editable breadcrumb-item d-none d-lg-inline-block">
                                     <a t-att-href="keep(shop_path)">
                                         <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/>All Products
@@ -1901,18 +1909,22 @@
                                     <span t-field="product.name" />
                                 </li>
                             </ol>
-                        </div>
-                        <div class="col-lg-6 col-xl-5 col-xxl-4 d-flex align-items-center">
-                            <div class="d-flex justify-content-between w-100">
-                                <t t-if="is_view_active('website_sale.search')" t-call="website_sale.search">
-                                    <t t-set="search" t-value="False"/>
-                                    <t t-set="_form_classes" t-valuef="mb-4 mb-lg-0"/>
-                                    <t t-set="_classes" t-value="'me-sm-2'"/>
-                                </t>
-                                <t t-call="website_sale.pricelist_list">
-                                    <t t-set="_classes" t-valuef="d-lg-inline ms-2"/>
-                                </t>
+                            <div class="d-flex d-md-none gap-2 ms-auto">
+                                <t t-call="website_sale.pricelist_list"/>
+                                <a
+                                    t-attf-class="o_wsale_product_search_mobile_btn o_not_editable btn btn-{{navClass}} d-none"
+                                    data-bs-target="#o_wsale_product_search_modal"
+                                    data-bs-toggle="modal"
+                                    role="button"
+                                    title="Search Products"
+                                    href="#"
+                                >
+                                    <i class="oi oi-search" role="img"/>
+                                </a>
                             </div>
+                        </div>
+                        <div class="o_wsale_product_top_bar_desktop d-none d-md-flex flex-wrap gap-2 w-100 w-lg-auto mb-4 mb-lg-auto">
+                            <t t-call="website_sale.pricelist_list"/>
                         </div>
                     </div>
                     <div class="row" id="product_detail_main" data-name="Product Page"
@@ -1927,158 +1939,199 @@
                             <t t-call="website_sale.shop_product_images"/>
                         </div>
                         <div t-attf-class="col-lg-#{image_cols[1]} mt-md-4" id="product_details">
-                            <t t-set="base_url" t-value="website.get_base_url()"/>
-                            <h1 class="h3" t-field="product.name">Product Name</h1>
-                            <t t-if="is_view_active('website_sale.product_comment')">
-                                <a href="#o_product_page_reviews" class="o_product_page_reviews_link text-decoration-none">
-                                    <t t-call="portal_rating.rating_widget_stars_static">
-                                        <!-- sudo: product.product - visitor can access product average rating -->
-                                        <t t-set="rating_avg" t-value="product.sudo().rating_avg"/>
-                                        <t t-set="trans_text_plural">%s reviews</t>
-                                        <t t-set="trans_text_singular">%s review</t>
-                                        <t t-set="rating_count" t-value="(trans_text_plural if product.rating_count > 1 else trans_text_singular) % product.rating_count"/>
-                                    </t>
-                                </a>
-                            </t>
-                            <div t-field="product.description_ecommerce" class="oe_structure"
-                                placeholder="A detailed, formatted description to promote your product on this page. Use '/' to discover more features."/>
-                            <form t-if="product._is_add_to_cart_possible()">
-                                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
-                                <div class="js_product js_main_product mb-3">
-                                    <div>
-                                        <t t-call="website_sale.product_price"/>
-                                        <small t-if="combination_info.get('base_unit_price')"
-                                               class="ms-1 text-muted o_base_unit_price_wrapper d-none">
-                                            <t t-call="website_sale.base_unit_price">
-                                                <t t-set="base_unit_price" t-value="combination_info['base_unit_price']"/>
-                                            </t>
-                                        </small>
-                                    </div>
-                                    <t name="variant_info">
-                                        <input
-                                            type="hidden"
-                                            class="o_not_editable product_id"
-                                            name="product_id"
-                                            t-att-value="product_variant.id"
-                                        />
-                                        <input
-                                            type="hidden"
-                                            class="o_not_editable product_template_id"
-                                            name="product_template_id"
-                                            t-att-value="product.id"
-                                        />
-                                        <input
-                                            t-if="product.public_categ_ids.ids"
-                                            type="hidden"
-                                            class="product_category_id"
-                                            name="product_category_id"
-                                            t-att-value="product.public_categ_ids.ids[0]"
-                                        />
-                                        <input
-                                            type="hidden"
-                                            name="product_type"
-                                            t-att-value="product.type"
-                                        />
-                                        <t t-call="website_sale.variants">
-                                            <t t-set="ul_class" t-valuef="flex-column" />
-                                            <t t-set="parent_combination" t-value="None" />
-                                            <t t-set="combination" t-value="combination_info['combination']"/>
-                                        </t>
-                                    </t>
-                                    <p class="css_not_available_msg alert alert-warning">
-                                        This combination does not exist.
-                                    </p>
-                                    <div id="o_wsale_cta_wrapper" class="d-flex flex-wrap align-items-center">
-                                        <div id="add_to_cart_wrap" t-attf-class="{{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-flex'}} align-items-center mb-2 me-auto">
-                                            <a
-                                                id="add_to_cart"
-                                                role="button"
-                                                href="#"
-                                                t-attf-class="btn btn-primary js_check_product a-submit flex-grow-1"
-                                                t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
-                                                data-animation-selector=".o_wsale_product_images"
-                                            >
-                                                <i class="fa fa-shopping-cart me-2"/>
-                                                Add to cart
-                                            </a>
-                                        </div>
-                                        <div
-                                            id="contact_us_wrapper"
-                                            t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}} oe_structure oe_structure_solo mb-2 #{_div_classes}"
+                            <div t-attf-class="js_product js_main_product row position-sticky #{'o_wsale_product_sticky_col' if website.product_page_image_layout == 'grid' else ''}">
+                                <div t-att-class="'col-lg-7' if is_fullwidth_content else 'col-lg-12'">
+                                    <t t-set="base_url" t-value="website.get_base_url()"/>
+                                    <h1 class="h3" t-field="product.name">Product Name</h1>
+                                    <t t-if="is_view_active('website_sale.product_comment')">
+                                        <a
+                                            href="#o_product_page_reviews"
+                                            class="o_product_page_reviews_link d-block mb-2 text-decoration-none"
                                         >
-                                            <section
-                                                class="s_text_block"
-                                                data-snippet="s_text_block"
-                                                data-name="Text"
-                                            >
-                                                <div class="container">
-                                                    <a
-                                                        t-att-href="website.contact_us_button_url"
-                                                        t-att-data-url="website.contact_us_button_url"
-                                                        class="btn btn-primary btn_cta"
-                                                    >
-                                                        Contact Us
-                                                    </a>
-                                                </div>
-                                            </section>
-                                        </div>
-                                        <div id="product_option_block" class="d-flex flex-wrap w-100"/>
-                                    </div>
+                                            <t t-call="portal_rating.rating_widget_stars_static">
+                                                <!-- sudo: product.product - visitor can access product average rating -->
+                                                <t t-set="rating_avg" t-value="product.sudo().rating_avg"/>
+                                                <t t-set="trans_text_plural">%s reviews</t>
+                                                <t t-set="trans_text_singular">%s review</t>
+                                                <t
+                                                    t-set="rating_count"
+                                                    t-value="(trans_text_plural if product.rating_count > 1 else trans_text_singular) % product.rating_count"
+                                                />
+                                            </t>
+                                        </a>
+                                    </t>
+                                    <p
+                                        t-field="product.description_ecommerce"
+                                        t-attf-class="oe_structure text-muted {{not product.description_ecommerce and 'mb-0'}}"
+                                        placeholder="A detailed, formatted description to promote your product on this page. Use '/' to discover more features."
+                                    />
                                     <t
                                         t-if="is_view_active('website_sale.product_tags')"
                                         t-call="website_sale.product_tags"
                                     >
-                                      <t
+                                        <t
                                             t-set="all_product_tags"
                                             t-value="product_variant.all_product_tag_ids"
                                         />
                                     </t>
-                                </div>
-                            </form>
-                            <p t-elif="not product.active" class="alert alert-warning">
-                                This product is no longer available.
-                            </p>
-                            <p t-else="" class="alert alert-warning">
-                                This product has no valid combination.
-                            </p>
-                            <t t-call="website_sale.product_accordion"/>
-                            <div
-                                t-if="not is_view_active('website_sale_comparison.accordion_specs_item')"
-                                id="product_attributes_simple"
-                            >
-                                <t t-set="single_value_attributes" t-value="product.valid_product_template_attribute_line_ids._prepare_single_value_for_display()"/>
-                                <table t-attf-class="table table-sm text-muted {{'' if single_value_attributes else 'd-none'}}">
-                                    <t t-foreach="single_value_attributes" t-as="attribute">
-                                        <tr>
-                                            <td>
-                                                <span t-field="attribute.name"/>:
-                                                <t t-foreach="single_value_attributes[attribute]" t-as="ptal">
-                                                    <span t-field="ptal.product_template_value_ids._only_active().name"/><t t-if="not ptal_last">, </t>
+                                    <form t-if="product._is_add_to_cart_possible()">
+                                        <input
+                                            type="hidden"
+                                            name="csrf_token"
+                                            t-att-value="request.csrf_token()"
+                                            t-nocache="The csrf token must always be up to date."
+                                        />
+                                        <div>
+                                            <t
+                                                t-if="not is_view_active('website_sale.cta_wrapper_boxed')"
+                                                t-call="website_sale.product_price"
+                                            />
+                                            <small t-if="combination_info.get('base_unit_price')"
+                                                class="ms-1 text-muted o_base_unit_price_wrapper d-none">
+                                                <t t-call="website_sale.base_unit_price">
+                                                    <t
+                                                        t-set="base_unit_price"
+                                                        t-value="combination_info['base_unit_price']"
+                                                    />
                                                 </t>
-                                            </td>
-                                        </tr>
-                                    </t>
-                                </table>
-                            </div>
-                            <t t-set="product_documents" t-value="product.sudo().product_document_ids.filtered(lambda doc: doc.shown_on_product_page)"/>
-                            <div id="product_documents" class="my-2" t-if="product_documents">
-                                <h5>Documents</h5>
-                                <t t-foreach="product_documents" t-as="document_sudo">
-                                    <t t-set="attachment_sudo" t-value="document_sudo.ir_attachment_id"/>
-                                    <t t-set="target" t-value="attachment_sudo.type == 'url' and '_blank' or '_self'"/>
-                                    <t t-set="icon" t-value="attachment_sudo.type == 'url' and 'fa-link' or 'fa-download'"/>
-                                    <div>
-                                        <a t-att-href="'/shop/' + slug(product) + '/document/' + str(document_sudo.id)" t-att-target="target">
-                                            <i t-att-class="'fa ' + icon"/>
-                                            <t t-out="attachment_sudo.name"/>
-                                        </a>
+                                            </small>
+                                        </div>
+                                        <t name="variant_info">
+                                            <input
+                                                type="hidden"
+                                                class="o_not_editable product_id"
+                                                name="product_id"
+                                                t-att-value="product_variant.id"
+                                            />
+                                            <input
+                                                type="hidden"
+                                                class="o_not_editable product_template_id"
+                                                name="product_template_id"
+                                                t-att-value="product.id"
+                                            />
+                                            <input
+                                                t-if="product.public_categ_ids.ids"
+                                                type="hidden"
+                                                class="product_category_id"
+                                                name="product_category_id"
+                                                t-att-value="product.public_categ_ids.ids[0]"
+                                            />
+                                            <input
+                                                type="hidden"
+                                                name="product_type"
+                                                t-att-value="product.type"
+                                            />
+                                            <t t-call="website_sale.variants">
+                                                <t t-set="ul_class" t-valuef="flex-column" />
+                                                <t t-set="parent_combination" t-value="None" />
+                                                <t
+                                                    t-set="combination"
+                                                    t-value="combination_info['combination']"
+                                                />
+                                            </t>
+                                        </t>
+                                        <t
+                                            t-if="not is_fullwidth_content"
+                                            t-call="website_sale.cta_wrapper"
+                                        />
+                                    </form>
+                                    <p t-elif="not product.active" class="alert alert-warning">
+                                        This product is no longer available.
+                                    </p>
+                                    <p t-else="" class="alert alert-warning">
+                                        This product has no valid combination.
+                                    </p>
+                                    <t t-call="website_sale.product_accordion"/>
+                                    <div
+                                        id="contact_us_wrapper"
+                                        t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}} oe_structure oe_structure_solo #{_div_classes}"
+                                    >
+                                        <section
+                                            class="s_text_block"
+                                            data-snippet="s_text_block"
+                                            data-name="Text">
+                                            <div class="container">
+                                                <a
+                                                    t-att-href="website.contact_us_button_url"
+                                                    t-att-data-url="website.contact_us_button_url"
+                                                    class="btn btn-primary btn_cta"
+                                                >
+                                                    Contact Us
+                                                </a>
+                                            </div>
+                                        </section>
                                     </div>
-                                </t>
+                                    <div
+                                        t-if="not is_view_active('website_sale_comparison.accordion_specs_item')"
+                                        id="product_attributes_simple"
+                                    >
+                                        <t
+                                            t-set="single_value_attributes"
+                                            t-value="product.valid_product_template_attribute_line_ids._prepare_single_value_for_display()"
+                                        />
+                                        <table t-attf-class="table table-sm text-muted {{'' if single_value_attributes else 'd-none'}}">
+                                            <t t-foreach="single_value_attributes" t-as="attribute">
+                                                <tr>
+                                                    <td>
+                                                        <span t-field="attribute.name"/>:
+                                                        <t
+                                                            t-foreach="single_value_attributes[attribute]"
+                                                            t-as="ptal"
+                                                        >
+                                                            <span t-field="ptal.product_template_value_ids._only_active().name"/>
+                                                            <t t-if="not ptal_last">, </t>
+                                                        </t>
+                                                    </td>
+                                                </tr>
+                                            </t>
+                                        </table>
+                                    </div>
+                                    <t t-set="product_documents" t-value="product.sudo().product_document_ids.filtered(lambda doc: doc.shown_on_product_page)"/>
+                                    <div
+                                        id="product_documents"
+                                        class="my-4"
+                                        t-if="product_documents"
+                                    >
+                                        <h6>Documents</h6>
+                                        <div class="list-group">
+                                            <t t-foreach="product_documents" t-as="document_sudo">
+                                                <t
+                                                    t-set="attachment_sudo"
+                                                    t-value="document_sudo.ir_attachment_id"
+                                                />
+                                                <t
+                                                    t-set="target"
+                                                    t-value="attachment_sudo.type == 'url' and '_blank' or '_self'"
+                                                />
+                                                <t
+                                                    t-set="icon"
+                                                    t-value="attachment_sudo.type == 'url' and 'fa-link' or 'fa-download'"
+                                                />
+                                                <a
+                                                    class="list-group-item list-group-item-action"
+                                                    t-att-href="'/shop/' + slug(product) + '/document/' + str(document_sudo.id)"
+                                                    t-att-target="target">
+                                                    <i t-att-class="'fa ' + icon + ' me-2'"/>
+                                                    <t t-out="attachment_sudo.name"/>
+                                                </a>
+                                            </t>
+                                        </div>
+                                    </div>
+                                    <t
+                                        t-if="not is_fullwidth_content"
+                                        t-call="website_sale.product_terms_and_conditions"
+                                    />
+                                </div>
+                                <div
+                                    t-if="is_fullwidth_content"
+                                    t-attf-class="col-lg-4 offset-lg-1"
+                                >
+                                    <div class="o_wsale_product_sticky_col position-sticky">
+                                        <t t-call="website_sale.cta_wrapper"/>
+                                        <t t-call="website_sale.product_terms_and_conditions"/>
+                                    </div>
+                                </div>
                             </div>
-                            <div
-                                id="o_product_terms_and_share"
-                                class="mb-3"
-                            />
                         </div>
                     </div>
                 </section>
@@ -2089,7 +2142,139 @@
                 />
                 <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS"/>
             </div>
+            <div
+                id="o_wsale_product_search_modal"
+                class="modal fade css_editable_mode_hidden"
+                aria-hidden="true"
+                tabindex="-1"
+            >
+                <div class="modal-dialog modal-lg pt-5">
+                    <div class="modal-content mt-5 bg-transparent border-0">
+                        <div class="o_container_small">
+                            <t t-call="website.website_search_box_input">
+                                <t t-set="default_style" t-valuef="true"/>
+                                <t t-set="search_type" t-valuef="products"/>
+                                <t t-set="_classes" t-valuef="input-group rounded o_cc o_cc1 mb-1"/>
+                                <t t-set="_input_classes" t-valuef="border-0 p-3"/>
+                                <t t-set="_submit_classes" t-valuef="px-4"/>
+                                <t t-if="category" t-set="placeholder">Search in <t t-out="category.name"/></t>
+                            </t>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </t>
+    </template>
+
+    <template id="website_sale.cta_wrapper" name="CTA Wrapper">
+        <div
+            id="o_wsale_cta_wrapper"
+            t-att-class="'d-flex flex-wrap align-items-center gap-2 my-4' + (' w-100 w-lg-auto' if is_50_pc else ' w-100') + (' pt-3' if not is_fullwidth_content and not is_view_active('website_sale.cta_wrapper_boxed') else ' ')"
+        >
+            <div
+                id="add_to_cart_wrap"
+                t-attf-class="{{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-flex'}} flex-grow-1 flex-lg-grow-0 flex-wrap align-items-center gap-2 {{'' if is_50_pc else ' w-100'}}"
+            >
+                <a
+                    id="add_to_cart"
+                    role="button"
+                    href="#"
+                    t-attf-class="btn btn-primary js_check_product a-submit flex-grow-1"
+                    t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
+                    data-animation-selector=".o_wsale_product_images"
+                >
+                    <i class="fa fa-shopping-cart me-2"/>
+                    Add to cart
+                </a>
+            </div>
+            <div
+                id="product_option_block"
+                t-attf-class="d-flex d-empty-none flex-wrap gap-2 {{'' if is_50_pc and not (is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large')) else ' w-100'}}"
+            />
+        </div>
+    </template>
+
+    <template
+        id="website_sale.cta_wrapper_boxed"
+        inherit_id="website_sale.cta_wrapper"
+        active="False"
+        name="Bordered CTA Wrapper"
+    >
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="attributes">
+            <attribute
+                name="t-att-class"
+                remove="pt-3"
+                add="' o_wsale_cta_wrapper_boxed border rounded p-3'"
+                separator=" + "
+            />
+        </xpath>
+        <xpath expr="//div[@id='add_to_cart_wrap']" position="attributes">
+            <attribute name="t-attf-class" remove="flex-lg-grow-0" separator=" "/>
+        </xpath>
+        <xpath expr="//div[@id='product_option_block']" position="attributes">
+            <attribute name="t-att-class" remove="flex-lg-grow-0" separator=" "/>
+        </xpath>
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="inside">
+            <div class="d-flex gap-5 flex-grow-1 justify-content-between align-items-center order-first w-100 mb-3 pb-3 border-bottom">
+                <span class="text-muted">Price</span>
+                <t t-call="website_sale.product_price"/>
+            </div>
+        </xpath>
+    </template>
+
+    <template
+        id="website_sale.cta_wrapper_large"
+        inherit_id="website_sale.cta_wrapper"
+        active="False"
+        name="Large CTA Wrapper">
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="attributes">
+            <attribute name="t-att-class" add="' o_wsale_cta_wrapper_large'" separator=" + "/>
+        </xpath>
+        <xpath expr="//div[@id='add_to_cart_wrap']" position="attributes">
+            <attribute name="t-attf-class" remove="flex-lg-grow-0" separator=" "/>
+        </xpath>
+        <xpath expr="//div[@id='product_option_block']" position="attributes">
+            <attribute name="t-att-class" remove="flex-lg-grow-0" separator=" "/>
+        </xpath>
+        <xpath expr="//a[@id='add_to_cart']" position="attributes">
+            <attribute
+                name="t-attf-class"
+                add="btn-lg {{('' if is_50_pc else ' px-xl-0')}}"
+                separator=" "
+            />
+        </xpath>
+    </template>
+
+    <template
+        id="website_sale.cta_separator"
+        inherit_id="website_sale.cta_wrapper"
+        active="True"
+        name="CTA Separator">
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="attributes">
+            <attribute
+                name="t-att-class"
+                remove="(' pt-3' if not is_fullwidth_content and not is_view_active('website_sale.cta_wrapper_boxed') else ' ')"
+                add="(' border-0 pt-0' if is_fullwidth_content and not is_view_active('website_sale.cta_wrapper_boxed') else ' border-top pt-4')"
+                separator=" + "
+            />
+        </xpath>
+    </template>
+
+    <template
+        id="website_sale.product_search"
+        inherit_id="website_sale.product"
+        active="False"
+        name="Searchbar On Product Page"
+    >
+        <xpath expr="//div[hasclass('o_wsale_product_top_bar_desktop')]" position="inside">
+            <t t-call="website_sale.search">
+                <t t-set="search" t-value="False"/>
+                <t t-set="_classes" t-value="'me-sm-2'"/>
+            </t>
+        </xpath>
+        <xpath expr="//a[contains(@t-attf-class, 'o_wsale_product_search_mobile_btn')]" position="attributes">
+            <attribute name="t-attf-class" add="d-md-none" remove="d-none" separator=" "/>
+        </xpath>
     </template>
 
     <template id="product_accordion" name="Accordion On Product Page">
@@ -2131,7 +2316,7 @@
                 class="accordion-collapse collapse"
                 data-bs-parent="#product_accordion"
             >
-                <div class="accordion-body pt-0">
+                <div class="accordion-body py-0">
                     <p>This content will be shared across all product pages.</p>
                 </div>
             </div>
@@ -2139,7 +2324,10 @@
     </template>
 
     <template id="product_tags" name="Product Tags" active="True">
-        <div class="o_product_tags o_field_tags d-flex flex-wrap align-items-center gap-2 mb-2 mt-1">
+        <div
+            class="o_product_tags o_field_tags d-flex flex-wrap align-items-center gap-2 mb-2 mt-1"
+            t-if="any(tag.visible_on_ecommerce for tag in all_product_tags)"
+        >
             <t t-foreach="all_product_tags" t-as="tag">
                 <t t-if="tag.visible_to_customers">
                     <span t-if="tag.image"
@@ -2189,18 +2377,14 @@
 
     <template
         name="Terms and Conditions"
-        id="product_custom_text"
-        inherit_id="website_sale.product"
+        id="website_sale.product_terms_and_conditions"
         active="True"
-        priority="21"
-    >
-        <xpath expr="//div[@id='o_product_terms_and_share']" position="inside">
-            <p class="text-muted">
-                <a href="/terms" class="text-muted o_translate_inline"><u>Terms and Conditions</u></a><br/>
-                30-day money-back guarantee<br/>
-                Shipping: 2-3 Business Days
-            </p>
-        </xpath>
+        priority="21">
+        <small class="text-muted mb-0">
+            <a href="/terms" class="o_translate_inline text-muted"><u>Terms and Conditions</u></a><br/>
+            30-day money-back guarantee<br/>
+            Shipping: 2-3 Business Days
+        </small>
     </template>
 
     <!-- Product options: Zoom -->
@@ -2248,44 +2432,108 @@
         </xpath>
     </template>
 
-    <template id="product_quantity" inherit_id="website_sale.product" name="Select Quantity">
-        <div id="add_to_cart_wrap" position="before">
-            <div t-attf-class="css_quantity input-group {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-flex'}} me-2 mb-2 align-middle" contenteditable="false">
-                <a t-attf-href="#" class="btn btn-link js_add_cart_json" aria-label="Remove one" title="Remove one">
-                    <i class="fa fa-minus"/>
+    <template
+        id="website_sale.product_quantity"
+        inherit_id="website_sale.cta_wrapper"
+        name="Select Quantity"
+    >
+        <div id="add_to_cart_wrap" position="inside">
+            <div
+                t-attf-class="css_quantity input-group {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-flex order-first'}} align-middle border"
+                contenteditable="false"
+            >
+                <a
+                    t-attf-href="#"
+                    class="css_quantity_minus btn btn-link pe-2 js_add_cart_json border-0"
+                    aria-label="Remove one"
+                    title="Remove one"
+                >
+                    <i class="oi oi-minus text-600"/>
                 </a>
-                <input type="text" class="form-control quantity text-center" data-min="1" name="add_qty" t-att-value="1"/>
-                <a t-attf-href="#" class="btn btn-link float_left js_add_cart_json" aria-label="Add one" title="Add one">
-                    <i class="fa fa-plus"/>
+                <input
+                    type="text"
+                    t-attf-class="form-control quantity text-center border-0"
+                    data-min="1"
+                    name="add_qty"
+                    t-att-value="1"
+                />
+                <a
+                    t-attf-href="#"
+                    class="css_quantity_plus btn btn-link ps-2 js_add_cart_json border-0"
+                    aria-label="Add one"
+                    title="Add one"
+                >
+                    <i class="oi oi-plus text-600"/>
                 </a>
             </div>
         </div>
     </template>
 
-    <template id="product_buy_now" inherit_id="website_sale.product" active="False" name="Buy Now Button">
-        <xpath expr="//a[@id='add_to_cart']" position="after">
-            <a role="button" class="btn btn-outline-primary o_we_buy_now ms-1" href="#">
+    <template
+        id="website_sale.product_quantity_large"
+        inherit_id="website_sale.product_quantity"
+        active="False"
+        name="Select Quantity Large"
+    >
+        <xpath expr="//div[contains(@t-attf-class, 'css_quantity')]" position="attributes">
+            <attribute
+                name="t-attf-class"
+                add="input-group-lg {{(' css_quantity_50' if is_50_pc else '')}}"
+                separator=" "
+            />
+        </xpath>
+    </template>
+
+    <template
+        id="website_sale.product_buy_now"
+        inherit_id="website_sale.cta_wrapper"
+        active="False"
+        name="Buy Now Button"
+    >
+        <xpath expr="//div[@id='product_option_block']" position="before">
+            <a
+                role="button"
+                t-attf-class="btn btn-outline-primary o_we_buy_now {{'w-100' if is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large') else ''}} {{'flex-grow-1' if not is_50_pc else ''}}"
+                href="#"
+            >
                 <i class="fa fa-bolt me-2"/>
                 Buy now
             </a>
         </xpath>
     </template>
 
+    <template
+        id="website_sale.product_buy_now_large"
+        inherit_id="website_sale.product_buy_now"
+        active="False"
+        name="Large Buy Now Button"
+    >
+        <xpath expr="//a[contains(@t-attf-class, 'o_we_buy_now')]" position="attributes">
+            <attribute name="t-attf-class" add="btn-lg" separator=" "/>
+        </xpath>
+    </template>
+
     <template id="website_sale.tax_indication" active="False">
-        <span t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'" class="h6 text-muted">
-            Tax Excluded
+        <span
+            t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
+            class="fs-6 fw-normal text-muted text-nowrap"
+        >
+            (Tax excluded)
         </span>
-        <span t-else="" class="h6 text-muted">
-            Tax Included
+        <span t-else="" class="fs-6 fw-normal text-muted text-nowrap">
+            (Tax included)
         </span>
     </template>
 
     <template id="product_price">
         <div
             name="product_price"
-            t-attf-class="product_price mt-2 mb-3 {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-block'}}"
+            t-attf-class="product_price text-end {{'' if is_view_active('website_sale.cta_wrapper_boxed') else 'mt-2'}} {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-block'}}"
         >
-            <div name="product_price_container" class="css_editable_mode_hidden h4">
+            <div
+                name="product_price_container"
+                class="css_editable_mode_hidden d-flex align-items-center justify-content-end gap-2 flex-wrap h4 mb-0 text-wrap"
+            >
                 <span class="oe_price"
                       style="white-space: nowrap;"
                       t-out="combination_info['price']"
@@ -2311,7 +2559,7 @@
             <div
                 t-if="editable"
                 name="product_list_price_container"
-                class="css_non_editable_mode_hidden decimal_precision h3"
+                class="css_non_editable_mode_hidden decimal_precision h4"
                 t-att-data-precision="str(website.currency_id.decimal_places)"
             >
                 <span t-field="product.list_price"
@@ -2563,7 +2811,7 @@
 
     <template id="cart_lines_quantity" name="Shopping Cart Line quantity">
         <div
-            class="css_quantity input-group justify-content-end h-100"
+            class="css_quantity input-group justify-content-end h-100 border"
             t-attf-name="{{'website_sale_cart_line_quantity' if not is_mobile else 'website_sale_cart_line_quantity_mobile'}}"
         >
             <t
@@ -2577,11 +2825,11 @@
                     aria-label="Remove one"
                     title="Remove one"
                 >
-                    <i class="position-relative z-1 fa fa-minus"/>
+                    <i class="oi oi-minus position-relative z-1"/>
                 </a>
                 <input
                     type="text"
-                    class="js_quantity quantity form-control border-start-0 border-end-0"
+                    class="js_quantity quantity form-control border-0"
                     t-att-data-line-id="line.id"
                     t-att-data-product-id="line.product_id.id"
                     t-att-value="line._get_displayed_quantity()"
@@ -2603,7 +2851,7 @@
                     aria-label="Add one"
                     title="Add one"
                 >
-                    <i class="fa fa-plus position-relative z-1"/>
+                    <i class="oi oi-plus position-relative z-1"/>
                 </a>
             </t>
             <t t-else="">
@@ -3681,7 +3929,7 @@
                 t-options="{
                     'widget': 'image',
                     'preview_image': 'image_1024',
-                    'class': 'oe_unmovable product_detail_img w-100',
+                    'class': 'oe_unmovable product_detail_img w-100 rounded',
                     'alt-field': 'name',
                     'zoom': product_image.can_image_1024_be_zoomed and 'image_1920',
                 }"
@@ -3694,7 +3942,7 @@
             t-options="{
                 'widget': 'image',
                 'preview_image': 'image_1024',
-                'class': 'oe_unmovable product_detail_img w-100 mh-100',
+                'class': 'oe_unmovable product_detail_img w-100 mh-100 rounded',
                 'alt-field': 'name',
                 'zoom': product_image.can_image_1024_be_zoomed and 'image_1920',
             }"

--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -2,7 +2,10 @@
 <odoo>
     <template id="variants">
         <t t-set="attribute_exclusions" t-value="product._get_attribute_exclusions(parent_combination)"/>
-        <ul t-attf-class="list-unstyled js_add_cart_variants mb-0 #{ul_class}" t-att-data-attribute_exclusions="json.dumps(attribute_exclusions)">
+        <ul
+            t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants mt-4 pt-3 #{ul_class} #{'d-none' if not product.valid_product_template_attribute_line_ids else '' }"
+            t-att-data-attribute_exclusions="json.dumps(attribute_exclusions)"
+        >
             <t t-foreach="product.valid_product_template_attribute_line_ids" t-as="ptal">
                 <t t-set="attribute" t-value="ptal.attribute_id"/>
                 <t t-set="ptavs" t-value="ptal.product_template_value_ids._only_active()"/>
@@ -20,7 +23,19 @@
 
                     <!-- Used to customize layout if the only available attribute value is custom -->
                     <t t-set="single_and_custom" t-value="single and ptavs[0].is_custom"/>
-                    <strong t-field="ptal.attribute_id.name" class="attribute_name"/>
+                    <h6 class="attribute_name mb-2">
+                        <span t-field="ptal.attribute_id.name"/>
+                        <span t-if="attribute.display_type == 'color'" class="text-muted">
+                            -
+                            <t
+                                t-set="active_ptavs"
+                                t-value="[ptav for ptav in ptavs if ptav in combination]"
+                            />
+                            <t t-foreach="active_ptavs" t-as="ptav">
+                                <span class="attribute_value" t-field="ptav.name"/>
+                            </t>
+                        </span>
+                    </h6>
 
                     <t t-if="attribute.display_type == 'select'">
                         <select
@@ -45,14 +60,18 @@
                     </t>
 
                     <t t-elif="attribute.display_type in ('radio', 'multi')">
-                        <ul t-att-data-attribute_id="attribute.id" t-attf-class="list-inline list-unstyled o_wsale_product_attribute #{'d-none' if single_and_custom else ''}">
+                        <ul
+                            t-att-data-attribute_id="attribute.id"
+                            t-attf-class="o_wsale_product_attribute d-flex flex-wrap gap-3 list-unstyled #{'d-none' if single_and_custom else ''}"
+                        >
                             <t t-foreach="ptavs" t-as="ptav">
-                                <li class="list-inline-item mb-3 js_attribute_value" style="margin: 0;">
-                                    <label class="col-form-label">
-                                        <div class="form-check">
+                                <li class="js_attribute_value">
+                                    <label class="col-form-label p-0">
+                                        <div class="form-check cursor-pointer">
                                             <input t-att-type="'radio' if attribute.display_type == 'radio' else 'checkbox'"
                                                 t-attf-class="form-check-input js_variant_change #{attribute.create_variant}"
                                                 t-att-checked="ptav in combination"
+                                                t-att-title="ptav.name"
                                                 t-att-name="'ptal-%s' % ptal.id"
                                                 t-att-value="ptav.id"
                                                 t-att-data-attribute-value-id="ptav.product_attribute_value_id.id"
@@ -74,13 +93,15 @@
                     </t>
 
                     <t t-elif="attribute.display_type == 'pills'">
-                        <ul t-att-data-attribute_id="attribute.id"
-                            t-attf-class="btn-group-toggle list-inline list-unstyled o_wsale_product_attribute #{'d-none' if single_and_custom else ''}"
-                            data-bs-toggle="buttons">
+                        <ul
+                            t-att-data-attribute_id="attribute.id"
+                            t-attf-class="o_wsale_product_attribute d-flex flex-wrap list-unstyled gap-2 #{'d-none' if single_and_custom else ''}"
+                            data-bs-toggle="buttons"
+                        >
                             <t t-foreach="ptavs" t-as="ptav">
-                                <li t-attf-class="o_variant_pills btn btn-primary mb-1 list-inline-item js_attribute_value #{'active' if ptav in combination else ''}">
+                                <li t-attf-class="o_variant_pills js_attribute_value border btn m-0 cursor-pointer #{'active border-primary text-primary-emphasis bg-primary-subtle' if ptav in combination else ''}">
                                     <input type="radio"
-                                        t-attf-class="js_variant_change #{attribute.create_variant}"
+                                        t-attf-class="js_variant_change position-absolute #{attribute.create_variant} opacity-0"
                                         t-att-checked="ptav in combination"
                                         t-att-name="'ptal-%s' % ptal.id"
                                         t-att-value="ptav.id"
@@ -92,7 +113,7 @@
                                         t-att-data-is_custom="ptav.is_custom"
                                         t-att-data-is_single_and_custom="single_and_custom"
                                         t-att-autocomplete="off"/>
-                                    <label class="radio_input_value o_variant_pills_input_value"
+                                    <label class="radio_input_value o_variant_pills_input_value cursor-pointer"
                                            t-att-for="ptav.id">
                                         <span t-field="ptav.name"/>
                                         <t t-call="website_sale.badge_extra_price"/>
@@ -103,19 +124,22 @@
                     </t>
 
                     <t t-elif="attribute.display_type == 'color'">
-                        <ul t-att-data-attribute_id="attribute.id" t-attf-class="list-inline o_wsale_product_attribute #{'d-none' if single_and_custom else ''}">
-                            <li t-foreach="ptavs" t-as="ptav" class="list-inline-item me-1 mb-2">
+                        <ul
+                            t-att-data-attribute_id="attribute.id"
+                            t-attf-class="o_wsale_product_attribute d-flex flex-wrap gap-2 list-unstyled #{'d-none' if single_and_custom else ''}"
+                        >
+                            <li t-foreach="ptavs" t-as="ptav">
                                 <t t-set="img_style"
-                                   t-value="'background:url(/web/image/product.template.attribute.value/%s/image); background-size:cover;' % ptav.id if ptav.image else ''"
+                                   t-value="'background: url(/web/image/product.template.attribute.value/%s/image); background-size: cover; ' % ptav.id if ptav.image else ''"
                                 />
                                 <t t-set="color_style"
                                    t-value="'background:' + str(ptav.html_color or ptav.name if not ptav.is_custom else '')"
                                 />
                                 <label t-attf-style="#{img_style or color_style}"
-                                       t-attf-class="css_attribute_color #{'active' if ptav in combination else ''} #{'custom_value' if ptav.is_custom else ''} #{'transparent' if (not ptav.is_custom and not ptav.html_color) else ''}"
+                                       t-attf-class="css_attribute_color cursor-pointer #{'active' if ptav in combination else ''} #{'custom_value' if ptav.is_custom else ''} #{'transparent' if (not ptav.is_custom and not ptav.html_color) else ''}"
                                 >
                                       <input type="radio"
-                                        t-attf-class="js_variant_change  #{attribute.create_variant}"
+                                        t-attf-class="js_variant_change cursor-pointer #{attribute.create_variant}"
                                         t-att-checked="ptav in combination"
                                         t-att-name="'ptal-%s' % ptal.id"
                                         t-att-value="ptav.id"
@@ -137,7 +161,7 @@
     </template>
     <template id="badge_extra_price" name="Badge Extra Price">
         <t t-set="price_extra" t-value="ptav._get_extra_price(combination_info)"/>
-        <span t-if="price_extra" class="badge text-bg-info border">
+        <span t-if="price_extra" t-attf-class="{{'badge text-bg-primary' if attribute.display_type != 'pills' else 'small text-muted'}}">
             <!--
                 price_extra is displayed as catalog price instead of
                 price after pricelist because it is impossible to
@@ -147,14 +171,25 @@
                 attribute is therefore variable and it's not very
                 accurate to display it.
             -->
-            <span class="sign_badge_price_extra" t-out="price_extra > 0 and '+' or '-'"/>
-            <span t-out="abs(price_extra)"
-                class="variant_price_extra text-muted fst-italic"
-                style="white-space: nowrap;"
-                t-options='{
-                    "widget": "monetary",
-                    "display_currency": website.currency_id
-                }'/>
+        <t t-if="attribute.display_type in ['pills', 'select']">(</t><span class="sign_badge_price_extra"><t t-out="price_extra > 0 and '+' or '-'"/></span>
+        <span
+            t-out="abs(price_extra)"
+            class="variant_price_extra"
+            style="white-space: nowrap;"
+            t-options='{
+                "widget": "monetary",
+                "display_currency": website.currency_id
+            }'/><t t-if="attribute.display_type in ['pills', 'select']">)</t>
         </span>
+    </template>
+    <template
+        id="variants_separator"
+        inherit_id="website_sale.variants"
+        active="True"
+        name="Variants Separator"
+    >
+        <xpath expr="//ul" position="attributes">
+            <attribute name="t-attf-class" remove="pt-3" add="border-top pt-4" separator=" "/>
+        </xpath>
     </template>
 </odoo>

--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
@@ -2,10 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="website_sale_collect.ClickAndCollectAvailability">
-        <div class="btn border border-1 mb-3 text-start p-3 w-100 w-md-auto">
+        <div class="border rounded p-3 w-100 w-lg-75">
             <div
                 name="click_and_collect_availability"
                 t-on-click="openLocationSelector"
+                class="cursor-pointer"
                 t-att-class="{'disabled': !this.state.active}"
             >
                 <h6>
@@ -16,7 +17,7 @@
                     />
                     <t t-else="">Click and Collect</t>
                 </h6>
-                <div class="d-flex gap-5">
+                <div class="d-flex justify-content-between">
                     <t t-if="this.state.inStoreStockData.in_stock">
                         <div
                             t-if="this.state.inStoreStockData.show_quantity &amp;&amp; this.state.selectedLocationData.id"
@@ -42,7 +43,7 @@
             <div
                 name="delivery_availability"
                 t-if="this.state.deliveryStockData"
-                class="flex-row cursor-default"
+                class="flex-row"
             >
                 <h6>
                     <i class="fa fa-fw fa-truck text-muted"/>

--- a/addons/website_sale_collect/views/templates.xml
+++ b/addons/website_sale_collect/views/templates.xml
@@ -23,7 +23,7 @@
         </div>
     </template>
 
-    <template id="product_page_click_and_collect" inherit_id="website_sale.product">
+    <template id="product_page_click_and_collect" inherit_id="website_sale.cta_wrapper">
         <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="before">
             <owl-component
                 t-if="combination_info.get('show_click_and_collect_availability')"

--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
@@ -32,6 +32,11 @@
 }
 
 .oe_website_sale {
+    .o_add_compare_dyn.btn-lg {
+        aspect-ratio: 1/1;
+        height: calc(#{$btn-padding-y-lg} * 2 + #{$btn-font-size-lg} * #{$btn-line-height} + #{$btn-border-width} * 2);
+    }
+
     .product_summary > *{
         display: block;
         margin: 15px 0 15px 0;
@@ -40,10 +45,6 @@
         .o_product_comparison_collpase {
             margin-right: 8px;
         }
-    }
-
-    div.css_not_available .o_add_compare_dyn {
-        display: none;
     }
 
     .o_comparelist_remove {

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -25,18 +25,41 @@
         </t>
     </template>
 
-    <template id="product_add_to_compare" name='Add to comparison in product page' inherit_id="website_sale.product" priority="8">
-        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="after">
+    <template
+        id="product_add_to_compare"
+        name='Add to comparison in product page'
+        inherit_id="website_sale.cta_wrapper"
+        priority="8"
+    >
+        <xpath expr="//div[@id='product_option_block']" position="inside">
             <t t-set="attrib_categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
             <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
-            <button t-if="product_variant_id and attrib_categories"
+            <t
+                t-set="_button_classes"
+                t-valuef="o_add_compare_dyn btn btn-outline-primary d-none d-md-block order-last"
+            />
+            <t
+                t-if="not is_view_active('website_sale_wishlist.product_add_to_wishlist')"
+                t-set="_button_classes"
+                t-value="_button_classes + ' flex-grow-1'"
+            />
+            <t
+                t-if="is_view_active('website_sale.cta_wrapper_large')"
+                t-set="_button_classes"
+                t-value="_button_classes + ' btn-lg px-lg-0'"
+            />
+            <button
+                t-if="product_variant_id and attrib_categories"
                 type="button"
                 role="button"
-                class="d-none d-md-block btn btn-link px-0 o_add_compare_dyn"
-                aria-label="Compare"
+                t-att-class="_button_classes"
+                aria-label="Add to Compare"
+                title="Add to compare"
                 t-att-data-product-product-id="product_variant_id"
-                data-action="o_comparelist">
-                    <span class="fa fa-exchange me-2"/>Compare
+                data-action="o_comparelist"
+            >
+                <span class="fa fa-exchange"/>
+                <span t-att-class="'d-inline' + (' d-lg-none' if website.product_page_image_width == '50_pc' and not (is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large')) or is_view_active('website_sale_wishlist.product_add_to_wishlist') else '')">Add to Compare</span>
             </button>
         </xpath>
     </template>
@@ -73,6 +96,14 @@
         active="False"
     >
         <xpath expr="//div[@id='more_information_accordion_item']" position="before">
+            <t
+                t-set="attrib_categories"
+                t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"
+            />
+            <t
+                t-set="product_variant_id"
+                t-value="product._get_first_possible_variant_id()"
+            />
             <t t-if="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()">
                 <t t-foreach="attrib_categories" t-as="category">
                     <div class="accordion-item">

--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -2,22 +2,29 @@
 
 <templates>
     <t t-name="website_sale_stock.product_availability">
-        <div t-if="is_storable and !prevent_zero_price_sale" id="product_stock_availability">
+        <div
+            t-if="is_storable and !prevent_zero_price_sale"
+            id="product_stock_availability"
+            class="my-3"
+        >
             <div t-if="free_qty lte 0 and !cart_qty" t-attf-class="availability_message_#{product_template} mb-1">
-                <div id="out_of_stock_message">
-                    <t t-if="has_out_of_stock_message" t-out="out_of_stock_message"/>
+                <div id="out_of_stock_message" class="mb-3">
+                    <t t-if="has_out_of_stock_message">
+                        <div class="d-flex align-items-center badge text-bg-danger">
+                            <i class="fa fa-circle text-danger me-2"/>
+                            <t t-out="out_of_stock_message"/>
+                        </div>
+                    </t>
                     <t t-elif="!allow_out_of_stock_order">
-                        <div class="text-danger fw-bold">
-                            <i class="fa fa-times me-1"/>
-                            Out of Stock
+                        <div class="badge text-bg-danger">
+                            <i class="fa fa-circle text-danger me-2"/>Out of Stock
                         </div>
                     </t>
                 </div>
                 <div id="stock_notification_div" t-if="!allow_out_of_stock_order">
                     <div class="btn btn-link px-0" t-if="!has_stock_notification"
                          id="product_stock_notification_message">
-                        <i class="fa fa-envelope-o me-1"/>
-                        Get notified when back in stock
+                        <i class="fa fa-envelope-o me-2"/>Get notified when back in stock
                     </div>
                     <div id="stock_notification_form" class="d-none">
                         <div class="input-group">
@@ -25,36 +32,42 @@
                                    id="stock_notification_input" name="email"
                                    type="text" placeholder="youremail@gmail.com" t-att-value="stock_notification_email? stock_notification_email: ''"/>
                             <input name="product_id" type="hidden" t-att-value="product_id"/>
-                            <div id="product_stock_notification_form_submit_button" class="btn btn-secondary">
+                            <div id="product_stock_notification_form_submit_button" class="btn btn-primary">
                                 <i class="fa fa-paper-plane"/>
                             </div>
-                            <div id="stock_notification_input_incorrect" class="btn d-none">
-                                <i class="fa fa-times text-danger"/>
-                                Invalid email
-                            </div>
+                        </div>
+                        <div id="stock_notification_input_incorrect" class="d-none form-text text-danger">
+                            Invalid email
                         </div>
 
                     </div>
                     <div id="stock_notification_success_message"
                          t-att-class="has_stock_notification ? '' : 'd-none'">
-                        <div class="text-muted">
-                            <i class="fa fa-bell"/>
-                            We'll notify you once the product is back in stock.
+                        <div class="py-2 small text-muted">
+                            <i class="fa fa-bell me-2"/>We'll notify you once the product is back in stock
                         </div>
                     </div>
                 </div>
             </div>
-            <div id="threshold_message" t-elif="show_availability and free_qty lte available_threshold" t-attf-class="availability_message_#{product_template} text-warning fw-bold">
-                Only <t t-esc="formatQuantity(free_qty)"/> <t t-esc="uom_name" /> left in stock.
-            </div>
-
-            <div id="already_in_cart_message" t-if="!allow_out_of_stock_order and show_availability and cart_qty" t-attf-class="availability_message_#{product_template} text-warning mt8">
-                <t t-if="!free_qty">
-                    You already added all the available product in your cart.
-                </t>
-                <t t-else="">
-                    You already added <t t-esc="cart_qty" /> <t t-esc="uom_name" /> in your cart.
-                </t>
+            <div
+                id="threshold_message"
+                t-elif="show_availability and free_qty lte available_threshold"
+                t-attf-class="availability_message_#{product_template} badge text-bg-warning"
+            >
+                <i class="fa fa-circle text-warning me-2" role="presentation"/>
+                <t t-esc="formatQuantity(free_qty)"/> <t t-esc="uom_name" /> left in stock
+                <span
+                    id="already_in_cart_message"
+                    t-if="!allow_out_of_stock_order and show_availability and cart_qty"
+                    t-attf-class="availability_message_#{product_template}"
+                >
+                    <t t-if="!free_qty">
+                        You already added all the available product in your cart
+                    </t>
+                    <t t-else="">
+                        (<t t-esc="cart_qty" /> in your cart)
+                    </t>
+                </span>
             </div>
         </div>
     </t>

--- a/addons/website_sale_stock/views/website_sale_stock_templates.xml
+++ b/addons/website_sale_stock/views/website_sale_stock_templates.xml
@@ -10,11 +10,9 @@
         </xpath>
     </template>
 
-    <template id="website_sale_stock_product" inherit_id="website_sale.product" priority="4">
-        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="after">
+    <template id="website_sale_stock_product" inherit_id="website_sale.cta_wrapper" priority="4">
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="before">
             <div class="availability_messages o_not_editable"/>
-        </xpath>
-        <xpath expr="//div[@id='product_details']" position="inside">
             <input id="wsale_user_email" type="hidden" t-att-value="user_email"/>
         </xpath>
     </template>

--- a/addons/website_sale_stock_wishlist/static/src/xml/product_availability.xml
+++ b/addons/website_sale_stock_wishlist/static/src/xml/product_availability.xml
@@ -10,18 +10,16 @@
                     t-if="!is_in_wishlist"
                     type="button"
                     role="button"
-                    class="btn btn-secondary text-nowrap o_add_wishlist_dyn"
+                    class="btn btn-outline-primary text-nowrap o_add_wishlist_dyn"
                     t-att-data-product-template-id="product_id"
                     t-att-data-product-product-id="product_id"
                     data-action="o_wishlist"
                     title="Add to wishlist">
-                <i class="fa fa-clock-o me-2"/>
-                Save for later
+                <i class="fa fa-heart-o me-2"/>Add to wishlist
             </button>
             <div id="wsale_added_to_your_wishlist_alert" t-att-class="is_in_wishlist ? '' : 'd-none'">
-                <div class="alert alert-success">
-                    <i class="fa fa-heart me-1"/>
-                    Added to your wishlist
+                <div class="btn btn-outline-primary disabled">
+                    <i class="fa fa-heart me-2"/>Added to your wishlist
                 </div>
             </div>
 

--- a/addons/website_sale_stock_wishlist/views/website_sale_stock_wishlist_templates.xml
+++ b/addons/website_sale_stock_wishlist/views/website_sale_stock_wishlist_templates.xml
@@ -10,11 +10,10 @@
                    t-value="wish.product_id._has_stock_notification(wish.partner_id) or request and wish.product_id.id in request.session.get('product_with_stock_notification_enabled', set())"/>
                 <div id="stock_notification_div" t-if="not wish.product_id.allow_out_of_stock_order"
                      class="small d-inline-block">
-                    <div class="btn btn-link" t-if="not has_stock_notification"
+                    <div class="btn btn-link px-0" t-if="not has_stock_notification"
                          id="wishlist_stock_notification_message">
                         <small>
-                            <i class="fa fa-envelope-o"/>
-                            Get notified when back in stock
+                            <i class="fa fa-envelope-o me-2"/>Get notified when back in stock
                         </small>
                     </div>
                     <div id="stock_notification_form" class="d-none">
@@ -26,13 +25,12 @@
                                    placeholder="youremail@gmail.com"
                                    t-att-value="request.env.user.partner_id.email or request.session.get('stock_notification_email', '')"/>
                             <div id="wishlist_stock_notification_form_submit_button"
-                                    class="btn btn-secondary">
+                                    class="btn btn-primary">
                                 <i class="fa fa-paper-plane"/>
                             </div>
-                            <div id="stock_notification_input_incorrect" class="btn d-none">
-                                <i class="fa fa-times text-danger"/>
-                                Invalid email
-                            </div>
+                        </div>
+                        <div id="stock_notification_input_incorrect" class="d-none form-text text-danger">
+                            Invalid email
                         </div>
                     </div>
                     <div id="stock_notification_success_message" class="text-muted"

--- a/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
+++ b/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
@@ -7,8 +7,15 @@
         display: none;
     }
 
-    .btn.o_add_wishlist_dyn.disabled i::before {
-        content: "\f004";
+    .o_add_wishlist_dyn {
+        &.disabled i::before {
+            content: "\f004";
+        }
+
+        &.btn-lg {
+            aspect-ratio: 1/1;
+            height: calc(#{$btn-padding-y-lg} * 2 + #{$btn-font-size-lg} * #{$btn-line-height} + #{$btn-border-width} * 2);
+        }
     }
 }
 

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -56,23 +56,56 @@
         </xpath>
     </template>
 
-    <template id="product_add_to_wishlist" inherit_id="website_sale.product" name="Wishlist Button" priority="20">
+    <template
+        id="website_sale_wishlist.product_add_to_wishlist"
+        inherit_id="website_sale.cta_wrapper"
+        name="Wishlist Button"
+        priority="20"
+    >
         <xpath expr="//div[@id='product_option_block']" position="inside">
             <t t-nocache="The wishlist depends on the user and must not be shared with other users. The product come from the controller.">
                 <t t-set="product_variant" t-value="product_variant or product._create_first_product_variant()"/>
                 <t t-set="in_wish" t-value="product_variant and product_variant._is_in_wishlist()"/>
+                <t
+                    t-set="_button_classes"
+                    t-valuef="o_add_wishlist_dyn btn btn-outline-primary text-nowrap"
+                />
+                <t
+                    t-if="website.product_page_image_width == '50_pc' and not (is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large'))"
+                    t-set="_button_classes"
+                    t-value="_button_classes + ' flex-grow-0'"
+                />
+                <t
+                    t-else=""
+                    t-set="_button_classes"
+                    t-value="_button_classes + ' flex-grow-1'"
+                />
+                <t
+                    t-if="is_view_active('website_sale.cta_wrapper_large')"
+                    t-set="_button_classes"
+                    t-value="_button_classes + ' btn-lg px-lg-0'"
+                />
                 <!-- using A instead of BUTTON so space character works when editing -->
                 <a
                     t-if="product_variant"
-                    class="btn btn-link px-0 pe-3 o_add_wishlist_dyn"
+                    t-att-class="_button_classes"
                     t-att-disabled="in_wish"
                     t-att-data-product-template-id="product.id"
                     t-att-data-product-product-id="product_variant.id"
                     data-action="o_wishlist"
                     title="Add to wishlist"
                 >
-                    <i class="fa fa-heart-o me-2" role="img" aria-label="Add to wishlist"/>
-                    Add to wishlist
+                    <i class="fa fa-heart-o me-2 me-lg-0" role="img" aria-label="Add to wishlist"/>
+                    <t
+                        t-set="_span_classes"
+                        t-valuef="d-inline"
+                    />
+                    <t
+                        t-if="website.product_page_image_width == '50_pc' and not (is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large'))"
+                        t-set="_span_classes"
+                        t-value="_span_classes + ' d-lg-none'"
+                    />
+                    <span t-att-class="_span_classes">Add to wishlist</span>
                 </a>
             </t>
         </xpath>


### PR DESCRIPTION
*: website_sale, website_sale_collect, website_sale_comparison, website_sale_stock, website_sale_wishlist, website_sale_stock_wishlist, portal_rating

This PR modernizes the design on the components of the product page. (Typography, variants selectors, buttons, ratings, accordions, terms and conditions...)

Key Updates:

- UI Modernization: Improved typography, variant selectors, buttons, ratings, accordions, and terms & conditions.
- CTA Wrapper Options: Added support for three templates: default, boxed, and large.
- Sidebar Customization: Added option to show/hide separators.
- Search Bar Visibility: The search bar on the product page can now be hidden independently from the shop page (default: hidden).
- Product Details Layout: Now displayed in two columns for `none` and `100_pc` image sizes, with a sticky CTA section.
- Better Attribute Display: Selected attribute names are now shown for color and image display types.
- Stock Messaging: Improved design for out-of-stock and low-stock messages.
- Improved Quantity Selectors: Make use of new plus/minus icons from the `oi` icon-font.
- Preventing Invalid Selections: users can no longer select impossible combinations and are instead informed via tooltips, rather than encountering an error message afterward.

Enterprise PR: https://github.com/odoo/enterprise/pull/81065
Upgrade PR: https://github.com/odoo/upgrade/pull/7512

task-4527182

| Before | After |
|--------|--------|
| <img width="1712" alt="Screenshot 2025-03-11 at 09 52 51" src="https://github.com/user-attachments/assets/ea1e3fda-fdc9-42c0-a143-ff00cf948d40" /> | <img width="1712" alt="Screenshot 2025-03-11 at 13 58 58" src="https://github.com/user-attachments/assets/81f111c0-4ef5-4e2a-bfa8-91ba77cd03cf" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
