### PR TITLE
[IMP] iot_box_image: change default hostname

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -147,6 +147,10 @@ devtools() {
 source ~/.bashrc
 source /home/pi/.bashrc
 
+# Change default hostname from 'raspberrypi' to 'iotbox'
+echo iotbox | tee /etc/hostname
+sed -i 's/\braspberrypi/iotbox/g' /etc/hosts
+
 apt-get update
 
 # At the first start it is necessary to configure a password


### PR DESCRIPTION
Before this commit, the default hostname
of an IoT box was 'raspberrypi'.
After this commit, the default hostname
is now 'iotbox'.

task-4642516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
