### PR TITLE
[FIX] stock: correct filter behavior for stock picking

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -360,6 +360,7 @@
                     <filter name="reception" invisible="1" string="Receipts" domain="[('picking_type_code', '=', 'incoming')]"/>
                     <filter name="delivery" invisible="1" string="Deliveries" domain="[('picking_type_code', '=', 'outgoing')]"/>
                     <filter name="internal" invisible="1" string="Internal" domain="[('picking_type_code', '=', 'internal')]"/>
+                    <separator/>
                     <filter invisible="1" name="before" string="Before" domain="[('search_date_category', '=', 'before')]"/>
                     <filter name="yesterday" string="Yesterday" domain="[('search_date_category', '=', 'yesterday')]"/>
                     <filter name="today" string="Today" domain="[('search_date_category', '=', 'today')]"/>


### PR DESCRIPTION
Issue:
------------------------------------------
When opening deliveries and applying the 'late' filter, the results show:
- All `outgoing pickings`, regardless of whether they are `late` or not, and
- All `late pickings`, regardless of their `picking type`.
In short: `Deliveries OR Late`.
The same issue occurs with other picking types as well.

How to reproduce:
------------------------------------------
1. Install stock.
2. Open deliveries through operations menu.
3. Apply 'late' filter.

Cause of the issue:
------------------------------------------
There is no `seperator` between `picking_type_code` and `date_category` filters,
so OR operator is applied between them.

Solution:
------------------------------------------
Added `seperator` between `picking_type_code` and `date_category`.
which now shows only the outgoing pickings which are late.
In short: `Deliveries AND Late`.
This helps users to apply filters like: Find deliveries that are late.

Task ID: [4614363](https://www.odoo.com/odoo/project/966/tasks/4614363)