### PR TITLE
[FIX] l10n_in_ewaybill_stock: Missing tax detail for intra state

### DIFF
--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -508,27 +508,27 @@ class Ewaybill(models.Model):
                 0] or "OTH",
             "taxableAmount": AccountEDI._l10n_in_round_value(tax_details['total_excluded']),
         }
+        gst_types = ('sgst', 'cgst', 'igst')
+        gst_tax_rates = {}
         for tax in tax_details.get('taxes'):
-            gst_types = ['sgst', 'cgst', 'igst']
-            gst_tax_rates = {}
             for gst_type in gst_types:
                 if tax_rate := tax.get(f'{gst_type}_rate'):
                     gst_tax_rates.update({
                         f"{gst_type}Rate": AccountEDI._l10n_in_round_value(tax_rate)
                     })
-            line_details.update(
-                gst_tax_rates
-                or dict.fromkeys(
-                    [f"{gst_type}Rate" for gst_type in gst_types],
-                    0
-                )
-            )
             if cess_rate := tax.get("cess_rate"):
                 line_details.update({"cessRate": AccountEDI._l10n_in_round_value(cess_rate)})
             if cess_non_advol := tax.get("cess_non_advol_amount"):
                 line_details.update({
                     "cessNonadvol": AccountEDI._l10n_in_round_value(cess_non_advol)
                 })
+        line_details.update(
+            gst_tax_rates
+            or dict.fromkeys(
+                [f"{gst_type}Rate" for gst_type in gst_types],
+                0
+            )
+        )
         return line_details
 
     def _prepare_ewaybill_base_json_payload(self):


### PR DESCRIPTION
Use case:
When sending stock ewaybill with no taxes at that time government API is expecting the taxes values as `0`.

Issue:
When there is no tax applied we get an empty list due to which it doesn't set the default taxes to `0`

Fix:
We make sure if there no taxes then return a default taxes as `0`

opw-4639009



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
