### PR TITLE
[FIX] website, web_editor: block background video/image border layer fix

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6917,12 +6917,13 @@ registry.BackgroundImage = SnippetOptionWidget.extend({
         const parts = backgroundImageCssToParts(this.$target.css('background-image'));
         if (backgroundURL) {
             parts.url = `url('${backgroundURL}')`;
-            this.$target.addClass('oe_img_bg o_bg_img_center');
+            this.$target.addClass('oe_img_bg o_bg_img_center o_bg_img_origin_border_box');
         } else {
             delete parts.url;
             this.$target[0].classList.remove(
                 "oe_img_bg",
                 "o_bg_img_center",
+                "o_bg_img_origin_border_box",
                 "o_modified_image_to_save",
             );
         }

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -906,6 +906,9 @@ section, .oe_img_bg, [data-oe-shape-data] {
     &.o_bg_img_center {
         background-position: center;
     }
+    &.o_bg_img_origin_border_box {
+        background-origin: border-box;
+    }
 }
 
 // Gradient

--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -863,6 +863,12 @@ registry.backgroundVideo = publicWidget.Widget.extend(MobileYoutubeAutoplayMixin
                 videoContainerEl.classList.remove('d-none');
             });
         }
+        this.__adjustIframe = _.debounce(() => this._adjustIframe(), 100);
+        const resizeObserver = new ResizeObserver(this.__adjustIframe.bind(this));
+        // A change in an element padding does not trigger the resizeObserver so
+        // both inner and outer element are observed for any resizing.
+        resizeObserver.observe(this.$target[0].parentElement);
+        resizeObserver.observe(this.$target[0]);
         return Promise.all(proms).then(() => this._appendBgVideo());
     },
     /**


### PR DESCRIPTION
These commits fix two issues:
- If a block that has an image selected as background is given a
  border, its background image will fit awkwardly in the surrounding
  border, and similarly if the background image is positioned all the
  way to any edge, it does not cover all the block.
- If a video is selected as background for a block, the video does not
  always fill the block.

Steps to reproduce:

Bug 1
- Add a masonry block/big boxes block
- Add a background image to an element of the masonry/big boxes
- Add a big border
- Make the border translucent if it isn't already to better see the bug
=> The background image overflows on the border randomly
- Change the background position by shifting the image all the way to
  the left
=> The image does not cover all the border-box 

Bug 2
- Add a masonry block/big boxes block
- Add a video background
=> The video does not always fill the box, especially when the window
  gets resized

After the changes the image/video background completely covers its
block, even when resized or when a border is applied.

task-4174638
