### PR TITLE
[FIX] im_livechat: do not close live chat when non member unfollows

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -292,8 +292,11 @@ class DiscussChannel(models.Model):
         return super()._types_allowing_unfollow() + ["livechat"]
 
     def _action_unfollow(self, partner=None, guest=None, post_leave_message=True):
-        if partner and self.channel_type == "livechat" and len(self.channel_member_ids) <= 2:
-            # sudo: discuss.channel - last operator left the conversation, state must be updated
-            self.sudo().livechat_active = False
-            self._bus_send_store(Store(self, "livechat_active"))
         super()._action_unfollow(partner, guest, post_leave_message)
+        # sudo - discuss.channel: user just left but we need to close the live
+        # chat if the last operator left.
+        channel_sudo = self.sudo()
+        if channel_sudo.livechat_active and len(channel_sudo.channel_member_ids) == 1:
+            # sudo: discuss.channel - last operator left the conversation, state must be updated.
+            channel_sudo.livechat_active = False
+            self._bus_send_store(self, "livechat_active")

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -5,6 +5,7 @@ from . import chatbot_common
 from . import test_chatbot_form_ui
 from . import test_chatbot_internals
 from . import test_digest
+from . import test_discuss_channel
 from . import test_cors_livechat
 from . import test_get_discuss_channel
 from . import test_get_operator

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -1,0 +1,23 @@
+from odoo.tests import new_test_user, tagged
+from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
+
+
+@tagged("-at_install", "post_install")
+class TestDiscussChannel(TestImLivechatCommon):
+    def test_unfollow_from_non_member_does_not_close_livechat(self):
+        bob_user = new_test_user(
+            self.env, "bob_user", groups="base.group_user,im_livechat.im_livechat_group_manager"
+        )
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "channel_id": self.livechat_channel.id,
+                "anonymous_name": "Visitor",
+            },
+        )
+        chat = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
+        self.assertTrue(chat.livechat_active)
+        chat.with_user(bob_user).action_unfollow()
+        self.assertTrue(chat.livechat_active)
+        chat.with_user(chat.livechat_operator_id.user_ids[0]).action_unfollow()
+        self.assertFalse(chat.livechat_active)


### PR DESCRIPTION
When the last operator of a live chat closes the discussion, the live chat is closed. Technically, this is done with an override of the `_action_unfollow` method. However, this method can be called even when users are not members (e.g. channel pinned locally). The override does not take this into account which can lead to the chat being closed while an operator is still present. This PR fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
