### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: missing access rights  on journal field

### DIFF
--- a/addons/l10n_tr_nilvera/views/res_config_settings_views.xml
+++ b/addons/l10n_tr_nilvera/views/res_config_settings_views.xml
@@ -6,37 +6,41 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <block name="integration" position="inside">
-                <field name="country_code" invisible="True"/>
-                <setting id="nilvera_settings" string="Nilvera Electronic Document Invoicing" help="Configure Nilvera settings" invisible="country_code != 'TR'">
-                    <div class="content-group">
-                        <div class="row mt16">
-                            <label string="Environment" for="l10n_tr_nilvera_environment" class="col-lg-6 o_light_label"/>
-                            <field name="l10n_tr_nilvera_environment"/>
+            <xpath expr="//block[@id='peppol']" position="after">
+                <block title="Nilvera" id="nilvera">
+                    <setting id="nilvera_settings"
+                             string="Nilvera Electronic Document Invoicing"
+                             help="Configure Nilvera settings"
+                             invisible="country_code != 'TR'">
+                        <div class="content-group">
+                            <div class="row mt16">
+                                <label string="Environment" for="l10n_tr_nilvera_environment" class="col-lg-6 o_light_label"/>
+                                <field name="l10n_tr_nilvera_environment"/>
+                            </div>
+                            <div class="row">
+                                <label string="API KEY" for="l10n_tr_nilvera_api_key" class="col-lg-6 o_light_label" />
+                                <field name="l10n_tr_nilvera_api_key"/>
+                            </div>
+                            <div class="row">
+                                <label string="Incoming Invoices Journal"
+                                    for="l10n_tr_nilvera_purchase_journal_id"
+                                    class="col-lg-6 o_light_label"/>
+                                <field name="l10n_tr_nilvera_purchase_journal_id"/>
+                            </div>
+                            <div class="mt16" invisible="not l10n_tr_nilvera_api_key">
+                                <a href="https://portal.nilvera.com/" target="_new">
+                                    <i title="Go to Nilvera portal" role="img" aria-label="Go to Nilvera portal" class="fa fa-external-link-square fa-fw"/>
+                                    Nilvera portal
+                                </a>
+                                <button name="nilvera_ping" type="object" class="btn-link">
+                                    <i title="Test connection" role="img" aria-label="Test connection" class="fa fa-plug fa-fw"/>
+                                    Test connection
+                                </button>
+                            </div>
                         </div>
-                        <div class="row">
-                            <label string="API KEY" for="l10n_tr_nilvera_api_key" class="col-lg-6 o_light_label" />
-                            <field name="l10n_tr_nilvera_api_key"/>
-                        </div>
-                        <div class="row">
-                            <label string="Incoming Invoices Journal"
-                                   for="l10n_tr_nilvera_purchase_journal_id"
-                                   class="col-lg-6 o_light_label"/>
-                            <field name="l10n_tr_nilvera_purchase_journal_id"/>
-                        </div>
-                        <div class="mt16" invisible="not l10n_tr_nilvera_api_key">
-                            <a href="https://portal.nilvera.com/" target="_new">
-                                <i title="Go to Nilvera portal" role="img" aria-label="Go to Nilvera portal" class="fa fa-external-link-square fa-fw"/>
-                                Nilvera portal
-                            </a>
-                            <button name="nilvera_ping" type="object" class="btn-link">
-                                <i title="Test connection" role="img" aria-label="Test connection" class="fa fa-plug fa-fw"/>
-                                Test connection
-                            </button>
-                        </div>
-                    </div>
-                </setting>
-            </block>
+                    </setting>
+                </block>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
The l10n_tr_nilvera_purchase_journal_id field was causing access errors due to its placement in the "Integrations" section without any group restriction, exposing it to users without the necessary rights.

In contrast, the similar account_peppol_purchase_journal_id field is defined under the "Invoicing" section with the proper group restriction (account.group_account_manager), and behaves correctly.

This fix moves the Nilvera field into the same restricted section as the Peppol field, aligning its access control and visibility with other similar fields in the same context.

build_error-111279

