### PR TITLE
[FIX] l10n_sa_edi_pos: fix invoicing customization

### DIFF
--- a/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_order.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_order.js
@@ -15,18 +15,18 @@ patch(PosOrder.prototype, {
         return this.company.country_id?.code === "SA";
     },
 
-    is_to_invoice() {
+    isToInvoice() {
         if (this.isSACompany()) {
             return true;
         }
-        return super.is_to_invoice(...arguments);
+        return super.isToInvoice(...arguments);
     },
-    set_to_invoice(to_invoice) {
+    setToInvoice(to_invoice) {
         if (this.isSACompany()) {
-            this.assert_editable();
+            this.assertEditable();
             this.to_invoice = true;
         } else {
-            super.set_to_invoice(...arguments);
+            super.setToInvoice(...arguments);
         }
     },
 });


### PR DESCRIPTION
Steps to reproduce:
- Install l10n_sa_edi_pos
- In PoS, choose and order and go the the payment screen

-> We can toggle the invoice checkbox, which should not be the case.

That happened because the commit 0571173386c280508cc37306ef132a5b9554bcaa has changed the function names from snake_case to camelCase, but has not changed this file, allowing an sa order to not be invoiced, which is unintended.

opw-4615085
