### PR TITLE
[FIX] l10n_in_*: fix fiscal multi company issue

### DIFF
--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -182,7 +182,7 @@ class Ewaybill(models.Model):
     def _compute_fiscal_position(self):
         for ewaybill in self.filtered(lambda ewb: ewb.state == 'pending'):
             ewaybill.fiscal_position_id = (
-                self.env['account.fiscal.position']._get_fiscal_position(
+                self.env['account.fiscal.position'].with_company(ewaybill.company_id)._get_fiscal_position(
                     ewaybill.picking_type_code == 'incoming'
                     and ewaybill.partner_bill_from_id
                     or ewaybill.partner_bill_to_id


### PR DESCRIPTION
\* applies to: `l10n_in`, `l10n_in_ewaybill_stock`

- Before this commit: The fiscal position computation did not consider the company context, leading to errors in a multi-company environment.

- After this commit: The issue is addressed using the `with_company()` method to ensure the correct company context is applied during fiscal position computation.

opw-4615629
