### PR TITLE
[IMP] l10n_ar: RG 5614/2024: Tax Breakdown on B2C

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Argentina - Accounting',
     'icon': '/base/static/img/country_flags/ar.png',
-    'version': "3.6",
+    'version': "3.7",
     'description': """
 Functional
 ----------

--- a/addons/l10n_ar/data/account_tax_group_data.xml
+++ b/addons/l10n_ar/data/account_tax_group_data.xml
@@ -63,12 +63,20 @@
         <field name="name">Otros Impuestos</field>
         <field name="sequence">20</field>
         <field name="l10n_ar_tribute_afip_code">99</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_impuestos_internos">
         <field name="name">Internal Taxes</field>
         <field name="sequence">15</field>
         <field name="l10n_ar_tribute_afip_code">04</field>
+        <field name="country_id" ref="base.ar"/>
+    </record>
+
+    <record model="account.tax.group" id="tax_group_national_taxes">
+        <field name="name">National Taxes</field>
+        <field name="sequence">30</field>
+        <field name="l10n_ar_tribute_afip_code">01</field>
         <field name="country_id" ref="base.ar"/>
     </record>
 

--- a/addons/l10n_ar/i18n/es.po
+++ b/addons/l10n_ar/i18n/es.po
@@ -6,9 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 10:55+0000\n"
-"PO-Revision-Date: 2024-11-15 10:55+0000\n"
-"Last-Translator: María Fernanda Alvarez Ramírez <mfar@odoo.com>\n"
+"POT-Creation-Date: 2025-03-12 13:15+0000\n"
+"PO-Revision-Date: 2025-03-12 13:15+0000\n"
+"Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -1445,6 +1445,11 @@ msgid "Fiscal Position"
 msgstr "Posición fiscal"
 
 #. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
+msgid "Fiscal Transparency Regime for the Final Consumer (Law 27.743)"
+msgstr "Régimen de Transparencia Fiscal al Consumidor (Ley 27.743)"
+
+#. module: l10n_ar
 #: model:account.account,name:l10n_ar.3_base_fondo_comun_de_inversion
 #: model:account.account,name:l10n_ar.4_base_fondo_comun_de_inversion
 #: model:account.account,name:l10n_ar.5_base_fondo_comun_de_inversion
@@ -2503,6 +2508,11 @@ msgid "Name must be unique!"
 msgstr "¡El nombre debe ser único!"
 
 #. module: l10n_ar
+#: model:account.tax.group,name:l10n_ar.tax_group_national_taxes
+msgid "National Taxes"
+msgstr "Impuestos Nacionales"
+
+#. module: l10n_ar
 #: model:ir.model.fields,field_description:l10n_ar.field_res_country__l10n_ar_natural_vat
 msgid "Natural Person VAT"
 msgstr "CUIT persona física"
@@ -2572,6 +2582,13 @@ msgstr "Factura en linea"
 #, python-format
 msgid "Only numbers allowed for \"%s\""
 msgstr "Solo se permiten números para “%s”"
+
+#. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+#, python-format
+msgid "Other National Ind. Taxes %s"
+msgstr "Otros Impuestos Nacionales Ind. %s"
 
 #. module: l10n_ar
 #: model:account.tax.group,name:l10n_ar.tax_group_otras_percepciones
@@ -5332,6 +5349,13 @@ msgid "Untaxed"
 msgstr "No gravado"
 
 #. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+#, python-format
+msgid "Untaxed Amount"
+msgstr "Base imponible"
+
+#. module: l10n_ar
 #: model:product.template,name:l10n_ar.product_product_no_gravado_product_template
 msgid "Untaxed concepts (VAT NT)"
 msgstr "Conceptos no gravados"
@@ -5381,6 +5405,13 @@ msgstr "IVA 5%"
 #: model:ir.model.fields,field_description:l10n_ar.field_account_tax_group__l10n_ar_vat_afip_code
 msgid "VAT AFIP Code"
 msgstr "Código AFIP de IVA"
+
+#. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+#, python-format
+msgid "VAT Content %s"
+msgstr "IVA Contenido %s"
 
 #. module: l10n_ar
 #: model:account.tax.group,name:l10n_ar.tax_group_iva_exento

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 10:55+0000\n"
-"PO-Revision-Date: 2024-11-15 10:55+0000\n"
+"POT-Creation-Date: 2025-03-12 13:15+0000\n"
+"PO-Revision-Date: 2025-03-12 13:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1392,6 +1392,11 @@ msgid "Fiscal Position"
 msgstr ""
 
 #. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
+msgid "Fiscal Transparency Regime for the Final Consumer (Law 27.743)"
+msgstr ""
+
+#. module: l10n_ar
 #: model:account.account,name:l10n_ar.3_base_fondo_comun_de_inversion
 #: model:account.account,name:l10n_ar.4_base_fondo_comun_de_inversion
 #: model:account.account,name:l10n_ar.5_base_fondo_comun_de_inversion
@@ -2417,6 +2422,11 @@ msgid "Name must be unique!"
 msgstr ""
 
 #. module: l10n_ar
+#: model:account.tax.group,name:l10n_ar.tax_group_national_taxes
+msgid "National Taxes"
+msgstr ""
+
+#. module: l10n_ar
 #: model:ir.model.fields,field_description:l10n_ar.field_res_country__l10n_ar_natural_vat
 msgid "Natural Person VAT"
 msgstr ""
@@ -2482,6 +2492,13 @@ msgstr ""
 #: code:addons/l10n_ar/models/res_partner.py:0
 #, python-format
 msgid "Only numbers allowed for \"%s\""
+msgstr ""
+
+#. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+#, python-format
+msgid "Other National Ind. Taxes %s"
 msgstr ""
 
 #. module: l10n_ar
@@ -5195,6 +5212,13 @@ msgid "Untaxed"
 msgstr ""
 
 #. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+#, python-format
+msgid "Untaxed Amount"
+msgstr ""
+
+#. module: l10n_ar
 #: model:product.template,name:l10n_ar.product_product_no_gravado_product_template
 msgid "Untaxed concepts (VAT NT)"
 msgstr ""
@@ -5243,6 +5267,13 @@ msgstr ""
 #. module: l10n_ar
 #: model:ir.model.fields,field_description:l10n_ar.field_account_tax_group__l10n_ar_vat_afip_code
 msgid "VAT AFIP Code"
+msgstr ""
+
+#. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+#, python-format
+msgid "VAT Content %s"
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, RedirectWarning, ValidationError
+from odoo.tools.misc import formatLang
 from dateutil.relativedelta import relativedelta
 import logging
 _logger = logging.getLogger(__name__)
@@ -334,13 +335,22 @@ class AccountMove(models.Model):
         base_lines = self.line_ids.filtered(lambda x: x.display_type == 'product')
         tax_lines = self.line_ids.filtered(lambda x: x.display_type == 'tax')
 
+        involved_tax_group_ids = []
+        for subtotals in self.tax_totals['groups_by_subtotal'].values():
+            for subtotal in subtotals:
+                involved_tax_group_ids.append(subtotal['tax_group_id'])
+        involved_tax_groups = self.env['account.tax.group'].browse(involved_tax_group_ids)
+        nat_int_tax_groups = involved_tax_groups.filtered(lambda tax_group: tax_group.l10n_ar_tribute_afip_code in ('01', '04'))
+        vat_tax_groups = involved_tax_groups.filtered('l10n_ar_vat_afip_code')
+        both_tax_group_ids = nat_int_tax_groups.ids + vat_tax_groups.ids
+
         # Base lines.
         base_line_vals_list = [x._convert_to_tax_base_line_dict() for x in base_lines]
         if include_vat:
             for vals in base_line_vals_list:
                 vals['taxes'] = vals['taxes']\
                     .flatten_taxes_hierarchy()\
-                    .filtered(lambda tax: not tax.tax_group_id.l10n_ar_vat_afip_code)
+                    .filtered(lambda tax: tax.tax_group_id.id not in both_tax_group_ids)
 
         # Tax lines.
         tax_line_vals_list = [x._convert_to_tax_line_dict() for x in tax_lines]
@@ -348,7 +358,7 @@ class AccountMove(models.Model):
             tax_line_vals_list = [
                 x
                 for x in tax_line_vals_list
-                if not x['tax_repartition_line'].tax_id.tax_group_id.l10n_ar_vat_afip_code
+                if x['tax_repartition_line'].tax_id.tax_group_id.id not in both_tax_group_ids
             ]
 
         tax_totals = self.env['account.tax']._prepare_tax_totals(
@@ -357,10 +367,43 @@ class AccountMove(models.Model):
             tax_lines=tax_line_vals_list,
         )
 
+        temp = self.tax_totals
         if include_vat:
-            temp = self.tax_totals
             tax_totals['amount_total'] = temp['amount_total']
             tax_totals['formatted_amount_total'] = temp['formatted_amount_total']
+
+        # RG 5614/2024: Show ARCA VAT and Other National Internal Taxes
+        if self.l10n_latam_document_type_id.code in ['6', '7', '8']:
+
+            # Prepare the subtotals to show in the report
+            currency_symbol = self.currency_id.symbol
+            detail_info = {}
+
+            for subtotals in temp['groups_by_subtotal'].values():
+                for subtotal in subtotals:
+                    tax_group_id = subtotal['tax_group_id']
+                    tax_amount = subtotal['tax_group_amount']
+
+                    if tax_group_id in nat_int_tax_groups.ids:
+                        key = 'other_taxes'
+                        name = _("Other National Ind. Taxes %s", currency_symbol)
+                    elif tax_group_id in vat_tax_groups.ids:
+                        key = 'vat_taxes'
+                        name = _("VAT Content %s", currency_symbol)
+                    else:
+                        continue  # If not belongs to the needed groups we ignore them
+
+                    if key not in detail_info:
+                        if tax_amount != 0.0:
+                            detail_info[key] = {"name": name, "tax_amount": tax_amount}
+                    else:
+                        detail_info[key]["tax_amount"] += tax_amount
+
+            # Format the amounts to show in the report
+            for _item, values in detail_info.items():
+                values["formatted_amount_tax"] = formatLang(self.env, values["tax_amount"])
+
+            tax_totals["detail_ar_tax"] = list(detail_info.values())
 
         return tax_totals
 

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -180,6 +180,37 @@ class TestAr(AccountTestInvoicingCommon):
         cls.tax_perc_iibb = cls._search_tax(cls, 'percepcion_iibb_ba')
         cls.tax_iva_exento = cls._search_tax(cls, 'iva_exento')
 
+        cls.tax_national = cls.env['account.tax'].create({
+            "name": "National Tax",
+            "description": "National Tax",
+            "amount": "4",
+            "amount_type": "percent",
+            "type_tax_use": "sale",
+            "country_id": cls.env.ref("base.ar").id,
+            "company_id": cls.company_ri.id,
+            "tax_group_id": cls.env.ref("l10n_ar.tax_group_national_taxes").id,
+        })
+        cls.tax_internal = cls.env['account.tax'].create({
+            "name": "Internal Tax",
+            "description": "Internal Tax",
+            "amount": "3",
+            "amount_type": "percent",
+            "type_tax_use": "sale",
+            "country_id": cls.env.ref("base.ar").id,
+            "company_id": cls.company_ri.id,
+            "tax_group_id": cls.env.ref("l10n_ar.tax_impuestos_internos").id,
+        })
+        cls.tax_other = cls.env['account.tax'].create({
+            "name": "Other Tax",
+            "description": "Other Tax",
+            "amount": "100",
+            "amount_type": "fixed",
+            "type_tax_use": "sale",
+            "country_id": cls.env.ref("base.ar").id,
+            "company_id": cls.company_ri.id,
+            "tax_group_id": cls.env.ref("l10n_ar.tax_group_otros_impuestos").id,
+        })
+
         cls.tax_21_purchase = cls._search_tax(cls, 'iva_21', type_tax_use='purchase')
         cls.tax_no_gravado_purchase = cls._search_tax(cls, 'iva_no_gravado', type_tax_use='purchase')
 
@@ -592,6 +623,24 @@ class TestAr(AccountTestInvoicingCommon):
                         line_form.account_id = self.company_data['default_account_revenue']
             invoice = invoice_form.save()
             self.demo_invoices[key] = invoice
+
+    def _create_invoice_from_dict(self, values, use_current_date=True):
+        if not values.get('invoice_payment_term_id'):
+            values['invoice_payment_term_id'] = self.env.ref("account.account_payment_term_end_following_month")
+        if use_current_date:
+            values.pop('invoice_date', False)
+
+        for key, value in values.items():
+            if key.endswith("_id"):
+                values[key] = value.id
+
+        for line in values['invoice_line_ids']:
+            for key, value in line.items():
+                if key.endswith("_id"):
+                    line[key] = value.id
+
+        values['invoice_line_ids'] = [(0, 0, line_data) for line_data in values['invoice_line_ids']]
+        return self.env['account.move'].with_context(default_move_type=values['move_type']).create(values)
 
     # Helpers
 

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -112,3 +112,44 @@ class TestManual(common.TestAr):
             len_line_price_unit_digits = len(line_price_unit_decimal_part)
             if len_l10n_ar_price_unit_digits == len_line_price_unit_digits == decimal_price_digits_setting:
                 self.assertEqual(l10n_ar_price_unit_decimal_part, line_price_unit_decimal_part)
+
+    def test_16_invoice_b_tax_breakdown_1(self):
+        """ Display Both VAT and Other Taxes """
+        invoice1 = self._create_invoice_from_dict({
+            'ref': 'test_invoice_20:  Final Consumer Invoice B with multiple vat/perceptions/internal/other/national taxes',
+            "move_type": 'out_invoice',
+            "partner_id": self.partner_cf,
+            "company_id": self.company_ri,
+            "invoice_date": "2021-03-20",
+            "invoice_line_ids": [
+                {'product_id': self.service_iva_21, 'price_unit': 124.3, 'quantity': 3, 'name': 'Support Services 8',
+                 'tax_ids': [(6, 0, [self.tax_21.id, self.tax_perc_iibb.id])]},
+                {'product_id': self.service_iva_27, 'price_unit': 2250.0, 'quantity': 1,
+                    'tax_ids': [(6, 0, [self.tax_27.id, self.tax_national.id])]},
+                {'product_id': self.product_iva_105_perc, 'price_unit': 1740.0, 'quantity': 1,
+                    'tax_ids': [(6, 0, [self.tax_10_5.id, self.tax_internal.id])]},
+                {'product_id': self.product_iva_105_perc, 'price_unit': 10000.0, 'quantity': 1,
+                    'tax_ids': [(6, 0, [self.tax_0.id, self.tax_other.id])]},
+            ],
+        })
+        res1 = invoice1._l10n_ar_get_invoice_totals_for_report()
+        self.assertEqual(res1.get('detail_ar_tax'), [
+            {'formatted_amount_tax': '868.51', 'name': 'VAT Content $', 'tax_amount': 868.51},
+            {'formatted_amount_tax': '142.20', 'name': 'Other National Ind. Taxes $', 'tax_amount': 142.20}])
+
+    def test_17_invoice_b_tax_breakdown_2(self):
+        """ Display only Other Taxes (VAT taxes are 0) """
+        invoice2 = self._create_invoice_from_dict({
+            'ref': 'test_invoice_21:  inal Consumer Invoice B with 0 tax and internal tax',
+            "move_type": 'out_invoice',
+            "partner_id": self.partner_cf,
+            "company_id": self.company_ri,
+            "invoice_date": "2021-03-20",
+            "invoice_line_ids": [
+                {'product_id': self.product_iva_105_perc, 'price_unit': 10000.0, 'quantity': 1,
+                    'tax_ids': [(6, 0, [self.tax_no_gravado.id, self.tax_internal.id])]},
+            ],
+        })
+        res2 = invoice2._l10n_ar_get_invoice_totals_for_report()
+        self.assertEqual(res2.get('detail_ar_tax'), [
+            {'formatted_amount_tax': '300.00', 'name': 'Other National Ind. Taxes $', 'tax_amount': 300.00}])

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -278,6 +278,28 @@
             <attribute name="t-call">l10n_ar.document_tax_totals</attribute>
         </t>
 
+        <div id="qrcode" position="after">
+            <!-- RG 5614/2024: Show ARCA VAT and Other National Internal Taxes -->
+            <div class="col-sm-7 col-md-6">
+                <table class="table table-sm table-borderless" style="page-break-inside: avoid;" t-if="tax_totals.get('detail_ar_tax')">
+                    <th class="border-black" style="border-bottom: 1px solid" colspan="2">
+                           Fiscal Transparency Regime for the Final Consumer (Law 27.743)
+                    </th>
+                    <t t-foreach="tax_totals['detail_ar_tax']" t-as="detail">
+                        <tr>
+                            <td class="text-end"><strong t-esc="detail['name']"/></td>
+                            <td class="text-end">
+                                <span
+                                    t-att-class="oe_subtotal_footer_separator"
+                                    t-esc="detail['formatted_amount_tax']"
+                                />
+                            </td>
+                        </tr>
+                    </t>
+                </table>
+            </div>
+        </div>
+
     </template>
 
     <template id="document_tax_totals" inherit_id="account.document_tax_totals" primary="True">


### PR DESCRIPTION
LATAM task 1299 / Adhoc Task 47453

---

### Description of the issue/feature this PR addresses:

Update the Argentinean Legal Invoice Report regarding ARCA's new legal requirement: Tax breakdown on B2C. This only affects Factura B and related documents. Now, we will show an extra tax detail section with the title "Fiscal Transparency Regime for the Final Consumer (Law 27.743)" and show the details of the taxes grouped by type: VAT Taxes and Other National Internal Indirect Taxes.

For more info about the RG, go to https://servicioscf.afip.gob.ar/publico/sitio/contenido/novedad/ver.aspx?id=4448

### Current behavior before PR:

Old version of legal PDF report; we are not showing vat taxes, and summarying internal and national taxes on the tax totals

![before-print-detail-other-taxes](https://github.com/user-attachments/assets/2bc416c9-4231-42c4-8c71-fd1f5531d3d2)

### Desired behavior after PR is merged:

We add a special table at the end of the report (ask required in the RG) with the detail of the taxes group by type: vat taxes, and other internal and national taxes

![new-taxes](https://github.com/user-attachments/assets/d75ae2ad-b787-4399-a9d7-c6b3082c67ec)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
