### PR TITLE
[FIX] html_editor: remove text-align format in list

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -668,7 +668,7 @@ export class ListPlugin extends Plugin {
         }
         // Preserve style properties
         const dir = li.getAttribute("dir") || ul.getAttribute("dir");
-        const textAlign = ul.style.getPropertyValue("text-align");
+        const textAlign = li.style.getPropertyValue("text-align");
         const liColorStyle = getTextColorOrClass(li);
         const liFontSizeStyle = getFontSizeOrClass(li);
         const wrapChildren = (parent, tag) => {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -325,7 +325,7 @@ export class ListPlugin extends Plugin {
             // possible.
             const callingNode = element.firstChild;
             const group = getAdjacents(callingNode, (n) => !isBlock(n));
-            list = insertListAfter(this.document, callingNode, mode, [group]);
+            list = insertListAfter(this.document, callingNode, mode, group);
         } else {
             const parent = element.parentNode;
             const childIndex = childNodeIndex(element);
@@ -354,9 +354,13 @@ export class ListPlugin extends Plugin {
      */
     baseContainerToList(baseContainer, mode) {
         const cursors = this.dependencies.selection.preserveSelection();
-        const list = insertListAfter(this.document, baseContainer, mode, [
-            childNodes(baseContainer),
-        ]);
+        const list = insertListAfter(this.document, baseContainer, mode, childNodes(baseContainer));
+        const textAlign = baseContainer.style.getPropertyValue("text-align");
+        if (textAlign) {
+            // Copy text-align style from base container to li.
+            list.firstElementChild.style.setProperty("text-align", textAlign);
+            baseContainer.style.removeProperty("text-align");
+        }
         this.dependencies.dom.copyAttributes(baseContainer, list);
         this.adjustListPadding(list);
         baseContainer.remove();
@@ -366,7 +370,7 @@ export class ListPlugin extends Plugin {
 
     blockContentsToList(block, mode) {
         const cursors = this.dependencies.selection.preserveSelection();
-        const list = insertListAfter(this.document, block.lastChild, mode, [[...block.childNodes]]);
+        const list = insertListAfter(this.document, block.lastChild, mode, [...block.childNodes]);
         cursors.remapNode(block, list.firstChild).restore();
         return list;
     }

--- a/addons/html_editor/static/src/main/list/utils.js
+++ b/addons/html_editor/static/src/main/list/utils.js
@@ -8,35 +8,29 @@ export function createList(document, mode) {
     return node;
 }
 
-// @todo @phoenix Change this API (and implementation), as all use cases seem to
-// create a list with a single LI
 export function insertListAfter(document, afterNode, mode, content = []) {
     const list = createList(document, mode);
     afterNode.after(list);
-    list.append(
-        ...content.map((c) => {
-            const li = document.createElement("LI");
-            let fontSizeStyle;
-            if (c.length === 1 && c[0].tagName === "FONT" && c[0].style.color) {
-                li.style.color = c[0].style.color;
-                li.append(...c[0].childNodes);
-            } else if (
-                c.length === 1 &&
-                c[0].tagName === "SPAN" &&
-                (fontSizeStyle = getFontSizeOrClass(c[0]))
-            ) {
-                if (fontSizeStyle.type === "font-size") {
-                    li.style.fontSize = fontSizeStyle.value;
-                } else if (fontSizeStyle.type === "class") {
-                    li.classList.add(fontSizeStyle.value);
-                }
-                li.append(...c[0].childNodes);
-            } else {
-                li.append(...[].concat(c));
-            }
-            return li;
-        })
-    );
+    const li = document.createElement("LI");
+    let fontSizeStyle;
+    if (content.length === 1 && content[0].tagName === "FONT" && content[0].style.color) {
+        li.style.color = content[0].style.color;
+        li.append(...content[0].childNodes);
+    } else if (
+        content.length === 1 &&
+        content[0].tagName === "SPAN" &&
+        (fontSizeStyle = getFontSizeOrClass(content[0]))
+    ) {
+        if (fontSizeStyle.type === "font-size") {
+            li.style.fontSize = fontSizeStyle.value;
+        } else if (fontSizeStyle.type === "class") {
+            li.classList.add(fontSizeStyle.value);
+        }
+        li.append(...content[0].childNodes);
+    } else {
+        li.append(...content);
+    }
+    list.append(li);
     return list;
 }
 

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -864,3 +864,36 @@ describe("Toolbar", () => {
         expect(getContent(el)).toBe(`<p style="">[test</p><p style=""><br>]</p>`);
     });
 });
+
+describe("list", () => {
+    test("should be able to remove text-align format from unordered list", async () => {
+        await testEditor({
+            contentBefore: '<ul><li style="text-align: right;">[ab]</li></ul>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: "<ul><li>[ab]</li></ul>",
+        });
+    });
+    test("should be able to remove text-align format from ordered list", async () => {
+        await testEditor({
+            contentBefore: '<ol><li style="text-align: right;">[ab]</li></ol>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: "<ol><li>[ab]</li></ol>",
+        });
+    });
+    test("should be able to remove text-align format from multiple selected unordered list items", async () => {
+        await testEditor({
+            contentBefore:
+                '<ul><li style="text-align: right;">[ab</li><li style="text-align: center;">cd]</li></ul>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: "<ul><li>[ab</li><li>cd]</li></ul>",
+        });
+    });
+    test("should be able to remove text-align format from multiple selected ordered list items", async () => {
+        await testEditor({
+            contentBefore:
+                '<ol><li style="text-align: right;">[ab</li><li style="text-align: center;">cd]</li></ol>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: "<ol><li>[ab</li><li>cd]</li></ol>",
+        });
+    });
+});

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -400,5 +400,15 @@ describe("Range not collapsed", () => {
                 contentAfter: "<p>ab</p><ol><li>cd</li></ol><p>ef[gh]ij</p>",
             });
         });
+
+        test("should turn an ordered list into paragraphs with text alignment", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ol><li style="text-align: center;">[abc</li><li style="text-align: right;">def]</li></ol>',
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    '<p style="text-align: center;">[abc</p><p style="text-align: right;">def]</p>',
+            });
+        });
     });
 });

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -351,6 +351,22 @@ describe("Range not collapsed", () => {
                     '<ol><li style="text-align: center;">[abc</li><li style="text-align: center;">def]</li></ol>',
             });
         });
+        test("should apply text-align right when creating ordered list", async () => {
+            await testEditor({
+                contentBefore: '<p style="text-align: right;">[ab]</p>',
+                stepFunction: toggleOrderedList,
+                contentAfter: '<ol><li style="text-align: right;">[ab]</li></ol>',
+            });
+        });
+        test("should apply text-align format when creating ordered list from multiple selected blocks", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p style="text-align: right;">[ab</p><p style="text-align: center;">cd]</p>',
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    '<ol><li style="text-align: right;">[ab</li><li style="text-align: center;">cd]</li></ol>',
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn a list into a paragraph", async () => {

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -460,6 +460,22 @@ describe("Range not collapsed", () => {
                     '<ul><li style="text-align: center;">[abc</li><li style="text-align: center;">def]</li></ul>',
             });
         });
+        test("should apply text-align right when creating unordered list", async () => {
+            await testEditor({
+                contentBefore: '<p style="text-align: right;">[ab]</p>',
+                stepFunction: toggleUnorderedList,
+                contentAfter: '<ul><li style="text-align: right;">[ab]</li></ul>',
+            });
+        });
+        test("should apply text-align format when creating unordered list from multiple selected blocks", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p style="text-align: right;">[ab</p><p style="text-align: center;">cd]</p>',
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    '<ul><li style="text-align: right;">[ab</li><li style="text-align: center;">cd]</li></ul>',
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn a list into a paragraph", async () => {

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -518,5 +518,15 @@ describe("Range not collapsed", () => {
                 contentAfter: '<p>[ab</p><p contenteditable="false">cd</p><p>ef]</p>',
             });
         });
+
+        test("should turn an unordered list into paragraphs with text alignment", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul><li style="text-align: center;">[abc</li><li style="text-align: right;">def]</li></ul>',
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    '<p style="text-align: center;">[abc</p><p style="text-align: right;">def]</p>',
+            });
+        });
     });
 });


### PR DESCRIPTION
**Current behavior before PR:**


- In toolbar, after creating list from right aligned paragraph, remove format button is disabled and text alignment is not getting removed when clicking on it. This issue happens because when creating a new list from paragraph, text-align style of paragraph is set to ul tag. Remove format works here only if text-align property it applied to `closestBlock` which is li element.
- When turning list items into paragraph, text alignment styles are not getting preserved properly.

**Desired behavior after PR is merged:**

Now,
- Remove format button is active and text alignment is getting removed from list.
- Text aligments are preserved properly when turning list into paragraphs.
- Changes implementation of `insertListAfter` util to insert single LI element instead of multiple.

task-4637177



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
