### PR TITLE
[FIX] account: Display correct label for tax groups on invoices

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -172,7 +172,7 @@
                         <page string="Advanced Options" name="advanced_options">
                             <group>
                                 <group>
-                                    <field name="description" attrs="{'invisible':[('amount_type','=', 'group')]}"/>
+                                    <field name="description"/>
                                     <field name="tax_group_id" attrs="{'invisible': [('amount_type', '=', 'group')], 'required': [('amount_type', '!=', 'group')]}"/>
                                     <field name="analytic" attrs="{'invisible':[('amount_type','=', 'group')]}" groups="analytic.group_analytic_accounting" />
                                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>


### PR DESCRIPTION
- Ensured that when a group of taxes is selected, the designated label is displayed on the invoice instead of the tax names.

Task-4637341

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
