### PR TITLE
[FIX] mrp: fix traceback if there is no warehouse while opening bom overview

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -19,7 +19,9 @@ class ReportBomStructure(models.AbstractModel):
 
     @api.model
     def get_warehouses(self):
-        return self.env['stock.warehouse'].search_read([('company_id', 'in', self.env.companies.ids)], fields=['id', 'name'])
+        return self.env['stock.warehouse'].with_context(active_test=False).search_read([
+                ('company_id', 'in', self.env.companies.ids)
+            ], fields=['id', 'name'])
 
     @api.model
     def _compute_current_production_capacity(self, bom_data):


### PR DESCRIPTION
A traceback occurs when the user tries to open a BOM Overview
after archiving all the warehouses.

To reproduce this issue:

1) Install MRP without demo
2) Archive the warehouses from the inventory configuration 
3) Now create a BOM from MRP/products and try to open the overview

Error:- 
```
IndexError: list index out of range
```

This traeback is occurring because when the user tries to open the Overview of a BOM, it tries to fetch the warehouse record from the line below lines.

https://github.com/odoo/odoo/blob/a8fdf26ee138b1f71e0534cbef73efd95bb2445d/addons/mrp/report/mrp_report_bom_structure.py#L114

https://github.com/odoo/odoo/blob/a8fdf26ee138b1f71e0534cbef73efd95bb2445d/addons/mrp/report/mrp_report_bom_structure.py#L21-L22

In the above line, we are trying to fetch only the active records, 
but because the user archived all the warehouses, we don't get any records.

It leads to the above traceback.

sentry-6379275060
