### PR TITLE
[FIX] point_of_sale: allow pos user to validate a pos order

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -5,7 +5,8 @@ from odoo import fields, models, api
 
 
 class AccountMove(models.Model):
-    _inherit = 'account.move'
+    _name = 'account.move'
+    _inherit = ['account.move', 'pos.load.mixin']
 
     pos_order_ids = fields.One2many('pos.order', 'account_move')
     pos_payment_ids = fields.One2many('pos.payment', 'account_move_id')
@@ -87,6 +88,11 @@ class AccountMove(models.Model):
         else:
             action['domain'] = [('id', 'in', self.pos_order_ids.ids)]
         return action
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        result = super()._load_pos_data_fields(config_id)
+        return result or ['id']
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'


### PR DESCRIPTION
### Steps to reproduce:

- install l10n_ec_edi_pos
- Create a new POS in the EC Company.
- With a use without inventory adminstrator access rights:
- Open a pos session, select any product and a custome linked to the EC localisation.
- Try to validate the POS order that is invoiced using the cash payment method.
> An access error is raised with respect to the `stock_valuation_layer_ids` fields of the account.move model

### Cause of the issue:

Clicking on validate will launch a call of the `syncAllOrders` method. During this call, missing records will be fetched recursisvely here: https://github.com/odoo/odoo/blob/2108ad3f7c851eeceb84d7459485a18e1574fa64/addons/point_of_sale/static/src/app/store/pos_store.js#L1271 (Note that this call does not exist prior to 18.0). However, as the data contains a pos order that is related to account moves and since the `account.move` model of the localisation inherit from the `pos.load.mixin`:
https://github.com/odoo/enterprise/blob/efa1853cf1f9bbd945a91971ffe40c6906482063/l10n_ec_edi_pos/models/account_move.py#L6-L8 the account move will be fetched as a related record to the pos order and we will launch a `read` for the `fields=[]`:
https://github.com/odoo/odoo/blob/2108ad3f7c851eeceb84d7459485a18e1574fa64/addons/point_of_sale/static/src/app/models/data_service.js#L513-L515 https://github.com/odoo/odoo/blob/2108ad3f7c851eeceb84d7459485a18e1574fa64/addons/point_of_sale/models/pos_load_mixin.py#L9-L11 However, a read performed with a false value in the `fields` tries to read the value of each field on the records:
https://github.com/odoo/odoo/blob/2108ad3f7c851eeceb84d7459485a18e1574fa64/odoo/models.py#L3792-L3798 This includes protected fields such as the `stock_valuation_layer_ids` that can only be read by user's with administrator stock access rights.

opw-4498024
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
