### PR TITLE
[FIX] delivery: estimated delivery cost on SO line not rounded

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -123,7 +123,7 @@ class SaleOrder(models.Model):
         }
         if carrier.invoice_policy == 'real':
             values['price_unit'] = 0
-            values['name'] += _(' (Estimated Cost: %s )', self._format_currency_amount(price_unit))
+            values['name'] += _(' (Estimated Cost: %s )', self.currency_id.format(price_unit))
         else:
             values['price_unit'] = price_unit
         if carrier.free_over and self.currency_id.is_zero(price_unit) :
@@ -137,6 +137,7 @@ class SaleOrder(models.Model):
         values = self._prepare_delivery_line_vals(carrier, price_unit)
         return self.env['sale.order.line'].sudo().create(values)
 
+    # to remove in master
     def _format_currency_amount(self, amount):
         pre = post = u''
         if self.currency_id.position == 'before':


### PR DESCRIPTION
To reproduce:
- Install delivery_fedex (for example) and sale_management.
- Open Fedex US shipping method and set invoicing to real cost, margin on rate to 93.47 (for example).
- New SO to Azure Interior, 1x product 5555, Add shipping Fedex US and get the rate before adding to the SO.

Current behaviour:
Estimated cost on SO line description is not rounded according to the currency conventions.

Expected behaviour:
Estimated cost on SO line description is rounded, according to the currency conventions.

opw-4543605

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
