### PR TITLE
[FIX] l10n_ro_edi_stock(_batch): Carrier check runs for internal pickings

### DIFF
--- a/addons/l10n_ro_edi_stock_batch/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock_batch/models/stock_picking.py
@@ -17,4 +17,6 @@ class Picking(models.Model):
         # Override for when the batch picking calls this function to validate the carriers
         validate_carrier = self.env.context.get('l10n_ro_edi_stock_validate_carrier', False)
 
-        return picking.company_id.account_fiscal_country_id.code == 'RO' and (picking.l10n_ro_edi_stock_enable or validate_carrier)
+        return (picking.company_id.account_fiscal_country_id.code == 'RO'
+                and (picking.l10n_ro_edi_stock_enable or validate_carrier)
+                and picking.picking_type_code != 'internal')

--- a/addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py
+++ b/addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py
@@ -306,7 +306,7 @@ class StockPickingBatch(models.Model):
 
         data = {
             'partner_id': self.picking_ids[0].partner_id,
-            'transport_partner_id': self.picking_ids[0].carrier_id.l10n_ro_edi_stock_partner_id,
+            'carrier_id': self.picking_ids[0].carrier_id,
             'company_id': self.company_id,
             'scheduled_date': self.scheduled_date,
             'name': self.name,


### PR DESCRIPTION
Internal transfers are a bit of an exception because they almost never 
require an eTransport document to be sent, and therefore also does 
not need a carrier to be validated.

this commit fixes a bug where when a picking with its picking_type being 
internal was validated, an error would occur forcing a carrier to be set on the 
picking.

task: 4566929