### PR TITLE
[IMP] website_sale: prevent sending abandoned cart emails to old carts

### DIFF
--- a/addons/website_sale/tests/test_website_sale_cart_abandoned.py
+++ b/addons/website_sale/tests/test_website_sale_cart_abandoned.py
@@ -153,6 +153,15 @@ class TestWebsiteSaleCartAbandoned(TestWebsiteSaleCartAbandonedCommon):
 
         website = self.env['website'].get_current_website()
         website.send_abandoned_cart_email = True
+        website.write(
+            {
+                "send_abandoned_cart_email_activation_time": (
+                    datetime.utcnow()
+                    - relativedelta(hours=website.cart_abandoned_delay)
+                )
+                - relativedelta(minutes=10)
+            }
+        )
 
         product = self.env['product.product'].create({
             'name': 'The Product'

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -250,21 +250,20 @@
             <setting id="website_marketing_automation" position="after">
                 <setting
                     id="abandoned_carts_setting"
-                    title="Customer needs to be signed in otherwise the mail address is not known.
-    &#10;&#10;- If a potential customer creates one or more abandoned checkouts and then completes a sale before the recovery email gets sent, then the email won't be sent.
-    &#10;&#10;- If user has manually sent a recovery email, the mail will not be sent a second time
-    &#10;&#10;- If a payment processing error occurred when the customer tried to complete their checkout, then the email won't be sent.
-    &#10;&#10;- If your shop does not support shipping to the customer's address, then the email won't be sent.
-    &#10;&#10;- If none of the products in the checkout are available for purchase (empty inventory, for example), then the email won't be sent.
-    &#10;&#10;- If all the products in the checkout are free, and the customer does not visit the shipping page to add a shipping fee or the shipping fee is also free, then the email won't be sent."
                     string="Automatically send abandoned checkout emails"
-                    help="Mail only sent to signed in customers with items available for sale in their cart.">
+                    documentation="https://www.odoo.com/documentation/18.0/applications/websites/ecommerce/ecommerce_management/order_handling.html#abandoned-cart"
+                    help="Mail only sent to signed in customers with items available for sale in carts created after the feature activation.">
                     <field name="send_abandoned_cart_email"/>
 
-                    <div invisible="not send_abandoned_cart_email" class="content-group" title="Carts are flagged as abandoned after this delay.">
+                    <div invisible="not send_abandoned_cart_email" class="content-group">
                         <div class="row mt16">
                             <div class="col-12">
-                                <label for="cart_abandoned_delay" string="Send after" class="o_light_label"/>
+                                <label
+                                    for="cart_abandoned_delay"
+                                    string="Send after"
+                                    class="o_light_label"
+                                />
+                                <span> </span>
                                 <field class="col-2" name="cart_abandoned_delay" widget="float_time" /> Hours.
                             </div>
                         </div>

--- a/addons/website_sale_stock/tests/test_website_sale_stock_abandoned_cart_email.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_abandoned_cart_email.py
@@ -18,6 +18,14 @@ class TestWebsiteSaleStockAbandonedCartEmail(
 
         website = self.env['website'].get_current_website()
         website.send_abandoned_cart_email = True
+        website.write(
+            {
+                "send_abandoned_cart_email_activation_time": (
+                    datetime.utcnow() - relativedelta(hours=website.cart_abandoned_delay)
+                )
+                - relativedelta(minutes=10)
+            }
+        )
 
         storable_product_product = self._create_product()
         order_line = [[0, 0, {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Prevent sending abandoned cart email to old carts

Before this commit:
- Enabling the abandoned cart email feature in settings triggered emails for both old and new abandoned carts by default.

After this commit:
- Abandoned cart emails will only be sent for carts abandoned after the feature is activated.

Related PR: https://github.com/odoo/enterprise/pull/81150
Affected Version: Master
Task: 4512486

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
