### PR TITLE
[FIX] hr: fix error in `test_access_my_profile_toolbar`

### DIFF
--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -87,7 +87,8 @@ class TestSelfAccessProfile(TestHrCommon):
             'user_id': james.id,
         })
         view = self.env.ref('hr.res_users_view_form_profile')
-        available_actions = james.get_views([(view.id, 'form')], {'toolbar': True})['views']['form']['toolbar']['action']
+        toolbar = james.get_views([(view.id, 'form')], {'toolbar': True})['views']['form']['toolbar']
+        available_actions = toolbar.get('action', [])
         change_password_action = self.env.ref("base.change_password_wizard_action")
 
         self.assertFalse(any(x['id'] == change_password_action.id for x in available_actions))


### PR DESCRIPTION
Before this commit the test `test_access_my_profile_toolbar` was failing because there was no `action` available to the user in the toolbar. This commit changes the test to adapt to this situation.

Runbot Error: https://runbot.odoo.com/odoo/error/159894



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
