### PR TITLE
[FIX] html_editor: prevent protocol mismatch error in link preview

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -89,6 +89,10 @@ async function fetchInternalMetaData(url) {
     // Get the internal metadata
     const keepLastPromise = new KeepLast();
     const urlParsed = new URL(url);
+    // Enforce the current page's protocol to prevent mixed content issues.
+    if (urlParsed.protocol !== window.location.protocol) {
+        urlParsed.protocol = window.location.protocol;
+    }
 
     const result = await keepLastPromise
         .add(fetch(urlParsed))


### PR DESCRIPTION
### Current behavior before PR:

- Changing the protocol (http ↔ https) of an internal link in the editor caused a traceback due to a failed fetch request.

### Desired behavior after PR is merged:

- The URL now always follows the current page's protocol, preventing mixed content issues and fetch errors.

task-4531783

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
