### PR TITLE
[FIX] stock: fix searching on total_route_ids

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -1048,7 +1048,8 @@ class ProductCategory(models.Model):
     filter_for_stock_putaway_rule = fields.Boolean('stock.putaway.rule', store=False, search='_search_filter_for_stock_putaway_rule')
 
     def _search_total_route_ids(self, operator, value):
-        categ_ids = self.filtered_domain([('total_route_ids', operator, value)]).ids
+        categories = self.env['product.category'].sudo().search([])
+        categ_ids = categories.filtered_domain([('total_route_ids', operator, value)]).ids
         return [('id', 'in', categ_ids)]
 
     def _compute_total_route_ids(self):


### PR DESCRIPTION
Currently the search on total_route_ids always returns `[('id', 'in', [])]` as filtered_domain on
an empty recordset returns False.

This PR fixes that by first searching on the categories before filtering using the domain

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
