### PR TITLE
[IMP] marketing_card{_event}: allow multi-lang and integration with event apps

### DIFF
--- a/addons/marketing_card/__manifest__.py
+++ b/addons/marketing_card/__manifest__.py
@@ -24,6 +24,9 @@
         'web.assets_backend': [
             'marketing_card/static/src/scss/*',
         ],
+        'web.assets_frontend': [
+            'marketing_card/static/src/scss/frontend/*.scss',
+        ],
     },
     'application': True,
     'author': 'Odoo S.A.',

--- a/addons/marketing_card/controllers/marketing_card.py
+++ b/addons/marketing_card/controllers/marketing_card.py
@@ -69,13 +69,18 @@ class MarketingCardController(Controller):
     def card_campaign_preview(self, card_id=None, card_slug=None):
         """Route for users to preview their card and share it on their social platforms."""
         card = _get_card_from_url(card_id, card_slug)
+        card = card.with_context(lang=card.lang)
         if not card.share_status:
             card.sudo().share_status = 'visited'
 
         campaign_sudo = card.sudo().campaign_id
+        # ensure the page is displayed in the language of the card by default
+        request.update_context(lang=card.lang)
         return request.render('marketing_card.card_campaign_preview', {
-            'card': card,
             'campaign': campaign_sudo,
+            'card': card,
+            'edit_in_backend': True,
+            'main_object': campaign_sudo,
             'quote': quote,
         })
 

--- a/addons/marketing_card/controllers/marketing_card.py
+++ b/addons/marketing_card/controllers/marketing_card.py
@@ -106,10 +106,30 @@ class MarketingCardController(Controller):
         card = _get_card_from_url(card_id, card_slug)
 
         campaign_sudo = card.sudo().campaign_id
+        record_sudo = self.env[card.res_model].browse(card.res_id).sudo().exists()
+
+        record_url = None
+        untracked_url = campaign_sudo.target_url
+        if not untracked_url and record_sudo:
+            untracked_url = record_url = campaign_sudo._get_record_url(record_sudo)
+        if not untracked_url:
+            untracked_url = campaign_sudo.get_base_url()
+
         # don't count clicks from preview
-        redirect_url = campaign_sudo.target_url or campaign_sudo.get_base_url()
         if card.active:
-            redirect_url = campaign_sudo.link_tracker_id.short_url or redirect_url
+            if record_url:
+                redirect_url = untracked_url
+                # still track on the link tracker since it's meant to track across the whole campaign
+                if link_tracker_code := campaign_sudo.link_tracker_id.code:
+                    request.env['link.tracker.click'].sudo().add_click(
+                        link_tracker_code,
+                        ip=request.httprequest.remote_addr,
+                        country_code=request.geoip.country_code,
+                    )
+            else:
+                redirect_url = campaign_sudo.link_tracker_id.short_url or untracked_url
+        else:
+            redirect_url = untracked_url
 
         if _is_crawler(request):
             return request.render('marketing_card.card_campaign_crawler', {

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -150,6 +150,13 @@ class CardCampaign(models.Model):
             'card_template_id',
         ]
 
+    @api.model
+    def _get_model_dependent_fields(self):
+        return [
+            'content_header_path', 'content_image1_path', 'content_image2_path', 'content_section_path',
+            'content_sub_header_path', 'content_sub_section1_path', 'content_sub_section2_path'
+        ]
+
     def _check_access_right_dynamic_template(self):
         """ `_unrestricted_rendering` being True means we trust the value on model
         when rendering. This means once created, rendering is done without restriction.
@@ -190,7 +197,15 @@ class CardCampaign(models.Model):
     def _compute_res_model(self):
         for campaign in self:
             preview_model = campaign.preview_record_ref and campaign.preview_record_ref._name
-            campaign.res_model = preview_model or campaign.res_model or 'res.partner'
+            campaign.res_model = preview_model or campaign.res_model
+
+    @api.onchange('res_model')
+    def _onchange_model(self):
+        """Update with default values for the new model and reset field paths."""
+        reset_dict = dict.fromkeys(self._get_model_dependent_fields(), False)
+        for campaign in self:
+            if campaign._origin.res_model and campaign.res_model != campaign._origin.res_model:
+                campaign.update(reset_dict)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -19,7 +19,10 @@ class CardCampaign(models.Model):
 
     def _get_model_selection(self):
         """Hardcoded list of models, checked against actually-present models."""
-        allowed_models = ['res.partner', 'event.track', 'event.booth', 'event.registration']
+        allowed_models = [
+            'event.booth', 'event.track', 'event.registration', 'event.sponsor',
+            'res.partner',
+        ]
         models = self.env['ir.model'].sudo().search_fetch([('model', 'in', allowed_models)], ['model', 'name'])
         return [(model.model, model.name) for model in models]
 

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -504,7 +504,7 @@ class CardCampaign(models.Model):
             if not self[dyn_field]:
                 result[el] = self[text_field]
             elif not (field_path := self[path_field]):
-                result[el] = record
+                result[el] = False
             else:
                 fnames = field_path.split('.')
                 try:

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -49,8 +49,11 @@ class CardCampaign(models.Model):
     post_suggestion = fields.Text(help="Description below the card and default text when sharing on X")
     preview_record_ref = fields.Reference(string="Preview On", selection="_get_model_selection", required=True)
     tag_ids = fields.Many2many('card.campaign.tag', string='Tags')
-    target_url = fields.Char(string='Post Link')
+    target_url = fields.Char(
+        string='Post Link', help='Redirection link for clicks on the cards, defaults to the relevant record or the home page.',
+    )
     target_url_click_count = fields.Integer(related="link_tracker_id.count")
+    target_url_placeholder = fields.Char(compute='_compute_target_url_placeholder')
 
     user_id = fields.Many2one('res.users', string='Responsible', default=lambda self: self.env.user, domain="[('share', '=', False)]")
 
@@ -198,6 +201,15 @@ class CardCampaign(models.Model):
         for campaign in self:
             preview_model = campaign.preview_record_ref and campaign.preview_record_ref._name
             campaign.res_model = preview_model or campaign.res_model
+
+    @api.depends('res_model')
+    def _compute_target_url_placeholder(self):
+        """Overridable in case `_get_record_url` implements other fallbacks."""
+        for model_name, campaigns in self.grouped('res_model').items():
+            if model_name and isinstance(self.env[model_name], self.env.registry['website.published.mixin']):
+                campaigns.target_url_placeholder = _("Target record (if published) or Home page")
+            else:
+                campaigns.target_url_placeholder = _("Home page")
 
     @api.onchange('res_model')
     def _onchange_model(self):
@@ -376,6 +388,19 @@ class CardCampaign(models.Model):
 
 </div></div></div></div>
 """
+
+    # ==========================================================================
+    # URL Redirection
+    # ==========================================================================
+
+    def _get_record_url(self, record):
+        """Return url to be used for redirection on cards linked to this record when not target url is specified."""
+        if (
+            isinstance(record, self.env.registry['website.published.mixin'])
+            and record.is_published
+        ):
+            return record.website_absolute_url
+        return ''
 
     # ==========================================================================
     # Image generation

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -64,7 +64,7 @@ class CardCampaign(models.Model):
     content_button = fields.Char('Button')
 
     # Dynamic Content fields
-    content_header = fields.Char('Header', translate=True)
+    content_header = fields.Char('Header', default=lambda self: _('Card Title'), translate=True)
     content_header_dyn = fields.Boolean('Is Dynamic Header')
     content_header_path = fields.Char('Header Path')
     content_header_color = fields.Char('Header Color')
@@ -74,7 +74,7 @@ class CardCampaign(models.Model):
     content_sub_header_path = fields.Char('Sub-Header Path')
     content_sub_header_color = fields.Char('Sub Header Color')
 
-    content_section = fields.Char('Section', translate=True)
+    content_section = fields.Char('Section', default=lambda self: _('Details'), translate=True)
     content_section_dyn = fields.Boolean('Is Dynamic Section')
     content_section_path = fields.Char('Section Path')
 
@@ -206,6 +206,9 @@ class CardCampaign(models.Model):
         for campaign in self:
             if campaign._origin.res_model and campaign.res_model != campaign._origin.res_model:
                 campaign.update(reset_dict)
+                # set some default here to show the possible layout of the template
+                if campaign.res_model and isinstance(self.env[campaign.res_model], self.env.registry['image.mixin']) and not campaign.content_image1_path:
+                    campaign.content_image1_path = 'image_512'
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, UTC
 from zoneinfo import ZoneInfo
 
 from odoo import _, api, exceptions, fields, models, modules
-from odoo.tools import BinaryBytes
+from odoo.tools import BinaryBytes, SQL
 
 from .card_template import TEMPLATE_DIMENSIONS
 
@@ -51,35 +51,35 @@ class CardCampaign(models.Model):
 
     user_id = fields.Many2one('res.users', string='Responsible', default=lambda self: self.env.user, domain="[('share', '=', False)]")
 
-    reward_message = fields.Html(string='Thank You Message')
+    reward_message = fields.Html(string='Thank You Message', translate=True)
     reward_target_url = fields.Char(string='Reward Link')
-    request_title = fields.Char('Request', default=lambda self: _('Help us share the news'))
-    request_description = fields.Text('Request Description')
+    request_title = fields.Char('Request', default=lambda self: _('Help us share the news'), translate=True)
+    request_description = fields.Text('Request Description', translate=True)
 
     # Static Content fields
     content_background = fields.Image('Background')
     content_button = fields.Char('Button')
 
     # Dynamic Content fields
-    content_header = fields.Char('Header')
+    content_header = fields.Char('Header', translate=True)
     content_header_dyn = fields.Boolean('Is Dynamic Header')
     content_header_path = fields.Char('Header Path')
     content_header_color = fields.Char('Header Color')
 
-    content_sub_header = fields.Char('Sub-Header')
+    content_sub_header = fields.Char('Sub-Header', translate=True)
     content_sub_header_dyn = fields.Boolean('Is Dynamic Sub-Header')
     content_sub_header_path = fields.Char('Sub-Header Path')
     content_sub_header_color = fields.Char('Sub Header Color')
 
-    content_section = fields.Char('Section')
+    content_section = fields.Char('Section', translate=True)
     content_section_dyn = fields.Boolean('Is Dynamic Section')
     content_section_path = fields.Char('Section Path')
 
-    content_sub_section1 = fields.Char('Sub-Section 1')
+    content_sub_section1 = fields.Char('Sub-Section 1', translate=True)
     content_sub_section1_dyn = fields.Boolean('Is Dynamic Sub-Section 1')
     content_sub_section1_path = fields.Char('Sub-Section 1 Path')
 
-    content_sub_section2 = fields.Char('Sub-Section 2')
+    content_sub_section2 = fields.Char('Sub-Section 2', translate=True)
     content_sub_section2_dyn = fields.Boolean('Is Dynamic Sub-Section 2')
     content_sub_section2_path = fields.Char('Sub-Section 2 Path')
 
@@ -89,24 +89,52 @@ class CardCampaign(models.Model):
 
     @api.depends('card_ids')
     def _compute_card_stats(self):
-        cards_by_status_count = self.env['card.card']._read_group(
-            domain=[('campaign_id', 'in', self.ids)],
-            groupby=['campaign_id', 'share_status'],
-            aggregates=['__count'],
-            order='campaign_id ASC',
-        )
         self.update({
             'card_count': 0,
             'card_click_count': 0,
             'card_share_count': 0,
         })
-        for campaign, status, card_count in cards_by_status_count:
+        # avoid query for empty/newid recordsets
+        if not self.ids:
+            return
+        self.flush_recordset()
+        self.env['card.card'].flush_model(['active', 'campaign_id', 'res_id', 'share_status'])
+        # if there are multiple rows with the same res_id
+        # assign a rank from 0 to 2 going from "most advanced" status to "least advanced"
+        # if a recipient has "shared" ANY of their cards and "visited" 3 others
+        # then we only count 1 card, among all those that were shared
+        self.env.cr.execute(SQL("""
+            WITH first AS (
+                SELECT DISTINCT ON (card.res_id)
+                    campaign.id AS campaign_id,
+                    card.res_id,
+                    card.share_status
+                  FROM card_card card
+                  JOIN card_campaign campaign
+                    ON card.campaign_id = campaign.id
+                 WHERE card.active
+                   AND campaign.id IN %(card_campaign_ids)s
+              ORDER BY card.res_id,
+                  CASE card.share_status
+                       WHEN 'shared'  THEN 2
+                       WHEN 'visited' THEN 1
+                       ELSE 0
+                   END DESC
+            )
+          SELECT campaign_id, share_status, COUNT(*)
+            FROM first
+           GROUP BY campaign_id, share_status;
+        """, card_campaign_ids=tuple(self.ids)))
+        cards_by_status_count = self.env.cr.fetchall()
+
+        for campaign_id, status, count in cards_by_status_count:
+            campaign = self.browse(campaign_id)
             # shared cards are implicitly visited
             if status == 'shared':
-                campaign.card_share_count += card_count
+                campaign.card_share_count += count
             if status in ('shared', 'visited'):
-                campaign.card_click_count += card_count
-            campaign.card_count += card_count
+                campaign.card_click_count += count
+            campaign.card_count += count
 
     @api.model
     def _get_render_fields(self):
@@ -269,11 +297,13 @@ class CardCampaign(models.Model):
         it is rerendered later if sent.
         """
         self.ensure_one()
+        lang = self.env.lang or self.env.user.lang or 'en_US'
         card = self.env['card.card'].with_context(active_test=False).search([
             ('campaign_id', '=', self.id),
             ('res_id', '=', self.preview_record_ref.id),
+            ('lang', '=', lang),
         ])
-        image = self.image_preview
+        image = self.with_context(lang=lang)._get_image_bin(self.preview_record_ref)
         if card:
             card.write({
                 'image': image,
@@ -284,6 +314,7 @@ class CardCampaign(models.Model):
                 'campaign_id': self.id,
                 'res_id': self.preview_record_ref.id,
                 'image': image,
+                'lang': lang,
                 'active': False,
             })
         return card
@@ -354,7 +385,7 @@ class CardCampaign(models.Model):
     # Card creation
     # ==========================================================================
 
-    def _update_cards(self, domain, auto_commit=False):
+    def _update_cards(self, domain, lang, auto_commit=False):
         """Create missing cards and update cards if necessary based for the domain."""
         self.ensure_one()
         TargetModel = self.env[self.res_model]
@@ -362,11 +393,12 @@ class CardCampaign(models.Model):
         cards = self.env['card.card'].with_context(active_test=False).search_fetch([
             ('campaign_id', '=', self.id),
             ('res_id', 'in', res_ids),
+            ('lang', '=', lang),
         ], ['res_id', 'requires_sync'])
         # update active and res_model for preview cards
         cards.active = True
         self.env['card.card'].create([
-            {'campaign_id': self.id, 'res_id': res_id}
+            {'campaign_id': self.id, 'res_id': res_id, 'lang': lang}
             for res_id in set(res_ids) - set(cards.mapped('res_id'))
         ])
 
@@ -376,16 +408,17 @@ class CardCampaign(models.Model):
             ('requires_sync', '=', True),
             ('campaign_id', '=', self.id),
             ('res_id', 'in', res_ids),
+            ('lang', '=', lang),
         ], ['res_id'], limit=100):
             # no need to autocommit if it can be done in one batch
             if auto_commit and updated_cards:
                 self.env.cr.commit()
                 # avoid keeping hundreds of jpegs in memory
                 self.env['card.card'].invalidate_model(['image'])
-            TargetModelPrefetch = TargetModel.with_prefetch(cards.mapped('res_id'))
+            TargetModelPrefetch = TargetModel.with_prefetch(cards.mapped('res_id')).with_context(lang=lang)
             for card in cards.filtered('requires_sync'):
                 card.write({
-                    'image': self._get_image_bin(TargetModelPrefetch.browse(card.res_id)),
+                    'image': self.with_context(lang=lang)._get_image_bin(TargetModelPrefetch.browse(card.res_id)),
                     'requires_sync': False,
                     'active': True,
                 })
@@ -393,8 +426,8 @@ class CardCampaign(models.Model):
             updated_cards += cards
         return updated_cards
 
-    def _get_url_from_res_id(self, res_id, suffix='preview'):
-        card = self.env['card.card'].search([('campaign_id', '=', self.id), ('res_id', '=', res_id)])
+    def _get_url_from_res_id(self, res_id, lang, suffix='preview'):
+        card = self.env['card.card'].search([('campaign_id', '=', self.id), ('res_id', '=', res_id), ('lang', '=', lang)])
         return card and card._get_path(suffix) or self.target_url
 
     # ==========================================================================

--- a/addons/marketing_card/models/card_card.py
+++ b/addons/marketing_card/models/card_card.py
@@ -8,7 +8,12 @@ class CardCard(models.Model):
     _name = 'card.card'
     _description = 'Marketing Card'
 
+    @api.model
+    def _lang_get(self):
+        return self.env['res.lang'].get_installed()
+
     active = fields.Boolean('Active', default=True)
+    lang = fields.Selection(string='Language', selection=_lang_get, required=True)
     campaign_id = fields.Many2one('card.campaign', required=True, index=True, ondelete="cascade")
     res_model = fields.Selection(related='campaign_id.res_model')
     res_id = fields.Many2oneReference('Record ID', model_field='res_model', required=True)
@@ -19,9 +24,9 @@ class CardCard(models.Model):
         ('visited', 'Visited'),
     ])
 
-    _campaign_record_unique = models.Constraint(
-        'unique(campaign_id, res_id)',
-        'Each record should be unique for a campaign',
+    _campaign_record_lang_unique = models.Constraint(
+        'unique(campaign_id, lang, res_id)',
+        'Each record should be unique for a campaign and language',
     )
 
     @api.depends('res_model', 'res_id')

--- a/addons/marketing_card/models/mailing_mailing.py
+++ b/addons/marketing_card/models/mailing_mailing.py
@@ -5,7 +5,6 @@ from odoo.fields import Domain
 class MailingMailing(models.Model):
     _inherit = 'mailing.mailing'
 
-    mailing_model_id = fields.Many2one(compute="_compute_mailing_model_id", store=True, readonly=False)
     card_requires_sync_count = fields.Integer(compute="_compute_card_requires_sync_count")
     card_campaign_id = fields.Many2one('card.campaign', index='btree_not_null')
 
@@ -21,6 +20,7 @@ class MailingMailing(models.Model):
 
     @api.depends('card_campaign_id')
     def _compute_mailing_model_id(self):
+        super()._compute_mailing_model_id()
         for mailing in self.filtered('card_campaign_id'):
             mailing.mailing_model_id = self.env['ir.model']._get_id(mailing.card_campaign_id.res_model)
 

--- a/addons/marketing_card/models/mailing_mailing.py
+++ b/addons/marketing_card/models/mailing_mailing.py
@@ -5,6 +5,14 @@ from odoo.fields import Domain
 class MailingMailing(models.Model):
     _inherit = 'mailing.mailing'
 
+    @api.model
+    def _lang_get(self):
+        return self.env['res.lang'].get_installed()
+
+    card_lang = fields.Selection(
+        string='Card Language', help="Language in which the cards will be rendered",
+        selection=_lang_get, compute='_compute_card_lang', store=True, readonly=False,
+    )
     card_requires_sync_count = fields.Integer(compute="_compute_card_requires_sync_count")
     card_campaign_id = fields.Many2one('card.campaign', index='btree_not_null')
 
@@ -18,6 +26,15 @@ class MailingMailing(models.Model):
                         model_name=self.env['ir.model']._get(mailing.card_campaign_id.res_model).display_name
                     ))
 
+    @api.constrains('card_campaign_id', 'card_lang')
+    def _check_mailing_lang(self):
+        missing_lang_mailings = self.filtered(lambda mailing: mailing.card_campaign_id and not mailing.card_lang)
+        if missing_lang_mailings:
+            raise exceptions.ValidationError(_(
+                'Missing target language for card campaign mailings:\n\t- %(mailing_names)s',
+                mailing_names=_('\n\t- ').join(mailing.display_name for mailing in missing_lang_mailings),
+            ))
+
     @api.depends('card_campaign_id')
     def _compute_mailing_model_id(self):
         super()._compute_mailing_model_id()
@@ -25,6 +42,14 @@ class MailingMailing(models.Model):
             mailing.mailing_model_id = self.env['ir.model']._get_id(mailing.card_campaign_id.res_model)
 
     @api.depends('card_campaign_id')
+    def _compute_card_lang(self):
+        for mailing in self:
+            if not mailing.card_campaign_id:
+                mailing.card_lang = False
+            elif not mailing.card_lang:
+                mailing.card_lang = self.env.lang
+
+    @api.depends('card_campaign_id', 'card_lang')
     def _compute_card_requires_sync_count(self):
         """Check if there's any missing or outdated card."""
         self.card_requires_sync_count = 0
@@ -35,7 +60,8 @@ class MailingMailing(models.Model):
             out_of_date_count = self.env['card.card'].search_count([
                 ('campaign_id', '=', mailing.card_campaign_id.id),
                 ('res_id', 'in', recipients.ids),
-                ('requires_sync', '=', False)
+                ('lang', '=', mailing.card_lang or 'en_US'),
+                ('requires_sync', '=', False),
             ])
             mailing.card_requires_sync_count = len(recipients) - out_of_date_count
 
@@ -61,7 +87,7 @@ class MailingMailing(models.Model):
     def action_update_cards(self):
         """Update the cards in batches, commiting after each batch."""
         for campaign in self.filtered(lambda mailing: mailing.state == 'draft').card_campaign_id:
-            campaign._update_cards(self._parse_mailing_domain(), auto_commit=True)
+            campaign._update_cards(self._parse_mailing_domain(), self.card_lang, auto_commit=True)
         return {
             'type': 'ir.actions.act_window',
             'res_model': 'mailing.mailing',
@@ -74,6 +100,9 @@ class MailingMailing(models.Model):
         """Domain with an additional condition that the card must exist for the records."""
         domain = Domain(super()._get_recipients_domain())
         if self.card_campaign_id:
-            res_ids = self.env['card.card'].search_fetch([('campaign_id', '=', self.card_campaign_id.id)], ['res_id']).mapped('res_id')
+            res_ids = self.env['card.card'].search_fetch([
+                ('campaign_id', '=', self.card_campaign_id.id),
+                ('lang', '=', self.card_lang or 'en_US')
+            ], ['res_id']).mapped('res_id')
             domain &= Domain('id', 'in', res_ids)
         return domain

--- a/addons/marketing_card/models/mailing_mailing.py
+++ b/addons/marketing_card/models/mailing_mailing.py
@@ -1,5 +1,9 @@
+import re
+
 from odoo import _, api, exceptions, fields, models
 from odoo.fields import Domain
+
+from odoo.addons.marketing_card.wizards.mail_compose_message import CARD_IMAGE_URL, CARD_PREVIEW_URL
 
 
 class MailingMailing(models.Model):
@@ -64,6 +68,13 @@ class MailingMailing(models.Model):
                 ('requires_sync', '=', False),
             ])
             mailing.card_requires_sync_count = len(recipients) - out_of_date_count
+
+    @api.onchange('card_campaign_id')
+    def _onchange_card_campaign_id(self):
+        """Update body_arch preview image url to match the selected campaign."""
+        for mailing in self.filtered('body_arch').filtered('card_campaign_id'):
+            mailing.body_arch = re.sub(CARD_IMAGE_URL, f'src="/web/image/card.campaign/{mailing.card_campaign_id.id}/image_preview"', mailing.body_arch)
+            mailing.body_arch = re.sub(CARD_PREVIEW_URL, f'href="/cards/{mailing.card_campaign_id.id}/preview"', mailing.body_arch)
 
     def action_put_in_queue(self):
         """Detect mismatches before scheduling."""

--- a/addons/marketing_card/static/src/scss/frontend/card_website.scss
+++ b/addons/marketing_card/static/src/scss/frontend/card_website.scss
@@ -1,0 +1,29 @@
+.o_card_campaign_preview_frontend {
+    div.o_no_link_popover {
+        min-width: 100vw;
+        
+        div#url-div {
+            justify-content: center;
+            // desktop
+            @include media-breakpoint-up(sm) {
+                a.fa {
+                    margin: 0.5rem;
+                    width: 5rem;
+                    height: 5rem;
+                    line-height: 5rem;
+                    font-size: 2em;
+                }
+            }
+            // mobile
+            @include media-breakpoint-down(sm) {
+                a.fa {
+                    margin: 0.2rem;
+                    width: 4rem;
+                    height: 4rem;
+                    line-height: 4rem;
+                    font-size: 1.5em;
+                }
+            }
+        }
+    }
+}

--- a/addons/marketing_card/tests/common.py
+++ b/addons/marketing_card/tests/common.py
@@ -39,6 +39,9 @@ class MarketingCardCommon(TransactionCase, MockImageRender):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.env['res.lang']._activate_lang('fr_FR')
+        cls.env['res.lang']._activate_lang('nl_NL')
+
         cls.company = cls.env['res.company'].create({
             'country_id': cls.env.ref("base.be").id,
             'email': 'your.company@example.',
@@ -79,7 +82,7 @@ class MarketingCardCommon(TransactionCase, MockImageRender):
             {'name': 'Bob', 'email': 'bob@justbob.me',
              'phone': '+32 123 446 789', 'image_1920': BinaryBytes(VALID_JPEG),
              },
-        ])
+        ] + [{'name': f'Part{n}', 'email': f'partn{n}@test.lan'} for n in range(18)])
 
         cls.card_template = cls.env['card.template'].create({
             'name': 'Test Template',
@@ -135,6 +138,9 @@ class MarketingCardCommon(TransactionCase, MockImageRender):
             'reward_target_url': f"{cls.env['card.campaign'].get_base_url()}/share-rewards/2039-sharer-badge/",
             'target_url': cls.env['card.campaign'].get_base_url(),
         })
+
+        (cls.campaign + cls.static_campaign).with_context(lang='fr_FR').content_header = "Mon Titre Francais"
+        (cls.campaign + cls.static_campaign).with_context(lang='nl_NL').content_header = "Mijn Nederlands Titel"
 
     @contextmanager
     def mock_datetime_and_now(self, mock_dt):

--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -270,6 +270,20 @@ class TestMarketingCardRender(MarketingCardCommon):
             self.static_campaign.preview_record_ref = self.partners[0]
             self.assertEqual(self.static_campaign.res_model, 'res.partner')
 
+    @users('marketing_card_user')
+    def test_empty_path(self):
+        campaign = self.campaign.with_user(self.env.user)
+        with self.mock_image_renderer():
+            campaign.write({
+                'content_header': False,
+                'content_header_dyn': True,
+                'content_header_path': '',
+            })
+            self.assertTrue(campaign.image_preview)
+        self.assertFalse(campaign._get_card_element_values(campaign.preview_record_ref)['header'], 'Empty path should lead to a Falsy value.')
+        header_val = _extract_values_from_document(html.fromstring(self._wkhtmltoimage_bodies[0]))['header']
+        self.assertFalse(header_val, 'Empty path should lead to nothing rendered, with this test template.')
+
     @mock_image_render
     def test_fetch_datetime(self):
         """Fetching a datetime field should attempt to translate it in the relevant timezone."""

--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -31,11 +31,16 @@ def _extract_values_from_document(rendered_document):
 class TestMarketingCardMail(MailCase, MarketingCardCommon):
 
     def assertSentMailCorrectCard(self, sent_mails, cards):
+        """Check that every card was sent in at least one of the emails.
+
+        :sent_mails: an iterable of tuple[mail_values, language_code]
+        :cards: a recordset of cards to check were sent
+        """
         IrHttp = self.env['ir.http']
         sent_cards = self.env['card.card']
-        for sent_mail in sent_mails:
+        for sent_mail, lang in sent_mails:
             record_id = int(sent_mail['object_id'].split('-')[0])
-            card = cards.filtered(lambda card: card.res_id == record_id)
+            card = cards.filtered(lambda card: card.res_id == record_id and card.lang == lang)
             self.assertEqual(len(card), 1)
             sent_cards += card
             campaign_base_url = card.campaign_id.get_base_url()
@@ -56,6 +61,7 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
             'default_email_from': 'test@test.lan',
             'default_mailing_domain': [('id', 'in', partners.ids[:5])],
             'default_reply_to': 'test@test.lan',
+            'lang': 'fr_FR'
         }
         mailing = Form(self.env['mailing.mailing'].with_context(mailing_context)).save()
         mailing.body_html = mailing.body_arch  # normally the js html_field would fill this in
@@ -92,12 +98,22 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
         self.assertFalse(mailing.card_requires_sync_count)
 
         # modifying the campaign should lead to all cards relevant being re-rendered
-        campaign.content_header = "New Header"
+        campaign.content_header = f"{campaign.content_header} (modified)"
         mailing._compute_card_requires_sync_count()
         self.assertTrue(mailing.card_requires_sync_count)
         with self.mock_image_renderer():
             mailing.action_update_cards()
         self.assertEqual(len(self._wkhtmltoimage_bodies), 5)
+        self.assertIn("Mon Titre Francais", self._wkhtmltoimage_bodies[0])
+        mailing._compute_card_requires_sync_count()
+        self.assertFalse(mailing.card_requires_sync_count)
+
+        # modifying the language should lead to all cards being re-rendered
+        # setting it back to a language with generated cards should not require a new render
+        mailing.card_lang = 'nl_NL'
+        self.assertTrue(mailing.card_requires_sync_count)
+        mailing.card_lang = 'fr_FR'
+        self.assertFalse(mailing.card_requires_sync_count)
 
         with self.mock_mail_gateway(), self.assertQueryCount(65):
             mailing._action_send_mail()
@@ -107,8 +123,28 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
         sent_cards = cards.filtered(lambda card: not card.requires_sync)
         self.assertEqual(len(sent_cards), 5)
         self.assertEqual(len(self._mails), 5)
+        sent_mails = list(zip(self._mails, ['fr_FR'] * len(self._mails)))
 
-        self.assertSentMailCorrectCard(self._mails, sent_cards)
+        # send a copy in dutch
+        nl_mailing = mailing.copy(default={'card_lang': 'nl_NL'})
+        with self.mock_image_renderer():
+            nl_mailing.action_update_cards()
+        with self.mock_mail_gateway(), self.assertQueryCount(38):
+            nl_mailing._action_send_mail()
+        # render language should be based purely on the mailing language
+        self.assertNotEqual(nl_mailing.env.lang, 'nl_NL')
+        self.assertNotEqual(nl_mailing.env.user.lang, 'nl_NL')
+        self.assertIn("Mijn Nederlands Titel", self._wkhtmltoimage_bodies[0])
+
+        cards = self.env['card.card'].search([('campaign_id', '=', campaign.id)])
+        sent_cards = cards.filtered(lambda card: not card.requires_sync)
+        self.assertEqual(len(cards), 11)
+        self.assertEqual(len(sent_cards), 10)
+        self.assertEqual(len(cards.filtered(lambda card: not card.requires_sync)), 10)
+        self.assertEqual(len(self._mails), 5)
+        sent_mails += list(zip(self._mails, ['nl_NL'] * len(self._mails)))
+
+        self.assertSentMailCorrectCard(sent_mails, sent_cards)
 
     @users('marketing_card_user')
     @mute_logger('odoo.addons.mail.models.mail_mail')
@@ -124,6 +160,7 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
             'default_email_from': 'test@test.lan',
             'default_mailing_domain': [('id', 'in', partners.ids)],
             'default_reply_to': 'test@test.lan',
+            'lang': 'en_US'
         }
         mailing = Form(self.env['mailing.mailing'].with_context(mailing_context)).save()
         mailing.body_html = mailing.body_arch  # normally the js html_field would fill this in
@@ -138,7 +175,7 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
             mailing._action_send_mail()
         self.assertEqual(len(self._mails), 10)
 
-        self.assertSentMailCorrectCard(self._mails, cards)
+        self.assertSentMailCorrectCard([(mail, 'en_US') for mail in self._mails], cards)
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
@@ -168,7 +205,8 @@ class TestMarketingCardRender(MarketingCardCommon):
         self.assertFalse(role_values['image1'])
         self.assertFalse(role_values['image2'])
 
-        campaign.action_preview()
+        with self.mock_image_renderer():
+            campaign.action_preview()
         card = self.env['card.card'].search([
             ('campaign_id', '=', campaign.id),
             ('active', '=', False)
@@ -220,7 +258,7 @@ class TestMarketingCardRender(MarketingCardCommon):
             self.assertEqual(self.static_campaign.res_model, 'res.partner')
 
             # mismatch with card
-            self.env['card.card'].sudo().create({'campaign_id': self.static_campaign.id, 'res_id': 1})
+            self.env['card.card'].sudo().create({'campaign_id': self.static_campaign.id, 'res_id': 1, 'lang': 'fr_FR'})
 
             self.assertTrue(self.static_campaign.card_ids)
             with self.assertRaises(exceptions.ValidationError):
@@ -271,36 +309,42 @@ class TestMarketingCardRender(MarketingCardCommon):
 class TestMarketingCardRouting(HttpCase, MarketingCardCommon):
 
     @mock_image_render
-    def test_campaign_stats(self):
-        partners = self.env['res.partner'].create([{'name': f'Part{n}', 'email': f'partn{n}@test.lan'} for n in range(20)])
-        cards = self.campaign._update_cards([('id', 'in', partners.ids)]).sorted('res_id')
-        self.assertEqual(len(cards), 20)
+    def test_campaign_stats_update(self):
+        """Check that different routes update card status as expected."""
+        cards_fr = self.campaign._update_cards([('id', 'in', self.partners.ids)], 'fr_FR').sorted('res_id')
+        cards_nl = self.campaign._update_cards([('id', 'in', self.partners.ids)], 'nl_NL').sorted('res_id')
+
+        self.assertFalse(cards_fr & cards_nl)
+        self.assertEqual(len(cards_fr), 20)
+        self.assertEqual(len(cards_nl), 20)
         self.assertEqual(self.campaign.card_count, 20)
         self.assertEqual(self.campaign.card_click_count, 0)
         self.assertEqual(self.campaign.card_share_count, 0)
-        self.assertListEqual([i.content for i in cards.mapped('image')], [VALID_JPEG] * 20)
-        self.assertListEqual(cards.mapped('share_status'), [False] * 20)
-        self.assertListEqual(cards.mapped('requires_sync'), [False] * 20)
+        self.assertListEqual([i.content for i in (cards_fr + cards_nl).mapped('image')], [VALID_JPEG] * 40)
+        self.assertListEqual((cards_fr + cards_nl).mapped('share_status'), [False] * 40)
+        self.assertListEqual((cards_fr + cards_nl).mapped('requires_sync'), [False] * 40)
 
         # user checks preview
-        self.campaign.preview_record_ref = partners[0]
-        card = cards.filtered(lambda card: card.res_id == partners[0].id)
-        self.assertEqual(self.campaign.action_preview()['url'], card._get_path('preview'))
-        self.url_open(card._get_path('preview'))
-        image_request_headers = self.url_open(card._get_card_url()).headers
+        self.campaign.preview_record_ref = self.partners[0]
+        card_fr, card_nl = (cards_fr + cards_nl).filtered(lambda card: card.res_id == self.partners[0].id)
+        self.assertEqual(self.campaign.with_context(lang='fr_FR').action_preview()['url'], card_fr._get_path('preview'))
+        self.assertEqual(self.campaign.with_context(lang='nl_NL').action_preview()['url'], card_nl._get_path('preview'))
+        self.assertNotEqual(card_fr._get_path('preview'), card_nl._get_path('preview'))
+        self.url_open(card_fr._get_path('preview'))
+        image_request_headers = self.url_open(card_fr._get_card_url()).headers
         self.assertEqual(image_request_headers.get('Content-Type'), 'image/jpeg')
         self.assertTrue(image_request_headers.get('Content-Length'))
-        self.assertTrue(card.image)
-        self.assertEqual(card.share_status, 'visited')
-        self.assertEqual(card.active, False, "preview card was updated and is thus considered not valid")
+        self.assertTrue(card_fr.image)
+        self.assertEqual(card_fr.share_status, 'visited')
+        self.assertEqual(card_fr.active, False, "preview card was updated and is thus considered not valid")
         self.campaign.flush_recordset()
         self.assertEqual(self.campaign.card_count, 19)
         self.assertEqual(self.campaign.card_click_count, 0)
         self.assertEqual(self.campaign.card_share_count, 0, 'A regular user fetching the card should not count as a share.')
 
         # recipient opens the card they received
-        card.active = True  # reset as if it were never used as preview
-        image_request_headers = self.url_open(card._get_card_url())
+        card_fr.active = True  # reset as if it were never used as preview
+        image_request_headers = self.url_open(card_fr._get_card_url())
         self.campaign.flush_recordset()
         self.assertEqual(self.campaign.card_count, 20)
         self.assertEqual(self.campaign.card_click_count, 1)
@@ -308,13 +352,13 @@ class TestMarketingCardRouting(HttpCase, MarketingCardCommon):
 
         # user publishes redirect url, prompting social network crawler to check open-graph data
         self.opener.headers['User-Agent'] = f'v1 {SOCIAL_NETWORK_USER_AGENTS[0]} v1.2/'
-        opengraph_view = html.fromstring(self.url_open(card._get_redirect_url()).content)
+        opengraph_view = html.fromstring(self.url_open(card_fr._get_redirect_url()).content)
         self.assertTrue(opengraph_view is not None, 'Crawler should get a valid html page as response')
         opengraph_image_url_element = opengraph_view.find('.//meta[@property="og:image"]')
         self.assertTrue(opengraph_image_url_element is not None, 'page should contain image opengraph node')
         opengraph_image_url = opengraph_image_url_element.attrib.get('content')
         self.assertTrue(opengraph_image_url)
-        self.assertEqual(opengraph_image_url, card._get_card_url())
+        self.assertEqual(opengraph_image_url, card_fr._get_card_url())
 
         image_request_headers = self.url_open(opengraph_image_url).headers
         self.assertEqual(image_request_headers.get('Content-Type'), 'image/jpeg')
@@ -324,22 +368,59 @@ class TestMarketingCardRouting(HttpCase, MarketingCardCommon):
         self.assertEqual(self.campaign.card_count, 20)
         self.assertEqual(self.campaign.card_click_count, 1)
         self.assertEqual(self.campaign.card_share_count, 1, "A crawler fetching the card is considered a share.")
-        self.assertEqual(cards[0].share_status, 'shared')
+        self.assertEqual(card_fr.share_status, 'shared')
 
         # someone clicks the redirect url on the social network platform
         self.assertEqual(self.campaign.target_url_click_count, 0)
         self.opener.headers['User-Agent'] = 'someuseragent'
-        redirect_response = self.url_open(card._get_redirect_url(), allow_redirects=False)
+        redirect_response = self.url_open(card_fr._get_redirect_url(), allow_redirects=False)
         self.assertEqual(redirect_response.status_code, 303)
         self.assertEqual(redirect_response._next.url, self.campaign.link_tracker_id.short_url)
         self.url_open(redirect_response._next.url, allow_redirects=False)
         self.assertEqual(self.campaign.target_url_click_count, 1)
 
-        cards[1:10].share_status = 'visited'
-        cards[10:].share_status = 'shared'
+    def test_campaign_stats_multi_lang_overlap(self):
+        """Check that the same card in different languages is counted only once."""
+        cards_fr = self.campaign._update_cards([('id', 'in', self.partners.ids)], 'fr_FR').sorted('res_id')
+        cards_nl = self.campaign._update_cards([('id', 'in', self.partners.ids)], 'nl_NL').sorted('res_id')
+
+        no_status_cards_fr = cards_fr[0:2]
+        visited_cards_fr = cards_fr[2:10]
+        shared_cards_fr = cards_fr[10:]
+        no_status_cards_nl = cards_nl[0:2]
+        visited_cards_nl = cards_nl[2:10]
+        shared_cards_nl = cards_nl[10:]
+
+        no_status_cards_fr.share_status = False
+        visited_cards_fr.share_status = 'visited'
+        shared_cards_fr.share_status = 'shared'
+        self.assertEqual(self.campaign.card_count, 20)
+        self.assertEqual(self.campaign.card_click_count, 18, 'Shared cards are considered implicitly visited')
+        self.assertEqual(self.campaign.card_share_count, 10)
+
+        self.assertEqual(
+            (cards_nl).mapped('share_status'),
+            [False] * 20
+        )
+        # better status in another language => pick the highest status
+        visited_cards_nl[:5].share_status = 'shared'
+        self.campaign.invalidate_recordset()
+        self.assertEqual(self.campaign.card_count, 20)
+        self.assertEqual(self.campaign.card_click_count, 18, 'Shared cards are considered implicitly visited')
+        self.assertEqual(self.campaign.card_share_count, 15)
+        no_status_cards_nl[0].share_status = 'visited'
+        no_status_cards_nl[1].share_status = 'shared'
+        self.campaign.invalidate_recordset()
         self.assertEqual(self.campaign.card_count, 20)
         self.assertEqual(self.campaign.card_click_count, 20, 'Shared cards are considered implicitly visited')
-        self.assertEqual(self.campaign.card_share_count, 11)
+        self.assertEqual(self.campaign.card_share_count, 16)
+        # worse status in another language => still pick the highest status
+        shared_cards_nl[0].share_status = 'visited'
+        shared_cards_nl[1].share_status = False
+        self.campaign.invalidate_recordset()
+        self.assertEqual(self.campaign.card_count, 20)
+        self.assertEqual(self.campaign.card_click_count, 20, 'Shared cards are considered implicitly visited')
+        self.assertEqual(self.campaign.card_share_count, 16)
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
@@ -375,7 +456,7 @@ class TestMarketingCardSecurity(MarketingCardCommon):
         campaign = self.campaign.with_user(self.env.user)
         campaign.preview_record_ref = self.marketing_card_user.partner_id
         # should work fine with accessible fields
-        campaign._update_cards([('id', '=', self.marketing_card_user.partner_id.id)])
+        campaign._update_cards([('id', '=', self.marketing_card_user.partner_id.id)], 'fr_FR')
         with self.assertRaises(exceptions.UserError):
             campaign.write({
                 'content_header_dyn': True,
@@ -393,11 +474,11 @@ class TestMarketingCardSecurity(MarketingCardCommon):
         self.marketing_card_user.partner_id.state_id.invalidate_recordset()
 
         with self.assertRaises(exceptions.UserError), self.mock_image_renderer():
-            campaign._update_cards([('id', '=', self.marketing_card_user.partner_id.id)])
+            campaign._update_cards([('id', '=', self.marketing_card_user.partner_id.id)], 'fr_FR')
         self.assertFalse(self._wkhtmltoimage_bodies, 'There should have been no render on illegal fields')
 
         with self.mock_image_renderer():
-            campaign.with_user(self.system_admin)._update_cards([('id', '=', self.marketing_card_user.partner_id.id)])
+            campaign.with_user(self.system_admin)._update_cards([('id', '=', self.marketing_card_user.partner_id.id)], 'fr_FR')
         self.assertIn('test marketing card state', self._wkhtmltoimage_bodies[0])
 
     def test_campaign_ownership(self):

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -71,7 +71,8 @@
                 <group>
                     <group>
                         <field name="preview_record_ref" string="Recipients" placeholder="Preview on..." options="{'no_create': True}"/>
-                        <field name="target_url" placeholder="Your Home Page"/>
+                        <field name="target_url_placeholder" invisible="1"/><!--used in char field options-->
+                        <field name="target_url" options="{'placeholder_field': 'target_url_placeholder'}"/>
                         <field name="res_model" invisible="1"/><!--Get the default model for field pickers-->
                         <field name="res_model" groups="base.group_no_one"/>
                         <field name="post_suggestion" placeholder="Join me at this event!" widget="text_emojis"/>

--- a/addons/marketing_card/views/card_card_views.xml
+++ b/addons/marketing_card/views/card_card_views.xml
@@ -11,6 +11,7 @@
                 <field name="res_model" optional="hidden"/>
                 <field name="campaign_id" optional="hidden"/>
                 <field name="share_status"/>
+                <field name="lang" optional="hidden"/>
             </list>
         </field>
     </record>
@@ -28,7 +29,11 @@
                 </group>
                 <group>
                     <field name="campaign_id"/>
+                    <field name="lang"/>
+                    <field name="share_status"/>
                     <filter string="Campaign" name="by_campaign" context="{'group_by': 'campaign_id'}"/>
+                    <filter string="Language" name="group_by_lang" context="{'group_by': 'lang'}"/>
+                    <filter string="Status" name="by_status" context="{'group_by': 'share_status'}"/>
                 </group>
             </search>
         </field>

--- a/addons/marketing_card/views/card_frontend_templates.xml
+++ b/addons/marketing_card/views/card_frontend_templates.xml
@@ -9,7 +9,7 @@
             no_livechat="1">
             <t t-set="share_url" t-value="card._get_redirect_url()"/>
             <t t-set="share_url_quoted" t-value="quote(share_url)"/>
-            <div class="d-flex flex-column align-items-center justify-content-center h-100">
+            <div class="d-flex flex-column align-items-center text-center mt-5 h-100">
                 <div class="mb-5 d-flex flex-column align-items-center justify-content-center">
                     <h1 t-out="campaign.request_title">Share with your community!</h1>
                     <p t-out="campaign.request_description or None" class="mb-5"/>
@@ -21,13 +21,13 @@
                 </div>
                 <div class="d-flex flex-column align-items-center">
                     <h4>Select where to share</h4>
-                    <div class="text-start o_no_link_popover">
+                    <div class="o_no_link_popover">
                         <div id="url-div">
-                            <a class="fa fa-2x fa-facebook rounded m-2" t-attf-href="https://www.facebook.com/sharer/sharer.php?u={{share_url_quoted}}" target="_blank"/>
-                            <a class="fa fa-2x fa-twitter rounded m-2" t-attf-href="https://twitter.com/intent/tweet?url={{share_url_quoted}}{{'&amp;text=%s' % quote(campaign.post_suggestion) if campaign.post_suggestion else ''}}" target="_blank"/>
-                            <a class="fa fa-2x fa-linkedin rounded m-2" t-attf-href="https://www.linkedin.com/sharing/share-offsite/?url={{share_url_quoted}}" target="_blank"/>
-                            <a class="fa fa-2x fa-whatsapp rounded m-2" t-attf-href="https://wa.me/?text={{share_url_quoted}}" target="_blank"/>
-                            <a class="fa fa-2x fa-pinterest rounded m-2" t-attf-href="https://pinterest.com/pin/create/button/?url={{share_url_quoted}}" target="_blank"/>
+                            <a class="fa fa-facebook rounded" t-attf-href="https://www.facebook.com/sharer/sharer.php?u={{share_url_quoted}}" target="_blank"/>
+                            <a class="fa fa-twitter rounded" t-attf-href="https://twitter.com/intent/tweet?url={{share_url_quoted}}{{'&amp;text=%s' % quote(campaign.post_suggestion) if campaign.post_suggestion else ''}}" target="_blank"/>
+                            <a class="fa fa-linkedin rounded" t-attf-href="https://www.linkedin.com/sharing/share-offsite/?url={{share_url_quoted}}" target="_blank"/>
+                            <a class="fa fa-whatsapp rounded" t-attf-href="https://wa.me/?text={{share_url_quoted}}" target="_blank"/>
+                            <a class="fa fa-pinterest rounded" t-attf-href="https://pinterest.com/pin/create/button/?url={{share_url_quoted}}" target="_blank"/>
                         </div>
                     </div>
                 </div>

--- a/addons/marketing_card/views/card_frontend_templates.xml
+++ b/addons/marketing_card/views/card_frontend_templates.xml
@@ -11,8 +11,8 @@
             <t t-set="share_url_quoted" t-value="quote(share_url)"/>
             <div class="d-flex flex-column align-items-center text-center mt-5 h-100">
                 <div class="mb-5 d-flex flex-column align-items-center justify-content-center">
-                    <h1 t-out="campaign.request_title">Share with your community!</h1>
-                    <p t-out="campaign.request_description or None" class="mb-5"/>
+                    <h1 t-field="campaign.request_title">Share with your community!</h1>
+                    <p t-field="campaign.request_description" class="mb-5"/>
                     <a t-att-href="card._get_card_url()" class="border border-3"
                        style="max-width: 80%; height: auto; max-height: 80%;">
                         <img t-att-src="card._get_card_url()" class="w-100"/>
@@ -34,7 +34,7 @@
                 <br/>
                 <div id="thanks-section" t-if="not is_html_empty(campaign.reward_message) or campaign.reward_target_url" style="width: 50%;"
                 t-attf-class="alert alert-info d-flex flex-column align-items-center {{'d-none' if not card.share_status == 'shared' else ''}}">
-                    <p t-if="campaign.reward_message" t-out="campaign.reward_message"/>
+                    <p t-if="campaign.reward_message" t-field="campaign.reward_message"/>
                     <p t-if="campaign.reward_target_url"><a t-att-href="campaign.reward_target_url">Click here for your reward!</a></p>
                 </div>
             </div>

--- a/addons/marketing_card/views/mailing_mailing_views.xml
+++ b/addons/marketing_card/views/mailing_mailing_views.xml
@@ -22,6 +22,7 @@
                 <attribute name="readonly" separator=" or " add="card_campaign_id"/>
             </xpath>
             <xpath expr="//label[@for='mailing_model_id']" position="before">
+                <field name="card_lang" invisible="not card_campaign_id"/>
                 <field name="card_campaign_id" invisible="not card_campaign_id" readonly="1"/>
             </xpath>
         </field>

--- a/addons/marketing_card/wizards/mail_compose_message.py
+++ b/addons/marketing_card/wizards/mail_compose_message.py
@@ -16,7 +16,7 @@ class MailComposeMessage(models.TransientModel):
 
         if campaign := self.mass_mailing_id.card_campaign_id:
             card_from_res_id = self.env['card.card'].search_fetch(
-                [('campaign_id', '=', campaign.id), ('res_id', 'in', res_ids)],
+                [('campaign_id', '=', campaign.id), ('res_id', 'in', res_ids), ('lang', '=', self.mass_mailing_id.card_lang)],
                 ['res_id'],
             ).grouped('res_id')
 

--- a/addons/marketing_card_event/__init__.py
+++ b/addons/marketing_card_event/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/marketing_card_event/__manifest__.py
+++ b/addons/marketing_card_event/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'Marketing Card For Events',
+    'version': '1.1',
+    'category': 'Marketing/Marketing Card',
+    'summary': 'Generate dynamic shareable cards for entities linked to events.',
+    'depends': ['marketing_card', 'event'],
+    'data': [
+        'views/event_event_views.xml',
+        'views/mailing_mailing_views.xml',
+    ],
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/marketing_card_event/models/__init__.py
+++ b/addons/marketing_card_event/models/__init__.py
@@ -1,0 +1,3 @@
+from . import card_campaign
+from . import event_event
+from . import mailing_mailing

--- a/addons/marketing_card_event/models/card_campaign.py
+++ b/addons/marketing_card_event/models/card_campaign.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class CardCampaign(models.Model):
+    _inherit = 'card.campaign'
+
+    def _get_allowed_event_model_names(self):
+        """Get list of event models that are allowed in card campaigns."""
+        return [
+            model_name for model_name, _ in self._get_model_selection()
+            if model_name.startswith('event.')
+        ]
+

--- a/addons/marketing_card_event/models/card_campaign.py
+++ b/addons/marketing_card_event/models/card_campaign.py
@@ -1,8 +1,21 @@
-from odoo import models
+from odoo import models, _
 
 
 class CardCampaign(models.Model):
     _inherit = 'card.campaign'
+
+    def _compute_target_url_placeholder(self):
+        super()._compute_target_url_placeholder()
+        for model_name, campaigns in self.grouped('res_model').items():
+            if (
+                model_name
+                and 'event_id' in self.env[model_name]  # if there's no event_id field, we can't know what event to redirect to
+                and model_name in self._get_allowed_event_model_names()
+            ):
+                if isinstance(self.env[model_name], self.env.registry['website.published.mixin']):
+                    campaigns.target_url_placeholder = _("Target record (if published) or Event page")
+                else:
+                    campaigns.target_url_placeholder = _("Event page")
 
     def _get_allowed_event_model_names(self):
         """Get list of event models that are allowed in card campaigns."""
@@ -11,3 +24,16 @@ class CardCampaign(models.Model):
             if model_name.startswith('event.')
         ]
 
+    # ==========================================================================
+    # URL Redirection
+    # ==========================================================================
+
+    def _get_record_url(self, record):
+        """Return the url of the event if the record itself has no url."""
+        record_url = super()._get_record_url(record)
+        if not record_url and (
+            'event_id' in record
+            and record._name in self._get_allowed_event_model_names()
+        ):
+            return record.event_id.event_share_url
+        return record_url

--- a/addons/marketing_card_event/models/event_event.py
+++ b/addons/marketing_card_event/models/event_event.py
@@ -1,0 +1,22 @@
+from odoo import _, models
+
+
+class EventEvent(models.Model):
+    _inherit = 'event.event'
+
+    def action_open_card_mailing(self):
+        self.ensure_one()
+        view = self.env.ref('marketing_card_event.mailing_mailing_view_form_event_send_card', False)
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Send Cards'),
+            'res_model': 'mailing.mailing',
+            'context': {
+                'default_subject': self.name,
+                'default_mailing_model_id': self.env['ir.model']._get_id('event.registration'),
+                'default_body_arch': self.env['card.campaign']._action_share_get_default_body(),
+                'default_mailing_domain': repr([('event_id', '=', self.id)] + self.env['event.registration']._mailing_get_default_domain(self.env['mailing.mailing'])),
+            },
+            'views': [[view and view.id, 'form']],
+            'target': 'new',
+        }

--- a/addons/marketing_card_event/models/mailing_mailing.py
+++ b/addons/marketing_card_event/models/mailing_mailing.py
@@ -1,0 +1,31 @@
+from odoo import api, fields, models
+
+
+class MailingMailing(models.Model):
+    _inherit = 'mailing.mailing'
+
+    @api.depends('card_campaign_id')
+    def _compute_mailing_domain(self):
+        super()._compute_mailing_domain()
+
+        # we consider if the card campaign is based on an (allowed) model, from the event module, that has an "event_id" field
+        # it's always relevant to limit the domain to the related event
+        for mailing in self.filtered(
+            lambda m: m.card_campaign_id and m.card_campaign_id.res_model in m.card_campaign_id._get_allowed_event_model_names()
+        ):
+            mailing_domain = fields.Domain(mailing._parse_mailing_domain())
+            TargetModel = self.env[mailing.card_campaign_id.res_model]
+            if (event_record := mailing.card_campaign_id.preview_record_ref) and 'event_id' in event_record:
+                if not any(condition.field_expr == 'event_id' for condition in mailing_domain.iter_conditions()):
+                    final_domain = fields.Domain('event_id', '=', event_record.event_id.id) & mailing_domain
+                else:
+                    # only support explicit '=' or 'in', if the condition is more complex nothing happens
+                    # it is assumed the user knows what they are doing
+                    final_domain = mailing_domain.optimize(TargetModel).map_conditions(
+                        lambda condition: (
+                            fields.Domain('event_id', '=', event_record.event_id.id)
+                            if condition.field_expr == 'event_id' and condition.operator == 'in'
+                            else condition
+                        )
+                    ).optimize(TargetModel)
+            mailing.mailing_domain = repr(final_domain)

--- a/addons/marketing_card_event/tests/__init__.py
+++ b/addons/marketing_card_event/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mailing

--- a/addons/marketing_card_event/tests/test_mailing.py
+++ b/addons/marketing_card_event/tests/test_mailing.py
@@ -1,0 +1,75 @@
+import lxml.html
+
+from odoo.tests import Form, users
+
+from odoo.addons.marketing_card.tests.common import MarketingCardCommon
+
+
+class TestMarketingCardEventMailing(MarketingCardCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.marketing_card_user.group_ids += cls.env.ref('event.group_event_user')
+        cls.ziggurat_event, cls.moon_event = cls.env['event.event'].create([
+            {'name': 'Ziggurat Building Convention', 'company_id': False},
+            {'name': 'Artemis II Conference', 'company_id': False},
+        ])
+        cls.ziggurat_registration, cls.moon_registration = cls.env['event.registration'].create([
+            {'name': 'Gilgamesh', 'event_id': cls.ziggurat_event.id},
+            {'name': 'G-man', 'event_id': cls.moon_event.id},
+        ])
+
+        cls.ziggurat_campaign = cls.static_campaign.copy({'name': 'Ziggurat Event'})
+        cls.ziggurat_campaign.preview_record_ref = cls.ziggurat_registration
+        cls.moon_campaign = cls.static_campaign.copy({'name': 'Moon Campaign'})
+        cls.moon_campaign.preview_record_ref = cls.moon_registration
+
+    @users('marketing_card_user')
+    def test_picking_campaign_updates_domain(self):
+        """Ensure the domain of the mailing matches the selected marketing campaign."""
+        form_ctx = self.ziggurat_event.action_open_card_mailing()['context']
+        mailing_form = Form(self.env['mailing.mailing'].with_context(form_ctx), 'marketing_card_event.mailing_mailing_view_form_event_send_card')
+
+        self.assertEqual(mailing_form.mailing_domain, f"[('event_id', '=', {self.ziggurat_event.id}), ('state', 'not in', ['cancel', 'draft'])]")
+        self.assertFalse(mailing_form.card_campaign_id)
+
+        mailing_form.card_campaign_id = self.ziggurat_campaign
+        self.assertEqual(
+            mailing_form.mailing_domain,
+            repr(['&', ('event_id', 'in', [self.ziggurat_event.id]), ('state', 'not in', ['cancel', 'draft'])]),
+            'Selecting a campaign with the same event may normalize/optimize the domain.',
+        )
+        mailing_form.mailing_domain = [('event_id', 'in', [self.ziggurat_event.id]), ('create_date', '>', '2020-01-01')]
+
+        # FIXME? ideally picking a different campaign on the same model should not reset the domain, just update it
+        # compute dependencies and the lack of knowledge of previous values make this impossible "cleanly" currently
+        mailing_form.card_campaign_id = self.moon_campaign
+        self.assertEqual(
+            mailing_form.mailing_domain,
+            repr(['&', ('event_id', 'in', [self.moon_event.id]), ('state', 'not in', ['cancel', 'draft'])]),
+            'The event should correspond to the picked campaign.\n'
+            'Domain will be reset to model default due to framework limitations.'
+        )
+
+    @users('marketing_card_user')
+    def test_picking_campaign_updates_body(self):
+        """Ensure the card preview url matches the campaign.
+
+        In the regular flow the card campaign is locked to readonly.
+        Hence why this is tested here despite being a base module feature.
+        """
+        form_ctx = self.static_campaign.action_share()['context']
+        mailing_form = Form(self.env['mailing.mailing'].with_context(form_ctx), 'marketing_card_event.mailing_mailing_view_form_event_send_card')
+
+        # using lxml here helps ensure the structure is still valid html
+        body_arch = lxml.html.fragment_fromstring(mailing_form.body_arch)
+        image_element = body_arch.xpath("//img[@alt='Card Preview']")
+        self.assertEqual(len(image_element), 1)
+        self.assertEqual(image_element[0].attrib['src'], f'/web/image/card.campaign/{self.static_campaign.id}/image_preview')
+
+        mailing_form.card_campaign_id = self.campaign
+        body_arch = lxml.html.fragment_fromstring(mailing_form.body_arch)
+        image_element = body_arch.xpath("//img[@alt='Card Preview']")
+        self.assertEqual(len(image_element), 1)
+        self.assertEqual(image_element[0].attrib['src'], f'/web/image/card.campaign/{self.campaign.id}/image_preview')

--- a/addons/marketing_card_event/views/event_event_views.xml
+++ b/addons/marketing_card_event/views/event_event_views.xml
@@ -1,0 +1,15 @@
+<odoo>
+    <record id="event_event_view_form" model="ir.ui.view">
+        <field name="name">event.event.view.form.inherit.marketing.card.event</field>
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_mass_mailing_attendees']" position="before">
+                <button name="action_open_card_mailing" type="object" class="btn btn-secondary"
+                        groups="marketing_card.marketing_card_group_user">
+                    Send Cards
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/marketing_card_event/views/mailing_mailing_views.xml
+++ b/addons/marketing_card_event/views/mailing_mailing_views.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record id="mailing_mailing_view_form_event_send_card" model="ir.ui.view">
+        <field name="name">mailing.mailing.view.form.event.send.card</field>
+        <field name="mode">primary</field>
+        <field name="priority">900</field>
+        <field name="model">mailing.mailing</field>
+        <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_form"/>
+        <field name="arch" type="xml">
+            <field name="card_campaign_id" position="attributes">
+                <attribute name="domain">[('res_model', 'like', 'event.%')]</attribute>
+                <attribute name="invisible">0</attribute>
+                <attribute name="readonly">0</attribute>
+                <attribute name="required">1</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -154,7 +154,8 @@ class MailingMailing(models.Model):
         'ir.model', string='Recipients Model',
         ondelete='cascade', required=True,
         domain=[('is_mailing_enabled', '=', True)],
-        default=lambda self: self.env.ref('mass_mailing.model_mailing_list').id)
+        compute='_compute_mailing_model_id', precompute=True,
+        readonly=False, store=True)
     mailing_model_name = fields.Char(
         string='Recipients Model Name',
         related='mailing_model_id.model', readonly=True, related_sudo=True)
@@ -439,6 +440,10 @@ class MailingMailing(models.Model):
     def _compute_mailing_model_real(self):
         for mailing in self:
             mailing.mailing_model_real = 'mailing.contact' if mailing.mailing_model_id.model == 'mailing.list' else mailing.mailing_model_id.model
+
+    def _compute_mailing_model_id(self):
+        """Compute acts as default, this avoids issues when the field is made compute stored in overrides."""
+        self.filtered(lambda m: not m.mailing_model_id).mailing_model_id = self.env.ref('mass_mailing.model_mailing_list').id
 
     @api.depends('mailing_model_id')
     def _compute_mailing_on_mailing_list(self):


### PR DESCRIPTION
This PR enables picking a specific language to send cards in, as well as translatable static fields.
This is useful for roadshows where the same card can be shared for multiple shows in different countries
and for large international events where the attendees may want to share their attendance in their own
language around them.

We also add some integration with event apps, as these are the main apps marketing_cards is intended for.
Mainly we add a button on events to pick any card campaign related to an event, and add default target urls
on event-related campaigns. This is done fairly generically to avoid adding many bridge modules.

task-4247003