### PR TITLE
[IMP] payment: copy payment providers for new companies

### DIFF
--- a/addons/payment/models/res_company.py
+++ b/addons/payment/models/res_company.py
@@ -15,6 +15,23 @@ class ResCompany(models.Model):
             ('other', "Other"),
         ])
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        companies = super().create(vals_list)
+
+        # Duplicate providers in the new companies.
+        providers_sudo = self.env['payment.provider'].sudo().search(
+            [('company_id', '=', self.env.user.company_id.id)]
+        )
+        for company in companies:
+            if company.parent_id:  # The company is a branch.
+                continue  # Only consider top-level companies for provider duplication.
+
+            for provider_sudo in providers_sudo:
+                provider_sudo.copy({'company_id': company.id})
+
+        return companies
+
     def _run_payment_onboarding_step(self, menu_id=None):
         """ Install the suggested payment modules and configure the providers.
 

--- a/addons/payment/tests/__init__.py
+++ b/addons/payment/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_payment_method
 from . import test_payment_provider
 from . import test_payment_token
 from . import test_payment_transaction
+from . import test_res_company

--- a/addons/payment/tests/test_res_company.py
+++ b/addons/payment/tests/test_res_company.py
@@ -1,0 +1,22 @@
+from odoo.tests import tagged
+
+from odoo.addons.payment.tests.common import PaymentCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestResCompany(PaymentCommon):
+
+    def test_creating_company_duplicates_providers(self):
+        """Ensure that payment providers of an existing company are correctly duplicated
+        when a new company is created."""
+        main_company = self.env.company
+        main_company_providers_count = self.env['payment.provider'].search_count(
+            [('company_id', '=', main_company.id)]
+        )
+
+        new_company = self.env['res.company'].create({'name': 'New Company'})
+        new_company_providers_count = self.env['payment.provider'].search_count(
+            [('company_id', '=', new_company.id)]
+        )
+
+        self.assertEqual(new_company_providers_count, main_company_providers_count)

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -156,6 +156,7 @@
                         </aside>
                         <main class="ms-2">
                             <field name="name" class="mb-0 fw-bold fs-4"/>
+                            <field name="company_id" groups="base.group_multi_company" class="fs-6 text-muted mb-1"/>
                             <div class="d-flex">
                                 <t t-if="installed">
                                     <field name="state"
@@ -220,8 +221,14 @@
         <field name="view_mode">kanban,list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
-                Create a new payment provider
+                No providers available
             </p>
+            <p class="fw-bold">To add a provider to the current company:</p>
+            <ol class="text-start d-inline-block">
+                <li>Toggle the main company in the company switcher.</li>
+                <li>Duplicate the provider you want to add.</li>
+                <li>Set the current company as the company of the provider.</li>
+            </ol>
         </field>
     </record>
 


### PR DESCRIPTION
**Before this commit**:

- When creating a new company, payment providers were not copied from the main company.
- The process of adding payment providers was unintuitive; users had to manually duplicate providers and change the company field.

**After this commit**:

- Payment providers from the main company are automatically copied when a new company is created, reducing manual effort.
- A clear instructional message is added to the blank page for existing companies, guiding users on how to configure payment providers.

Affected Version - master
Task - 4523394

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
