### PR TITLE
[FIX] html_editor: perpetual mismatch editor-server values

### DIFF
--- a/addons/html_editor/i18n/html_editor.pot
+++ b/addons/html_editor/i18n/html_editor.pot
@@ -269,24 +269,28 @@ msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
+#: code:addons/html_editor/static/src/html_migrations/migration-1.2.js:0
 #: code:addons/html_editor/static/src/main/banner_plugin.js:0
 msgid "Banner Danger"
 msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
+#: code:addons/html_editor/static/src/html_migrations/migration-1.2.js:0
 #: code:addons/html_editor/static/src/main/banner_plugin.js:0
 msgid "Banner Info"
 msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
+#: code:addons/html_editor/static/src/html_migrations/migration-1.2.js:0
 #: code:addons/html_editor/static/src/main/banner_plugin.js:0
 msgid "Banner Success"
 msgstr ""
 
 #. module: html_editor
 #. odoo-javascript
+#: code:addons/html_editor/static/src/html_migrations/migration-1.2.js:0
 #: code:addons/html_editor/static/src/main/banner_plugin.js:0
 msgid "Banner Warning"
 msgstr ""

--- a/addons/html_editor/static/src/core/sanitize_plugin.js
+++ b/addons/html_editor/static/src/core/sanitize_plugin.js
@@ -8,7 +8,12 @@ import { Plugin } from "../plugin";
 
 export class SanitizePlugin extends Plugin {
     static id = "sanitize";
-    static shared = ["sanitize", "restoreSanitizedContentEditable"];
+    static shared = ["sanitize"];
+    resources = {
+        clean_for_save_handlers: this.cleanForSave.bind(this),
+        normalize_handlers: this.normalize.bind(this),
+    };
+
     setup() {
         if (!window.DOMPurify) {
             throw new Error("DOMPurify is not available");
@@ -30,9 +35,43 @@ export class SanitizePlugin extends Plugin {
         });
     }
 
-    restoreSanitizedContentEditable(root) {
-        for (const node of selectElements(root, ".o_not_editable, .o_editable")) {
-            node.contentEditable = node.matches(".o_editable");
+    normalize(element) {
+        for (const el of selectElements(
+            element,
+            ".o-contenteditable-false, .o-contenteditable-true"
+        )) {
+            el.contentEditable = el.matches(".o-contenteditable-true");
+        }
+        for (const el of selectElements(element, "[data-oe-role]")) {
+            el.setAttribute("role", el.dataset.oeRole);
+        }
+        for (const el of selectElements(element, "[data-oe-aria-label]")) {
+            el.setAttribute("aria-label", el.dataset.oeAriaLabel);
+        }
+    }
+
+    /**
+     * Ensure that attributes sanitized by the server are properly removed before
+     * the save, to avoid mismatches and a reset of the editable content.
+     * Only attributes under the responsibility (associated with an editor
+     * attribute or class) of the sanitize plugin are removed.
+     *
+     * /!\ CAUTION: using server-sanitized attributes without editor-specific
+     * classes/attributes in a custom plugin should be managed by that same
+     * custom plugin.
+     */
+    cleanForSave({ root }) {
+        for (const el of selectElements(
+            root,
+            ".o-contenteditable-false, .o-contenteditable-true"
+        )) {
+            el.removeAttribute("contenteditable");
+        }
+        for (const el of selectElements(root, "[data-oe-role]")) {
+            el.removeAttribute("role");
+        }
+        for (const el of selectElements(root, "[data-oe-aria-label]")) {
+            el.removeAttribute("aria-label");
         }
     }
 }

--- a/addons/html_editor/static/src/fields/html_viewer.js
+++ b/addons/html_editor/static/src/fields/html_viewer.js
@@ -61,9 +61,12 @@ export class HtmlViewer extends Component {
             });
         } else {
             this.readonlyElementRef = useRef("readonlyContent");
-            useEffect(() => {
-                this.retargetLinks(this.readonlyElementRef.el);
-            });
+            useEffect(
+                () => {
+                    this.processReadonlyContent(this.readonlyElementRef.el);
+                },
+                () => [this.props.config.value.toString(), this.readonlyElementRef?.el]
+            );
         }
 
         if (this.props.config.cssAssetId) {
@@ -119,6 +122,24 @@ export class HtmlViewer extends Component {
         return newVal;
     }
 
+    processReadonlyContent(container) {
+        this.retargetLinks(container);
+        this.applyAccessibilityAttributes(container);
+    }
+
+    /**
+     * Ensure that elements with accessibility editor attributes correctly get
+     * the standard accessibility attribute (aria-label, role).
+     */
+    applyAccessibilityAttributes(container) {
+        for (const el of container.querySelectorAll("[data-oe-role]")) {
+            el.setAttribute("role", el.dataset.oeRole);
+        }
+        for (const el of container.querySelectorAll("[data-oe-aria-label]")) {
+            el.setAttribute("aria-label", el.dataset.oeAriaLabel);
+        }
+    }
+
     /**
      * Ensure all links are opened in a new tab.
      */
@@ -139,7 +160,7 @@ export class HtmlViewer extends Component {
             ? contentWindow.document.documentElement
             : contentWindow.document.querySelector("#iframe_target");
         iframeTarget.innerHTML = content;
-        this.retargetLinks(iframeTarget);
+        this.processReadonlyContent(iframeTarget);
     }
 
     onLoadIframe(value) {

--- a/addons/html_editor/static/src/html_migrations/manifest.js
+++ b/addons/html_editor/static/src/html_migrations/manifest.js
@@ -1,7 +1,9 @@
 import { registry } from "@web/core/registry";
 
+const html_upgrade = registry.category("html_editor_upgrade");
+
 // Remove the Excalidraw EmbeddedComponent and replace it with a link.
-registry
-    .category("html_editor_upgrade")
-    .category("1.1")
-    .add("html_editor", "@html_editor/html_migrations/migration-1.1");
+html_upgrade.category("1.1").add("html_editor", "@html_editor/html_migrations/migration-1.1");
+
+// Fix Banner classes to properly handle `contenteditable` attribute
+html_upgrade.category("1.2").add("html_editor", "@html_editor/html_migrations/migration-1.2");

--- a/addons/html_editor/static/src/html_migrations/migration-1.2.js
+++ b/addons/html_editor/static/src/html_migrations/migration-1.2.js
@@ -1,0 +1,47 @@
+import { _t } from "@web/core/l10n/translation";
+
+const ARIA_LABELS = {
+    ".o_editor_banner.alert-danger": _t("Banner Danger"),
+    ".o_editor_banner.alert-info": _t("Banner Info"),
+    ".o_editor_banner.alert-success": _t("Banner Success"),
+    ".o_editor_banner.alert-warning": _t("Banner Warning"),
+};
+
+function getAriaLabel(element) {
+    for (const [selector, ariaLabel] of Object.entries(ARIA_LABELS)) {
+        if (element.matches(selector)) {
+            return ariaLabel;
+        }
+    }
+}
+
+/**
+ * Replace the `o_editable` and `o_not_editable` on `banner` elements by
+ * `o-contenteditable-true` and `o-content-editable-false`.
+ * Add `o_editor_banner_content` to the content parent element.
+ * Add accessibility editor-specific attributes (data-oe-role and
+ * data-oe-aria-label).
+ *
+ * @param {HTMLElement} container
+ */
+export function upgrade(container) {
+    const bannerContainers = container.querySelectorAll(".o_editor_banner");
+    for (const bannerContainer of bannerContainers) {
+        bannerContainer.classList.remove("o_not_editable");
+        bannerContainer.classList.add("o-contenteditable-false");
+        bannerContainer.dataset.oeRole = "status";
+        const icon = bannerContainer.querySelector(".o_editor_banner_icon");
+        if (icon) {
+            const ariaLabel = getAriaLabel(bannerContainer);
+            if (ariaLabel) {
+                icon.dataset.oeAriaLabel = ariaLabel;
+            }
+        }
+        const bannerContent = bannerContainer.querySelector(".o_editor_banner_icon ~ div");
+        if (bannerContent) {
+            bannerContent.classList.remove("o_editable");
+            bannerContent.classList.add("o_editor_banner_content");
+            bannerContent.classList.add("o-contenteditable-true");
+        }
+    }
+}

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -10,9 +10,9 @@ function isAvailable(selection) {
 }
 export class BannerPlugin extends Plugin {
     static id = "banner";
+    // sanitize plugin is required to handle `contenteditable` attribute.
     static dependencies = ["baseContainer", "history", "dom", "emoji", "selection", "sanitize"];
     resources = {
-        normalize_handlers: this.normalize.bind(this),
         user_commands: [
             {
                 id: "banner_info",
@@ -92,9 +92,9 @@ export class BannerPlugin extends Plugin {
         const baseContainerHtml = baseContainer.outerHTML;
         const bannerElement = parseHTML(
             this.document,
-            `<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" role="status">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="${title}">${emoji}</i>
-                <div class="w-100 px-3 o_editable">
+            `<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" data-oe-role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="${title}">${emoji}</i>
+                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
                     ${baseContainerHtml}
                 </div>
             </div`
@@ -102,15 +102,15 @@ export class BannerPlugin extends Plugin {
         this.dependencies.dom.insert(bannerElement);
         // If the first child of editable is contenteditable false element
         // a chromium bug prevents selecting the container.
-        // Add a paragraph above it so it's no longer the first child.
+        // Add a baseContainer above it so it's no longer the first child.
         if (this.editable.firstChild === bannerElement) {
-            const p = this.document.createElement("p");
-            p.append(this.document.createElement("br"));
-            bannerElement.before(p);
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.append(this.document.createElement("br"));
+            bannerElement.before(baseContainer);
         }
         const baseContainerName = this.dependencies.baseContainer.getDefaultNodeName();
         this.dependencies.selection.setCursorStart(
-            bannerElement.querySelector(`.o_editor_banner > div > ${baseContainerName}`)
+            bannerElement.querySelector(`.o_editor_banner_content > ${baseContainerName}`)
         );
         this.dependencies.history.addStep();
     }
@@ -123,9 +123,5 @@ export class BannerPlugin extends Plugin {
                 this.dependencies.history.addStep();
             },
         });
-    }
-
-    normalize(root) {
-        this.dependencies.sanitize.restoreSanitizedContentEditable(root);
     }
 }

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -17,9 +17,9 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     await press("enter");
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3 o_editable" contenteditable="true">
+            `<p>Test</p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
                     </div>
                 </div><p><br></p>`
@@ -49,9 +49,9 @@ test("should insert a banner with DIV as basecontainer and focus inside it", asy
     expect(unformat(getContent(el))).toBe(
         unformat(
             `<div class="o-paragraph">Test</div>
-            <div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3 o_editable" contenteditable="true">
+            <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                     <div class="o-paragraph o-we-hint" placeholder='Type "/" for commands'>[]<br></div>
                 </div>
             </div>
@@ -72,9 +72,9 @@ test("press 'ctrl+a' inside a banner should select all the banner content", asyn
     await press(["ctrl", "a"]);
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3 o_editable" contenteditable="true">
+            `<p>Test</p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>[Test1</p><p>Test2]<br></p>
                     </div>
                 </div><p><br></p>`
@@ -94,9 +94,9 @@ test("remove all content should preserves the first paragraph tag inside the ban
     await press(["ctrl", "a"]);
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3 o_editable" contenteditable="true">
+            `<p>Test</p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>[Test1</p><p>Test2]<br></p>
                     </div>
                 </div><p><br></p>`
@@ -106,9 +106,9 @@ test("remove all content should preserves the first paragraph tag inside the ban
     await press("Backspace");
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3 o_editable" contenteditable="true"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></div>
+            `<p>Test</p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></div>
                 </div><p><br></p>`
         )
     );
@@ -121,9 +121,9 @@ test("Inserting a banner at the top of the editable also inserts a paragraph abo
     expect(unformat(getContent(el))).toBe(
         unformat(
             `<p><br></p>
-            <div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3 o_editable" contenteditable="true">
+            <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                     <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
                 </div>
             </div>
@@ -134,8 +134,8 @@ test("Inserting a banner at the top of the editable also inserts a paragraph abo
 
 test("Everything gets selected with ctrl+a, including a contenteditable=false as first element", async () => {
     const { el } = await setupEditor(
-        `<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+        `<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                 <div class="w-100 px-3" contenteditable="true">
                     <p><br></p>
                 </div>
@@ -144,8 +144,8 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     await press(["ctrl", "a"]);
     await animationFrame();
     expect(getContent(el)).toBe(
-        `[<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
+        `[<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                 <div class="w-100 px-3" contenteditable="true">
                     <p><br></p>
                 </div>
@@ -166,9 +166,9 @@ test("Everything gets selected with ctrl+a, including a banner", async () => {
     await insertText(editor, "Test2");
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        `<p>[<br></p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3 o_editable" contenteditable="true">
+        `<p>[<br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                     <p><br></p>
                 </div>
             </div><p>Test1</p><p>Test2]<br></p>`,
@@ -183,11 +183,11 @@ test("Everything gets selected with ctrl+a, including a banner", async () => {
 
 test("Everything gets selected with ctrl+a, including a contenteditable=false as first two elements", async () => {
     const { el } = await setupEditor(
-        '<div contenteditable="false">a</div><div contenteditable="false">b</div><p>cd[]</p>'
+        '<div data-oe-role="status" contenteditable="false" role="status">a</div><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd[]</p>'
     );
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        '[<div contenteditable="false">a</div><div contenteditable="false">b</div><p>cd]</p>'
+        '[<div data-oe-role="status" contenteditable="false" role="status">a</div><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd]</p>'
     );
 
     await press("Backspace");
@@ -219,9 +219,9 @@ test("add banner inside empty list", async () => {
     await press("enter");
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<ul><li><br><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3 o_editable" contenteditable="true">
+            `<ul><li><br><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
                     </div>
                 </div><br></li></ul>`
@@ -235,9 +235,9 @@ test("add banner inside non-empty list", async () => {
     await press("enter");
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<ul><li>Test<div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
-                    <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                    <div class="w-100 px-3 o_editable" contenteditable="true">
+            `<ul><li>Test<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
                     </div>
                 </div><br></li></ul>`

--- a/addons/html_editor/static/tests/field.test.js
+++ b/addons/html_editor/static/tests/field.test.js
@@ -17,7 +17,7 @@ describe("monetary field", () => {
             stepFunction: deleteBackward,
             contentAfter: unformat(`
                 <p>
-                    <span data-oe-model="product.template" data-oe-id="27" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable" contenteditable="true">
+                    <span data-oe-model="product.template" data-oe-id="27" data-oe-field="list_price" data-oe-type="monetary" data-oe-expression="product.list_price" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable">
                         $&nbsp;
                         <span class="oe_currency_value">[]</span>
                     </span>

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -565,6 +565,60 @@ test("create new record and load it correctly", async () => {
     expect(".odoo-editor-editable").toHaveInnerHTML("<p>2</p>");
 });
 
+test("edit a html field with `o-contenteditable-true` or `o-contenteditable-false` in its content should not reset the editable value when saving", async () => {
+    patchWithCleanup(HtmlField.prototype, {
+        updateValue() {
+            expect.step("update_value");
+            super.updateValue(...arguments);
+        },
+    });
+    patchWithCleanup(Wysiwyg.prototype, {
+        setup() {
+            super.setup();
+            // This should not be called again after the edit (if it is, it
+            // means that the content was reset from the server value, and that
+            // an entirely new editor replaced the previous one).
+            expect.step("setup_wysiwyg");
+        },
+    });
+    const getTxtValue = (innerContent, withContentEditable = false) =>
+        `<div class="o-contenteditable-false"${
+            withContentEditable ? ' contenteditable="false"' : ""
+        }>outside<div class="o-contenteditable-true"${
+            withContentEditable ? ' contenteditable="true"' : ""
+        }><p>${innerContent}</p></div></div>`;
+    Partner._records = [
+        {
+            id: 1,
+            txt: getTxtValue("inside"),
+        },
+    ];
+    onRpc("partner", "web_save", ({ args }) => {
+        expect.step("web_save");
+        // server representation removes `contenteditable` attribute
+        let txt = args[1].txt;
+        txt = txt.replace(` contenteditable="true"`, "");
+        txt = txt.replace(` contenteditable="false"`, "");
+        return [{ id: 1, txt }];
+    });
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+    expect.verifySteps(["setup_wysiwyg"]);
+    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(getTxtValue("inside", true));
+    setSelectionInHtmlField();
+    pasteOdooEditorHtml(htmlEditor, "addon");
+    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(getTxtValue("addoninside", true));
+    await clickSave();
+    expect.verifySteps(["update_value", "web_save"]);
+});
+
 test.tags("focus required");
 test("edit html field and blur multiple time should apply 1 onchange", async () => {
     const def = new Deferred();

--- a/addons/html_editor/static/tests/html_migrations.test.js
+++ b/addons/html_editor/static/tests/html_migrations.test.js
@@ -1,5 +1,6 @@
 import { HtmlField } from "@html_editor/fields/html_field";
-import { beforeEach, describe, expect, test } from "@odoo/hoot";
+import { htmlEditorVersions } from "@html_editor/html_migrations/html_migrations_utils";
+import { beforeEach, describe, expect, getFixture, test } from "@odoo/hoot";
 import {
     defineModels,
     fields,
@@ -8,6 +9,9 @@ import {
     patchWithCleanup,
 } from "@web/../tests/web_test_helpers";
 
+const VERSIONS = htmlEditorVersions();
+const CURRENT_VERSION = VERSIONS.at(-1);
+
 class Partner extends models.Model {
     txt = fields.Html({ trim: true });
     name = fields.Char();
@@ -15,10 +19,34 @@ class Partner extends models.Model {
     _records = [
         {
             id: 1,
-            name: "first",
+            name: "excalidraw",
             txt: `<p>Hello World</p><div data-embedded="draw" data-embedded-props='{"source": "https://excalidraw.com"}'/>`,
         },
+        {
+            id: 2,
+            name: "banner",
+            txt: `
+                <p>test</p>
+                <div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3">
+                    <i class="o_editor_banner_icon mb-3 fst-normal">💡</i>
+                    <div class="w-100 px-3 o_editable">
+                        <p>content</p>
+                    </div>
+                </div>`,
+        },
     ];
+}
+
+async function mountViewWithRecord({ resId, readonly }) {
+    return mountView({
+        type: "form",
+        resId,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"${readonly ? ' readonly="1"' : ""}/>
+            </form>`,
+    });
 }
 
 defineModels([Partner]);
@@ -33,38 +61,58 @@ describe("test the migration process", () => {
             },
         });
     });
+
     describe("In html field", () => {
         test("Excalidraw EmbeddedComponent is replaced by a link (editable)", async () => {
-            await mountView({
-                type: "form",
-                resId: 1,
-                resModel: "partner",
-                arch: `
-                    <form>
-                        <field name="txt" widget="html"/>
-                    </form>`,
-            });
+            await mountViewWithRecord({ resId: 1 });
             expect("[data-embedded='draw']").toHaveCount(0);
             expect("a[href='https://excalidraw.com']").toHaveCount(1);
             expect(htmlFieldComponent.editor.getContent()).toBe(
-                `<p data-oe-version="1.1">Hello World</p><p><a href="https://excalidraw.com">https://excalidraw.com</a></p>`
+                `<p data-oe-version="${CURRENT_VERSION}">Hello World</p><p><a href="https://excalidraw.com">https://excalidraw.com</a></p>`
+            );
+        });
+        test("Banner classes are properly updated (editable)", async () => {
+            await mountViewWithRecord({ resId: 2 });
+            const fixture = getFixture();
+            expect(fixture.querySelector(".odoo-editor-editable")).toHaveInnerHTML(
+                `<p>test</p>
+                <div class="o_editor_banner user-select-none lh-1 d-flex align-items-center alert alert-info pb-0 pt-3 o-contenteditable-false" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3 o_editor_banner_content o-contenteditable-true" contenteditable="true">
+                        <p>content</p>
+                    </div>
+                </div>`
+            );
+            expect(htmlFieldComponent.editor.getContent()).toBe(
+                `<p data-oe-version="${CURRENT_VERSION}">test</p>
+                <div class="o_editor_banner user-select-none lh-1 d-flex align-items-center alert alert-info pb-0 pt-3 o-contenteditable-false" data-oe-role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3 o_editor_banner_content o-contenteditable-true">
+                        <p>content</p>
+                    </div>
+                </div>`
             );
         });
     });
 
     describe("In html viewer", () => {
         test("Excalidraw EmbeddedComponent is replaced by a link (readonly)", async () => {
-            await mountView({
-                type: "form",
-                resId: 1,
-                resModel: "partner",
-                arch: `
-                    <form>
-                        <field name="txt" widget="html" readonly="1"/>
-                    </form>`,
-            });
+            await mountViewWithRecord({ resId: 1, readonly: true });
             expect("[data-embedded='draw']").toHaveCount(0);
             expect("a[href='https://excalidraw.com']").toHaveCount(1);
+        });
+        test("Banner classes are properly updated (readonly)", async () => {
+            await mountViewWithRecord({ resId: 2, readonly: true });
+            const fixture = getFixture();
+            expect(fixture.querySelector(".o_readonly")).toHaveInnerHTML(
+                `<p>test</p>
+                <div class="o_editor_banner user-select-none lh-1 d-flex align-items-center alert alert-info pb-0 pt-3 o-contenteditable-false" data-oe-role="status" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="w-100 px-3 o_editor_banner_content o-contenteditable-true">
+                        <p>content</p>
+                    </div>
+                </div>`
+            );
         });
     });
 });

--- a/addons/html_editor/static/tests/sanitize.test.js
+++ b/addons/html_editor/static/tests/sanitize.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { setupEditor } from "./_helpers/editor";
+import { setupEditor, testEditor } from "./_helpers/editor";
 
 test("sanitize should remove nasty elements", async () => {
     const { editor } = await setupEditor("");
@@ -10,4 +10,28 @@ test("sanitize should remove nasty elements", async () => {
     expect(
         editor.shared.sanitize.sanitize("<p>abc<iframe//src=jAva&Tab;script:alert(3)>def</p>")
     ).toBe("<p>abc</p>");
+});
+
+test("sanitize plugin should handle contenteditable attribute with o-contenteditable-[true/false] class", async () => {
+    await testEditor({
+        contentBefore: `<p class="o-contenteditable-true">a[]</p><p class="o-contenteditable-false">b</p>`,
+        contentAfterEdit: `<p class="o-contenteditable-true" contenteditable="true">a[]</p><p class="o-contenteditable-false" contenteditable="false">b</p>`,
+        contentAfter: `<p class="o-contenteditable-true">a[]</p><p class="o-contenteditable-false">b</p>`,
+    });
+});
+
+test("sanitize plugin should handle role attribute with data-oe-role attribute", async () => {
+    await testEditor({
+        contentBefore: `<p data-oe-role="status">a[]</p>`,
+        contentAfterEdit: `<p data-oe-role="status" role="status">a[]</p>`,
+        contentAfter: `<p data-oe-role="status">a[]</p>`,
+    });
+});
+
+test("sanitize plugin should handle aria-label attribute with data-oe-aria-label attribute", async () => {
+    await testEditor({
+        contentBefore: `<p data-oe-aria-label="status">a[]</p>`,
+        contentAfterEdit: `<p data-oe-aria-label="status" aria-label="status">a[]</p>`,
+        contentAfter: `<p data-oe-aria-label="status">a[]</p>`,
+    });
 });

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -62,6 +62,7 @@ safe_attrs = defs.safe_attrs | frozenset(
      'data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-type', 'data-oe-expression', 'data-oe-translation-source-sha', 'data-oe-nodeid',
      'data-last-history-steps', 'data-oe-protected', 'data-embedded', 'data-embedded-editable', 'data-embedded-props', 'data-oe-version',
      'data-oe-transient-content', 'data-behavior-props', 'data-prop-name', 'data-width', 'data-height', 'data-scale-x', 'data-scale-y', 'data-x', 'data-y',  # legacy editor
+     'data-oe-role', 'data-oe-aria-label',
      'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
      'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
      'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',


### PR DESCRIPTION
Prior to this commit, using a `/banner` block would create elements that always
have `contenteditable` attributes when saving, that are always different from
the server value which removes these `contenteditable` attributes, resulting in
a new `Wysiwyg` instance being constructed after each `save`.

Resolution:
1- Introduce new classes to handle the `contenteditable` attribute:
  `o-contenteditable-true` and `o-contenteditable-false` to avoid a namespace
  conflict with `website` specific features. They replace `o_editable` and
  `o_not_editable` for the `banner` block.
2- Ensure that `contenteditable` attribute handled by these classes are removed
  during `cleanForSave`, to create a value comparable to the server value. This
  is because the server sanitizes the `contenteditable` attribute. If both
  compared values are not equal, the current `Wysiwyg` and `Editor` instances
  would be fully replaced after each save, resulting in a loss of edition
  history. This should ideally never happen.
3- Ensure the attributes `role` and `aria-label` which are also sanitized by the
  server are removed during `cleanForSave` and maintained during
  `normalize` through `data-oe-role` and `data-oe-aria-label`.
4- Introduce a `o_editor_banner_content` class for the `banner` content, for
  ease of selector creation.
5- Ensure that the `baseContainer` created before the `banner` if it is the
  first element in the `editable` has the proper `tagName` based on the
  `HtmlField` configuration.

A `html_migrations` version is added to adjust existing `banners` to the new
classes usage.

task-4640490