### PR TITLE
[FIX] stock: improve traceability PDF header spacing

### DIFF
--- a/addons/stock/report/stock_traceability.py
+++ b/addons/stock/report/stock_traceability.py
@@ -225,7 +225,7 @@ class MrpStockReport(models.TransientModel):
             [body],
             header=header.decode(),
             landscape=True,
-            specific_paperformat_args={'data-report-margin-top': 17, 'data-report-header-spacing': 12}
+            specific_paperformat_args={'data-report-margin-top': 30, 'data-report-header-spacing': 25}
         )
 
     def _get_main_lines(self):


### PR DESCRIPTION
Task: [4591489](https://www.odoo.com/odoo/49/tasks/4591489)

Description of the issue/feature this PR addresses:
The reference and company name in the header of Traceability Report are currently overlapping a bit. This PR increases the spacing of elements, to resolve the issue.

Current behavior before PR:
The formatting of the Traceability Report's header is incorrect, reference and company name are overlapping:

![Screenshot from 2025-03-13 13-28-16](https://github.com/user-attachments/assets/d9f3710c-1555-4fc1-9bc6-2c10a19b05e6)

Desired behavior after PR is merged:
The Traceability Report's header is displayed properly:

![Screenshot from 2025-03-13 13-28-53](https://github.com/user-attachments/assets/f1286512-af3b-418d-adc9-4c9b3136a044)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

