### PR TITLE
[FIX] point_of_sale: typo in documentation URL

### DIFF
--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -320,7 +320,7 @@
                                      documentation="/applications/sales/point_of_sale/payment_methods/terminals/adyen.html">
                                 <field name="module_pos_adyen"/>
                             </setting>
-                            <setting id="stripe_payment_terminal_setting" title="The transactions are processed by Stripe. Set your Stripe credentials on the related payment method." string="Stripe" help="Accept payments with a Stripe payment terminal" documentation="applications/sales/point_of_sale/payment_methods/terminals/stripe.html">
+                            <setting id="stripe_payment_terminal_setting" title="The transactions are processed by Stripe. Set your Stripe credentials on the related payment method." string="Stripe" help="Accept payments with a Stripe payment terminal" documentation="/applications/sales/point_of_sale/payment_methods/terminals/stripe.html">
                                 <field name="module_pos_stripe"/>
                             </setting>
                             <setting title="The transactions are processed by Six. Set the IP address of the terminal on the related payment method." string="Six" documentation="/applications/sales/point_of_sale/payment_methods/terminals/six.html" help="Accept payments with a Six payment terminal">


### PR DESCRIPTION
A link (behind a small '?' icon) to online documentation for the Stripe payment provider is broken, on the `Point of Sale > Settings > Payment Terminals` page section. 

Versions affected: 18.0

![stripe-help](https://github.com/user-attachments/assets/2545270a-ff75-4b3a-8950-4788eb7338a0)

Current behavior before PR:

- The user is directed to a 404 error page.

Desired behavior after PR is merged:

- The Odoo online documentation for the Stripe payment provider should be displayed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
