### PR TITLE
[FIX] mail: show corresponding message in the conversation when clicked

### DIFF
--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -161,6 +161,7 @@ patch(Message.prototype, {
 
     openRecord() {
         this.message.thread.open({ focus: true });
+        this.message.thread.highlightMessage = this.message;
     },
 
     /**

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -1258,3 +1258,24 @@ test("Sidebar compact is crosstab synced", async () => {
     await contains(".o-mail-DiscussSidebar.o-compact", { target: env1 });
     await contains(".o-mail-DiscussSidebar.o-compact", { target: env2 });
 });
+
+test("Redirect to the thread containing the starred message and highlight the message", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+    });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        model: "discuss.channel",
+        res_id: channelId,
+        body: "<p>Hello there!!!</p>",
+    });
+    await start();
+    await openDiscuss();
+    await click(".o-mail-DiscussSidebarChannel", { text: "General" });
+    await click(".o-mail-Message [title='Mark as Todo']");
+    await click("button", { text: "Starred", contains: [".badge", { count: 1 }] });
+    await click(".o-mail-Message-header a", { text: "#General" });
+    await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "General" });
+    await contains(".o-mail-Message.o-highlighted", { text: "Hello there!!!" });
+});


### PR DESCRIPTION
Before this commit, clicking on a starred message only opened the related record. 
After this commit, it now opens the specific message within the conversation.

task-4630138
