### PR TITLE
[FIX] web: remove non-existent record from breadcrumb

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -26,6 +26,7 @@ import {
     reactive,
 } from "@odoo/owl";
 import { downloadReport, getReportUrl } from "./reports/utils";
+import { FetchRecordError } from "@web/model/relational_model/utils";
 
 class BlankComponent extends Component {
     static props = ["onMounted", "withControlPanel", "*"];
@@ -692,6 +693,14 @@ function makeActionManager(env) {
                     if (action.target === "new") {
                         removeDialogFn?.();
                     } else {
+                        if (controller?.jsId) {
+                            if (error?.cause instanceof FetchRecordError) {
+                                // remove error controller from breadcrumb
+                                controllerStack = controllerStack.filter(
+                                    (c) => c.jsId !== controller.jsId
+                                );
+                            }
+                        }
                         const lastCt = controllerStack[controllerStack.length - 1];
                         if (lastCt) {
                             if (lastCt.jsId !== controller.jsId) {

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -2332,8 +2332,9 @@ QUnit.module("ActionManager", (hooks) => {
 
         await click(target.querySelector(".o_data_row .o_data_cell"));
         assert.containsOnce(target, ".o_form_view");
+        await click(target.querySelector(".breadcrumb .breadcrumb-item .dropdown-toggle"));
         assert.deepEqual(getNodesTextContent(target.querySelectorAll(".breadcrumb-item")), [
-            "",
+            "Partners",
             "First record",
             "Partners",
         ]);
@@ -2347,8 +2348,9 @@ QUnit.module("ActionManager", (hooks) => {
         await click(target.querySelector(".o_dialog .modal-footer .btn-primary"));
 
         assert.containsOnce(target, ".o_form_view");
+        await click(target.querySelector(".breadcrumb .breadcrumb-item .dropdown-toggle"));
         assert.deepEqual(getNodesTextContent(target.querySelectorAll(".breadcrumb-item")), [
-            "",
+            "Partners",
             "First record",
             "Partners",
         ]);
@@ -2362,7 +2364,6 @@ QUnit.module("ActionManager", (hooks) => {
         await nextTick();
         assert.containsOnce(target, ".o_form_view");
         assert.deepEqual(getNodesTextContent(target.querySelectorAll(".breadcrumb-item")), [
-            "",
             "Partners",
             "Partners",
         ]);


### PR DESCRIPTION
In commit [1], when clicking on a deleted record in the breadcrumb was handled
correctly, a notification was displayed, and the previous controller was
restored.

However, the deleted record remained in the breadcrumb, and the name was
changed after the click (it took the same name as the previously restored
controller). This led to some confusion, and the possibility of clicking on the
deleted record again.

This commit, removes the deleted record from the breadcrumb.

[1]: https://github.com/odoo/odoo/commit/a7a7c150aa9bb6c3e36f3842d6df6f7316fe8e95

opw-4630624