### PR TITLE
[FIX] web: pass `type` field correctly when exporting data

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -383,6 +383,7 @@ class Export(http.Controller):
         elif parent_field:
             parent_field['string'] = request.env._('External ID')
             fields['id'] = parent_field
+            fields['id']['type'] = parent_field['field_type']
 
         exportable_fields = {}
         for field_name, field in fields.items():


### PR DESCRIPTION
**Problem**:
When exporting, the field dictionary is expected to have a `type` key. However, when adding `parent_field`, the `type` value is stored in `field_type` instead of `type`, causing issues.

**Solution**:
Ensure that `parent_field` creates a `type` key in the dictionary.

**Steps to Reproduce**:
1. Go to **"Lots / Serial Numbers"**.
2. Group by **"Location"** (or any other field).
3. Select any item from the list.
4. Open the **Export** modal.
5. In the modal:
   - Add **"Product/External IDs"** to the fields to export.
   - Click **Export**.
6. **Issue**: A traceback occurs.

**opw-4563055**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
