### PR TITLE
[FIX] mail: Discuss on Mobile - Enter key behavior

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -181,6 +181,10 @@ For more specific needs, you may also assign custom-defined actions
             'mail/static/tests/**/*',
             ('remove', 'mail/static/tests/tours/**/*'),
             ('remove', 'mail/static/tests/helpers/**/*'),
+            ('remove', 'mail/static/tests/mobile/**/*'),
+        ],
+        'web.qunit_mobile_suite_tests': [
+            'mail/static/tests/mobile/**/*',
         ],
         'mail.assets_odoo_sfu': [
             'mail/static/lib/odoo_sfu/odoo_sfu.js',

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -424,6 +424,9 @@ export class Composer extends Component {
                     ev.preventDefault();
                     return;
                 }
+                if (this.isMobileOS()) {
+                    return;
+                }
                 const shouldPost = this.props.mode === "extended" ? ev.ctrlKey : !ev.shiftKey;
                 if (!shouldPost) {
                     return;

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -107,7 +107,7 @@
 
 <t t-name="mail.Composer.sendButton">
     <button t-if="!compact or ui.isSmall" class="o-mail-Composer-send btn o-last"
-        t-att-class="{'btn-primary': extended, 'rounded-0 rounded-end-3': !extended and !compact, 'btn-link align-self-stretch': !extended, 'border-start-0 ms-2 me-3': env.inDiscussApp}"
+        t-att-class="{'btn-primary': extended or (ui.isSmall and !isSendButtonDisabled), 'rounded-0 rounded-end-3': !extended and !compact, 'btn-link': !extended and !(ui.isSmall and !isSendButtonDisabled), 'align-self-stretch': !extended, 'border-start-0 ms-2 me-3': env.inDiscussApp}"
         t-on-click="sendMessage"
         t-att-disabled="isSendButtonDisabled"
         t-att-aria-label="SEND_TEXT"

--- a/addons/mail/static/tests/mobile/composer_tests.js
+++ b/addons/mail/static/tests/mobile/composer_tests.js
@@ -1,0 +1,32 @@
+/* @odoo-module */
+
+import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+
+import { start } from "@mail/../tests/helpers/test_utils";
+import { triggerHotkey, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { contains, insertText, click } from "@web/../tests/utils";
+import { browser } from "@web/core/browser/browser";
+
+QUnit.module("mobile composer");
+
+QUnit.test(
+    'Mobile: enter key should create a newline in composer',
+    async () => {
+        const pyEnv = await startServer();
+        pyEnv["discuss.channel"].create({ name: "General" });
+        // patching navigator to fake a mobile device
+        patchWithCleanup(browser.navigator, {
+            userAgent: "Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)",
+        });
+        const { openDiscuss } = await start();
+        openDiscuss();
+        await click(".o-mail-MessagingMenu-tab", { text: "Channel" });
+        await click(".o-mail-NotificationItem", { text: "General" });
+        await insertText(".o-mail-Composer-input", "Test\n");
+        triggerHotkey("Enter");
+        await insertText(".o-mail-Composer-input", "Other");
+        await click(".o-mail-Composer-send");
+        await contains(".o-mail-Message-body");
+        await contains(".o-mail-Message-body:has(br)", { textContent: "TestOther" });
+    }
+)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The composer should not send the current input on Enter key when being on a mobile device, since it is impossible for them to create a new line with either ctrl-Enter or alt-enter.

The style of send button in mobile was too subtle between active and inactive. Since this button becomes the only way to send message in mobile, its visual as been adapted to make it more obvious.

Task-4209142

Before / After (visual)
![before](https://github.com/user-attachments/assets/aeb4dd34-9959-4794-80fc-6e9ab23b8dda)
![after](https://github.com/user-attachments/assets/6129aeea-5814-4146-ab27-3695417c93d7)

