### PR TITLE
[FIX] im_livechat: proper tests for CORS bundle

### DIFF
--- a/addons/im_livechat/tests/test_im_livechat_support_page.py
+++ b/addons/im_livechat/tests/test_im_livechat_support_page.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from unittest.mock import patch
+
 import odoo
+from odoo.addons.im_livechat.controllers.main import LivechatController
 from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 
 @odoo.tests.tagged("-at_install", "post_install")
@@ -12,3 +15,11 @@ class TestImLivechatSupportPage(TestGetOperatorCommon):
             {"name": "Support Channel", "user_ids": [operator.id]}
         )
         self.start_tour(f"/im_livechat/support/{livechat_channel.id}", "im_livechat.basic_tour")
+
+    def test_load_modules_cors(self):
+        operator = self._create_operator()
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {"name": "Support Channel", "user_ids": [operator.id]}
+        )
+        with patch.object(LivechatController, "_is_cors_request", return_value=True):
+            self.start_tour(f"/im_livechat/support/{livechat_channel.id}", "im_livechat.basic_tour")


### PR DESCRIPTION
Maintaing several bundles can be error prone. Live chat tests exist for external and backend bundles but not for the CORS one. This is an issue as adding a new dependency can break the CORS live chat without any way to notice it (e.g. adding a dependency in mail that is loaded in the website_livechat context but not in the standalone one).

This PR adds a simple sanity check tour to the support page, forcing the CORS bundle. While it's not a fully realistic CORS scenario it will be enough to catch simple dependenc mistakes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
