### PR TITLE
[REF] account,l10n_in(_pos): hsn summary using base lines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1244,6 +1244,7 @@ class AccountTax(models.Model):
 
             # Basic fields:
             'product_id': load('product_id', self.env['product.product']),
+            'product_uom_id': load('product_uom_id', self.env['uom.uom']),
             'tax_ids': load('tax_ids', self.env['account.tax']),
             'price_unit': load('price_unit', 0.0),
             'quantity': load('quantity', 0.0),

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -748,28 +748,60 @@ export const accountTaxHelpers = {
         // The expected tax amount of the whole document is round(12.12 * 12.12 * 0.23 * 2) = 67.57
         // The delta in term of tax amount is 67.57 - 33.79 - 33.79 = -0.01
         for (const tax_amounts of Object.values(total_per_tax)) {
+            const is_reverse_charge = tax_amounts.is_reverse_charge;
+            const currency = tax_amounts.currency;
+            const tax = tax_amounts.tax;
             if (!tax_amounts.base_lines.length) {
                 continue;
             }
 
-            const base_line = tax_amounts.base_lines.sort(
-                (a, b) =>
-                    a.tax_details.total_included_currency - b.tax_details.total_included_currency
-            )[0];
-            tax_amounts.reference_base_line = base_line;
-            const tax = tax_amounts.tax;
-            if(!tax){
+            tax_amounts.sorted_base_line_x_tax_data = tax_amounts.base_lines
+                .sort((a, b) => b.tax_details.total_included_currency - a.tax_details.total_included_currency)
+                .map(base_line => [
+                    base_line,
+                    base_line.tax_details.taxes_data.find(
+                        tax_data => tax_data.tax.id === tax.id && tax_data.is_reverse_charge === is_reverse_charge
+                    ) || null
+                ]);
+
+            tax_amounts.total_included_currency = tax_amounts.base_lines.reduce(
+                (sum, base_line) => sum + Math.abs(base_line.tax_details.total_included_currency),
+                0
+            );
+
+            if (!tax || !tax_amounts.total_included_currency) {
                 continue;
             }
 
-            const tax_details = base_line.tax_details;
             const delta_tax_amount_currency = tax_amounts.raw_tax_amount_currency - tax_amounts.tax_amount_currency;
             const delta_tax_amount = tax_amounts.raw_tax_amount - tax_amounts.tax_amount;
+            for (const [delta, delta_field, delta_currency] of [
+                [delta_tax_amount_currency, 'tax_amount_currency', currency],
+                [delta_tax_amount, 'tax_amount', company.currency_id]
+            ]) {
+                if (floatIsZero(delta, delta_currency.decimal_places)) {
+                    continue;
+                }
 
-            const tax_data = tax_details.taxes_data.find(x => x.tax.id === tax_amounts.tax.id && x.is_reverse_charge === tax_amounts.is_reverse_charge);
-            tax_amounts.reference_tax_data = tax_data;
-            tax_data.tax_amount_currency += delta_tax_amount_currency;
-            tax_data.tax_amount += delta_tax_amount;
+                const sign = delta < 0.0 ? -1 : 1;
+                let nb_of_errors = Math.round(Math.abs(delta / delta_currency.rounding));
+                let remaining_errors = nb_of_errors;
+
+                for (const [base_line, tax_data] of tax_amounts.sorted_base_line_x_tax_data) {
+                    const tax_details = base_line.tax_details;
+                    if (!remaining_errors || !tax_data) {
+                        break;
+                    }
+
+                    const nb_of_amount_to_distribute = Math.min(
+                        Math.ceil(Math.abs(tax_details.total_included_currency * nb_of_errors / tax_amounts.total_included_currency)),
+                        remaining_errors
+                    );
+                    remaining_errors -= nb_of_amount_to_distribute;
+                    const amount_to_distribute = sign * nb_of_amount_to_distribute * delta_currency.rounding;
+                    tax_data[delta_field] += amount_to_distribute;
+                }
+            }
         }
 
         // Dispatch the delta of base amounts accross the base lines.
@@ -780,30 +812,48 @@ export const accountTaxHelpers = {
         // The expected base amount of the whole document is round(12.12 * 12.12 * 2) = 293.79
         // The delta in term of base amount is 293.79 - 146.89 - 146.89 = 0.01
         for (const tax_amounts of Object.values(total_per_tax)) {
-            const base_line = tax_amounts.reference_base_line;
-            if (!base_line){
+            const currency = tax_amounts.currency;
+            if (!tax_amounts.sorted_base_line_x_tax_data || !tax_amounts.total_included_currency) {
                 continue;
             }
 
             const delta_base_amount_currency = tax_amounts.raw_base_amount_currency - tax_amounts.base_amount_currency;
             const delta_base_amount = tax_amounts.raw_base_amount - tax_amounts.base_amount;
-            if (floatIsZero(delta_base_amount_currency, tax_amounts.currency.decimal_places) && floatIsZero(delta_base_amount, company.currency_id.decimal_places)) {
-                continue;
-            }
+            for (const [delta, delta_currency_indicator, delta_currency] of [
+                [delta_base_amount_currency, '_currency', currency],
+                [delta_base_amount, '', company.currency_id]
+            ]) {
+                if (floatIsZero(delta, delta_currency.decimal_places)) {
+                    continue;
+                }
 
-            const tax_details = base_line.tax_details;
-            const tax_data = tax_amounts.reference_tax_data;
-            if (tax_data) {
-                tax_data.base_amount_currency += delta_base_amount_currency;
-                tax_data.base_amount += delta_base_amount;
-            } else {
-                tax_details.delta_total_excluded_currency += delta_base_amount_currency;
-                tax_details.delta_total_excluded += delta_base_amount;
+                const sign = delta < 0.0 ? -1 : 1;
+                let nb_of_errors = Math.round(Math.abs(delta / delta_currency.rounding));
+                let remaining_errors = nb_of_errors;
 
-                const base_rounding_key = [tax_amounts.currency.id, base_line.is_refund];
-                const base_amounts = total_per_base[base_rounding_key];
-                base_amounts.base_amount_currency += delta_base_amount_currency;
-                base_amounts.base_amount += delta_base_amount;
+                for (const [base_line, tax_data] of tax_amounts.sorted_base_line_x_tax_data) {
+                    const tax_details = base_line.tax_details;
+                    if (!remaining_errors) {
+                        break;
+                    }
+
+                    const nb_of_amount_to_distribute = Math.min(
+                        Math.ceil(Math.abs(tax_details.total_included_currency * nb_of_errors / tax_amounts.total_included_currency)),
+                        remaining_errors
+                    );
+                    remaining_errors -= nb_of_amount_to_distribute;
+                    const amount_to_distribute = sign * nb_of_amount_to_distribute * delta_currency.rounding;
+
+                    if (tax_data) {
+                        tax_data[`base_amount${delta_currency_indicator}`] += amount_to_distribute;
+                    } else {
+                        tax_details[`delta_total_excluded${delta_currency_indicator}`] += amount_to_distribute;
+
+                        const base_rounding_key = [currency.id, base_line.is_refund];
+                        const base_amounts = total_per_base[base_rounding_key];
+                        base_amounts[`base_amount${delta_currency_indicator}`] += amount_to_distribute;
+                    }
+                }
             }
         }
 

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -484,6 +484,7 @@ export const accountTaxHelpers = {
             record: record,
             id: load('id', 0),
             product_id: load('product_id', {}),
+            product_uom_id: load('product_uom_id', {}),
             tax_ids: load('tax_ids', {}),
             price_unit: load('price_unit', 0.0),
             quantity: load('quantity', 0.0),

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -856,6 +856,12 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             return {}
         return taxes._eval_taxes_computation_turn_to_product_values(product=product)
 
+    def _jsonify_product_uom(self, uom):
+        return {
+            'id': uom.id,
+            'name': uom.name,
+        }
+
     def _jsonify_tax_group(self, tax_group):
         return {
             'id': tax_group.id,
@@ -903,6 +909,7 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             'currency_id': self._jsonify_currency(line.get('currency_id') or document['currency']),
             'rate': line['rate'] if 'rate' in line else document['rate'],
             'product_id': self._jsonify_product(line['product_id'], line['tax_ids']),
+            'product_uom_id': self._jsonify_product_uom(line['product_uom_id']),
             'tax_ids': [self._jsonify_tax(tax) for tax in line['tax_ids']],
             'price_unit': line['price_unit'],
             'quantity': line['quantity'],
@@ -931,6 +938,20 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             'currency_id': self._jsonify_currency(company.currency_id),
         }
 
+    def convert_base_line_to_invoice_line(self, document, base_line):
+        values = {
+            'price_unit': base_line['price_unit'],
+            'discount': base_line['discount'],
+            'quantity': base_line['quantity'],
+        }
+        if base_line['product_id']:
+            values['product_id'] = base_line['product_id'].id
+        if base_line['product_uom_id']:
+            values['product_uom_id'] = base_line['product_uom_id'].id
+        if base_line['tax_ids']:
+            values['tax_ids'] = [Command.set(base_line['tax_ids'].ids)]
+        return values
+
     def convert_document_to_invoice(self, document):
         invoice_date = '2020-01-01'
         currency = self.setup_other_currency(document['currency'].name.upper(), rates=[(invoice_date, document['rate'])])
@@ -940,13 +961,7 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             'currency_id': currency.id,
             'invoice_cash_rounding_id': document['cash_rounding'] and document['cash_rounding'].id,
             'invoice_line_ids': [
-                Command.create({
-                    'product_id': base_line['product_id'].id,
-                    'price_unit': base_line['price_unit'],
-                    'discount': base_line['discount'],
-                    'quantity': base_line['quantity'],
-                    'tax_ids': [Command.set(base_line['tax_ids'].ids)],
-                })
+                Command.create(self.convert_base_line_to_invoice_line(document, base_line))
                 for base_line in document['lines']
             ],
         })

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -237,17 +237,6 @@ class AccountMove(models.Model):
 
     def _l10n_in_get_hsn_summary_table(self):
         self.ensure_one()
+        base_lines, _tax_lines = self._get_rounded_base_and_tax_lines()
         display_uom = self.env.user.has_group('uom.group_uom')
-
-        base_lines = []
-        for line in self.invoice_line_ids.filtered(lambda x: x.display_type == 'product'):
-            base_lines.append({
-                'l10n_in_hsn_code': line.l10n_in_hsn_code,
-                'quantity': line.quantity,
-                'price_unit': line.price_unit,
-                'discount': line.discount or 0.0,
-                'product': line.product_id,
-                'uom': line.product_uom_id,
-                'taxes_data': line.tax_ids,
-            })
         return self.env['account.tax']._l10n_in_get_hsn_summary_table(base_lines, display_uom)

--- a/addons/l10n_in/models/account_tax.py
+++ b/addons/l10n_in/models/account_tax.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from odoo import api, fields, models
 from odoo.tools import frozendict
 
@@ -36,87 +38,86 @@ class AccountTax(models.Model):
     # HSN SUMMARY
     # -------------------------------------------------------------------------
 
+    def _prepare_base_line_for_taxes_computation(self, record, **kwargs):
+        # EXTENDS 'account'
+        results = super()._prepare_base_line_for_taxes_computation(record, **kwargs)
+        results['l10n_in_hsn_code'] = self._get_base_line_field_value_from_record(record, 'l10n_in_hsn_code', kwargs, False)
+        return results
+
     @api.model
     def _l10n_in_get_hsn_summary_table(self, base_lines, display_uom):
-        results_map = {}
         l10n_in_tax_types = set()
-        for base_line in base_lines:
-            l10n_in_hsn_code = base_line['l10n_in_hsn_code']
-            if not l10n_in_hsn_code:
-                continue
+        items_map = defaultdict(lambda: {
+            'quantity': 0.0,
+            'amount_untaxed': 0.0,
+            'tax_amount_igst': 0.0,
+            'tax_amount_cgst': 0.0,
+            'tax_amount_sgst': 0.0,
+            'tax_amount_cess': 0.0,
+        })
 
-            price_unit = base_line['price_unit']
-            discount = base_line['discount']
-            quantity = base_line['quantity']
-            product = base_line['product']
-            uom = base_line['uom']
-            taxes = base_line['taxes_data']
-
-            final_price_unit = price_unit * (1 - (discount / 100))
-
-            # Compute the taxes.
-            taxes_computation = taxes._get_tax_details(
-                final_price_unit,
-                quantity,
-                rounding_method='round_per_line',
-                product=product,
-            )
-            # Rate.
+        def get_base_line_grouping_key(base_line):
             unique_taxes_data = set(
                 tax_data['tax']
-                for tax_data in taxes_computation['taxes_data']
+                for tax_data in base_line['tax_details']['taxes_data']
                 if tax_data['tax']['l10n_in_tax_type'] in ('igst', 'cgst', 'sgst')
             )
             rate = sum(tax.amount for tax in unique_taxes_data)
 
-            key = frozendict({
-                'l10n_in_hsn_code': l10n_in_hsn_code,
+            return {
+                'l10n_in_hsn_code': base_line['l10n_in_hsn_code'],
+                'uom_name': base_line['product_uom_id'].name,
                 'rate': rate,
-                'uom_name': uom.name,
-            })
-
-            if key in results_map:
-                values = results_map[key]
-                values['quantity'] += quantity
-                values['amount_untaxed'] += taxes_computation['total_excluded']
-            else:
-                results_map[key] = {
-                    **key,
-                    'quantity': quantity,
-                    'amount_untaxed': taxes_computation['total_excluded'],
-                    'tax_amounts': {
-                        'igst': 0.0,
-                        'cgst': 0.0,
-                        'sgst': 0.0,
-                        'cess': 0.0,
-                    },
-                }
-
-            for tax_data in taxes_computation['taxes_data']:
-                l10n_in_tax_type = tax_data['tax'].l10n_in_tax_type
-                if l10n_in_tax_type:
-                    results_map[key]['tax_amounts'][l10n_in_tax_type] += tax_data['tax_amount']
-                    l10n_in_tax_types.add(l10n_in_tax_type)
-
-        items = [
-            {
-                'l10n_in_hsn_code': value['l10n_in_hsn_code'],
-                'uom_name': value['uom_name'],
-                'rate': value['rate'],
-                'quantity': value['quantity'],
-                'amount_untaxed': value['amount_untaxed'],
-                'tax_amount_igst': value['tax_amounts']['igst'],
-                'tax_amount_cgst': value['tax_amounts']['cgst'],
-                'tax_amount_sgst': value['tax_amounts']['sgst'],
-                'tax_amount_cess': value['tax_amounts']['cess'],
             }
-            for value in results_map.values()
-        ]
+
+        # quantity / amount_untaxed.
+        for base_line in base_lines:
+            key = frozendict(get_base_line_grouping_key(base_line))
+            if not key['l10n_in_hsn_code']:
+                continue
+
+            item = items_map[key]
+            item['quantity'] += base_line['quantity']
+            item['amount_untaxed'] += (
+                base_line['tax_details']['total_excluded_currency']
+                + base_line['tax_details']['delta_total_excluded_currency']
+            )
+
+        # Tax amounts.
+        def grouping_function(base_line, tax_data):
+            return {
+                **get_base_line_grouping_key(base_line),
+                'l10n_in_tax_type': tax_data['tax'].l10n_in_tax_type,
+            }
+
+        base_lines_aggregated_values = self._aggregate_base_lines_tax_details(base_lines, grouping_function)
+        values_per_grouping_key = self._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
+        for grouping_key, values in values_per_grouping_key.items():
+            if (
+                not grouping_key
+                or not grouping_key['l10n_in_hsn_code']
+                or not grouping_key['l10n_in_tax_type']
+            ):
+                continue
+
+            key = frozendict({
+                'l10n_in_hsn_code': grouping_key['l10n_in_hsn_code'],
+                'rate': grouping_key['rate'],
+                'uom_name': grouping_key['uom_name'],
+            })
+            item = items_map[key]
+            l10n_in_tax_type = grouping_key['l10n_in_tax_type']
+            item[f'tax_amount_{l10n_in_tax_type}'] += values['tax_amount_currency']
+            l10n_in_tax_types.add(l10n_in_tax_type)
+
         return {
             'has_igst': 'igst' in l10n_in_tax_types,
             'has_gst': bool({'cgst', 'sgst'} & l10n_in_tax_types),
             'has_cess': 'cess' in l10n_in_tax_types,
             'nb_columns': 5 + len(l10n_in_tax_types),
             'display_uom': display_uom,
-            'items': items,
+            'items': [
+                key | values
+                for key, values in items_map.items()
+            ],
         }

--- a/addons/l10n_in/static/src/components/tests_shared_js_python/tests_shared_js_python.js
+++ b/addons/l10n_in/static/src/components/tests_shared_js_python/tests_shared_js_python.js
@@ -6,8 +6,9 @@ import { accountTaxHelpers } from "@account/helpers/account_tax";
 patch(TestsSharedJsPython.prototype, {
     /** override **/
     processTest(params){
-        if(params.test === "l10n_in_hsn_summary"){
-            return {'hsn': accountTaxHelpers.l10n_in_get_hsn_summary_table(params.base_lines, params.display_uom)};
+        if (params.test === "l10n_in_hsn_summary") {
+            const document = this.populateDocument(params.document);
+            return {'hsn': accountTaxHelpers.l10n_in_get_hsn_summary_table(document.lines, params.display_uom)};
         }
         return super.processTest(...arguments);
     },

--- a/addons/l10n_in/tests/test_hsn_summary.py
+++ b/addons/l10n_in/tests/test_hsn_summary.py
@@ -373,7 +373,7 @@ class TestL10nInHSNSummary(TestTaxCommon):
         self.cess_5_plus_1591.sequence = 100
 
         document = self.populate_document(self.init_document([
-            {'l10n_in_hsn_code': self.test_hsn_code_1, 'quantity': 1.0,'price_unit': 15.80, 'product_uom_id': self.uom_unit, 'tax_ids': self.gst_18 + self.cess_5_plus_1591},
+            {'l10n_in_hsn_code': self.test_hsn_code_1, 'quantity': 1.0, 'price_unit': 15.80, 'product_uom_id': self.uom_unit, 'tax_ids': self.gst_18 + self.cess_5_plus_1591},
         ]))
         expected_values = {
             'has_igst': False,
@@ -675,7 +675,7 @@ class TestL10nInHSNSummary(TestTaxCommon):
     def _test_l10n_in_hsn_summary_6(self):
         """ Test with Sale RC tax. """
         document = self.populate_document(self.init_document([
-            {'l10n_in_hsn_code': self.test_hsn_code_1, 'quantity': 1.0,'price_unit': 100.0, 'product_uom_id': self.uom_unit, 'tax_ids': self.igst_18_rc},
+            {'l10n_in_hsn_code': self.test_hsn_code_1, 'quantity': 1.0, 'price_unit': 100.0, 'product_uom_id': self.uom_unit, 'tax_ids': self.igst_18_rc},
         ]))
         expected_values = {
             'has_igst': True,
@@ -758,8 +758,8 @@ class TestL10nInHSNSummary(TestTaxCommon):
                     'rate': 5.0,
                     'amount_untaxed': 1000.0,
                     'tax_amount_igst': 0.0,
-                    'tax_amount_cgst': 24.0,
-                    'tax_amount_sgst': 24.0,
+                    'tax_amount_cgst': 24.5,
+                    'tax_amount_sgst': 24.5,
                     'tax_amount_cess': 0.0,
                 },
                 {
@@ -769,8 +769,8 @@ class TestL10nInHSNSummary(TestTaxCommon):
                     'rate': 5.0,
                     'amount_untaxed': 1000.0,
                     'tax_amount_igst': 0.0,
-                    'tax_amount_cgst': 25.0,
-                    'tax_amount_sgst': 25.0,
+                    'tax_amount_cgst': 24.5,
+                    'tax_amount_sgst': 24.5,
                     'tax_amount_cess': 0.0,
                 },
             ],

--- a/addons/l10n_in/tests/test_hsn_summary.py
+++ b/addons/l10n_in/tests/test_hsn_summary.py
@@ -1,9 +1,10 @@
+from odoo import Command
 from odoo.addons.account.tests.common import TestTaxCommon
 from odoo.tests import tagged
 
 
 @tagged('post_install', '-at_install', 'post_install_l10n')
-class TestHSNsummary(TestTaxCommon):
+class TestL10nInHSNSummary(TestTaxCommon):
 
     @classmethod
     @TestTaxCommon.setup_country('in')
@@ -37,15 +38,26 @@ class TestHSNsummary(TestTaxCommon):
         cls.igst_18_rc = ChartTemplate.ref('igst_sale_18_rc')
 
     def _jsonify_tax(self, tax):
+        # EXTENDS 'account.
         values = super()._jsonify_tax(tax)
         values['l10n_in_tax_type'] = tax.l10n_in_tax_type
         return values
 
-    def _jsonify_uom(self, uom):
-        return {
-            'id': uom.id,
-            'name': uom.name,
-        }
+    def _jsonify_document_line(self, document, index, line):
+        # EXTENDS 'account.
+        values = super()._jsonify_document_line(document, index, line)
+        values['l10n_in_hsn_code'] = line['l10n_in_hsn_code']
+        return values
+
+    def convert_base_line_to_invoice_line(self, document, base_line):
+        # EXTENDS 'account.
+        values = super().convert_base_line_to_invoice_line(document, base_line)
+        values['l10n_in_hsn_code'] = base_line['l10n_in_hsn_code']
+        return values
+
+    # -------------------------------------------------------------------------
+    # l10n_in_hsn_summary
+    # -------------------------------------------------------------------------
 
     def _assert_sub_test_l10n_in_hsn_summary(self, results, expected_values):
         self.assertEqual(
@@ -56,29 +68,21 @@ class TestHSNsummary(TestTaxCommon):
         for item, expected_item in zip(results['hsn']['items'], expected_values['items']):
             self.assertDictEqual(item, expected_item)
 
-    def _create_py_sub_test_l10n_in_hsn_summary(self, base_lines, display_uom):
+    def _create_py_sub_test_l10n_in_hsn_summary(self, document, display_uom):
         return {
-            'hsn': self.env['account.tax']._l10n_in_get_hsn_summary_table(base_lines, display_uom),
+            'hsn': self.env['account.tax']._l10n_in_get_hsn_summary_table(document['lines'], display_uom),
         }
 
-    def _create_js_sub_test_l10n_in_hsn_summary(self, base_lines, display_uom):
-        new_base_lines = []
-        for base_line in base_lines:
-            base_line = dict(base_line)
-            taxes = base_line['taxes_data']
-            base_line['taxes_data'] = [self._jsonify_tax(tax) for tax in taxes]
-            base_line['product'] = self._jsonify_product(base_line['product'], taxes)
-            base_line['uom'] = self._jsonify_uom(base_line['uom'])
-            new_base_lines.append(base_line)
+    def _create_js_sub_test_l10n_in_hsn_summary(self, document, display_uom):
         return {
             'test': 'l10n_in_hsn_summary',
+            'document': self._jsonify_document(document),
             'display_uom': display_uom,
-            'base_lines': new_base_lines,
         }
 
     def assert_l10n_in_hsn_summary(
         self,
-        base_lines,
+        document,
         expected_values,
         display_uom=False,
     ):
@@ -87,9 +91,25 @@ class TestHSNsummary(TestTaxCommon):
             self._create_py_sub_test_l10n_in_hsn_summary,
             self._create_js_sub_test_l10n_in_hsn_summary,
             self._assert_sub_test_l10n_in_hsn_summary,
-            base_lines,
+            document,
             display_uom,
         )
+
+    # -------------------------------------------------------------------------
+    # invoice l10n_in_hsn_summary
+    # -------------------------------------------------------------------------
+
+    def assert_invoice_l10n_in_hsn_summary(self, invoice, expected_values):
+        results = {'hsn': {
+            **invoice._l10n_in_get_hsn_summary_table(),
+            # 'display_uom' is just checking if the user has the uom group. It's irrelevant to test it.
+            'display_uom': expected_values['display_uom'],
+        }}
+        self._assert_sub_test_l10n_in_hsn_summary(results, expected_values)
+
+    # -------------------------------------------------------------------------
+    # Tests
+    # -------------------------------------------------------------------------
 
     def create_base_line_dict(self, l10n_in_hsn_code, quantity, price_unit, discount, uom, taxes=None, product=None):
         return {
@@ -102,539 +122,656 @@ class TestHSNsummary(TestTaxCommon):
             'taxes_data': taxes or self.env['account.tax'],
         }
 
-    def test_l10n_in_hsn_summary_1(self):
+    def _test_l10n_in_hsn_summary_1(self):
         """ Test GST/IGST taxes. """
-        base_lines1 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, 0.0, self.uom_unit, self.gst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, 0.0, self.uom_unit, self.gst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, 0.0, self.uom_unit, self.gst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, 0.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, 0.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, 0.0, self.uom_unit, self.gst_18),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines1,
-            {
-                'has_igst': False,
-                'has_gst': True,
-                'has_cess': False,
-                'nb_columns': 7,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 8.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 5.0,
-                        'amount_untaxed': 2300.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 57.5,
-                        'tax_amount_sgst': 57.5,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 8.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 2300.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 207.0,
-                        'tax_amount_sgst': 207.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 600.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 600.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+        ]))
+        expected_values = {
+            'has_igst': False,
+            'has_gst': True,
+            'has_cess': False,
+            'nb_columns': 7,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 8.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 5.0,
+                    'amount_untaxed': 2300.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 57.5,
+                    'tax_amount_sgst': 57.5,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 8.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 2300.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 207.0,
+                    'tax_amount_sgst': 207.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 1, document, expected_values
 
-        # Change the UOM of the second line.
-        base_lines2 = [
-            base_lines1[0],
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 12000.0, 0.0, self.uom_dozen, self.gst_5),
-        ] + base_lines1[2:]
-        self.assert_l10n_in_hsn_summary(
-            base_lines2,
-            {
-                'has_igst': False,
-                'has_gst': True,
-                'has_cess': False,
-                'nb_columns': 7,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 7.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 5.0,
-                        'amount_untaxed': 1700.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 42.5,
-                        'tax_amount_sgst': 42.5,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 1.0,
-                        'uom_name': self.uom_dozen.name,
-                        'rate': 5.0,
-                        'amount_untaxed': 12000.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 300.0,
-                        'tax_amount_sgst': 300.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 8.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 2300.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 207.0,
-                        'tax_amount_sgst': 207.0,
-                        'tax_amount_cess': 0.0,
-                    }
-                ]
-            },
-        )
+        # Another UOM on the second line.
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 12000.0,  'product_uom_id': self.uom_dozen,   'tax_ids': self.gst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 600.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+        ]))
+        expected_values = {
+            'has_igst': False,
+            'has_gst': True,
+            'has_cess': False,
+            'nb_columns': 7,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 7.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 5.0,
+                    'amount_untaxed': 1700.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 42.5,
+                    'tax_amount_sgst': 42.5,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_dozen.name,
+                    'rate': 5.0,
+                    'amount_untaxed': 12000.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 300.0,
+                    'tax_amount_sgst': 300.0,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 8.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 2300.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 207.0,
+                    'tax_amount_sgst': 207.0,
+                    'tax_amount_cess': 0.0,
+                }
+            ]
+        }
+        yield 2, document, expected_values
 
         # Change GST 5% taxes to IGST.
-        base_lines3 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, 0.0, self.uom_unit, self.igst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 12000.0, 0.0, self.uom_dozen, self.igst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, 0.0, self.uom_unit, self.igst_5),
-        ] + base_lines1[3:]
-        self.assert_l10n_in_hsn_summary(
-            base_lines3,
-            {
-                'has_igst': True,
-                'has_gst': True,
-                'has_cess': False,
-                'nb_columns': 8,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 7.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 5.0,
-                        'amount_untaxed': 1700.0,
-                        'tax_amount_igst': 85.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 1.0,
-                        'uom_name': self.uom_dozen.name,
-                        'rate': 5.0,
-                        'amount_untaxed': 12000.0,
-                        'tax_amount_igst': 600.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 8.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 2300.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 207.0,
-                        'tax_amount_sgst': 207.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 12000.0,  'product_uom_id': self.uom_dozen,   'tax_ids': self.igst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 600.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+        ]))
+        expected_values = {
+            'has_igst': True,
+            'has_gst': True,
+            'has_cess': False,
+            'nb_columns': 8,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 7.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 5.0,
+                    'amount_untaxed': 1700.0,
+                    'tax_amount_igst': 85.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_dozen.name,
+                    'rate': 5.0,
+                    'amount_untaxed': 12000.0,
+                    'tax_amount_igst': 600.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 8.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 2300.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 207.0,
+                    'tax_amount_sgst': 207.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 3, document, expected_values
 
         # Put back the UOM of the second line to unit.
-        base_lines4 = [
-            base_lines3[0],
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, 0.0, self.uom_unit, self.igst_5),
-        ] + base_lines3[2:]
-        self.assert_l10n_in_hsn_summary(
-            base_lines4,
-            {
-                'has_igst': True,
-                'has_gst': True,
-                'has_cess': False,
-                'nb_columns': 8,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 8.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 5.0,
-                        'amount_untaxed': 2300.0,
-                        'tax_amount_igst': 115.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 8.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 2300.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 207.0,
-                        'tax_amount_sgst': 207.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 600.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 600.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+        ]))
+        expected_values = {
+            'has_igst': True,
+            'has_gst': True,
+            'has_cess': False,
+            'nb_columns': 8,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 8.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 5.0,
+                    'amount_untaxed': 2300.0,
+                    'tax_amount_igst': 115.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 8.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 2300.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 207.0,
+                    'tax_amount_sgst': 207.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 4, document, expected_values
 
         # Change GST 18% taxes to IGST.
-        base_lines5 = base_lines4[:3] + [
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, 0.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, 0.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, 0.0, self.uom_unit, self.igst_18),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines5,
-            {
-                'has_igst': True,
-                'has_gst': False,
-                'has_cess': False,
-                'nb_columns': 6,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 8.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 5.0,
-                        'amount_untaxed': 2300.0,
-                        'tax_amount_igst': 115.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 8.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 2300.0,
-                        'tax_amount_igst': 414.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 600.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_5},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 600.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 5.0,    'price_unit': 300.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_18},
+        ]))
+        expected_values = {
+            'has_igst': True,
+            'has_gst': False,
+            'has_cess': False,
+            'nb_columns': 6,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 8.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 5.0,
+                    'amount_untaxed': 2300.0,
+                    'tax_amount_igst': 115.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 8.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 2300.0,
+                    'tax_amount_igst': 414.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 5, document, expected_values
+
+    def test_l10n_in_hsn_summary_1_generic_helpers(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_1():
+            with self.subTest(test_index=test_index):
+                self.assert_l10n_in_hsn_summary(document, expected_values)
         self._run_js_tests()
 
-    def test_l10n_in_hsn_summary_2(self):
+    def test_l10n_in_hsn_summary_1_invoices(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_1():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
+                self.assert_invoice_l10n_in_hsn_summary(invoice, expected_values)
+
+    def _test_l10n_in_hsn_summary_2(self):
         """ Test CESS taxes in combination with GST/IGST. """
         # Need the tax to be evaluated at the end.
         self.cess_5_plus_1591.sequence = 100
 
-        base_lines1 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 15.80, 0.0, self.uom_unit, self.gst_18 + self.cess_5_plus_1591),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines1,
-            {
-                'has_igst': False,
-                'has_gst': True,
-                'has_cess': True,
-                'nb_columns': 8,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 1.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 15.8,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 1.42,
-                        'tax_amount_sgst': 1.42,
-                        'tax_amount_cess': 2.38,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1, 'quantity': 1.0,'price_unit': 15.80, 'product_uom_id': self.uom_unit, 'tax_ids': self.gst_18 + self.cess_5_plus_1591},
+        ]))
+        expected_values = {
+            'has_igst': False,
+            'has_gst': True,
+            'has_cess': True,
+            'nb_columns': 8,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 15.8,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 1.42,
+                    'tax_amount_sgst': 1.42,
+                    'tax_amount_cess': 2.38,
+                },
+            ],
+        }
+        yield 1, document, expected_values
 
         # Change GST 18% taxes to IGST.
-        base_lines2 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 15.80, 0.0, self.uom_unit, self.igst_18 + self.cess_5_plus_1591),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines2,
-            {
-                'has_igst': True,
-                'has_gst': False,
-                'has_cess': True,
-                'nb_columns': 7,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 1.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 15.8,
-                        'tax_amount_igst': 2.84,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 2.38,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 15.80,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_18 + self.cess_5_plus_1591},
+        ]))
+        expected_values = {
+            'has_igst': True,
+            'has_gst': False,
+            'has_cess': True,
+            'nb_columns': 7,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 15.8,
+                    'tax_amount_igst': 2.84,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 2.38,
+                },
+            ],
+        }
+        yield 2, document, expected_values
+
+    def test_l10n_in_hsn_summary_2_generic_helpers(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_2():
+            with self.subTest(test_index=test_index):
+                self.assert_l10n_in_hsn_summary(document, expected_values)
         self._run_js_tests()
 
-    def test_l10n_in_hsn_summary_3(self):
+    def test_l10n_in_hsn_summary_2_invoices(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_2():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
+                self.assert_invoice_l10n_in_hsn_summary(invoice, expected_values)
+
+    def _test_l10n_in_hsn_summary_3(self):
         """ Test with mixed HSN codes. """
-        base_lines1 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, 0.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 50.0, 0.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_2, 1.0, 100.0, 0.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_2, 2.0, 50.0, 0.0, self.uom_unit, self.gst_18),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines1,
-            {
-                'has_igst': False,
-                'has_gst': True,
-                'has_cess': False,
-                'nb_columns': 7,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 3.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 200.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 18.0,
-                        'tax_amount_sgst': 18.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_2,
-                        'quantity': 3.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 200.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 18.0,
-                        'tax_amount_sgst': 18.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 50.0,     'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_2,  'quantity': 1.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_2,  'quantity': 2.0,    'price_unit': 50.0,     'product_uom_id': self.uom_unit,    'tax_ids': self.gst_18},
+        ]))
+        expected_values = {
+            'has_igst': False,
+            'has_gst': True,
+            'has_cess': False,
+            'nb_columns': 7,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 3.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 200.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 18.0,
+                    'tax_amount_sgst': 18.0,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_2,
+                    'quantity': 3.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 200.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 18.0,
+                    'tax_amount_sgst': 18.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 1, document, expected_values
 
         # Change GST 18% taxes to IGST.
-        base_lines2 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, 0.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 50.0, 0.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_2, 1.0, 100.0, 0.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_2, 2.0, 50.0, 0.0, self.uom_unit, self.igst_18),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines2,
-            {
-                'has_igst': True,
-                'has_gst': False,
-                'has_cess': False,
-                'nb_columns': 6,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 3.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 200.0,
-                        'tax_amount_igst': 36.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_2,
-                        'quantity': 3.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 200.0,
-                        'tax_amount_igst': 36.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 2.0,    'price_unit': 50.0,     'product_uom_id': self.uom_unit,    'tax_ids': self.igst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_2,  'quantity': 1.0,    'price_unit': 100.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_2,  'quantity': 2.0,    'price_unit': 50.0,     'product_uom_id': self.uom_unit,    'tax_ids': self.igst_18},
+        ]))
+        expected_values = {
+            'has_igst': True,
+            'has_gst': False,
+            'has_cess': False,
+            'nb_columns': 6,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 3.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 200.0,
+                    'tax_amount_igst': 36.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_2,
+                    'quantity': 3.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 200.0,
+                    'tax_amount_igst': 36.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 2, document, expected_values
+
+    def test_l10n_in_hsn_summary_3_generic_helpers(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_3():
+            with self.subTest(test_index=test_index):
+                self.assert_l10n_in_hsn_summary(document, expected_values)
         self._run_js_tests()
 
-    def test_l10n_in_hsn_summary_4(self):
+    def test_l10n_in_hsn_summary_3_invoices(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_3():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
+                self.assert_invoice_l10n_in_hsn_summary(invoice, expected_values)
+
+    def _test_l10n_in_hsn_summary_4(self):
         """ Zero rated GST or no taxes at all."""
-        base_lines1 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines1,
-            {
-                'has_igst': False,
-                'has_gst': False,
-                'has_cess': False,
-                'nb_columns': 5,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 2.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 0.0,
-                        'amount_untaxed': 700.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 350.0,    'product_uom_id': self.uom_unit},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 350.0,    'product_uom_id': self.uom_unit},
+        ]))
+        expected_values = {
+            'has_igst': False,
+            'has_gst': False,
+            'has_cess': False,
+            'nb_columns': 5,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 2.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 0.0,
+                    'amount_untaxed': 700.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 1, document, expected_values
 
         # No tax to IGST 0%/exempt.
-        base_lines2 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit, self.igst_0),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit, self.exempt_0),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines2,
-            {
-                'has_igst': False,
-                'has_gst': False,
-                'has_cess': False,
-                'nb_columns': 5,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 2.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 0.0,
-                        'amount_untaxed': 700.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 350.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_0},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 350.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.exempt_0},
+        ]))
+        expected_values = {
+            'has_igst': False,
+            'has_gst': False,
+            'has_cess': False,
+            'nb_columns': 5,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 2.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 0.0,
+                    'amount_untaxed': 700.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 2, document, expected_values
 
         # Put one IGST 18% to get a value on the IGST column.
-        base_lines3 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit, self.igst_18),
-            base_lines2[1],
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines3,
-            {
-                'has_igst': True,
-                'has_gst': False,
-                'has_cess': False,
-                'nb_columns': 6,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 1.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 350.0,
-                        'tax_amount_igst': 63.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 1.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 0.0,
-                        'amount_untaxed': 350.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 350.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.igst_18},
+            {'l10n_in_hsn_code': self.test_hsn_code_1,  'quantity': 1.0,    'price_unit': 350.0,    'product_uom_id': self.uom_unit,    'tax_ids': self.exempt_0},
+        ]))
+        expected_values = {
+            'has_igst': True,
+            'has_gst': False,
+            'has_cess': False,
+            'nb_columns': 6,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 350.0,
+                    'tax_amount_igst': 63.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 0.0,
+                    'amount_untaxed': 350.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 3, document, expected_values
+
+    def test_l10n_in_hsn_summary_4_generic_helpers(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_4():
+            with self.subTest(test_index=test_index):
+                self.assert_l10n_in_hsn_summary(document, expected_values)
         self._run_js_tests()
 
-    def test_l10n_in_hsn_summary_5(self):
+    def test_l10n_in_hsn_summary_4_invoices(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_4():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
+                self.assert_invoice_l10n_in_hsn_summary(invoice, expected_values)
+
+    def _test_l10n_in_hsn_summary_5(self):
         """ Test with discount. """
-        base_lines = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, 10.0, self.uom_unit),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines,
-            {
-                'has_igst': False,
-                'has_gst': False,
-                'has_cess': False,
-                'nb_columns': 5,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 1.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 0.0,
-                        'amount_untaxed': 90.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1, 'quantity': 1.0, 'price_unit': 100.0, 'discount': 10.0, 'product_uom_id': self.uom_unit},
+        ]))
+        expected_values = {
+            'has_igst': False,
+            'has_gst': False,
+            'has_cess': False,
+            'nb_columns': 5,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 0.0,
+                    'amount_untaxed': 90.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 1, document, expected_values
+
+    def test_l10n_in_hsn_summary_5_generic_helpers(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_5():
+            with self.subTest(test_index=test_index):
+                self.assert_l10n_in_hsn_summary(document, expected_values)
         self._run_js_tests()
 
-    def test_l10n_in_hsn_summary_6(self):
+    def test_l10n_in_hsn_summary_5_invoices(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_5():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
+                self.assert_invoice_l10n_in_hsn_summary(invoice, expected_values)
+
+    def _test_l10n_in_hsn_summary_6(self):
         """ Test with Sale RC tax. """
-        base_lines = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, 0.0, self.uom_unit, self.igst_18_rc),
-        ]
-        self.assert_l10n_in_hsn_summary(
-            base_lines,
-            {
-                'has_igst': True,
-                'has_gst': False,
-                'has_cess': False,
-                'nb_columns': 6,
-                'display_uom': False,
-                'items': [
-                    {
-                        'l10n_in_hsn_code': self.test_hsn_code_1,
-                        'quantity': 1.0,
-                        'uom_name': self.uom_unit.name,
-                        'rate': 18.0,
-                        'amount_untaxed': 100.0,
-                        'tax_amount_igst': 0.0,
-                        'tax_amount_cgst': 0.0,
-                        'tax_amount_sgst': 0.0,
-                        'tax_amount_cess': 0.0,
-                    },
-                ],
-            },
-        )
+        document = self.populate_document(self.init_document([
+            {'l10n_in_hsn_code': self.test_hsn_code_1, 'quantity': 1.0,'price_unit': 100.0, 'product_uom_id': self.uom_unit, 'tax_ids': self.igst_18_rc},
+        ]))
+        expected_values = {
+            'has_igst': True,
+            'has_gst': False,
+            'has_cess': False,
+            'nb_columns': 6,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 18.0,
+                    'amount_untaxed': 100.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 0.0,
+                    'tax_amount_sgst': 0.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        }
+        yield 1, document, expected_values
+
+    def test_l10n_in_hsn_summary_6_generic_helpers(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_6():
+            with self.subTest(test_index=test_index):
+                self.assert_l10n_in_hsn_summary(document, expected_values)
         self._run_js_tests()
+
+    def test_l10n_in_hsn_summary_6_invoices(self):
+        for test_index, document, expected_values in self._test_l10n_in_hsn_summary_6():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
+                self.assert_invoice_l10n_in_hsn_summary(invoice, expected_values)
+
+    def test_l10n_in_hsn_summary_manual_edit_invoice_taxes(self):
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'invoice_date': '2017-01-01',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'price_unit': 1000.0,
+                    'tax_ids': [Command.set(self.gst_5.ids)],
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'l10n_in_hsn_code': self.test_hsn_code_2,
+                    'price_unit': 1000.0,
+                    'tax_ids': [Command.set(self.gst_5.ids)],
+                }),
+            ],
+        })
+
+        # Manual edition of the tax.
+        sgst_tax = self.gst_5.children_tax_ids.filtered(lambda tax: tax.l10n_in_tax_type == 'sgst')
+        cgst_tax = self.gst_5.children_tax_ids.filtered(lambda tax: tax.l10n_in_tax_type == 'cgst')
+        tax_line_sgst = invoice.line_ids.filtered(lambda aml: aml.tax_line_id == sgst_tax)
+        tax_line_cgst = invoice.line_ids.filtered(lambda aml: aml.tax_line_id == cgst_tax)
+        payment_term = invoice.line_ids.filtered(lambda aml: aml.display_type == 'payment_term')
+        invoice.line_ids = [
+            Command.update(tax_line_sgst.id, {'amount_currency': tax_line_sgst.amount_currency + 1.0}),
+            Command.update(tax_line_cgst.id, {'amount_currency': tax_line_cgst.amount_currency + 1.0}),
+            Command.update(payment_term.id, {'amount_currency': payment_term.amount_currency - 2.0}),
+        ]
+
+        self.assert_invoice_l10n_in_hsn_summary(invoice, {
+            'has_igst': False,
+            'has_gst': True,
+            'has_cess': False,
+            'nb_columns': 7,
+            'display_uom': False,
+            'items': [
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_1,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 5.0,
+                    'amount_untaxed': 1000.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 24.0,
+                    'tax_amount_sgst': 24.0,
+                    'tax_amount_cess': 0.0,
+                },
+                {
+                    'l10n_in_hsn_code': self.test_hsn_code_2,
+                    'quantity': 1.0,
+                    'uom_name': self.uom_unit.name,
+                    'rate': 5.0,
+                    'amount_untaxed': 1000.0,
+                    'tax_amount_igst': 0.0,
+                    'tax_amount_cgst': 25.0,
+                    'tax_amount_sgst': 25.0,
+                    'tax_amount_cess': 0.0,
+                },
+            ],
+        })

--- a/addons/l10n_in_pos/__manifest__.py
+++ b/addons/l10n_in_pos/__manifest__.py
@@ -24,6 +24,9 @@
             'l10n_in/static/src/helpers/hsn_summary.js',
             'l10n_in_pos/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'l10n_in_pos/static/tests/tours/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
@@ -29,7 +29,8 @@
         <xpath expr="//div[@class='before-footer']" position="after">
             <br/>
             <t t-set="l10n_in_hsn_summary" t-value="props.data?.l10n_in_hsn_summary"/>
-            <table t-if="l10n_in_hsn_summary and props.data.headerData.company.country_id?.code === 'IN' and l10n_in_hsn_summary.items.length > 0" style="width:100%;">
+            <table class="l10n_in_hsn_summary_table"
+                   t-if="l10n_in_hsn_summary and props.data.headerData.company.country_id?.code === 'IN' and l10n_in_hsn_summary.items.length > 0" style="width:100%;">
               <tr>
                     <th class="text-center fw-bolder" colspan="6">HSN Summary</th>
                 </tr>

--- a/addons/l10n_in_pos/static/src/overrides/models/pos_order_line.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/pos_order_line.js
@@ -13,6 +13,13 @@ patch(PosOrderline.prototype, {
             l10n_in_hsn_code: this.get_product().l10n_in_hsn_code || "",
         };
     },
+
+    // EXTENDS 'point_of_sale'
+    prepareBaseLineForTaxesComputationExtraValues(customValues = {}) {
+        const extraValues = super.prepareBaseLineForTaxesComputationExtraValues(customValues);
+        extraValues.l10n_in_hsn_code = this.product_id.l10n_in_hsn_code;
+        return extraValues;
+    },
 });
 
 patch(Orderline, {

--- a/addons/l10n_in_pos/static/tests/tours/test_hsn_summary.js
+++ b/addons/l10n_in_pos/static/tests/tours/test_hsn_summary.js
@@ -1,0 +1,58 @@
+import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import { registry } from "@web/core/registry";
+
+export function addDocument(documentParams) {
+    const steps = [];
+    for (const values of documentParams) {
+        steps.push(...ProductScreen.addOrderline(values.product, values.quantity));
+        if (values.discount) {
+            steps.push(ProductScreen.addDiscount(values.discount));
+        }
+    }
+    steps.push(ProductScreen.clickPayButton());
+    return steps;
+}
+
+registry.category("web_tour.tours").add("test_l10n_in_hsn_summary_pos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ...addDocument([
+                { product: "product_1_1", quantity: "2" },
+                { product: "product_1_2", quantity: "1" },
+                { product: "product_1_3", quantity: "5" },
+                { product: "product_1_4", quantity: "2" },
+                { product: "product_1_5", quantity: "1" },
+                { product: "product_1_6", quantity: "5" },
+            ]),
+            PaymentScreen.totalIs("5,129.0"),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.remainingIs("0.0"),
+            PaymentScreen.clickValidate(),
+            {
+                isActive: ["desktop"], // not rendered on mobile
+                trigger:
+                    '.receipt-screen .l10n_in_hsn_summary_table tr:nth-child(3) td:nth-child(3):contains("57.50")',
+            },
+            {
+                isActive: ["desktop"], // not rendered on mobile
+                trigger:
+                    '.receipt-screen .l10n_in_hsn_summary_table tr:nth-child(3) td:nth-child(4):contains("57.50")',
+            },
+            {
+                isActive: ["desktop"], // not rendered on mobile
+                trigger:
+                    '.receipt-screen .l10n_in_hsn_summary_table tr:nth-child(4) td:nth-child(3):contains("207.00")',
+            },
+            {
+                isActive: ["desktop"], // not rendered on mobile
+                trigger:
+                    '.receipt-screen .l10n_in_hsn_summary_table tr:nth-child(4) td:nth-child(4):contains("207.00")',
+            },
+        ].flat(),
+});

--- a/addons/l10n_in_pos/tests/__init__.py
+++ b/addons/l10n_in_pos/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_hsn_summary

--- a/addons/l10n_in_pos/tests/test_hsn_summary.py
+++ b/addons/l10n_in_pos/tests/test_hsn_summary.py
@@ -1,0 +1,27 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.l10n_in.tests.test_hsn_summary import TestL10nInHSNSummary
+from odoo.addons.point_of_sale.tests.test_frontend import TestTaxCommonPOS
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestL10nInHSNSummaryPos(TestTaxCommonPOS, TestL10nInHSNSummary):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('in')
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def create_base_line_product(self, base_line, **kwargs):
+        # OVERRIDE 'point_of_sale'
+        return super().create_base_line_product(base_line, **kwargs, l10n_in_hsn_code=base_line['l10n_in_hsn_code'])
+
+    def test_l10n_in_hsn_summary_pos(self):
+        # We only do the first test just to be sure the code is not crashing.
+        # There is no custom code in the POS for that so we suppose the results
+        # are exactly the same.
+        tests = self._test_l10n_in_hsn_summary_1()
+        test1 = next(tests)
+        self.ensure_products_on_document(test1[1], 'product_1')
+        with self.with_new_session(user=self.pos_user):
+            self.start_pos_tour('test_l10n_in_hsn_summary_pos')

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -8,7 +8,7 @@ from odoo import Command
 
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 from odoo.tests import tagged
-from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
+from odoo.addons.account.tests.common import TestTaxCommon, AccountTestInvoicingHttpCommon
 from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_combo_items
 from datetime import date, timedelta
 from odoo.addons.point_of_sale.tests.common import archive_products
@@ -1773,3 +1773,31 @@ class MobileTestUi(TestUi):
     browser_size = '375x667'
     touch_enabled = True
     allow_inherited_tests_method = True
+
+
+class TestTaxCommonPOS(TestPointOfSaleHttpCommon, TestTaxCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_a.name = "AAAAAA"  # The POS only load the first 100 partners
+
+    def create_base_line_product(self, base_line, **kwargs):
+        return self.env['product.product'].create({
+            **kwargs,
+            'available_in_pos': True,
+            'list_price': base_line['price_unit'],
+            'taxes_id': [Command.set(base_line['tax_ids'].ids)],
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+
+    def ensure_products_on_document(self, document, product_prefix):
+        for i, base_line in enumerate(document['lines'], start=1):
+            base_line['product_id'] = self.create_base_line_product(base_line, name=f'{product_prefix}_{i}')
+
+    def assert_pos_order_totals(self, order, expected_values):
+        expected_amounts = {}
+        if 'tax_amount_currency' in expected_values:
+            expected_amounts['amount_tax'] = expected_values['tax_amount_currency']
+        if 'total_amount_currency' in expected_values:
+            expected_amounts['amount_total'] = expected_values['total_amount_currency']
+        self.assertRecordValues(order, [expected_amounts])


### PR DESCRIPTION
Since 18.0, the taxes computation engine is managing the round globally. It means we have helpers and tools to manage features based on multiple base lines at a time. The hsn summary was using a custom representation of a base line with an explicit call to the low level _get_tax_details method. This commit removes this custom code to use the generic base lines instead.

Also, this commit adds a test in POS to ensure the feature is working.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
