### PR TITLE
[IMP] various: remove kanban grouped view

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -80,18 +80,36 @@ body.editor_has_snippets .o_field_mass_mailing_html div.d-flex:has(iframe) {
         }
         &.o_kanban_ungrouped {
             padding: 0;
-            .o_mailing_list_kanban_grouped {
-                display: none !important;
-            }
             .o_kanban_record {
                 width: 100%;
                 margin: 0;
             }
         }
-        &.o_kanban_grouped .o_mailing_list_kanban_ungrouped {
-            display: none !important;
+        @mixin kanban-stats-button-style {
+            font-size: 150% !important;
+            margin-bottom: 30px;
+            min-width: 90px;
+            width: 40%;
+            margin-right: 1rem !important;
         }
-        .o_mailing_list_kanban_ungrouped {
+        &.o_kanban_grouped {
+            .flex-row > div {
+                flex: 1 1 100% !important;
+                max-width: 100% !important;
+
+                &.col-6 {
+                    flex: 1 1 50% !important;
+                    max-width: 50% !important;
+                }
+                &.d-none {
+                    display: none !important; //forcing the d-none to override the d-lg or d-sm classes for grouped view
+                }
+                &.o_mailing_list_kanban_stats > a {
+                    @include kanban-stats-button-style;
+                }
+            }
+        }
+        article > div {
             --KanbanRecord-padding-h: #{$o-horizontal-padding};
 
             .o_mailing_list_kanban_stats > div {
@@ -103,11 +121,7 @@ body.editor_has_snippets .o_field_mass_mailing_html div.d-flex:has(iframe) {
                     color: rgb(1, 126, 132) !important;
                 }
                 @include media-breakpoint-down(sm) {
-                    font-size: 1.4rem !important;
-                    height: 40px;
-                    margin-bottom: 30px;
-                    min-width: 90px;
-                    width: 30%;
+                    @include kanban-stats-button-style;
                 }
             }
             .o_mailing_list_kanban_button {

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -111,49 +111,7 @@
                 <field name="active"/>
                 <templates>
                     <t t-name="card">
-                        <!-- Card when the Kanban view is grouped  -->
-                        <div class="o_mailing_list_kanban_grouped d-flex flex-column h-100">
-                            <field name="name" class="fw-bold fs-2 mb-3 text-truncate"/>
-                            <div class="d-flex align-items-center">
-                                <button class="btn btn-primary me-3" name="action_view_contacts" type="object">
-                                    <field name="contact_count"/> <span>Contacts</span>
-                                </button>
-                                <div class="flex-grow-1 d-flex flex-column align-items-end o_mass_mailing_kanban_contact_links">
-                                    <a name="action_view_contacts_email" type="object">
-                                        <span>Valid Email Recipients</span>
-                                        <field name="contact_count_email" class="ms-3"/>
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="flex-grow-1 d-flex mt-4 row g-0">
-                                <div class="col-3 border-end">
-                                    <a name="action_view_mailings" type="object" class="d-flex flex-column align-items-center">
-                                        <field name="mailing_count"/>
-                                        <span class="text-muted">Mailings</span>
-                                    </a>
-                                </div>
-                                <div class="col-3 border-end">
-                                    <a name="action_view_contacts_bouncing" type="object" class="d-flex flex-column align-items-center">
-                                        <span><field name="contact_pct_bounce"/>%</span>
-                                        <span class="text-muted">Bounce</span>
-                                    </a>
-                                </div>
-                                <div class="col-3 border-end">
-                                    <a name="action_view_contacts_opt_out" type="object" class="d-flex flex-column align-items-center">
-                                        <span><field name="contact_pct_opt_out"/>%</span>
-                                        <span class="text-muted">Opt-out</span>
-                                    </a>
-                                </div>
-                                <div class="col-3">
-                                    <a name="action_view_contacts_blacklisted" type="object" class="d-flex flex-column align-items-center">
-                                        <span><field name="contact_pct_blacklisted"/>%</span>
-                                        <span class="text-muted">Blacklist</span>
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Card when the Kanban view is not grouped -->
-                        <div class="o_mailing_list_kanban_ungrouped d-flex gap-1 flex-row justify-content-between align-items-center flex-wrap">
+                        <div class="d-flex gap-1 flex-row justify-content-between align-items-center flex-wrap">
                             <div class="col-lg-3 col-sm-6 col-12 py-0 my-auto">
                                 <span class="d-inline-block text-truncate fs-2 fw-normal lh-sm" t-att-title="record.name.value">
                                     <field name="name"/>
@@ -172,7 +130,7 @@
                                 </div>
                             </div>
                             <div class="o_mailing_list_kanban_stats order-4 order-lg-3 col-lg-5 col-sm-12 col-12 py-0 my-3 my-sm-auto d-flex justify-content-sm-between justify-content-start flex-wrap">
-                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1 text-truncate" tabindex="-1"
                                     name="action_view_contacts_email" type="object">
                                     <field name="contact_count_email" class="fw-normal"/>
                                     <br/>
@@ -180,14 +138,14 @@
                                         <i class="fa fa-envelope-o"/> Contacts
                                     </span>
                                 </a>
-                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1 text-truncate" tabindex="-1"
                                     name="action_view_mailings" type="object">
                                     <field name="mailing_count" class="fw-normal"/>
                                     <br/>
                                     <span class="text-muted">Mailings</span>
                                 </a>
                                 <hr class="w-100 d-block d-sm-none opacity-0 m-0 p-0"/>
-                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1 text-truncate" tabindex="-1"
                                     name="action_view_contacts_bouncing" type="object">
                                     <span class="fw-normal">
                                         <field name="contact_pct_bounce"/> %
@@ -195,7 +153,7 @@
                                     <br/>
                                     <span class="text-muted">Bounce</span>
                                 </a>
-                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1 text-truncate" tabindex="-1"
                                     name="action_view_contacts_opt_out" type="object">
                                     <span class="fw-normal">
                                         <field name="contact_pct_opt_out"/> %
@@ -203,7 +161,7 @@
                                     <br/>
                                     <span class="text-muted">Opt-Out</span>
                                 </a>
-                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1 text-truncate" tabindex="-1"
                                     name="action_view_contacts_blacklisted" type="object">
                                     <span class="fw-normal">
                                         <field name="contact_pct_blacklisted"/> %

--- a/addons/mass_mailing_sms/views/mailing_list_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_list_views.xml
@@ -5,12 +5,6 @@
         <field name="model">mailing.list</field>
         <field name="inherit_id" ref="mass_mailing.mailing_list_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('o_mass_mailing_kanban_contact_links')]" position="inside">
-              <a name="action_view_contacts_sms" type="object">
-                  <span >Valid SMS Recipients</span>
-                  <field name="contact_count_sms" class="ms-3"/>
-              </a>
-            </xpath>
             <xpath expr="//div[hasclass('o_mailing_list_kanban_stats')]//a" position="after">
                 <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
                     name="action_view_contacts_sms" type="object">

--- a/addons/survey/static/src/scss/survey_survey_views.scss
+++ b/addons/survey/static/src/scss/survey_survey_views.scss
@@ -13,13 +13,17 @@
 
     // Grouped / Ungrouped sections hidding
     &.o_kanban_grouped {
-        .o_survey_kanban_card_ungrouped {
-            display:none !important;
-        }
-    }
-    &.o_kanban_ungrouped {
-        .o_survey_kanban_card_grouped {
-            display:none !important;
+        .row > div {
+            flex: 1 1 100% !important;
+            max-width: 100% !important;
+            padding-left: 0 !important;
+            &.col-6 {
+                flex: 1 1 50% !important;
+                max-width: 50% !important;
+            }
+            &.d-none {
+                display: none !important; //forcing the d-none to override the d-lg or d-sm classes for grouped view
+            }
         }
     }
 
@@ -39,13 +43,6 @@
 
     // Grouped specific
     &.o_kanban_grouped {
-        // Set a minimal height otherwise display may have different card sized
-        .o_survey_kanban_card_grouped {
-            & > .row {
-                min-height: 60px;
-            }
-        }
-
         // Due to activity widget crashing if present twice, have to set absolute and tweak
         .o_survey_kanban_card_bottom {
             position: absolute;
@@ -57,10 +54,8 @@
     // Ungrouped specific
     &.o_kanban_ungrouped {
         // Set a minimal height otherwise display may have different card sized
-        .o_survey_kanban_card_ungrouped {
-            &.row {
+        .o_survey_kanban_card > div.row {
                 min-height: 60px;
-            }
         }
 
         // Left semi-trophy icon for certifications: tweak display for list view
@@ -87,7 +82,7 @@
 
     // RIBBON: Kanban specific
     // Ungrouped specific
-    .o_survey_kanban_card_ungrouped {
+    .o_survey_kanban_card {
         .ribbon {
             --Ribbon-wrapper-width: 6rem;
 

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -247,8 +247,7 @@
                     </div>
                     <div t-name="card"
                         t-attf-class="o_survey_kanban_card #{record.certification.raw_value ? 'o_survey_kanban_card_certification' : ''}" class="px-0">
-                        <!-- displayed in ungrouped mode -->
-                        <div class="o_survey_kanban_card_ungrouped row mx-4">
+                        <div class="row mx-4">
                             <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                             <div class="col-lg-2 col-sm-8 py-0 my-2 my-lg-0 col-12 g-0">
                                 <div class="d-flex flex-grow-1 flex-column my-0 my-lg-2">
@@ -261,18 +260,18 @@
                                     </span>
                                 </div>
                             </div>
-                            <div t-attf-class="col-lg-1 col-sm-4 d-none d-sm-block py-0 my-2 col-#{selection_mode ? '12' : '6'}">
+                            <div t-attf-class="col-lg-1 col-sm-4 d-sm-block py-0 my-2 col-#{selection_mode ? '12' : '6'}">
                                 <field name="question_count" class="fw-bold"/><br t-if="!selection_mode"/>
                                 <span class="text-muted">Questions</span>
                             </div>
                             <div t-if="selection_mode" class="col-12 d-flex justify-content-end">
                                 <field name="user_id" widget="many2one_avatar_user"/>
                             </div>
-                            <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 py-0 my-2">
+                            <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 d-none py-0 my-2">
                                 <field name="answer_duration_avg" widget="float_time" class="fw-bold"/>
                                 <span class="text-muted">Average Duration</span>
                             </div>
-                            <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 py-0 my-2">
+                            <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 d-none py-0 my-2">
                                 <a type="object"
                                    name="action_survey_user_input"
                                    class="fw-bold">
@@ -280,7 +279,7 @@
                                     <span class="text-muted">Registered</span>
                                 </a>
                             </div>
-                            <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 d-none d-sm-block py-0 my-2">
+                            <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 d-sm-block py-0 my-2">
                                 <a type="object"
                                    name="action_survey_user_input_completed"
                                    class="fw-bold">
@@ -330,35 +329,6 @@
                                         invisible="session_state not in ['ready', 'in_progress'] or not active">
                                     End Live Session
                                 </button>
-                            </div>
-                        </div>
-                        <!-- displayed in grouped mode -->
-                        <div class="o_survey_kanban_card_grouped px-1">
-                            <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                            <field name="title" class="fw-bold mb-1 fs-5 mb-1"/>
-                            <div class="row g-0">
-                                <div class="col-10 p-0 pb-1" t-if="record.answer_count.raw_value != 0">
-                                    <div class="row mt-4 ms-2">
-                                        <div class="col-4 p-0">
-                                            <a name="action_survey_user_input" type="object" class="d-flex flex-column align-items-center">
-                                                <field name="answer_count" class="fw-bold"/>
-                                                <span class="text-break text-muted">Registered</span>
-                                            </a>
-                                        </div>
-                                        <div class="col-4 p-0 border-start">
-                                            <a name="action_survey_user_input_completed" type="object" class="d-flex flex-column align-items-center">
-                                                <field name="answer_done_count" class="fw-bold"/>
-                                                <span class="text-break text-muted">Completed</span>
-                                            </a>
-                                        </div>
-                                        <div class="col-4 p-0 border-start" t-if="record.scoring_type.raw_value != 'no_scoring'" >
-                                            <a name="action_survey_user_input_certified" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="fw-bold"> <t t-esc="Math.round(record.success_ratio.raw_value)"></t> %</span>
-                                                <span class="text-break text-muted">Success</span>
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
                             </div>
                         </div>
                         <!-- Generic -->

--- a/addons/website/static/src/scss/website_visitor_views.scss
+++ b/addons/website/static/src/scss/website_visitor_views.scss
@@ -4,14 +4,24 @@
         .o_kanban_record {
             width: 100%;
             margin: 0px;
-            .o_kanban_grouped {
-                display:none !important;
-            }
         }
     }
     &.o_kanban_grouped {
-        .o_kanban_detail_ungrouped {
-            display:none !important;
+        .row > div {
+            flex: 1 1 100% !important;
+            max-width: 100% !important;
+            margin: 8px 0 !important;
+
+            &.col-6 {
+                flex: 1 1 50% !important;
+                max-width: 50% !important;
+            }
+            &.d-none {
+                display: none !important; //forcing the d-none to override the d-lg or d-sm classes for grouped view
+            }
+            &.text-lg-end {
+                text-align: left !important; //overrides the text-lg-end for grouped view.
+            }
         }
     }
 }
@@ -21,7 +31,7 @@
     height: 16px;
 }
 
-.w_visitor_kanban_actions_ungrouped .btn {
+.w_visitor_kanban_actions .btn {
     margin: inherit;
     &:not(:last-child){
         margin-right: 0.25rem;

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -87,9 +87,8 @@
                 <field name="partner_image"/>
                 <templates>
                     <t t-name="card" class="p-0">
-                        <!-- displayed in ungrouped mode -->
                         <div class="o_kanban_detail_ungrouped row mx-0">
-                            <div class="col-lg-2 col-sm-8 col-12 py-0 my-2 my-lg-0">
+                            <div class="col-lg-2 col-sm-8 col-12 py-0 my-2">
                                 <div class="d-flex">
                                     <field t-if="record.partner_image.raw_value" name="partner_id" widget="image" options="{'preview_image': 'image_128', 'size': [54, 54]}" alt="Visitor" class="me-3"/>
                                     <img t-else=""
@@ -128,26 +127,7 @@
                                 </span>
                                 <div t-att-class="record.page_count.raw_value ? '' : 'text-muted'">Visited Pages</div>
                             </div>
-                            <div class="w_visitor_kanban_actions_ungrouped col-lg-3 col-sm-12 py-0 my-2 text-lg-end">
-                                <button name="action_send_mail" type="object"
-                                        class="btn btn-secondary" invisible="not email">
-                                        Email
-                                </button>
-                            </div>
-                        </div>
-                        <!-- displayed in grouped mode -->
-                        <div class="o_kanban_grouped p-2">
-                            <span class="fa fa-circle text-success float-end" t-if="record.is_connected.raw_value" aria-label="Online" title="Online"/>
-                            <span class="fa fa-circle text-danger float-end" t-else="" aria-label="Offline" title="Offline"/>
-                            <div class="d-flex">
-                                <field t-if="record.country_id.raw_value" name="country_flag" widget="image_url" class="o_country_flag" alt="Country"/>
-                                <field name="display_name" class="fw-bolder"/>
-                            </div>
-                            <div class="mb-2">Active <field name="time_since_last_action"/></div>
-                            <div t-if="record.page_count.raw_value">Last Page<field name="last_visited_page_id" class="float-end fw-bold"/></div>
-                            <div>Visits<field name="visit_count" class="float-end fw-bold"/></div>
-                            <div t-if="record.page_count.raw_value" id="o_page_count">Visited Pages<span class="float-end fw-bold"><field name="page_count"/></span></div>
-                            <div name="w_visitor_kanban_actions" class="d-flex gap-1">
+                            <div class="w_visitor_kanban_actions col-lg-3 col-sm-12 py-0 my-2 text-lg-end">
                                 <button name="action_send_mail" type="object"
                                         class="btn btn-secondary" invisible="not email">
                                         Email

--- a/addons/website_crm/views/website_visitor_views.xml
+++ b/addons/website_crm/views/website_visitor_views.xml
@@ -45,12 +45,6 @@
         <field name="model">website.visitor</field>
         <field name="inherit_id" ref="website.website_visitor_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='o_page_count']" position="after">
-                <div t-if="record.lead_count.raw_value" groups="sales_team.group_sale_salesman">
-                    Leads / Opportunities
-                    <field name="lead_count" class="float-end fw-bold"/>
-                </div>
-            </xpath>
             <xpath expr="//div[@id='wvisitor_visited_page']" position="after">
                 <div class="col-lg col-sm-4 col-6 py-0 my-2" groups="sales_team.group_sale_salesman">
                     <span t-att-class="record.lead_count.raw_value ? 'fw-bold' : 'text-muted'">

--- a/addons/website_livechat/views/website_visitor_views.xml
+++ b/addons/website_livechat/views/website_visitor_views.xml
@@ -36,21 +36,7 @@
                 <field name="livechat_operator_id"/>
                 <field name="session_count"/>
             </field>
-            <xpath expr="//div[@name='w_visitor_kanban_actions']" position="before">
-                <div t-if="record.session_count.raw_value">Chats<field name="session_count" class="float-end fw-bold"/></div>
-                <div t-if="record.livechat_operator_id.raw_value">
-                    Speaking With
-                    <div name="livechat_operator_id"
-                        class="fw-bold float-end d-inline-block">
-                        <field name="livechat_operator_id" widget="image" options="{'preview_image': 'avatar_128', 'size': [19, 19]}" class="rounded-circle" alt="Operator Avatar"/>
-                        <field name="livechat_operator_name"/>
-                    </div>
-                </div>
-                <t t-else="">
-                    <br invisible="livechat_operator_id or not is_connected"/>
-                </t>
-            </xpath>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions_ungrouped')]" position="before">
+            <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="before">
                 <div class="col-lg col-sm-4 col-6 py-0 my-2">
                     <span t-att-class="record.session_count.raw_value ? 'fw-bold' : 'text-muted'">
                         <field name="session_count"/>
@@ -64,14 +50,7 @@
                 </div>
                 <div t-else="" class="col-lg d-none d-lg-block"/>
             </xpath>
-            <xpath expr="//div[@name='w_visitor_kanban_actions']" position="inside">
-                <button name="action_send_chat_request" type="object"
-                        class="btn btn-secondary"
-                        invisible="livechat_operator_id or not is_connected">
-                        Chat
-                </button>
-            </xpath>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions_ungrouped')]" position="inside">
+            <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="inside">
                 <button name="action_send_chat_request" type="object"
                         class="btn btn-secondary"
                         invisible="livechat_operator_id or not is_connected">

--- a/addons/website_sale/views/website_sale_visitor_views.xml
+++ b/addons/website_sale/views/website_sale_visitor_views.xml
@@ -95,9 +95,6 @@
             <field name="country_id" position="after">
                 <field name="product_ids"/>
             </field>
-            <xpath expr="//div[@id='o_page_count']" position="after">
-                 <div id="o_product_count">Visited Products<field name="product_count" class="float-end fw-bold"/></div>
-            </xpath>
         </field>
     </record>
 

--- a/addons/website_sms/views/website_visitor_views.xml
+++ b/addons/website_sms/views/website_visitor_views.xml
@@ -20,12 +20,7 @@
             <field name="country_id" position="after">
                 <field name="mobile" widget="phone"/>
             </field>
-            <xpath expr="//div[@name='w_visitor_kanban_actions']" position="inside">
-                <button name="action_send_sms" type="object" class="btn btn-secondary"
-                        invisible="not mobile">SMS
-                </button>
-            </xpath>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions_ungrouped')]" position="inside">
+            <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="inside">
                 <button name="action_send_sms" type="object" class="btn btn-secondary"
                         invisible="not mobile">SMS
                 </button>


### PR DESCRIPTION
Previously, a separate kanban grouped view was used when records had groups applied.This task removes the grouped view and adjusts the ungrouped view to fit the necessary columns dynamically, ensuring responsiveness and consistency across views.

Task-4582920