### PR TITLE
[FIX] point_of_sale: fix traceback when searching a partner in pos

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -201,6 +201,6 @@ export class PartnerList extends Component {
     }
 
     getPhoneSearchTerms() {
-        return ["phone", "mobile"];
+        return ["phone"];
     }
 }


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to search a partner,
while creating a pos order after uninstalling the POS_sms.

To reproduce this issue

1) Install POS, then uninstall the sms gateway or pos_sms
2) Open a POS Session and create an order
3) While creating an Order, click on Customers to choose Customer
4) Write anything in the input field
5) Traceback will occurrs in the backend

Error:-
```
Invalid field res.partner.mobile in condition ('mobile', 'ilike', 'test')
```

In saas-18.2, the `mobile` field is removed from the below commit. https://github.com/odoo/odoo/commit/6b820eb6fc6f782ba6a83d605d87b4a1dd2a87be

https://github.com/odoo/odoo/blob/d73eb9190963544dabbb8c11d78dc9b973a5f7db/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js#L179-L182

https://github.com/odoo/odoo/blob/d73eb9190963544dabbb8c11d78dc9b973a5f7db/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js#L203-L204

But it is used in the above line, this leads to the above traceback from the below line.
https://github.com/odoo/odoo/blob/d73eb9190963544dabbb8c11d78dc9b973a5f7db/addons/point_of_sale/models/res_partner.py#L31-L32 

sentry-6388082368
