### PR TITLE
[FIX] pos_self_order: fix pay after meal & notify floorplan

### DIFF
--- a/addons/pos_online_payment/static/src/app/services/pos_store.js
+++ b/addons/pos_online_payment/static/src/app/services/pos_store.js
@@ -5,11 +5,16 @@ import { floatIsZero } from "@web/core/utils/numbers";
 patch(PosStore.prototype, {
     async setup() {
         await super.setup(...arguments);
-        this.data.connectWebSocket("ONLINE_PAYMENTS_NOTIFICATION", ({ id }) => {
+        this.data.connectWebSocket("ONLINE_PAYMENTS_NOTIFICATION", async ({ id }) => {
             // The bus communication is only protected by the name of the channel.
             // Therefore, no sensitive information is sent through it, only a
             // notification to invite the local browser to do a safe RPC to
             // the server to check the new state of the order.
+            const order = this.models["pos.order"].find((o) => o.id == id);
+            const updatedOrder = await this.data.read("pos.order", [id])[0];
+            if (updatedOrder) {
+                order.state = updatedOrder.state;
+            }
             if (this.getOrder()?.id === id) {
                 this.updateOnlinePaymentsDataWithServer(this.getOrder(), false);
             }

--- a/addons/pos_online_payment_self_order/__manifest__.py
+++ b/addons/pos_online_payment_self_order/__manifest__.py
@@ -21,6 +21,9 @@
         'web.assets_tests': [
             'pos_online_payment_self_order/static/tests/tours/pos_online_payment_multi_table_order.js',
         ],
+        'pos_self_order.assets_tests': [
+            'pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
@@ -1,0 +1,29 @@
+import { registry } from "@web/core/registry";
+import * as Utils from "@pos_self_order/../tests/tours/utils/common";
+import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
+import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
+import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
+import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
+
+registry.category("web_tour.tours").add("self_mobile_online_payment_meal_table", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        Utils.clickBtn("Order"),
+        ...CartPage.selectTable("103"),
+        Utils.clickBtn("Ok"),
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Fanta"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Fanta", "2.53", "1"),
+        Utils.clickBtn("Order"),
+        ConfirmationPage.isShown(),
+        Utils.clickBtn("Ok"),
+        Utils.clickBtn("My Order"),
+        Utils.clickBtn("Pay"),
+    ],
+});

--- a/addons/pos_online_payment_self_order/tests/__init__.py
+++ b/addons/pos_online_payment_self_order/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_self_order_frontend
+from . import test_self_order_mobile

--- a/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
@@ -1,0 +1,44 @@
+
+import odoo.tests
+from odoo import Command
+from odoo.addons.pos_online_payment.tests.online_payment_common import OnlinePaymentCommon
+from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.payment_provider = cls.provider
+
+        cls.payment_provider_old_company_id = cls.payment_provider.company_id.id
+        cls.payment_provider_old_journal_id = cls.payment_provider.journal_id.id
+        cls.payment_provider.write({
+            'company_id': cls.company.id,
+        })
+        cls.online_payment_method = cls.env['pos.payment.method'].create({
+            'name': 'Online payment',
+            'is_online_payment': True,
+            'online_payment_provider_ids': [Command.set([cls.payment_provider.id])],
+        })
+
+    def test_online_payment_self_pay_after_meal_table(self):
+        """
+        Verify that we can make multiple orders with online payment in self ordering mode
+        with pay after meal and service mode table.
+        """
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'meal',
+            'self_ordering_service_mode': 'table',
+            'self_order_online_payment_method_id': self.online_payment_method.id,
+        })
+        self.pos_config.write({
+            'self_ordering_pay_after': 'meal',
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "self_mobile_online_payment_meal_table")

--- a/addons/pos_self_order/static/src/app/components/popup_table/popup_table.xml
+++ b/addons/pos_self_order/static/src/app/components/popup_table/popup_table.xml
@@ -5,7 +5,7 @@
         <div class="self_order_popup_table shadow-lg position-absolute fixed-bottom bg-white w-100 p-4 flex-column d-flex justify-content-between">
             <div class="mb-5 d-flex justify-content-between align-items-start">
                 <div>
-                    <h3>Table detective time!</h3>
+                    <h3>Table selection</h3>
                     <span>Could you please confirm your table number?<br/>Thanks a lot!</span>
                 </div>
                 <button class="btn btn-close" t-on-click="close"/>

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -386,6 +386,7 @@ export class SelfOrder extends Reactive {
         ); // Stripe, Adyen, Online
 
         let order = this.currentOrder;
+        const orderHasChanges = Object.keys(order.changes).length > 0;
 
         // Stand number page will recall this function after the stand number is set
         if (
@@ -409,7 +410,7 @@ export class SelfOrder extends Reactive {
         if (paymentMethods.length === 0) {
             let screenMode = "pay";
 
-            if (Object.keys(order.changes).length > 0) {
+            if (orderHasChanges) {
                 screenMode = payAfter === "meal" ? "order" : "pay";
             }
 
@@ -419,7 +420,7 @@ export class SelfOrder extends Reactive {
             // and we redirect him to the confirmation page, the next time he validate his order
             // if the order is already saved on the server, we redirect him to the payment page
             // In each mode, we redirect the customer to the payment page directly
-            if (payAfter === "meal" && Object.keys(order.changes).length > 0) {
+            if (payAfter === "meal" && orderHasChanges) {
                 await this.sendDraftOrderToServer();
                 this.confirmationPage("order", device, order.access_token);
             } else {


### PR DESCRIPTION
- Automatically update the floorplan when an order is paid from `self order`, marking the table as empty.
- Fix "Pay After Each Meal" to prevent redirection to the payment page after every order.
- Add a test tour for self-order payments (pay after meal, service at table) with online payment enabled.

task-id: 4610893




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
