### PR TITLE
[FIX] website: prevent error when clicking optimize SEO button

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -825,6 +825,10 @@ class Website(Home):
         if request.env.user.has_group('website.group_website_restricted_editor'):
             record = record.sudo()
 
+        if any(field not in record._fields for field in fields):
+            res['can_edit_seo'] = False
+            return res
+
         res.update(record.read(fields)[0])
         res['has_social_default_image'] = request.website.has_social_default_image
 


### PR DESCRIPTION
Currently, an error occurs when clicking the optimize SEO button for the livechat page.

**Steps to reproduce:**
- Install the `website_livechat` module.
- Add menuitem with url `/livechat/channel/yourwebsite-com-1` as `livechat`.
- Go to the **Home** page and publish it using the `Published` button (shows `Optimize SEO` popup).
- Change the page to `livechat` and click the `Optimize SEO` button before it disappears.
- Observe the error.

**Error:**
`ValueError: Invalid field 'website_meta_title' on 'im_livechat.channel'`

The error occurs because the system attempts to update the default `fields` [1] on the current model at [2] who doesn't have the fields.

This commit ensures that if any required SEO fields are missing from the model, the system will return early with `can_edit_seo` set to `False`, thereby preventing the error.

[1] - https://github.com/odoo/odoo/blob/c87acdcfa48b1d8aa66bb5d27d58e3edb70a86ba/addons/website/controllers/main.py#L810

[2] - https://github.com/odoo/odoo/blob/c87acdcfa48b1d8aa66bb5d27d58e3edb70a86ba/addons/website/controllers/main.py#L824

Sentry - 6330105753

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
