### PR TITLE
[FIX] l10n_sa_edi: fix ZATCA posting with reversed downpayment

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -364,7 +364,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             to be included in the UBL
         """
         if not line.move_id._is_downpayment() and line.sale_line_ids and all(sale_line.is_downpayment for sale_line in line.sale_line_ids):
-            prepayment_move_id = line.sale_line_ids.invoice_lines.move_id.filtered(lambda m: m._is_downpayment())
+            prepayment_move_id = line.sale_line_ids.invoice_lines.move_id.filtered(lambda m: m.move_type == 'out_invoice' and m._is_downpayment())
             return {
                 'prepayment_id': prepayment_move_id.name,
                 'issue_date': fields.Datetime.context_timestamp(self.with_context(tz='Asia/Riyadh'),

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -38,6 +38,24 @@ class TestEdiZatca(TestSaEdiCommon):
         if 'sale' not in self.env["ir.module.module"]._installed():
             self.skipTest("Sale module is not installed")
 
+        def test_generated_file(move, test_file, xpath_to_apply):
+            move.write({
+                'invoice_date': '2022-09-05',
+                'invoice_date_due': '2022-09-22',
+                'state': 'posted',
+                'l10n_sa_confirmation_datetime': datetime.now(),
+            })
+            move._l10n_sa_generate_unsigned_data()
+            generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(move)
+            current_tree = self.get_xml_tree_from_string(generated_file)
+            current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
+
+            expected_file = misc.file_open(f'l10n_sa_edi/tests/test_files/{test_file}.xml', 'rb').read()
+            expected_tree = self.get_xml_tree_from_string(expected_file)
+            expected_tree = self.with_applied_xpath(expected_tree, xpath_to_apply)
+
+            self.assertXmlTreeEqual(current_tree, expected_tree)
+
         with freeze_time(datetime(year=2022, month=9, day=5, hour=8, minute=20, second=2, tzinfo=timezone('Etc/GMT-3'))):
             self.partner_us.vat = 'US12345677'
 
@@ -74,23 +92,26 @@ class TestEdiZatca(TestSaEdiCommon):
                 (downpayment, "downpayment_invoice"),
                 (final, "final_invoice")
             ):
-                move.write({
-                    'invoice_date': '2022-09-05',
-                    'invoice_date_due': '2022-09-22',
-                    'state': 'posted',
-                    'l10n_sa_confirmation_datetime': datetime.now(),
-                })
-                move._l10n_sa_generate_unsigned_data()
+                with self.subTest(move=move, test_file=test_file):
+                    test_generated_file(move, test_file, self.invoice_applied_xpath)
 
-                generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(move)
-                current_tree = self.get_xml_tree_from_string(generated_file)
-                current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
-
-                expected_file = misc.file_open(f'l10n_sa_edi/tests/test_files/{test_file}.xml', 'rb').read()
-                expected_tree = self.get_xml_tree_from_string(expected_file)
-                expected_tree = self.with_applied_xpath(expected_tree, self.invoice_applied_xpath)
-
-                self.assertXmlTreeEqual(current_tree, expected_tree)
+            for move, test_file in (
+                (downpayment, "downpayment_credit_note"),
+                (final, "final_credit_note")
+            ):
+                with self.subTest(move=move, test_file=test_file):
+                    wiz_context = {
+                        'active_model': 'account.move',
+                        'active_ids': [move.id],
+                        'default_journal_id': move.journal_id.id,
+                    }
+                    refund_invoice_wiz = self.env['account.move.reversal'].with_context(wiz_context).create({
+                        'reason': 'please reverse :c',
+                        'refund_method': 'refund',
+                        'date': '2022-09-05',
+                    })
+                    refund_invoice = self.env['account.move'].browse(refund_invoice_wiz.reverse_moves()['res_id'])
+                    test_generated_file(refund_invoice, test_file, self.credit_note_applied_xpath)
 
     def testCreditNoteStandard(self):
 

--- a/addons/l10n_sa_edi/tests/test_files/downpayment_credit_note.xml
+++ b/addons/l10n_sa_edi/tests/test_files/downpayment_credit_note.xml
@@ -1,17 +1,22 @@
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
   <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
-  <cbc:ID>INV/2022/00002</cbc:ID>
-  <cbc:UUID>f60b0627-777e-4374-b8a3-ea071d9220cc</cbc:UUID>
+  <cbc:ID>RINV/2022/00001</cbc:ID>
+  <cbc:UUID>ea8e1ab4-6b4e-4cb2-8efc-f8e229622774</cbc:UUID>
   <cbc:IssueDate>2022-09-05</cbc:IssueDate>
   <cbc:IssueTime>08:20:02</cbc:IssueTime>
-  <cbc:InvoiceTypeCode name="0100100">388</cbc:InvoiceTypeCode>
+  <cbc:InvoiceTypeCode name="0100100">381</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
   <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
   <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
   <cac:OrderReference>
-    <cbc:ID>INV/2022/00002</cbc:ID>
+    <cbc:ID>Reversal of: INV/2022/00001, please reverse :c</cbc:ID>
   </cac:OrderReference>
+  <cac:BillingReference>
+    <cac:InvoiceDocumentReference>
+      <cbc:ID>INV/2022/00001</cbc:ID>
+    </cac:InvoiceDocumentReference>
+  </cac:BillingReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>PIH</cbc:ID>
     <cac:Attachment>
@@ -84,7 +89,7 @@
         </cac:RegistrationAddress>
       </cac:PartyLegalEntity>
       <cac:Contact>
-        <cbc:ID>316</cbc:ID>
+        <cbc:ID>346</cbc:ID>
         <cbc:Name>SA Company Test</cbc:Name>
         <cbc:Telephone>+966512345678</cbc:Telephone>
         <cbc:ElectronicMail>info@company.saexample.com</cbc:ElectronicMail>
@@ -131,7 +136,7 @@
         </cac:RegistrationAddress>
       </cac:PartyLegalEntity>
       <cac:Contact>
-        <cbc:ID>320</cbc:ID>
+        <cbc:ID>350</cbc:ID>
         <cbc:Name>Chichi Lboukla</cbc:Name>
         <cbc:Telephone>+18709310505</cbc:Telephone>
         <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
@@ -144,14 +149,14 @@
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode listID="UN/ECE 4461">1</cbc:PaymentMeansCode>
     <cbc:PaymentDueDate>2022-09-22</cbc:PaymentDueDate>
-    <cbc:InstructionID>INV/2022/00001</cbc:InstructionID>
-    <cbc:PaymentID>INV/2022/00001</cbc:PaymentID>
+    <cbc:InstructionNote>Reversal of: INV/2022/00001, please reverse :c</cbc:InstructionNote>
+    <cbc:PaymentID>RINV/2022/00001</cbc:PaymentID>
   </cac:PaymentMeans>
   <cac:TaxTotal>
-    <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>
+    <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
     <cac:TaxSubtotal>
-      <cbc:TaxableAmount currencyID="SAR">1000.00</cbc:TaxableAmount>
-      <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>
+      <cbc:TaxableAmount currencyID="SAR">100.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
       <cbc:Percent>15.0</cbc:Percent>
       <cac:TaxCategory>
         <cbc:ID>S</cbc:ID>
@@ -163,70 +168,26 @@
     </cac:TaxSubtotal>
   </cac:TaxTotal>
   <cac:TaxTotal>
-    <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>
+    <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
   </cac:TaxTotal>
   <cac:LegalMonetaryTotal>
-    <cbc:LineExtensionAmount currencyID="SAR">1000.00</cbc:LineExtensionAmount>
-    <cbc:TaxExclusiveAmount currencyID="SAR">1000.00</cbc:TaxExclusiveAmount>
-    <cbc:TaxInclusiveAmount currencyID="SAR">1150.00</cbc:TaxInclusiveAmount>
+    <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="SAR">100.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="SAR">115.00</cbc:TaxInclusiveAmount>
     <cbc:AllowanceTotalAmount currencyID="SAR">0.00</cbc:AllowanceTotalAmount>
-    <cbc:PrepaidAmount currencyID="SAR">115.00</cbc:PrepaidAmount>
-    <cbc:PayableAmount currencyID="SAR">1035.00</cbc:PayableAmount>
+    <cbc:PrepaidAmount currencyID="SAR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="SAR">115.00</cbc:PayableAmount>
   </cac:LegalMonetaryTotal>
   <cac:InvoiceLine>
     <cbc:ID>1</cbc:ID>
     <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-    <cbc:LineExtensionAmount currencyID="SAR">1000.00</cbc:LineExtensionAmount>
+    <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
     <cac:TaxTotal>
-      <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>
-      <cbc:RoundingAmount currencyID="SAR">1150.00</cbc:RoundingAmount>
+      <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+      <cbc:RoundingAmount currencyID="SAR">115.00</cbc:RoundingAmount>
     </cac:TaxTotal>
     <cac:Item>
-      <cbc:Description>[P0001] Product A</cbc:Description>
-      <cbc:Name>Product A</cbc:Name>
-      <cac:SellersItemIdentification>
-        <cbc:ID>P0001</cbc:ID>
-      </cac:SellersItemIdentification>
-      <cac:ClassifiedTaxCategory>
-        <cbc:ID>S</cbc:ID>
-        <cbc:Percent>15.0</cbc:Percent>
-        <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
-        </cac:TaxScheme>
-      </cac:ClassifiedTaxCategory>
-    </cac:Item>
-    <cac:Price>
-      <cbc:PriceAmount currencyID="SAR">1000.0</cbc:PriceAmount>
-    </cac:Price>
-  </cac:InvoiceLine>
-  <cac:InvoiceLine>
-    <cbc:ID>2</cbc:ID>
-    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-    <cbc:LineExtensionAmount currencyID="SAR">0.00</cbc:LineExtensionAmount>
-    <cac:DocumentReference>
-      <cbc:ID>INV/2022/00001</cbc:ID>
-      <cbc:IssueDate>2022-09-05</cbc:IssueDate>
-      <cbc:IssueTime>08:20:02</cbc:IssueTime>
-      <cbc:DocumentTypeCode>386</cbc:DocumentTypeCode>
-    </cac:DocumentReference>
-    <cac:TaxTotal>
-      <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
-      <cbc:RoundingAmount currencyID="SAR">0.00</cbc:RoundingAmount>
-      <cac:TaxSubtotal>
-        <cbc:TaxableAmount currencyID="SAR">100.00</cbc:TaxableAmount>
-        <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
-        <cbc:Percent>15.0</cbc:Percent>
-        <cac:TaxCategory>
-          <cbc:ID>S</cbc:ID>
-          <cbc:Percent>15.0</cbc:Percent>
-          <cac:TaxScheme>
-            <cbc:ID>VAT</cbc:ID>
-          </cac:TaxScheme>
-        </cac:TaxCategory>
-      </cac:TaxSubtotal>
-    </cac:TaxTotal>
-    <cac:Item>
-      <cbc:Description>Down Payment: 09 2022 (Draft)</cbc:Description>
+      <cbc:Description>Down Payment</cbc:Description>
       <cbc:Name>Down payment</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
@@ -237,7 +198,7 @@
       </cac:ClassifiedTaxCategory>
     </cac:Item>
     <cac:Price>
-      <cbc:PriceAmount currencyID="SAR">0</cbc:PriceAmount>
+      <cbc:PriceAmount currencyID="SAR">100.0</cbc:PriceAmount>
     </cac:Price>
   </cac:InvoiceLine>
 </Invoice>

--- a/addons/l10n_sa_edi/tests/test_files/final_credit_note.xml
+++ b/addons/l10n_sa_edi/tests/test_files/final_credit_note.xml
@@ -1,17 +1,22 @@
-<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+<Invoice xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
   <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
-  <cbc:ID>INV/2022/00002</cbc:ID>
-  <cbc:UUID>f60b0627-777e-4374-b8a3-ea071d9220cc</cbc:UUID>
+  <cbc:ID>RINV/2022/00002</cbc:ID>
+  <cbc:UUID>e2ab7427-4f07-4f3b-b874-9ca03da4880a</cbc:UUID>
   <cbc:IssueDate>2022-09-05</cbc:IssueDate>
   <cbc:IssueTime>08:20:02</cbc:IssueTime>
-  <cbc:InvoiceTypeCode name="0100100">388</cbc:InvoiceTypeCode>
+  <cbc:InvoiceTypeCode name="0100100">381</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
   <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
   <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
   <cac:OrderReference>
-    <cbc:ID>INV/2022/00002</cbc:ID>
+    <cbc:ID>Reversal of: INV/2022/00002, please reverse :c</cbc:ID>
   </cac:OrderReference>
+  <cac:BillingReference>
+    <cac:InvoiceDocumentReference>
+      <cbc:ID>RINV/2022/00002</cbc:ID>
+    </cac:InvoiceDocumentReference>
+  </cac:BillingReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>PIH</cbc:ID>
     <cac:Attachment>
@@ -84,7 +89,7 @@
         </cac:RegistrationAddress>
       </cac:PartyLegalEntity>
       <cac:Contact>
-        <cbc:ID>316</cbc:ID>
+        <cbc:ID>366</cbc:ID>
         <cbc:Name>SA Company Test</cbc:Name>
         <cbc:Telephone>+966512345678</cbc:Telephone>
         <cbc:ElectronicMail>info@company.saexample.com</cbc:ElectronicMail>
@@ -131,7 +136,7 @@
         </cac:RegistrationAddress>
       </cac:PartyLegalEntity>
       <cac:Contact>
-        <cbc:ID>320</cbc:ID>
+        <cbc:ID>370</cbc:ID>
         <cbc:Name>Chichi Lboukla</cbc:Name>
         <cbc:Telephone>+18709310505</cbc:Telephone>
         <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
@@ -144,8 +149,8 @@
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode listID="UN/ECE 4461">1</cbc:PaymentMeansCode>
     <cbc:PaymentDueDate>2022-09-22</cbc:PaymentDueDate>
-    <cbc:InstructionID>INV/2022/00001</cbc:InstructionID>
-    <cbc:PaymentID>INV/2022/00001</cbc:PaymentID>
+    <cbc:InstructionNote>Reversal of: INV/2022/00002, please reverse :c</cbc:InstructionNote>
+    <cbc:PaymentID>RINV/2022/00002</cbc:PaymentID>
   </cac:PaymentMeans>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>


### PR DESCRIPTION
An error occurs when trying to send a reversed invoice to ZATCA if it included a downpayment that was also reversed.

Steps to reproduce:
- Install "Sales" and "Saudi Arabia - E-invoicing" apps.
- Create a quotation and confirm it.
- Create a downpayment and post it to ZATCA.
- Create an invoice **A** including the downpayment and post it.
- Reverse the downpayment and post it to ZATCA.
- Reverse invoice **A** and try posting it to ZATCA.

An error will occur:
```python
File ".../l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py", line 356, in _l10n_sa_get_line_prepayment_vals
    'prepayment_id': prepayment_move_id.name,
                     ^^^^^^^^^^^^^^^^^^^^^^^
File ".../odoo/fields.py", line 1154, in __get__
    record.ensure_one()
File ".../odoo/models.py", line 5204, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.move(190098, 190096)
```

This fix ensures that only the actual downpayment move is used by filtering on the move type.

opw-4567756