### PR TITLE
[FIX] test_mail: use mock server for performance tests

### DIFF
--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -195,6 +195,11 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         super().setUp()
         # warm up group access cache: 5 queries + 1 query per user
         self.user_employee.has_group('base.group_user')
+        # mock mail gateway to send e-mails
+        # self.enterContext(self.mock_smtplib_connection())  # py3.11
+        smtp = self.mock_smtplib_connection()
+        smtp.__enter__()
+        self.addCleanup(lambda: smtp.__exit__(None, None, None))
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
     @warmup


### PR DESCRIPTION
Enable sending e-mails during performance testing. Since the change to disable mail sending during tests, we need to mock the connection so that e-mails get sent during testing to a dummy server.

Ref: #186884

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
