### PR TITLE
[FIX] website_sale: display product images that aren't video

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2988,22 +2988,7 @@
 
     <template id="website_sale.shop_product_image">
         <div
-            t-if="'video_url' in product_image"
-            t-att-data-oe-model="product_image._name"
-            t-att-data-oe-id="product_image.id"
-            t-att-class="image_classes + ' ratio ratio-16x9'"
-        >
-            <div class="media_iframe_video">
-                <div class="css_editable_mode_display"/>
-                <div class="media_iframe_video_size" contenteditable="false"/>
-                <iframe
-                    t-att-src="product_image.video_url"
-                    allowfullscreen="allowfullscreen">
-                </iframe>
-            </div>
-        </div>
-        <div
-            t-elif="product_image._name == 'product.image' and product_image.embed_code"
+            t-if="product_image._name == 'product.image' and product_image.embed_code"
             t-att-class="image_classes + ' ratio ratio-16x9'"
         >
             <t t-out="product_image.embed_code"/>


### PR DESCRIPTION
Versions
--------
- saas-18.2+

Steps
-----
1. Go to a front-end product page;
2. open editor;
3. add extra product image;
4. save;
5. try to view extra image in carousel.

Issue
-----
Image doesn't get displayed.

Cause
-----
Commit 2bcff9dda3e45 added  support for adding videos as extra media. To decide whether an object is a video, it currently just checks if it has a `video_url` key, but not whether it has an actual value.

Solution
--------
The intended code suggested in a review (https://github.com/odoo/odoo/pull/189396#discussion_r1914977614) was added in a `t-elif` branch instead of replacing the `t-if` code. Using this branch would fix the issue.

opw-4625008