### PR TITLE
[PERF] stock: do optimal scan & join warehouse_cte

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -56,9 +56,10 @@ WITH
         SELECT m.id, m.product_id, pt.id, m.product_qty, m.date, m.state, m.company_id, source.w_id, dest.w_id
         FROM stock_move m
         LEFT JOIN warehouse_cte source ON source.sl_id = m.location_id
-        LEFT JOIN warehouse_cte dest ON
-            (m.state != 'done' AND dest.sl_id = COALESCE(m.location_final_id, m.location_dest_id)) OR
-            (m.state = 'done' AND dest.sl_id = m.location_dest_id)
+        LEFT JOIN warehouse_cte dest ON dest.sl_id = CASE
+            WHEN m.state != 'done' THEN COALESCE(m.location_final_id, m.location_dest_id)
+            ELSE m.location_dest_id
+        END
         LEFT JOIN product_product pp on pp.id=m.product_id
         LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
         WHERE pt.is_storable = true AND


### PR DESCRIPTION
In commit b81314b we replaced a join on a case with a join on a boolean expression- however this did not materially increase performance (same order of magnitutde).

Instead we should have simply used a valued case expression, which permits an entirely different (and much more optimal) query plan- specifically during sequential scans of the warehouse_cte common table expression.

*See PR for further details*