### PR TITLE
[FIX] account_payment: test fails in Odoo CE due to invoice_payment_state mismatch

### DIFF
--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -288,7 +288,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 90.0,
                 'payment_amount_total': 100.0,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_eligible._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 90.0,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 90.0, 'account_type': 'asset_current'},
@@ -317,7 +317,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 100.0,
                 'payment_amount_total': 100.0,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_ineligible._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 100.0,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 100.0, 'account_type': 'asset_current'},
@@ -354,7 +354,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 103.5,
                 'payment_amount_total': 115.0,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_eligible_with_tax._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 103.5,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 103.5, 'account_type': 'asset_current'},
@@ -398,7 +398,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 113.5,
                 'payment_amount_total': 113.5,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_ineligible_with_mixed_and_tax._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 113.5,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 113.5, 'account_type': 'asset_current'},
@@ -441,7 +441,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 105.0,
                 'payment_amount_total': 115.0,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_eligible_with_excluded_and_tax._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 105.0,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 105.0, 'account_type': 'asset_current'},
@@ -478,7 +478,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 90,
                 'payment_amount_total': 100,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_eligible_with_foreign_currency._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 90,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 45.0, 'account_type': 'asset_current'},


### PR DESCRIPTION
In Odoo CE, the invoice_payment_state is "paid".
In Odoo Enterprise, the invoice_payment_state is "in_payment". This causes the test to fail in CE but pass in Enterprise, making the test unreliable when running in an environment without Enterprise.

Current behavior before PR
Running the test in Odoo CE only → Fails (expects "in_payment", but gets "paid").
Running the test in Odoo CE + Enterprise → Passes.

Desired behavior after PR is merged
The test should pass in both CE and Enterprise.
The test will no longer check the exact value of invoice_payment_state, ensuring it remains valid across both versions.

Steps to reproduce
Run the test in an Odoo CE-only environment.
Observe that it fails due to the unexpected invoice_payment_state value. Run the test in an environment with Enterprise, and see that it passes.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
