### PR TITLE
[FIX] web,*: prevent mutually exclusive test tags

### DIFF
--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -6,14 +6,13 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { animationFrame } from "@odoo/hoot-mock";
-import { describe, test } from "@odoo/hoot";
-import { Command, serverState } from "@web/../tests/web_test_helpers";
-import { defineLivechatModels } from "./livechat_test_helpers";
 import { withGuest } from "@mail/../tests/mock_server/mail_mock_server";
+import { test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
+import { Command, serverState } from "@web/../tests/web_test_helpers";
 import { rpc } from "@web/core/network/rpc";
+import { defineLivechatModels } from "./livechat_test_helpers";
 
-describe.current.tags("desktop");
 defineLivechatModels();
 
 test.tags("mobile");
@@ -40,6 +39,7 @@ test("can fold livechat chat windows in mobile", async () => {
     await contains(".o-mail-ChatBubble");
 });
 
+test.tags("desktop");
 test("closing a chat window with no message from admin side unpins it", async () => {
     const pyEnv = await startServer();
     const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([
@@ -79,7 +79,7 @@ test("closing a chat window with no message from admin side unpins it", async ()
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Partner 2" });
 });
 
-test.tags("focus required");
+test.tags("desktop", "focus required");
 test("Focus should not be stolen when a new livechat open", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 12" });

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -10,13 +10,12 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
-import { mockUserAgent } from "@odoo/hoot-mock";
+import { test } from "@odoo/hoot";
 import { mockService } from "@web/../tests/web_test_helpers";
 
-describe.current.tags("desktop");
 defineMailModels();
 
+test.tags("desktop");
 test("no auto-call on joining chat", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Mario" });
@@ -31,6 +30,7 @@ test("no auto-call on joining chat", async () => {
     await contains(".o-discuss-Call", { count: 0 });
 });
 
+test.tags("desktop");
 test("no auto-call on joining group chat", async () => {
     const pyEnv = await startServer();
     const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([
@@ -51,9 +51,8 @@ test("no auto-call on joining group chat", async () => {
 });
 
 test.tags("mobile");
-test("show Push-to-Talk button on mobile", async () => {
+test.skip("show Push-to-Talk button on mobile", async () => {
     mockGetMedia();
-    mockUserAgent("android");
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     mockService("discuss.ptt_extension", {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -16,7 +16,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, leave, press, queryFirst } from "@odoo/hoot-dom";
-import { Deferred, mockDate, tick } from "@odoo/hoot-mock";
+import { Deferred, mockDate, mockTouch, mockUserAgent, tick } from "@odoo/hoot-mock";
 import {
     asyncStep,
     Command,
@@ -122,10 +122,10 @@ test("Edit message (mobile)", async () => {
     await contains(".o-mail-Message-content", { text: "edited message (edited)" });
 });
 
-test.tags("mobile");
 test("Can add reaction to a message on an ipad", async () => {
-    // most ipad users have large screen (landscape) but touch device, thus should use mobile UI/UX
-    patchUiSize({ size: SIZES.LG });
+    mockTouch(true);
+    mockUserAgent("android");
+
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "general",
@@ -202,9 +202,7 @@ test("Can edit message comment in chatter", async () => {
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });
 });
 
-test.tags("mobile");
-test("Can edit message comment in chatter (mobile)", async () => {
-    patchUiSize({ size: SIZES.SM });
+test.skip("Can edit message comment in chatter (mobile)", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
     pyEnv["mail.message"].create({

--- a/addons/web/static/lib/hoot/core/tag.js
+++ b/addons/web/static/lib/hoot/core/tag.js
@@ -1,10 +1,18 @@
 /** @odoo-module */
 
-import { isIterable } from "@web/../lib/hoot-dom/hoot_dom_utils";
-import { HootError, levenshtein, normalize, stringToNumber } from "../hoot_utils";
+import { HootError, levenshtein, normalize, stringify, stringToNumber } from "../hoot_utils";
 
 /**
+ * @typedef {import("./job").Job} Job
  * @typedef {import("./suite").Suite} Suite
+ * @typedef {import("./suite").Test} Test
+ *
+ * @typedef {{
+ *  name: string;
+ *  exclude?: string[];
+ *  before?: (test: Test) => any;
+ *  after?: (test: Test) => any;
+ * }} TagDefinition
  */
 
 //-----------------------------------------------------------------------------
@@ -29,21 +37,22 @@ const {
  *   it from other similar tags);
  * - the edit distance between the 2 is <= 10% of the length of the largest string
  *
+ * @param {string} tagKey
  * @param {string} tagName
  */
-const checkTagSimilarity = (tagName) => {
-    if (R_UNIQUE_TAG.test(tagName)) {
+const checkTagSimilarity = (tagKey, tagName) => {
+    if (R_UNIQUE_TAG.test(tagKey)) {
         return;
     }
-    for (const name of $keys(existingTags)) {
-        if (R_UNIQUE_TAG.test(name)) {
+    for (const key of $keys(existingTags)) {
+        if (R_UNIQUE_TAG.test(key)) {
             continue;
         }
-        const maxLength = $max(tagName.length, name.length);
+        const maxLength = $max(tagKey.length, key.length);
         const threshold = $ceil(SIMILARITY_PERCENTAGE * maxLength);
-        const editDistance = levenshtein(name, tagName, { normalize: true });
+        const editDistance = levenshtein(key, tagKey);
         if (editDistance <= threshold) {
-            similarities.push([name, tagName]);
+            similarities.push([existingTags[key], tagName]);
         }
     }
 };
@@ -66,19 +75,96 @@ const TAG_COLORS = [
 const existingTags = $create(null);
 /** @type {[string, string][]} */
 const similarities = [];
-let canCreateTag = false;
 
 //-----------------------------------------------------------------------------
 // Exports
 //-----------------------------------------------------------------------------
+
+/**
+ * @param {Job} job
+ * @param {Iterable<Tag>} [tags]
+ */
+export function applyTags(job, tags) {
+    if (!tags?.length) {
+        return;
+    }
+    const existingKeys = new Set(job.tags.map((t) => t.key));
+    for (const tag of tags) {
+        if (existingKeys.has(tag.key)) {
+            continue;
+        }
+        const excluded = tag.exclude?.filter((key) => existingKeys.has(key));
+        if (excluded?.length) {
+            throw new HootError(
+                `cannot apply tag ${stringify(tag.name)} on test/suite ${stringify(
+                    job.name
+                )} as it explicitly excludes tags ${excluded.map(stringify).join(" & ")}`
+            );
+        }
+        job.tags.push(tag);
+        existingKeys.add(tag.key);
+        tag.weight++;
+    }
+}
+
+/**
+ * Globally defines specifications for a list of tags.
+ * This is useful to add metadata or side-effects to a given tag, like an exclusion
+ * to prevent specific tags to be added at the same time.
+ *
+ * @param {...TagDefinition} definitions
+ * @example
+ *  defineTags({
+ *      name: "desktop",
+ *      exclude: ["mobile"],
+ *  });
+ */
+export function defineTags(...definitions) {
+    return definitions.map((def) => {
+        const tagKey = def.key || normalize(def.name);
+        if (existingTags[tagKey]) {
+            throw new HootError(`duplicate definition for tag "${def.name}"`);
+        }
+        checkTagSimilarity(tagKey, def.name);
+
+        existingTags[tagKey] = new Tag(tagKey, def);
+
+        return existingTags[tagKey];
+    });
+}
+
+/**
+ * @param {string[]} tagNames
+ */
+export function getTags(tagNames) {
+    const tagKeys = tagNames.map(normalize);
+    return tagKeys.map((tagKey, i) => {
+        const tag = existingTags[tagKey] || defineTags({ key: tagKey, name: tagNames[i] })[0];
+        return tag;
+    });
+}
 
 export function getTagSimilarities() {
     return similarities;
 }
 
 /**
- * Cannot be instantiated outside of {@link Tag.get}.
- * @see {@link Tag.get}
+ * ! SHOULD NOT BE EXPORTED OUTSIDE OF HOOT
+ *
+ * Used in Hoot internal tests to remove tags introduced within a test.
+ *
+ * @private
+ * @param  {Iterable<string>} tagKeys
+ */
+export function undefineTags(tagKeys) {
+    for (const tagKey of tagKeys) {
+        delete existingTags[tagKey];
+    }
+}
+
+/**
+ * Should **not** be instantiated outside of {@link defineTags}.
+ * @see {@link defineTags}
  */
 export class Tag {
     static DEBUG = "debug";
@@ -88,52 +174,26 @@ export class Tag {
 
     weight = 0;
 
-    /**
-     * @param {string} name
-     */
-    constructor(name) {
-        if (!canCreateTag) {
-            throw new HootError(`illegal constructor: use \`createTag("${name}")\` instead`);
-        }
+    get id() {
+        return this.key;
+    }
 
+    /**
+     * @param {string} key normalized tag name
+     * @param {TagDefinition} definition
+     */
+    constructor(key, { name, exclude, before, after }) {
+        this.key = key;
         this.name = name;
-        this.id = this.name;
-        this.key = normalize(this.name);
-
         this.color = TAG_COLORS[stringToNumber(this.key) % TAG_COLORS.length];
-    }
-
-    /**
-     * @param {Tag | string} tagSpec
-     * @returns {Tag}
-     */
-    static get(tagSpec) {
-        if (tagSpec instanceof this) {
-            return tagSpec;
+        if (exclude) {
+            this.exclude = exclude.map(normalize);
         }
-        const tagName = String(tagSpec).trim();
-        if (!existingTags[tagName]) {
-            checkTagSimilarity(tagName);
-
-            canCreateTag = true;
-            existingTags[tagName] = new this(tagName);
-            canCreateTag = false;
+        if (before) {
+            this.before = before;
         }
-        return existingTags[tagName];
-    }
-
-    /**
-     * @param {Iterable<Tag | string>} [tagSpecs]
-     * @returns {Set<Tag>}
-     */
-    static getAll(tagSpecs) {
-        /** @type {Set<Tag>} */
-        const tags = new Set();
-        if (isIterable(tagSpecs)) {
-            for (const tagSpec of tagSpecs) {
-                tags.add(this.get(tagSpec));
-            }
+        if (after) {
+            this.after = after;
         }
-        return tags;
     }
 }

--- a/addons/web/static/lib/hoot/hoot.js
+++ b/addons/web/static/lib/hoot/hoot.js
@@ -57,6 +57,7 @@ export const stop = runner.exportFn(runner.stop);
 
 export { makeExpect } from "./core/expect";
 export { destroy } from "./core/fixture";
+export { defineTags } from "./core/tag";
 export { createJobScopedGetter } from "./hoot_utils";
 
 // Constants

--- a/addons/web/static/lib/hoot/hoot_utils.js
+++ b/addons/web/static/lib/hoot/hoot_utils.js
@@ -920,7 +920,6 @@ export function isOfType(value, type) {
  *
  * @param {string} a
  * @param {string} b
- * @param {{ normalize?: boolean }} [options]
  * @returns {number}
  * @example
  *  levenshtein("abc", "àbc"); // => 0
@@ -929,16 +928,12 @@ export function isOfType(value, type) {
  * @example
  *  levenshtein("abc", "adc"); // => 1
  */
-export function levenshtein(a, b, options) {
+export function levenshtein(a, b) {
     if (!a.length) {
         return b.length;
     }
     if (!b.length) {
         return a.length;
-    }
-    if (options?.normalize) {
-        a = normalize(a);
-        b = normalize(b);
     }
     const dp = $from({ length: b.length + 1 }, (_, i) => i);
     for (let i = 1; i <= a.length; i++) {

--- a/addons/web/static/lib/hoot/tests/core/runner.test.js
+++ b/addons/web/static/lib/hoot/tests/core/runner.test.js
@@ -1,14 +1,21 @@
 /** @odoo-module */
 
-import { describe, expect, test } from "@odoo/hoot";
+import { after, defineTags, describe, expect, test } from "@odoo/hoot";
 import { parseUrl } from "../local_helpers";
 
 import { Runner } from "../../core/runner";
 import { Suite } from "../../core/suite";
+import { undefineTags } from "../../core/tag";
+
+const makeTestRunner = () => {
+    const runner = new Runner();
+    after(() => undefineTags(runner.tags.keys()));
+    return runner;
+};
 
 describe(parseUrl(import.meta.url), () => {
     test("can register suites", () => {
-        const runner = new Runner();
+        const runner = makeTestRunner();
         runner.describe("a suite", () => {});
         runner.describe("another suite", () => {});
 
@@ -20,14 +27,14 @@ describe(parseUrl(import.meta.url), () => {
     });
 
     test("can register nested suites", () => {
-        const runner = new Runner();
+        const runner = makeTestRunner();
         runner.describe(["a", "b", "c"], () => {});
 
         expect([...runner.suites.values()].map((s) => s.name)).toEqual(["a", "b", "c"]);
     });
 
     test("can register tests", () => {
-        const runner = new Runner();
+        const runner = makeTestRunner();
         runner.describe("suite 1", () => {
             runner.test("test 1", () => {});
         });
@@ -41,7 +48,7 @@ describe(parseUrl(import.meta.url), () => {
     });
 
     test("should not have duplicate suites", () => {
-        const runner = new Runner();
+        const runner = makeTestRunner();
         runner.describe(["parent", "child a"], () => {});
         runner.describe(["parent", "child b"], () => {});
 
@@ -53,7 +60,7 @@ describe(parseUrl(import.meta.url), () => {
     });
 
     test("can refuse standalone tests", async () => {
-        const runner = new Runner();
+        const runner = makeTestRunner();
         expect(() =>
             runner.test([], "standalone test", () => {
                 expect(true).toBe(false);
@@ -62,7 +69,7 @@ describe(parseUrl(import.meta.url), () => {
     });
 
     test("can register test tags", async () => {
-        const runner = new Runner();
+        const runner = makeTestRunner();
         runner.describe("suite", () => {
             let testFn = runner.test;
             for (let i = 1; i <= 10; i++) {
@@ -75,5 +82,38 @@ describe(parseUrl(import.meta.url), () => {
 
         expect(runner.tags).toHaveLength(10);
         expect(runner.tests.values().next().value.tags).toHaveLength(10);
+    });
+
+    test("can define exclusive test tags", async () => {
+        expect.assertions(3);
+
+        defineTags(
+            {
+                name: "a",
+                exclude: ["b"],
+            },
+            {
+                name: "b",
+                exclude: ["a"],
+            }
+        );
+
+        const runner = makeTestRunner();
+        runner.describe("suite", () => {
+            runner.test.tags("a");
+            runner.test("first test", () => {});
+
+            runner.test.tags("b");
+            runner.test("second test", () => {});
+
+            runner.test.tags("a", "b");
+            expect(() => runner.test("third test", () => {})).toThrow(`cannot apply tag "b"`);
+
+            runner.test.tags("a", "c");
+            runner.test("fourth test", () => {});
+        });
+
+        expect(runner.tests).toHaveLength(3);
+        expect(runner.tags).toHaveLength(3);
     });
 });

--- a/addons/web/static/lib/hoot/tests/hoot_utils.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot_utils.test.js
@@ -154,7 +154,7 @@ describe(parseUrl(import.meta.url), () => {
     });
 
     test("levenshtein", () => {
-        expect(levenshtein("abc", "àbc ", { normalize: true })).toBe(0);
+        expect(levenshtein("abc", "abc")).toBe(0);
         expect(levenshtein("abc", "àbc ")).toBe(2);
         expect(levenshtein("abc", "def")).toBe(3);
         expect(levenshtein("abc", "adc")).toBe(1);

--- a/addons/web/static/tests/_framework/start.hoot.js
+++ b/addons/web/static/tests/_framework/start.hoot.js
@@ -1,6 +1,33 @@
 // ! WARNING: this module cannot depend on modules not ending with ".hoot" (except libs) !
 
+import { defineTags } from "@odoo/hoot";
 import { runTests } from "./module_set.hoot";
+
+defineTags(
+    {
+        name: "desktop",
+        exclude: ["headless", "mobile"],
+    },
+    {
+        name: "mobile",
+        exclude: ["desktop", "headless"],
+    },
+    {
+        name: "headless",
+        exclude: ["desktop", "mobile"],
+    },
+    {
+        name: "focus required",
+        before: (test) => {
+            if (!document.hasFocus()) {
+                console.warn(
+                    "[FOCUS REQUIRED]",
+                    `test "${test.name}" requires focus inside of the browser window and will probably fail without it`
+                );
+            }
+        },
+    }
+);
 
 // Invoke tests after the module loader finished loading.
 queueMicrotask(() => runTests({ fileSuffix: ".test" }));

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, getFixture, test } from "@odoo/hoot";
+import { expect, getFixture, test } from "@odoo/hoot";
 import {
     clear,
     click,
@@ -88,8 +88,6 @@ import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { ListController } from "@web/views/list/list_controller";
 import { WebClient } from "@web/webclient/webclient";
-
-describe.current.tags("desktop");
 
 const { ResCompany, ResPartner, ResUsers } = webModels;
 
@@ -1629,6 +1627,7 @@ test(`multi_edit: clicking on a readonly field switches the focus to the next ed
     expect(`.o_field_widget[name=foo] input`).toBeFocused();
 });
 
+test.tags("desktop");
 test(`save a record with an required field computed by another`, async () => {
     Foo._onChanges = {
         foo(record) {
@@ -2372,6 +2371,7 @@ test(`enabling archive in list when groupby m2m field`, async () => {
     });
 });
 
+test.tags("desktop");
 test(`enabling archive in list when groupby m2m field and multi selecting the same record`, async () => {
     onRpc("has_group", () => false);
     onRpc("action_archive", ({ args }) => {
@@ -2449,6 +2449,7 @@ test(`enabling duplicate in list when groupby m2m field`, async () => {
     });
 });
 
+test.tags("desktop");
 test(`enabling duplicate in list when groupby m2m field and multi selecting the same record`, async () => {
     onRpc("has_group", () => false);
     onRpc("copy", ({ args }) => {
@@ -2526,6 +2527,7 @@ test(`enabling delete in list when groupby m2m field`, async () => {
     });
 });
 
+test.tags("desktop");
 test(`enabling delete in list when groupby m2m field and multi selecting the same record`, async () => {
     onRpc("has_group", () => false);
     onRpc("unlink", ({ args }) => {
@@ -2611,6 +2613,7 @@ test(`enabling unarchive in list when groupby m2m field`, async () => {
     });
 });
 
+test.tags("desktop");
 test(`enabling unarchive in list when groupby m2m field and multi selecting the same record`, async () => {
     onRpc("has_group", () => false);
     onRpc("action_unarchive", ({ args }) => {
@@ -2742,6 +2745,7 @@ test(`editing a record should change same record in other groups when grouped by
     expect(queryAllTexts(`.o_list_char`)).toEqual(["xyz", "blip", "blip", "xyz", "blip"]);
 });
 
+test.tags("desktop");
 test(`selecting the same record on different groups and editing it when grouping by m2m field`, async () => {
     onRpc("write", ({ args }) => {
         expect.step("write");
@@ -11719,6 +11723,7 @@ test(`editable list with fields with readonly modifier`, async () => {
     expect(`.o_selected_row .o_field_many2one input`).toBeFocused();
 });
 
+test.tags("desktop");
 test(`editable form alongside html field: click out to unselect the row`, async () => {
     Bar._fields.name = fields.Char();
 
@@ -14479,6 +14484,7 @@ test(`list view with optional fields and async rendering`, async () => {
     expect(`.o-dropdown--menu input:checked`).toHaveCount(1);
 });
 
+test.tags("desktop");
 test(`change the viewType of the current action`, async () => {
     defineActions([
         {


### PR DESCRIPTION
Before this commit, it was possible to add all 3 of the "desktop", "mobile" & "headless" tags on a same test.

Having 2 of these 3 tags on a test effectively meant that the test was ignored by all the test runs, as they exclude the "opposite" tags in each of them.

Now, tags can have metadata attached on them, such as a list of excluded tag names that cannot co-exist on a given test.

Tests that were silently ignored have been adapted if they passed without further changes, or skipped if they failed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
