### PR TITLE
[IMP] im_livechat: conversation failure report statistic

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -56,6 +56,8 @@ Help your customers with this chat, and analyse their feedback.
         "demo/im_livechat_channel/im_livechat_session_9.xml",
         "demo/im_livechat_channel/im_livechat_session_10.xml",
         "demo/im_livechat_channel/im_livechat_session_11.xml",
+        "demo/im_livechat_channel/im_livechat_session_12.xml",
+        "demo/im_livechat_channel/im_livechat_session_13.xml",
     ],
     'depends': ["mail", "rating", "digest", "utm"],
     'installable': True,

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
@@ -5,6 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #234, Odoo</field>
             <field name="anonymous_name">Visitor #234</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
@@ -5,6 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #235, Odoo</field>
             <field name="anonymous_name">Visitor #235</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
@@ -5,6 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="livechat_failure">no_agent</field>
             <field name="name">Visitor #236, Odoo</field>
             <field name="anonymous_name">Visitor #235</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
@@ -6,6 +6,7 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="channel_type">livechat</field>
             <field name="anonymous_name">Visitor</field>
             <field name="country_id" ref="base.be"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
@@ -5,6 +5,7 @@
             <field name="name">Visitor, Mitchell Admin</field>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="create_date" eval="datetime.now()"/>
             <field name="channel_type">livechat</field>
             <field name="anonymous_name">Visitor</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_12.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_12.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record id="livechat_channel_session_12" model="discuss.channel">
+            <field name="name">Visitor, Mitchell Admin</field>
+            <field name="livechat_operator_id" ref="base.partner_admin"/>
+            <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
+            <field name="livechat_failure">no_answer</field>
+            <field name="create_date" eval="datetime.now()"/>
+            <field name="channel_type">livechat</field>
+            <field name="anonymous_name">Visitor</field>
+            <field name="country_id" ref="base.us"/>
+        </record>
+        <record id="im_livechat.livechat_channel_session_12_member_admin" model="discuss.channel.member">
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="channel_id" ref="im_livechat.livechat_channel_session_12"/>
+            <field name="livechat_member_type">agent</field>
+        </record>
+        <record id="im_livechat.livechat_channel_session_12_guest" model="mail.guest">
+            <field name="name">Visitor</field>
+        </record>
+        <record id="im_livechat.livechat_channel_session_12_member_guest" model="discuss.channel.member">
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_12_guest"/>
+            <field name="channel_id" ref="im_livechat.livechat_channel_session_12"/>
+            <field name="livechat_member_type">visitor</field>
+        </record>
+
+        <record id="livechat_channel_session_12_message_1" model="mail.message">
+            <field name="author_guest_id" ref="im_livechat.livechat_channel_session_12_guest"/>
+            <field name="author_id"/>
+            <field name="record_name">Visitor</field>
+            <field name="date" eval="datetime.now()"/>
+            <field name="create_date" eval="datetime.now()"/>
+            <field name="write_date" eval="datetime.now()"/>
+            <field name="body">Hello? Anybody there?</field>
+            <field name="email_from">Visitor</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="res_id" ref="im_livechat.livechat_channel_session_12"/>
+            <field name="model">discuss.channel</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record id="livechat_channel_session_13" model="discuss.channel">
+            <field name="name">Visitor, Mitchell Admin</field>
+            <field name="livechat_operator_id" ref="base.partner_admin"/>
+            <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
+            <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
+            <field name="livechat_failure">no_answer</field>
+            <field name="channel_type">livechat</field>
+            <field name="anonymous_name">Visitor</field>
+            <field name="country_id" ref="base.be"/>
+        </record>
+        <record id="im_livechat.livechat_channel_session_13_member_admin" model="discuss.channel.member">
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="channel_id" ref="im_livechat.livechat_channel_session_13"/>
+            <field name="unpin_dt" eval="DateTime.today()"/>
+            <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
+        </record>
+        <record id="im_livechat.livechat_channel_session_13_guest" model="mail.guest">
+            <field name="name">Visitor</field>
+        </record>
+        <record id="im_livechat.livechat_channel_session_13_member_guest" model="discuss.channel.member">
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_13_guest"/>
+            <field name="channel_id" ref="im_livechat.livechat_channel_session_13"/>
+            <field name="livechat_member_type">visitor</field>
+        </record>
+
+        <record id="livechat_channel_session_13_message_1" model="mail.message">
+            <field name="author_guest_id" ref="im_livechat.livechat_channel_session_13_guest"/>
+            <field name="author_id"/>
+            <field name="email_from">Visitor</field>
+            <field name="record_name">Visitor</field>
+            <field name="date" eval="datetime.now() - timedelta(days=1)"/>
+            <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
+            <field name="write_date" eval="datetime.now() - timedelta(days=1)"/>
+            <field name="body">Help! My database is on fire!</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="res_id" ref="im_livechat.livechat_channel_session_13"/>
+            <field name="model">discuss.channel</field>
+        </record>
+        <record id="livechat_channel_session_13_rating_message" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="im_livechat.livechat_channel_session_13"/>
+            <field name="author_guest_id" ref="im_livechat.livechat_channel_session_13_guest"/>
+            <field name="author_id"/>
+            <field name="subtype_id" ref="mail.mt_note"/>
+            <field name="message_type">notification</field>
+            <field eval="datetime.now() - timedelta(days=1, seconds=-60)" name="date"/>
+        </record>
+        <record id="livechat_channel_session_13_rating" model="rating.rating">
+            <field name="access_token">LIVECHAT_13</field>
+            <field name="res_model_id" ref="mail.model_discuss_channel"/>
+            <field name="message_id" ref="im_livechat.livechat_channel_session_13_rating_message"/>
+            <field name="rated_partner_id" ref="base.partner_admin"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="create_date" eval="datetime.now() - timedelta(days=1, seconds=-53)"/>
+            <field name="res_id" ref="im_livechat.livechat_channel_session_13"/>
+        </record>
+        <function model="discuss.channel" name="rating_apply"
+            eval="([ref('im_livechat.livechat_channel_session_13')], 1, 'LIVECHAT_13', None, 'I have been ghosted!')"/>
+    </data>
+</odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
@@ -5,6 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_demo"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="name">Joel Willis, Marc Demo</field>
             <field name="anonymous_name">Joel Willis</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-3)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -5,6 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #532, Mitchell Admin</field>
             <field name="anonymous_name">Visitor #532</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-4)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -5,6 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #649, Mitchell Admin</field>
             <field name="anonymous_name">Visitor #649</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-5)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
@@ -5,6 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="name">Joel Willis, Mitchell Admin</field>
             <field name="anonymous_name">Joel Willis</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-6)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -5,6 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_demo"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #722, Marc Demo</field>
             <field name="anonymous_name">Visitor #722</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-7)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
@@ -5,6 +5,7 @@
             <field name="name">Visitor, Mitchell Admin</field>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
+            <field name="livechat_failure">no_failure</field>
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
             <field name="channel_type">livechat</field>
             <field name="anonymous_name">Visitor</field>

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -393,6 +393,7 @@ class ChatbotScriptStep(models.Model):
             # finally, rename the channel to include the operator's name
             channel_sudo.write(
                 {
+                    "livechat_failure": "no_answer",
                     "livechat_operator_id": human_operator.partner_id,
                     "name": " ".join(
                         [
@@ -426,6 +427,9 @@ class ChatbotScriptStep(models.Model):
             )
             channel_sudo._broadcast(human_operator.partner_id.ids)
             discuss_channel.channel_pin(pinned=True)
+        else:
+            # sudo: discuss.channel - visitor tried getting operator, outcome must be updated
+            discuss_channel.sudo().livechat_failure = "no_agent"
 
         return posted_message
 

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -255,6 +255,7 @@ class Im_LivechatChannel(models.Model):
             'livechat_active': True,
             'livechat_operator_id': operator_partner_id,
             'livechat_channel_id': self.id,
+            "livechat_failure": "no_answer" if user_operator else "no_failure",
             'chatbot_current_step_id': chatbot_script._get_welcome_steps()[-1].id if chatbot_script else False,
             'anonymous_name': False if user_id else anonymous_name,
             'country_id': country_id,

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -68,7 +68,9 @@
                     <field name="visitor_partner_id"/>
                     <filter name="my_session" domain="[('partner_id.user_id', '=', uid)]" string="My Sessions"/>
                     <separator/>
-                    <filter name="not_answered" string="Not Answered" domain="[('is_without_answer', '=', 1)]"/>
+                    <filter name="escalated" string="Escalated" domain="[('session_outcome', '=', 'escalated')]"/>
+                    <filter name="no_answer" string="Not Answered" domain="[('session_outcome', '=', 'no_answer')]"/>
+                    <filter name="no_agent" string="No one Available" domain="[('session_outcome', '=', 'no_agent')]"/>
                     <separator/>
                     <filter name="rating_happy" string="Happy" domain="[('rating_text','=', 'Happy')]"/>
                     <filter name="rating_neutral" string="Neutral" domain="[('rating_text','=', 'Neutral')]"/>

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -21,3 +21,58 @@ class TestDiscussChannel(TestImLivechatCommon):
         self.assertTrue(chat.livechat_active)
         chat.with_user(chat.livechat_operator_id.user_ids[0]).action_unfollow()
         self.assertFalse(chat.livechat_active)
+
+    def test_human_operator_failure_states(self):
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "channel_id": self.livechat_channel.id,
+                "anonymous_name": "Visitor",
+            },
+        )
+        chat = self.env["discuss.channel"].browse(data["channel_id"])
+        self.assertFalse(chat.chatbot_current_step_id)  # assert there is no chatbot
+        self.assertEqual(chat.livechat_failure, "no_answer")
+        chat.with_user(chat.livechat_operator_id.user_ids[0]).message_post(
+            body="I am here to help!",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+        )
+        self.assertEqual(chat.livechat_failure, "no_failure")
+
+    def test_chatbot_failure_states(self):
+        chatbot_script = self.env["chatbot.script"].create({"title": "Testing Bot"})
+        self.livechat_channel.rule_ids = [(0, 0, {"chatbot_script_id": chatbot_script.id})]
+        self.env["chatbot.script.step"].create({
+            "step_type": "forward_operator",
+            "message": "I will transfer you to a human.",
+            "chatbot_script_id": chatbot_script.id,
+        })
+        bob_operator = new_test_user(
+            self.env, "bob_user", groups="im_livechat.im_livechat_group_user"
+        )
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Visitor",
+                "chatbot_script_id": chatbot_script.id,
+                "channel_id": self.livechat_channel.id,
+            },
+        )
+        chat = self.env["discuss.channel"].browse(data["channel_id"])
+        self.assertTrue(chat.chatbot_current_step_id)  # assert there is a chatbot
+        self.assertEqual(chat.livechat_failure, "no_failure")
+        self.livechat_channel.user_ids = False  # remove operators so forwarding will fail
+        chat.chatbot_current_step_id._process_step_forward_operator(chat)
+        self.assertEqual(chat.livechat_failure, "no_agent")
+        self.livechat_channel.user_ids += bob_operator
+        self.assertTrue(self.livechat_channel.available_operator_ids)
+        chat.chatbot_current_step_id._process_step_forward_operator(chat)
+        self.assertEqual(chat.livechat_operator_id, bob_operator.partner_id)
+        self.assertEqual(chat.livechat_failure, "no_answer")
+        chat.with_user(bob_operator).message_post(
+            body="I am here to help!",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+        )
+        self.assertEqual(chat.livechat_failure, "no_failure")


### PR DESCRIPTION
This commit adds the field `conversation_outcome` to `discuss.channel` to keep track of the outcome of live chat conversations.

task-4614101