### PR TITLE
[FIX] base_import: prevent using `nextval` in PSQL during test import

### DIFF
--- a/addons/base_import/models/__init__.py
+++ b/addons/base_import/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import base_import
+from . import ir_sequence

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1381,6 +1381,7 @@ class Import(models.TransientModel):
         import_limit = options.pop('limit', None)
         model = self.env[self.res_model].with_context(
             import_file=True,
+            import_dryrun=dryrun,
             name_create_enabled_fields=name_create_enabled_fields,
             import_set_empty_fields=options.get('import_set_empty_fields', []),
             import_skip_records=options.get('import_skip_records', []),

--- a/addons/base_import/models/ir_sequence.py
+++ b/addons/base_import/models/ir_sequence.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrSequence(models.Model):
+    _inherit = 'ir.sequence'
+
+    def _next(self, sequence_date=None):
+        """Prevent PSQL calls that cannot be rolled back during test import."""
+        if self.implementation == 'standard' and self.env.context.get('import_dryrun'):
+            # will be rolled back later
+            self.write({
+                'number_next': self.number_next_actual,
+                'implementation': 'no_gap',
+            })
+        return super()._next(sequence_date=sequence_date)

--- a/addons/test_base_import/models/test_base_import.py
+++ b/addons/test_base_import/models/test_base_import.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 def model(suffix_name):
@@ -81,6 +81,14 @@ class PreviewModel(models.Model):
     name = fields.Char('Name')
     somevalue = fields.Integer(string='Some Value', required=True)
     othervalue = fields.Integer(string='Other Variable')
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if 'name' not in vals:
+                vals['name'] = self.env['ir.sequence'].next_by_code(self._name)
+        return super().create(vals_list)
+
 
 class FloatModel(models.Model):
     _name = model('float')


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have a sizeable file with sales order records you can import;
2. have a db with no sale orders;
3. ensure its `sale.order` sequence has next number set to 1;
4. upload the file;
5. deselect "name" from fields to import if present;
6. click "Test Import";
7. click "Import".

Issue
-----
The sequence used to generate the names of the newly created records didn't start at 1.

Cause
-----
Sequences with implementation `standard` call the `nextval` function in PSQL. This is an action that cannot be rolled back after aborting a transaction[^1]. Hence changes to the sequence number during test imports are permanent if the user doesn't manually switch it to a `no_gap` implementation first.

Solution
--------
When calling the `ir.sequence._next` method on dry runs, temporarily switch to the `no_gap` implementation, which doesn't perform any actions that cannot be rolled back.

opw-4573088

[^1]: https://www.postgresql.org/docs/14/functions-sequence.html