### PR TITLE
[FIX] stock: fix delivery slip for moves containing packages

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -274,7 +274,7 @@ class ProductPricelistItem(models.Model):
             )
 
     def _get_integer(self, percentage):
-        return int(percentage) if percentage.is_integer() else percentage
+        return int(percentage) if percentage == int(percentage) else percentage
 
     def _get_displayed_discount(self, item):
         if item.base == 'standard_price':

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -62,7 +62,7 @@
                         </div>
                     </div>
                     <div class="oe_structure"></div>
-                    <t t-set="format_number" t-value="lambda x: int(x) if x.is_integer() else x"/>
+                    <t t-set="format_number" t-value="lambda x: int(x) if x == int(x) else x"/>
                     <table class="table table-sm" t-if="o.state!='done'" name="stock_move_table" style="table-layout: fixed; width: 100%">
                         <thead>
                             <tr>

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -91,7 +91,7 @@
                             </tr>
                         </tbody>
                     </table>
-                    <table class="table table-sm mt48" t-elif="o.move_line_ids and o.state=='done'" name="stock_move_line_table" style="table-layout: fixed; width: 100%">
+                    <table class="table table-sm mt48" t-elif="o.move_line_ids and o.state=='done'" name="stock_move_line_table">
                         <t t-set="has_serial_number" t-value="False"/>
                         <t t-set="has_serial_number" t-value="o.move_line_ids.mapped('lot_id')" groups="stock.group_lot_on_delivery_slip"/>
                         <thead>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -88,7 +88,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <t t-set="format_number" t-value="lambda x: int(x) if x.is_integer() else '{:.2f}'.format(x)"/>
+                            <t t-set="format_number" t-value="lambda x: int(x) if x == int(x) else '{:.2f}'.format(x)"/>
                             <!-- In this step, we loop over every move of the picking and do the following
                                 1. We add the barcode column if any of the products has a barcode or if we have a tracked move
                                 2. We add From/To columns according to the type of the picking


### PR DESCRIPTION
Delivery slips for moves containing packages are broken because the columns collapse into one-letter width. Here we unfix the width of the table containing the lot/serial number and delivered status columns to allow it to accommodate changes.

A sneaky additional commit replaces all instances of `is_integer()` in stock and product with `x == int(x)` for Python 3.10 compatibility.

OPW: [4633670](https://www.odoo.com/odoo/project/49/tasks/4633670)