### PR TITLE
[FIX] website: remove outdated "on hover" adaptation of submenus

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -636,10 +636,6 @@ publicWidget.registry.FadeOutHeader = BaseDisappearingHeader.extend({
 publicWidget.registry.hoverableDropdown = animations.Animation.extend({
     selector: 'header.o_hoverable_dropdown',
     disabledInEditableMode: false,
-    effects: [{
-        startEvents: 'resize',
-        update: '_dropdownHover',
-    }],
     events: {
         'mouseenter .dropdown': '_onMouseEnter',
         'mouseleave .dropdown': '_onMouseLeave',
@@ -651,7 +647,6 @@ publicWidget.registry.hoverableDropdown = animations.Animation.extend({
     start: function () {
         this.$dropdownMenus = this.$el.find('.dropdown-menu');
         this.$dropdownToggles = this.$el.find('.dropdown-toggle');
-        this._dropdownHover();
         return this._super.apply(this, arguments);
     },
 
@@ -659,19 +654,6 @@ publicWidget.registry.hoverableDropdown = animations.Animation.extend({
     // Private
     //--------------------------------------------------------------------------
 
-    /**
-     * @private
-     */
-    _dropdownHover: function () {
-        this.$dropdownMenus.attr('data-bs-popper', 'none');
-        if (uiUtils.getSize() >= SIZES.LG) {
-            this.$dropdownMenus.css('margin-top', '0');
-            this.$dropdownMenus.css('top', 'unset');
-        } else {
-            this.$dropdownMenus.css('margin-top', '');
-            this.$dropdownMenus.css('top', '');
-        }
-    },
     /**
      * Hides all opened dropdowns.
      *


### PR DESCRIPTION
Steps to reproduce (on master):

- Go to website and switch the navbar to "Hover" mode.

- Hover a navbar item with a submenu (user menu, language selector...)

- The dropdown won't be displayed in the correct position (there is a
gap between the item and its submenu).

Before `16.3` and since Bootstrap does not provide a built-in way to use
the "hover" as a dropdown trigger, a custom implementation was used to
handle the "show on hover" scenario (see: `hoverableDropdown`). This
code also relies on the submenus being correctly positioned on hover.

With the "Hover" mode enabled, the `.dropdown-menu` position was also
adapted when switching from mobile to desktop view [A].

Starting from [1], the public `menuDirection` widget was completely
removed (used to align website navbar submenus in an optimal way) and
was replaced by a patch that allows Bootstrap to position dropdowns
dynamically inside a navbar (using `Popper`).

With this update, the code from [A] will no longer have an effect on
the submenus position since Bootstrap is now adding its own style to
the `.dropdown-menu` when displayed (using the Bootstrap default
offset config).

After the public widgets refactoring in [2], the code from [A] was
moved to an `Interaction`'s `dynamicContent` and was forced again,
leading to the issue described above.

The goal of this commit is to simply remove this "on hover" adaptation
since submenus should be correctly positioned by Bootstrap starting
from `16.3`.

[1]: https://github.com/odoo/odoo/commit/8689241f86e2d4ddb4e4510951f92b80e115b914
[2]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f