### PR TITLE
[FIX] website_sale: don't show product configurator if variant is set

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -35,6 +35,24 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...selectElementInWeSelectWidget('product_variant_picker_opt', 'Product Yes Variant 2 (Pink)'),
         ...clickOnSave(),
         clickOnElement('add to cart button', ':iframe .s_add_to_cart_btn'),
+        // Since 18.2, even if a specific variant is selected, the product configuration modal is displayed
+        // The variant set on the modal used the default variants attributes (so will not correspond to the selected variant)
+        // TODO: fix this misbahvior by setting the variant attributes based on the chosen variant 
+        // https://github.com/odoo/odoo/pull/201217#issuecomment-2721871718
+        {
+            content: "Check if the red variant is selected",
+            trigger: ":iframe .modal li:contains(Red) input:checked",
+        },
+        {
+            content: "Click the pink variant",
+            trigger: ":iframe .modal li:contains(Pink) input",
+            run: "click",
+        },
+        {
+            content: "Check if the pink variant is selected",
+            trigger: ":iframe .modal li:contains(Pink) input:checked",
+        },
+        clickOnElement('continue shopping', ':iframe .modal button:contains(Continue Shopping)',),
 
         // Basic product with no variants and action=buy now
         ...editAddToCartSnippet(),


### PR DESCRIPTION
To reproduce:
Set a website with a "Add to cart" button set the product on it on a given product variant (like Customize Desk (Steel, Black)).
When clicked on the website, the product configurator will appear (without the variant attributes set to what we chose).
 
![image](https://github.com/user-attachments/assets/1ba6a140-41f1-479b-808b-071199975c4b) -> ![image](https://github.com/user-attachments/assets/41aef602-c09f-4fba-aba8-888af7ea083f)

Likely an unintended side effect from:
https://github.com/odoo/odoo/pull/158473

After this commit:
The test have been adapted to fit with the changes.
So now we manually change the product attribute to the variant one

rb-159682