### PR TITLE
[FIX] project: only compute duration tracking when project stage feature enabled

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -169,6 +169,7 @@ class Project(models.Model):
     # Not `required` since this is an option to enable in project settings.
     stage_id = fields.Many2one('project.project.stage', string='Stage', ondelete='restrict', groups="project.group_project_stages",
         tracking=True, index=True, copy=False, default=_default_stage_id, group_expand='_read_group_expand_full')
+    duration_tracking = fields.Json(groups="project.group_project_stages")
 
     update_ids = fields.One2many('project.update', 'project_id', export_string_translation=False)
     last_update_id = fields.Many2one('project.update', string='Last Update', copy=False, export_string_translation=False)


### PR DESCRIPTION
Before this commit, a traceback is occurred when the user would like to see the raw data of a specific project and the project stage feature is disabled.

This commit adds a group on `duration_tracking` field definition to be sure this field will only be computed when  the project stage feature is enabled.

opw-3709542

Closes #197321
