### PR TITLE
[FIX] iot_box_image: incorrect touchscreen scaling

### DIFF
--- a/addons/iot_box_image/overwrite_after_init/etc/X11/xorg.conf
+++ b/addons/iot_box_image/overwrite_after_init/etc/X11/xorg.conf
@@ -1,7 +1,8 @@
 Section "ServerLayout"
     Identifier  "Multihead"
+    # place both at the same place to avoid touchscreens scale issues
+    Screen      1 "Screen1" 0 0
     Screen      0 "Screen0" 0 0
-    Screen      1 "Screen1" RightOf "Screen0"
 EndSection
 
 Section "Monitor"
@@ -31,6 +32,8 @@ Section "Screen"
     EndSubSection
 EndSection
 
+# Dummy is required to avoid lightdm to loop waiting for a signal from X
+# server when no monitor is connected
 Section "Screen"
     Identifier  "Screen1"
     Device      "DummyDevice"


### PR DESCRIPTION
Dummy display was misaligned (introduced back in odoo/odoo#191340), causing incorrect touch scaling. This fix aligns it with the real display to ensure proper touchscreen synchronization.

Task: 4636629
