### PR TITLE
[FIX] account: recompute commercial_partner_id before accessed

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -671,6 +671,8 @@ class ResPartner(models.Model):
     @api.depends_context('company')
     def _compute_invoice_edi_format(self):
         for partner in self:
+            if not partner.commercial_partner_id:
+                partner._compute_commercial_partner()
             if partner.commercial_partner_id.invoice_edi_format_store == 'none':
                 partner.invoice_edi_format = False
             else:


### PR DESCRIPTION
Typically, the field `commercial_partner_id` on `res.partner` is not displayed on the Form view. However, adding it via Studio or other means will lead to an error if the following conditions are met.

### Issue
- We click `New` to start creating a new record (still in `NewId` phase)
- We trigger an onchange that will lead to `invoice_edi_format` being computed

When clicking `New` the `commercial_partner_id` is computed initially. However, this value isn't present on the Form view yet which leaves the field empty until we actually save (and create) the record. Prior to this, if another onchange is called we'll pass `commercial_partner_id` as `False` in the onchange, eventually erroring out when we try to call a method on the value's record.

### Solution
We can check for the case above and compute the field again, ensuring that it has a proper value prior to accessing it.

opw-4630096
