### PR TITLE
[FIX] stock_picking_batch: Keep schedule date on picking copy

### DIFF
--- a/addons/stock_picking_batch/models/stock_move_line.py
+++ b/addons/stock_picking_batch/models/stock_move_line.py
@@ -73,6 +73,7 @@ class StockMoveLine(models.Model):
                 'move_ids': [],
                 'move_line_ids': [],
                 'batch_id': wave.id,
+                'scheduled_date': picking.scheduled_date,
             })[0]
             for move, move_lines in line_by_move.items():
                 picking_to_wave_vals['move_line_ids'] += [Command.link(line.id) for line in lines]

--- a/addons/stock_picking_batch/tests/test_wave_picking.py
+++ b/addons/stock_picking_batch/tests/test_wave_picking.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
@@ -238,6 +238,7 @@ class TestBatchPicking(TransactionCase):
         move = lines.move_id
         self.assertEqual(len(move), 1)
         all_db_pickings = self.env['stock.picking'].search([])
+        all_db_pickings.write({'scheduled_date': '2025-01-01 00:00:00'})
         res_dict = lines.action_open_add_to_wave()
         res_dict['context'] = {'active_model': 'stock.move.line', 'active_ids': lines.ids}
         self.assertEqual(res_dict.get('res_model'), 'stock.add.to.wave')
@@ -258,6 +259,8 @@ class TestBatchPicking(TransactionCase):
         self.assertTrue(lines.batch_id == wave)
         new_all_db_picking = self.env['stock.picking'].search([])
         self.assertEqual(len(all_db_pickings) + 1, len(new_all_db_picking))
+        new_picking = new_all_db_picking - all_db_pickings
+        self.assertEqual(new_picking.scheduled_date, fields.Datetime.to_datetime('2025-01-01 00:00:00'))
 
     def test_wave_split_move(self):
         lines = self.picking_internal.move_ids.filtered(lambda m: m.product_id == self.productB).move_line_ids[0:2]


### PR DESCRIPTION
- Activate wave transfers and group by product or any other, easy to see it by product.
- Create a sales order with two different products in the sales order lines
- Changed the delivery date in the other info tab.
- When confirming the sales order, two transfers will be created, each will have one product.

Current behavior:
- One picking will respect the scheduled date and the other one will have it for today.

Expected:
- Both picking have the sale order schedule date.

It happens because the picking copy miss some data

opw-4571808

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
