### PR TITLE
[IMP] l10n_*_pos: add all l10n tests

### DIFF
--- a/addons/l10n_ar_pos/tests/__init__.py
+++ b/addons/l10n_ar_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_ar_pos

--- a/addons/l10n_ar_pos/tests/test_ar_pos.py
+++ b/addons/l10n_ar_pos/tests/test_ar_pos.py
@@ -1,0 +1,9 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericAR(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.main_pos_config.company_id.country_id = self.env.ref('base.ar')

--- a/addons/l10n_ch_pos/tests/__init__.py
+++ b/addons/l10n_ch_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_ch_pos

--- a/addons/l10n_ch_pos/tests/test_ch_pos.py
+++ b/addons/l10n_ch_pos/tests/test_ch_pos.py
@@ -1,0 +1,9 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericCH(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.main_pos_config.company_id.country_id = self.env.ref('base.ch')

--- a/addons/l10n_co_pos/tests/__init__.py
+++ b/addons/l10n_co_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_co_pos

--- a/addons/l10n_co_pos/tests/test_co_pos.py
+++ b/addons/l10n_co_pos/tests/test_co_pos.py
@@ -1,0 +1,9 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericCO(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.main_pos_config.company_id.country_id = self.env.ref('base.co')

--- a/addons/l10n_es_edi_tbai_pos/tests/__init__.py
+++ b/addons/l10n_es_edi_tbai_pos/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_tbai_pos
+from . import test_es_tbai_pos

--- a/addons/l10n_es_edi_tbai_pos/tests/test_es_tbai_pos.py
+++ b/addons/l10n_es_edi_tbai_pos/tests/test_es_tbai_pos.py
@@ -1,0 +1,10 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericESTbai(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.company.l10n_es_tbai_tax_agency = 'bizkaia'
+        self.main_pos_config.company_id.country_id = self.env.ref('base.es')

--- a/addons/l10n_es_pos/tests/__init__.py
+++ b/addons/l10n_es_pos/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_frontend
+from . import test_es_pos

--- a/addons/l10n_es_pos/tests/test_es_pos.py
+++ b/addons/l10n_es_pos/tests/test_es_pos.py
@@ -1,0 +1,10 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericES(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.main_pos_config.company_id.country_id = self.env.ref('base.es')
+        self.main_pos_config.l10n_es_simplified_invoice_journal_id = self.main_pos_config.journal_id

--- a/addons/l10n_fr_pos_cert/tests/__init__.py
+++ b/addons/l10n_fr_pos_cert/tests/__init__.py
@@ -1,1 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_fr_pos
 from . import test_string_to_hash

--- a/addons/l10n_fr_pos_cert/tests/test_fr_pos.py
+++ b/addons/l10n_fr_pos_cert/tests/test_fr_pos.py
@@ -1,0 +1,9 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericFR(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.main_pos_config.company_id.country_id = self.env.ref('base.fr')

--- a/addons/l10n_gcc_pos/tests/__init__.py
+++ b/addons/l10n_gcc_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_gcc_pos

--- a/addons/l10n_gcc_pos/tests/test_gcc_pos.py
+++ b/addons/l10n_gcc_pos/tests/test_gcc_pos.py
@@ -1,0 +1,9 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericGCC(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.main_pos_config.company_id.country_id = self.env.ref('base.sa')

--- a/addons/l10n_in_pos/tests/test_in_pos.py
+++ b/addons/l10n_in_pos/tests/test_in_pos.py
@@ -1,0 +1,20 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericIN(TestGenericLocalization):
+
+    def setUp(self):
+        super().setUp()
+        self.state_in_gj = self.env.ref('base.state_in_gj')
+        self.main_pos_config.company_id.write({
+            'name': "Default Company",
+            'state_id': self.state_in_gj.id,
+            'vat': "24AAGCC7144L6ZE",
+            'street': "Khodiyar Chowk",
+            'street2': "Sala Number 3",
+            'city': "Amreli",
+            'zip': "365220",
+        })
+        self.main_pos_config.company_id.country_id = self.env.ref('base.in')

--- a/addons/l10n_pe_pos/tests/__init__.py
+++ b/addons/l10n_pe_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_pe_pos

--- a/addons/l10n_pe_pos/tests/test_pe_pos.py
+++ b/addons/l10n_pe_pos/tests/test_pe_pos.py
@@ -1,0 +1,9 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericPE(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.main_pos_config.company_id.country_id = self.env.ref('base.pe')

--- a/addons/l10n_sa_edi_pos/__manifest__.py
+++ b/addons/l10n_sa_edi_pos/__manifest__.py
@@ -20,5 +20,8 @@ E-invoice implementation for Saudi Arabia; Integration with ZATCA (POS)
         'point_of_sale._assets_pos': [
             'l10n_sa_edi_pos/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'l10n_sa_edi_pos/static/tests/tours/**/*',
+        ],
     }
 }

--- a/addons/l10n_sa_edi_pos/static/tests/tours/utils/generic_hooks.js
+++ b/addons/l10n_sa_edi_pos/static/tests/tours/utils/generic_hooks.js
@@ -1,0 +1,26 @@
+import { patch } from "@web/core/utils/patch";
+import { GenericHooks } from "@point_of_sale/../tests/tours/utils/generic_hooks";
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import { session } from "@web/session";
+
+patch(GenericHooks, {
+    onProductScreen(...args) {
+        const company_name =
+            session.user_companies.allowed_companies[session.user_companies.current_company].name;
+        if (company_name == "Generic SA EDI") {
+            return [...ProductScreen.clickPartnerButton(), ...ProductScreen.clickCustomer("A")];
+        } else {
+            return super.onProductScreen(...args);
+        }
+    },
+    afterValidateHook(...args) {
+        const company_name =
+            session.user_companies.allowed_companies[session.user_companies.current_company].name;
+        if (company_name == "Generic SA EDI") {
+            return [Dialog.confirm()];
+        } else {
+            return super.afterValidateHook(...args);
+        }
+    },
+});

--- a/addons/l10n_sa_edi_pos/tests/__init__.py
+++ b/addons/l10n_sa_edi_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_sa_edi_pos

--- a/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
+++ b/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
@@ -1,0 +1,10 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericSAEdi(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.main_pos_config.company_id.country_id = self.env.ref('base.sa')
+        self.main_pos_config.company_id.name = 'Generic SA EDI'

--- a/addons/l10n_sa_pos/__manifest__.py
+++ b/addons/l10n_sa_pos/__manifest__.py
@@ -16,7 +16,10 @@ Saudi Arabia POS Localization
         'point_of_sale._assets_pos': [
             'web/static/lib/zxing-library/zxing-library.js',
             'l10n_sa_pos/static/src/**/*',
-        ]
+        ],
+                'web.assets_tests': [
+            'l10n_sa_pos/static/tests/tours/**/*',
+        ],
     },
     'auto_install': True,
 }

--- a/addons/l10n_sa_pos/static/tests/tours/utils/generic_hooks.js
+++ b/addons/l10n_sa_pos/static/tests/tours/utils/generic_hooks.js
@@ -1,0 +1,26 @@
+import { patch } from "@web/core/utils/patch";
+import { GenericHooks } from "@point_of_sale/../tests/tours/utils/generic_hooks";
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import { session } from "@web/session";
+
+patch(GenericHooks, {
+    onProductScreen(...args) {
+        const company_name =
+            session.user_companies.allowed_companies[session.user_companies.current_company].name;
+        if (company_name == "Generic SA") {
+            return [...ProductScreen.clickPartnerButton(), ...ProductScreen.clickCustomer("A")];
+        } else {
+            return super.onProductScreen(...args);
+        }
+    },
+    afterValidateHook(...args) {
+        const company_name =
+            session.user_companies.allowed_companies[session.user_companies.current_company].name;
+        if (company_name == "Generic SA") {
+            return [Dialog.confirm()];
+        } else {
+            return super.afterValidateHook(...args);
+        }
+    },
+});

--- a/addons/l10n_sa_pos/tests/__init__.py
+++ b/addons/l10n_sa_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_sa_pos

--- a/addons/l10n_sa_pos/tests/test_sa_pos.py
+++ b/addons/l10n_sa_pos/tests/test_sa_pos.py
@@ -1,0 +1,10 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n', 'l10n_pos_test')
+class TestGenericSA(TestGenericLocalization):
+    def setUp(self):
+        super().setUp()
+        self.main_pos_config.company_id.country_id = self.env.ref('base.sa')
+        self.main_pos_config.company_id.name = 'Generic SA'

--- a/addons/point_of_sale/static/tests/tours/generic_tour.js
+++ b/addons/point_of_sale/static/tests/tours/generic_tour.js
@@ -1,0 +1,30 @@
+import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import { GenericHooks } from "@point_of_sale/../tests/tours/utils/generic_hooks";
+import { registry } from "@web/core/registry";
+
+//This tour is meant to be run on all localizations
+registry.category("web_tour.tours").add("generic_localization_tour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            GenericHooks.onProductScreen(),
+            ProductScreen.clickDisplayedProduct("Test Product 1"),
+            ProductScreen.clickDisplayedProduct("Test Product 2"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            GenericHooks.afterValidateHook(),
+            ProductScreen.closePos(),
+            Dialog.confirm("Close Register"),
+            {
+                trigger: "button:contains(backend)",
+                run: "click",
+                expectUnloadPage: true,
+            },
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/utils/generic_hooks.js
+++ b/addons/point_of_sale/static/tests/tours/utils/generic_hooks.js
@@ -1,0 +1,11 @@
+export class GenericHooks {
+    static onProductScreen() {
+        // This function should be overridden in the localization
+        return [];
+    }
+
+    static afterValidateHook() {
+        // This function can be overridden in the localization to add steps after payment validation
+        return [];
+    }
+}

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -22,4 +22,5 @@ from . import test_pos_stock_account
 from . import test_report_pos_order
 from . import test_report_session
 from . import test_res_config_settings
+from . import test_generic_localization
 from . import test_stock_product_updates

--- a/addons/point_of_sale/tests/test_generic_localization.py
+++ b/addons/point_of_sale/tests/test_generic_localization.py
@@ -1,0 +1,36 @@
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo.tests import tagged
+from odoo import Command
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericLocalization(TestPointOfSaleHttpCommon):
+    allow_inherited_tests_method = True
+
+    def setUp(self):
+        super().setUp()
+        self.genericTourName = 'generic_localization_tour'
+        self.test_product_1 = self.env['product.product'].create({
+            'name': 'Test Product 1',
+            'type': 'consu',
+            'list_price': 10.0,
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'available_in_pos': True,
+            'taxes_id': [Command.set(self.tax_sale_a.ids)],
+            'standard_price': 5.0,
+        })
+        self.test_product_2 = self.env['product.product'].create({
+            'name': 'Test Product 2',
+            'type': 'consu',
+            'list_price': 20.0,
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'available_in_pos': True,
+            'taxes_id': [Command.set(self.tax_sale_a.ids)],
+            'standard_price': 15.0,
+        })
+
+    def test_generic_localization(self):
+        self.main_pos_config.open_ui()
+        current_session = self.main_pos_config.current_session_id
+        self.start_pos_tour(self.genericTourName, login="accountman")
+        self.assertEqual(current_session.state, 'closed')


### PR DESCRIPTION
Thi commit add a generic tour that can be run in all pos l10n_modules.
In some cases it requires some extra steps, this can be done with hooks.
The hooks will execute different steps depending on the country the tour
is run in.

opw-4606788