### PR TITLE
[IMP] core: make delegate declarations more strict

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -72,6 +72,8 @@ class IrCron(models.Model):
     _description = 'Scheduled Actions'
     _allow_sudo_commands = False
 
+    _inherits = {'ir.actions.server': 'ir_actions_server_id'}
+
     ir_actions_server_id = fields.Many2one(
         'ir.actions.server', 'Server action',
         delegate=True, ondelete='restrict', required=True)

--- a/odoo/addons/test_inherit/models/test_models.py
+++ b/odoo/addons/test_inherit/models/test_models.py
@@ -7,6 +7,7 @@ from odoo import models, fields, api
 class Test_Inherit_Daughter(models.Model):
     _name = 'test_inherit_daughter'
     _description = 'Test Inherit Daughter'
+    _inherits = {'test.inherit.mother': 'template_id'}
 
     template_id = fields.Many2one('test.inherit.mother', 'Template',
                                   delegate=True, required=True, ondelete='cascade')

--- a/odoo/addons/test_inherit/tests/test_inherit.py
+++ b/odoo/addons/test_inherit/tests/test_inherit.py
@@ -8,17 +8,6 @@ from ..models.mother_inherit_4 import TestInheritMother
 
 class test_inherits(common.TransactionCase):
 
-    def test_00_inherits(self):
-        """ Check that a many2one field with delegate=True adds an entry in _inherits """
-        daughter = self.env['test_inherit_daughter']
-
-        self.assertEqual(daughter._inherits, {'test.inherit.mother': 'template_id'})
-
-        # the field supporting the inheritance should be auto_join
-        field = daughter._fields['template_id']
-        self.assertTrue(field.delegate)
-        self.assertTrue(field.auto_join, "delegate fields should be auto_join")
-
     def test_10_access_from_child_to_parent_model(self):
         """ check whether added field in model is accessible from children models (_inherits) """
         # This test checks if the new added column of a parent model
@@ -133,6 +122,14 @@ class test_override_property(common.TransactionCase):
 
 
 class TestInherit(common.TransactionCase):
+    def test_ir_model_inherit(self):
+        imi = self.env['ir.model.inherit'].search(
+            [('model_id.model', '=', 'test_inherit_child')]
+        )
+        self.assertEqual(len(imi), 1)
+        self.assertEqual(imi.parent_id.model, 'test_inherit_parent')
+        self.assertFalse(imi.parent_field_id)
+
     def test_extend_parent(self):
         """ test whether a model extension is visible in its children models. """
         parent = self.env['test_inherit_parent']

--- a/odoo/addons/test_inherits/tests/test_inherits.py
+++ b/odoo/addons/test_inherits/tests/test_inherits.py
@@ -6,6 +6,14 @@ from odoo import Command
 
 class test_inherits(common.TransactionCase):
 
+    def test_ir_model_inherit(self):
+        imi = self.env['ir.model.inherit'].search(
+            [('model_id.model', '=', 'test.box')]
+        )
+        self.assertEqual(len(imi), 1)
+        self.assertEqual(imi.parent_id.model, 'test.unit')
+        self.assertEqual(imi.parent_field_id.name, 'unit_id')
+
     def test_create_3_levels_inherits(self):
         """ Check that we can create an inherits on 3 levels """
         pallet = self.env['test.pallet'].create({

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -191,11 +191,16 @@ class Many2one(_Relational[M]):
     def _setup_attrs__(self, model_class, name):
         super()._setup_attrs__(model_class, name)
         # determine self.delegate
-        if not self.delegate and name in model_class._inherits.values():
+        if name in model_class._inherits.values():
             self.delegate = True
-        # self.delegate implies self.auto_join
-        if self.delegate:
+            # self.delegate implies self.auto_join
             self.auto_join = True
+        elif self.delegate:
+            comodel_name = self.comodel_name or 'comodel_name'
+            raise TypeError((
+                f"The delegate field {self} must be declared in the model class e.g.\n"
+                f"_inherits = {{{comodel_name!r}: {name!r}}}"
+            ))
 
     def setup_nonrelated(self, model):
         super().setup_nonrelated(model)


### PR DESCRIPTION
This commit refines delegate inheritance by imposing stricter constraints on
delegation declarations, reducing complexity in the ORM.

1. _inherits dictionary declaration: [mandatory]
``_inherits = {'comodel_name': 'delegation_field_name'}``
The field delegation_field_name is required to be declared in the model or its
parent models

2. Many2one delegate field [optional]
``field_name = Many2one(delegate=True)``

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
