### PR TITLE
[FIX] survey: translate frontend code terms


### DIFF
--- a/addons/survey/models/__init__.py
+++ b/addons/survey/models/__init__.py
@@ -7,4 +7,5 @@ from . import survey_question
 from . import survey_user_input
 from . import badge
 from . import challenge
+from . import ir_http
 from . import res_partner

--- a/addons/survey/models/ir_http.py
+++ b/addons/survey/models/ir_http.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = "ir.http"
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super()._get_translation_frontend_modules_name()
+        return mods + ["survey"]


### PR DESCRIPTION

Scenario: go to a survey in frontend in spanish, go to second page

Result: "or press Enter", "or press ⌘+Enter", "or press CTRL+Enter" are
not translated.

Cause: the frontend translation only contain translation of listed
modules, of which survey was missing.

opw-4573884
