### PR TITLE
[REF] mail, various: lessen subscribe, better followers

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -650,23 +650,11 @@ class EventEvent(models.Model):
             if parsed_url.scheme not in ('http', 'https'):
                 event.event_url = 'https://' + event.event_url
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        events = super(EventEvent, self).create(vals_list)
-        for res in events:
-            if res.organizer_id:
-                res.message_subscribe([res.organizer_id.id])
-        self.env.flush_all()
-        return events
-
     def write(self, vals):
         if 'stage_id' in vals and 'kanban_state' not in vals:
             # reset kanban state when changing stage
             vals['kanban_state'] = 'normal'
-        res = super(EventEvent, self).write(vals)
-        if vals.get('organizer_id'):
-            self.message_subscribe([vals['organizer_id']])
-        return res
+        return super().write(vals)
 
     @api.depends('event_registrations_sold_out', 'seats_limited', 'seats_max', 'seats_available')
     @api.depends_context('name_with_seats_availability')
@@ -708,6 +696,21 @@ class EventEvent(models.Model):
     def _set_tz_context(self):
         self.ensure_one()
         return self.with_context(tz=self.date_tz or 'UTC')
+
+    # ------------------------------------------------------------
+    # MAILING
+    # ------------------------------------------------------------
+
+    def _message_add_suggested_recipients(self, force_primary_email=False):
+        # override to suggested organizer instead of adding them as follower
+        suggested = super()._message_add_suggested_recipients(force_primary_email=force_primary_email)
+        for event in self.filtered('organizer_id'):
+            suggested[event.id]['partners'] |= event.organizer_id
+        return suggested
+
+    # ------------------------------------------------------------
+    # ACTIONS
+    # ------------------------------------------------------------
 
     def action_set_done(self):
         """

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -193,7 +193,7 @@ class EventEvent(models.Model):
     registration_ids = fields.One2many('event.registration', 'event_id', string='Attendees')
     event_ticket_ids = fields.One2many(
         'event.event.ticket', 'event_id', string='Event Ticket', copy=True,
-        compute='_compute_event_ticket_ids', readonly=False, store=True)
+        compute='_compute_event_ticket_ids', readonly=False, store=True, precompute=True)
     event_registrations_started = fields.Boolean(
         'Registrations started', compute='_compute_event_registrations_started',
         help="registrations have started if the current datetime is after the earliest starting date of tickets."

--- a/addons/event/tests/common.py
+++ b/addons/event/tests/common.py
@@ -10,7 +10,7 @@ class EventCase(common.TransactionCase):
 
     @classmethod
     def setUpClass(cls):
-        super(EventCase, cls).setUpClass()
+        super().setUpClass()
 
         cls.admin_user = cls.env.ref('base.user_admin')
         cls.admin_user.write({
@@ -92,6 +92,7 @@ class EventCase(common.TransactionCase):
             'country_id': cls.env.ref('base.be').id,
             'email': 'organizer@example.com',
             'name': 'Organizer',
+            'phone': '+32455123456',
             'street': 'Organizer Street',
         })
         cls.event_customer = cls.env['res.partner'].create({

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -609,7 +609,7 @@ class TestMailSchedule(EventMailCommon):
         # a new scheduler after)
         self.env.invalidate_all()
         # event 19
-        with self.assertQueryCount(36), self.mock_datetime_and_now(reference_now), \
+        with self.assertQueryCount(37), self.mock_datetime_and_now(reference_now), \
              self.mock_mail_gateway():
             _existing = self.env['event.registration'].create([
                 {

--- a/addons/event/tests/test_mailing.py
+++ b/addons/event/tests/test_mailing.py
@@ -6,7 +6,7 @@ from odoo.tests import Form, tagged, users
 from odoo.tools import formataddr
 
 
-@tagged("event_mail", "mail_template", "post_install", "-at_install")
+@tagged("event_mail", "mail_template", "mail_thread", "post_install", "-at_install")
 class TestMailing(EventCase, MockEmail):
 
     @classmethod
@@ -104,6 +104,45 @@ class TestMailing(EventCase, MockEmail):
                     fields_values=exp_mail_values,
                 )
                 self.assertEqual(len(self._new_mails), 4)
+
+    @users("user_eventmanager")
+    def test_event_mail_recipients(self):
+        """ Check default / suggested recipients """
+        default_organizer = self.user_eventmanager.company_id.partner_id
+        for event_values, exp_followers, exp_defaults, exp_suggested in [
+            (
+                {"organizer_id": self.event_organizer.id, "user_id": self.user_eventuser.id},
+                self.user_eventmanager.partner_id + self.event_organizer + self.user_eventuser.partner_id,
+                {"email_cc": "", "email_to": "", "partner_ids": []},
+                [],
+            ),
+            (
+                {"organizer_id": False, "user_id": self.user_eventuser.id},
+                self.user_eventmanager.partner_id + self.user_eventuser.partner_id,
+                {"email_cc": "", "email_to": "", "partner_ids": []},
+                [],
+            ),
+            (
+                {},
+                self.user_eventmanager.partner_id + default_organizer,
+                {"email_cc": "", "email_to": "", "partner_ids": []},
+                [],
+            ),
+        ]:
+            with self.subTest(event_values=event_values):
+                test_event = self.env['event.event'].create({
+                    'date_begin': self.event_date_begin,
+                    'date_end': self.event_date_end,
+                    'date_tz': 'Europe/Brussels',
+                    'event_mail_ids': False,
+                    'name': 'TestEvent',
+                    **event_values,
+                })
+                self.assertEqual(test_event.message_partner_ids, exp_followers)
+                defaults = test_event._message_get_default_recipients()[test_event.id]
+                self.assertDictEqual(defaults, exp_defaults)
+                suggested = test_event._message_get_suggested_recipients()
+                self.assertEqual(suggested, exp_suggested)
 
     @users("user_eventuser")
     def test_mail_template_creation(self):

--- a/addons/event/tests/test_mailing.py
+++ b/addons/event/tests/test_mailing.py
@@ -112,9 +112,9 @@ class TestMailing(EventCase, MockEmail):
         for event_values, exp_followers, exp_defaults, exp_suggested in [
             (
                 {"organizer_id": self.event_organizer.id, "user_id": self.user_eventuser.id},
-                self.user_eventmanager.partner_id + self.event_organizer + self.user_eventuser.partner_id,
+                self.user_eventmanager.partner_id + self.user_eventuser.partner_id,
                 {"email_cc": "", "email_to": "", "partner_ids": []},
-                [],
+                [{'email': self.event_organizer.email, 'name': self.event_organizer.name, 'partner_id': self.event_organizer.id, 'create_values': {}}],
             ),
             (
                 {"organizer_id": False, "user_id": self.user_eventuser.id},
@@ -124,9 +124,9 @@ class TestMailing(EventCase, MockEmail):
             ),
             (
                 {},
-                self.user_eventmanager.partner_id + default_organizer,
+                self.user_eventmanager.partner_id,
                 {"email_cc": "", "email_to": "", "partner_ids": []},
-                [],
+                [{'email': default_organizer.email, 'name': default_organizer.name, 'partner_id': default_organizer.id, 'create_values': {}}],
             ),
         ]:
             with self.subTest(event_values=event_values):

--- a/addons/event_booth/models/event_booth.py
+++ b/addons/event_booth/models/event_booth.py
@@ -67,25 +67,9 @@ class EventBooth(models.Model):
 
     def write(self, vals):
         to_confirm = self.filtered(lambda booth: booth.state == 'available')
-        wpartner = {}
-        if 'state' in vals or 'partner_id' in vals:
-            wpartner = dict(
-                (booth, booth.partner_id.ids)
-                for booth in self.filtered(lambda booth: booth.partner_id)
-            )
-
         res = super(EventBooth, self).write(vals)
-
-        if vals.get('state') == 'unavailable' or vals.get('partner_id'):
-            for booth in self:
-                booth.message_subscribe(booth.partner_id.ids)
-        for booth in self:
-            if wpartner.get(booth) and booth.partner_id.id not in wpartner[booth]:
-                booth.message_unsubscribe(wpartner[booth])
-
         if vals.get('state') == 'unavailable':
             to_confirm._action_post_confirm(vals)
-
         return res
 
     def _post_confirmation_message(self):

--- a/addons/event_booth/models/event_event.py
+++ b/addons/event_booth/models/event_event.py
@@ -11,7 +11,7 @@ class EventEvent(models.Model):
 
     event_booth_ids = fields.One2many(
         'event.booth', 'event_id', string='Booths', copy=True,
-        compute='_compute_event_booth_ids', readonly=False, store=True)
+        compute='_compute_event_booth_ids', readonly=False, store=True, precompute=True)
     event_booth_count = fields.Integer(
         string='Total Booths',
         compute='_compute_event_booth_count')

--- a/addons/event_booth/security/ir.model.access.csv
+++ b/addons/event_booth/security/ir.model.access.csv
@@ -3,7 +3,8 @@ access_event_booth_category,event.booth.category,model_event_booth_category,,0,0
 access_event_booth_category_desk,event.booth.category.desk,model_event_booth_category,event.group_event_registration_desk,1,0,0,0
 access_event_booth_category_manager,event.booth.category.manager,model_event_booth_category,event.group_event_manager,1,1,1,1
 access_event_booth_all,event.booth.public,model_event_booth,,0,0,0,0
-access_event_booth_user,event.booth.user,model_event_booth,event.group_event_registration_desk,1,0,0,0
+access_event_booth_desk,event.booth.user,model_event_booth,event.group_event_registration_desk,1,0,0,0
+access_event_booth_user,event.booth.user,model_event_booth,event.group_event_user,1,1,1,1
 access_event_booth_manager,event.booth.manager,model_event_booth,event.group_event_manager,1,1,1,1
 access_event_type_booth_user,event.type.booth.user,model_event_type_booth,event.group_event_registration_desk,1,0,0,0
 access_event_type_booth_manager,event.type.booth.manager,model_event_type_booth,event.group_event_manager,1,1,1,1

--- a/addons/event_booth/tests/test_event_internals.py
+++ b/addons/event_booth/tests/test_event_internals.py
@@ -67,7 +67,7 @@ class TestEventData(TestEventBoothCommon):
         event.event_booth_ids[1].write({'partner_id': self.event_customer.id})
         self.assertEqual(event.event_booth_count, 2)
         self.assertEqual(event.event_booth_count_available, 2)
-        self.assertEqual(event.event_booth_ids[1].message_partner_ids, self.event_customer)
+        self.assertEqual(event.event_booth_ids[1].message_partner_ids, self.env['res.partner'])
 
         # one booth is sold
         event.event_booth_ids[1].write({'state': 'unavailable'})

--- a/addons/event_booth_sale/tests/test_event_internals.py
+++ b/addons/event_booth_sale/tests/test_event_internals.py
@@ -63,7 +63,7 @@ class TestEventData(TestEventBoothSaleCommon):
         event.event_booth_ids[1].write({'partner_id': self.event_customer.id})
         self.assertEqual(event.event_booth_count, 2)
         self.assertEqual(event.event_booth_count_available, 2)
-        self.assertEqual(event.event_booth_ids[1].message_partner_ids, self.event_customer)
+        self.assertEqual(event.event_booth_ids[1].message_partner_ids, self.env['res.partner'])
 
         # one booth is sold
         event.event_booth_ids[1].write({'state': 'unavailable'})

--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -209,11 +209,6 @@ class GamificationChallenge(models.Model):
 
         write_res = super().write(vals)
 
-        if vals.get('report_message_frequency', 'never') != 'never':
-            # _recompute_challenge_users do not set users for challenges with no reports, subscribing them now
-            for challenge in self:
-                challenge.message_subscribe([user.partner_id.id for user in challenge.user_ids])
-
         if vals.get('state') == 'inprogress':
             self._recompute_challenge_users()
             self._generate_goals_from_challenge()

--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -99,35 +99,14 @@ class HrDepartment(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        # TDE note: auto-subscription of manager done by hand, because currently
-        # the tracking allows to track+subscribe fields linked to a res.user record
-        # An update of the limited behavior should come, but not currently done.
-        departments = super(HrDepartment, self.with_context(mail_create_nosubscribe=True)).create(vals_list)
-        for department, vals in zip(departments, vals_list):
-            manager = self.env['hr.employee'].browse(vals.get("manager_id"))
-            if manager.user_id:
-                department.message_subscribe(partner_ids=manager.user_id.partner_id.ids)
-        return departments
+        return super(HrDepartment, self.with_context(mail_create_nosubscribe=True)).create(vals_list)
 
     def write(self, vals):
         """ If updating manager of a department, we need to update all the employees
             of department hierarchy, and subscribe the new manager.
         """
-        # TDE note: auto-subscription of manager done by hand, because currently
-        # the tracking allows to track+subscribe fields linked to a res.user record
-        # An update of the limited behavior should come, but not currently done.
         if 'manager_id' in vals:
             manager_id = vals.get("manager_id")
-            if manager_id:
-                manager = self.env['hr.employee'].browse(manager_id)
-                # subscribe the manager user
-                if manager.user_id:
-                    self.message_subscribe(partner_ids=manager.user_id.partner_id.ids)
-            manager_to_unsubscribe = set()
-            for department in self:
-                if department.manager_id and department.manager_id.user_id:
-                    manager_to_unsubscribe.update(department.manager_id.user_id.partner_id.ids)
-            self.message_unsubscribe(partner_ids=list(manager_to_unsubscribe))
             # set the employees's parent to the new manager
             self._update_employee_manager(manager_id)
         return super().write(vals)

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -565,6 +565,7 @@ class HrEmployee(models.Model):
                             bank_account.partner_id = vals['work_contact_id']
             self.message_unsubscribe(self.work_contact_id.ids)
             if vals['work_contact_id']:
+                # TDE FIXME: should be suggested, to check in master
                 self._message_subscribe([vals['work_contact_id']])
         if vals.get('user_id'):
             # Update the profile pictures with user, except if provided

--- a/addons/hr_maintenance/models/equipment.py
+++ b/addons/hr_maintenance/models/equipment.py
@@ -45,6 +45,7 @@ class MaintenanceEquipment(models.Model):
     def create(self, vals_list):
         equipments = super().create(vals_list)
         for equipment in equipments:
+            # TDE FIXME: check if we can use suggested recipients for employee and department manager
             # subscribe employee or department manager when equipment assign to him.
             partner_ids = []
             if equipment.employee_id and equipment.employee_id.user_id:
@@ -99,6 +100,7 @@ class MaintenanceRequest(models.Model):
     def create(self, vals_list):
         requests = super().create(vals_list)
         for request in requests:
+            # TDE FIXME: check default recipients (master)
             if request.employee_id.user_id:
                 request.message_subscribe(partner_ids=[request.employee_id.user_id.partner_id.id])
         return requests
@@ -114,6 +116,7 @@ class MaintenanceRequest(models.Model):
     def message_new(self, msg, custom_values=None):
         if custom_values is None:
             custom_values = {}
+        # TDE FIXME: check author_id, should be set (master-)
         email = tools.email_normalize(msg.get('from'), strict=False)
         user = self.env['res.users'].search([('login', '=', email)], limit=1) if email else self.env['res.users']
         if user:

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -637,9 +637,6 @@ class HrApplicant(models.Model):
         applicants = super().create(vals_list)
         applicants.sudo().interviewer_ids._create_recruitment_interviewers()
 
-        department_manager_partner = applicants.department_id.manager_id._get_related_partners()
-        applicants.message_unsubscribe(partner_ids=department_manager_partner.ids)
-
         if (applicants.interviewer_ids.partner_id - self.env.user.partner_id):
             for applicant in applicants:
                 interviewers_to_notify = applicant.interviewer_ids.partner_id - self.env.user.partner_id
@@ -694,7 +691,6 @@ class HrApplicant(models.Model):
             interviewers_to_clean = old_interviewers - self.interviewer_ids
             interviewers_to_clean._remove_recruitment_interviewers()
             self.sudo().interviewer_ids._create_recruitment_interviewers()
-            self.message_unsubscribe(partner_ids=interviewers_to_clean.partner_id.ids)
 
             new_interviewers = self.interviewer_ids - old_interviewers - self.env.user
             if new_interviewers:

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -302,7 +302,7 @@ class MailThread(models.AbstractModel):
 
         threads = super(MailThread, self).create(vals_list)
         # subscribe uid unless asked not to
-        if not self._context.get('mail_create_nosubscribe') and threads and self.env.user.active:
+        if not self._context.get('mail_create_nosubscribe') and threads and self.env.user.active and not self.env.user.share:
             self.env['mail.followers']._insert_followers(
                 threads._name, threads.ids,
                 self.env.user.partner_id.ids, subtypes=None,
@@ -2304,8 +2304,9 @@ class MailThread(models.AbstractModel):
         # posted 'in behalf of'). Limit to active and internal partners, as external
         # customers should be proposed through suggested recipients.
         author_subscribe = (
-            not self._context.get('mail_post_autofollow_author_skip')
-            and msg_values['message_type'] not in ('notification', 'user_notification', 'auto_comment')
+            not self._context.get('mail_post_autofollow_author_skip') and
+            msg_values['message_type'] not in ('notification', 'user_notification', 'auto_comment') and
+            subtype_id == self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
         )
         if author_subscribe:
             real_author = self._message_compute_real_author(msg_values['author_id'])

--- a/addons/portal/wizard/portal_share.py
+++ b/addons/portal/wizard/portal_share.py
@@ -107,8 +107,4 @@ class PortalShare(models.TransientModel):
         # when partner not user send individual mail with signup token
         self._send_signup_link(self.partner_ids - partner_ids)
 
-        # subscribe all recipients so that they receive future communication (better than
-        # using autofollow as more precise)
-        self.resource_ref.message_subscribe(partner_ids=self.partner_ids.ids)
-
         return {'type': 'ir.actions.act_window_close'}

--- a/addons/product_email_template/models/account_move.py
+++ b/addons/product_email_template/models/account_move.py
@@ -12,9 +12,6 @@ class AccountMove(models.Model):
             self = self.with_user(SUPERUSER_ID)
         for invoice in self.filtered(lambda x: x.move_type == 'out_invoice'):
             # send template only on customer invoice
-            # subscribe the partner to the invoice
-            if invoice.partner_id not in invoice.message_partner_ids:
-                invoice.message_subscribe([invoice.partner_id.id])
             comment_subtype_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
             for line in invoice.invoice_line_ids:
                 if line.product_id.email_template_id:

--- a/addons/test_event_full/tests/test_event_event.py
+++ b/addons/test_event_full/tests/test_event_event.py
@@ -43,7 +43,7 @@ class TestEventEvent(TestEventFullCommon):
         self.assertEqual(len(event.event_ticket_ids), 2)
         self.assertTrue(event.introduction_menu)
         self.assertTrue(event.location_menu)
-        self.assertEqual(event.message_partner_ids, self.env.user.partner_id + self.env.user.company_id.partner_id)
+        self.assertEqual(event.message_partner_ids, self.env.user.partner_id)
         self.assertEqual(event.note, '<p>Template note</p>')
         self.assertTrue(event.register_menu)
         self.assertEqual(len(event.question_ids), 3)

--- a/addons/website_crm_partner_assign/wizard/crm_forward_to_partner.py
+++ b/addons/website_crm_partner_assign/wizard/crm_forward_to_partner.py
@@ -100,6 +100,7 @@ class CrmLeadForwardToPartner(models.TransientModel):
                 leads |= lead_data['lead_id']
             values = {'partner_assigned_id': partner_id, 'user_id': partner_leads['partner'].user_id.id}
             leads.with_context(mail_auto_subscribe_no_notify=1).write(values)
+            # TDE FIXME: check for assigned in suggested recipients (master-)
             self.env['crm.lead'].message_subscribe([partner_id])
         return True
 


### PR DESCRIPTION
Since odoo/odoo#185240 customers are given as default or suggested recipients
for communications. Both chatter and templates proposes them by default.
Followers should now be mostly be internal users that want to receive
news from a record while customers should be actively displayed and
chosen.

In this task we remove some of auto subscription done in code. This is done
on models where it has few impact. A master PR will be done for models more
tightly coupled with followers, like SO, invoices, timesheets, ...

See sub commits for more details.

Task-4655022