### PR TITLE
[FIX] html_editor: enable Translate/AI buttons when applicable

### DIFF
--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
@@ -7,7 +7,7 @@ import { ChatGPTTranslateDialog } from "./chatgpt_translate_dialog";
 import { LanguageSelector } from "./language_selector";
 import { withSequence } from "@html_editor/utils/resource";
 import { user } from "@web/core/user";
-
+import { isContentEditable } from "@html_editor/utils/dom_info";
 
 export class ChatGPTPlugin extends Plugin {
     static id = "chatgpt";
@@ -41,12 +41,12 @@ export class ChatGPTPlugin extends Plugin {
                 isAvailable: (selection) => {
                     return !selection.isCollapsed && user.userId;
                 },
-                isDisabled: this.isReplaceableByAI.bind(this),
+                isDisabled: this.isNotReplaceableByAI.bind(this),
                 Component: LanguageSelector,
                 props: {
                     onSelected: (language) => this.openDialog({ language }),
                     isDisabled: (selection) => {
-                        return this.isReplaceableByAI(selection);
+                        return this.isNotReplaceableByAI(selection);
                     },
                 },
             },
@@ -55,7 +55,7 @@ export class ChatGPTPlugin extends Plugin {
                 groupId: "ai",
                 commandId: "openChatGPTDialog",
                 text: "AI",
-                isDisabled: this.isReplaceableByAI.bind(this),
+                isDisabled: this.isNotReplaceableByAI.bind(this),
             },
         ],
 
@@ -68,12 +68,12 @@ export class ChatGPTPlugin extends Plugin {
         },
     };
 
-    isReplaceableByAI(selection = this.dependencies.selection.getEditableSelection()) {
+    isNotReplaceableByAI(selection = this.dependencies.selection.getEditableSelection()) {
         const isEmpty = !selection.textContent().replace(/\s+/g, "");
-        const crossBlocks = [...selection.commonAncestorContainer.childNodes].find(
-            (el) => this.dependencies.split.isUnsplittable(el) && el.isContentEditable
+        const cannotReplace = [...selection.commonAncestorContainer.childNodes].find(
+            (el) => this.dependencies.split.isUnsplittable(el) || !isContentEditable(el)
         );
-        return crossBlocks || isEmpty;
+        return cannotReplace || isEmpty;
     }
 
     openDialog(params = {}) {

--- a/addons/html_editor/static/tests/chatgpt.test.js
+++ b/addons/html_editor/static/tests/chatgpt.test.js
@@ -1,11 +1,11 @@
 import { expect, test } from "@odoo/hoot";
-import { press, queryAll, waitFor } from "@odoo/hoot-dom";
+import { press, queryAll, tick, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { loadLanguages } from "@web/core/l10n/translation";
 import { ChatGPTPlugin } from "../src/main/chatgpt/chatgpt_plugin";
 import { setupEditor } from "./_helpers/editor";
-import { getContent } from "./_helpers/selection";
+import { getContent, setContent } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
 
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
@@ -116,6 +116,28 @@ test("ChatGPT dialog opens in translate mode when clicked on translate dropdown 
     const alternativesDialogHeaderSelector = `.o_dialog .modal-header:contains("${ALTERNATIVES_DIALOG_TITLE}")`;
     expect(alternativesDialogHeaderSelector).toHaveCount(0);
     loadLanguages.installedLanguages = false;
+});
+
+test("Translate/ChatGPT should be disabled if selection spans across non editable content or unsplittable", async () => {
+    const { el } = await setupEditor("<div>[ab]</div>");
+    await animationFrame();
+    await tick();
+    expect(".o-we-toolbar [name='translate']").not.toHaveAttribute("disabled");
+
+    setContent(el, "<div>a[b</div><div>c]d</div>");
+    await animationFrame();
+    await tick();
+    expect(".o-we-toolbar [name='translate']").not.toHaveAttribute("disabled");
+
+    setContent(el, '<div contenteditable="false">a[b</div><div>c]d</div>');
+    await animationFrame();
+    await tick();
+    expect(".o-we-toolbar [name='translate']").toHaveAttribute("disabled");
+
+    setContent(el, '<div class="oe_unbreakable">a[b</div><div>c]d</div>');
+    await animationFrame();
+    await tick();
+    expect(".o-we-toolbar [name='translate']").toHaveAttribute("disabled");
 });
 
 test("ChatGPT alternatives dialog generates alternatives for each button", async () => {


### PR DESCRIPTION
**Problem**:
The Translate/AI buttons should only be disabled when selecting non-editable content or an unsplittable node. Currently, they are disabled incorrectly when selecting multiple paragraphs.

**Solution**:
Disable Translate/AI buttons only when a non-editable content or an unsplittable node is selected.

**Steps to Reproduce**:
1. Add two paragraphs.
2. Select all the text.
3. **Issue**: The Translate button is disabled but should be enabled.

**opw-4629920**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
