### PR TITLE
[FIX] account_edi_ubl_cii: add actual delivery date to facturx

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -92,7 +92,7 @@ class AccountEdiXmlCII(models.AbstractModel):
     def _get_scheduled_delivery_time(self, invoice):
         # don't create a bridge only to get line.sale_line_ids.order_id.picking_ids.date_done
         # line.sale_line_ids.order_id.picking_ids.scheduled_date or line.sale_line_ids.order_id.commitment_date
-        return invoice.invoice_date
+        return invoice.delivery_date or invoice.invoice_date
 
     def _get_invoicing_period(self, invoice):
         # get the Invoicing period (BG-14): a list of dates covered by the invoice


### PR DESCRIPTION
- Create an invoice and set its delivery date to a date other than today.

- Generate the cii facturx xml.

Under <ram:ActualDeliverySupplyChainEvent>, the date is incorrectly set to today instead of the invoice's delivery date.

This commit applies the same treatment as https://github.com/odoo/odoo/commit/dda560005b2372ed8f6fa0cf3fd6c6f7ca0d1fe3 but for account_edi_xml_cii_facturx.

opw-4531928

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
