### PR TITLE
[FIX] html_editor: properly align list markers with text content

### DIFF
--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -91,12 +91,13 @@ export class HintPlugin extends Plugin {
     }
 
     makeHint(el, text) {
-        this.dispatchTo("make_hint_handlers", el);
+        this.dispatchTo("make_hint_handlers", el, text);
         el.setAttribute("o-we-hint-text", text);
         el.classList.add("o-we-hint");
     }
 
     removeHint(el) {
+        this.dispatchTo("reset_hint_handlers", el);
         el.removeAttribute("o-we-hint-text");
         removeClass(el, "o-we-hint");
         this.getResource("system_style_properties").forEach((n) => el.style.removeProperty(n));

--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -2,10 +2,18 @@ li p {
     margin-bottom: 0px;
 }
 
+*[contenteditable="true"] {
+    ul, ol {
+        li {
+            max-width: fit-content;
+            text-align: start;
+        }
+    }
+}
+
 // Checklist
 ul.o_checklist {
     > li {
-        list-style: none;
         position: relative;
         margin-left: 20px;
 

--- a/addons/html_editor/static/tests/align.test.js
+++ b/addons/html_editor/static/tests/align.test.js
@@ -94,6 +94,16 @@ describe("left", () => {
                 '<div style="text-align: center;"><p style="text-align: left;">a[]b</p></div>',
         });
     });
+
+    test("should properly align list to left", async () => {
+        await testEditor({
+            contentBefore:
+                '<ol style="display: flex; flex-direction: column;"><li style="align-self: center;">a[]</li></ol>',
+            stepFunction: alignLeft,
+            contentAfter:
+                '<ol style="display: flex; flex-direction: column;"><li style="align-self: flex-start;">a[]</li></ol>',
+        });
+    });
 });
 
 describe("center", () => {
@@ -178,6 +188,16 @@ describe("center", () => {
                 '<div style="text-align: left;"><p style="text-align: center;">a[]b</p></div>',
         });
     });
+
+    test("should properly center list", async () => {
+        await testEditor({
+            contentBefore:
+                '<ol style="display: flex; flex-direction: column;"><li style="align-self: flex-start;">a[]</li></ol>',
+            stepFunction: alignCenter,
+            contentAfter:
+                '<ol style="display: flex; flex-direction: column;"><li style="align-self: center;">a[]</li></ol>',
+        });
+    });
 });
 
 describe("right", () => {
@@ -259,6 +279,16 @@ describe("right", () => {
             stepFunction: () => press(["ctrl", "shift", "r"]),
             contentAfter:
                 '<div style="text-align: left;"><p style="text-align: right;">a[]b</p></div>',
+        });
+    });
+
+    test("should properly align list to the right", async () => {
+        await testEditor({
+            contentBefore:
+                '<ol style="display: flex; flex-direction: column;"><li style="align-self: flex-start;">a[]</li></ol>',
+            stepFunction: alignRight,
+            contentAfter:
+                '<ol style="display: flex; flex-direction: column;"><li style="align-self: flex-end;">a[]</li></ol>',
         });
     });
 });

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -9,6 +9,7 @@ import {
     setSelection,
 } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
+import { press } from "@odoo/hoot-dom";
 
 test("hints are removed when editor is destroyed", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
@@ -152,4 +153,55 @@ test("hint for blockquote should have the same padding as its text content", asy
     expect(hintStyle.content).toBe("none");
     const paddingText = getComputedStyle(blockquote).padding;
     expect(paddingHint).toBe(paddingText);
+});
+
+test("list with direction should have min-width to properly show the hint (right)", async () => {
+    const { el } = await setupEditor(
+        `<ul style="text-align: right; display: flex; flex-direction: column;"><li style="align-self: flex-end;">a[]</li></ul>`
+    );
+    await press("Backspace");
+    const li = document.createElement("li");
+    li.innerText = "List";
+    el.firstChild.appendChild(li);
+    const liMinWidth = getComputedStyle(li).width;
+    el.firstChild.removeChild(li);
+    expect(el.innerHTML).toBe(
+        `<ul style="text-align: right; display: flex; flex-direction: column;"><li style="align-self: flex-end; min-width: ${liMinWidth};" o-we-hint-text="List" class="o-we-hint"><br></li></ul>`
+    );
+});
+
+test("list with direction should have min-width to properly show the hint (center)", async () => {
+    const { el } = await setupEditor(
+        `<ul style="text-align: center; display: flex; flex-direction: column;"><li style="align-self: center;">a[]</li></ul>`
+    );
+    await press("Backspace");
+    const li = document.createElement("li");
+    li.innerText = "List";
+    el.firstChild.appendChild(li);
+    const liMinWidth = getComputedStyle(li).width;
+    el.firstChild.removeChild(li);
+    expect(el.innerHTML).toBe(
+        `<ul style="text-align: center; display: flex; flex-direction: column;"><li style="align-self: center; min-width: ${liMinWidth};" o-we-hint-text="List" class="o-we-hint"><br></li></ul>`
+    );
+});
+
+test("list with direction should have min-width to properly show the hint (left default)", async () => {
+    const { el } = await setupEditor(`<ul><li>a[]</li></ul>`);
+    await press("Backspace");
+    expect(el.innerHTML).toBe(`<ul><li o-we-hint-text="List" class="o-we-hint"><br></li></ul>`);
+});
+
+test("list with direction should have min-width to properly show the hint (left aligned)", async () => {
+    const { el } = await setupEditor(
+        `<ul style="text-align: left; display: flex; flex-direction: column;"><li style="align-self: flex-start;">a[]</li></ul>`
+    );
+    await press("Backspace");
+    const li = document.createElement("li");
+    li.innerText = "List";
+    el.firstChild.appendChild(li);
+    const liMinWidth = getComputedStyle(li).width;
+    el.firstChild.removeChild(li);
+    expect(el.innerHTML).toBe(
+        `<ul style="text-align: left; display: flex; flex-direction: column;"><li style="align-self: flex-start; min-width: ${liMinWidth};" o-we-hint-text="List" class="o-we-hint"><br></li></ul>`
+    );
 });

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -304,6 +304,30 @@ describe("Range collapsed", () => {
                 `),
             });
         });
+
+        test("should keep alignement when removing list (1)", async () => {
+            await testEditor({
+                contentBefore: `<div><ul style="display: flex; flex-direction: column;"><li style="align-self: center">a[]</li></ul></div>`,
+                stepFunction: toggleUnorderedList,
+                contentAfter: `<div><p style="text-align: center;">a[]</p></div>`,
+            });
+        });
+
+        test("should keep alignement when removing list (2)", async () => {
+            await testEditor({
+                contentBefore: `<div><ul style="display: flex; flex-direction: column;"><li style="align-self: flex-start">a[]</li></ul></div>`,
+                stepFunction: toggleUnorderedList,
+                contentAfter: `<div><p style="text-align: left;">a[]</p></div>`,
+            });
+        });
+
+        test("should keep alignement when removing list (3)", async () => {
+            await testEditor({
+                contentBefore: `<div><ul style="display: flex; flex-direction: column;"><li style="align-self: flex-end">a[]</li></ul></div>`,
+                stepFunction: toggleUnorderedList,
+                contentAfter: `<div><p style="text-align: right;">a[]</p></div>`,
+            });
+        });
     });
     describe("Transform", () => {
         test("should turn an empty ordered list into an unordered list", async () => {
@@ -458,6 +482,30 @@ describe("Range not collapsed", () => {
                 stepFunction: toggleUnorderedList,
                 contentAfter:
                     '<ul><li style="text-align: center;">[abc</li><li style="text-align: center;">def]</li></ul>',
+            });
+        });
+
+        test("should keep alignement when inserting a list (1)", async () => {
+            await testEditor({
+                contentBefore: `<div><p style="text-align: center;">a[]</p></div>`,
+                stepFunction: toggleUnorderedList,
+                contentAfter: `<div><ul style="text-align: center; display: flex; flex-direction: column;"><li style="align-self: center;">a[]</li></ul></div>`,
+            });
+        });
+
+        test("should keep alignement when inserting a list (2)", async () => {
+            await testEditor({
+                contentBefore: `<div><p style="text-align: left;">a[]</p></div>`,
+                stepFunction: toggleUnorderedList,
+                contentAfter: `<div><ul style="text-align: left; display: flex; flex-direction: column;"><li style="align-self: flex-start;">a[]</li></ul></div>`,
+            });
+        });
+
+        test("should keep alignement when inserting a list (3)", async () => {
+            await testEditor({
+                contentBefore: `<div><p style="text-align: right;">a[]</p></div>`,
+                stepFunction: toggleUnorderedList,
+                contentAfter: `<div><ul style="text-align: right; display: flex; flex-direction: column;"><li style="align-self: flex-end;">a[]</li></ul></div>`,
             });
         });
     });


### PR DESCRIPTION
**Problem**:
After introducing "Text Align," list markers (`::marker`) are not
properly aligned when changing text alignment. This happens because
`list-style-position: outside` keeps markers outside `li`, and
`text-align: center;` does not affect `::marker`. Since `li` has
`width: 100%`, markers always remain left-aligned.

**Solution**:
- Set `width: fit-content` for `li`.
- Calculate `min-width` when adding a "hint."
- Use `flex` to align `li` inside `ol, ul`.

**Steps to Reproduce**:
1. Add text.
2. Align text to center.
3. Convert text to a bullet list.
   - **Issue**: `::marker` remains left-aligned instead of centering.

**opw-4639049**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
