### PR TITLE
[FIX] web: pass new context key in /json request

### DIFF
--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from psycopg2.errors import UniqueViolation
 
-from odoo.tests import Form, users
+from odoo.tests import Form, users, HttpCase, tagged
 from odoo.addons.hr.tests.common import TestHrCommon
 from odoo.tools import mute_logger
 from odoo.exceptions import ValidationError
@@ -458,3 +458,20 @@ class TestHrEmployee(TestHrCommon):
         employee.resource_calendar_id = False
         self.assertTrue(employee.is_flexible)
         self.assertTrue(employee.is_fully_flexible)
+
+
+@tagged('-at_install', 'post_install')
+class TestHrEmployeeWebJson(HttpCase):
+
+    def test_webjson_employees(self):
+        #check that json employees can be accessed
+        url = "/json/1/employees"
+        self.authenticate('admin', 'admin')
+        CSRF_USER_HEADERS = {
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": 'none',
+            "Sec-Fetch-User": "?1",
+        }
+        res = self.url_open(url, headers=CSRF_USER_HEADERS)
+        self.assertEqual(res.status_code, 200)

--- a/addons/web/controllers/json.py
+++ b/addons/web/controllers/json.py
@@ -232,6 +232,7 @@ class WebJsonController(http.Controller):
             action._get_eval_context(action),
             active_id=active_id,
             context=context,
+            allowed_company_ids=request.env.user.company_ids.ids,
         )
         # update the context and return
         context.update(safe_eval(action.context, eval_context))


### PR DESCRIPTION
An internal server error happened when trying to acces json from the url in the employees app

Steps to reproduce:
-------------------
* Open employees app
* Change /odoo/ for /json/ in the url
> Observation:
 ValueError: NameError("name allowed_company_ids is not defined") while evaluating
"[(company_id, in, allowed_company_ids)]"

Why the fix:
------------
With the odoo web route allowed_company_ids is added to the context here https://github.com/odoo/odoo/blob/648956b75bdd09396bae3b7162f236236fccae23/addons/web/static/src/webclient/actions/action_service.js#L346    from user.context.
With the json route we need to add it manually as it's not in the env
 
opw-4601689

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
