### PR TITLE
[FIX] mail: malformed CSS rule for mentions

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -97,7 +97,6 @@
 }
 
 a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention {
-    @include rfs($btn-font-size-sm, $btn-font-size-sm);
     border-radius: $btn-border-radius-sm;
     padding: 0rem 0.1875rem;
 }


### PR DESCRIPTION
This commit fixes a malformed CSS rule (introduced in commit [1]) trying to define the `font-size` of the mentions.

In a nutshell, the `rfs()` Bootstrap's mixin has two arguments:
- the first is the base size
- the second is the property to apply the calculated size to

In this case, it generated the following malformed rule: `0.8125rem: 0.8125rem;`.

As this rule isn't applied anyway and the visual result is OK, this commit simply removes it.

[1]: https://github.com/odoo/odoo/pull/170765