### PR TITLE
[FIX] *: fix multiple tours

### DIFF
--- a/addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js
+++ b/addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js
@@ -55,6 +55,9 @@ registry.category("web_tour.tours").add("test_brazilian_address", {
         },
         tourUtils.goToCheckout(),
         {
+            trigger: "form[data-company-country-code=BR]:has(#o_city_id:hidden)",
+        },
+        {
             content: 'Input a zip first',
             trigger: 'input[name="zip"]',
             run: 'fill 83490-000',

--- a/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
+++ b/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
@@ -13,6 +13,8 @@ registry.category("web_tour.tours").add("PosRestaurantRewardStay", {
             ProductScreen.clickDisplayedProduct("Water"),
             ProductScreen.totalAmountIs("1.98"),
             Chrome.clickPlanButton(),
+            Chrome.clickBtn("second floor"),
+            Chrome.clickBtn("main floor"),
             FloorScreen.clickTable("5"),
             ProductScreen.totalAmountIs("1.98"),
         ].flat(),

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -357,15 +357,11 @@ registry.category('web_tour.tours').add('test_inventory_adjustment_apply_all', {
         trigger: "body:not(:has(.modal))",
     },
     {
-        trigger: '.o_searchview_input_container',
-        run: () => {
-            const applyButtons = document.querySelectorAll('button[name=action_apply_inventory]');
-            if (applyButtons.length > 0){
-                console.error('Not all quants were applied!');
-            }
-        },
+        content: "Check that all quants were applied.",
+        trigger: "body:not(:has(button[name=action_apply_inventory]))",
     },
-]});
+    ],
+});
 
 registry.category("web_tour.tours").add('test_add_new_line', {
     steps: () => [

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -55,7 +55,10 @@ export class TourAutomatic {
                 {
                     initialDelay: () => (this.previousStepIsJustACheck ? 0 : null),
                     trigger: step.trigger ? () => step.findTrigger() : null,
-                    timeout: step.timeout || this.timeout || 10000,
+                    timeout:
+                        step.pause && this.debugMode
+                            ? 9999999
+                            : step.timeout || this.timeout || 10000,
                     action: async (trigger) => {
                         if (delayToCheckUndeterminisms > 0) {
                             await step.checkForUndeterminisms(trigger, delayToCheckUndeterminisms);

--- a/addons/web_tour/static/src/tour_service/tour_helpers.js
+++ b/addons/web_tour/static/src/tour_service/tour_helpers.js
@@ -1,4 +1,5 @@
 import * as hoot from "@odoo/hoot-dom";
+import { waitForStable } from "@web/core/macro";
 
 export class TourHelpers {
     /**
@@ -197,8 +198,8 @@ export class TourHelpers {
      * @example
      *  run : "press Enter",
      */
-    press(...args) {
-        return hoot.press(args.flatMap((arg) => typeof arg === "string" && arg.split("+")));
+    async press(...args) {
+        await hoot.press(args.flatMap((arg) => typeof arg === "string" && arg.split("+")));
     }
 
     /**
@@ -265,9 +266,9 @@ export class TourHelpers {
      * @example
      *  run: "uncheck input[type=checkbox]", // Unchecks the selector
      */
-    uncheck(selector) {
+    async uncheck(selector) {
         const element = this._get_action_element(selector);
-        hoot.uncheck(element);
+        await hoot.uncheck(element);
     }
 
     /**
@@ -277,10 +278,12 @@ export class TourHelpers {
      * @example
      *  run: "goToUrl /shop", // Go to /shop
      */
-    goToUrl(url) {
+    async goToUrl(url) {
         const linkEl = document.createElement("a");
         linkEl.href = url;
-        linkEl.click();
+        //We want DOM is stable before quit it.
+        await waitForStable();
+        await hoot.click(linkEl);
     }
 
     /**

--- a/addons/website/static/tests/tours/client_action_redirect.js
+++ b/addons/website/static/tests/tours/client_action_redirect.js
@@ -7,9 +7,7 @@ const testUrl = '/test_client_action_redirect';
 const goToFrontendSteps = [{
     content: "Go to the frontend",
     trigger: 'body',
-    run: () => {
-        window.location.href = testUrl;
-    },
+    run: `goToUrl ${testUrl}`,
 }, {
     content: "Check we are in the frontend",
     trigger: 'body:not(:has(.o_website_preview)) #test_contact_FE',
@@ -17,12 +15,10 @@ const goToFrontendSteps = [{
 const goToBackendSteps = [{
     content: "Go to the backend",
     trigger: 'body',
-    run: () => {
-        window.location.href = `/@${testUrl}`;
-    },
+    run: `goToUrl /@${testUrl}`,
 }, {
     content: "Check we are in the backend",
-    trigger: '.o_website_preview',
+    trigger: ".o_website_preview[data-view-xmlid='website.test_client_action_redirect'] :iframe",
 }];
 const checkEditorSteps = [{
     content: "Check that the editor is loaded",
@@ -30,8 +26,9 @@ const checkEditorSteps = [{
     timeout: 30000,
 }, {
     content: "exit edit mode",
-    trigger: '.o_we_website_top_actions button.btn-primary:contains("Save")',
+    trigger: "button[data-action=save]:enabled:contains(save)",
     run: "click",
+    timeout: 30000,
 }, {
     content: "wait for editor to close",
     trigger: ':iframe body:not(.editor_enable)',

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -8,7 +8,12 @@ const demoCssModif = '// demo_edition';
 
 registerWebsitePreviewTour('html_editor_language', {
     url: '/test_page',
-}, () => [{
+}, () => [
+    {
+        content: "Wait the content is loaded and html/css editor is in menu before clicking on open site menu",
+        trigger: ":iframe main:contains(rommelpot)",
+    },
+    {
     content: "open site menu",
     trigger: 'button[data-menu-xmlid="website.menu_site"]',
     run: "click",

--- a/addons/website/tests/test_client_action.py
+++ b/addons/website/tests/test_client_action.py
@@ -20,7 +20,7 @@ class TestClientAction(odoo.tests.HttpCase):
             'url': '/test_client_action_redirect',
             'is_published': True,
         })
-        self.start_tour(page.url, 'client_action_redirect', login='admin')
+        self.start_tour(page.url, 'client_action_redirect', login='admin', timeout=180)
 
     def test_02_client_action_iframe_fallback(self):
         self.start_tour('/@/', 'client_action_iframe_fallback', login='admin')

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -423,7 +423,7 @@ class TestUi(odoo.tests.HttpCase):
     def test_10_website_conditional_visibility(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_1', login='admin')
         self.start_tour('/odoo', 'conditional_visibility_2', login='admin')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_3', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_3', login='admin', step_delay=500, timeout=180)
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_4', login='admin')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_5', login='admin')
 


### PR DESCRIPTION
- addons/l10n_br_website_sale/static/tests/tours/brazilian_address.js We need to wait the form is loaded before to modify address to prevent js failures.
- addons/stock/static/tests/tours/stock_picking_tour.js We prefer to use more precise trigger instead of run with console.error(). As it's the last step, it's more efficient.
- addons/website/static/tests/tours/client_action_redirect.js When we exit edit mode in website, we must wait the dom is stable to continue.
- addons/website/tests/test_ui.py Add a step_delay to ensure tour works each time (undeterminisms)
- addons/web_tour/static/src/tour_service/tour_helpers.js Harmonize usage of async / await. Wait the dom is stable before to click on a link.
- addons/web_tour/static/src/tour_service/tour_automatic.js Set a large timeout when step is paused.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
