### PR TITLE
[FIX] discuss: gather logs from all tabs when downloading them

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -102,16 +102,7 @@ export class CallSettings extends Component {
     }
 
     onClickDownloadLogs() {
-        this.rtc.logSnapshot();
-        const data = JSON.stringify(this.rtc.state.globalLogs);
-        const blob = new Blob([data], { type: "application/json" });
-        const downloadLink = document.createElement("a");
-        const now = luxon.DateTime.now().toFormat("yyyy-LL-dd_HH-mm");
-        downloadLink.download = `RtcLogs_${now}.json`;
-        const url = URL.createObjectURL(blob);
-        downloadLink.href = url;
-        downloadLink.click();
-        URL.revokeObjectURL(url);
+        this.rtc.dumpLogs({ download: true });
     }
 
     onClickRegisterKeyButton() {

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -39,6 +39,7 @@ function subscribe(target, event, f) {
 
 const SW_MESSAGE_TYPE = {
     UNEXPECTED_CALL_TERMINATION: "UNEXPECTED_CALL_TERMINATION",
+    POST_RTC_LOGS: "POST_RTC_LOGS",
 };
 export const CONNECTION_TYPES = { P2P: "p2p", SERVER: "server" };
 const SCREEN_CONFIG = {
@@ -341,7 +342,6 @@ export class Rtc extends Record {
             connectionType: undefined,
             hasPendingRequest: false,
             channel: undefined,
-            globalLogs: { odooInfo: odoo.info },
             logs: new Map(), // deprecated
             sendCamera: false,
             sendScreen: false,
@@ -532,7 +532,6 @@ export class Rtc extends Record {
      */
     async leaveCall(channel = this.state.channel) {
         this.state.hasPendingRequest = true;
-        this.logSnapshot();
         await this.rpcLeaveCall(channel);
         this.endCall(channel);
         this.state.hasPendingRequest = false;
@@ -546,6 +545,8 @@ export class Rtc extends Record {
         channel.rtcInvitingSession = undefined;
         channel.activeRtcSession = undefined;
         if (channel.eq(this.state.channel)) {
+            this.state.logs.end = new Date().toISOString();
+            this.dumpLogs();
             this.pttExtService.unsubscribe();
             this.network?.disconnect();
             this.clear();
@@ -924,9 +925,16 @@ export class Rtc extends Record {
             toRaw(session)._raw,
             param2
         );
-        let sessionEntry = this.state.logs[session.id];
+        if (!this.state.logs) {
+            return;
+        }
+        let sessionEntry = this.state.logs.entriesBySessionId[session.id];
         if (!sessionEntry) {
-            this.state.logs[session.id] = sessionEntry = { step: "", state: "", logs: [] };
+            this.state.logs.entriesBySessionId[session.id] = sessionEntry = {
+                step: "",
+                state: "",
+                logs: [],
+            };
         }
         if (step) {
             sessionEntry.step = step;
@@ -935,7 +943,7 @@ export class Rtc extends Record {
             sessionEntry.state = state;
         }
         sessionEntry.logs.push({
-            event: `${luxon.DateTime.now().toFormat("HH:mm:ss")}: ${entry}`,
+            event: `${new Date().toISOString()}: ${entry}`,
             error: error && {
                 name: error.name,
                 message: error.message,
@@ -1243,17 +1251,41 @@ export class Rtc extends Record {
     }
 
     newLogs() {
-        const date = luxon.DateTime.now().toFormat("yyyy-MM-dd-HH:mm:ss");
-        const id = `c:${this.state.channel.id}-s:${this.localSession.id}-d:${date}`;
-        this.state.logs = this.state.globalLogs[id] = {};
-        this.state.logs["hasTurn"] = hasTurn(this.iceServers);
+        this.state.logs = {
+            channelId: this.state.channel.id,
+            selfSessionId: this.localSession.id,
+            start: new Date().toISOString(),
+            hasTurn: hasTurn(this.iceServers),
+            entriesBySessionId: {},
+        };
     }
 
-    logSnapshot() {
-        if (!this.state.channel) {
-            // a snapshot out of a call would not collect any data
-            return;
+    /**
+     * @param {Object} [param0={}]
+     * @param  {boolean} [param0.download=false] true if we want to download the logs
+     */
+    dumpLogs({ download = false } = {}) {
+        const logs = [];
+        if (this.state.logs) {
+            logs.push({
+                type: "timeline",
+                entry: this.state.logs.start,
+                value: toRaw(this.state.logs),
+            });
         }
+        if (this.state.channel) {
+            logs.push(this.buildSnapshot());
+        }
+        if (logs.length || download) {
+            browser.navigator.serviceWorker?.controller?.postMessage({
+                name: SW_MESSAGE_TYPE.POST_RTC_LOGS,
+                logs,
+                download,
+            });
+        }
+    }
+
+    buildSnapshot() {
         const server = {};
         if (this.state.connectionType === CONNECTION_TYPES.SERVER) {
             server.info = this.serverInfo;
@@ -1291,13 +1323,27 @@ export class Rtc extends Record {
             }
             return sessionInfo;
         });
-        this.state.globalLogs[`snapshot-${luxon.DateTime.now().toFormat("yyyy-MM-dd-HH-mm-ss")}`] =
-            {
+        return {
+            type: "snapshot",
+            entry: new Date().toISOString(),
+            value: {
                 server,
                 sessions,
                 connectionType: this.state.connectionType,
                 fallback: this.state.fallbackMode,
-            };
+            },
+        };
+    }
+
+    logSnapshot() {
+        if (!this.state.channel) {
+            // a snapshot out of a call would not collect any data
+            return;
+        }
+        browser.navigator.serviceWorker?.controller?.postMessage({
+            name: SW_MESSAGE_TYPE.POST_RTC_LOGS,
+            logs: [this.buildSnapshot()],
+        });
     }
 
     async rpcLeaveCall(channel) {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
@@ -59,6 +59,18 @@ export class DiscussCorePublicWeb {
                         await this.rtcService.leaveCall();
                     }
                     this.rtcService.joinCall(channel);
+                } else if (action === "POST_RTC_LOGS") {
+                    const logs = data || {};
+                    logs.odooInfo = odoo.info;
+                    const string = JSON.stringify(logs);
+                    const blob = new Blob([string], { type: "application/json" });
+                    const downloadLink = document.createElement("a");
+                    const now = luxon.DateTime.now().toFormat("yyyy-LL-dd_HH-mm");
+                    downloadLink.download = `RtcLogs_${now}.json`;
+                    const url = URL.createObjectURL(blob);
+                    downloadLink.href = url;
+                    downloadLink.click();
+                    URL.revokeObjectURL(url);
                 }
             }
         );


### PR DESCRIPTION
Before this commit, logs had to be downloaded from the tab that
hosted the call from which we wanted the logs. If we want logs from
all the calls that happened across tabs, they currently have to be
downloaded separately.

Moreover, since the addition of a shared call state between tabs, it has
become less obvious to know which tab actually hosts the call.

This commit fixes this issue by collecting logs from all tabs before
generating the file.