### PR TITLE
[FIX] account: correctly display localization-specific journal fields for South America

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -45,7 +45,6 @@
                         <div class="oe_title">
                             <label for="name"/>
                             <field name="name_placeholder" invisible="1" force_save="1"/>
-                            <field name="type" invisible="1"/>
                             <h1><field name="name" options="{'placeholder_field': 'name_placeholder'}" required="not type"/></h1>
                         </div>
                         <group>


### PR DESCRIPTION
PR odoo/odoo#192031 added a duplicate, hidden `type` field tag to the journal form views.
This misplaced tag is causing localized journal fields (for Central/South American localizations), which should follow the correct `type` tag, to be rendered in the wrong location, distorting the layout.

**To Reproduce:**
1. Install the Accounting app and a localization module like Uruguay, Argentina, Peru, Ecuador, Chile...
2. Navigate to Accounting > Configuration > Journals. 
3. Open a Sales or Purchase Journal.
Some localization fields are missing, misplaced, or unreadable.

Enterprise PR: odoo/enterprise#81173

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4601714)
opw-4601714