### PR TITLE
[FIX] l10n_it_edi: fix conversion rate division by zero

### DIFF
--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -314,7 +314,7 @@ class AccountMove(models.Model):
         conversion_line = self.invoice_line_ids.sorted(lambda l: abs(l.balance), reverse=True)[0] if self.invoice_line_ids else None
         conversion_rate = float_repr(
             abs(conversion_line.balance / conversion_line.amount_currency), precision_digits=5,
-        ) if convert_to_euros and conversion_line else None
+        ) if convert_to_euros and conversion_line and conversion_line.amount_currency else None
 
         invoice_lines = self._l10n_it_edi_prepare_fatturapa_line_details(reverse_charge_refund, is_downpayment, convert_to_euros)
         tax_lines = self._l10n_it_edi_prepare_fatturapa_tax_details(tax_details, reverse_charge_refund)


### PR DESCRIPTION
The Issue:
Before this commit, if some entries had journal items with a zero amount (or if all journal items were zero), it would result in a division by zero error.

The Fix:
Retrieve the conversion rate only when amount_currency is present and not equal to zero.

opw-4497797
