### PR TITLE
[FIX] stock: check inactive types as well

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -248,7 +248,9 @@ class PickingType(models.Model):
     @api.constrains('default_location_dest_id')
     def _check_default_location(self):
         for record in self:
-            if record.code == 'mrp_operation' and record.default_location_dest_id.scrap_location:
+            if record.active and record.code == 'mrp_operation' and record.default_location_dest_id.scrap_location:
+                if record.active:
+                    raise ValidationError(_("You cannot unarchive manufacturing type operation that has a scrap location as destination location"))
                 raise ValidationError(_("You cannot set a scrap location as the destination location for a manufacturing type operation."))
 
     def _get_action(self, action_xmlid):


### PR DESCRIPTION
Usually we cannot set a scrap location as destination location for manufacturing type operation. But there is a way to get around this constraint.

To get around
1) Archive manufacturing type.
2) change the type of destination location to scrap location.

But if you update the picking types, we will be in violation of this constraint.



Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
