### PR TITLE
[FIX] point_of_sale: refund order with global discount

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -190,10 +190,10 @@ class PosOrder(models.Model):
     @api.model
     def _get_invoice_lines_values(self, line_values, pos_line, move_type):
         # correct quantity sign based on move type and if line is refund.
-        is_refund = line_values.get('is_refund', False)
+        is_refund_order = pos_line.order_id.amount_total < 0.0
         qty_sign = -1 if (
-            (move_type == 'out_invoice' and is_refund)
-            or (move_type == 'out_refund' and not is_refund)
+            (move_type == 'out_invoice' and is_refund_order)
+            or (move_type == 'out_refund' and not is_refund_order)
         ) else 1
 
         return {

--- a/addons/pos_discount/static/tests/tours/global_discount_tour.js
+++ b/addons/pos_discount/static/tests/tours/global_discount_tour.js
@@ -1,4 +1,6 @@
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { registry } from "@web/core/registry";
@@ -24,5 +26,26 @@ registry.category("web_tour.tours").add("pos_global_discount_tax_group_2", {
             ProductScreen.clickControlButton("Discount"),
             Dialog.confirm(),
             ProductScreen.totalAmountIs(108),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_invoice_order_with_global_discount", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Test Product"),
+            ProductScreen.clickControlButton("Discount"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("90.00"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAAAAA"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("90.00"),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.remainingIs("0.00"),
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptAmountTotalIs("90.00"),
         ].flat(),
 });


### PR DESCRIPTION
When invoicing a pos.order with global discount, the created invoice don't have the correct amount because the sign of the quantity of the discount line is inverted. To identify the sign of the discount_line, we must base it on the sign of the order, not on the line.
