### PR TITLE
[FIX] hr: fix access my profile test case failure

### DIFF
--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -87,7 +87,7 @@ class TestSelfAccessProfile(TestHrCommon):
             'user_id': james.id,
         })
         view = self.env.ref('hr.res_users_view_form_profile')
-        available_actions = james.get_views([(view.id, 'form')], {'toolbar': True})['views']['form']['toolbar']['action']
+        available_actions = james.get_views([(view.id, 'form')], {'toolbar': True})['views']['form']['toolbar'].get('action', {})
         change_password_action = self.env.ref("base.change_password_wizard_action")
 
         self.assertFalse(any(x['id'] == change_password_action.id for x in available_actions))


### PR DESCRIPTION
version 17.0

Issue:
- test_access_my_profile_toolbar test case fail

reason:
- could not find the action from the toolbar menu because toolbar menu is empty

fix
- get empty dictionary using .get('action', {})
