### PR TITLE
[FIX] base: reactive mail tests

### DIFF
--- a/odoo/addons/base/tests/test_ir_mail_server_smtpd.py
+++ b/odoo/addons/base/tests/test_ir_mail_server_smtpd.py
@@ -135,13 +135,6 @@ class TestIrMailServerSMTPD(TransactionCaseWithUserDemo):
         patcher.start()
         cls.addClassCleanup(patcher.stop)
 
-        # reactivate sending emails during this test suite, make sure
-        # NOT TO send emails using another ir.mail_server than the one
-        # created in setUp!
-        patcher = patch.object(modules.module, 'current_test', False)
-        patcher.start()
-        cls.addClassCleanup(patcher.stop)
-
         # fix runbot, docker uses a single ipv4 stack but it gives ::1
         # when resolving "localhost" (so stupid), use the following to
         # force aiosmtpd/odoo to bind/connect to a fixed ipv4 OR ipv6
@@ -149,6 +142,15 @@ class TestIrMailServerSMTPD(TransactionCaseWithUserDemo):
         family, _, cls.port = _find_free_local_address()
         cls.localhost = getaddrinfo('localhost', cls.port, family)
         cls.startClassPatcher(patch('socket.getaddrinfo', cls.getaddrinfo))
+
+    def setUp(self):
+        super().setUp()
+        # reactivate sending emails during this test suite, make sure
+        # NOT TO send emails using another ir.mail_server than the one
+        # created in setUp!
+        patcher = patch.object(modules.module, 'current_test', False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     @classmethod
     def getaddrinfo(cls, host, port, *args, **kwargs):


### PR DESCRIPTION
That were previously failing since this change
https://github.com/odoo/odoo/commit/7aac5cecf198ed07fd6c71a0958f948512c50416#diff-d2dd39541c27864eca6e3d570d14208095c4c5509214e650bdc5bb8d69b5f672R40

making it so that the mail server refuses to connect https://github.com/odoo/odoo/blob/18.0/odoo/addons/base/models/ir_mail_server.py#L374

and later on raises an error as it returns None

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
