### PR TITLE
[FIX] base,product: synchronization of company_dependent commercial f…

### DIFF
--- a/addons/product/models/res_partner.py
+++ b/addons/product/models/res_partner.py
@@ -47,3 +47,7 @@ class ResPartner(models.Model):
 
     def _commercial_fields(self):
         return super()._commercial_fields() + ['property_product_pricelist']
+
+    def _company_dependent_commercial_fields(self):
+        # property_product_pricelist is not a company_dependent field but technically behaves as one
+        return super()._company_dependent_commercial_fields() + ['property_product_pricelist']

--- a/addons/product/tests/test_product_pricelist.py
+++ b/addons/product/tests/test_product_pricelist.py
@@ -310,3 +310,35 @@ class TestProductPricelist(ProductCommon):
 
         # Assert: The set value is kept
         self.assertEqual(pricelist_item.min_quantity, precise_value)
+
+    def test_pricelist_sync_on_partners(self):
+        ResPartner = self.env['res.partner']
+
+        company_1, company_2 = self.env['res.company'].create([
+            {'name': 'company_1'},
+            {'name': 'company_2'},
+        ])
+
+        test_partner_company = ResPartner.create({
+            'name': 'This company',
+            'is_company': True,
+        })
+        test_partner_company.with_company(company_1).property_product_pricelist = self.business_pricelist.id
+        test_partner_company.with_company(company_2).property_product_pricelist = self.customer_pricelist.id
+
+        child_address = ResPartner.create({
+            'name': 'Contact',
+            'parent_id': test_partner_company.id,
+        })
+        self.assertEqual(
+            child_address.property_product_pricelist,
+            test_partner_company.property_product_pricelist,
+        )
+        self.assertEqual(
+            child_address.with_company(company_1).property_product_pricelist,
+            self.business_pricelist,
+        )
+        self.assertEqual(
+            child_address.with_company(company_2).property_product_pricelist,
+            self.customer_pricelist,
+        )

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -608,6 +608,13 @@ class Partner(models.Model):
         extended by inheriting classes. """
         return ['vat', 'company_registry', 'industry_id']
 
+    @api.model
+    def _company_dependent_commercial_fields(self):
+        return [
+            fname for fname in self._commercial_fields()
+            if self._fields[fname].company_dependent
+        ]
+
     def _commercial_sync_from_company(self):
         """ Handle sync of commercial fields when a new parent commercial entity is set,
         as if they were related fields """
@@ -615,7 +622,23 @@ class Partner(models.Model):
         if commercial_partner != self:
             sync_vals = commercial_partner._update_fields_values(self._commercial_fields())
             self.write(sync_vals)
+            self._company_dependent_commercial_sync()
             self._commercial_sync_to_children()
+
+    def _company_dependent_commercial_sync(self):
+        company_dependent_commercial_field_ids = [
+            self.env['ir.model.fields']._get(self._name, fname).id
+            for fname in self._company_dependent_commercial_fields()
+        ]
+        if company_dependent_commercial_field_ids:
+            parent_properties = self.env['ir.property'].search([
+                ('fields_id', 'in', company_dependent_commercial_field_ids),
+                ('res_id', '=', f'res.partner,{self.commercial_partner_id.id}'),
+                # value was already assigned for current company
+                ('company_id', '!=', self.env.company.id),
+            ])
+            for prop in parent_properties:
+                prop.copy({'res_id': f'res.partner,{self.id}'})
 
     def _commercial_sync_to_children(self):
         """ Handle sync of commercial fields to descendants """


### PR DESCRIPTION
…ields

Commercial fields are supposed to be synchronized between a customer and their commercial entity. Nevertheless, the synchronization doesn't work for company_dependent fields whose values are only copied for the current company.

This commit makes sure the values are properly synchronized for company_dependent fields (+ pricelist) between the contacts and their commercial partner.

opw-4523466


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
