### PR TITLE
[FIX] website_twitter: change field label

### DIFF
--- a/addons/website_twitter/i18n/website_twitter.pot
+++ b/addons/website_twitter/i18n/website_twitter.pot
@@ -56,12 +56,20 @@ msgstr ""
 
 #. module: website_twitter
 #: model:ir.model.fields,field_description:website_twitter.field_res_config_settings__twitter_api_key
+msgid "X API Key"
+msgstr ""
+
+#. module: website_twitter
 #: model_terms:ir.ui.view,arch_db:website_twitter.res_config_settings_view_form
 msgid "API Key"
 msgstr ""
 
 #. module: website_twitter
 #: model:ir.model.fields,field_description:website_twitter.field_res_config_settings__twitter_api_secret
+msgid "X API secret"
+msgstr ""
+
+#. module: website_twitter
 #: model_terms:ir.ui.view,arch_db:website_twitter.res_config_settings_view_form
 msgid "API secret"
 msgstr ""

--- a/addons/website_twitter/models/res_config_settings.py
+++ b/addons/website_twitter/models/res_config_settings.py
@@ -28,11 +28,11 @@ class ResConfigSettings(models.TransientModel):
 
     twitter_api_key = fields.Char(
         related='website_id.twitter_api_key', readonly=False,
-        string='API Key',
+        string='X API Key',
         help='X API key you can get it from https://apps.twitter.com/')
     twitter_api_secret = fields.Char(
         related='website_id.twitter_api_secret', readonly=False,
-        string='API secret',
+        string='X API secret',
         help='X API secret you can get it from https://apps.twitter.com/')
     twitter_screen_name = fields.Char(
         related='website_id.twitter_screen_name', readonly=False,


### PR DESCRIPTION
The field `res.config.settings.twitter_api_key` has the same label `API Key` as the field `res.config.settings.employment_hero_api_key` from module `employment_hero`, which takes it from its related field
`res.company.employment_hero_api_key`[[1]](https://github.com/odoo/enterprise/blob/365fbed2db68626bc175aed4a349c09d872cc717/l10n_employment_hero/models/res_company.py#L19C5-L19C28)[[2]](https://github.com/odoo/enterprise/blob/365fbed2db68626bc175aed4a349c09d872cc717/l10n_employment_hero/models/res_config_settings.py#L9).
Having multiple fields on the same model with the same label generates [warnings](https://github.com/odoo/odoo/blob/1ca879612fe546108fd1067839924ae8c25b2bb9/odoo/addons/base/models/ir_model.py#L1193-L1196) when loading the module.
The [view](https://github.com/odoo/odoo/blob/ef3aac00ce7737498589a3df68be47c7a3b45d24/addons/website_twitter/views/res_config_settings_views.xml#L12-L16) using the twitter_api_key field already sets the same label.

The module is removed in 18.0


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
