### PR TITLE
[FIX] l10n_ar: Invoice report tax detail

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -114,6 +114,9 @@
         <!-- remove default document title -->
         <h2 position="replace"/>
 
+        <!-- remove detail of taxes when currency != from company's currency -->
+        <t t-call="account.document_tax_totals_company_currency_template" position="replace"/>
+
         <!-- NCM column for fiscal bond -->
         <th name="th_description" position="after">
             <th t-if="fiscal_bond" name="th_ncm_code" class="text-start"><span>NCM</span></th>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

There is no need to print the tax detail information when the invoice's currency is not the same as the company's currency. This change removes that part of the report, and it only affects the AR Invoice Legal report.

This functionality was added to the account module and affects all the invoice reports, but we do not want them to be in the AR legal report. For more information about the extra tax detail in the company's currency, you can check this commit https://github.com/odoo/odoo/commit/8823e01040f9522947e5d11c7312d09c50867cc4

### Current behavior before PR:

![before](https://github.com/user-attachments/assets/7d0fcb9a-1cbc-4e66-8904-98e8b2010478)

### Desired behavior after PR is merged:

![after](https://github.com/user-attachments/assets/156c8771-e87e-495a-9633-136063bab5d3)

LATAM task 1329 / Adhoc ticket 88609

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
