### PR TITLE
[FIX] website_event_booth: adapt for stable view changes

### DIFF
--- a/addons/website_event_booth/static/src/js/booth_register.js
+++ b/addons/website_event_booth/static/src/js/booth_register.js
@@ -111,9 +111,12 @@ publicWidget.registry.boothRegistration = publicWidget.Widget.extend({
         this.el
             .querySelector(".o_wbooth_registration_error_section")
             .classList.toggle("d-none", !errors.length);
-        this.el
-            .querySelector('.o_wbooth_registration_error_signin')
-            .classList.add('d-none');
+
+        const errorSigninEl = this.el
+            .querySelector('.o_wbooth_registration_error_signin');
+        if (errorSigninEl) {
+            errorSigninEl.classList.add('d-none');
+        }
 
         let errorMessages = [];
         const errorMessageEl = this.el.querySelector(".o_wbooth_registration_error_message");
@@ -132,9 +135,9 @@ publicWidget.registry.boothRegistration = publicWidget.Widget.extend({
 
         if (errors.includes('existingPartnerError')) {
             errorMessages.push(_t("It looks like your email is linked to an existing account."));
-            this.el
-                .querySelector('.o_wbooth_registration_error_signin')
-                .classList.remove('d-none');
+            if (errorSigninEl) {
+                errorSigninEl.classList.remove('d-none');
+            }
         }
 
         errorMessageEl.textContent = errorMessages.join(" ");


### PR DESCRIPTION
Oversight of odoo/odoo@8a5019c5e576a4bd9ef745768de47bfab8d31a49

The previous versions of the code were using jQuery, which was compliant with the view element not existing.

However, the FW to version 18.0 now uses native JavaScript.

When switching to native JavaScript, we have to adapt the code to account for the selected block not existing to avoid a crash.
