### PR TITLE
[FIX] l10n_in_ewaybill_stock: invisible field error

### DIFF
--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -120,7 +120,7 @@
                         <page string="Item Details">
                             <field name="move_ids" mode="list,kanban" force_save="1" readonly="state != 'pending'">
                                 <list editable="bottom" create="0" delete="0">
-                                    <field name="company_currency_id" column_invisible="1"/>
+                                    <field name="company_currency_id" column_invisible="1"/> <!-- To display the currency symbol  -->
                                     <field name="product_id" readonly="1"/>
                                     <field name="quantity" string="Quantity" readonly="1"/>
                                     <field name="ewaybill_price_unit" string="Unit Price"/>


### PR DESCRIPTION
In this commit-
We fix the invisible fields failing test for `l10n_in_ewaybill_stock`

runbot error-https://runbot.odoo.com/runbot/build/76485337
opw-4628736




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
