### PR TITLE
[FIX] account: prevent error when add a vat number in res_partner form view

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -664,10 +664,11 @@ class ResPartner(models.Model):
     @api.depends_context('company')
     def _compute_invoice_edi_format(self):
         for partner in self:
-            if partner.commercial_partner_id.invoice_edi_format_store == 'none':
+            commercial_partner = partner.commercial_partner_id
+            if not commercial_partner or commercial_partner.invoice_edi_format_store == 'none':
                 partner.invoice_edi_format = False
             else:
-                partner.invoice_edi_format = partner.commercial_partner_id.invoice_edi_format_store or partner.commercial_partner_id._get_suggested_invoice_edi_format()
+                partner.invoice_edi_format = commercial_partner.invoice_edi_format_store or commercial_partner._get_suggested_invoice_edi_format()
 
     def _inverse_invoice_edi_format(self):
         for partner in self:


### PR DESCRIPTION
Currently, An error occurs when adding a `vat` number in res_partner form view without saving a record.

Steps to produce:

- Install the `account` and `web_studio` modules
- Create a customer, Add field name 'commercial_partner_id' in customer form view.
- Enter a `VAT` number and click anywhere in the form view before saving the record.

`ValueError: Expected singleton: res.partner()`

An error occurs when the system is attempts to access a value of `commercial_partner_id` at [1], but it is not available.

Link 1: https://github.com/odoo/odoo/blob/c87acdcfa48b1d8aa66bb5d27d58e3edb70a86ba/addons/account/models/partner.py#L670

To prevent this error, add a condition to check if value of `commercial_partner_id` is not available. then set `invoice_edi_format` to False.

Sentry-6383383350

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
