### PR TITLE
[FIX] im_livechat: allow live chat manager to join or invite anyone

### DIFF
--- a/addons/im_livechat/security/im_livechat_channel_security.xml
+++ b/addons/im_livechat/security/im_livechat_channel_security.xml
@@ -31,11 +31,10 @@
         </record>
 
         <record id="ir_rule_discuss_channel_member_group_im_livechat_group_manager" model="ir.rule">
-            <field name="name">discuss.channel.member: livechat manager can read all livechat channel members</field>
+            <field name="name">discuss.channel.member: livechat manager can read all livechat channel members and can invite anyone</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>
             <field name="groups" eval="[(4, ref('im_livechat_group_manager'))]"/>
             <field name="domain_force">[('channel_id.channel_type', '=', 'livechat')]</field>
-            <field name="perm_create" eval="False"/>
             <field name="perm_write" eval="False"/>
             <field name="perm_unlink" eval="False"/>
         </record>

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -233,3 +233,20 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             ],
         ):
             channel.execute_command_help()
+
+    def test_livechat_manager_can_invite_anyone(self):
+        channel = self.env["discuss.channel"].create(
+            {
+                "channel_type": "livechat",
+                "livechat_operator_id": self.operators[2].partner_id.id,
+                "name": "test",
+            }
+        )
+        other_member = channel.with_user(self.operators[0]).add_members(
+            partner_ids=self.operators[1].partner_id.ids
+        )
+        self.assertEqual(other_member.partner_id, self.operators[1].partner_id)
+        self_member = channel.with_user(self.operators[0]).add_members(
+            partner_ids=self.operators[0].partner_id.ids
+        )
+        self.assertEqual(self_member.partner_id, self.operators[0].partner_id)


### PR DESCRIPTION
Live chat sessions are accessible to live chat managers so they should be able to join or invite anyone to said session.

task-4637836

https://github.com/odoo/upgrade/pull/7372