### PR TITLE
[FIX] web_editor: fix form statusbar overlap in fullscreen

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -109,6 +109,6 @@
         height: 100vh !important;
         overflow: hidden !important;
         transform: none !important;
-        z-index: $zindex-dropdown - 2; // oe_snippets has $zindex-dropdown - 1
+        z-index: $zindex-modal-backdrop; // oe_snippets has $zindex-modal-backdrop + 1 with o_field_widgetTextHtml_fullscreen
     }
 }


### PR DESCRIPTION
[Commit] introduced a `z-index` change for the `form_statusbar` element,
which resulted in that element overlapping with the fullscreen view for the
`mass_mailing` html_field.

The `z-index` of `o_mass_mailing_iframe_ancestor_fullscreen` is adjusted to be
just 1 lower than `oe_snippets` (the snippets sidebar), hopefully preventing
overlaps in the future.

[Commit]: https://github.com/odoo/odoo/commit/a7864fcbc00d245df76b62bbed421b5171dbd4d4

task-4643999
