### PR TITLE
[FIX] web: avoid reloading the view we are leaving.

### DIFF
--- a/addons/web/static/src/views/view_button/view_button_hook.js
+++ b/addons/web/static/src/views/view_button/view_button_hook.js
@@ -80,8 +80,12 @@ export function useViewButtons(model, ref, options = {}) {
                     resIds,
                     context: params.context || {}, //LPE FIXME new Context(payload.env.context).eval();
                     buttonContext,
-                    onClose: async () => {
-                        if (!closeDialog && status(comp) !== "destroyed") {
+                    onClose: async (onCloseInfo) => {
+                        if (
+                            !closeDialog &&
+                            status(comp) !== "destroyed" &&
+                            !onCloseInfo?.noReload
+                        ) {
                             const reload = options.reload || (() => model.load());
                             await reload();
                         }

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -835,7 +835,7 @@ function makeActionManager(env) {
             controller.props.globalState = controller.action.globalState;
         }
 
-        const closingProm = _executeCloseAction();
+        const closingProm = _executeCloseAction({ onCloseInfo: { noReload: true } });
 
         if (options.clearBreadcrumbs && !options.noEmptyTransition) {
             const def = new Deferred();


### PR DESCRIPTION
- Install the CRM app;
- Activate leads from the settings;
- Create an opportunity with an email address;
- Create a lead with the same email address;
- Save the lead;
- Click on "Convert to Opportunity" (this opens a dialog);
- Choose "Merge with existing opportunities";
- Click on "Create Opportunity";

Before this commit, a record not found error notification is displayed. This is
because, when closing the dialog, we try to reload the current view and the
record doesn't exist any more. This causes an RPC to reload a view that we are
leaving, which is not ideal.

Now, we avoid reloading views that we are leaving when closing the dialog.

opw-4630624
