### PR TITLE
[FIX] account: improve sequence mixin concurrency

### DIFF
--- a/addons/sale/models/__init__.py
+++ b/addons/sale/models/__init__.py
@@ -5,6 +5,7 @@ from . import analytic
 from . import account_move
 from . import account_move_line
 from . import crm_team
+from . import ir_config_parameter
 from . import onboarding_onboarding
 from . import onboarding_onboarding_step
 from . import payment_provider

--- a/addons/sale/models/ir_config_parameter.py
+++ b/addons/sale/models/ir_config_parameter.py
@@ -1,0 +1,31 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, api
+from odoo.tools.misc import str2bool
+
+
+class IrConfigParameter(models.Model):
+    _inherit = 'ir.config_parameter'
+
+    def _sale_sync_cron(self, unlink=False):
+        for config in self:
+            if (
+                config.key == 'sale.automatic_invoice'
+                and (send_invoice_cron := self.env.ref('sale.send_invoice_cron', raise_if_not_found=False))
+            ):
+                send_invoice_cron.active = False if unlink else str2bool(config.value)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        configs = super().create(vals_list)
+        configs._sale_sync_cron()
+        return configs
+
+    def write(self, vals):
+        res = super().write(vals)
+        self._sale_sync_cron()
+        return res
+
+    def unlink(self):
+        self._sale_sync_cron(unlink=True)
+        return super().unlink()

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -108,7 +108,3 @@ class ResConfigSettings(models.TransientModel):
         super().set_values()
         if self.default_invoice_policy != 'order':
             self.env['ir.config_parameter'].set_param('sale.automatic_invoice', False)
-
-        send_invoice_cron = self.env.ref('sale.send_invoice_cron', raise_if_not_found=False)
-        if send_invoice_cron and send_invoice_cron.active != self.automatic_invoice:
-            send_invoice_cron.active = self.automatic_invoice


### PR DESCRIPTION
In order to avoid locking for longer periods, we want to put the
sequence assignment as late as possible in the SQL transaction.
In order to do that, we flush everything before assigning the number so
that the ORM doesn't have to flush it implicitly before committing.

We also reuse the same savepoint to avoid messing with the memory of
Postgres