### PR TITLE
[FIX] web,*: prevent adding link for m2o avatar in list

### DIFF
--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.js
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.js
@@ -47,6 +47,9 @@ registry.category("fields").add("many2one_avatar_employee", {
         return {
             ...extractM2OFieldProps(staticInfo, dynamicInfo),
             relation: staticInfo.options.relation,
+            canOpen: "no_open" in staticInfo.options
+                ? !staticInfo.options.no_open
+                : staticInfo.viewType === "form",
         };
     },
 });

--- a/addons/hr/static/tests/m2x_avatar_employee.test.js
+++ b/addons/hr/static/tests/m2x_avatar_employee.test.js
@@ -49,6 +49,7 @@ test("many2one in list view", async () => {
     expect(".o_data_cell div[name='employee_id']:eq(0)").toHaveText("Mario");
     expect(".o_data_cell div[name='employee_id']:eq(1)").toHaveText("Luigi");
     expect(".o_data_cell div[name='employee_id']:eq(2)").toHaveText("Mario");
+    expect("div[name='employee_id'] a").toHaveCount(0);
 
     // click on first employee avatar
     await contains(".o_data_cell .o_m2o_avatar > img:eq(0)").click();

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
@@ -42,9 +42,13 @@ registry.category("fields").add("many2one_avatar_user", {
     ...buildM2OFieldDescription(Many2OneAvatarUserField),
     additionalClasses: ["o_field_many2one_avatar"],
     extractProps(staticInfo, dynamicInfo) {
-        const props = extractM2OFieldProps(staticInfo, dynamicInfo);
-        props.withCommand = ["form", "list"].includes(staticInfo.viewType);
-        return props;
+        return {
+            ...extractM2OFieldProps(staticInfo, dynamicInfo),
+            withCommand: ["form", "list"].includes(staticInfo.viewType),
+            canOpen: "no_open" in staticInfo.options
+                ? !staticInfo.options.no_open
+                : staticInfo.viewType === "form",
+        };
     },
     listViewWidth: [110],
 });

--- a/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
@@ -60,6 +60,7 @@ test('many2one_avatar_user widget edited by the smart action "Assign to..."', as
     await openFormView("m2x.avatar.user", avatarUserId_1, {
         arch: "<form><field name='user_id' widget='many2one_avatar_user'/></form>",
     });
+    await contains(".o_field_many2one_avatar_user .o_external_button");
     await contains(".o_field_many2one_avatar_user input", { value: "Mario" });
     triggerHotkey("control+k");
     await click(".o_command", { text: "Assign to ...ALT + I" });
@@ -361,6 +362,8 @@ test("many2one_avatar_user widget in list view", async () => {
     await openListView("m2x.avatar.user", {
         arch: "<list><field name='user_id' widget='many2one_avatar_user'/></list>",
     });
+    await contains(".o_data_cell .o_many2one span");
+    await contains(".o_data_cell .o_many2one a", { count: 0 });
     await click(".o_data_cell .o_m2o_avatar > img");
     await contains(".o_avatar_card");
     await contains(".o_card_user_infos > span", { text: "Mario" });

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.js
@@ -2,7 +2,7 @@ import { Component } from "@odoo/owl";
 import { AvatarResource } from "@resource_mail/components/avatar_resource/avatar_resource";
 import { registry } from "@web/core/registry";
 import { computeM2OProps, Many2One } from "@web/views/fields/many2one/many2one";
-import { buildM2OFieldDescription, Many2OneField } from "@web/views/fields/many2one/many2one_field";
+import { buildM2OFieldDescription, extractM2OFieldProps, Many2OneField } from "@web/views/fields/many2one/many2one_field";
 
 export class Many2OneAvatarResourceField extends Component {
     static template = "resource_mail.Many2OneAvatarResourceField";
@@ -23,6 +23,14 @@ export class Many2OneAvatarResourceField extends Component {
 export const many2OneAvatarResourceField = {
     ...buildM2OFieldDescription(Many2OneAvatarResourceField),
     additionalClasses: ["o_field_many2one_avatar"],
+    extractProps(staticInfo, dynamicInfo) {
+        return {
+            ...extractM2OFieldProps(staticInfo, dynamicInfo),
+            canOpen: "no_open" in staticInfo.options
+                ? !staticInfo.options.no_open
+                : staticInfo.viewType === "form",
+        };
+    },
     fieldDependencies: [
         { name: "display_name", type: "char" },
         // to add in model that will use this widget for m2o field related to resource.resource record (as related field is only supported for x2m)

--- a/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
@@ -3,6 +3,7 @@ import {
     contains,
     openFormView,
     openKanbanView,
+    openListView,
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
@@ -91,6 +92,23 @@ test("many2one_avatar_resource widget in form view", async () => {
             </form>`,
     });
     expect(queryFirst(".o_material_resource")).toHaveClass("o_material_resource");
+    expect(".o_field_many2one_avatar_resource .o_external_button").toHaveCount(1);
+});
+
+test("many2one_avatar_resource widget in list view", async () => {
+    await start();
+    await openListView("resource.task", {
+        arch: `<list>
+                <field name="display_name"/>
+                <field name="resource_id" widget="many2one_avatar_resource"/>
+            </list>`,
+    });
+    await contains(".o_m2o_avatar", { count: 3 });
+    // fa-wrench should be displayed for the first task
+    await contains(".o_m2o_avatar > span.o_material_resource > i.fa-wrench");
+    // Second and third slots should display employee avatar
+    await contains(".o_field_many2one_avatar_resource img", { count: 2 });
+    await contains(".o_field_many2one_avatar_resource a", { count: 0 });
 });
 
 test("many2one_avatar_resource widget in kanban view", async () => {

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
@@ -22,7 +22,9 @@ registry.category("fields").add("many2one_avatar", {
     extractProps(staticInfo, dynamicInfo) {
         return {
             ...extractM2OFieldProps(staticInfo, dynamicInfo),
-            canOpen: staticInfo.viewType === "form",
+            canOpen: "no_open" in staticInfo.options
+                ? !staticInfo.options.no_open
+                : staticInfo.viewType === "form",
         };
     },
 });

--- a/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
@@ -277,6 +277,27 @@ test("readonly many2one_avatar in list view should not contain a link", async ()
     expect("[name='user_id'] a").toHaveCount(0);
 });
 
+test("readonly many2one_avatar in form view with no_open set to true", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form><field name="user_id" widget="many2one_avatar" readonly="1" options="{'no_open': 1}"/></form>`,
+    });
+
+    expect("[name='user_id'] a").toHaveCount(0);
+});
+
+test("readonly many2one_avatar in list view with no_open set to false", async () => {
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: `<list><field name="user_id" widget="many2one_avatar" options="{'no_open': 0}"/></list>`,
+    });
+
+    expect("[name='user_id'] a").toHaveCount(3);
+});
+
 test.tags("desktop");
 test("cancelling create dialog should clear value in the field", async () => {
     Users._views = {


### PR DESCRIPTION
*hr,mail,resource_mail

Since the commit [1], the many2one avatar widgets are clickable in list views and open the related record form view. This was an issue and it's fixed by this commit. But with the issue, we reintroduced the support of "no_open" for these widgets and this commit keeps the support.

task-4512123
task-4637916

[1]: https://github.com/odoo/odoo/pull/196785/commits/bcaa9e9b23d637edfe05baff83aea2ac18d9f4b2