### PR TITLE
[IMP] sale_timesheet: add `Non-billable` placeholder in so_line field

### DIFF
--- a/addons/project/static/src/components/project_many2one_field/project_many2one_field.xml
+++ b/addons/project/static/src/components/project_many2one_field/project_many2one_field.xml
@@ -4,11 +4,9 @@
         <div class="d-flex align-items-center gap-1">
             <t t-set="isPrivateTask" t-value="props.readonly and !props.record.data.parent_id and !props.record.data.project_id"/>
             <Many2One t-if="!isPrivateTask" t-props="m2oProps"/>
-            <t t-if="isPrivateTask">
-                <span class="text-danger fst-italic text-muted">
-                    <i class="fa fa-lock"></i> Private
-                </span>
-            </t>
+            <span class="text-danger fst-italic text-muted"
+                t-out="this.props.record.fields[this.props.name].falsy_value_label"
+                t-if="isPrivateTask"/>
         </div>
     </t>
 

--- a/addons/project/static/tests/project_task_project_many2one_field.test.js
+++ b/addons/project/static/tests/project_task_project_many2one_field.test.js
@@ -35,7 +35,6 @@ test("ProjectMany2one: project.task list view", async () => {
     });
     expect("div[name='project_id']").toHaveCount(3);
     expect("div[name='project_id'] .o_many2one").toHaveCount(2);
-    expect("div[name='project_id'] i.fa-lock").toHaveCount(1);
     expect("div[name='project_id'] span.text-danger.fst-italic.text-muted").toHaveCount(1);
-    expect("div[name='project_id'] span.text-danger.fst-italic.text-muted").toHaveText("Private");
+    expect("div[name='project_id'] span.text-danger.fst-italic.text-muted").toHaveText("🔒 Private");
 });

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -54,6 +54,9 @@ have real delivered quantities in sales orders.
             'sale_timesheet/static/tests/**/*',
             ('remove', 'sale_timesheet/static/tests/tours/**/*'),
         ],
+        'project.webclient': [
+            'sale_timesheet/static/src/components/so_line_field/*',
+        ]
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -38,7 +38,7 @@ class AccountAnalyticLine(models.Model):
     commercial_partner_id = fields.Many2one('res.partner', compute="_compute_commercial_partner")
     timesheet_invoice_id = fields.Many2one('account.move', string="Invoice", readonly=True, copy=False, help="Invoice created from the timesheet", index='btree_not_null')
     so_line = fields.Many2one(compute="_compute_so_line", store=True, readonly=False,
-        domain=_domain_so_line,
+        domain=_domain_so_line, falsy_value_label="Non-billable",
         help="Sales order item to which the time spent will be added in order to be invoiced to your customer. Remove the sales order item for the timesheet entry to be non-billable.")
     # we needed to store it only in order to be able to groupby in the portal
     order_id = fields.Many2one(related='so_line.order_id', store=True, readonly=True, index=True)

--- a/addons/sale_timesheet/static/src/components/so_line_field/so_line_field.xml
+++ b/addons/sale_timesheet/static/src/components/so_line_field/so_line_field.xml
@@ -3,6 +3,7 @@
 
     <t t-name="sale_timesheet.SoLineField">
         <Many2One t-props="m2oProps"/>
+        <span class="text-muted" t-out="this.props.record.fields[this.props.name].falsy_value_label" t-if="props.readonly and !props.record.data.so_line"/>
     </t>
 
 </templates>

--- a/addons/sale_timesheet/views/project_portal_templates.xml
+++ b/addons/sale_timesheet/views/project_portal_templates.xml
@@ -14,7 +14,8 @@
         <xpath expr="//tr/td[t[@t-esc='timesheet.name']]" position="after">
             <td  t-if="display_sol">
 	        <t t-if="timesheet.so_line.order_id.access_url and so_accessible"><a t-att-href="'%s' % timesheet.so_line.order_id.access_url"><t t-out="timesheet.so_line.display_name"/></a></t>
-		<t t-else=""><t t-out="timesheet.so_line.display_name"/></t>
+		    <t t-elif="timesheet.so_line.display_name" t-out="timesheet.so_line.display_name"></t>
+            <span t-else="" class="text-muted">Non-billable</span>
 	    </td>
         </xpath>
         <xpath expr="//div[@name='allocated_time']" position="after">

--- a/addons/sale_timesheet/views/project_sharing_views.xml
+++ b/addons/sale_timesheet/views/project_sharing_views.xml
@@ -12,7 +12,7 @@
             </xpath>
             <xpath expr="//field[@name='timesheet_ids']/list/field[@name='unit_amount']" position="before">
                 <field name="timesheet_invoice_id" column_invisible="True"/>
-                <field name="so_line"
+                <field name="so_line" widget="so_line_field"
                     column_invisible="not parent.allow_billable"
                     context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True, 'no_open': True}"
                     optional="hide"/>

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -63,7 +63,10 @@
             <th t-if="not groupby == 'timesheet_invoice_id'">Invoice</th>
         </th>
         <xpath expr="//tbody//td[hasclass('text-end')]" position="before">
-            <td t-if="not groupby == 'so_line' and timesheets[0].env['account.analytic.line']._show_portal_timesheets()"><span t-field="timesheet.so_line" t-att-title="timesheet.so_line.display_name"></span></td>
+            <td t-if="not groupby == 'so_line' and timesheets[0].env['account.analytic.line']._show_portal_timesheets()">
+                <span t-if="timesheet.so_line" t-field="timesheet.so_line" t-att-title="timesheet.so_line.display_name"></span>
+                <span t-else="" class="text-muted">Non-billable</span>
+            </td>
             <td t-if="not groupby == 'timesheet_invoice_id'"><span t-field="timesheet.timesheet_invoice_id" t-att-title="timesheet.timesheet_invoice_id.display_name"></span></td>
         </xpath>
     </template>


### PR DESCRIPTION
Added a Non-billable placeholder in the empty sales order line field, making it easier for users to identify non-billable entries.

task-4123616