### PR TITLE
[IMP] l10n_za: Added necessary 'Tax Invoice' wording

### DIFF
--- a/addons/l10n_za/__manifest__.py
+++ b/addons/l10n_za/__manifest__.py
@@ -9,7 +9,8 @@
 This is the latest basic South African localisation necessary to run Odoo in ZA:
 ================================================================================
     - a generic chart of accounts
-    - SARS VAT Ready Structure""",
+    - SARS VAT Ready Structure
+    - correct title on Tax Invoice""",
     'author': 'Paradigm Digital (https://www.paradigmdigital.co.za)',
     'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
     'depends': [
@@ -20,6 +21,7 @@ This is the latest basic South African localisation necessary to run Odoo in ZA:
     'data': [
         'data/account.account.tag.csv',
         'data/account_tax_report_data.xml',
+        'views/report_invoice.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_za/models/__init__.py
+++ b/addons/l10n_za/models/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_move
 from . import template_za

--- a/addons/l10n_za/models/account_move.py
+++ b/addons/l10n_za/models/account_move.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _get_name_invoice_report(self):
+        if self.company_id.account_fiscal_country_id.code == 'ZA':
+            return 'l10n_za.report_invoice_document'
+        return super()._get_name_invoice_report()
+

--- a/addons/l10n_za/views/report_invoice.xml
+++ b/addons/l10n_za/views/report_invoice.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
+        <xpath expr="//div[@id='informations']" position="before">
+            <t t-set="forced_vat" t-value="o.company_id.vat"/>
+        </xpath>
+        <xpath expr="//div[hasclass('page')]/t[@t-set='layout_document_title']" position="replace">
+	    <t t-set="layout_document_title">
+		<span t-if="o.move_type == 'out_invoice' and o.state == 'posted' and o.company_id.vat">Tax Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft' and o.company_id.vat">Draft Tax Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel' and o.company_id.vat">Cancelled Tax Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>
+                <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Credit Note</span>
+                <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Credit Note</span>
+                <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
+                <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
+                <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
+                <span t-if="o.name != '/'" t-field="o.name"/>
+            </t>
+        </xpath>
+    </template>
+    <template id="report_invoice" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-elif="o._get_name_invoice_report() == 'l10n_za.report_invoice_document'"
+               t-call="l10n_za.report_invoice_document"
+               t-lang="lang"/>
+        </xpath>
+    </template>
+</odoo>
+


### PR DESCRIPTION
In South Africa, many companies require that 'Tax Invoice' appears on any invoice they will pay if you are VAT registered.

I took inspiration from the Zambian localisation, I just added a case for when you are not VAT registered (i.e. don't have a VAT number set).

I'll create a separate PR for 16.0 since the invoice report layout changed in 18.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
