### PR TITLE
[FIX] spreadsheet(_dashboard): fix css of dashboard global filters

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filter_date_value/filter_date_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_date_value/filter_date_value.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <div t-name="spreadsheet_edition.DateFilterValue" class="date_filter_values">
-        <select t-if="dateOptions.length" class="o_input me-3" t-on-change="onPeriodChanged">
+        <select t-if="dateOptions.length" class="o_input me-1 text-truncate" t-on-change="onPeriodChanged">
             <option value="empty">Select period...</option>
             <t t-foreach="dateOptions" t-as="periodOption" t-key="periodOption.id">
                 <option t-if="isSelected(periodOption.id)" selected="1" t-att-value="periodOption.id">

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.scss
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.scss
@@ -7,4 +7,13 @@
         gap: map-get($spacers, 2);
         align-items: baseline;
     }
+
+    select:has(option[value="empty"]:checked),
+    select:has(option[value=""]:checked) {
+        color: $input-placeholder-color;
+    }
+
+    select option {
+        color: $o-gray-700;
+    }
 }

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -20,7 +20,7 @@
             <div t-if="filter.type === 'date'" class="w-100">
                 <select t-if="filter.rangeType === 'relative'"
                     t-on-change="(e) => this.onDateInput(filter.id, e.target.value || undefined)"
-                    class="date_filter_values o_input me-3"
+                    class="date_filter_values o_input me-3 text-truncate"
                     required="true">
                     <option value="">Select period...</option>
                     <t t-foreach="relativeDateRangesTypes"
@@ -44,7 +44,7 @@
                     onTimeRangeChanged="(value) => this.onDateInput(filter.id, value)"/>
             </div>
             <i t-if="getters.isGlobalFilterActive(filter.id)"
-                class="fa fa-times btn btn-link text-muted o_side_panel_filter_icon ms-1"
+                class="fa fa-times btn btn-link text-muted o_side_panel_filter_icon ms-1 mt-1"
                 title="Clear"
                 t-on-click="() => this.clear(filter.id)"/>
         </div>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
@@ -55,14 +55,27 @@
 
     .o_cp_top_right {
         display: flex;
-        justify-content: flex-end;
         align-items: flex-start;
         flex: 4;
+        row-gap: 8px;
         min-width: 0;
     }
 
     .o_control_panel_actions {
         gap: map-get($spacers, 2);
+        max-height: 200px;
+        overflow: auto;
+        flex-wrap: wrap;
+        justify-content: start !important;
+        align-items: start !important;
+        order: 1 !important;
+
+        .o_filter_value_container {
+            width: 235px;
+            max-height: 150px;
+            overflow: hidden auto;
+            padding-right: 18px;
+        }
 
         .o-filter-value {
             min-height: 25px;

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -4,15 +4,17 @@
         <ControlPanel display="controlPanelDisplay">
             <t t-set-slot="layout-actions">
                 <t t-set="status" t-value="state.activeDashboard and state.activeDashboard.status"/>
-                <FilterValue
-                    t-if="status === Status.Loaded"
-                    filter="filter"
-                    model="state.activeDashboard.model"
-                    t-as="filter"
+                <div t-if="status === Status.Loaded"
+                    class="o_filter_value_container"
                     t-foreach="filters"
                     t-key="filter.id"
-                    showTitle="true"
-                />
+                    t-as="filter">
+                    <FilterValue
+                        filter="filter"
+                        model="state.activeDashboard.model"
+                        showTitle="true"
+                    />
+                </div>
             </t>
             <t t-set-slot="control-panel-navigation-additional">
                 <SpreadsheetShareButton t-key="activeDashboardId" model="state.activeDashboard?.model" onSpreadsheetShared.bind="shareSpreadsheet"/>


### PR DESCRIPTION
The CSS of global filters in dashboard was broken if there was too many filters or if a filter was too tall (e.g. relation filter with many options).

This commit fixes those issues. Now the filters are wrapped in multiple lines if there are too many filters. That mean that we have to define a fixed width for the filters, otherwise the filters won't be aligned over multiple lines and will be ugly. The commit also adds max-height and overflow on the filters to avoid the filters  being too tall.

It also changes the style of the `Select period...` option to be more placeholder-like.

Note: the same fix cannot easily be done in 16.0, because there the date picker isn't a popover there, this adding `overflow` to the CSS breaks it.

Task: [4624108](https://www.odoo.com/web#id=4624108&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
