### PR TITLE
[FIX] portal: don't update company name if child address

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -656,6 +656,10 @@ class CustomerPortal(Controller):
                     else:
                         address_values.pop(commercial_field_name, None)
 
+                # Company name shouldn't be updated on a child address, even if it's not in the
+                # fields returned by _commercial_fields.
+                address_values.pop('company_name', None)
+
             # Prevent changing the VAT number on a commercial partner if documents have been issued.
             elif (
                 'vat' in address_values


### PR DESCRIPTION
Despite being already readonly on child addresses, the company name was still being submitted and set on the partner address when updated through the portal.

Steps to reproduce:
* Create company for Joel Willis
* Update their address through the portal (logged in as portal user)
* The created company isn't shown on Joel Willis form view (backend)

The res partner form view is configured to show the company name if set, instead of the parent company.

To avoid this issue, we simply pop the company name when the updated address isn't the address commercial entity of the current customer.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
