### PR TITLE
[FIX] website_livechat: fix non deterministic live chat tours

### DIFF
--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -16,7 +16,8 @@ registry.category("web_tour.tours").add("website_livechat_login_after_chat_start
             run: "press Enter",
         },
         {
-            trigger: ".o-livechat-root:shadow .o-mail-Message-content:contains('Hello!')",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-Thread:not([data-transient]) .o-mail-Message-content:contains('Hello!')",
         },
         {
             trigger: "a:contains(Sign in)",
@@ -62,7 +63,8 @@ registry.category("web_tour.tours").add("website_livechat_logout_after_chat_star
             run: "press Enter",
         },
         {
-            trigger: ".o-livechat-root:shadow .o-mail-Message-content:contains('Hello!')",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-Thread:not([data-transient]) .o-mail-Message-content:contains('Hello!')",
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_user_known_after_reload.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_user_known_after_reload.js
@@ -16,7 +16,7 @@ registry.category("web_tour.tours").add("website_livechat_user_known_after_reloa
         },
         {
             trigger:
-                ".o-livechat-root:shadow .o-mail-Message:contains('Hello, I need help!').o-selfAuthored ",
+                ".o-livechat-root:shadow .o-mail-Thread:not([data-transient]) .o-mail-Message:contains('Hello, I need help!').o-selfAuthored ",
             run() {
                 window.location.reload();
             },


### PR DESCRIPTION
Some live chat tours rely on the presence of the first message
after chat creation  to assume the thread was properly created
which is not enough as the message is first posted in the temporary
thread for seamless transition.

fixes runbot-135255

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
