### PR TITLE
[FIX] l10n_pe_website_sale: Preserve city and district selections on …

### DIFF
--- a/addons/l10n_pe_website_sale/static/src/js/website_sale.js
+++ b/addons/l10n_pe_website_sale/static/src/js/website_sale.js
@@ -23,6 +23,7 @@ WebsiteSale.include({
         }).then((data) => {
             if (this.isPeruvianCompany) {
                 if (data[place]?.length) {
+                    let previousValue = selectElement.value;
                     selectElement.innerHTML = "";
                     data[place].forEach((item) => {
                         let opt = document.createElement("option");
@@ -31,6 +32,9 @@ WebsiteSale.include({
                         opt.setAttribute("data-code", item[2]);
                         selectElement.appendChild(opt);
                     });
+                if ([...selectElement.options].some(opt => opt.value === previousValue)) {
+                    selectElement.value = previousValue;
+                }
                     selectElement.parentElement.style.display = "block";
                 } else {
                     selectElement.value = "";

--- a/addons/l10n_pe_website_sale/static/tests/tours/website_sale_address.js
+++ b/addons/l10n_pe_website_sale/static/tests/tours/website_sale_address.js
@@ -38,3 +38,76 @@ registry.category("web_tour.tours").add('update_the_address_for_peru_company', {
         ...tourUtils.payWithTransfer(),
     ],
 });
+
+registry.category("web_tour.tours").add('maintain_city_district_on_reload', {
+    test: true,
+    url: '/shop',
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "Test Product" }),
+        tourUtils.goToCart({ quantity: 1 }),
+        {
+            content: "Go to checkout",
+            trigger: "a:contains('Checkout')",
+            run: "click",
+        },
+        {
+            content: "Enter an initial value for the State",
+            trigger: 'select[name="state_id"]',
+            run: "text Lima",
+        },
+        {
+            trigger: 'select[name="city_id"]',
+            run() {},
+        },
+        {
+            content: "Enter an initial value for the city",
+            trigger: 'select[name="city_id"]',
+            run: "text Lima",
+        },
+        {
+            trigger: 'select[name="l10n_pe_district"]',
+            run() {},
+        },
+        {
+            content: "Select an initial value for the district",
+            trigger: 'select[name="l10n_pe_district"]',
+            run: "text Lima",
+        },
+        {
+            content: "Enter an invalid VAT value to trigger a potential reload",
+            trigger: 'input[name="vat"]',
+            run: 'text XAXX010101000',
+        },
+        {
+            content: "Save address",
+            trigger: 'a:contains("Save address")',
+            run: "click",
+        },
+        {
+            content: "Wait for the page to reload",
+            trigger: '.text-danger',
+        },
+        {
+            content: "Check if the city field still has the previously entered value",
+            trigger: 'select[name="city_id"]' ,
+            run: () => {
+                const selectElement = document.querySelector('select[name="city_id"]');
+                const selectedOption = selectElement.options[selectElement.selectedIndex]
+	            if (selectedOption.dataset.code != "1501") {
+                    throw new Error("City has a different value");
+                }
+            },
+        },
+        {
+            content: "Check if the district field still has the previously selected value",
+            trigger: 'select[name="l10n_pe_district"]',
+            run: () => {
+                const selectElement = document.querySelector('select[name="l10n_pe_district"]');
+                const selectedOption = selectElement.options[selectElement.selectedIndex]
+	            if (selectedOption.dataset.code != "150101") {
+                    throw new Error("District has a different value");
+                }
+            },
+        }
+    ],
+});

--- a/addons/l10n_pe_website_sale/tests/test_l10n_pe_website_sale.py
+++ b/addons/l10n_pe_website_sale/tests/test_l10n_pe_website_sale.py
@@ -1,11 +1,33 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import HttpCase, tagged
+from odoo import Command
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
 class TestWebsiteSalePe(HttpCase):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = cls.env['product.product'].create({
+            'name': 'Test Product',
+            'standard_price': 70.0,
+            'list_price': 70.0,
+            'website_published': True,
+        })
+
+        cls.country_peru = cls.env.ref('base.pe')
+        cls.env.company.account_fiscal_country_id = cls.country_peru
+        cls.env.company.country_id = cls.country_peru
+        cls.env['website'].get_current_website().company_id = cls.env.company.id
+
+        admin = cls.env['res.users'].search([('login', '=', 'admin')])
+        admin.write({
+                'company_id': cls.env.company.id,
+                'company_ids': [Command.link(cls.env.company.id)]
+        })
+    
     def test_change_address(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
             self.skipTest("Transfer provider is not installed")
@@ -16,12 +38,7 @@ class TestWebsiteSalePe(HttpCase):
             'is_published': True,
         })
         transfer_provider._transfer_ensure_pending_msg_is_set()
-        self.env['product.product'].create({
-            'name': 'Test Product',
-            'standard_price': 70.0,
-            'list_price': 70.0,
-            'website_published': True,
-        })
+        
         # Avoid Shipping/Billing address page (Needed when test is run without demo data)
         country_us_id = self.env['ir.model.data']._xmlid_to_res_id('base.us')
         country_us_state_id = self.env['ir.model.data']._xmlid_to_res_id('base.state_us_39')
@@ -34,8 +51,17 @@ class TestWebsiteSalePe(HttpCase):
             'phone': '+1 555-555-5555',
             'email': 'admin@yourcompany.example.com',
         })
-        country_peru = self.env.ref('base.pe')
-        self.env.company.account_fiscal_country_id = country_peru
-        self.env.company.country_id = country_peru
-        self.env['website'].get_current_website().company_id = self.env.company.id
+
         self.start_tour("/", 'update_the_address_for_peru_company', login="admin", watch=True)
+
+    def test_maintain_city_district(self):
+
+        self.env.ref('base.partner_admin').write({
+            'street': 'Some Street',
+            'zip': '12345',
+            'country_id': self.country_peru.id,
+            'phone': '+51 1 1234567',
+            'email': 'test@example.com',
+        })
+
+        self.start_tour("/", 'maintain_city_district_on_reload', login="admin")


### PR DESCRIPTION
…page reload

**Issue:**
When the shipping page of the eCommerce site, with the Peruvian module, is reloaded due to incorrect input (such as an invalid VAT number), the city and district fields reset to the first available option instead of retaining the user's selection.

**Steps to Reproduce:**
1. Install the Ecommerce app
2. Install the l10n_pe_website_sale module
3. Switch to PE Company
4. Go to the website
5. Buy a product
6. Click checkout
7. Edit the shipping address
8. Select a province, city, and district
9. Choose VAT as the Identification Type
10. Enter an incorrect VAT number (e.g., XAXX010101000)
11. Click Save Address
12. Observe that the city and district selections have been reset

Expected Behavior: The city and district fields should retain the user’s selection after the page reloads

Actual Behavior: The city and district fields are reset to the first available option instead of keeping the user’s choices.

**Root Cause**

When the page reloads due to form validation errors, the state selection is preserved, but the city and district selections are lost because they are dynamically populated based on the selected state. The dropdowns for city and district are repopulated, but there is no mechanism to restore the previously selected values after reloading.

**Fix**
Store the selected city and district values before form submission. If these values still exist in the updated list, retain the previous selection, as it indicates that the choice has not changed.

Opw-4628466

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
