### PR TITLE
[IMP] hw_posbox_homepage: ux improvements

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -146,7 +146,8 @@ class IotBoxOwlHomePage(http.Controller):
             'name': device.device_name,
             'value': str(device.data['value']),
             'type': device.device_type,
-            'identifier': device.device_identifier
+            'identifier': device.device_identifier,
+            'connection': device.device_connection,
         } for device in iot_devices.values()]
         device_type_key = lambda device: device['type']
         grouped_devices = {

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
@@ -17,6 +17,14 @@ export const DEVICE_ICONS = {
     scanner: "fa-barcode",
 };
 
+export const CONNECTION_ICONS = {
+    hdmi: "fa-desktop",
+    direct: "fa-usb",
+    serial: "fa-usb",
+    network: "fa-sitemap",
+    bluetooth: "fa-bluetooth",
+};
+
 export class DeviceDialog extends Component {
     static props = {};
     static components = { BootstrapDialog };
@@ -24,6 +32,7 @@ export class DeviceDialog extends Component {
     setup() {
         this.store = useStore();
         this.icons = DEVICE_ICONS;
+        this.connectionIcons = CONNECTION_ICONS;
     }
 
     formatDeviceType(deviceType, numDevices) {
@@ -58,7 +67,10 @@ export class DeviceDialog extends Component {
                             <div class="d-flex flex-column p-1 gap-2">
                                 <div t-foreach="devices[deviceType]" t-as="device" t-key="device.identifier" class="d-flex flex-column bg-light rounded p-2 gap-1">
                                     <span t-out="device.name" class="one-line"/>
-                                    <span t-out="device.identifier" class="text-secondary one-line"/>
+                                    <span class="text-secondary one-line">
+                                        <span t-att-class="'me-2 fa fa-fw ' + connectionIcons[device.connection]"/>
+                                        <t t-out="device.identifier"/>
+                                    </span>
                                     <div t-if="device.value" class="text-secondary one-line">
                                         <i>Last sent value was <t t-out="device.value"/></i>
                                     </div>

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -68,14 +68,14 @@ class StatusPage extends Component {
                         </p>
                     </div>
                     <!-- If the IoT Box is in access point and not connected to internet yet -->
-                    <div t-elif="state.data.is_access_point_up and state.data.qr_code_url and state.data.qr_code_url"> 
-                        <p>1. Connect to the IoT Box network</p>
+                    <div t-elif="state.data.is_access_point_up and state.data.qr_code_wifi and state.data.qr_code_url"> 
+                        <p>Scan this QR code with your smartphone to connect to the IoT box's <b>Wi-Fi hotspot</b>:</p>
                         <div class="qr-code">
                             <img t-att-src="state.data.qr_code_wifi" alt="QR Code Access Point"/>
                         </div>
                         <br/>
                         <br/>
-                        <p>2. Configure Wi-Fi connection</p>
+                        <p>Once you are connected to the Wi-Fi hotspot, you can scan this QR code to access the IoT box <b>Wi-Fi configuration page</b>:</p>
                         <div class="qr-code">
                             <img t-att-src="state.data.qr_code_url" alt="QR Code Wifi Config"/>
                         </div>


### PR DESCRIPTION
This commit implements two changes:
- On the IoT box homepage, a small icon is added for each device indicating if it is connected via USB/Network/Bluetooth etc.
- On the IoT box status page, additional explanation has been added for the use of the QR codes.

task-4642274

![connectiontypes](https://github.com/user-attachments/assets/7c9d1d12-b6c5-4306-ab01-e5040113cf4f)


![qrcodeexplanation](https://github.com/user-attachments/assets/ad1ecc98-a9e0-4e04-a3a6-373b7796e9a5)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
