### PR TITLE
[IMP] sale_stock: display related company in forecast report

### DIFF
--- a/addons/sale_stock/report/stock_forecasted.py
+++ b/addons/sale_stock/report/stock_forecasted.py
@@ -24,7 +24,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
                         'id': picking.sale_id.id,
                         'amount_untaxed': picking.sale_id.amount_untaxed,
                         'currency_id': picking.sale_id.currency_id.read(fields=['id', 'name'])[0],
-                        'partner_id': picking.sale_id.partner_id.read(fields=['id', 'name'])[0],
+                        'partner_id': picking.sale_id.partner_id.read(fields=['id', 'display_name'])[0],
                     }
                 }
             })

--- a/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
+++ b/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
@@ -18,7 +18,7 @@
         <xpath expr="//td[@name='usedby_cell']" position="inside">
             <span t-if="line.move_out and line.move_out.picking_id and line.move_out.picking_id.sale_id">
                 | <span t-out="_formatMonetary(line.move_out.picking_id.sale_id.amount_untaxed, line.move_out.picking_id.sale_id.currency_id.id)" class="fw-bold"/>
-                | <span t-out="line.move_out.picking_id.sale_id.partner_id.name"/>
+                | <span t-out="line.move_out.picking_id.sale_id.partner_id.display_name"/>
             </span>
         </xpath>
     </t>


### PR DESCRIPTION
The forecast report should include the company name of the sales order (SO) customer.

Task Id : 4596513