### PR TITLE
[FIX] product: enable pricelists for test user

### DIFF
--- a/addons/product/tests/test_pricelist.py
+++ b/addons/product/tests/test_pricelist.py
@@ -42,6 +42,8 @@ class TestPricelist(ProductCommon):
                 }),
             ],
         })
+        # Enable pricelist feature
+        cls.env.user.group_ids += cls.env.ref('product.group_product_pricelist')
         cls.uom_ton = cls.env.ref('uom.product_uom_ton')
 
     def test_10_discount(self):


### PR DESCRIPTION
In the PR https://github.com/odoo/odoo/pull/179354 The line that added pricelist group to the test user was removed and was not adapted, leading to errors as the pricelist was not visible in the view.

This commit brings back the addition of group and adapts it to the changes made by the PR above.

Runbot Error: https://runbot.odoo.com/odoo/error/134223


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
