### PR TITLE
[ADD] mail_plugin: add search endpoints for leads and tasks

### DIFF
--- a/addons/crm_mail_plugin_search/__init__.py
+++ b/addons/crm_mail_plugin_search/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/addons/crm_mail_plugin_search/__manifest__.py
+++ b/addons/crm_mail_plugin_search/__manifest__.py
@@ -1,0 +1,8 @@
+{
+    'name': 'CRM Mail Plugin Search',
+    'version': '1.0',
+    'category': 'Sales/CRM',
+    'depends': ['crm','mail_plugin'],
+    'license': 'LGPL-3',
+    'installable': True,
+}

--- a/addons/crm_mail_plugin_search/controllers/__init__.py
+++ b/addons/crm_mail_plugin_search/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_plugin

--- a/addons/crm_mail_plugin_search/controllers/mail_plugin.py
+++ b/addons/crm_mail_plugin_search/controllers/mail_plugin.py
@@ -1,0 +1,53 @@
+from odoo import _, http
+from odoo.addons.mail_plugin.controllers import mail_plugin
+from odoo.http import request
+from odoo.tools.misc import formatLang
+
+
+class MailPluginController(mail_plugin.MailPluginController):
+
+    @http.route('/mail/plugin/leads/refresh', type='json', auth='outlook', cors='*')
+    def refresh_leads(self, partner, **kwargs):
+        partner = request.env['res.partner'].browse(partner['id'])
+        leads = self._fetch_partner_leads(partner)
+
+        return leads
+
+    @http.route('/mail/plugin/leads/search', type='json', auth='outlook', cors='*')
+    def get_leads(self, query='', partner=None, **kwargs):
+        if not partner:
+            return {'error': _('Partner ID is required.')}
+
+        partner = request.env['res.partner'].browse(partner['id']).exists()
+        if not partner:
+            return {'error': _('The Partner does not exist.')}
+
+        if not query.strip():
+            return {'error': _('Search query cannot be empty.')}
+
+        partner_leads = request.env['crm.lead'].search([
+            '|','|',
+            ('partner_id.email', 'ilike', query),
+            ('partner_id.name', 'ilike', query),
+            ('name', 'ilike', query)
+        ], order='create_date')
+        recurring_revenues = request.env.user.has_group('crm.group_use_recurring_revenues')
+
+        leads = []
+        for lead in partner_leads:
+            record = {
+                'lead_id': lead.id,
+                'name': lead.name,
+                'expected_revenue': formatLang(request.env, lead.expected_revenue, currency_obj=lead.company_currency),
+                'probability': lead.probability,
+            }
+
+            if recurring_revenues:
+                record.update({
+                    'recurring_revenue': formatLang(request.env, lead.recurring_revenue, currency_obj=lead.company_currency),
+                    'recurring_plan': lead.recurring_plan.name,
+                })
+
+            leads.append(record)
+
+        return leads

--- a/addons/project_task_mail_plugin_search/__init__.py
+++ b/addons/project_task_mail_plugin_search/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/addons/project_task_mail_plugin_search/__manifest__.py
+++ b/addons/project_task_mail_plugin_search/__manifest__.py
@@ -1,0 +1,8 @@
+{
+    'name': 'Project Task Mail Plugin Search',
+    'version': '1.0',
+    'category': 'Services/Project',
+    'depends': ['project','mail_plugin'],
+    'license':'LGPL-3',
+    'installable': True,
+}

--- a/addons/project_task_mail_plugin_search/controllers/__init__.py
+++ b/addons/project_task_mail_plugin_search/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_plugin

--- a/addons/project_task_mail_plugin_search/controllers/mail_plugin.py
+++ b/addons/project_task_mail_plugin_search/controllers/mail_plugin.py
@@ -1,0 +1,54 @@
+from odoo import _, http
+from odoo.addons.mail_plugin.controllers import mail_plugin
+from odoo.http import request
+
+
+class MailPluginController(mail_plugin.MailPluginController):
+
+    @http.route('/mail/plugin/tasks/refresh', type='json', auth='outlook', cors='*')
+    def refresh_tasks(self, partner, **kwargs):
+        partner = request.env['res.partner'].browse(partner['id'])
+        partner_tasks = request.env['project.task'].search([('partner_id', '=', partner.id)], offset=0, limit=5)
+        accessible_projects = partner_tasks.project_id._filtered_access('read').ids
+
+        tasks_values = []
+        for task in partner_tasks:
+            if task.project_id.id in accessible_projects:
+                record = {
+                    'task_id': task.id,
+                    'name': task.name,
+                    'project_name': task.project_id.name,
+                }
+                tasks_values.append(record)
+
+        return tasks_values
+
+    @http.route('/mail/plugin/tasks/search', type='json', auth='outlook', cors='*')
+    def get_tasks(self, query='', partner=None, **kwargs):
+        if not partner:
+            return {'error': _('Partner ID is required.')}
+
+        partner = request.env['res.partner'].browse(partner['id']).exists()
+        if not partner:
+            return {'error': _('The Partner does not exist.')}
+        if not query.strip():
+            return {'error': _('Search query cannot be empty.')}
+
+        partner_tasks = request.env['project.task'].search([
+            '|', '|',
+            ('name', 'ilike', query),
+            ('partner_id.name', 'ilike', query),
+            ('project_id.name', 'ilike', query)
+        ], order='create_date')
+
+        tasks = []
+        for task in partner_tasks:
+            record = {
+                'task_id': task.id,
+                'name': task.name,
+                'project_name': task.project_id.name,
+                'company_id': task.company_id,
+            }
+            tasks.append(record)
+
+        return tasks


### PR DESCRIPTION
In this commit:
- Implemented '/mail/plugin/leads/search' to fetch CRM leads based on partner email, name, or lead name.
- Implemented '/mail/plugin/tasks/search' to fetch Project tasks by task name, partner name, or project name.