### PR TITLE
[FIX] point_of_sale: hide product price on product card

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
@@ -8,6 +8,7 @@ export class ProductCard extends Component {
         product: Object,
         productId: Number | String,
         price: String,
+        priceExtra: { type: String, optional: true },
         color: { type: [Number, undefined], optional: true },
         imageUrl: [String, Boolean],
         productInfo: { Boolean, optional: true },

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -3,7 +3,7 @@
 
     <t t-name="point_of_sale.ProductCard">
         <article tabindex="0"
-            t-attf-class="{{props.class}} {{props.color ? `o_colorlist_item_color_transparent_${props.color}` : ''}} product position-relative btn btn-light d-flex align-items-stretch p-0 m-0 rounded-3 text-start cursor-pointer transition-base"
+            t-attf-class="{{props.class}} {{props.color ? `o_colorlist_item_color_transparent_${props.color}` : ''}} product position-relative btn btn-light d-flex align-items-stretch justify-content-between p-0 m-0 rounded-3 text-start cursor-pointer transition-base"
             t-on-keypress="(event) => event.code === 'Space' ? props.onClick(event) : ()=>{}"
             t-on-click="props.onClick"
             t-att-data-product-id="props.productId"
@@ -23,8 +23,8 @@
                     t-out="this.productQty"
                     class="product-cart-qty text-muted display-6 fw-bolder m-0 mt-auto" />
             </div>
-            <div class="w-100 d-flex justify-content-between align-items-center px-2">
-                <span t-if="props.price" class="price-tag py-1 text-end" t-esc="props.price" />
+            <div class="d-flex px-2 pb-1">
+                <span t-if="props.priceExtra" class="price-extra px-2 py-1 rounded-pill text-bg-info" t-out="props.priceExtra" />
             </div>
         </article>
     </t>

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -23,6 +23,7 @@
                                     productId="product.id"
                                     product="product"
                                     price="formattedComboPrice(combo_item)"
+                                    priceExtra="formattedComboPrice(combo_item)"
                                     imageUrl="product.getImageUrl()"
                                     onClick="(ev) => this.onClickProduct({ product, combo_item }, ev)" />
                             </label>

--- a/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
@@ -120,7 +120,7 @@ registry.category("web_tour.tours").add("ProductComboChangeFP", {
             Dialog.confirm("Open Register"),
 
             ProductScreen.clickDisplayedProduct("Office Combo"),
-            ProductScreen.checkExtraPrice("2"),
+            ProductScreen.checkProductExtraPrice("Combo Product 3", "2"),
             combo.select("Combo Product 2"),
             combo.select("Combo Product 4"),
             combo.select("Combo Product 6"),

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -650,9 +650,10 @@ export function checkTaxAmount(amount) {
     };
 }
 
-export function checkExtraPrice(amount) {
+export function checkProductExtraPrice(productName, extraAmount) {
     return {
-        trigger: `.price-tag.py-1:contains(${amount})`,
+        content: `'${productName}' should have '${extraAmount}' extra price`,
+        trigger: `article.product:has(.product-name:contains("${productName}")):has(.price-extra:contains("${extraAmount}"))`,
     };
 }
 


### PR DESCRIPTION
Since commit 5a26402d33570dd6ad18be122aac74bfe8397445, product prices have been unintentionally displayed on product cards.

This commit fixes that issue by hiding the unintended price display. Additionally, it improves how extra prices are shown on combo products,

Task: 4644777
