### PR TITLE
[IMP] l10n_id_efaktur_coretax: luxury tax group error handling

### DIFF
--- a/addons/l10n_id_efaktur_coretax/__init__.py
+++ b/addons/l10n_id_efaktur_coretax/__init__.py
@@ -2,3 +2,19 @@
 
 from . import models
 from . import controllers
+
+from odoo import api, SUPERUSER_ID
+
+def _post_init_hook(cr, registry):
+    # When installed, should create the luxury tax group with specific XML ID
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    if not env.ref("l10n_id.l10n_id_tax_group_luxury_goods", raise_if_not_found=False):
+        env['ir.model.data'].create({
+            "name": "l10n_id_tax_group_luxury_goods",
+            "module": "l10n_id",
+            "model": "account.tax.group",
+            "res_id": env['account.tax.group'].create({'name': 'Luxury Good Taxes (ID)'}).id,
+            'noupdate': True
+        })

--- a/addons/l10n_id_efaktur_coretax/__manifest__.py
+++ b/addons/l10n_id_efaktur_coretax/__manifest__.py
@@ -34,5 +34,6 @@
     ],
     'installable': True,
     'auto_install': True,
+    'post_init_hook': '_post_init_hook',
     'license': 'LGPL-3',
 }

--- a/addons/l10n_id_efaktur_coretax/models/account_move_line.py
+++ b/addons/l10n_id_efaktur_coretax/models/account_move_line.py
@@ -17,7 +17,8 @@ class AccountMoveLine(models.Model):
         product = self.product_id
 
         # Separate tax into the regular and luxury component
-        luxury_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id == self.env.ref('l10n_id.l10n_id_tax_group_luxury_goods'))
+        luxury_tax_group = self.env.ref('l10n_id.l10n_id_tax_group_luxury_goods', raise_if_not_found=False)
+        luxury_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id == luxury_tax_group)
         regular_tax = self.tax_ids - luxury_tax
 
         line_val = {


### PR DESCRIPTION
For existing customers, when coretax is installed, the new luxury tax group and its tax will not be loaded into Odoo. During XML generation, it will look for the tax group by XML ID which will not be found and hence resulting to traceback error. To mitigate this issue, we will introduce a post_init_hook to manually create the tax group and not raise exception when env.ref() doesn't find the tax group

opw-4635356



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
