### PR TITLE
[REV] website_sale: remove overridden of _getRpcParameters as it is not used and give warning on the log

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -95,6 +95,21 @@ const DynamicSnippetProducts = DynamicSnippetCarousel.extend({
         }
         return searchDomain;
     },
+    /**
+     * Add `productTemplateId` for product snippets (Accessories, Alternatives and Recently sold).
+     *
+     * See `dynamic_snippet_accessories_action`, `dynamic_snippet_recently_sold_with_action` and
+     * `dynamic_snippet_alternative_products`.
+     *
+     * @override
+     * @private
+     */
+    _getRpcParameters: function () {
+        const productTemplateId = $("#product_details").find(".product_template_id");
+        return Object.assign(this._super.apply(this, arguments), {
+            productTemplateId: productTemplateId && productTemplateId.length ? productTemplateId[0].value : undefined,
+        });
+    },
 });
 
 const DynamicSnippetProductsCard = publicWidget.Widget.extend({


### PR DESCRIPTION
This reverts commit aef59e06d8d0ba388cd781fd9a9511d6ff74ea05.

It was wrongly assumed that `_getRpcParameters` was useless in `s_dynamic_snippet_products`. It adds a parameter  `productTemplateId` to the request to `/website/snippet/filters` which is used by `ir.actions.server`:
- `dynamic_snippet_accessories_action`,
- `dynamic_snippet_recently_sold_with_action`,
- `dynamic_snippet_alternative_products`.
