### PR TITLE
[FIX] account: undefined `duplicated_ref_ids` in bills list view

### DIFF
--- a/addons/account/static/src/views/account_move_list/account_move_list_renderer.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_renderer.js
@@ -8,10 +8,10 @@ export class AccountMoveListRenderer extends FileUploadListRenderer {
         BillGuide,
     };
 
-	// Add warning background color in the ref column if we detect that the move has a duplicated
+    // Add warning background color in the ref column if we detect that the move has a duplicated
     getCellClass(column, record) {
         const classNames = super.getCellClass(column, record);
-        if (column.name === 'ref' && record.data.duplicated_ref_ids.count !== 0) {
+        if (column.name === 'ref' && record.data.duplicated_ref_ids && record.data.duplicated_ref_ids.count !== 0) {
             return `${classNames} table-warning`;
         }
         return classNames;


### PR DESCRIPTION
In b2200c8928b240d78f2f24ced39a0d45c928a666, we added a feature to show a warning background in the vendor bills list view if it had duplicated.

However, we had to add the field `duplicated_ref_ids` in the xml view so that we could use it in the JS part. However, this field will only be available in JS upon upgrading the `account` module.

To avoid this, we now check that `duplicated_ref_ids` is defined before accessing its `count`.

opw-none