### PR TITLE
[FIX] account: compute analytic lines partner

### DIFF
--- a/addons/account/models/account_analytic_line.py
+++ b/addons/account/models/account_analytic_line.py
@@ -55,7 +55,7 @@ class AccountAnalyticLine(models.Model):
             if line.move_line_id and line.general_account_id != line.move_line_id.account_id:
                 raise ValidationError(_('The journal item is not linked to the correct financial account'))
 
-    @api.depends('move_line_id')
+    @api.depends('move_line_id.partner_id')
     def _compute_partner_id(self):
         for line in self:
             line.partner_id = line.move_line_id.partner_id or line.partner_id

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -318,3 +318,53 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
         self.assertEqual(score, 2)
         score = applicability_with_company._get_score(business_domain='invoice', product=self.product_a.id)
         self.assertEqual(score, 1)
+
+    def test_analytic_lines_partner_compute(self):
+        ''' Ensures analytic lines partner is changed when changing partner on move line'''
+        def get_analytic_lines():
+            return self.env['account.analytic.line'].search([
+                ('move_line_id', 'in', entry.line_ids.ids)
+            ]).sorted('amount')
+
+        entry = self.env['account.move'].create([{
+            'move_type': 'entry',
+            'partner_id': self.partner_a.id,
+            'line_ids': [
+                Command.create({
+                    'account_id': self.company_data['default_account_receivable'].id,
+                    'debit': 200.0,
+                    'partner_id': self.partner_a.id,
+                }),
+                Command.create({
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'credit': 200.0,
+                    'partner_id': self.partner_b.id,
+                    'analytic_distribution': {
+                        self.analytic_account_a.id: 100,
+                    },
+                }),
+            ]
+        }])
+        entry.action_post()
+
+        # Analytic lines are created when posting the invoice
+        analytic_line = get_analytic_lines()
+        self.assertRecordValues(analytic_line, [{
+            'amount': 200,
+            self.default_plan._column_name(): self.analytic_account_a.id,
+            'partner_id': self.partner_b.id,
+        }])
+        # Change the move line on the analytic line, partner changes on the analytic line
+        analytic_line.move_line_id = entry.line_ids[0]
+        self.assertRecordValues(analytic_line, [{
+            'amount': 200,
+            self.default_plan._column_name(): self.analytic_account_a.id,
+            'partner_id': self.partner_a.id,
+        }])
+        # Change the move line's partner, partner changes on the analytic line
+        entry.line_ids.write({'partner_id': self.partner_b.id})
+        self.assertRecordValues(analytic_line, [{
+            'amount': 200,
+            self.default_plan._column_name(): self.analytic_account_a.id,
+            'partner_id': self.partner_b.id,
+        }])

--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -94,6 +94,10 @@ class AccountAnalyticLine(models.Model):
         for line in self:
             line.auto_account_id = bool(plan) and line[plan._column_name()]
 
+    def _compute_partner_id(self):
+        # TO OVERRIDE
+        pass
+
     def _inverse_auto_account(self):
         for line in self:
             line[line.auto_account_id.plan_id._column_name()] = line.auto_account_id

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -99,6 +99,7 @@ class AccountAnalyticLine(models.Model):
 
     @api.depends('task_id.partner_id', 'project_id.partner_id')
     def _compute_partner_id(self):
+        super()._compute_partner_id()
         for timesheet in self:
             if timesheet.project_id:
                 timesheet.partner_id = timesheet.task_id.partner_id or timesheet.project_id.partner_id


### PR DESCRIPTION
Analytic lines partner is not computed when changing the partner of the related move line.
To solve this, we add the `move_line_id.partner_id` in the `depends` of the compute.

To reproduce:

- Create a journal entry
- Set an analytic account on one of a line
- Confirm journal entry
- From the account move line list view, select the lines from the previous entry
- Change the partner
- Go to analytic reporting
-> The partner on the analytic line has not been changed


Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4626366)
opw-4626366
