### PR TITLE
[IMP] pos_restaurant: remove 'set' from table and tab in actionpad

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -65,13 +65,13 @@
                         t-att-class="{'o_catch_attention_vibrate': this.pos.shouldSetTable}"
                         t-on-click="() => this.props.setTable()"
                     >
-                        Set Table
+                        Table
                     </button>
                     <button
                         class="new-tab h-100 button btn btn-lg d-flex align-items-center flex-fill position-relative px-3 btn-primary justify-content-center"
                         t-on-click="() => this.pos.editFloatingOrderName(this.currentOrder)"
                     >
-                        Set Tab
+                        Tab
                     </button>
                 </t>
                 <t t-elif="this.currentOrder.isDirectSale and this.pos.numpadMode == 'table'">


### PR DESCRIPTION
In this commit,
removed the 'Set' in front of the table and tab to prevent translation issues.

task - 4643364



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
