### PR TITLE
[FIX] sale_project, project_hr_expense: column reference "analytic_di…

### DIFF
--- a/addons/project_hr_expense/models/project.py
+++ b/addons/project_hr_expense/models/project.py
@@ -21,10 +21,10 @@ class Project(models.Model):
 
         query.order = None
         query_string, query_param = query.select(
-            'jsonb_object_keys(analytic_distribution) as account_id',
+            'jsonb_object_keys(hr_expense.analytic_distribution) as account_id',
             'COUNT(DISTINCT(id)) as expense_count',
         )
-        query_string = f'{query_string} GROUP BY jsonb_object_keys(analytic_distribution)'
+        query_string = f'{query_string} GROUP BY jsonb_object_keys(hr_expense.analytic_distribution)'
         self._cr.execute(query_string, query_param)
         data = {int(record.get('account_id')): record.get('expense_count') for record in self._cr.dictfetchall()}
         for project in self:

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -101,7 +101,7 @@ class Project(models.Model):
 
     def _compute_invoice_count(self):
         query = self.env['account.move.line']._search([('move_id.move_type', 'in', ['out_invoice', 'out_refund'])])
-        query.add_where('analytic_distribution ?| %s', [[str(project.analytic_account_id.id) for project in self]])
+        query.add_where('account_move_line.analytic_distribution ?| %s', [[str(project.analytic_account_id.id) for project in self]])
         query.order = None
         query_string, query_param = query.select(
             'jsonb_object_keys(account_move_line.analytic_distribution) as account_id',
@@ -184,7 +184,7 @@ class Project(models.Model):
 
     def action_open_project_invoices(self):
         query = self.env['account.move.line']._search([('move_id.move_type', 'in', ['out_invoice', 'out_refund'])])
-        query.add_where('analytic_distribution ? %s', [str(self.analytic_account_id.id)])
+        query.add_where('account_move_line.analytic_distribution ? %s', [str(self.analytic_account_id.id)])
         query.order = None
         query_string, query_param = query.select('DISTINCT move_id')
         self._cr.execute(query_string, query_param)
@@ -600,7 +600,7 @@ class Project(models.Model):
 
     def action_open_project_vendor_bills(self):
         query = self.env['account.move.line']._search([('move_id.move_type', 'in', ['in_invoice', 'in_refund'])])
-        query.add_where('analytic_distribution ? %s', [str(self.analytic_account_id.id)])
+        query.add_where('account_move_line.analytic_distribution ? %s', [str(self.analytic_account_id.id)])
         query.order = None
         query_string, query_param = query.select('DISTINCT move_id')
         self._cr.execute(query_string, query_param)


### PR DESCRIPTION
…stribution" is ambiguous

Steps to reproduce:
- projects App
- project update for a project having "invoices count" stat btn => psycopg2.errors.AmbiguousColumn: column reference "analytic_distribution" is ambiguous

Source:
- analytic_distribution exists in more than one table

Fix:
- table alias added

task-4637044
