### PR TITLE
[IMP] sale,loyalty: remove forgotten unused tax fields

### DIFF
--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -109,12 +109,6 @@ class LoyaltyReward(models.Model):
         copy=False,
     )
     is_global_discount = fields.Boolean(compute='_compute_is_global_discount')
-    tax_ids = fields.Many2many(
-        string="Taxes",
-        help="Taxes to add on the discount line.",
-        comodel_name='account.tax',
-        domain="[('type_tax_use', '=', 'sale'), ('company_id', '=', company_id)]",
-    )
 
     # Product rewards
     reward_product_id = fields.Many2one(

--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -37,7 +37,6 @@
 
                         <group string="Discount" invisible="reward_type != 'discount' or program_type in ('gift_card','ewallet')">
                             <field name="discount_max_amount"/>
-                            <field name="tax_ids" invisible="1"/>
                             <field name="discount_product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}" invisible="discount_applicability == 'order'"/>
                             <field name="discount_product_ids" widget="many2many_tags" invisible="discount_applicability == 'order'"/>
                             <field name="discount_product_category_id" invisible="discount_applicability == 'order'"/>

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -26,12 +26,6 @@ class SaleOrderDiscount(models.TransientModel):
         ],
         default='sol_discount',
     )
-    tax_ids = fields.Many2many(
-        string="Taxes",
-        help="Taxes to add on the discount line.",
-        comodel_name='account.tax',
-        domain="[('type_tax_use', '=', 'sale'), ('company_id', '=', company_id)]",
-    )
 
     # CONSTRAINT METHODS #
 

--- a/addons/sale/wizard/sale_order_discount_views.xml
+++ b/addons/sale/wizard/sale_order_discount_views.xml
@@ -21,7 +21,6 @@
                                 <field name="discount_percentage"
                                        invisible="discount_type not in ('so_discount', 'sol_discount')"
                                        widget="percentage" nolabel="1"/>
-                                <field name="tax_ids" invisible="1"/>
                             </group>
                         </div>
                         <div class="col-sm-7 col-md-8 col-lg-8 col-8">


### PR DESCRIPTION
Commit fc82d7db8caf8e56defd0410e77a216c24defd06 reverting commit db12319e8b3b662a1498ee9a519fbced457174cc arrived in master and was merged as is, forgetting to remove to now useless fields.

See also:
- https://github.com/odoo/upgrade/pull/7368