### PR TITLE
[FIX] base: use partner lang when naming displayed_type partners

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -359,10 +359,10 @@ class Partner(models.Model):
                 name = f"{self.commercial_company_name or self.sudo().parent_id.name}, {name}"
         return name.strip()
 
-    @api.depends('is_company', 'name', 'parent_id.name', 'type', 'company_name', 'commercial_company_name')
+    @api.depends('is_company', 'name', 'parent_id.name', 'type', 'company_name', 'commercial_company_name', 'lang')
     def _compute_complete_name(self):
         for partner in self:
-            partner.complete_name = partner.with_context({})._get_complete_name()
+            partner.complete_name = partner.with_context({'lang': partner.lang})._get_complete_name()
 
     @api.depends('lang')
     def _compute_active_lang_count(self):


### PR DESCRIPTION
There are two competing issues and their solutions when using the list view for `res.partner`.

### Issue
- If a Delivery/Invoice Address partner is created, but isn't named, we instead concatenate the parent's name with the `type_description` title. However, this value is stored in
 `complete_name` in English and isn't translated. To remedy this, `display_name` was used
to translate on the fly depending on the user's language, showing the proper translation when viewing the `display_name`.
Previous Fix: #147650

- `display_name` is computed and not stored, which prevents us from alphabetically sorting the list by the name column. While the records are ordered by `complete_name ASC`, this still prevents DESC ordering when using the view. To rememdy this, `display_name` was replaced by `complete_name` in the list view.
Previous Fix: #186031

Unfortunately, this leaves us back where we started, where these types of partners always have their names in English. We can either sort or show the translation, but not both.

### Solution
The issue is really only noticeable when 1) the Delivery/Invoice/etc partners aren't given a name and 2) the user is using a non-English language. Instead of translating the `type_description` every time, we can use the partner's `lang` to compute the `complete_name` from the start. This will always display the `Delivery Address` portion in that language, no matter what language the user has set.

opw-4595049
