### PR TITLE
[IMP] l10n_za: Added necessary 'Tax Invoice' wording

### DIFF
--- a/addons/l10n_za/__manifest__.py
+++ b/addons/l10n_za/__manifest__.py
@@ -10,7 +10,8 @@
 This is the latest basic South African localisation necessary to run Odoo in ZA:
 ================================================================================
     - a generic chart of accounts
-    - SARS VAT Ready Structure""",
+    - SARS VAT Ready Structure
+    - correct title on Tax Invoice""",
     'author': 'Paradigm Digital',
     'website': 'https://www.paradigmdigital.co.za',
     'depends': ['account', 'base_vat'],
@@ -23,6 +24,7 @@ This is the latest basic South African localisation necessary to run Odoo in ZA:
         'data/account_tax_template_data.xml',
         'data/account_chart_template_post_data.xml',
         'data/account_chart_template_configure_data.xml',
+        'views/report_invoice.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_za/models/__init__.py
+++ b/addons/l10n_za/models/__init__.py
@@ -1,2 +1,2 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from . import models
+from . import account_move

--- a/addons/l10n_za/models/account_move.py
+++ b/addons/l10n_za/models/account_move.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _get_name_invoice_report(self):
+        if self.company_id.account_fiscal_country_id.code == 'ZA':
+            return 'l10n_za.report_invoice_document'
+        return super()._get_name_invoice_report()

--- a/addons/l10n_za/views/report_invoice.xml
+++ b/addons/l10n_za/views/report_invoice.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
+        <xpath expr="//div[@id='informations']" position="before">
+            <t t-set="forced_vat" t-value="o.company_id.vat"/>
+        </xpath>
+        <xpath expr="//div[hasclass('page')]/h2" position="replace">
+            <h2>
+                <span t-if="o.move_type == 'out_invoice' and o.state == 'posted' and o.company_id.vat">Tax Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft' and o.company_id.vat">Draft Tax Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel' and o.company_id.vat">Cancelled Tax Invoice</span>
+                <span t-elif="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>
+                <span t-elif="o.move_type == 'out_refund' and o.state == 'posted'">Credit Note</span>
+                <span t-elif="o.move_type == 'out_refund' and o.state == 'draft'">Draft Credit Note</span>
+                <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
+                <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
+                <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
+                <span t-if="o.name != '/'" t-field="o.name"/>
+            </h2>
+        </xpath>
+    </template>
+    <template id="report_invoice" inherit_id="account.report_invoice">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-elif="o._get_name_invoice_report() == 'l10n_za.report_invoice_document'"
+               t-call="l10n_za.report_invoice_document"
+               t-lang="lang"/>
+        </xpath>
+    </template>
+    <template id="report_invoice_with_payments" inherit_id="account.report_invoice_with_payments">
+        <xpath expr='//t[@t-call="account.report_invoice_document"]' position="after">
+            <t t-elif="o._get_name_invoice_report() == 'l10n_za.report_invoice_document'"
+               t-call="l10n_za.report_invoice_document"
+               t-lang="lang"/>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
In South Africa, many companies require that 'Tax Invoice' appears on any invoice they will pay if you are VAT registered.

This is the similar to #201295 except that the invoice layout changed in 18.0, so this is a "backport".


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
