### PR TITLE
[FIX] orm: prevent error when import data on model

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -7403,5 +7403,5 @@ def get_columns_from_sql_diagnostics(cr, diagnostics, *, check_registry=False) -
         WHERE conname = %s
             AND t.relname = %s
     """, diagnostics.constraint_name, diagnostics.table_name))
-    [columns] = cr.fetchone() or ([])
-    return columns
+    columns = cr.fetchone()
+    return columns[0] if columns else []


### PR DESCRIPTION
Currently, an error occurs when importing or testing data from a CSV file, particularly when setting related fields. This results in an unhandled error during the error message creation process.

** Steps to reproduce:**
- Open the **Product Variants** list view.
- Import the csv file: [file](https://drive.google.com/file/d/1pW9zBWQ0dzFRBHnLUk3DC34YWuK4tUV0/view?usp=drive_link)
- Set the Odoo fields as `Name` and `Products / Cost` accordingly.
- Click on `Test` or `Import` button.
- Observe the error at the backend.

**Error:**
`ValueError - not enough values to unpack (expected 1, got 0)`

The error occurs because `[columns]` attempts to unpack an empty list when `cr.fetchone()` returns `None` at [1].

This commit ensures that if `cr.fetchone()` returns `None`, `columns` is assigned an empty list without causing an unpacking error.

[1] - https://github.com/odoo/odoo/blob/30efa3c90226e77fb175b533dd60734f58a4f27c/odoo/orm/models.py#L7374

This issue will also fix Sentry IDs: 6398456413, 6518332727, 6316946127
Sentry - 6278940594