### PR TITLE
[FIX] account: changed the name of fields in invoice_report read_group

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -141,8 +141,8 @@ class AccountInvoiceReport(models.Model):
         set_fields = set(fields)
 
         if 'price_average:avg' in fields:
-            set_fields.add('quantity')
-            set_fields.add('price_subtotal')
+            set_fields.add('quantity:sum')
+            set_fields.add('price_subtotal:sum')
 
         res = super().read_group(domain, list(set_fields), groupby, offset, limit, orderby, lazy)
 
@@ -150,9 +150,9 @@ class AccountInvoiceReport(models.Model):
             for data in res:
                 data['price_average'] = data['price_subtotal'] / data['quantity'] if data['quantity'] else 0
 
-                if 'quantity' not in fields:
+                if 'quantity:sum' not in fields:
                     del data['quantity']
-                if 'price_subtotal' not in fields:
+                if 'price_subtotal:sum' not in fields:
                     del data['price_subtotal']
 
         return res

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -157,7 +157,7 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
 
         report = self.env['account.invoice.report'].read_group(
             [('product_id', '=', product.id)],
-            ['price_subtotal', 'quantity', 'price_average:avg'],
+            ['price_subtotal:sum', 'quantity:sum', 'price_average:avg'],
             [],
         )
         self.assertEqual(report[0]['quantity'], 35)


### PR DESCRIPTION
Steps to reproduce the bug:
- Install accounting
- Go to reporting, Invoice analysis
- Select Product Quantity, Untaxed Total and Average Price in Measures

Traceback is thrown that the field prive_subtotal is used twice for the combination Untaxed total and Average price.
Another traceback is thrown that quantity field is used twice for the combination Product Quantity and Average price.

This is because the override of the read_group in the account.account_invoice_report in case of average price in the fields it add fields of quantity and price_subtotal. By default the fields are added with the default agg, so they are as <field>:sum. And the Untaxed Total and Poruct Quantity by default add both quantity and prive_subtotal as well. So they are duplicate columns to show on pivot and view crashes. The override of the read_group was introduced in d741788306.

opw-4638089

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
