### PR TITLE
[FIX] sale_loyalty: compare db rec id to NewId rec id

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -844,7 +844,7 @@ class SaleOrder(models.Model):
             reward = reward_key[0]
             program = reward.program_id
             points = self._get_real_points_for_coupon(coupon)
-            if coupon not in all_coupons or points < reward.required_points or program not in domain_matching_programs:
+            if coupon.id not in all_coupons.ids or points < reward.required_points or program not in domain_matching_programs:
                 # Reward is not applicable anymore, the reward lines will simply be removed at the end of this function
                 continue
             try:


### PR DESCRIPTION
Loyalty card model in UI is changeable and its values are not in the database yet It can not be compared to already existing records of loyalty cards in the database As they are not of the same datatype, so we should compare their ids instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
