### PR TITLE
[FIX] point_of_sale: show price on product card only in combo

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
@@ -7,7 +7,7 @@ export class ProductCard extends Component {
         name: String,
         product: Object,
         productId: Number | String,
-        price: String,
+        comboExtraPrice: { String, optional: true },
         color: { type: [Number, undefined], optional: true },
         imageUrl: [String, Boolean],
         productInfo: { Boolean, optional: true },

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -23,8 +23,10 @@
                     t-out="this.productQty"
                     class="product-cart-qty text-muted display-6 fw-bolder m-0 mt-auto" />
             </div>
-            <div class="w-100 d-flex justify-content-between align-items-center px-2">
-                <span t-if="props.price" class="price-tag py-1 text-end" t-esc="props.price" />
+            <div t-if="props.comboExtraPrice" class="d-flex px-2 pb-1">
+                <span class="price-extra px-2 py-0 rounded-pill text-bg-info">
+                    + <t t-esc="props.comboExtraPrice"/>
+                </span>
             </div>
         </article>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -33,7 +33,6 @@
                             class="pos.productViewMode"
                             name="getProductName(product)"
                             color="product.pos_categ_ids?.at(-1)?.color"
-                            price="this.getProductPrice(product)"
                             imageUrl="pos.config.show_product_images and this.getProductImage(product)"
                             onClick.bind="() => this.addProductToOrder(product)"
                             productInfo="true"

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -22,7 +22,7 @@
                                     class="'flex-column h-100 border'"
                                     productId="product.id"
                                     product="product"
-                                    price="formattedComboPrice(combo_item)"
+                                    comboExtraPrice="formattedComboPrice(combo_item)"
                                     imageUrl="product.getImageUrl()"
                                     onClick="(ev) => this.onClickProduct({ product, combo_item }, ev)" />
                             </label>

--- a/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
@@ -120,7 +120,7 @@ registry.category("web_tour.tours").add("ProductComboChangeFP", {
             Dialog.confirm("Open Register"),
 
             ProductScreen.clickDisplayedProduct("Office Combo"),
-            ProductScreen.checkExtraPrice("2"),
+            ProductScreen.checkProductExtraPrice("Combo Product 3", "2"),
             combo.select("Combo Product 2"),
             combo.select("Combo Product 4"),
             combo.select("Combo Product 6"),

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -650,9 +650,10 @@ export function checkTaxAmount(amount) {
     };
 }
 
-export function checkExtraPrice(amount) {
+export function checkProductExtraPrice(productName, extraAmount) {
     return {
-        trigger: `.price-tag.py-1:contains(${amount})`,
+        content: `'${productName}' should have '${extraAmount}' extra price`,
+        trigger: `article.product:has(.product-name:contains("${productName}")):has(.price-extra:contains("${extraAmount}"))`,
     };
 }
 


### PR DESCRIPTION
- Fix issue where the price was displayed on every product card (like in product screen). To fix this we want to only display the price of the card in combo choice.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
