### PR TITLE
[FIX] pos_sale: used sale.order.line read_converted in settleOrder

### DIFF
--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -376,3 +376,14 @@ registry.category("web_tour.tours").add("PoSDownPaymentFixedTax", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_settle_order_with_lot", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            PosSale.settleNthOrder(1, { loadSN: true }),
+            PosSale.selectedOrderLinesHasLots("Product A", ["1001", "1002"]),
+        ].flat(),
+});


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product, that is tracked by serial number
- Add to in Hand the product and set the serial number to it
- Create a quotation of this product and confirm to be a sale order
- Open a pos session, and select quotations and orders from pos
- Select the sales order created and settle the order
- The order line will be imported without asking if serial number can be linked

Issue:
The function settleOrder in pos_sale/pos_store.js reads the sales order using this.data.read, this will read the sales order with the sale order line but without the information of the lot numbers and more info. These informations are returned in a read_converted function on sale.order.line inherited model on pos_sale, and this function is not used to read the sale order lines, hence no information related to the lots and the pop up that asks if the lot number may be linked will not appear anymore.

opw-4591887

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
