### PR TITLE
[FIX] pos_sale: used sale.order.line read_converted in settleOrder

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -112,10 +112,11 @@ patch(PosStore.prototype, {
             }
             const newLine = await this.addLineToCurrentOrder(newLineValues, {}, false);
             previousProductLine = newLine;
+            const converted_line = (await this.data.call("sale.order.line", "read_converted", [line.id]))[0];
             if (
                 newLine.get_product().tracking !== "none" &&
                 (this.pickingType.use_create_lots || this.pickingType.use_existing_lots) &&
-                line.pack_lot_ids?.length > 0
+                converted_line.lot_names.length > 0
             ) {
                 if (!useLoadedLots && !userWasAskedAboutLoadedLots) {
                     useLoadedLots = await ask(this.dialog, {
@@ -127,7 +128,7 @@ patch(PosStore.prototype, {
                 if (useLoadedLots) {
                     newLine.setPackLotLines({
                         modifiedPackLotLines: [],
-                        newPackLotLines: (line.lot_names || []).map((name) => ({
+                        newPackLotLines: (converted_line.lot_names || []).map((name) => ({
                             lot_name: name,
                         })),
                     });

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -376,3 +376,25 @@ registry.category("web_tour.tours").add("PoSDownPaymentFixedTax", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosSettleOrderWithLot", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            PosSale.selectNthOrder(1),
+            {
+                content: `Choose to settle the order`,
+                trigger: `.modal:not(.o_inactive_modal) .selection-item:contains('Settle the order')`,
+                in_modal: false,
+                run: "click",
+            },
+            {
+                content: `Choose to auto link the lot number to the order line`,
+                trigger: `.modal-content:contains('Do you want to load the SN/Lots linked to the Sales Order?') button:contains('Ok')`,
+                run: "click",
+            },
+            PosSale.selectedOrderLineHas("Product A", ["1001", "1002"]),
+        ].flat(),
+});

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -4,7 +4,7 @@ import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_scre
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 
-function selectNthOrder(n) {
+export function selectNthOrder(n) {
     return [
         ProductScreen.clickControlButton("Quotation/Order"),
         {
@@ -51,5 +51,22 @@ export function checkOrdersListEmpty() {
             content: "Check that the orders list is empty",
             trigger: "p:contains(No record found)",
         },
+    ];
+}
+
+export function selectedOrderLineHas(productName, lots) {
+    const getSerialStep = (index, serialNumber) => {
+        return {
+            content: `check lot${index} is linked`,
+            trigger: `.info-list li:contains(${serialNumber})`,
+        }
+    }
+    const lotSteps = lots.reduce(
+        (acc, serial, i) => acc.concat(getSerialStep(i, serial)),
+        []
+    );
+    return [
+        ...ProductScreen.selectedOrderlineHas(productName),
+        ...lotSteps
     ];
 }

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1075,3 +1075,59 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentFixedTax', login="accountman")
+
+    def test_settle_order_with_lot(self):
+        self.company_data.update({
+            'default_warehouse': self.env['stock.warehouse'].search(
+                [('company_id', '=', self._get_main_company().id)],
+                limit=1,
+            ),
+        })
+        stock_location = self.company_data['default_warehouse'].lot_stock_id
+        product = self.env['product.product'].create({
+            'name': 'Product A',
+            'tracking': 'serial',
+            'is_storable': True,
+            'lst_price': 10,
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+
+        lot1 = self.env['stock.lot'].create({
+            'name': '1001',
+            'product_id': product.id,
+            'company_id': self.env.company.id,
+        })
+        lot2 = self.env['stock.lot'].create({
+            'name': '1002',
+            'product_id': product.id,
+            'company_id': self.env.company.id,
+        })
+
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': product.id,
+            'inventory_quantity': 1,
+            'location_id': stock_location.id,
+            'lot_id': lot1.id
+        }).action_apply_inventory()
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': product.id,
+            'inventory_quantity': 1,
+            'location_id': stock_location.id,
+            'lot_id': lot2.id
+        }).action_apply_inventory()
+
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': product.id,
+                'name': product.name,
+                'product_uom_qty': 2,
+                'product_uom': product.uom_id.id,
+                'price_unit': product.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderWithLot', login="accountman", watch=True, step_delay=1000)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product, that is tracked by serial number
- Add to in Hand the product and set the serial number to it
- Create a quotation of this product and confirm to be a sale order
- Open a pos session, and select quotations and orders from pos
- Select the sales order created and settle the order
- The order line will be imported without asking if serial number can be linked

Issue:
The function settleOrder in pos_sale/pos_store.js reads the sales order using this.data.read, this will read the sales order with the sale order line but without the information of the lot numbers and more info. These informations are returned in a read_converted function on sale.order.line inherited model on pos_sale, and this function is not used to read the sale order lines, hence no information related to the lots and the pop up that asks if the lot number may be linked will not appear anymore.

opw-4591887

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
