### PR TITLE
[FIX] *_livechat: test_chatbot_fw_operator_matching_lang in master

### DIFF
--- a/addons/mail/i18n/fr.po
+++ b/addons/mail/i18n/fr.po
@@ -17457,7 +17457,7 @@ msgstr "joey"
 #. odoo-python
 #: code:addons/mail/models/discuss/discuss_channel.py:0
 msgid "joined the channel"
-msgstr ""
+msgstr "a rejoint le canal"
 
 #. module: mail
 #. odoo-javascript


### PR DESCRIPTION
*: website

Follow-up of https://github.com/odoo/odoo/pull/200622

PR above adapte a test that is failing due to message notification whose language depends on livechat operator: English in 1st tour, French in 2nd tour.

The assertion of notification message content for French requires `fr.po` that has the right translation for "joined the channel".

This translation was missing, so the test fails. This commit adds the translated entry for the good working of this test.

runbot-159949