### PR TITLE
[FIX] l10n_gcc_invoice: fix invoice layout with customer reference

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -140,7 +140,7 @@
                             <strong style="white-space:nowrap">Reference:
                             </strong>
                         </div>
-                        <div class="col-8">
+                        <div class="col-2">
                             <span t-field="o.ref"/>
                         </div>
                         <div class="col-2 text-end">


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_sa
- Switch to a Saudi Arabian company (e.g. SA Company)
- Create an invoice without a customer reference
- Print the invoice
- Create the same invoice with a customer reference
- Print the invoice

**Issue:**
The font size is smaller for the second invoice and the reference label in Arabic doesn't appear.

**Cause:**
The reference row in the printed invoice is separated in 3 columns like the other information, but the Bootstrap width of the second column is 8 (i.e. col-8) instead of 2.
As the first column has an offset of 6 as it is the case for all the rows, the row width exceeds the grid system size (i.e. 12) defined in Bootstrap.

opw-4494547



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
