### PR TITLE
[IMP] point_of_sale: add product info button to controls

### DIFF
--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.js
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.js
@@ -10,15 +10,12 @@ export class ProductCard extends Component {
         comboExtraPrice: { String, optional: true },
         color: { type: [Number, undefined], optional: true },
         imageUrl: [String, Boolean],
-        productInfo: { Boolean, optional: true },
         onClick: { type: Function, optional: true },
-        onProductInfoClick: { type: Function, optional: true },
         showWarning: { type: Boolean, optional: true },
         productCartQty: { type: [Number, undefined], optional: true },
     };
     static defaultProps = {
         onClick: () => {},
-        onProductInfoClick: () => {},
         class: "",
         showWarning: false,
     };

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -8,9 +8,6 @@
             t-on-click="props.onClick"
             t-att-data-product-id="props.productId"
             t-attf-aria-labelledby="article_product_{{props.productId}}">
-            <div t-if="props.productInfo" class="product-information-tag position-absolute top-0 end-0 z-2 w-0 h-0 rounded-end-2 text-light text-center" t-on-click.stop="props.onProductInfoClick" t-att-class="{'red-tag' : props.showWarning, 'favorite-product': props.product.is_favorite}">
-                <i class="product-information-tag-logo fa fa-info" role="img" aria-label="Product Information" title="Product Information" />
-            </div>
             <div t-if="props.imageUrl" class="product-img ratio ratio-4x3 rounded-top rounded-3">
                 <img class="w-100 o_object_fit_cover bg-200" t-att-src="props.imageUrl" t-att-alt="props.name" />
             </div>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -7,6 +7,7 @@ import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { _t } from "@web/core/l10n/translation";
 import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { SelectPartnerButton } from "@point_of_sale/app/screens/product_screen/control_buttons/select_partner_button/select_partner_button";
+import { ProductInfoPopup } from "@point_of_sale/app/components/popups/product_info_popup/product_info_popup";
 
 export class ControlButtons extends Component {
     static template = "point_of_sale.ControlButtons";
@@ -128,6 +129,22 @@ export class ControlButtons extends Component {
         return this.props.showRemainingButtons
             ? "btn btn-secondary btn-lg py-5"
             : "btn btn-secondary btn-lg lh-lg";
+    }
+
+    displayProductInfoBtn() {
+        const selectedOrderLine = this.currentOrder?.getSelectedOrderline();
+        return (
+            selectedOrderLine &&
+            selectedOrderLine.product_id.product_tmpl_id &&
+            !this.pos
+                .getExcludedProductIds()
+                .includes(selectedOrderLine.product_id.product_tmpl_id.id)
+        );
+    }
+
+    async onProductInfoClick(productTemplate) {
+        const info = await this.pos.getProductInfo(productTemplate, 1);
+        this.dialog.add(ProductInfoPopup, { info: info, productTemplate: productTemplate });
     }
 }
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -44,6 +44,9 @@
                     <t t-if="currentOrder?.fiscal_position_id" t-esc="currentOrder.fiscal_position_id.display_name" />
                     <t t-else="">Tax</t>
                 </button>
+                <button t-if="this.displayProductInfoBtn()" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.onProductInfoClick(currentOrder.getSelectedOrderline().product_id.product_tmpl_id)">
+                    <i class="fa fa-info-circle me-1" role="img" aria-label="Product Info" title="Product Info" /> Info
+                </button>
                 <button t-if="this.pos.cashier._role != 'minimal'" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())">
                     <i class="fa fa-trash me-1" role="img" /> Cancel Order 
                 </button>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -16,7 +16,6 @@ import {
 import { ActionpadWidget } from "@point_of_sale/app/screens/product_screen/action_pad/action_pad";
 import { Orderline } from "@point_of_sale/app/components/orderline/orderline";
 import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
-import { ProductInfoPopup } from "@point_of_sale/app/components/popups/product_info_popup/product_info_popup";
 import { ProductCard } from "@point_of_sale/app/components/product_card/product_card";
 import {
     ControlButtons,
@@ -371,11 +370,6 @@ export class ProductScreen extends Component {
                 productTemplate: product,
             });
         }
-    }
-
-    async onProductInfoClick(productTemplate) {
-        const info = await this.pos.getProductInfo(productTemplate, 1);
-        this.dialog.add(ProductInfoPopup, { info: info, productTemplate: productTemplate });
     }
 }
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -35,9 +35,7 @@
                             color="product.pos_categ_ids?.at(-1)?.color"
                             imageUrl="pos.config.show_product_images and this.getProductImage(product)"
                             onClick.bind="() => this.addProductToOrder(product)"
-                            productInfo="true"
-                            productCartQty="this.state.quantityByProductTmplId[product.id]"
-                            onProductInfoClick.bind="() => this.onProductInfoClick(product)" />
+                            productCartQty="this.state.quantityByProductTmplId[product.id]" />
                     </div>
                     <div t-else="" class="flex-grow-1 text-center mt-5">
                         <p t-if="searchWord">No products found for <b>"<t t-esc="searchWord"/>"</b> in this category.</p>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2181,6 +2181,15 @@ export class PosStore extends WithLazyGetterTrap {
         return this.config.proxy_ip;
     }
 
+    getExcludedProductIds() {
+        return [
+            this.config.tip_product_id?.product_tmpl_id?.id,
+            ...this.session._pos_special_products_ids.map(
+                (id) => this.models["product.product"].get(id)?.product_tmpl_id?.id
+            ),
+        ].filter(Boolean);
+    }
+
     get productsToDisplay() {
         const searchWord = this.searchProductWord.trim();
         const allProducts = this.models["product.template"].getAll();
@@ -2208,12 +2217,7 @@ export class PosStore extends WithLazyGetterTrap {
             return [];
         }
 
-        const excludedProductIds = [
-            this.config.tip_product_id?.product_tmpl_id?.id,
-            ...this.session._pos_special_products_ids.map(
-                (id) => this.models["product.product"].get(id)?.product_tmpl_id?.id
-            ),
-        ].filter(Boolean);
+        const excludedProductIds = this.getExcludedProductIds();
 
         list = list
             .filter((product) => !excludedProductIds.includes(product.id) && product.canBeDisplayed)

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -107,13 +107,7 @@ export function clickDisplayedProduct(
     return step;
 }
 export function clickInfoProduct(name) {
-    return [
-        {
-            content: `click product '${name}'`,
-            trigger: `article.product:contains("${name}") .product-information-tag`,
-            run: "click",
-        },
-    ];
+    return [...clickDisplayedProduct(name), ...inLeftSide(clickControlButton("Info"))];
 }
 export function clickOrderline(productName, quantity = "1") {
     return [

--- a/addons/pos_event/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_event/static/src/app/components/product_card/product_card.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_event.ProductCard" t-inherit="point_of_sale.ProductCard" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('product-information-tag')]" position="attributes">
-            <attribute name="t-if" add="!this.props.product.event_id" separator=" and " />
-        </xpath>
-        <xpath expr="//div[hasclass('product-information-tag')]" position="after">
+        <xpath expr="//div[hasclass('product-img')]" position="before">
             <t t-set="availableSeats" t-value="this.totalTicketSeats" />
             <div t-if="displayRemainingSeats" class="shadow-sm m-1 py-1 px-2 rounded position-absolute top-0 end-0 bg-white">
                 <span t-if="availableSeats > 0">


### PR DESCRIPTION
- Remove 'Product Info' button from product card (user tend to miss click the info button when clicking on product card).
- Add product info button to control buttons (for non excluded products).

task-id: 4636700




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
