### PR TITLE
[FIX] point_of_sale: prevent duplicate lot numbers on receipts

### DIFF
--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -55,7 +55,7 @@
                             <t t-slot="pack-lot-icon" />
                         </div>
                         <div class="col ps-0">
-                            <li t-foreach="line.packLotLines or []" t-as="lot" t-key="lot_index" t-esc="lot" />
+                            <li class="lot-number" t-foreach="line.packLotLines or []" t-as="lot" t-key="lot_index" t-esc="lot" />
                         </div>
                     </div>
                     <t t-slot="default" />

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1223,6 +1223,7 @@ export class PosStore extends WithLazyGetterTrap {
             const newData = this.models.loadData(this.models, missingRecords, [], false);
 
             for (const line of newData["pos.order.line"]) {
+                line.pack_lot_ids = line.pack_lot_ids.filter((lot) => typeof lot.id === "number");
                 const refundedOrderLine = line.refunded_orderline_id;
 
                 if (refundedOrderLine && ["paid", "done"].includes(line.order_id.state)) {

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -172,6 +172,6 @@ registry.category("web_tour.tours").add("ReceiptTrackingMethodTour", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
-            ReceiptScreen.trackingMethodIsLot(),
+            ReceiptScreen.trackingMethodIsLot("123456789"),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -158,11 +158,16 @@ export function emailIsSuccessful() {
         },
     ];
 }
-export function trackingMethodIsLot() {
+export function trackingMethodIsLot(lot) {
     return [
         {
             content: `tracking method is Lot`,
-            trigger: `li:contains("Lot Number")`,
+            trigger: `li.lot-number:contains("Lot Number ${lot}")`,
+            run: function () {
+                if (document.querySelectorAll("li.lot-number").length !== 1) {
+                    throw new Error(`Expected exactly one 'Lot Number ${lot}' element.`);
+                }
+            },
         },
     ];
 }


### PR DESCRIPTION
- Filter pack_lot_ids to exclude non-numeric IDs when syncing data from the UI, ensuring lot numbers are not duplicated on the receipt.

task-id: 4633355


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
