### PR TITLE
[IMP] tests: fix test-file with dots in path

### DIFF
--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -212,6 +212,15 @@ class TestSelector(TransactionCase):
         self.assertEqual({(None, 'module', None, None, None), }, tags.include)  # all in module
         self.assertEqual({('standard', None, None, None, None), }, tags.exclude)  # exept standard ones
 
+        tags = TagsSelector('/some/absolute/path/v.3/module.py')
+        self.assertEqual({('standard', None, None, None, '/some/absolute/path/v.3/module.py'), }, tags.include)  # all in module
+
+        tags = TagsSelector('/some/absolute/path/v.3/module.py')
+        self.assertEqual({('standard', None, None, None, '/some/absolute/path/v.3/module.py'), }, tags.include)  # all in module
+
+        tags = TagsSelector('/module.method')
+        self.assertEqual({('standard', 'module', None, 'method', None), }, tags.include)  # all in module
+
 
 @tagged('nodatabase')
 class TestSelectorSelection(TransactionCase):

--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -6,7 +6,14 @@ _logger = logging.getLogger(__name__)
 
 class TagsSelector(object):
     """ Test selector based on tags. """
-    filter_spec_re = re.compile(r'^([+-]?)(\*|\w*)(?:\/([\w\/]*(?:.py)?))?(?::(\w*))?(?:\.(\w*))?$')  # [-][tag][/module][:class][.method]
+    filter_spec_re = re.compile(r'''^
+        ([+-]?)
+        (\*|\w*)
+        (\/[\w\/\.]+.py)?
+        (?:\/(\w+))?
+        (?::(\w*))?
+        (?:\.(\w*))?
+        $''',re.VERBOSE)  # [-][tag][/module][:class][.method]
 
     def __init__(self, spec):
         """ Parse the spec to determine tags to include and exclude. """
@@ -20,7 +27,7 @@ class TagsSelector(object):
                 _logger.error('Invalid tag %s', filter_spec)
                 continue
 
-            sign, tag, module, klass, method = match.groups()
+            sign, tag, file_path, module, klass, method = match.groups()
             is_include = sign != '-'
 
             if not tag and is_include:
@@ -29,10 +36,6 @@ class TagsSelector(object):
             elif not tag or tag == '*':
                 # '*' indicates all tests (instead of 'standard' tests only)
                 tag = None
-            file_path = None
-            if module and (module.endswith('.py')):
-                file_path = f"/{module}"
-                module = None
             test_filter = (tag, module, klass, method, file_path)
 
             if is_include:


### PR DESCRIPTION
Since test-file are now used as test-tags, module part of a test-tags needs to support dots in the path.


