### PR TITLE
[FIX] mail: no crash on mic permission after call end

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -899,8 +899,8 @@ export class Rtc extends Record {
         if (camera) {
             await this.toggleVideo("camera");
         }
-        await this.resetAudioTrack({ force: audio });
         await this._initConnection();
+        await this.resetAudioTrack({ force: audio });
         if (!this.state.channel?.id) {
             return;
         }


### PR DESCRIPTION
Before this commit, closing the microphone permission request outside of a call would result in a traceback.

Steps to reproduce:
1. Start a call on a channel (observe the browser's microphone permission request pop-up)
2. Quit the call
3. Refuse the microphone permissions -> traceback

This happens because the `joinCall` method waits for the permissions before accessing `selfSession` in `_initConnection`, if that happens after the call has ended it produces a traceback as there is no `selfSession`.
This commit fixes the issue by moving the permission request after the `_initConnection`, thus ensuring that `selfSession` does not get accessed if there is no call.