### PR TITLE
[FIX] chat: fold conversation on mobile when redirecting to webpage

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -200,6 +200,9 @@ export class Chatbot extends Record {
         );
         if (!redirectionAlreadyDone) {
             browser.location.assign(answer.redirect_link);
+        } else if (this.store.env.services.ui.isSmall) {
+            await this.store.chatHub.initPromise;
+            this.store.ChatWindow.get({ thread: this.thread })?.fold();
         }
         return redirectionAlreadyDone || !isRedirecting;
     }

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { delay } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
     url: "/contactus",
@@ -39,6 +40,14 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
         {
             trigger:
                 ".o-livechat-root:shadow .o-mail-Message:contains('Go to the /chatbot-redirect page')",
+        },
+        {
+            isActive: ["mobile"], //chatwindow is folded on mobile
+            trigger: ".o-livechat-root:shadow .o-mail-ChatBubble[name='Redirection Bot']",
+            async run(helpers) {
+                await delay(500);
+                await helpers.click();
+            },
         },
         {
             trigger: ".o-livechat-root:shadow .o-mail-Message:last:contains('Tadam')",


### PR DESCRIPTION
**Current behavior before PR:**

When the chatbot redirects a visitor to a webpage on mobile, the chat window remains open, covering the redirected page. Making it difficult for the visitor to interact with the redirected page.

**Desired behavior after PR is merged:**

The conversation is automatically folded when the chatbot redirects a visitor to a webpage on mobile.

**Task**-4630719

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
