### PR TITLE
[FIX] mail: adapt canned response helper with new shortcut

### DIFF
--- a/addons/im_livechat/data/digest_data.xml
+++ b/addons/im_livechat/data/digest_data.xml
@@ -16,7 +16,7 @@
             <field name="tip_description" type="html">
 <div>
     <p class="tip_title">Tip: Use canned responses to chat faster</p>
-    <p class="tip_content">Use canned responses to define templates of messages in the livechat app. To load a canned response, start your sentence with ':' and select the template.</p>
+    <p class="tip_content">Use canned responses to define templates of messages in the livechat app. To load a canned response, start your sentence with '::' and select the template.</p>
     <img src="https://download.odoocdn.com/digests/im_livechat/static/src/img/milk-canned-responses.gif" width="540" class="illustration_border" />
 </div>
             </field>

--- a/addons/im_livechat/i18n/im_livechat.pot
+++ b/addons/im_livechat/i18n/im_livechat.pot
@@ -1646,12 +1646,6 @@ msgid "Search history"
 msgstr ""
 
 #. module: im_livechat
-#. odoo-javascript
-#: code:addons/im_livechat/static/src/core/web/channel_invitation_patch.js:0
-msgid "Search people, languages or expertise"
-msgstr ""
-
-#. module: im_livechat
 #: model_terms:ir.ui.view,arch_db:im_livechat.im_livechat_report_channel_view_search
 #: model_terms:ir.ui.view,arch_db:im_livechat.im_livechat_report_operator_view_search
 msgid "Search report"
@@ -1951,7 +1945,7 @@ msgstr ""
 #: model_terms:digest.tip,tip_description:im_livechat.digest_tip_im_livechat_0
 msgid ""
 "Use canned responses to define templates of messages in the livechat app. To"
-" load a canned response, start your sentence with ':' and select the "
+" load a canned response, start your sentence with '::' and select the "
 "template."
 msgstr ""
 

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -1848,15 +1848,6 @@ msgid "Canned responses"
 msgstr ""
 
 #. module: mail
-#: model_terms:ir.actions.act_window,help:mail.mail_canned_response_action
-msgid ""
-"Canned responses allow you to insert prewritten responses in\n"
-"                    your messages by typing <i>:shortcut</i>. The shortcut is\n"
-"                    replaced directly in your message, so that you can still edit\n"
-"                    it before sending."
-msgstr ""
-
-#. module: mail
 #. odoo-python
 #: code:addons/mail/models/discuss/discuss_channel.py:0
 msgid "Cannot change authorized group of sub-channel: %(channels)s."
@@ -2536,11 +2527,6 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_fetchmail_server__object_id
 msgid "Create a New Record"
-msgstr ""
-
-#. module: mail
-#: model_terms:ir.actions.act_window,help:mail.mail_canned_response_action
-msgid "Create a new canned response"
 msgstr ""
 
 #. module: mail
@@ -6425,6 +6411,11 @@ msgid "No activities."
 msgstr ""
 
 #. module: mail
+#: model_terms:ir.actions.act_window,help:mail.mail_canned_response_action
+msgid "No canned response found. Let's create one!"
+msgstr ""
+
+#. module: mail
 #. odoo-javascript
 #: code:addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js:0
 msgid "No conversation found"
@@ -10234,6 +10225,13 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.res_config_settings_view_form
 msgid "Use an Outlook Server"
+msgstr ""
+
+#. module: mail
+#: model_terms:ir.actions.act_window,help:mail.mail_canned_response_action
+msgid ""
+"Use canned responses to quickly insert prewritten messages with "
+"<i>::shortcut</i>. You can edit the text before sending."
 msgstr ""
 
 #. module: mail

--- a/addons/mail/views/mail_canned_response_views.xml
+++ b/addons/mail/views/mail_canned_response_views.xml
@@ -61,12 +61,9 @@
             }</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
-                    Create a new canned response
+                    No canned response found. Let's create one!
                 </p><p>
-                    Canned responses allow you to insert prewritten responses in
-                    your messages by typing <i>:shortcut</i>. The shortcut is
-                    replaced directly in your message, so that you can still edit
-                    it before sending.
+                    Use canned responses to quickly insert prewritten messages with <i>::shortcut</i>. You can edit the text before sending.
                 </p>
             </field>
         </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The description of the canned response is not correct anymore, we're just fixing it to the right value and improving the text.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
