### PR TITLE
[IMP] base/ir.qweb: new `.translate` options for attributes and f-string

### DIFF
--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -14,8 +14,7 @@
 </template>
 
 <template id="snippet_options_image_optimization_widgets">
-    <t t-set="filter_label">Filter</t>
-    <we-select t-att-string="filter_label" t-att-class="indent and 'o_we_sublevel_2'">
+    <we-select string.translate="Filter" t-att-class="indent and 'o_we_sublevel_2'">
         <we-button data-gl-filter="">None</we-button>
         <we-button data-gl-filter="blur">Blur</we-button>
         <we-button data-gl-filter="1977">1977</we-button>

--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -56,8 +56,7 @@
                 <we-button data-select-data-attribute="onClick" data-name="onclick_opt">On Click (via link)</we-button>
             </we-select>
             <we-input string="&#8985; Delay" title="Automatically opens the pop-up if the user stays on a page longer than the specified time." data-select-data-attribute="" data-attribute-name="showAfter" data-unit="s" data-save-unit="ms" data-dependencies="show_delay"/>
-            <t t-set="unit_popup_duration">days</t>
-            <we-input string="Hide For" title="Once the user closes the popup, it won't be shown again for that period of time." t-attf-data-select-data-attribute="7#{unit_popup_duration}" data-attribute-name="consentsDuration" t-att-data-unit="unit_popup_duration" data-dependencies="!onclick_opt"/>
+            <we-input string="Hide For" title="Once the user closes the popup, it won't be shown again for that period of time." data-select-data-attribute.translate="7 days" data-attribute-name="consentsDuration" data-unit.translate="days" data-dependencies="!onclick_opt"/>
             <we-select string="Show on" data-no-preview="true">
                 <we-button data-move-block="currentPage">This page</we-button>
                 <we-button data-move-block="allPages">All pages</we-button>

--- a/addons/website/views/snippets/s_social_media.xml
+++ b/addons/website/views/snippets/s_social_media.xml
@@ -38,8 +38,8 @@ title stay editable after a save (see SOCIAL_MEDIA_TITLE_CONTENTEDITABLE).
 <template id="s_social_media_options" inherit_id="website.snippet_options">
     <xpath expr="." position="inside">
         <div data-js="SocialMedia" data-selector=".s_social_media">
-            <t t-set="add_item_title">Add New Social Network</t>
-            <we-list string="Social Networks" t-att-data-add-item-title="add_item_title"
+            <we-list string="Social Networks"
+                data-add-item-title.translate="Add New Social Network"
                 data-render-list-items="" data-has-default="multiple" data-name="social_media_list"
                 data-default-value="https://www.example.com" data-id-mode="name"
                 data-new-elements-not-toggleable="true" data-no-preview="true"

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -208,17 +208,16 @@
             <we-input string="Placeholder" class="o_we_large"
                 data-select-attribute="" data-attribute-name="placeholder"
                 data-apply-to="input[type='text'], input[type='email'], input[type='number'], input[type='tel'], input[type='url'], textarea"/>
-            <t t-set="default_value_label">Default Value</t>
-            <we-input t-att-string="default_value_label" class="o_we_large" data-select-textarea-value="" data-apply-to="textarea"/>
-            <we-checkbox t-att-string="default_value_label" data-select-attribute="checked" data-attribute-name="checked"
+            <we-input string.translate="Default Value" class="o_we_large" data-select-textarea-value="" data-apply-to="textarea"/>
+            <we-checkbox string.translate="Default Value" data-select-attribute="checked" data-attribute-name="checked"
                       data-apply-to=".col-sm > * > input[type='checkbox']" data-no-preview="true"/>
-            <we-input t-att-string="default_value_label" class="o_we_large" data-select-attribute="" data-attribute-name="value" data-select-property=""
+            <we-input string.translate="Default Value" class="o_we_large" data-select-attribute="" data-attribute-name="value" data-select-property=""
                       data-property-name="value" data-apply-to="input[type='text']:not(.datetimepicker-input), input[type='email'], input[type='tel'], input[type='url']"/>
-            <we-input t-att-string="default_value_label" class="o_we_large" data-select-attribute="" data-attribute-name="value" data-select-property=""
+            <we-input string.translate="Default Value" class="o_we_large" data-select-attribute="" data-attribute-name="value" data-select-property=""
                       data-step="1" data-property-name="value" data-apply-to="input[type='number']"/>
-            <we-datetimepicker t-att-string="default_value_label" data-select-attribute="" data-attribute-name="value" data-select-value-property=""
+            <we-datetimepicker string.translate="Default Value" data-select-attribute="" data-attribute-name="value" data-select-value-property=""
                                data-apply-to=".s_website_form_datetime input"/>
-            <we-datepicker t-att-string="default_value_label" data-select-attribute="" data-attribute-name="value" data-select-value-property=""
+            <we-datepicker string.translate="Default Value" data-select-attribute="" data-attribute-name="value" data-select-value-property=""
                            data-apply-to=".s_website_form_date input"/>
             <we-checkbox string="Required" data-name="required_opt" data-no-preview="true"
                 data-toggle-required="s_website_form_required"/>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1719,24 +1719,15 @@
     <!-- Mega Menu settings -->
     <div data-js="MegaMenuLayout" data-selector=".o_mega_menu">
         <we-select string="Template" data-name="mega_menu_template_opt">
-            <t t-set="_label">Multi Menus</t>
-            <we-button t-att-data-select-label="_label" data-select-template="website.s_mega_menu_multi_menus" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_multi_menus.svg" t-out="_label"/>
-            <t t-set="_label">Image Menu</t>
-            <we-button t-att-data-select-label="_label" data-select-template="website.s_mega_menu_menu_image_menu" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_menu_image_menu.svg" t-out="_label"/>
-            <t t-set="_label">Odoo Menu</t>
-            <we-button t-att-data-select-label="_label" data-select-template="website.s_mega_menu_odoo_menu" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_odoo_menu.svg" t-out="_label"/>
-            <t t-set="_label">Little Icons</t>
-            <we-button t-att-data-select-label="_label" data-select-template="website.s_mega_menu_little_icons" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_little_icons.svg" t-out="_label"/>
-            <t t-set="_label">Big Icons Subtitles</t>
-            <we-button t-att-data-select-label="_label" data-select-template="website.s_mega_menu_big_icons_subtitles" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_big_icons_subtitles.svg" t-out="_label"/>
-            <t t-set="_label">Images Subtitles</t>
-            <we-button t-att-data-select-label="_label" data-select-template="website.s_mega_menu_images_subtitles" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_images_subtitles.svg" t-out="_label"/>
-            <t t-set="_label">Logos</t>
-            <we-button t-att-data-select-label="_label" data-select-template="website.s_mega_menu_menus_logos" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_menus_logos.svg" t-out="_label"/>
-            <t t-set="_label">Thumbnails</t>
-            <we-button t-att-data-select-label="_label" data-select-template="website.s_mega_menu_thumbnails" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_thumbnails.svg" t-out="_label"/>
-            <t t-set="_label">Cards</t>
-            <we-button t-att-data-select-label="_label" data-select-template="website.s_mega_menu_cards" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_cards.svg" t-out="_label"/>
+            <we-button data-select-label.translate="Multi Menus" data-select-template="website.s_mega_menu_multi_menus" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_multi_menus.svg">Multi Menus</we-button>
+            <we-button data-select-label.translate="Image Menu" data-select-template="website.s_mega_menu_menu_image_menu" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_menu_image_menu.svg">Image Menu</we-button>
+            <we-button data-select-label.translate="Odoo Menu" data-select-template="website.s_mega_menu_odoo_menu" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_odoo_menu.svg">Odoo Menu</we-button>
+            <we-button data-select-label.translate="Little Icons" data-select-template="website.s_mega_menu_little_icons" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_little_icons.svg">Little Icons</we-button>
+            <we-button data-select-label.translate="Big Icons Subtitles" data-select-template="website.s_mega_menu_big_icons_subtitles" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_big_icons_subtitles.svg">Big Icons Subtitles</we-button>
+            <we-button data-select-label.translate="Images Subtitles" data-select-template="website.s_mega_menu_images_subtitles" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_images_subtitles.svg">Images Subtitles</we-button>
+            <we-button data-select-label.translate="Logos" data-select-template="website.s_mega_menu_menus_logos" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_menus_logos.svg">Logos</we-button>
+            <we-button data-select-label.translate="Thumbnails" data-select-template="website.s_mega_menu_thumbnails" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_thumbnails.svg">Thumbnails</we-button>
+            <we-button data-select-label.translate="Cards" data-select-template="website.s_mega_menu_cards" data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_cards.svg">Cards</we-button>
         </we-select>
         <we-select string="Size">
             <we-button data-select-class="">Full-Width</we-button>

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -39,20 +39,17 @@ list of filtered posts (by date or tag).
             <t t-if="not tag and not date_begin and not search">
                 <div id="o_wblog_blog_top_droppable"/>
                 <t t-if="blog">
-                    <t t-set="oe_structure_blog_single_header_description">Edit the '<t t-esc="blog.name"/>' page header.</t>
-                    <div t-field="blog.content" t-att-data-editor-sub-message="oe_structure_blog_single_header_description"/>
+                    <div t-field="blog.content" t-attf-data-editor-sub-message.translate="Edit the '{{blog.name}}' page header."/>
                 </t>
                 <t t-elif="blogs">
-                    <t t-set="oe_structure_blog_all_header_description">Edit the 'All Blogs' page header.</t>
-                    <div class="oe_structure" t-att-data-editor-sub-message="oe_structure_blog_all_header_description"/>
+                    <div class="oe_structure" data-editor-sub-message.translate="Edit the 'All Blogs' page header."/>
                 </t>
             </t>
             <t t-else="">
                 <!-- Droppable-area for filtered results (tags or date) -->
-                <t t-set="oe_structure_blog_filtered_header_description">Edit the 'Filter Results' page header.</t>
                 <div class="oe_structure"
                     id="oe_structure_blog_filtered_header"
-                    t-att-data-editor-sub-message="oe_structure_blog_filtered_header_description"/>
+                    data-editor-sub-message.translate="Edit the 'Filter Results' page header."/>
             </t>
         </div>
 

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -6,12 +6,13 @@
     <t t-call="website.layout">
         <t t-set="additional_title">Resellers</t>
         <div id="wrap">
-            <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL RESELLERS</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_crm_partner_assign_layout_1" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_crm_partner_assign_layout_1"
+                data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL RESELLERS"/>
             <div class="container mb-3">
                 <t t-out="0" />
             </div>
-            <div class="oe_structure oe_empty" id="oe_structure_website_crm_partner_assign_layout_2" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_crm_partner_assign_layout_2"
+                data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL RESELLERS"/>
         </div>
     </t>
 </template>

--- a/addons/website_customer/views/website_customer_templates.xml
+++ b/addons/website_customer/views/website_customer_templates.xml
@@ -253,8 +253,8 @@
 <template id="details" name="Customer Detail">
   <t t-call="website.layout">
     <div id="wrap">
-        <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL CUSTOMERS</t>
-        <div class="oe_structure oe_empty" id="oe_structure_website_customer_details_1" t-att-data-editor-message="editor_message"/>
+        <div class="oe_structure oe_empty" id="oe_structure_website_customer_details_1"
+            data-editor-message="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL CUSTOMERS"/>
         <div class="container mb-3">
             <div class="row">
                 <div class="mt-4 mb-3" t-if="not edit_page">
@@ -267,7 +267,8 @@
                 </t>
             </div>
         </div>
-        <div class="oe_structure oe_empty" id="oe_structure_website_customer_details_2" t-att-data-editor-message="editor_message"/>
+        <div class="oe_structure oe_empty" id="oe_structure_website_customer_details_2"
+            data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL CUSTOMERS"/>
     </div>
   </t>
 </template>

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -9,8 +9,7 @@
         <div id="wrap" t-attf-class="o_wevent_event js_event d-flex flex-column h-100 #{'o_wevent_hide_sponsors' if hide_sponsors else ''}">
             <t t-if="not hide_submenu" t-call="website_event.navbar"/>
             <t t-out="0"/>
-            <t t-set="editor_sub_message">Following content will appear on all events.</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_1" t-att-data-editor-sub-message="editor_sub_message"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_1" data-editor-sub-message.translate="Following content will appear on all events."/>
         </div>
 
         <!-- The registration modal is available in any event page  -->

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -29,15 +29,14 @@
                 <t t-call="website_event_track.agenda_topbar"/>
             </div>
             <!-- Drag/Drop Area -->
-            <t t-set="editor_message">Available on all event Agenda pages</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_1" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_1" data-editor-message.translate="Available on all event Agenda pages"/>
 
             <!-- Content -->
             <div class="o_wevent_online o_weagenda_index mb-3">
                 <t t-call="website_event_track.agenda_main"/>
             </div>
             <!-- Drag/Drop Area -->
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_2" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_2" data-editor-message.translate="Available on all event Agenda pages"/>
         </t>
     </t>
 </template>

--- a/addons/website_event_track/views/event_track_templates_proposal.xml
+++ b/addons/website_event_track/views/event_track_templates_proposal.xml
@@ -4,8 +4,7 @@
 <template id="event_track_proposal">
     <t t-call="website_event.layout">
         <t t-set="hide_submenu" t-value="True"/>
-        <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PROPOSAL PAGES OF ALL EVENTS</t>
-        <div class="oe_structure" id="oe_structure_website_event_track_proposal_1" t-att-data-editor-message="editor_message"/>
+        <div class="oe_structure" id="oe_structure_website_event_track_proposal_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PROPOSAL PAGES OF ALL EVENTS"/>
         <div class="container">
             <t t-call="website_event.navbar"/>
 
@@ -120,7 +119,7 @@
                             </div>
                         </form>
                     </section>
-                    <div class="oe_structure" id="oe_structure_website_event_track_proposal_2" t-att-data-editor-message="editor_message"/>
+                    <div class="oe_structure" id="oe_structure_website_event_track_proposal_2" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PROPOSAL PAGES OF ALL EVENTS"/>
                 </div> <!-- Close main column -->
 
                 <!-- Sidebar: visible if proposals are allowed only -->
@@ -152,7 +151,7 @@
                 </aside>
             </div>
         </div>
-        <div class="oe_structure" id="oe_structure_website_event_track_proposal_3" t-att-data-editor-message="editor_message"/>
+        <div class="oe_structure" id="oe_structure_website_event_track_proposal_3" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PROPOSAL PAGES OF ALL EVENTS"/>
     </t>
 </template>
 

--- a/addons/website_membership/views/website_membership_templates.xml
+++ b/addons/website_membership/views/website_membership_templates.xml
@@ -125,14 +125,13 @@
 <template id="partner" name="Members">
     <t t-call="website.layout">
         <div id="wrap">
-            <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL MEMBERS</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_membership_partner_1" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_membership_partner_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL MEMBERS"/>
             <div class="container">
                 <div class="row">
                     <t t-call="website_partner.partner_detail"/>
                 </div>
             </div>
-            <div class="oe_structure oe_empty" id="oe_structure_website_membership_partner_2" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_membership_partner_2" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL MEMBERS"/>
         </div>
     </t>
 </template>

--- a/addons/website_partner/views/website_partner_templates.xml
+++ b/addons/website_partner/views/website_partner_templates.xml
@@ -3,14 +3,13 @@
 <template id="partner_page" name="Partner Page">
     <t t-call="website.layout">
         <div id="wrap">
-            <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PARTNERS</t>
-            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_1" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PARTNERS"/>
             <div class="container">
                 <div class="row">
                     <t t-call="website_partner.partner_detail"></t>
                 </div>
             </div>
-            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_2" t-att-data-editor-message="editor_message"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_2" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PARTNERS"/>
         </div>
     </t>
 </template>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1285,8 +1285,7 @@
         <t t-call="website.layout">
             <t t-set="additional_title" t-value="product.name" />
             <div id="wrap" class="js_sale o_wsale_product_page">
-                <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS</t>
-                <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_product_1" t-att-data-editor-message="editor_message"/>
+                <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_product_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS"/>
                 <section id="product_detail"
                          t-attf-class="oe_website_sale container my-3 my-lg-4 #{'discount'
                             if combination_info['has_discounted_price'] else ''}"
@@ -1502,7 +1501,7 @@
                     t-field="product.website_description"
                     class="oe_structure oe_empty mt16"
                 />
-                <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" t-att-data-editor-message="editor_message"/>
+                <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS"/>
             </div>
         </t>
     </template>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -293,8 +293,7 @@
             <a t-att-href="'/slides/%s/tag/%s' % (slug(slide.channel_id), slug(tag))" class="badge text-bg-info" t-esc="tag.name"/>
         </t>
     </div>
-    <t t-set="editor_message">BUILDING BLOCKS DROPPED HERE WILL BE SHOWN ACROSS ALL LESSONS</t>
-    <div class="oe_structure oe_empty" id="oe_structure_website_slides_lesson_top_1" t-att-data-editor-message="editor_message"/>
+    <div class="oe_structure oe_empty" id="oe_structure_website_slides_lesson_top_1" data-editor-message.translate="BUILDING BLOCKS DROPPED HERE WILL BE SHOWN ACROSS ALL LESSONS"/>
     <div t-if="slide.slide_category == 'infographic'" class="o_wslides_lesson_content_type" t-field='slide.image_1920' t-options="{'widget': 'image', 'style': 'width: 100%;'}"/>
     <div t-else="" class="o_wslides_lesson_content_type">
         <div t-if="slide.slide_category == 'document'" class="ratio ratio-4x3 embed-responsive-item mb8" style="height: 600px;">


### PR DESCRIPTION
- Simplified templates: you no longer need to declare a t-set tag to
translate phrases used as variables.
- Better performance, translated elements can be considered static (only
compile time) instead of running time
- Consistency between py and js: JavaScript XML templates use the same
semantics for attribute
translations.
- Security: Python expressions will no longer appear in translations.

The attributes ending by `.translate` (not starting by `.t-` are translated. The attribute is not a qweb directive and the element can be computed as a static node.

The directives `t-attf-*` and `t-valuef` can be marked as as translatable with `.translate`. Translations do not contain python expressions but only placeholders `{{0}}`, `{{1}}`... This avoids introducing errors made during the translations. If a new expression is added `{{unwanted code}}` or a non-existent placeholder, it will be replaced by `None`.
