### PR TITLE
[FIX] l10n_ro_efactura: change field label

### DIFF
--- a/addons/l10n_ro_efactura/i18n/l10n_ro_efactura.pot
+++ b/addons/l10n_ro_efactura/i18n/l10n_ro_efactura.pot
@@ -109,6 +109,11 @@ msgstr ""
 #. module: l10n_ro_efactura
 #: model:ir.model.fields,field_description:l10n_ro_efactura.field_res_company__l10n_ro_edi_client_id
 #: model:ir.model.fields,field_description:l10n_ro_efactura.field_res_config_settings__l10n_ro_edi_client_id
+msgid "eFactura Client ID"
+msgstr ""
+
+#. module: l10n_ro_efactura
+#: model_terms:ir.ui.view,arch_db:l10n_ro_efactura.res_config_settings_form_inherit_l10n_ro_edi
 msgid "Client ID"
 msgstr ""
 

--- a/addons/l10n_ro_efactura/models/res_company.py
+++ b/addons/l10n_ro_efactura/models/res_company.py
@@ -15,7 +15,7 @@ from odoo.tools.safe_eval import json
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    l10n_ro_edi_client_id = fields.Char(string='Client ID')
+    l10n_ro_edi_client_id = fields.Char(string='eFactura Client ID')
     l10n_ro_edi_client_secret = fields.Char(string='Client Secret')
     l10n_ro_edi_access_token = fields.Char(string='Access Token')
     l10n_ro_edi_refresh_token = fields.Char(string='Refresh Token')

--- a/addons/l10n_ro_efactura/views/res_config_settings_views.xml
+++ b/addons/l10n_ro_efactura/views/res_config_settings_views.xml
@@ -49,7 +49,7 @@
                                 <field name="l10n_ro_edi_oauth_error" widget="text" class="w-100"/>
                             </div>
                             <div class="row">
-                                <label for="l10n_ro_edi_client_id" class="col-lg-3 o_light_label"/>
+                                <label for="l10n_ro_edi_client_id" string="Client ID" class="col-lg-3 o_light_label"/>
                                 <field name="l10n_ro_edi_client_id"/>
                             </div>
                             <div class="row">


### PR DESCRIPTION
The field `res.config.settings.l10n_ro_edi_client_id` [[1]](https://github.com/odoo/odoo/blob/63e0285ade407074c8e054d6d14a71b633d55f17/addons/l10n_ro_efactura/models/res_config_settings.py#L7C5-L7C26) [[2]](https://github.com/odoo/odoo/blob/63e0285ade407074c8e054d6d14a71b633d55f17/addons/l10n_ro_efactura/models/res_company.py#L18) in module `l10n_ro_efactura` has the same label `Client ID` as the field `res.config.settings.auth_oauth_google_client_id` [[3]](https://github.com/odoo/odoo/blob/63e0285ade407074c8e054d6d14a71b633d55f17/addons/auth_oauth/models/res_config_settings.py#L15C5-L15C32) from module `auth_oauth`.
Field labels should be unique on the same model so we can change the label and set it in the view where this setting is shown.

starting `saas-17.4` the change should be applied to module `l10n_ro_edi` as the efactura was merged in it


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
