### PR TITLE
[IMP] account, *sale: sale_order/move line unit price computation

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -228,40 +228,11 @@ class ProductProduct(models.Model):
         if product_uom and product.uom_id != product_uom:
             product_price_unit = product.uom_id._compute_price(product_price_unit, product_uom)
 
-        # Apply fiscal position.
-        if product_taxes and fiscal_position:
-            product_price_unit = self._get_tax_included_unit_price_from_price(
-                product_price_unit,
-                product_taxes,
-                fiscal_position=fiscal_position,
-            )
-
         # Apply currency rate.
         if currency != product_currency:
             product_price_unit = product_currency._convert(product_price_unit, currency, company, document_date, round=False)
 
         return product_price_unit
-
-    def _get_tax_included_unit_price_from_price(
-        self, product_price_unit, product_taxes,
-        fiscal_position=None,
-        product_taxes_after_fp=None,
-    ):
-        if not product_taxes:
-            return product_price_unit
-
-        if product_taxes_after_fp is None:
-            if not fiscal_position:
-                return product_price_unit
-
-            product_taxes_after_fp = fiscal_position.map_tax(product_taxes)
-
-        return product_taxes._adapt_price_unit_to_another_taxes(
-            price_unit=product_price_unit,
-            product=self,
-            original_taxes=product_taxes,
-            new_taxes=product_taxes_after_fp,
-        )
 
     @api.depends('lst_price', 'product_tmpl_id', 'taxes_id')
     @api.depends_context('company')

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -216,7 +216,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
 
     def test_in_invoice_line_onchange_product_2_with_fiscal_pos(self):
         ''' Test mapping a price-included tax (10%) with a price-excluded tax (20%) on a price_unit of 110.0.
-        The price_unit should be 100.0 after applying the fiscal position.
+        The price_unit and price_subtotal should still be 110.0 after applying the fiscal position.
         '''
         tax_price_include = self.env['account.tax'].create({
             'name': '10% incl',
@@ -227,10 +227,10 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'include_base_amount': True,
         })
         tax_price_exclude = self.env['account.tax'].create({
-            'name': '15% excl',
+            'name': '20% excl',
             'type_tax_use': 'purchase',
             'amount_type': 'percent',
-            'amount': 15,
+            'amount': 20,
         })
 
         fiscal_position = self.env['account.fiscal.position'].create({
@@ -262,14 +262,14 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(invoice, [
             {
                 'product_id': product.id,
-                'price_unit': 200.0,
-                'price_subtotal': 200.0,
-                'price_total': 230.0,
+                'price_unit': 220.0,
+                'price_subtotal': 220.0,
+                'price_total': 264.0,
                 'tax_ids': tax_price_exclude.ids,
                 'tax_line_id': False,
                 'currency_id': self.other_currency.id,
-                'amount_currency': 200.0,
-                'debit': 100.0,
+                'amount_currency': 220.0,
+                'debit': 110.0,
                 'credit': 0.0,
             },
             {
@@ -280,8 +280,8 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'tax_ids': [],
                 'tax_line_id': tax_price_exclude.id,
                 'currency_id': self.other_currency.id,
-                'amount_currency': 30.0,
-                'debit': 15.0,
+                'amount_currency': 44.0,
+                'debit': 22.0,
                 'credit': 0.0,
             },
             {
@@ -292,16 +292,16 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'tax_ids': [],
                 'tax_line_id': False,
                 'currency_id': self.other_currency.id,
-                'amount_currency': -230.0,
+                'amount_currency': -264.0,
                 'debit': 0.0,
-                'credit': 115.0,
+                'credit': 132.0,
             },
         ], {
             'currency_id': self.other_currency.id,
             'fiscal_position_id': fiscal_position.id,
-            'amount_untaxed': 200.0,
-            'amount_tax': 30.0,
-            'amount_total': 230.0,
+            'amount_untaxed': 220.0,
+            'amount_tax': 44.0,
+            'amount_total': 264.0,
         })
 
         uom_dozen = self.env.ref('uom.product_uom_dozen')
@@ -313,14 +313,14 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             {
                 'product_id': product.id,
                 'product_uom_id': uom_dozen.id,
-                'price_unit': 2400.0,
-                'price_subtotal': 2400.0,
-                'price_total': 2760.0,
+                'price_unit': 2640.0,
+                'price_subtotal': 2640.0,
+                'price_total': 3168.0,
                 'tax_ids': tax_price_exclude.ids,
                 'tax_line_id': False,
                 'currency_id': self.other_currency.id,
-                'amount_currency': 2400.0,
-                'debit': 1200.0,
+                'amount_currency': 2640.0,
+                'debit': 1320.0,
                 'credit': 0.0,
             },
             {
@@ -332,8 +332,8 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'tax_ids': [],
                 'tax_line_id': tax_price_exclude.id,
                 'currency_id': self.other_currency.id,
-                'amount_currency': 360.0,
-                'debit': 180.0,
+                'amount_currency': 528.0,
+                'debit': 264.0,
                 'credit': 0.0,
             },
             {
@@ -345,21 +345,21 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'tax_ids': [],
                 'tax_line_id': False,
                 'currency_id': self.other_currency.id,
-                'amount_currency': -2760.0,
+                'amount_currency': -3168.0,
                 'debit': 0.0,
-                'credit': 1380.0,
+                'credit': 1584.0,
             },
         ], {
             'currency_id': self.other_currency.id,
             'fiscal_position_id': fiscal_position.id,
-            'amount_untaxed': 2400.0,
-            'amount_tax': 360.0,
-            'amount_total': 2760.0,
+            'amount_untaxed': 2640.0,
+            'amount_tax': 528.0,
+            'amount_total': 3168.0,
         })
 
     def test_in_invoice_line_onchange_product_2_with_fiscal_pos_2(self):
-        ''' Test mapping a price-included tax (10%) with another price-included tax (20%) on a price_unit of 110.0.
-        The price_unit should be 120.0 after applying the fiscal position.
+        ''' Test mapping a price-included tax (10%) with another price-included tax (20%) on a price_unit of 120.0.
+        The price_unit should still be 120.00 while price_subtotal should be 100.00 after applying the fiscal position.
         '''
         tax_price_include_1 = self.env['account.tax'].create({
             'name': '10% incl',
@@ -391,7 +391,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         product = self.env['product.product'].create({
             'name': 'product',
             'uom_id': self.env.ref('uom.product_uom_unit').id,
-            'standard_price': 110.0,
+            'standard_price': 120.0,
             'supplier_taxes_id': [(6, 0, tax_price_include_1.ids)],
         })
 

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -202,7 +202,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
 
     def test_out_invoice_line_onchange_product_2_with_fiscal_pos_1(self):
         ''' Test mapping a price-included tax (10%) with a price-excluded tax (20%) on a price_unit of 110.0.
-        The price_unit should be 100.0 after applying the fiscal position.
+        The price_unit and price_subtotal should still be 110.0 after applying the fiscal position.
         '''
         tax_price_include = self.env['account.tax'].create({
             'name': '10% incl',
@@ -213,10 +213,10 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'include_base_amount': True,
         })
         tax_price_exclude = self.env['account.tax'].create({
-            'name': '15% excl',
+            'name': '20% excl',
             'type_tax_use': 'sale',
             'amount_type': 'percent',
-            'amount': 15,
+            'amount': 20,
         })
 
         fiscal_position = self.env['account.fiscal.position'].create({
@@ -248,15 +248,15 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(invoice, [
             {
                 'product_id': product.id,
-                'price_unit': 200.0,
-                'price_subtotal': 200.0,
-                'price_total': 230.0,
+                'price_unit': 220.0,
+                'price_subtotal': 220.0,
+                'price_total': 264.0,
                 'tax_ids': tax_price_exclude.ids,
                 'tax_line_id': False,
                 'currency_id': self.other_currency.id,
-                'amount_currency': -200.0,
+                'amount_currency': -220.0,
                 'debit': 0.0,
-                'credit': 100.0,
+                'credit': 110.0,
             },
             {
                 'product_id': False,
@@ -266,9 +266,9 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'tax_ids': [],
                 'tax_line_id': tax_price_exclude.id,
                 'currency_id': self.other_currency.id,
-                'amount_currency': -30.0,
+                'amount_currency': -44.0,
                 'debit': 0.0,
-                'credit': 15.0,
+                'credit': 22.0,
             },
             {
                 'product_id': False,
@@ -278,16 +278,16 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'tax_ids': [],
                 'tax_line_id': False,
                 'currency_id': self.other_currency.id,
-                'amount_currency': 230.0,
-                'debit': 115.0,
+                'amount_currency': 264.0,
+                'debit': 132.0,
                 'credit': 0.0,
             },
         ], {
             'currency_id': self.other_currency.id,
             'fiscal_position_id': fiscal_position.id,
-            'amount_untaxed': 200.0,
-            'amount_tax': 30.0,
-            'amount_total': 230.0,
+            'amount_untaxed': 220.0,
+            'amount_tax': 44.0,
+            'amount_total': 264.0,
         })
 
         uom_dozen = self.env.ref('uom.product_uom_dozen')
@@ -299,15 +299,15 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             {
                 'product_id': product.id,
                 'product_uom_id': uom_dozen.id,
-                'price_unit': 2400.0,
-                'price_subtotal': 2400.0,
-                'price_total': 2760.0,
+                'price_unit': 2640.0,
+                'price_subtotal': 2640.0,
+                'price_total': 3168.0,
                 'tax_ids': tax_price_exclude.ids,
                 'tax_line_id': False,
                 'currency_id': self.other_currency.id,
-                'amount_currency': -2400.0,
+                'amount_currency': -2640.0,
                 'debit': 0.0,
-                'credit': 1200.0,
+                'credit': 1320.0,
             },
             {
                 'product_id': False,
@@ -318,9 +318,9 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'tax_ids': [],
                 'tax_line_id': tax_price_exclude.id,
                 'currency_id': self.other_currency.id,
-                'amount_currency': -360.0,
+                'amount_currency': -528.0,
                 'debit': 0.0,
-                'credit': 180.0,
+                'credit': 264.0,
             },
             {
                 'product_id': False,
@@ -331,16 +331,16 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'tax_ids': [],
                 'tax_line_id': False,
                 'currency_id': self.other_currency.id,
-                'amount_currency': 2760.0,
-                'debit': 1380.0,
+                'amount_currency': 3168.0,
+                'debit': 1584.0,
                 'credit': 0.0,
             },
         ], {
             'currency_id': self.other_currency.id,
             'fiscal_position_id': fiscal_position.id,
-            'amount_untaxed': 2400.0,
-            'amount_tax': 360.0,
-            'amount_total': 2760.0,
+            'amount_untaxed': 2640.0,
+            'amount_tax': 528.0,
+            'amount_total': 3168.0,
         })
 
         # Check rounding.
@@ -364,15 +364,15 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             ],
         })
         self.assertRecordValues(invoice.invoice_line_ids, [{
-            'price_unit': 163.6425, # 90.0034 / 1.10 * 2
+            'price_unit': 180.0068,
             'tax_ids': tax_price_exclude.ids,
-            'price_subtotal': 163.643,
-            'price_total': 188.189,
+            'price_subtotal': 180.007,
+            'price_total': 216.008,
         }])
 
     def test_out_invoice_line_onchange_product_2_with_fiscal_pos_2(self):
-        ''' Test mapping a price-included tax (10%) with another price-included tax (20%) on a price_unit of 110.0.
-        The price_unit should be 120.0 after applying the fiscal position.
+        ''' Test mapping a price-included tax (10%) with another price-included tax (20%) on a price_unit of 120.0.
+        The price_unit should still be 120.00 while price_subtotal should be 100.00 after applying the fiscal position.
         '''
         tax_price_include_1 = self.env['account.tax'].create({
             'name': '10% incl',
@@ -404,7 +404,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         product = self.env['product.product'].create({
             'name': 'product',
             'uom_id': self.env.ref('uom.product_uom_unit').id,
-            'lst_price': 110.0,
+            'lst_price': 120.0,
             'taxes_id': [(6, 0, tax_price_include_1.ids)],
         })
 

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -261,7 +261,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
             line.product_uom_qty = 1.0
         sale_order = order_form.save()
 
-        self.assertRecordValues(sale_order.order_line, [{'price_subtotal': 9.09, 'price_total': 10.45}])
+        self.assertRecordValues(sale_order.order_line, [{'price_subtotal': 10.0, 'price_total': 11.5}])
 
         # Now trying to add the delivery line using the delivery wizard, the results should be the same as before
         delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context(default_order_id=sale_order.id,
@@ -274,7 +274,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
             ('is_delivery', '=', True),
         ])
 
-        self.assertRecordValues(line, [{'price_subtotal': 9.09, 'price_total': 10.45}])
+        self.assertRecordValues(line, [{'price_subtotal': 10.0, 'price_total': 11.5}])
 
     def test_estimated_weight(self):
         """

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -536,15 +536,7 @@ class SaleOrderLine(models.Model):
                 line.price_unit = 0.0
                 line.technical_price_unit = 0.0
             else:
-                line = line.with_company(line.company_id)
-                price = line._get_display_price()
-                line.price_unit = line.product_id._get_tax_included_unit_price_from_price(
-                    price,
-                    product_taxes=line.product_id.taxes_id.filtered(
-                        lambda tax: tax.company_id == line.env.company
-                    ),
-                    fiscal_position=line.order_id.fiscal_position_id,
-                )
+                line.price_unit = line._get_display_price()
                 line.technical_price_unit = line.price_unit
 
     def _get_order_date(self):

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -569,11 +569,6 @@ class ProductTemplate(models.Model):
         website=None,
     ):
         website = website or self.env['website'].get_current_website()
-        price = self.env['product.product']._get_tax_included_unit_price_from_price(
-            price,
-            product_taxes,
-            product_taxes_after_fp=taxes,
-        )
         show_tax = website.show_line_subtotals_tax_selection
         tax_display = 'total_excluded' if show_tax == 'tax_excluded' else 'total_included'
 


### PR DESCRIPTION
### Before
Different behavior when:
1. Adding a product to an invoice/sale order -> adding a fiscal position and refreshing taxes: unit price (price_unit) stays the same while tax and price_subtotal adjust depending on other settings.
2. Adding a fiscal position -> adding a product: unit price (price_unit) changes and keeps the same un-taxed price which is based on the original sales price minus the tax set on the product. 

### Now
Scenario 2 behaves the same as 1, therefore keeping the same unit price when setting a fiscal position before adding a product to an invoice/sale order. 

odoo/enterprise/pull/81692

task-4430319