### PR TITLE
[FIX] mrp: Check 'no_variant' attributes for bom operation/byproducts

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -538,6 +538,39 @@ class MrpBom(models.Model):
         attachements = self.env['product.document'].search(final_domain).ir_attachment_id
         return attachements
 
+    @api.model
+    def _skip_for_no_variant(self, product, bom_attribule_values, never_attribute_values=False):
+        """ Controls if a Component/Operation/Byproduct line should be skipped based on the 'no_variant' attributes
+            Cases:
+                - no_variant:
+                    1. attribute present on the line
+                        => need to be at least one attribute value matching between the one passed as args and the ones one the line
+                    2. attribute not present on the line
+                        => valid if the line has no attribute value selected for that attribute
+                - always and dynamic: match_all_variant_values()
+        """
+        no_variant_bom_attributes = bom_attribule_values.filtered(lambda av: av.attribute_id.create_variant == 'no_variant')
+
+        # Attributes create_variant 'always' and 'dynamic'
+        other_attribute_valid = product._match_all_variant_values(bom_attribule_values - no_variant_bom_attributes)
+
+        # If there are no never attribute values on the line => 'always' and 'dynamic'
+        if not no_variant_bom_attributes:
+            return not other_attribute_valid
+
+        # Or if there are never attribute on the line values but no value is passed => impossible to match
+        if not never_attribute_values:
+            return True
+
+        bom_values_by_attribute = no_variant_bom_attributes.grouped('attribute_id')
+        never_values_by_attribute = never_attribute_values.grouped('attribute_id')
+
+        for attribute, values in bom_values_by_attribute.items():
+            if any(val.id in never_values_by_attribute[attribute].ids for val in values):
+                continue
+            return True
+        return not other_attribute_valid
+
 
 class MrpBomLine(models.Model):
     _name = 'mrp.bom.line'
@@ -660,29 +693,7 @@ class MrpBomLine(models.Model):
         if not product or product._name == 'product.template':
             return False
 
-        # attributes create_variant 'always' and 'dynamic'
-        other_attribute_valid = product._match_all_variant_values(self.bom_product_template_attribute_value_ids.filtered(lambda a: a.attribute_id.create_variant != 'no_variant'))
-
-        # if there are no never attribute values on the bom line => always and dynamic
-
-        if not self.bom_product_template_attribute_value_ids.filtered(lambda a: a.attribute_id.create_variant == 'no_variant'):
-            return not other_attribute_valid
-
-        # or if there are never attribute on the line values but no value is passed => impossible to match
-        if not never_attribute_values:
-            return True
-
-        bom_values_by_attribute = self.bom_product_template_attribute_value_ids.filtered(
-                lambda a: a.attribute_id.create_variant == 'no_variant'
-            ).grouped('attribute_id')
-
-        never_values_by_attribute = never_attribute_values.grouped('attribute_id')
-
-        for a_id, a_values in bom_values_by_attribute.items():
-            if any(a.id in never_values_by_attribute[a_id].ids for a in a_values):
-                continue
-            return True
-        return not other_attribute_valid
+        return self.env['mrp.bom']._skip_for_no_variant(product, self.bom_product_template_attribute_value_ids, never_attribute_values)
 
     def action_see_attachments(self):
         domain = [
@@ -790,7 +801,9 @@ class MrpByProduct(models.Model):
         self.ensure_one()
         if not product or product._name == 'product.template':
             return False
-        return not product._match_all_variant_values(self.bom_product_template_attribute_value_ids)
+
+        never_attribute_values = self.env.context.get('never_attribute_ids')
+        return self.env['mrp.bom']._skip_for_no_variant(product, self.bom_product_template_attribute_value_ids, never_attribute_values)
 
     # -------------------------------------------------------------------------
     # CATALOG

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -562,7 +562,7 @@ class MrpProduction(models.Model):
             elif any(production.move_raw_ids.mapped('picked')):
                 production.state = 'progress'
 
-    @api.depends('bom_id', 'product_id', 'product_qty', 'product_uom_id')
+    @api.depends('bom_id', 'product_id', 'product_qty', 'product_uom_id', 'never_product_template_attribute_value_ids')
     def _compute_workorder_ids(self):
         for production in self:
             if production.state != 'draft':
@@ -590,7 +590,11 @@ class MrpProduction(models.Model):
                     if not (bom.operation_ids and (not bom_data['parent_line'] or bom_data['parent_line'].bom_id.operation_ids != bom.operation_ids)):
                         continue
                     for operation in bom.operation_ids:
-                        if operation._skip_operation_line(bom_data['product']):
+                        if operation.with_context(never_attribute_ids=production.never_product_template_attribute_value_ids)._skip_operation_line(bom_data['product']):
+                            workorder = production.workorder_ids.filtered(lambda wo: wo.operation_id == operation and wo.operation_id.bom_id == bom)
+                            if workorder:
+                                # If for some reason a non-relevant workorder is still there, e.g. after a change in never_product_template_attribute_value_ids
+                                workorders_list += [Command.delete(workorder.id)]
                             continue
                         workorders_values += [{
                             'name': operation.name,
@@ -762,7 +766,7 @@ class MrpProduction(models.Model):
             else:
                 production.move_raw_ids = [Command.delete(move.id) for move in production.move_raw_ids.filtered(lambda m: m.bom_line_id)]
 
-    @api.depends('product_id', 'bom_id', 'product_qty', 'product_uom_id', 'location_dest_id', 'date_finished', 'move_dest_ids')
+    @api.depends('product_id', 'bom_id', 'product_qty', 'product_uom_id', 'location_dest_id', 'date_finished', 'move_dest_ids', 'never_product_template_attribute_value_ids')
     def _compute_move_finished_ids(self):
         for production in self:
             if production.state != 'draft':
@@ -780,7 +784,7 @@ class MrpProduction(models.Model):
             production.move_finished_ids = [Command.delete(m) for m in production.move_finished_ids.ids]
             production.move_finished_ids = [Command.clear()]
             if production.product_id:
-                production._create_update_move_finished()
+                production.with_context(never_attribute_ids=production.never_product_template_attribute_value_ids)._create_update_move_finished()
             else:
                 production.move_finished_ids = [
                     Command.delete(move.id) for move in production.move_finished_ids if move.bom_line_id

--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -174,7 +174,9 @@ class MrpRoutingWorkcenter(models.Model):
             return True
         if not product or product._name == 'product.template':
             return False
-        return not product._match_all_variant_values(self.bom_product_template_attribute_value_ids)
+
+        never_attribute_values = self.env.context.get('never_attribute_ids')
+        return self.env['mrp.bom']._skip_for_no_variant(product, self.bom_product_template_attribute_value_ids, never_attribute_values)
 
     def _get_duration_expected(self, product, quantity, unit=False, workcenter=False):
         product = product or self.bom_id.product_tmpl_id

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2351,17 +2351,18 @@ class TestBoM(TestMrpCommon):
         self.assertEqual((notification['type'], notification['tag']), ('ir.actions.client', 'display_notification'))
 
     def test_bom_never_attribute(self):
-        # We create 4 bom lines, one without any attribute values, two with one value and one with two values
-        # Create a MO with, modify its never_product_template_attribute_value_ids and check if the moves created are correct
+        # We create 4 bom lines, 4 operations and 4 byproducts, each with:
+        # one without any attribute values, two with one value and one with two values
+        # Create a MO with, modify its never_product_template_attribute_value_ids and check if the moves/workorders created are correct
 
         product_attribute_radio = self.env['product.attribute'].create({
             'name': 'PA',
             'display_type': 'radio',
             'create_variant': 'no_variant',
         })
-        product = self.env['product.product'].create({
-            'name': 'test1',
-        })
+        product, bp1, bp2, bp3, bp4 = self.env['product.product'].create([{
+            'name': name,
+        } for name in ['test1', 'bp1', 'bp2', 'bp3', 'bp4']])
         self.env['product.attribute.value'].create([{
             'name': 'radio_PAV' + str(i),
             'attribute_id': product_attribute_radio.id
@@ -2398,7 +2399,49 @@ class TestBoM(TestMrpCommon):
                     'product_qty': 10,
                     'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[1].id), Command.link(tmpl_attr_line_radio.product_template_value_ids[2].id)]
                 }),
-            ]
+            ],
+            'operation_ids': [
+                Command.create({
+                    'name': 'OPE_ALL',
+                    'workcenter_id': self.workcenter_1.id,
+                }),
+                Command.create({
+                    'name': 'OPE_VAR_1',
+                    'workcenter_id': self.workcenter_1.id,
+                    'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[0].id)],
+                }),
+                Command.create({
+                    'name': 'OPE_VAR_2',
+                    'workcenter_id': self.workcenter_1.id,
+                    'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[1].id)],
+                }),
+                Command.create({
+                    'name': 'OPE_VAR_2_3',
+                    'workcenter_id': self.workcenter_1.id,
+                    'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[1].id), Command.link(tmpl_attr_line_radio.product_template_value_ids[2].id)],
+                }),
+            ],
+            'byproduct_ids': [
+                Command.create({
+                    'product_id': bp1.id,
+                    'product_qty': 1.0,
+                }),
+                Command.create({
+                    'product_id': bp2.id,
+                    'product_qty': 1.0,
+                    'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[0].id)],
+                }),
+                Command.create({
+                    'product_id': bp3.id,
+                    'product_qty': 1.0,
+                    'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[1].id)],
+                }),
+                Command.create({
+                    'product_id': bp4.id,
+                    'product_qty': 1.0,
+                    'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[1].id), Command.link(tmpl_attr_line_radio.product_template_value_ids[2].id)],
+                }),
+            ],
         })
 
         mo_form = Form(self.env['mrp.production'])
@@ -2408,16 +2451,28 @@ class TestBoM(TestMrpCommon):
         # no never values, so only the first bom line should be used
         self.assertEqual(len(mo_order.move_raw_ids), 1, "Only one move with no never_product_template_attribute_value_ids should be created")
         self.assertEqual(mo_order.move_raw_ids.product_id, self.product_2)
+        self.assertEqual(len(mo_order.workorder_ids), 1)
+        self.assertEqual(mo_order.workorder_ids.name, 'OPE_ALL')
+        self.assertEqual(len(mo_order.move_byproduct_ids), 1)
+        self.assertEqual(mo_order.move_byproduct_ids.product_id, bp1)
 
         # one never values, the two first bom line should match
         mo_order.never_product_template_attribute_value_ids = tmpl_attr_line_radio.product_template_value_ids[0]
         self.assertEqual(len(mo_order.move_raw_ids), 2)
         self.assertEqual(mo_order.move_raw_ids.product_id, self.product_2 + self.product_3)
+        self.assertEqual(len(mo_order.workorder_ids), 2)
+        self.assertListEqual(mo_order.workorder_ids.mapped('name'), ['OPE_ALL', 'OPE_VAR_1'])
+        self.assertEqual(len(mo_order.move_byproduct_ids), 2)
+        self.assertEqual(mo_order.move_byproduct_ids.product_id, bp1 + bp2)
 
         # two never values, the first and fourth bom line should match
         mo_order.never_product_template_attribute_value_ids = tmpl_attr_line_radio.product_template_value_ids[1] + tmpl_attr_line_radio.product_template_value_ids[2]
         self.assertEqual(len(mo_order.move_raw_ids), 3)
         self.assertEqual(mo_order.move_raw_ids.product_id, self.product_2 + product + self.product_8)
+        self.assertEqual(len(mo_order.workorder_ids), 3)
+        self.assertListEqual(mo_order.workorder_ids.mapped('name'), ['OPE_ALL', 'OPE_VAR_2', 'OPE_VAR_2_3'])
+        self.assertEqual(len(mo_order.move_byproduct_ids), 3)
+        self.assertEqual(mo_order.move_byproduct_ids.product_id, bp1 + bp3 + bp4)
 
     def test_workorders_on_bom_changes(self):
         """


### PR DESCRIPTION
Steps to reproduce:
- Create a Product with an attribute that 'Never' create variants, with two attributes
- Create a Bom for that product that has:
  - 2 components, one restricted to the first variant
  - 2 operations, one restricted to the first variant
  - 2 byproducts, one restricted to the first variant
- Set that product to MTO/Manufacture
- Create a sale order for that product, and pick the first variant
- Confirm the sale order and check the linked MO.

Issue:
Both the operation and byproduct set for that specific variant won't be in the Manufacturing Order, despite the variant-specific component being properly added.

Since the requirements to skip the bom/operation/byproduct line is the same, regardless of the model, extract it and use it in the three `_skip` methods so we handle it in each case.

opw-4636956

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
