### PR TITLE
[FIX] portal_rating: correct message reaction placement on websites

### DIFF
--- a/addons/portal_rating/static/src/chatter/frontend/message_patch.xml
+++ b/addons/portal_rating/static/src/chatter/frontend/message_patch.xml
@@ -8,7 +8,7 @@
                 </t>
             </div>
         </xpath>
-        <xpath expr="//div[hasclass('o-mail-Message-contentContainer')]" position="after">
+        <xpath expr="//*[@t-ref='messageContent']" position="inside">
             <!--Only possible if a rating is link to the message, for now we can't comment if no rating
                 is link to the message (because publisher comment data
                 is on the rating.rating model - one comment max) -->


### PR DESCRIPTION
Before this commit, message reactions appeared at the bottom of the publisher's comment instead of the original linked message. This commit ensures they are correctly positioned under the original message.

Before
![image](https://github.com/user-attachments/assets/e32626c7-ce4b-47c2-b541-fa074c2253fa)
After
![image](https://github.com/user-attachments/assets/d85c0506-2772-4424-9dd8-38e926c9121d)


task-4619148
