### PR TITLE
[IMP] point_of_sale,*: ticket (receipt after payment) revamp

### DIFF
--- a/addons/l10n_co_pos/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/l10n_co_pos/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -2,9 +2,9 @@
 
 <templates id="template" xml:space="preserve">
     <t t-name="l10n_co_pos.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('pos-receipt-order-data')]" position="inside">
+        <xpath expr="//div[hasclass('before-footer')]" position="inside">
             <t t-if="order.name !== false">
-                <div style="word-wrap:break-word;"><t t-esc="order.name"/></div>
+                <div style="word-wrap:break-word;" class="pt-3"><t t-out="order.name"/></div>
             </t>
         </xpath>
     </t>

--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="l10n_fr_pos_cert.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('pos-receipt-order-data')]" position="inside">
+        <xpath expr="//div[hasclass('before-footer')]" position="inside">
             <t t-if="order.l10n_fr_hash !== false">
-                <br/>
-                <div style="word-wrap:break-word;"><t t-out="order.l10n_fr_hash"/></div>
+                <div class="text-break pt-3"><t t-out="order.l10n_fr_hash"/></div>
             </t>
         </xpath>
     </t>

--- a/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.xml
@@ -4,7 +4,7 @@
         <xpath expr="//div[hasclass('pos-receipt-contact')]" position="after">
             <t t-if="order.partner_id and order.company?.country_id?.code == 'IN'">
                 <div class="pos-receipt-center-align">
-                    <div><t t-out="order.partner_id.name" /></div>
+                    <div t-if="order.preset_id?.identification != 'address'" t-out="order.partner_id.name"/>
                     <t t-if="order.partner_id.phone">
                         <div>
                             <span>Phone: </span>
@@ -27,9 +27,8 @@
             </t>
         </xpath>
         <xpath expr="//div[@class='before-footer']" position="after">
-            <br/>
             <t t-set="l10n_in_hsn_summary" t-value="order._prepareL10nInHsnSummary()"/>
-            <table t-if="l10n_in_hsn_summary and header.company.country_id?.code === 'IN' and l10n_in_hsn_summary.items.length > 0" style="width:100%;">
+            <table t-if="l10n_in_hsn_summary and header.company.country_id?.code === 'IN' and l10n_in_hsn_summary.items.length > 0" class="pt-3 w-100">
               <tr>
                     <th class="text-center fw-bolder" colspan="6">HSN Summary</th>
                 </tr>

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -241,6 +241,8 @@ class PosConfig(models.Model):
     def _post_read_pos_data(self, data):
         if not data[0]['use_pricelist']:
             data[0]['pricelist_id'] = False
+        if data:
+            data[0]['_IS_VAT'] = self.env.company.country_id.id in self.env.ref("base.europe").country_ids.ids
         return super()._post_read_pos_data(data)
 
     @api.depends('payment_method_ids')

--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
@@ -13,7 +13,7 @@
                         t-attf-class="{{this.props.mode === 'receipt' ? 'mt-1 bg-opacity-75 p-0 ' : 'customer-note w-100 p-2 text-break bg-warning bg-opacity-25 mt-0 text-warning'}}">
                         <div class="flex-wrap w-100 m-0">
                             <div class="ps-1">
-                                <t t-foreach="order.general_customer_note.split('\n')" t-as="subNote" t-key="subNote_index">
+                                <t t-foreach="order.general_customer_note.trim().split('\n')" t-as="subNote" t-key="subNote_index">
                                     <div class="d-inline text-break">
                                         <t t-esc="subNote"/><br/>
                                     </div>
@@ -21,7 +21,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="internal-note-container d-flex flex-wrap gap-2 p-2">
+                    <div t-if="order.internal_note" class="internal-note-container d-flex flex-wrap gap-2" t-attf-class="{{this.props.mode === 'receipt' ? 'py-2' : 'p-2'}}">
                         <TagsList tags="getInternalNotes()"/>
                     </div>
                 </div>

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -2,47 +2,55 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.Orderline">
         <li t-if="line.order_id" class="orderline position-relative d-flex align-items-center lh-sm cursor-pointer"
-            t-attf-class="{{ line.combo_parent_id ? 'orderline-combo fst-italic ms-4 border-start' : '' }}"
-            t-att-class="{'selected' : line.isSelected() and this.props.mode === 'display', ...line.getDisplayClasses(), ...(props.class || [])}">
+            t-attf-class="{{ line.combo_parent_id ? 'orderline-combo fst-italic ms-4' : '' }}"
+            t-att-class="{'selected' : line.isSelected() and this.props.mode === 'display', ...line.getDisplayClasses(), ...(props.class || []), 'border-start': props.mode != 'receipt' and line.combo_parent_id}">
             <div class="product-order"></div>
             <div t-if="props.showImage and line.product_id.getImageUrl()" class="o_line_container d-flex align-items-center justify-content-center">
                 <img t-attf-style="border-radius: 1rem;" t-att-src="line.product_id.getImageUrl()"/>
             </div>
             <div class="d-flex flex-column w-100"
-                 t-attf-class="{{ line.combo_parent_id ? 'px-2 py-1' : 'p-2' }}">
-                <div class="line-details d-flex justify-content-between align-items-center">
-                    <div class="product-name d-flex flex-grow-1 align-items-center pe-2 text-truncate">
-                        <span class="qty d-inline-block px-1 fw-bolder">
+                 t-attf-class="{{ line.combo_parent_id ? props.mode == 'receipt' ? 'px-2' : 'p-2' : props.mode == 'receipt' ? line.combo_line_ids.length > 0 ? '' : 'py-1' : 'p-2' }}">
+                <div class="line-details d-flex justify-content-between" t-att-class="{ 'align-items-center' : props.mode == 'receipt' }">
+                    <div class="product-name d-flex flex-grow-1 pe-2 text-truncate" t-att-class="{ 'align-items-center' : props.mode == 'receipt' }">
+                        <span class="qty d-inline-block fw-bolder"
+                            t-attf-class="{{ props.mode == 'receipt' ? 'pe-2' : 'px-1' }}">
                             <t t-esc="line.getQuantityStr().unitPart"/>
-                            <small t-if="line.getQuantityStr().decimalPart" class="fw-normal text-muted" t-esc="line.getQuantityStr().decimalPart"/>
-                        </span>
-                        <span class="text-wrap d-inline">
-                            <t t-esc="line.orderDisplayProductName.name" />
-                            <br/>
-                            <small class="attribute-line fst-italic" t-if="line.orderDisplayProductName.attributeString">
-                                - <t t-esc="line.orderDisplayProductName.attributeString" />
+                            <small t-if="line.getQuantityStr().decimalPart" class="fw-normal" style="font-size: 85%;">
+                                <t t-esc="line.getQuantityStr().decimalPoint"/>
+                                <t t-esc="line.getQuantityStr().decimalPart"/>
                             </small>
                         </span>
+                        <span class="text-wrap d-inline">
+                            <t t-if="props.mode == 'receipt'">
+                                <t t-out="line.full_product_name" />
+                            </t>
+                            <t t-else="">
+                                <t t-esc="line.orderDisplayProductName.name" />
+                                <br/>
+                                <small class="attribute-line fst-italic" t-if="line.orderDisplayProductName.attributeString">
+                                    - <t t-esc="line.orderDisplayProductName.attributeString" />
+                                </small>
+                            </t>
+                        </span>
                     </div>
-                    <div t-if="!props.basic_receipt" t-esc="line.getPriceString()" class="product-price price fw-bolder"/>
+                    <div t-if="!props.basic_receipt" t-out="line.getPriceString()" class="product-price price" t-attf-class="{{ props.mode == 'receipt' ? 'font-monospace' : 'fw-bolder' }}"/>
                     <div t-if="props.showTaxGroup" t-esc="this.taxGroup" class="text-end" style="width: 2rem"/>
                 </div>
-                <ul class="info-list d-flex flex-column mb-0" t-att-class="{'gap-1' : line.customer_note || line.note || line.discount || line.packLotLines?.length}">
+                <ul class="info-list d-flex flex-column mb-0 ms-2" t-att-style="props.mode == 'receipt' and 'font-size: 75%;'" t-attf-class="{{ props.mode === 'receipt' ? '' : (line.customer_note || line.note || line.discount || line.packLotLines?.length) ? 'gap-2 mt-1' : '' }}">
+                    <li class="price-per-unit" t-if="!props.basic_receipt and this.props.line.getQuantity() != 1 and (props.mode == 'receipt' || (line.price_type !== 'original' and !line.combo_parent_id))">
+                        <t t-if="line.price !== 0">
+                            <t t-esc="formatCurrency(line.unitDisplayPrice)" />
+                        </t>
+                        /
+                        <t t-if="line.product_id.uom_id?.name" t-esc="line.product_id.uom_id?.name" />
+                    </li>
                     <li t-if="line.discount" class="price-per-unit">
                         <t t-set="discount" t-value="line.getDiscountStr()" />
                         <t t-if="!props.basic_receipt and line.price_unit !== 0 and discount and discount !== '0'">
                             <i class="fa fa-tag pe-1"/><em><t t-esc="discount" />% </em> discount off on <t t-esc="env.utils.formatCurrency(line.allPrices.priceWithTaxBeforeDiscount)"/>
                         </t>
                     </li>
-                    <li class="price-per-unit" t-if="!props.basic_receipt and (props.mode == 'receipt' || (line.price_type !== 'original' and !line.combo_parent_id))">
-                        <t t-if="line.price !== 0">
-                            <i class="fa fa-money center pe-1"/>
-                            <t t-esc="formatCurrency(line.unitDisplayPrice)" />
-                        </t>
-                        /
-                        <t t-if="line.product_id.uom_id?.name" t-esc="line.product_id.uom_id?.name" />
-                    </li>
-                    <li t-if="line.customer_note" class="customer-note w-100 rounded text-break bg-opacity-25 mb-1" t-att-class="{'bg-warning text-warning p-2 mt-2': this.props.mode === 'display'}">
+                    <li t-if="line.customer_note" class="customer-note w-100 rounded text-break bg-opacity-25" t-att-class="{'bg-warning text-warning p-2': this.props.mode === 'display'}">
                         <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
                         <t t-esc="line.customer_note" />
                     </li>
@@ -50,7 +58,7 @@
                         <TagsList tags="getInternalNotes()" />
                     </div>
                     <li t-if="line.product_id.tracking !== 'none'" class="row flex-wrap w-100 m-0">
-                        <div class="col-auto px-1">
+                        <div class="col-auto" t-attf-class="{{ props.mode == 'receipt' ? 'p-0' : 'px-1' }}">
                             <t t-slot="pack-lot-icon" />
                         </div>
                         <div class="col ps-0">

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_receipt/cash_move_receipt.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_receipt/cash_move_receipt.xml
@@ -4,12 +4,14 @@
     <t t-name="point_of_sale.CashMoveReceipt">
         <div class="pos-receipt">
             <ReceiptHeader order="props.order" />
+            <div class="pos-receipt-order-data text-center">
+                <div><t t-esc="props.date" /></div>
+            </div>
             <div class="pos-receipt-center-align">
                 CASH
                 <t t-esc="props.translatedType.toUpperCase()" />
             </div>
-            <br />
-            <div>
+            <div class="pt-3">
                 AMOUNT
                 <span t-esc="props.formattedAmount" class="pos-receipt-right-align" />
             </div>
@@ -17,9 +19,30 @@
                 REASON
                 <span t-esc="props.reason" class="pos-receipt-right-align" />
             </div>
-            <br />
-            <div class="pos-receipt-order-data">
-                <div><t t-esc="props.date" /></div>
+            <t t-set="company" t-value="props.order.company" />
+            <div class="d-flex gap-2 pt-3">
+                <!-- Left: Company Address -->
+                <div class="w-50 text-break text-start" style="font-size: 75%;">
+                    <div t-out="company.name"/>
+                    <div>
+                        <t t-if="company.street" t-out="company.street"/>
+                        <t t-if="company.city" t-out="', ' + company.city"/>
+                        <t t-if="company.state_id?.code" t-out="', ' + company.state_id.code"/>
+                        <t t-if="company.zip" t-out="', ' +  company.zip"/>
+                    </div>
+                </div>
+
+                <!-- Right: Contact Info -->
+                <div class="w-50 text-break text-end" style="font-size: 75%;">
+                    <div>
+                        <div t-if="company.vat" t-out="vatText"/>
+                        <div t-if="company.phone">
+                            Tel: <t t-out="company.phone"/>
+                        </div>
+                        <div t-if="company.email" t-out="company.email"/>
+                        <div t-if="company.website" t-out="company.website"/>
+                    </div>
+                </div>
             </div>
         </div>
     </t>

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.scss
@@ -45,7 +45,7 @@
     }
 
     > .qty {
-        min-width: 2rem;
+        min-width: 2.5rem;
     }
 }
 

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -83,7 +83,7 @@ export class PosOrderline extends Base {
                 } else {
                     const formatted = formatFloat(this.qty, { digits: [69, ProductUnit.digits] });
                     const parts = formatted.split(decimalPoint);
-                    unitPart = parts[0] + decimalPoint;
+                    unitPart = parts[0];
                     decimalPart = parts[1] || "";
                 }
             } else {
@@ -95,6 +95,7 @@ export class PosOrderline extends Base {
         return {
             qtyStr: unitPart + (decimalPart ? decimalPoint + decimalPart : ""),
             unitPart: unitPart,
+            decimalPoint: decimalPoint,
             decimalPart: decimalPart,
         };
     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/orderline_note_button/orderline_note_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/orderline_note_button/orderline_note_button.js
@@ -99,8 +99,15 @@ export class InternalNoteButton extends NoteButton {
     reframeNotes(payload) {
         const notesArray = [];
         for (const noteName of payload.split("\n")) {
-            const defaultNote = this.pos.models["pos.note"].find((note) => note.name === noteName);
-            notesArray.push({ text: noteName, colorIndex: defaultNote ? defaultNote.color : 0 });
+            if (noteName.trim()) {
+                const defaultNote = this.pos.models["pos.note"].find(
+                    (note) => note.name === noteName
+                );
+                notesArray.push({
+                    text: noteName,
+                    colorIndex: defaultNote ? defaultNote.color : 0,
+                });
+            }
         }
         return JSON.stringify(notesArray);
     }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -57,4 +57,14 @@ export class OrderReceipt extends Component {
     getPortalURL() {
         return `${this.order.session._base_url}/pos/ticket`;
     }
+
+    get vatText() {
+        if (this.order.company.country_id?.vat_label) {
+            return _t("%(vatLabel)s: %(vatId)s", {
+                vatLabel: this.order.company.country_id.vat_label,
+                vatId: this.order.company.vat,
+            });
+        }
+        return _t("Tax ID: %(vatId)s", { vatId: this.order.company.vat });
+    }
 }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -4,6 +4,7 @@
         <div class="pos-receipt p-2">
             <t t-set="showTaxGroupLabels" t-value="doesAnyOrderlineHaveTaxLabel()"/>
             <ReceiptHeader order="order" />
+            <div class="pt-3"/>
             <OrderDisplay order="order" t-slot-scope="scope" mode="'receipt'">
                 <t t-set="line" t-value="scope.line"/>
                 <Orderline line="line" showTaxGroup="showTaxGroupLabels" mode="'receipt'" basic_receipt="props.basic_receipt">
@@ -15,133 +16,136 @@
             </OrderDisplay>
             <t t-if="!props.basic_receipt">
                 <t t-set="taxTotals" t-value="order.taxTotals"/>
-                <div t-if="taxTotals and taxTotals.has_tax_groups" class="pos-receipt-taxes">
-                    <div class="text-center">--------------------------------</div>
+                <div t-if="taxTotals and taxTotals.has_tax_groups" class="pos-receipt-taxes pt-3">
                     <t t-foreach="taxTotals.subtotals" t-as="subtotal" t-key="subtotal.name">
                         <div class="d-flex">
-                            <span t-if="showTaxGroupLabels" class="me-2" style="visibility: hidden;">A</span>
-                            <span class="fw-bolder text-nowrap mw-100" t-out="subtotal.name"/>
-                            <span t-esc="formatCurrency(subtotal.base_amount_currency)" class="ms-auto"/>
+                            <span class="text-nowrap mw-100">Subtotal</span>
+                            <span t-out="formatCurrency(subtotal.base_amount_currency)" class="ms-auto font-monospace"/>
                         </div>
 
                         <div t-foreach="subtotal.tax_groups" t-as="tax_group" t-key="tax_group.id" class="d-flex">
-                            <t t-if="showTaxGroupLabels">
-                                <span t-if="tax_group.group_label" t-out="tax_group.group_label" class="me-2"/>
-                                <span t-else="" class="me-2" style="visibility: hidden;">A</span>
-                            </t>
                             <span>
                                 <span t-esc="tax_group.group_name"/>
+                                <t t-if="showTaxGroupLabels">
+                                    (<span t-if="tax_group.group_label" t-out="tax_group.group_label"/>)
+                                </t>
                                 <t id="tax_base" t-if="!taxTotals.same_tax_base">
                                     on
                                     <span t-esc="formatCurrency(tax_group.base_amount_currency)"/>
                                 </t>
                             </span>
-                            <span t-esc="formatCurrency(tax_group.tax_amount_currency)" class="ms-auto"/>
+                            <span t-out="formatCurrency(tax_group.tax_amount_currency)" class="ms-auto font-monospace"/>
                         </div>
                     </t>
                 </div>
 
                 <!-- Total -->
-                <div class="text-center">--------------------------------</div>
-                <div class="pos-receipt-amount receipt-total">
-                    <span class="label-total">TOTAL</span>
-                    <span t-esc="formatCurrency(taxTotals.order_sign * taxTotals.order_total)" class="pos-receipt-right-align"/>
+                <div class="pos-receipt-amount receipt-total fw-bolder">
+                    <span class="label-total">Total</span>
+                    <span t-out="formatCurrency(taxTotals.order_sign * taxTotals.order_total)" class="pos-receipt-right-align font-monospace"/>
                 </div>
                 <t t-if="order.showRounding">
                     <div class="pos-receipt-amount receipt-rounding">
                         <span class="label-rounding">Rounding</span>
-                        <span t-esc='formatCurrency(taxTotals.order_sign * taxTotals.order_rounding)' class="pos-receipt-right-align"/>
+                        <span t-out='formatCurrency(taxTotals.order_sign * taxTotals.order_rounding)' class="pos-receipt-right-align font-monospace"/>
                     </div>
                     <div class="pos-receipt-amount receipt-to-pay">
                         To Pay
-                        <span t-esc='formatCurrency(taxTotals.order_sign * (taxTotals.order_total + taxTotals.order_rounding))' class="pos-receipt-right-align"/>
+                        <span t-out='formatCurrency(taxTotals.order_sign * (taxTotals.order_total + taxTotals.order_rounding))' class="pos-receipt-right-align font-monospace"/>
                     </div>
                 </t>
 
                 <!-- Payment Lines -->
-                <div class="paymentlines text-start" t-foreach="paymentLines" t-as="line" t-key="line_index">
+                <div class="paymentlines text-start pt-1" t-foreach="paymentLines" t-as="line" t-key="line_index">
                     <t t-esc="line.payment_method_id.name" />
-                    <span t-esc="formatCurrency(line.getAmount())" class="pos-receipt-right-align"/>
+                    <span t-out="formatCurrency(line.getAmount())" class="pos-receipt-right-align font-monospace"/>
                 </div>
 
                 <div t-if="order.showChange" class="pos-receipt-amount receipt-change">
-                    <span class="label-change">CHANGE</span>
-                    <span t-esc="formatCurrency(order.orderChange)" class="pos-receipt-right-align"/>
+                    <span class="label-change">Change</span>
+                    <span t-out="formatCurrency(order.orderChange)" class="pos-receipt-right-align font-monospace"/>
                 </div>
 
                 <!-- Extra Payment Info -->
                 <t t-set="totalDiscount" t-value="order.getTotalDiscount()" />
                 <t t-if="totalDiscount">
-                    <div class="text-center">
+                    <div class="text-start">
                         <span class="label-discount">Discounts</span>
-                        <span t-esc="formatCurrency(totalDiscount)" class="pos-receipt-right-align"/>
+                        <span t-out="formatCurrency(totalDiscount)" class="pos-receipt-right-align font-monospace"/>
                     </div>
                 </t>
 
-                <div class="before-footer" />
-
-                <!-- This prevents missing receipt elements in modules like `l10n_fr_pos_cert`, `l10n_co_pos`, etc. -->
-                <div class="pos-receipt-order-data" />
-
-                <t t-set="useQrCode" t-value="this.qrCode" />
-                <div t-if="useQrCode">
-                    <br/>
-                    <div class="pos-receipt-order-data mb-2">
-                        Need an invoice for your purchase ?
+                <div t-if="qrCode" class="gap-2 d-flex flex-row pt-3" style="font-size: 75%;">
+                    <div t-if="['qr_code', 'qr_code_and_url'].includes(header.company.point_of_sale_ticket_portal_url_display_mode)" class="pt-1">
+                        <img id="posqrcode" t-att-src="qrCode" class="pos-receipt-logo m-0 w-100"/>
+                    </div>
+                    <div class="w-100">
+                        <div class="fw-bolder">
+                            Need an invoice?
+                        </div>
+                        <div t-if="['url', 'qr_code_and_url'].includes(header.company.point_of_sale_ticket_portal_url_display_mode)" class="portal-url text-break">
+                            <t t-out="getPortalURL()"/>
+                        </div>
+                        <div class="unique-code">
+                            Code: <t t-out="order.ticket_code"/>
+                        </div>
                     </div>
                 </div>
-
-                <div t-if="['qr_code', 'qr_code_and_url'].includes(this.header.company.point_of_sale_ticket_portal_url_display_mode) and useQrCode" class="mb-2">
-                    <img id="posqrcode" t-att-src="useQrCode" class="pos-receipt-logo"/>
-                </div>
-
-                <div t-if="useQrCode">
-                    <div class="unique-code pos-receipt-order-data">
-                        Unique Code: <t t-esc="order.ticket_code"/>
-                    </div>
-                </div>
-
-                <div t-if="['url', 'qr_code_and_url'].includes(this.header.company.point_of_sale_ticket_portal_url_display_mode) and useQrCode">
-                    <div class="portal-url pos-receipt-order-data">
-                        Portal URL: <t t-esc="getPortalURL()"/>
-                    </div>
-                </div>
+                <!-- handle xpath using before-footer! -->
+                <div class="before-footer"/>
             </t>
 
             <!-- Footer -->
-           <div t-if="order.config.receipt_footer" class="pos-receipt-center-align" style="white-space:pre-line">
-                <br/>
+            <div t-if="order.config.receipt_footer" class="pos-receipt-center-align pt-3 text-center" style="white-space:pre-line">
                 <t t-esc="order.config.receipt_footer" />
-                <br/>
-                <br/>
             </div>
 
             <div class="after-footer">
                 <t t-foreach="paymentLines" t-as="line" t-key="line_index">
                     <t t-if="line.ticket">
-                        <br />
-                        <div class="pos-payment-terminal-receipt">
+                        <div class="pos-payment-terminal-receipt pt-3">
                             <pre t-esc="line.ticket" />
                         </div>
                     </t>
                 </t>
             </div>
 
-            <br/>
             <t t-if="order.shipping_date">
-                <div class="pos-receipt-order-data">
+                <div class="pos-receipt-order-data d-flex gap-2 pt-3">
                     Expected delivery:
                     <div><t t-esc="order.formatDateOrTime('shipping_date', 'date')" /></div>
                 </div>
             </t>
 
-            <br/>
-            <div class="pos-receipt-order-data">
-                <p>Powered by Odoo</p>
-                <div t-esc="order.pos_reference" />
-                <div id="order-date" t-esc="order.formatDateOrTime('date_order')" />
+            <t t-set="company" t-value="order.company" />
+            <div class="d-flex gap-2 pt-3">
+                <!-- Left: Company Address -->
+                <div class="w-50 text-break text-start" style="font-size: 75%;">
+                    <div t-out="company.name"/>
+                    <div>
+                        <t t-if="company.street" t-out="company.street"/>
+                        <t t-if="company.city" t-out="', ' + company.city"/>
+                        <t t-if="company.state_id?.code" t-out="', ' + company.state_id.code"/>
+                        <t t-if="company.zip" t-out="', ' +  company.zip"/>
+                    </div>
+                </div>
+
+                <!-- Right: Contact Info -->
+                <div class="w-50 text-break text-end" style="font-size: 75%;">
+                    <div>
+                        <div t-if="company.vat" t-out="vatText"/>
+                        <div t-if="company.phone">
+                            Tel: <t t-out="company.phone"/>
+                        </div>
+                        <div t-if="company.email" t-out="company.email"/>
+                        <div t-if="company.website" t-out="company.website"/>
+                    </div>
+                </div>
             </div>
 
+            <div class="pos-receipt-order-data text-center pt-3">
+                <span>Powered by <b> Odoo </b></span>
+            </div>
         </div>
     </t>
 </templates>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
@@ -1,4 +1,3 @@
-import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
 
 export class ReceiptHeader extends Component {
@@ -12,16 +11,9 @@ export class ReceiptHeader extends Component {
     }
 
     get partnerAddress() {
-        return this.order.partner_id?.pos_contact_address.split(/\n\n+/).join("\n").split("\n");
-    }
-
-    get vatText() {
-        if (this.order.company.country_id?.vat_label) {
-            return _t("%(vatLabel)s: %(vatId)s", {
-                vatLabel: this.order.company.country_id.vat_label,
-                vatId: this.order.company.vat,
-            });
-        }
-        return _t("Tax ID: %(vatId)s", { vatId: this.order.company.vat });
+        return this.order.partner_id.pos_contact_address
+            .split("\n")
+            .filter((line) => line.trim() !== "")
+            .join(", ");
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -2,39 +2,31 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ReceiptHeader">
         <img t-attf-src="/web/image?model=res.company&amp;id={{order.company.id}}&amp;field=logo" alt="Logo" class="pos-receipt-logo"/>
-        <br/>
+        <div class="text-center pt-3" style="font-size: 75%;">
+            <span>
+                <t t-if="order.config._IS_VAT"> VAT </t>
+                Ticket
+                <t t-out="order.pos_reference"/>
+            </span>
+            <div t-if="order.date_order" id="order-date" t-out="order.formatDateOrTime('date_order')"/>
+        </div>
         <div class="d-flex flex-column align-items-center">
             <div class="pos-receipt-contact">
-                <!-- contact address -->
-                <div t-if="order.company?.name" t-esc="order.company.name" />
-                <t t-if="order.company.phone">
-                    <div>Tel:<t t-esc="order.company.phone" /></div>
-                </t>
-                <t t-if="order.company.vat">
-                    <div t-esc="vatText"/>
-                </t>
-                <div t-if="order.company.email" t-esc="order.company.email" />
-                <div t-if="order.company.website" t-esc="order.company.website" />
                 <div t-if="order.config.receipt_header" style="white-space:pre-line" t-esc="order.config.receipt_header" />
                 <div t-if="order?.getCashierName() and (!order.preset_id or order.preset_id.identification === 'name')" class="cashier">
-                    <div>--------------------------------</div>
                     <div>Served by: <t t-esc="order.getCashierName()" /></div>
                 </div>
-                <div t-if="order.preset_id?.identification !== 'none'">
-                    <div>--------------------------------</div>
-                    <t t-if="order.preset_id?.identification === 'name'"> Takeout for: <t t-esc="order.floatingOrderName" /><br/></t>
-                    <t t-elif="order.preset_id?.identification === 'address'"> Delivery to: <t t-esc="order.floatingOrderName" /><br/>
-                        <span t-foreach="partnerAddress" t-as="line" t-key="line_index">
-                            <t t-esc="line"/><br/>
-                        </span>
-                    </t>
-                    <t t-if="order.presetDateTime" t-out="order.presetDateTime" />
-                </div>
-            </div>
-            <div t-if="order.tracking_number">
-                <span class="tracking-number fs-1" t-esc="order.tracking_number" />
             </div>
         </div>
-        <br />
+        <div t-if="order?.presetDateTime" class="pt-2">
+            <span>
+                <t t-out="order.preset_id.name"/>: <t t-out="order.presetDateTime"/>
+            </span>
+        </div>
+        <div t-if="order.preset_id?.identification === 'address'" t-attf-class="{{ order?.presetDateTime ? '' : 'pt-2'}}">
+            <div class="text-break">
+                <span class="fw-bolder" t-out="order.partner_id.name"/> (<span t-out="partnerAddress"/>)
+            </div>
+        </div>
     </t>
 </templates>

--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -1,6 +1,6 @@
 .pos-receipt-print {
     width: 512px;
-    font-size: 27px;
+    font-size: 22px;
     color: #000000;
 }
 
@@ -34,12 +34,10 @@
 }
 
 .pos-receipt .pos-receipt-order-data {
-    text-align: center;
     font-size: 75%;
 }
 
 .pos-receipt .pos-receipt-amount {
-    font-size: 125%;
     text-align: start;
 }
 
@@ -85,4 +83,12 @@
 .pos-receipt .orderlines {
     /*rtl:ignore*/
     direction: ltr;
+}
+
+.pos-receipt-print .qty {
+    min-width: 3.5rem;
+}
+
+.pos-receipt-print .info-list {
+    margin-left: 1.5rem !important;
 }

--- a/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -3,55 +3,35 @@
 
     <t t-name="pos_coupon.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('pos-receipt')]//div[hasclass('before-footer')]" position="inside">
-            <t t-foreach="order.getLoyaltyPoints() or []" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">
-                <!-- Show only if portal_visible. -->
-                <div t-if="_loyaltyStat.program.portal_visible and (_loyaltyStat.points.won || _loyaltyStat.points.spent)" class='loyalty'>
-                    <span class="pos-receipt-center-align">
-                        <div>--------------------------------</div>
-                    </span>
-                    <t t-if='_loyaltyStat.points.won'>
-                        <div><t t-esc="_loyaltyStat.points.name"/> Won: <span t-esc='_loyaltyStat.points.won' class="pos-receipt-right-align"/></div>
-                    </t>
-                    <t t-if='_loyaltyStat.points.spent'>
-                        <div><t t-esc="_loyaltyStat.points.name"/> Spent: <span t-esc='_loyaltyStat.points.spent' class="pos-receipt-right-align"/></div>
-                    </t>
-                    <!-- Don't use points.total, it's wrong in this context (after the order synced). -->
-                    <!-- Show balance as it's updated during _postPushOrderResolve. -->
-                    <t t-if='_loyaltyStat.points.balance'>
-                        <div>Balance <t t-esc="_loyaltyStat.points.name"/>: <span t-esc='_loyaltyStat.points.balance' class="pos-receipt-right-align"/></div>
-                    </t>
-                </div>
-            </t>
-            <t t-if="order.partner_id">
-                <br/>
-                <div>Customer <span t-esc='order.partner_id.name' class='pos-receipt-right-align'/></div>
-            </t>
             <t t-if="order.new_coupon_info and order.new_coupon_info.length !== 0">
-                <div class="pos-coupon-rewards">
-                    <div>------------------------</div>
-                    <br/>
-                    <div>
-                        Coupon Codes
-                    </div>
+                <div class="pos-coupon-rewards pt-3">
                     <t t-foreach="order.new_coupon_info" t-as="coupon_info" t-key="coupon_info.code">
+                        <t t-if="order.partner_id and order.preset_id?.identification != 'address'">
+                            <div class="d-flex pb-1" style="font-size: 75%;">
+                                <span>Customer</span>
+                                <span t-out="order.partner_id.name" class="ms-auto fw-bolder"/>
+                            </div>
+                        </t>
                         <div class="coupon-container">
-                            <div style="font-size: 110%;">
-                                <t t-esc="coupon_info['program_name']"/>
-                            </div>
-                            <div>
-                                <span>Valid until: </span> 
-                                <t t-if="coupon_info['expiration_date']">
-                                    <t t-esc="coupon_info['expiration_date']"/>
-                                </t>
-                                <t t-else="">
-                                    no expiration
-                                </t>
-                            </div>
-                            <div>
-                                <img t-att-src="'/report/barcode/Code128/'+coupon_info['code']" style="width:200px;height:50px" alt="Barcode"/>
-                            </div>
-                            <div>
-                                <t t-esc="coupon_info['code']"/>
+                            <div class="row g-2">
+                                <div class="col-6">
+                                    <t t-out="coupon_info['program_name']"/>
+                                </div>
+                                <div class="col-6">
+                                    <img style="transform: translateX(13%);" t-att-src="'/report/barcode/Code128/'+coupon_info['code']" class="img-fluid" alt="Barcode"/>
+                                </div>
+                                <div class="col-6">
+                                    <span>Until: </span>
+                                    <t t-if="coupon_info['expiration_date']">
+                                        <t t-out="coupon_info['expiration_date']"/>
+                                    </t>
+                                    <t t-else="">
+                                        no expiration
+                                    </t>
+                                </div>
+                                <div class="col-6 text-end">
+                                    <t t-out="coupon_info['code']"/>
+                                </div>
                             </div>
                         </div>
                     </t>

--- a/addons/pos_loyalty/static/src/css/Loyalty.scss
+++ b/addons/pos_loyalty/static/src/css/Loyalty.scss
@@ -1,9 +1,3 @@
-.pos-receipt .pos-coupon-rewards {
-    text-align: center;
-    padding: 1em;
-}
-
 .pos-coupon-rewards .coupon-container {
-    padding-top: 1em;
     font-size: 75%;
 }

--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -36,4 +36,5 @@ class PosSession(models.Model):
     def _post_read_pos_self_data(self, data):
         if data:
             data[0]['_base_url'] = self.get_base_url()
+            data[0]['_self_order_pos'] = True
         return super()._post_read_pos_self_data(data)

--- a/addons/pos_self_order/static/src/app/self_order_index.scss
+++ b/addons/pos_self_order/static/src/app/self_order_index.scss
@@ -85,3 +85,7 @@ li {
 .touch-device * {
     cursor: none !important;
 }
+
+.pos-receipt .info-list {
+    padding-left: 2rem;
+}

--- a/addons/pos_self_order/static/src/overrides/components/receipt_header/receipt_header.xml
+++ b/addons/pos_self_order/static/src/overrides/components/receipt_header/receipt_header.xml
@@ -2,17 +2,18 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.ReceiptHeader" t-inherit="point_of_sale.ReceiptHeader" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('pos-receipt-contact')]" position="before">
-            <div t-if="order.preset_id or order.config.self_ordering_mode !== 'nothing'" class="picking-service text-center pb-2">
-                <span t-if="order.preset_id?.identification == 'none' or (!order.preset_id and order.config.self_ordering_service_mode == 'table')">Service at Table</span>
-                <span t-elif="order.preset_id?.identification == 'name' or (!order.preset_id and order.config.self_ordering_service_mode != 'table')">Pickup At Counter</span>
-                <span t-else="">Delivery</span>
-            </div>
-        </xpath>
-        <xpath expr="//div[hasclass('pos-receipt-contact')]" position="before">
-            <div t-if="order.config.self_ordering_mode !== 'nothing' and order.table_stand_number" class="table-tracker text-center pb-2">
-                Table Tracker:
-                <span class="pt-3" t-esc="order.table_stand_number" />
-            </div>
+            <t t-if="order.session?._self_order_pos">
+                <div t-if="order.preset_id or order.config.self_ordering_mode !== 'nothing'" class="picking-service text-center pt-3">
+                    <span t-if="order.preset_id?.identification == 'none' or (!order.preset_id and order.config.self_ordering_service_mode == 'table')">Service at Table</span>
+                    <span t-elif="order.preset_id?.identification == 'name' or (!order.preset_id and order.config.self_ordering_service_mode != 'table')">Pickup At Counter</span>
+                    <span t-else="">Delivery</span>
+                </div>
+                <h1 class="tracking-number text-center" style="font-size: 100px" t-out="order.tracking_number" />
+                <div t-if="order.config.self_ordering_mode !== 'nothing' and order.table_stand_number" class="table-tracker text-center">
+                    Table Tracker:
+                    <span class="pt-3" t-out="order.table_stand_number" />
+                </div>
+            </t>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION

`point_of_sale`, `l10n_co_pos`, `l10n_fr_pos_cert`, `pos_loyalty`, `pos_restaurant`, `pos_self_order`, `‎l10n_cl_edi_pos`, `‎pos_urban_piper`

In this commit:
===
- Aligned order lines with total, tax line, etc.
- font family changed to `monospace` for prices in ordelines.
- Removed loyalty point lines.
- Adjusted alignment of self-invoicing QR code and loyalty barcode code.
- Added company name and address in the footer, moving contact details from the header to the footer.
- Organized preset data properly in the header.
- Added VAT prefix in ticket if county is in `Europian union VAT` country group.
- `Untaxed Amount` text replaced with `Subtotal`.
- Order tracking number configured only to show on self-order or kiosk receipt.

Task: 4552788
Related PR: odoo/enterprise#81118