### PR TITLE
[IMP] project: set kanban cover image from project sharing

### DIFF
--- a/addons/project/controllers/__init__.py
+++ b/addons/project/controllers/__init__.py
@@ -3,4 +3,5 @@
 
 from . import portal
 from . import project_sharing_chatter
+from . import project_sharing_cover_img
 from . import thread

--- a/addons/project/controllers/project_sharing_cover_img.py
+++ b/addons/project/controllers/project_sharing_cover_img.py
@@ -1,0 +1,71 @@
+import json
+import unicodedata
+from odoo import _, http
+from odoo.addons.web.controllers.binary import clean, _logger
+from odoo.exceptions import AccessError
+from odoo.http import request
+
+class ProjectSharingCoverImg(http.Controller):
+
+    @http.route('/project/controllers/upload_attachment', type='http', auth="user")
+    def upload_attachment(self, model, id, ufile, callback=None):
+        files = request.httprequest.files.getlist('ufile')
+        out = """<script language="javascript" type="text/javascript">
+                    var win = window.top.window;
+                    win.jQuery(win).trigger(%s, %s);
+                </script>"""
+        args = []
+        for ufile in files:
+
+            filename = ufile.filename
+            if request.httprequest.user_agent.browser == 'safari':
+                # Safari sends NFD UTF-8 (where é is composed by 'e' and [accent])
+                # we need to send it the same stuff, otherwise it'll fail
+                filename = unicodedata.normalize('NFD', ufile.filename)
+
+            try:
+                attachment =  self.env['ir.attachment'].sudo().create({
+                    'name': filename,
+                    'raw': ufile.read(),
+                    'res_model': model,
+                    'res_id': int(id),
+                    'public':True,
+                })
+            except AccessError:
+                args.append({'error': _("You are not allowed to upload an attachment here.")})
+            except Exception:
+                args.append({'error': _("Something horrible happened")})
+                _logger.exception("Fail to upload attachment %s", ufile.filename)
+            else:  
+                args.append({
+                    'filename': clean(filename),
+                    'mimetype': attachment.mimetype,
+                    'id': attachment.id,
+                    'size': attachment.file_size
+                })
+        return out % (json.dumps(clean(callback)), json.dumps(args)) if callback else json.dumps(args)
+
+    @http.route('/project/controllers/set_attachment', type='jsonrpc', auth="user")
+    def set_attachment(self, model, field, task_id, attachment_id, callback=None):
+        try:
+            task =  self.env[model].sudo().browse(int(task_id))
+            task.write({
+                field : attachment_id 
+            })
+            return { 'status': 'success' }
+        except Exception:
+            return { 'status': 'error' }
+
+    @http.route('/project/controllers/get_attachment', type='jsonrpc', auth="user")
+    def get_attachment(self, model, id, callback=None):
+        attachments =  self.env['ir.attachment'].sudo().search_read(
+                [
+                    ("res_model", "=", model),
+                    ("res_id", "=", int(id)),
+                    ("mimetype", "ilike", "image"),
+                ],
+                ["id"]
+        )
+        return {
+            'attachments': attachments,
+        }

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -30,7 +30,6 @@ PROJECT_TASK_READABLE_FIELDS = {
     'create_date',
     'write_date',
     'company_id',
-    'displayed_image_id',
     'display_name',
     'portal_user_names',
     'user_ids',
@@ -71,6 +70,7 @@ PROJECT_TASK_WRITABLE_FIELDS = {
     'priority',
     'state',
     'is_closed',
+    'displayed_image_id',
 }
 
 CLOSED_STATES = {

--- a/addons/project/static/src/project_sharing/views/kanban/file_input_patch.js
+++ b/addons/project/static/src/project_sharing/views/kanban/file_input_patch.js
@@ -1,0 +1,10 @@
+import { FileInput } from "@web/core/file_input/file_input";
+import { patch } from "@web/core/utils/patch";
+
+patch(FileInput,{
+    defaultProps: {
+        ...FileInput.defaultProps,
+        route: "/project/controllers/upload_attachment",
+
+    }
+});

--- a/addons/project/static/src/project_sharing/views/kanban/kanban_cover_image_dialog_patch.js
+++ b/addons/project/static/src/project_sharing/views/kanban/kanban_cover_image_dialog_patch.js
@@ -1,0 +1,24 @@
+import { KanbanCoverImageDialog } from "@web/views/kanban/kanban_cover_image_dialog";
+import { patch } from "@web/core/utils/patch";
+import { rpc } from "@web/core/network/rpc";
+
+patch(KanbanCoverImageDialog.prototype,{
+
+    async _getAttachments() {
+        const attachment = await rpc("/project/controllers/get_attachment", { model: this.props.record.resModel, id: this.props.record.resId });
+        return attachment.attachments;
+    },
+
+    async setCover() {
+        const id = this.state.selectedAttachmentId ? this.state.selectedAttachmentId : false;
+        await rpc("/project/controllers/set_attachment",
+            {   model: this.props.record.resModel, 
+                field: this.props.fieldName, 
+                task_id: this.props.record.resId, 
+                attachment_id: id 
+            });
+        await this.props.record.load();
+        this.props.close();
+    }
+
+});

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -10,6 +10,7 @@ from . import test_project_milestone
 from . import test_project_profitability
 from . import test_project_recurrence
 from . import test_project_sharing
+from . import test_project_sharing_cover_img_controller
 from . import test_project_sharing_portal_access
 from . import test_project_sharing_ui
 from . import test_project_stage_multicompany

--- a/addons/project/tests/test_project_sharing_cover_img_controller.py
+++ b/addons/project/tests/test_project_sharing_cover_img_controller.py
@@ -1,0 +1,111 @@
+import json
+from odoo import http
+from odoo.tests import RecordCapturer, tagged
+from odoo.tests.common import HttpCase, new_test_user
+from odoo.tools import file_open
+
+@tagged('post_install', '-at_install')
+class TestProjectSharingCoverImg(HttpCase):
+
+    def setUp(self):
+        super(TestProjectSharingCoverImg, self).setUp()
+        self.portal_user = new_test_user(
+            self.env,
+            groups='base.group_portal',
+            **({'login': 'portal_user'}),
+        )
+        self.task = self.env['project.task'].create({
+            'name': 'Test Task',
+        })
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        self.csrf_token = http.Request.csrf_token(self)
+
+    def upload_attachment(self):
+        """
+            Helper method to upload an attachment and return its ID.
+
+            This is NOT a test case because:
+            - Uploading an image is a prerequisite for setting an image (`test_set_attachment`).
+            - If this were a separate test case, the image would have to be uploaded twice
+             (once for upload testing and again for image setup).
+        """
+        # Simulate a file upload
+        with RecordCapturer(self.env['ir.attachment'].sudo(), []) as capture, \
+             file_open('project/static/src/img/tasks_icon.png', 'rb') as file:
+                file.seek(0)
+                response = self.url_open(
+                    '/project/controllers/upload_attachment',
+                    files={'ufile': file},
+                    data={
+                        'csrf_token': self.csrf_token,
+                        'model': 'project.task',
+                        'id': self.task.id,
+                    }
+                )
+        self.assertEqual(response.status_code, 200)
+        response_str = response.content.decode('utf-8')
+
+        # Use regex to extract the JSON data
+        start_index = response_str.find('[{')
+        end_index = response_str.find('}]') + 2 
+        response_str = response_str[start_index:end_index]
+
+        data = json.loads(response_str)
+        self.assertIsNotNone(data,msg="json response not found")
+        self.assertTrue(data[0]['filename'],msg="file name not found")
+        self.assertEqual(data[0]['filename'], 'tasks_icon.png')
+        return data[0]['id']
+
+    def test_get_attachment(self,datalen= 0):
+        """
+            Test retrieving attachments for a given project task.
+
+            Args:
+                datalen (int): The expected number of attachments. Defaults to 0.
+
+            This method sends a request to the '/project/controllers/get_attachment' endpoint
+            to fetch attachments for the specified task. It then verifies that the number 
+            of returned attachments matches the expected count.
+
+            - Before uploading an attachment, it should return 0.
+            - After uploading an attachment, it should return 1 (or more, if applicable).
+        """
+        response = self.url_open(
+            '/project/controllers/get_attachment',
+            data=json.dumps({
+                'params':{
+                    "model": "project.task",
+                    "id": self.task.id, 
+                    }}), 
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(
+            len(data["result"]["attachments"]),
+            datalen,
+            msg=f"Expected {datalen} attachments, but got {len(data['result']['attachments'])}.Image retrieval failed."
+            )
+
+    def test_set_attachment(self):
+        # Create an attachment
+        attachment_id = self.upload_attachment()
+        response = self.url_open(
+            '/project/controllers/set_attachment',
+            data=json.dumps({
+                'params':{
+                    "model": "project.task",
+                    "field": "displayed_image_id",
+                    "task_id": self.task.id, 
+                    "attachment_id": attachment_id,
+                    }}), 
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(
+            data["result"]["status"],
+            'success',
+            msg=f"Failed to set the image. Expected status 'success'"
+            )
+        self.test_get_attachment(1)

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -37,6 +37,7 @@
                 <progressbar field="state" colors='{"1_done": "success", "03_approved": "success", "02_changes_requested": "warning", "1_canceled": "danger", "04_waiting_normal": "200", "01_in_progress": "200"}'/>
                 <templates>
                 <t t-name="menu" t-if="!selection_mode">
+                    <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>
                     <div role="separator" class="dropdown-divider"></div>
                     <field name="color" widget="kanban_color_picker"/>
                 </t>
@@ -51,7 +52,7 @@
                     </div>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" context="{'project_id': project_id}"/>
                     <field t-if="record.date_deadline.raw_value" name="date_deadline" invisible="state in ['1_done', '1_canceled']" widget="remaining_days"/>
-                    <field t-if="record.displayed_image_id.value" groups="base.group_user" name="displayed_image_id" widget="attachment_image"/>
+                    <field name="displayed_image_id" widget="attachment_image"/>
                     <footer t-if="!selection_mode">
                         <field name="priority" class="me-2" widget="priority"/>
                         <div class="d-flex ms-auto text-truncate">

--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.js
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.js
@@ -21,17 +21,21 @@ export class KanbanCoverImageDialog extends Component {
             selectedAttachmentId: attachment[0],
         });
         onWillStart(async () => {
-            this.attachments = await this.orm.searchRead(
+            this.attachments = await this._getAttachments();
+            this.state.selectFile = this.props.autoOpen && this.attachments.length;
+        });
+    }
+
+    async _getAttachments() {
+        return await this.orm.searchRead(
                 "ir.attachment",
                 [
-                    ["res_model", "=", record.resModel],
-                    ["res_id", "=", record.resId],
+                    ["res_model", "=", this.props.record.resModel],
+                    ["res_id", "=", this.props.record.resId],
                     ["mimetype", "ilike", "image"],
                 ],
                 ["id"]
             );
-            this.state.selectFile = this.props.autoOpen && this.attachments.length;
-        });
     }
 
     get hasCoverImage() {


### PR DESCRIPTION
Before this commit:

- The Kanban cover image is not set due to access rights for ir.attachment model and displayed_image_id field in project_task

After this commit:

- Introduce a new controllers to handle image retrieval, setting, and uploading from ir.attachment in project sharing.

- Use a patch approach since project sharing has its own assets bundle.

task-4495861

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
