### PR TITLE
[FIX] web : signature field rpc spamming

### DIFF
--- a/addons/web/static/src/views/fields/signature/signature_field.js
+++ b/addons/web/static/src/views/fields/signature/signature_field.js
@@ -15,6 +15,7 @@ const placeholder = "/web/static/img/placeholder.png";
 export class SignatureField extends Component {
     setup() {
         this.displaySignatureRatio = 3;
+        this.isPopupDisplayed = false;
 
         this.dialogService = useService("dialog");
         this.state = useState({
@@ -98,12 +99,21 @@ export class SignatureField extends Component {
                 nameAndSignatureProps,
                 uploadSignature: (signature) => this.uploadSignature(signature),
             };
-            this.dialogService.add(SignatureDialog, dialogProps);
+            
+            if (!this.isPopupDisplayed){
+                this.isPopupDisplayed = true;
+                this.dialogService.add(SignatureDialog, dialogProps, {
+                    onClose: async () => {
+                        this.isPopupDisplayed = false;
+                    },
+                });
+            }
         }
     }
 
     onLoadFailed() {
         this.state.isValid = false;
+        this.isPopupDisplayed = false;
         this.notification.add(this.env._t("Could not display the selected image"), {
             type: "danger",
         });


### PR DESCRIPTION
Steps:
- throttle your connection (it makes it easier to see, but not required)
- click a signature field, be impatient and click it again
-> 3 calls are made to the get_fonts route, two popups appear

Current behaviour:

- Multiple popup appears
- Multiple get_fonts call
- User can spam click

Expected behaviour:

- One popup
- One fonts call
- No spam click