### PR TITLE
[FIX] l10n_it_edi: fix ImportoTotaleDocumento

### DIFF
--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -34,15 +34,10 @@ class AccountMove(models.Model):
 
     def _get_l10n_it_amount_split_payment(self):
         self.ensure_one()
-        amount = 0.0
-        if self.is_sale_document(False):
-            for line in self.line_ids:
-                if line.tax_line_id and line.tax_line_id._l10n_it_is_split_payment():
-                    if self.move_type  == 'out_invoice':
-                        amount += line.credit
-                    else:
-                        amount += line.debit
-        return amount
+        if not self.is_sale_document(False):
+            return 0.0
+        sign = -1 if self.move_type == "out_invoice" else 1
+        return sum(sign * line.balance for line in self.line_ids.filtered(lambda l: l.tax_line_id and l.tax_line_id._l10n_it_is_split_payment()))
 
     @api.depends('edi_document_ids', 'edi_document_ids.attachment_id')
     def _compute_l10n_it_einvoice(self):


### PR DESCRIPTION
When multiple split payments taxes are involved in  (e.g., 22% SP), and some lines are negative, the split payment is not calculated correctly. It sums only the credits, but when the lines are negative, the credit is 0.

Steps to reproduce:
- Install Italy - E-invoicing
- Duplicate the "22% SP" tax group and its subtaxes (22% SP neg. and 22% SP pos.)
- Create an invoice:
  - 1 product at 100€ with "22% SP"
  - 1 product at -50€ with "22% SP (copy)"
- Validate the invoice
- Process through E-invoicing service

In the resulting XML, the value of ImportoTotaleDocumento should be 61€ (100-50+22-11), but it will be 72€.

This fix ensures all tax values are considered in the split payment calculation.

Task [link](https://www.odoo.com/odoo/project/967/tasks/4630987)
opw-4630987