### PR TITLE
[FIX] {purchase_,}stock: fix returns for exchange for receipts

### DIFF
--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -746,3 +746,35 @@ class TestCreatePicking(common.TestProductCommon):
 
         self.assertTrue(exchange_return_picking)
         self.assertEqual(exchange_return_picking.origin, 'Return of ' + stock_picking.name)
+
+    def test_po_with_return_for_exchange_shows_3_transfers(self):
+        po = self.env['purchase.order'].create(self.po_vals)
+        po.button_confirm()
+
+        stock_picking = po.picking_ids
+        stock_picking.button_validate()
+
+        return_picking_wizard = self.env['stock.return.picking'].with_context(
+            active_ids=stock_picking.ids, active_id=stock_picking.id, active_model='stock.picking'
+        ).create({})
+
+        return_picking_wizard.product_return_moves.quantity = 1.0
+        return_picking_wizard.action_create_exchanges()
+
+        self.assertEqual(
+            po.incoming_picking_count, 3,
+            'All 3 transfers (orig, return, exchange) should be associated with the PO.'
+        )
+
+        picking_type_out = self.env.ref('stock.picking_type_out')
+        picking_type_in = self.env.ref('stock.picking_type_in')
+
+        # Orig: receipt for 5 items
+        self.assertEqual(po.picking_ids[0].picking_type_id, picking_type_in)
+        self.assertEqual(po.picking_ids[0].move_ids.quantity, 5)
+        # Return: delivery for 1 item
+        self.assertEqual(po.picking_ids[1].picking_type_id, picking_type_out)
+        self.assertEqual(po.picking_ids[1].move_ids.quantity, 1)
+        # Exchange: receipt for 1 item
+        self.assertEqual(po.picking_ids[2].picking_type_id, picking_type_in)
+        self.assertEqual(po.picking_ids[2].move_ids.quantity, 1)

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -130,19 +130,22 @@ class ReturnPicking(models.TransientModel):
         }
 
     def _prepare_picking_default_values(self):
-        location = self.picking_id.location_dest_id
-        r_type = self.picking_id.picking_type_id.return_picking_type_id
-        if r_type and r_type.code == 'incoming':
-            location_dest = r_type.default_location_dest_id
+        return self._prepare_picking_default_values_based_on(self.picking_id)
+
+    def _prepare_picking_default_values_based_on(self, picking):
+        location = picking.location_dest_id
+        return_type = picking.picking_type_id.return_picking_type_id
+        if return_type and return_type.code == 'incoming':
+            location_dest = return_type.default_location_dest_id
         else:
-            location_dest = self.picking_id.location_id
+            location_dest = picking.location_id
 
         vals = {
             'move_ids': [],
-            'picking_type_id': self.picking_id.picking_type_id.return_picking_type_id.id or self.picking_id.picking_type_id.id,
+            'picking_type_id': return_type.id or picking.picking_type_id.id,
             'state': 'draft',
-            'return_id': self.picking_id.id,
-            'origin': _("Return of %(picking_name)s", picking_name=self.picking_id.name),
+            'return_id': picking.id,
+            'origin': _("Return of %(picking_name)s", picking_name=picking.name),
             'location_id': location.id,
             'location_dest_id': location_dest.id,
         }
@@ -170,6 +173,22 @@ class ReturnPicking(models.TransientModel):
         new_picking.action_confirm()
         new_picking.action_assign()
         return new_picking
+
+    def _create_exchange(self, return_picking):
+        # Create a new picking for exchanged products
+        exchange_picking = return_picking.copy(self._prepare_picking_default_values_based_on(return_picking))
+        exchange_picking.user_id = False
+        exchange_picking.message_post_with_source(
+            'mail.message_origin_link',
+            render_values={'self': exchange_picking, 'origin': return_picking},
+            subtype_xmlid='mail.mt_note',
+        )
+        for return_line in self.product_return_moves:
+            return_line._process_line(exchange_picking)
+
+        exchange_picking.action_confirm()
+        exchange_picking.action_assign()
+        return exchange_picking
 
     def action_create_returns(self):
         self.ensure_one()
@@ -204,6 +223,13 @@ class ReturnPicking(models.TransientModel):
         """ Create a return for the active picking, then create a return of
         the return for the exchange picking and open it."""
         action = self.action_create_returns()
+        # For receipts: ignore the procurement and create an exchange directly
+        if self.picking_id.picking_type_id.code == 'incoming':
+            return_picking = self.env['stock.picking'].browse([action['res_id']])
+            exchange_picking = self._create_exchange(return_picking)
+            # Set the exchange as a return of the return
+            exchange_picking.return_id = return_picking
+            return action
 
         proc_list = []
         for line in self.product_return_moves:


### PR DESCRIPTION
Currently, a return for exchange made on an incoming transfer (receipt) creates a procurement, which usually ends up with a purchase of the exchanged products.
After the "Return" popup is closed, the exchange transfer is not created; instead, Odoo creates a PO that needs to be approved first in order to create the exchange transfer.

That is a bit confusing for the users, who might expect the exchange to be created immediately.
Also, the procurement process requires the product to have a "Buy" route enabled (in "Inventory" tab) and at least one vendor configured in the "Purchase" tab. Without this configuration, the return for exchange process shows an error message.

After this commit, a return for exchange made on a receipt will ignore the procurement process, and instead it will create the exchange picking immediately.
That way users will see the exchange transfer immediately after closing the "Return" popup. Also, all 3 transfers (original, return, exchange) will be linked to the initial PO (if a PO was created).
Additionally, the exchange picking will be shown as a return of the return picking.

Task: 4453571