### PR TITLE
[FIX] web: save kanban m2o quick assign

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one.js
+++ b/addons/web/static/src/views/fields/many2one/many2one.js
@@ -61,7 +61,7 @@ export function computeM2OProps(fieldProps) {
         relation: fieldProps.record.fields[fieldProps.name].relation,
         searchThreshold: fieldProps.searchThreshold,
         string: fieldProps.string || fieldProps.record.fields[fieldProps.name].string || "",
-        update: (value) => fieldProps.record.update({ [fieldProps.name]: value }),
+        update: (value, options = {}) => fieldProps.record.update({ [fieldProps.name]: value }, options),
         value: toRaw(fieldProps.record.data[fieldProps.name]),
     };
 }
@@ -355,6 +355,10 @@ export class KanbanMany2One extends Component {
             canQuickCreate: false,
             placeholder: this.props.placeholder || _t("Search user..."),
             readonly: false,
+            update: async (value) => {
+                await this.props.update(value, { save: true });
+                this.assignPopover.close();
+            },
         });
     }
 }

--- a/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
@@ -12,6 +12,7 @@ import {
     models,
     mountView,
     patchWithCleanup,
+    stepAllNetworkCalls,
 } from "@web/../tests/web_test_helpers";
 import { registry } from "@web/core/registry";
 
@@ -370,8 +371,6 @@ test("widget many2one_avatar in kanban view (load more dialog)", async () => {
 });
 
 test("widget many2one_avatar in kanban view", async () => {
-    expect.assertions(5);
-
     await mountView({
         type: "kanban",
         resModel: "partner",
@@ -386,6 +385,8 @@ test("widget many2one_avatar in kanban view", async () => {
                 </templates>
             </kanban>`,
     });
+    stepAllNetworkCalls();
+
     expect(
         ".o_kanban_record:nth-child(1) .o_field_many2one_avatar .o_m2o_avatar > img"
     ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");
@@ -397,8 +398,10 @@ test("widget many2one_avatar in kanban view", async () => {
         ".o_kanban_record:nth-child(4) .o_field_many2one_avatar .o_m2o_avatar > .o_quick_assign"
     ).click();
     expect(".o-overlay-container input").toBeFocused();
+    expect.verifySteps(["web_name_search"]);
     // select first input
     await contains(".o-overlay-container .o-autocomplete--dropdown-item").click();
+    expect.verifySteps(["web_save"]);
     expect(
         ".o_kanban_record:nth-child(4) .o_field_many2one_avatar .o_m2o_avatar > img"
     ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");


### PR DESCRIPTION
Since the commit [1], the kanban many2one widgets does not save anymore when quick assigning an user. This commit fixes the issue.

[1]: https://github.com/odoo-dev/odoo/commit/bcaa9e9b23d637edfe05baff83aea2ac18d9f4b2

task-4640118