### PR TITLE
[FIX] mail: remove bg class from seen indicator

### DIFF
--- a/addons/mail/static/src/discuss/core/common/message_patch.xml
+++ b/addons/mail/static/src/discuss/core/common/message_patch.xml
@@ -11,7 +11,7 @@
             </div>
         </xpath>
         <xpath expr="//AttachmentList" position="after">
-            <div t-if="props.message.isBodyEmpty and message.attachment_ids.length > 0" class="o-mail-Message-seenContainer position-absolute bg-white ratio-1x1 rounded-circle p-1">
+            <div t-if="props.message.isBodyEmpty and message.attachment_ids.length > 0" class="o-mail-Message-seenContainer position-absolute ratio-1x1 rounded-circle p-1">
                 <MessageSeenIndicator
                     t-if="showSeenIndicator"
                     message="props.message"


### PR DESCRIPTION
There is a  dot displayed at the bottom of the
attachment only type message.

task-4630097

before/after
![image](https://github.com/user-attachments/assets/02a9d532-f344-415b-88db-b390490a8122)

![image](https://github.com/user-attachments/assets/c6155fc3-a72a-4a00-8250-c3c7de2960c4)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
