### PR TITLE
[FIX] website: return correct current website in a `MockRequest`

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -53,6 +53,7 @@ def MockRequest(
             geoip={'country_code': country_code},
             sale_order_id=sale_order_id,
             website_sale_current_pl=website_sale_current_pl,
+            force_website_id=website and website.id,
             context={'lang': ''},
         ),
         geoip={},


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps (saas-17.4)
-----------------
1. Install `l10n_ar_website_sale`;
2. run `:TestWebsiteSaleProductFilters` test suite.

Issue
-----
2 tests fails.

Cause
-----
The filters search for sale orders from `get_current_website`. Even though the correct website is passed to the `MockRequest`, the result of the call is a website from an Argentinian company with no sales orders.

Solution
--------
Add `force_website_id` to the `MockRequest` session, so `get_current_website` returns the intended website: https://github.com/odoo/odoo/blob/1ea4f285aba925d437a5129cd36143d9987c6e6a/addons/website/models/website.py#L1121

> [!Note]
> Alternatively, we can check for `request.website` being set in `get_current_website`. No idea if there's a reason it doesn't already.

runbot-111554
runbot-111555