### PR TITLE
[FIX] web: prevent address wrap in report header

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -320,7 +320,7 @@
                             </span>
                         </li>
                         <li t-else="">
-                            <span t-field="company.company_details">
+                            <span t-field="company.company_details" class="text-nowrap">
                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -375,7 +375,7 @@
                                 </div>
                             </span></li>
                             <li t-else="">
-                                <span t-field="company.company_details">
+                                <span t-field="company.company_details" class="text-nowrap">
                                     <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
                                         <strong>Company details block</strong>
                                         <div>Contains the company details.</div>
@@ -434,7 +434,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details">
+                            <span t-field="company.company_details" class="text-nowrap">
                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -494,7 +494,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details">
+                            <span t-field="company.company_details" class="text-nowrap">
                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -568,7 +568,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details">
+                            <span t-field="company.company_details" class="text-nowrap">
                                 <div class="d-flex flex-column align-items-center justify-content-center border-1 rounded p-4 h-100 w-100 bg-light opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -636,7 +636,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details">
+                            <span t-field="company.company_details" class="text-nowrap">
                                 <div class="d-flex flex-column align-items-center justify-content-center border-1 rounded p-4 h-100 w-100 bg-light opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -702,7 +702,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details">
+                            <span t-field="company.company_details" class="text-nowrap">
                                 <div class="d-flex flex-column align-items-center justify-content-center border-1 rounded p-4 h-100 w-100 bg-light opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>


### PR DESCRIPTION
Steps:
- Open Settings
- Configure document layout
- Set address to "123 avenue bois cambre" (just an example)
- Choose a new layout, bubble for example

Actual result:
- Address is wrapped after "bois" without reason by wkhtmltopdf
![image](https://github.com/user-attachments/assets/bb637887-faaf-41db-99d1-c0f9f3de244d)


Expected result:
- Address is not wrapped

Seems good for standard, bold and striped layout,
Updating it to be aligned with other and to ensure no-wrap

opw-4637433