### PR TITLE
[FIX] web: protect menu cache.

### DIFF
--- a/addons/web/static/src/webclient/menus/menu_service.js
+++ b/addons/web/static/src/webclient/menus/menu_service.js
@@ -25,18 +25,22 @@ export const menuService = {
 
         if (storedMenus && storedMenusVersion === odoo.info.server_version) {
             fetchMenus().then((res) => {
-                const fetchedMenus = JSON.stringify(res);
-                if (fetchedMenus !== storedMenus) {
-                    browser.localStorage.setItem("webclient_menus", fetchedMenus);
-                    menusData = res;
-                    env.bus.trigger("MENUS:APP-CHANGED");
+                if (res) {
+                    const fetchedMenus = JSON.stringify(res);
+                    if (fetchedMenus !== storedMenus) {
+                        browser.localStorage.setItem("webclient_menus", fetchedMenus);
+                        menusData = res;
+                        env.bus.trigger("MENUS:APP-CHANGED");
+                    }
                 }
             });
             menusData = JSON.parse(storedMenus);
         } else {
             menusData = await fetchMenus();
-            browser.localStorage.setItem("webclient_menus_version", odoo.info.server_version);
-            browser.localStorage.setItem("webclient_menus", JSON.stringify(menusData));
+            if (menusData) {
+                browser.localStorage.setItem("webclient_menus_version", odoo.info.server_version);
+                browser.localStorage.setItem("webclient_menus", JSON.stringify(menusData));
+            }
         }
 
         function _getMenu(menuId) {


### PR DESCRIPTION
Before this commit, if the fetch menus returned `undefined`, there was an issue
when the web client would crash on reload. This is because the cache was set to
`undefined`, and it's not possible to parse it on read.

This was the case for the applications that use the whole web client code on
the Portal (POS, Knowledge, Documents, and Project). In these cases, the
`loadMenusPromise` is set to `undefined` to avoid fetching the menus that
aren't used.

This commit aims to safeguard the menus cache to avoid setting the menu cache
to `undefined`.
