### PR TITLE
[FIX] fleet: fix error when odometer readings on same date

### DIFF
--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -549,7 +549,7 @@
         <field name="color">Red</field>
         <field name="location">Grand-Rosiere</field>
         <field name="driver_id" ref="base.res_partner_address_25" />
-        <field name="acquisition_date" eval="(DateTime.now() - timedelta(days=233)).strftime('%Y-%m-%d')" />
+        <field name="acquisition_date" eval="(DateTime.now() - timedelta(days=263)).strftime('%Y-%m-%d')" />
         <field name="state_id" ref="fleet_vehicle_state_downgraded"/>
         <field name="odometer_unit">kilometers</field>
         <field name="car_value">16000</field>

--- a/addons/fleet/views/fleet_vehicle_odometer_report.xml
+++ b/addons/fleet/views/fleet_vehicle_odometer_report.xml
@@ -36,6 +36,7 @@
               Manage efficiently your vehicle Odometers with Odoo.
             </p>
         </field>
+        <field name="domain">[('vehicle_id.active', '=', True)]</field>
         <field name="context">{'search_default_groupby_date': 1, 'search_default_groupby_category': 1}</field>
     </record>
 


### PR DESCRIPTION
This PR cover the following:
- The report caused a division by zero exception when two odometer readings
were done on the same day. This commit fixes the issue by taking the highest
reading per date.
- Report was inconsistent when the first odometer reading is very high. To
mitigate this, we take the acquisition date as the first odometer reading
if it exists (with a value of zero).
- Filter out the archived vehicles.
- Improvement of the query performances.
