### PR TITLE
[FIX] web: no crash on quick open/close of emoji picker

### DIFF
--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -170,23 +170,24 @@ export class EmojiPicker extends Component {
         );
         useEffect(
             (el) => {
-                const gridEl = this.gridRef?.el;
+                const gridEl = this.gridRef.el;
                 const activeEl = gridEl?.querySelector(".o-Emoji.o-active");
-                if (
-                    gridEl &&
-                    activeEl &&
-                    this.keyboardNavigated &&
-                    !isElementVisible(activeEl, gridEl)
-                ) {
+                if (!gridEl) {
+                    return;
+                }
+                if (activeEl && this.keyboardNavigated && !isElementVisible(activeEl, gridEl)) {
                     activeEl.scrollIntoView({ block: "center", behavior: "instant" });
                     this.keyboardNavigated = false;
                 }
                 this.state.hoveredEmoji = this.activeEmoji;
             },
-            () => [this.state.activeEmojiIndex, this.gridRef?.el]
+            () => [this.state.activeEmojiIndex, this.gridRef.el]
         );
         useEffect(
             () => {
+                if (!this.gridRef.el) {
+                    return;
+                }
                 if (this.searchTerm) {
                     this.gridRef.el.scrollTop = 0;
                     this.state.categoryId = null;
@@ -212,6 +213,9 @@ export class EmojiPicker extends Component {
     }
 
     adaptNavbar() {
+        if (!this.navbarRef.el) {
+            return;
+        }
         const computedStyle = getComputedStyle(this.navbarRef.el);
         const availableWidth =
             this.navbarRef.el.getBoundingClientRect().width -
@@ -415,7 +419,7 @@ export class EmojiPicker extends Component {
             case "Enter":
                 ev.preventDefault();
                 this.gridRef.el
-                    .querySelector(
+                    ?.querySelector(
                         `.o-EmojiPicker-content .o-Emoji[data-index="${this.state.activeEmojiIndex}"]`
                     )
                     ?.click();


### PR DESCRIPTION
Before this commit, when opening and closing emoji picker quickly, it could crash with the following error:

```
TypeError: Cannot read properties of null (reading 'querySelector')
```

Steps to reproduce:
- Open website editor
- Add a new content block
- In content block, add banner with `/banner`
- spam click quickly on the banner icon

This happens because when clicking very quickly on emoji picker button, the `EmojiPicker` component is in a mounted state and the `gridRef.el` is undefined, thus resulting in the crash when attempting `gridRef.el.querySelector`

The grid has no reason to not be in the template. However, the `useRef()` has a special check to determine whether the ref is attached to DOM, and when not then it returns `null`. The website editor uses web editor, which itself mount the emoji picker in a popover. The click handler closes the popover if it was open and re-opens the emoji picker. Close of popover, when too fast, results to destroying popover before the emoji picker, which detaches the emoji picker from DOM, therefore all refs are `null`. The `EmojiPicker` is about to be destroyed, but for a fraction of time it can re-render itself and access to null refs.

Emoji picker relies heavily on template to model its matrice of emojis for keyboard navigation and managing overflow of
the category navbar. That's why mounting the emoji picker results to 2 renderings. Because of quick mount/unmount, overlay and double rendering of emoji picker, all this puts sometimes the emoji picker in a case of being status "mounted", in a fragment, and calling useEffect to set the active emoji in the grid. This requires `gridRef.el`, which is unfortunately `null` because of being in fragment, thus leading to the crash.

This commit fixes the issue by making the code more defensive against `gridRef.el` not be set, to tackle the case the component is in a fragment while it's being unmounted. `navbarRef.el` could also be `null` for a similar reason but instead of useEffect this is triggered from ResizeObserver.