### PR TITLE
[IMP] web: reduce empty stars opacity of priority field

### DIFF
--- a/addons/web/static/src/views/fields/priority/priority_field.scss
+++ b/addons/web/static/src/views/fields/priority/priority_field.scss
@@ -19,10 +19,14 @@
 
             &.fa-star-o {
                 color: $o-main-color-muted;
+                opacity: 0.1;
             }
             &.fa-star {
                 color: $o-main-favorite-color;
             }
+        }
+        &:hover .fa-star-o {
+            opacity: 1;
         }
     }
 }


### PR DESCRIPTION
This commit changes the priority field's empty stars opacity to be much tamer when the field is not hovered.

task-4610799
