### PR TITLE
[FIX] certificate: Hide empty loading error message

### DIFF
--- a/addons/certificate/views/certificate_views.xml
+++ b/addons/certificate/views/certificate_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <form string="certificate form">
                 <sheet>
-                    <div class="alert alert-warning" role="alert" invisible="loading_error == ''">
+                    <div class="alert alert-warning" role="alert" invisible="not loading_error">
                         <field name="loading_error"/>
                     </div>
                     <group id="certificate_input">

--- a/addons/certificate/views/key_views.xml
+++ b/addons/certificate/views/key_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <form string="key form">
                 <sheet>
-                    <div class="alert alert-warning" role="alert" invisible="loading_error == ''">
+                    <div class="alert alert-warning" role="alert" invisible="not loading_error">
                         <field name="loading_error"/>
                     </div>
                     <group id="key_input">


### PR DESCRIPTION
Problem
---------
When the certificate or the key is created through SQL INSERT, the compute functions are not triggered. This lead to the 'loading_error' field to remain FALSE.

Since the condition that checked whether or not to display the loading error message was "loading_error == ''", it meant that the message would be display when it was equal to FALSE.

Instead, we now just check if there is a loading error message with 'not loading_error' which solves the issue and makes it more robust.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
