### PR TITLE
[FIX] hr_recruitment: define phone number field for hr.candidate

### DIFF
--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -105,6 +105,9 @@ class HrCandidate(models.Model):
             candidate.email_from = candidate.partner_id.email
             if not candidate.partner_phone:
                 candidate.partner_phone = candidate.partner_id.phone
+    
+    def _phone_get_number_fields(self):
+        return ['partner_phone']
 
     def _inverse_partner_email(self):
         for candidate in self:


### PR DESCRIPTION
The default [`_phone_get_number_fields`](https://github.com/odoo/odoo/blob/e8bbb6e9d99bdf6a31290e0d41cc9abff376938a/addons/phone_validation/models/models.py#L16-L21) returns `mobile` and `phone` fields if they exist on the model, but they do not exist for `hr.candidate`, leading to [errors](https://github.com/odoo/odoo/blob/ddbc09607f23b0e9dd9e721bceeaee250e6339bd/addons/phone_validation/models/mail_thread_phone.py#L217) when asserting phone fields in the `mail.thread.phone` mixin. The only field that holds a phone number for this model is `partner_phone`.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
