### PR TITLE
[FIX] web: Prevent flickering in foldable domain fields

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.xml
+++ b/addons/web/static/src/views/fields/domain/domain_field.xml
@@ -5,7 +5,7 @@
         <div t-att-class="{ o_inline_mode: !props.editInDialog }">
             <t t-set="resModel" t-value="getResModel()"/>
             <t t-if="resModel">
-                <t t-if="props.isFoldable and state.folded and state.isValid">
+                <t t-if="props.isFoldable and state.folded and state.isValid !== false">
                     <div class="d-flex align-items-center" t-on-click="() => state.folded = false">
                         <i data-tooltip="Modify filter" class="fa fa-lg fa-caret-right pe-2"/>
                         <div class="d-print-contents">

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -1111,6 +1111,34 @@ test("folded domain field with any operator", async function () {
     expect(`.o_field_domain .o_facet_values`).toHaveText("Company matches ( Id is equal 1 )");
 });
 
+test("foldable domain, search_count delayed", async function () {
+    Partner._records[0].foo = '[("id", "=", 1)]';
+    const def = new Deferred();
+    onRpc("search_count", async () => {
+        await def;
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="foo" widget="domain" options="{'model': 'partner.type', 'foldable': true}" />
+                    </group>
+                </sheet>
+            </form>`,
+    });
+    expect(".o_domain_show_selection_button").toHaveCount(0);
+    expect(".o_tree_editor").toHaveCount(0);
+    expect(`.o_field_domain .o_facet_values`).toHaveText("Id is equal 1");
+    def.resolve();
+    await animationFrame();
+    expect(".o_domain_show_selection_button").toHaveCount(1);
+});
+
 test("folded domain field with withinh operator", async function () {
     Partner._fields.company_id = fields.Many2one({ relation: "partner" });
     Partner._records[0].foo = `[


### PR DESCRIPTION
This commit fixes a visual bug where a foldable domain field briefly appears unfolded before folding itself when search count data arrives. The issue occurs because the isValid state defaults to null, preventing the folded display until props are validated and isValid is explicitly set to true or false.

The fix updates the display condition to check if isValid is not false, ensuring a smoother rendering experience.

task-4633348