### PR TITLE
[FIX] website_blog: preventing an error when blog has a string value

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -14,6 +14,7 @@ from odoo.http import request
 from odoo.tools import html2plaintext
 from odoo.tools.misc import get_lang
 from odoo.tools import sql
+from werkzeug.exceptions import NotFound
 
 
 class WebsiteBlog(http.Controller):
@@ -70,6 +71,9 @@ class WebsiteBlog(http.Controller):
         """ Prepare all values to display the blogs index page or one specific blog"""
         BlogPost = request.env['blog.post']
         BlogTag = request.env['blog.tag']
+
+        if blog and not isinstance(blog, models.Model):
+            raise NotFound()
 
         # prepare domain
         domain = request.website.website_domain()


### PR DESCRIPTION
Currently, an exception is raised when a user accesses the blog page with an invalid blog parameter.

Steps to Reproduce:

1. Go to the blog page using a URL with a query parameter:
```
http://localhost:8069/blog?blog=1
```
2. The page fails to load, and an error occurs.

Error:
`AttributeError
'str' object has no attribute 'id'
`

The issue [1] occurs when the blog value is passed as string instead of an Odoo model instance, causing an error when trying to access blog.id.

[1] - https://github.com/odoo/odoo/blob/2ad5a0d0229c774ba45e5d8e7ad325c9131b2895/addons/website_blog/controllers/main.py#L78

This fix ensures that if blog has a value, the system first checks whether it is an instance of models.Model. If it is not, it raises a NotFound() error.

sentry - 6378662116

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
