### PR TITLE
[FIX] web_editor: keep background on border outlook fix


### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1750,12 +1750,17 @@ function correctBorderAttributes(style) {
     }, 0);
 
     if (totalBorderWidth === 0) {
-        stylesObject["border-style"] = "none";
+        let correctedStyle = style.trim();
+        if (correctedStyle.slice(-1) != ';') {
+            correctedStyle += ';';
+        }
+        correctedStyle = correctedStyle.replace(
+            /(;|^)\s*border-style\s*:[^;]*(;|$)|$/, '$1border-style:none$2'
+        );
+        return correctedStyle;
     }
 
-    return Object.entries(stylesObject)
-        .map(([attribute, value]) => `${attribute}:${value}`)
-        .join(";");
+    return style;
 }
 
 export default {

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -1068,7 +1068,7 @@ QUnit.module('convert_inline', {}, function () {
     });
 
     QUnit.test('Correct border attributes for outlook', async function (assert) {
-        assert.expect(2);
+        assert.expect(3);
 
         const $styleSheet = $('<style type="text/css" title="test-stylesheet"/>');
         document.head.appendChild($styleSheet[0])
@@ -1094,20 +1094,34 @@ QUnit.module('convert_inline', {}, function () {
             }
         `, 1);
 
+        styleSheet.insertRule(`
+            .test-border-background {
+                background-image: url("data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==");
+            }
+        `, 2);
+
         let $editable = $(`<div><div class="test-border-zero"></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-border-zero" style="border-style:none;box-sizing:border-box;border-top-width:0px;border-right-width:0px;border-left-width:0px;border-bottom-width:0px"></div>`,
+            `<div class="test-border-zero" style="border-style:none;box-sizing:border-box;border-top-width:0px;border-right-width:0px;border-left-width:0px;border-bottom-width:0px;"></div>`,
             "Should change border-style to none",
         );
 
         $editable = $(`<div><div class="test-border-one"></div></div>`);
         convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
         assert.strictEqual($editable.html(),
-            `<div class="test-border-one" style="border-style:solid;box-sizing:border-box;border-top-width:1px;border-right-width:1px;border-left-width:1px;border-bottom-width:1px"></div>`,
+            `<div class="test-border-one" style="border-style:solid;box-sizing:border-box;border-top-width:1px;border-right-width:1px;border-left-width:1px;border-bottom-width:1px;"></div>`,
             "Should keep border style solid"
         );
 
+        $editable = $(`<div><div class="test-border-zero test-border-background"></div></div>`);
+        convertInline.classToStyle($editable, convertInline.getCSSRules($editable[0].ownerDocument));
+        assert.strictEqual($editable.html(),
+            `<div class="test-border-zero test-border-background" style="border-style:none;box-sizing:border-box;background-image:url(&quot;data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==&quot;);border-top-width:0px;border-right-width:0px;border-left-width:0px;border-bottom-width:0px;"></div>`,
+            "Should keep background-image",
+        );
+
+        styleSheet.deleteRule(0);
         styleSheet.deleteRule(0);
         styleSheet.deleteRule(0);
         $styleSheet.remove();


### PR DESCRIPTION

Scenario:
- create marketing email in 17.0 or above
- use the Cover widget
- change the cover image to get a base64 endoded image
- send the mail

Result: no image is sent

Cause: commit 1605b81b12e0dee78905e6eb3526fdb7e4908050 could have issue
when parsing the CSS because of having inside a CSS value eg.
url("data:image/webp;base64,..."), then when the CSS was modified, the
background image would be broken (with a :undefined after the value).

Fix: instead of replacing all the style to change the border-style,
update it with regex.

opw-4613524
