### PR TITLE
[FIX] stock: use the product's UoM quantity to calculate reserved qty

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1142,11 +1142,11 @@ class StockQuant(models.Model):
         reserved_move_lines = self.env['stock.move.line']._read_group(
             [
                 ('state', 'in', ['assigned', 'partially_available', 'waiting', 'confirmed']),
-                ('quantity', '!=', 0),
+                ('quantity_product_uom', '!=', 0),
                 ('product_id.is_storable', '=', True),
             ],
             ['product_id', 'location_id', 'lot_id', 'package_id', 'owner_id'],
-            ['quantity:sum'],
+            ['quantity_product_uom:sum'],
         )
         reserved_move_lines = {
             (product, location, lot, package, owner): reserved_quantity

--- a/addons/stock/tests/test_robustness.py
+++ b/addons/stock/tests/test_robustness.py
@@ -355,3 +355,33 @@ class TestRobustness(TransactionCase):
         self.assertEqual(quant.reserved_quantity, 2)
         self.env['stock.quant']._clean_reservations()
         self.assertEqual(quant.reserved_quantity, 0)
+
+    def test_clean_quants_synch_with_different_uom(self):
+        """ Ensure the _clean_reservaion method align the quants on stock.move.line when using different UoM """
+        uom_kg = self.env.ref('uom.product_uom_kgm')
+        product_reservation_too_high = self.env['product.product'].create({
+            'name': 'Product Reservation',
+            'is_storable': True,
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'uom_id': uom_kg.id,
+        })
+        # update available quantity to 1 kg
+        self.env['stock.quant']._update_available_quantity(product_reservation_too_high, self.stock_location, 1)
+        quant = self.env['stock.quant']._gather(product_reservation_too_high, self.stock_location)
+        # reserve 0.1 kg with a move
+        move = self.env['stock.move'].create({
+            'name': 'test_clean_quants_synch',
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': product_reservation_too_high.id,
+            'product_uom_qty': 100,
+            'product_uom': self.env.ref('uom.product_uom_gram').id,
+        })
+        move._action_confirm()
+        move._action_assign()
+        # update reserved quantity to 0.2 kg
+        self.env['stock.quant']._update_reserved_quantity(product_reservation_too_high, self.stock_location, 0.2)
+        self.assertEqual(quant.reserved_quantity, 0.3)
+        self.env['stock.quant']._clean_reservations()
+        # the reserved quantity should be cleaned to the quantity reserved by the move
+        self.assertEqual(quant.reserved_quantity, 0.1)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - UoM: Kg

- Create a delivery order:
    - product: P1
    - qty: 100 g
- Mark the delivery as "To Do"
- Set the quantity to 100 g
- Go to the product form of P1 → Update quantity

Problem:
The reserved quantity is set to 100 kg instead of 0.1 kg

opw-4638315
