### PR TITLE
[FIX] web, account: better handle records deletion from selection

### DIFF
--- a/addons/account/static/src/components/account_move_form/account_move_form.js
+++ b/addons/account/static/src/components/account_move_form/account_move_form.js
@@ -6,6 +6,7 @@ import { FormCompiler } from "@web/views/form/form_compiler";
 import { FormRenderer } from "@web/views/form/form_renderer";
 import { FormController } from '@web/views/form/form_controller';
 import { useService } from "@web/core/utils/hooks";
+import { deleteConfirmationMessage } from "@web/core/confirmation_dialog/confirmation_dialog";
 import {_t} from "@web/core/l10n/translation";
 
 
@@ -32,9 +33,9 @@ export class AccountMoveFormController extends FormController {
 
 
     async deleteRecord() {
-        if ( !await this.account_move_service.addDeletionDialog(this, this.model.root.resId)) {
-            return super.deleteRecord(...arguments);
-        }
+        const deleteConfirmationDialogProps = this.deleteConfirmationDialogProps;
+        deleteConfirmationDialogProps.body = await this.account_move_service.getDeletionDialogBody(deleteConfirmationMessage, this.model.root.resId);
+        this.deleteRecordsWithConfirmation(deleteConfirmationDialogProps, [this.model.root]);
     }
 }
 

--- a/addons/account/static/src/services/account_move_service.js
+++ b/addons/account/static/src/services/account_move_service.js
@@ -1,5 +1,4 @@
 import { _t } from "@web/core/l10n/translation";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { escape } from "@web/core/utils/strings";
 import { markup } from "@odoo/owl";
 import { registry } from "@web/core/registry";
@@ -16,16 +15,13 @@ export class AccountMoveService {
         this.orm = services.orm;
     }
 
-    async addDeletionDialog(component, moveIds) {
+    async getDeletionDialogBody(body, moveIds) {
         const isMoveEndOfChain = await this.orm.call("account.move", "check_move_sequence_chain", [moveIds]);
         if (!isMoveEndOfChain) {
             const message = _t("This operation will create a gap in the sequence.");
-            const confirmationDialogProps = component.deleteConfirmationDialogProps;
-            confirmationDialogProps.body = markup(`<div class="text-danger">${escape(message)}</div>${escape(confirmationDialogProps.body)}`);
-            this.dialog.add(ConfirmationDialog, confirmationDialogProps);
-            return true;
+            return markup(`<div class="text-danger">${escape(message)}</div>${escape(body)}`);
         }
-        return false;
+        return body;
     }
 
     async downloadPdf(accountMoveId, target = "download") {

--- a/addons/account/static/src/views/account_move_list/account_move_list_controller.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_controller.js
@@ -1,6 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { FileUploadListController } from "../file_upload_list/file_upload_list_controller";
 import { AccountFileUploader } from "@account/components/account_file_uploader/account_file_uploader";
+import { deleteConfirmationMessage } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 import { useService } from "@web/core/utils/hooks";
 
@@ -30,9 +31,17 @@ export class AccountMoveListController extends FileUploadListController {
     }
 
     async onDeleteSelectedRecords() {
+        const deleteConfirmationDialogProps = this.deleteConfirmationDialogProps;
         const selectedResIds = await this.model.root.getResIds(true);
-        if (this.props.resModel !== "account.move" || !await this.account_move_service.addDeletionDialog(this, selectedResIds)) {
-            return super.onDeleteSelectedRecords(...arguments);
+        if (this.props.resModel === "account.move") {
+            let body = deleteConfirmationMessage;
+            if (this.model.root.isDomainSelected || this.model.root.selection.length > 1) {
+                body = _t("Are you sure you want to delete these records?");
+            }
+            deleteConfirmationDialogProps.body = await this.account_move_service.getDeletionDialogBody(body, selectedResIds);
         }
+        this.deleteRecordsWithConfirmation(
+            deleteConfirmationDialogProps
+        );
     }
 }

--- a/addons/account/static/tests/account_move_form.test.js
+++ b/addons/account/static/tests/account_move_form.test.js
@@ -6,8 +6,8 @@ import {
     startServer,
     triggerHotkey
 } from "@mail/../tests/mail_test_helpers";
-import { test } from "@odoo/hoot";
-import { asyncStep, onRpc, waitForSteps } from "@web/../tests/web_test_helpers";
+import { expect, test } from "@odoo/hoot";
+import { asyncStep, contains, onRpc, waitForSteps } from "@web/../tests/web_test_helpers";
 import { defineAccountModels } from "./account_test_helpers";
 
 defineAccountModels();
@@ -35,4 +35,30 @@ test("When I switch tabs, it saves", async () => {
     triggerHotkey("Enter");
     await click('a[name="aml_tab"]');
     await waitForSteps(["tab saved"]);
+});
+
+test("Confirmation dialog on delete contains a warning", async () => {
+    const pyEnv = await startServer();
+    const accountMove = pyEnv["account.move"].create({ name: "move0" });
+    await start();
+    onRpc("account.move", "check_move_sequence_chain", () => {
+        return false;
+    });
+    await openFormView("account.move", accountMove, {
+        arch: `<form js_class='account_move_form'>
+            <sheet>
+                <notebook>
+                    <page id="invoice_tab" name="invoice_tab" string="Invoice Lines">
+                        <field name="name"/>
+                    </page>
+                    <page id="aml_tab" string="Journal Items" name="aml_tab"></page>
+                </notebook>
+            </sheet>
+        </form>`,
+    });
+    await contains(".o_cp_action_menus button").click();
+    await contains(".o_menu_item:contains(Delete)").click();
+    expect(".o_dialog div.text-danger").toHaveText("This operation will create a gap in the sequence.", {
+        message: "warning message has been added in the dialog"
+    });
 });

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -1,8 +1,4 @@
-import {
-    deleteConfirmationMessage,
-    AlertDialog,
-    ConfirmationDialog,
-} from "@web/core/confirmation_dialog/confirmation_dialog";
+import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { unique } from "@web/core/utils/arrays";
 import { DataPoint } from "./datapoint";
@@ -218,22 +214,6 @@ export class DynamicList extends DataPoint {
         } else {
             this.unarchive(isSelected);
         }
-    }
-
-    deleteRecordsWithConfirmation(dialogProps = {}, records) {
-        let body = deleteConfirmationMessage;
-        if (this.isDomainSelected || this.selection.length > 1) {
-            body = _t("Are you sure you want to delete these records?");
-        }
-        const defaultProps = {
-            body,
-            cancel: () => {},
-            cancelLabel: _t("No, keep it"),
-            confirm: () => this.deleteRecords(records),
-            confirmLabel: _t("Delete"),
-            title: _t("Bye-bye, record!"),
-        };
-        this.model.dialog.add(ConfirmationDialog, { ...defaultProps, ...dialogProps });
     }
 
     // -------------------------------------------------------------------------

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -1,9 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { hasTouch } from "@web/core/browser/feature_detection";
-import {
-    deleteConfirmationMessage,
-    ConfirmationDialog,
-} from "@web/core/confirmation_dialog/confirmation_dialog";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { makeContext } from "@web/core/context";
 import { useDebugCategory } from "@web/core/debug/debug_context";
 import { registry } from "@web/core/registry";
@@ -24,6 +21,7 @@ import { Field } from "@web/views/fields/field";
 import { useModel } from "@web/model/model";
 import { addFieldDependencies, extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
 import { useViewCompiler } from "@web/views/view_compiler";
+import { useDeleteRecords } from "@web/views/view_hook";
 import { Widget } from "@web/views/widgets/widget";
 import { STATIC_ACTIONS_GROUP_NUMBER } from "@web/search/action_menus/action_menus";
 
@@ -331,6 +329,8 @@ export class FormController extends Component {
         if (this.env.inDialog) {
             useFormViewInDialog();
         }
+
+        this.deleteRecordsWithConfirmation = useDeleteRecords(this.model);
     }
 
     get cogMenuProps() {
@@ -573,22 +573,17 @@ export class FormController extends Component {
 
     get deleteConfirmationDialogProps() {
         return {
-            title: _t("Bye-bye, record!"),
-            body: deleteConfirmationMessage,
             confirm: async () => {
                 await this.model.root.delete();
                 if (!this.model.root.resId) {
                     this.env.config.historyBack();
                 }
             },
-            confirmLabel: _t("Delete"),
-            cancel: () => {},
-            cancelLabel: _t("No, keep it"),
         };
     }
 
     async deleteRecord() {
-        this.dialogService.add(ConfirmationDialog, this.deleteConfirmationDialogProps);
+        this.deleteRecordsWithConfirmation(this.deleteConfirmationDialogProps, [this.model.root]);
     }
 
     async beforeExecuteActionButton(clickParams) {

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -15,7 +15,7 @@ import { useModelWithSampleData } from "@web/model/model";
 import { standardViewProps } from "@web/views/standard_view_props";
 import { MultiRecordViewButton } from "@web/views/view_button/multi_record_view_button";
 import { useViewButtons } from "@web/views/view_button/view_button_hook";
-import { useExportRecords } from "@web/views/view_hook";
+import { useExportRecords, useDeleteRecords } from "@web/views/view_hook";
 import { addFieldDependencies, extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
 import { KanbanCogMenu } from "./kanban_cog_menu";
 import { KanbanRenderer } from "./kanban_renderer";
@@ -207,6 +207,7 @@ export class KanbanController extends Component {
         this.exportRecords = useExportRecords(this.env, this.props.context, () =>
             this.getExportableFields()
         );
+        this.deleteRecordsWithConfirmation = useDeleteRecords(this.model);
     }
 
     get display() {
@@ -379,9 +380,7 @@ export class KanbanController extends Component {
                 icon: "fa fa-trash-o",
                 description: _t("Delete"),
                 callback: () =>
-                    this.model.root.deleteRecordsWithConfirmation(
-                        this.deleteConfirmationDialogProps
-                    ),
+                    this.deleteRecordsWithConfirmation(this.deleteConfirmationDialogProps),
             },
         };
     }
@@ -391,7 +390,7 @@ export class KanbanController extends Component {
     }
 
     deleteRecord(record) {
-        this.model.root.deleteRecordsWithConfirmation({}, [record]);
+        this.deleteRecordsWithConfirmation(this.deleteConfirmationDialogProps, [record]);
     }
 
     async openRecord(record, { newWindow } = {}) {

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -22,7 +22,7 @@ import { session } from "@web/session";
 import { ListCogMenu } from "./list_cog_menu";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { SelectionBox } from "@web/views/view_components/selection_box";
-import { useExportRecords } from "@web/views/view_hook";
+import { useExportRecords, useDeleteRecords } from "@web/views/view_hook";
 
 import {
     Component,
@@ -183,6 +183,7 @@ export class ListController extends Component {
         this.exportRecords = useExportRecords(this.env, this.props.context, () =>
             this.getExportableFields()
         );
+        this.deleteRecordsWithConfirmation = useDeleteRecords(this.model);
     }
 
     get modelParams() {
@@ -256,7 +257,7 @@ export class ListController extends Component {
     }
 
     onDeleteSelectedRecords() {
-        this.model.root.deleteRecordsWithConfirmation(this.deleteConfirmationDialogProps);
+        this.deleteRecordsWithConfirmation(this.deleteConfirmationDialogProps);
     }
 
     /**


### PR DESCRIPTION
This commit fixes the wrong implementation, breaking extensions of the
deletion feature from controllers. Now, a hook has been created instead
of implementing the feature in the DynamicList itself. Controllers can use
this hook easily, while having extension points like the deleteConfirmationDialogProps
getter.

A test has been added in the 'account' module for account_move deletion dialog
when a warning must be added before the main confirmation message.