### PR TITLE
[IMP] account: validate mandatory analytic plans when batch posting

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 from functools import lru_cache
 
 from odoo import api, fields, models, Command, _
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import ValidationError, UserError, RedirectWarning
 from odoo.tools import frozendict, formatLang, format_date, float_compare, Query
 from odoo.tools.sql import create_index
 from odoo.addons.web.controllers.utils import clean_action
@@ -2574,15 +2574,37 @@ class AccountMoveLine(models.Model):
     # -------------------------------------------------------------------------
 
     def _validate_analytic_distribution(self):
+        lines_with_missing_analytic_distribution = self.env['account.move.line']
         for line in self.filtered(lambda line: line.display_type == 'product'):
-            line._validate_distribution(**{
-                        'product': line.product_id.id,
-                        'account': line.account_id.id,
-                        'business_domain': line.move_id.move_type in ['out_invoice', 'out_refund', 'out_receipt'] and 'invoice'
-                                           or line.move_id.move_type in ['in_invoice', 'in_refund', 'in_receipt'] and 'bill'
-                                           or 'general',
-                        'company_id': line.company_id.id,
-            })
+            try:
+                line._validate_distribution(
+                    company_id=line.company_id.id,
+                    product=line.product_id.id,
+                    account=line.account_id.id,
+                    business_domain=(
+                        'invoice' if line.move_id.is_sale_document(True)
+                        else 'bill' if line.move_id.is_purchase_document(True)
+                        else 'general'
+                    ),
+                )
+            except ValidationError:
+                lines_with_missing_analytic_distribution += line
+        if lines_with_missing_analytic_distribution:
+            msg = _("One or more lines require a 100% analytic distribution.")
+            if len(self.move_id) == 1:
+                raise ValidationError(msg)
+            raise RedirectWarning(
+                message=msg,
+                action={
+                    'view_mode': 'list',
+                    'name': _('Items With Missing Analytic Distribution'),
+                    'res_model': 'account.move.line',
+                    'type': 'ir.actions.act_window',
+                    'domain': [('id', 'in', lines_with_missing_analytic_distribution.ids)],
+                    'views': [(self.env.ref('account.view_move_line_tree').id, 'list')],
+                },
+                button_text=_("See items"),
+            )
 
     def _create_analytic_lines(self):
         """ Create analytic items upon validation of an account.move.line having an analytic distribution.

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -211,6 +211,32 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
         invoice.action_post()
         self.assertEqual(invoice.state, 'posted')
 
+    def test_mandatory_plan_validation_mass_posting(self):
+        """
+        In case of mass posting, we should still check for mandatory analytic plans. This may raise a RedirectWarning,
+        if more than one entry was selected for posting, or a ValidationError if only one entry was selected.
+        """
+        invoice1 = self.create_invoice(self.partner_a, self.product_a)
+        invoice2 = self.create_invoice(self.partner_b, self.product_a)
+        self.default_plan.write({
+            'applicability_ids': [Command.create({
+                'business_domain': 'invoice',
+                'product_categ_id': self.product_a.categ_id.id,
+                'applicability': 'mandatory',
+            })]
+        })
+
+        vam = self.env['validate.account.move'].create({'force_post': True})
+        for invoices in [invoice1, invoice1 | invoice2]:
+            with self.subTest(invoices=invoices):
+                with self.assertRaises(Exception):
+                    vam.with_context({
+                        'active_model': 'account.move',
+                        'active_ids': [invoice1.id, invoice2.id],
+                        'validate_analytic': True,
+                    }).validate_move()
+                self.assertTrue('posted' not in invoices.mapped('state'))
+
     def test_set_anaylytic_distribution_posted_line(self):
         """
         Test that we can set the analytic distribution on the product line of a move, when the line has tax with

--- a/addons/account/wizard/account_validate_move_view.xml
+++ b/addons/account/wizard/account_validate_move_view.xml
@@ -13,7 +13,13 @@
                     </group>
                     <span class="o_form_label">All selected journal entries will be validated and posted. You won't be able to modify them afterwards.</span>
                     <footer>
-                        <button string="Post Journal Entries" name="validate_move" type="object" default_focus="1" class="btn-primary" data-hotkey="q"/>
+                        <button string="Post Journal Entries"
+                                name="validate_move"
+                                type="object"
+                                default_focus="1"
+                                class="btn-primary"
+                                data-hotkey="q"
+                                context="{'validate_analytic': True}"/>
                         <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
                     </footer>
                 </form>


### PR DESCRIPTION
When we have an Analytic Plan being Mandatory, confirming an invoice from the form view, if it has a line without an Analytic distribution, correctly raises a ValidationError.
Confirming invoices from the list view does not raise the same error, yet it should.

To replicate:
1. [Activate](https://www.odoo.com/documentation/18.0/applications/finance/accounting/reporting/analytic_accounting.html) Analytic accounting:
   a. Install `accountant`
   b. In Settings, activate Analytic Accounting
   c. Create an Analytic plan (with an Analytic account associated)
2. Set its default applicability to mandatory
3. Create two invoices, remove the analytic distribution from one of the lines in one invoice.
4. In the invoices list view, select both newly created invoices, click on Actions > Confirm Entries
5. Click Confirm
6. The invoices were posted, even though they have no analytic distributions.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4603919)
opw-4603919