### PR TITLE
[FIX] html_editor: close toolbar when opening link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -581,9 +581,7 @@ export class LinkPlugin extends Plugin {
             }
         }
         if (!selectionData.documentSelectionIsInEditable) {
-            // note that data-prevent-closing-overlay also used in color picker but link popover
-            // and color picker don't open at the same time so it's ok to query like this
-            const popoverEl = document.querySelector("[data-prevent-closing-overlay=true]");
+            const popoverEl = document.querySelector(".o-we-linkpopover");
             if (popoverEl?.contains(selectionData.documentSelection?.anchorNode)) {
                 return;
             }

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -2,7 +2,7 @@
 
     <t t-name="html_editor.linkPopover">
         <div class="o-we-linkpopover d-flex bg-white overflow-auto shadow" t-on-keydown="onKeydown">
-            <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper"  data-prevent-closing-overlay="true">
+            <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper">
                 <div t-if="state.isImage" class="col p-2" style="max-width: 250px;">
                     <div class="input-group mb-1">
                         <input t-ref="url" class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -758,6 +758,26 @@ test("close the toolbar if the selection contains any nodes (traverseNode = [], 
 });
 
 test.tags("desktop");
+test("toolbar should close on open link popover", async () => {
+    await setupEditor("<p>[a]</p>");
+    expect(".o-we-toolbar").toHaveCount(1);
+    await click(".o-we-toolbar .fa-link");
+    await waitForNone(".o-we-toolbar");
+    expect(".o-we-toolbar").toHaveCount(0);
+});
+
+test.tags("desktop");
+test("toolbar should close on edit link from preview", async () => {
+    await setupEditor(`<p><a href="#">[a]</a></p>`);
+    expect(".o-we-toolbar").toHaveCount(1);
+    await click(".o-we-toolbar .fa-link");
+    await waitFor(".o-we-linkpopover");
+    await click(".o_we_edit_link");
+    await waitForNone(".o-we-toolbar");
+    expect(".o-we-toolbar").toHaveCount(0);
+});
+
+test.tags("desktop");
 test("close the toolbar if the selection contains any nodes (traverseNode = [], ignore zws)", async () => {
     const { el } = await setupEditor(`<p>ab${strong("\u200B", "first")}cd</p>`);
     expect(".o-we-toolbar").toHaveCount(0);


### PR DESCRIPTION
**Problem**:
When clicking "Link" in the toolbar, the link popover opens, but the
toolbar remains visible instead of closing.

**Cause**:
Previously (`saas-18.1`), clicking "Link" created an `<a>` tag and
changed the selection to it. This triggered `updateToolbarVisibility`,
which detected the selection on a link (where `[data-prevent-closing-overlay]`
was `false`), allowing the toolbar to close.

Now, the `<a>` tag is created only when applying link changes.
So `updateToolbarVisibility` is triggered with selection inside the
link popover’s input field (where `[data-prevent-closing-overlay]` is
`true`), preventing the toolbar from closing.

**Solution**:
remove `data-prevent-closing-overlay` from link popover and only close toolbar
if selection is inside link popover using `.o-we-linkpopover` as selector.

**Steps to Reproduce**:
1. Open the toolbar.
2. Click "Link".
   - **Issue**: The link popover opens, but the toolbar remains open.

**opw-4639049**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
