### PR TITLE
[FIX] web: Many2OneAvatarField canOpen option

### DIFF
--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
@@ -18,7 +18,7 @@ export const many2OneAvatarField = {
     component: Many2OneAvatarField,
     extractProps(fieldInfo) {
         const props = many2OneField.extractProps(...arguments);
-        props.canOpen = fieldInfo.viewType === "form";
+        props.canOpen = fieldInfo.viewType === "form" && props.canOpen;
         return props;
     },
 };

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -23,3 +23,4 @@ Joan Sisquella joan.sisquella@forgeflow.com https://github.com/JoanSForgeFlow
 Guillem Casassas guillem.casassas@forgeflow.com https://github.com/GuillemCForgeFlow
 Arnau Cruz arnau.cruz@forgeflow.com https://github.com/ArnauCForgeFlow
 Ricard Calvo ricard.calvo@forgeflow.com https://github.com/RicardCForgeFlow
+Laura Cazorla laura.cazorla@forgeflow.com https://github.com/LauraCForgeFlow


### PR DESCRIPTION
The goal of this commit is to be able to use the option _no_open_ when displaying fields with the many2one_avatar_user widget in a form view (similar to #194845).

Prior to this commit, the _no_open_ option was ineffective for fields using the many2one_avatar_user widget in form views if the view type was a form. This was because the _no_open_ option was overridden, and the expression `fieldInfo.viewType === "form"` was always used, regardless of the specified value for _no_open_. As a result, the field's behavior could not be customized to prevent opening.

After this commit, the _no_open_ option is fully supported in this scenario. If the view type is not form, the canOpen expression will always evaluate to False, maintaining the expected behavior. However, when the view type is form, you can now explicitly use the _no_open_ option to control whether the field can be opened.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
