### PR TITLE
[FIX] purchase_requisition: show vendor payment terms on alternative rfq

### DIFF
--- a/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
@@ -79,6 +79,7 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
                 'dest_address_id': origin_po.dest_address_id.id,
                 'origin': origin_po.origin,
                 'currency_id': partner.property_purchase_currency_id.id or self.env.company.currency_id.id,
+                'payment_term_id': partner.property_supplier_payment_term_id.id,
             }
             if self.copy_products and origin_po:
                 val['order_line'] = [Command.create(self._get_alternative_line_value(line, product_tmpl_ids_with_description)) for line in origin_po.order_line]


### PR DESCRIPTION
Issue Before This Commit:
============================

When creating an alternative RFQ, the payment terms of the vendor were not set on the RFQ.

Steps to Reproduce:
============================

- Install the purchase_requisition module.
- Set different payment terms for two different vendors.
- Create an RFQ with the first vendor and observe that the payment terms are set correctly.
- Create an alternative RFQ for the second vendor, and notice that the payment terms are not set.

With This Commit:
============================

This commit ensures that when creating an alternative RFQ, the payment terms are correctly set based on the vendor. Now, the payment terms will be consistently applied to the RFQ as per the vendor's configuration.

task - [4633270](https://www.odoo.com/odoo/my-tasks/4633270)
