### PR TITLE
[FIX] l10n_gt: In Guatemala, both taxes are tax_included

### DIFF
--- a/addons/l10n_gt/data/template/account.tax-gt.csv
+++ b/addons/l10n_gt/data/template/account.tax-gt.csv
@@ -1,5 +1,5 @@
 "id","name","description","invoice_label","amount","amount_type","type_tax_use","tax_group_id","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/account_id","description@es","invoice_label@es","price_include_override"
-"impuestos_plantilla_iva_por_cobrar","12%","Unpaid VAT","Unpaid VAT","12.0","percent","purchase","tax_group_iva_12","base","invoice","","IVA por Cobrar","IVA por Cobrar",""
+"impuestos_plantilla_iva_por_cobrar","12%","Unpaid VAT","Unpaid VAT","12.0","percent","purchase","tax_group_iva_12","base","invoice","","IVA por Cobrar","IVA por Cobrar","tax_included"
 "","","","","","","","","tax","invoice","cta110301","","",""
 "","","","","","","","","base","refund","","","",""
 "","","","","","","","","tax","refund","cta110301","","",""


### PR DESCRIPTION
In Guatemala, both sales and purchases VAT are tax_included. Currently, in version 18.0, only sales VAT has the tax_included configured. But it should be both.

On previous versions of Odoo, this was correctly configured as can be seen here:

https://github.com/odoo/odoo/blob/17.0/addons/l10n_gt/data/template/account.tax-gt.csv?plain=1#L2

Here, the price_include field is True for both.

Version 18.0 should have this same behavior.

Fixes #201036

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
