### PR TITLE
[FIX] mail: ensure correct width for deleted message bubble

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -735,7 +735,10 @@ export class Composer extends Component {
         } else {
             this.env.services.dialog.add(MessageConfirmDialog, {
                 message: composer.message,
-                onConfirm: () => this.message.remove(),
+                onConfirm: () => {
+                    this.message.remove();
+                    this.props.onDiscardCallback?.();
+                },
                 prompt: _t("Are you sure you want to delete this message?"),
             });
         }


### PR DESCRIPTION
**Current behavior before PR:**

When a user edited a posted message and cleared its body, a confirmation dialog appeared for deletion. After confirming, the message was deleted, but `exitEditMode` was not called. This caused the message to take the full width of the composer.

**Desired behavior after PR is merged:**

`exitEditMode` is now called when an empty message is deleted, ensuring the composer resets properly and the message bubble maintains the correct width.

Task-4642532


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
