### PR TITLE
[FIX] pos: allow creation of physical gift cards without expiration

### DIFF
--- a/addons/pos_loyalty/static/src/utils/manage_giftcard_popup/manage_giftcard_popup.js
+++ b/addons/pos_loyalty/static/src/utils/manage_giftcard_popup/manage_giftcard_popup.js
@@ -50,7 +50,7 @@ export class ManageGiftCardPopup extends Component {
         this.props.getPayload(
             this.state.inputValue,
             parseFloat(this.state.amountValue),
-            serializeDate(this.state.expirationDate)
+            this.state.expirationDate ? serializeDate(this.state.expirationDate) : false
         );
         this.props.close();
     }

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -144,3 +144,14 @@ registry.category("web_tour.tours").add("GiftCardProgramInvoice", {
             ReceiptScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_gift_card_no_date", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Gift Card"),
+            PosLoyalty.createManualGiftCard("test", "42", ""),
+            PosLoyalty.finalizeOrder("Cash", "42"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -140,8 +140,8 @@ export function checkAddedLoyaltyPoints(points) {
     ];
 }
 
-export function createManualGiftCard(code, amount) {
-    return [
+export function createManualGiftCard(code, amount, date = false) {
+    const steps = [
         {
             trigger: `a:contains("Sell physical gift card?")`,
             run: "click",
@@ -156,11 +156,19 @@ export function createManualGiftCard(code, amount) {
             trigger: `input[id="amount"]`,
             run: `edit ${amount}`,
         },
-        {
-            trigger: `.btn-primary:contains("Add Balance")`,
-            run: "click",
-        },
     ];
+    if (date !== false) {
+        steps.push({
+            content: `Input date '${date}'`,
+            trigger: `.modal input.o_datetime_input.cursor-pointer.form-control.form-control-lg`,
+            run: `edit ${date}`,
+        });
+    }
+    steps.push({
+        trigger: `.btn-primary:contains("Add Balance")`,
+        run: "click",
+    });
+    return steps;
 }
 
 export function clickPhysicalGiftCard(code = "Sell physical gift card?") {

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2609,3 +2609,16 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_loyalty_on_order_with_fixed_tax', login="pos_user")
+
+    def test_gift_card_no_date(self):
+        """
+        This test create a physical gift card without expiracy date.
+        """
+        LoyaltyProgram = self.env['loyalty.program']
+        # Deactivate all other programs to avoid interference and activate the gift_card_product_50
+        LoyaltyProgram.search([]).write({'pos_ok': False})
+        self.env.ref('loyalty.gift_card_product_50').write({'active': True})
+
+        # Create gift card program
+        self.create_programs([('name', 'gift_card')])
+        self.start_pos_tour("test_gift_card_no_date")


### PR DESCRIPTION
Creating a physical gift card in the PoS without an expiration date led to an Odoo error.

Steps to reproduce:
-------------------
* Open a PoS
* Add a gift card
* Click on Sell physical gift card?
* Input a unique code and a value
* Remove the default expiration date
* Click on Add Balance
> Observation:
TypeError: value.toFormat is not a function
    at serializeDate

Why the fix:
------------
the addBalance() method was trying to format the expiration date with serializeDate(this.state.expirationDate) without verrifing that it exists.

opw-4623141

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
