### PR TITLE
[IMP] hr_recruitment: enable kanban card reordering in job applications

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -38,7 +38,9 @@ class HrApplicant(models.Model):
     _mailing_enabled = True
     _primary_email = 'email_from'
     _track_duration_field = 'stage_id'
+    _order = "sequence"
 
+    sequence = fields.Integer(string='Sequence', index=True, default=10)
     active = fields.Boolean("Active", default=True, help="If the active field is set to false, it will allow you to hide the case without removing it.", index=True)
 
     partner_id = fields.Many2one('res.partner', "Contact", copy=False, index='btree_not_null')


### PR DESCRIPTION
This change allows recruiters to manually reposition Kanban cards in the Job Applications view, improving prioritization and workflow efficiency.

Key Changes:
- Enabled drag-and-drop reordering in the Job Applications Kanban view.
- Ensured sequence values auto-adjust for efficient reordering.

Task - 4638952


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr