### PR TITLE
[FIX] mail: add common utils html/format in frontend

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -168,6 +168,10 @@ For more specific needs, you may also assign custom-defined actions
         "web.assets_web_dark": [
             'mail/static/src/**/*.dark.scss',
         ],
+        "web.assets_frontend": [
+            "mail/static/src/utils/common/html.js",
+            "mail/static/src/utils/common/format.js",
+        ],
         'mail.assets_discuss_public_test_tours': [
             'web_tour/static/src/tour_pointer/**/*',
             'web/static/lib/hoot-dom/**/*',


### PR DESCRIPTION
Those are used in some website modules, it's best if they are immediately added to the mail module manifest rather than each invididual module that needs them, with the risk of forgetting them.

In general, everything that is "common" is made to be shared across all bundles, and it should be assumed to be available without having to double check.

runbot-134831

https://github.com/odoo/enterprise/pull/81184