### PR TITLE
[FIX] mail: unavailable store service on lazy loading ChatHub

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -85,4 +85,10 @@ export class ChatHub extends Component {
     }
 }
 
-registry.category("main_components").add("mail.ChatHub", { Component: ChatHub });
+export const chatHubService = {
+    dependencies: ["bus.monitoring_service", "mail.store", "ui"],
+    start() {
+        registry.category("main_components").add("mail.ChatHub", { Component: ChatHub });
+    },
+};
+registry.category("services").add("mail.chat_hub", chatHubService);

--- a/addons/mail/static/src/discuss/call/common/call_invitations.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitations.js
@@ -17,4 +17,12 @@ export class CallInvitations extends Component {
     }
 }
 
-registry.category("main_components").add("discuss.CallInvitations", { Component: CallInvitations });
+export const callInvitationsService = {
+    dependencies: ["discuss.rtc", "mail.store"],
+    start() {
+        registry
+            .category("main_components")
+            .add("discuss.CallInvitations", { Component: CallInvitations });
+    },
+};
+registry.category("services").add("discuss.call_invitations", callInvitationsService);

--- a/addons/mail/static/src/discuss/core/public_web/bus_connection_alert.js
+++ b/addons/mail/static/src/discuss/core/public_web/bus_connection_alert.js
@@ -16,4 +16,12 @@ export class BusConnectionAlert extends Component {
     }
 }
 
-registry.category("main_components").add("bus.connection_alert", { Component: BusConnectionAlert });
+export const connectionAlertService = {
+    dependencies: ["bus.monitoring_service", "mail.store"],
+    start() {
+        registry
+            .category("main_components")
+            .add("bus.ConnectionAlert", { Component: BusConnectionAlert });
+    },
+};
+registry.category("services").add("bus.connection_alert", connectionAlertService);


### PR DESCRIPTION
When we create a public root, we do:
- Create env
- Wait for services to load
- Create `MainComponentsContainer`

In a usual scenario, all the services are started in the second step above, so
when we create the MainComponentsContainer, all the services we need are already
 available. The problem with the lazy loading chatter bundle is that one of the
 services in the second step is responsible for loading that bundle. So while
 the lazy bundle is loading, new services and main components are being added to
 the registry.

The steps become like this:
- Create env
- Wait for services to start
- Start loading chatter bundle
- Lazy services (from chatter bundle) are not yet completely started
- A main component from lazy bundle is added to the registry (in this case
ChatHub) => crash
- Lazy services are completely started

Steps to reproduce:
- Install a module that has portal chatter for example sales
- Go to the portal page of a sale order
- Error: `service mail.store is not available`

This PR defines a new service for each main component to ensure that main
components are registered when their dependent services are deployed.

runbot-116358
task-4642192

[Related enterprise PR](https://github.com/odoo/enterprise/pull/81327)