### PR TITLE
[IMP] web: customize ModelSelector placeholder and keep focus with draggable hook

### DIFF
--- a/addons/web/static/src/core/model_selector/model_selector.js
+++ b/addons/web/static/src/core/model_selector/model_selector.js
@@ -12,6 +12,7 @@ export class ModelSelector extends Component {
         onModelSelected: Function,
         id: { type: String, optional: true },
         value: { type: String, optional: true },
+        placeholder: { type: String, optional: true },
         // list of models technical name, if not set
         // we will fetch all models we have access to
         models: { type: Array, optional: true },
@@ -42,6 +43,11 @@ export class ModelSelector extends Component {
     get sources() {
         return [this.optionsSource];
     }
+
+    get placeholder() {
+        return this.props.placeholder || _t("Type a model here...");
+    }
+
     get optionsSource() {
         return {
             placeholder: _t("Loading..."),

--- a/addons/web/static/src/core/model_selector/model_selector.xml
+++ b/addons/web/static/src/core/model_selector/model_selector.xml
@@ -13,7 +13,7 @@
                 id="props.id"
                 value="props.value || ''"
                 sources="sources"
-                placeholder.translate="Type a model here..."
+                placeholder="this.placeholder"
                 autoSelect="props.autoSelect"
                 onSelect.bind="onSelect"
             />

--- a/addons/web/static/src/core/utils/draggable_hook_builder.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.js
@@ -704,6 +704,7 @@ export function makeDraggableHook(hookParams) {
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=1352061
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=339293
                 safePrevent(ev);
+                ev.target.focus();
                 let activeElement = document.activeElement;
                 while (activeElement?.nodeName === "IFRAME") {
                     activeElement = activeElement.contentDocument?.activeElement;

--- a/addons/web/static/tests/core/utils/draggable.test.js
+++ b/addons/web/static/tests/core/utils/draggable.test.js
@@ -404,3 +404,26 @@ test("Elements are confined within their container", async () => {
 
     await drop();
 });
+
+test("Focusing is not lost after clicking", async () => {
+    expect.assertions(1);
+
+    class List extends Component {
+        static template = xml`
+            <div t-ref="root" class="root">
+                <input type="checkbox" class="item">Something</input>
+            </div>`;
+        static props = ["*"];
+        setup() {
+            useDraggable({
+                ref: useRef("root"),
+                elements: ".item",
+            });
+        }
+    }
+
+    await mountWithCleanup(List);
+
+    await contains(".item").click();
+    expect(".item").toBeFocused();
+});


### PR DESCRIPTION
Purpose
=======
1.  Allow to customize the ModelSelector placeholder.

2. Keep focusing records after clicking on them when target of used DraggableHook.

Task-4596337