### PR TITLE
[FIX] mrp: avoid traceback When Computing Qty Packaging for Kit

### DIFF
--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -625,3 +625,57 @@ class TestKitPicking(common.TestMrpCommon):
         self.assertRecordValues(scrap.move_ids, [
             {'product_id': component.id, 'quantity': 1, 'state': 'done'}
         ])
+
+    def test_kit_with_packaging_different_uom(self):
+        """
+        Test that a quantity packaging is correctly computed on a move line
+        when a kit is in a different uom than its components.
+        - Component(uom=Kg)
+        - Kit (uom=unit) -> Bom (1 dozen) -> Component (10 g)
+        - Packaging (qty=2 units of kit)
+        """
+        bom = self.bom_4
+        bom.type = 'phantom'
+        kit = bom.product_id
+        kit.is_storable = True
+        # product is in unit and bom in dozen
+        kit.uom_id = self.uom_unit
+        bom.product_uom_id = self.uom_dozen
+        bom.product_qty = 1
+        # create a packaging with 2 units
+        packaging = self.env['product.packaging'].create({
+            'name': 'Packaging',
+            'qty': 2,
+            'product_id': kit.id,
+        })
+        # component is in Kg but bom_line in gram
+        component = bom.bom_line_ids.product_id
+        component.uom_id = self.uom_kg
+        bom.bom_line_ids.product_uom_id = self.uom_gram
+        bom.bom_line_ids.product_qty = 10
+
+        # create a delivery with 20 units of kit
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        customer_location = self.env.ref('stock.stock_location_customers')
+        stock_location = warehouse.lot_stock_id
+
+        delivery = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+            'location_id': stock_location.id,
+            'location_dest_id': customer_location.id,
+            'move_ids': [Command.create({
+                'name': kit.name,
+                'product_id': kit.id,
+                'product_uom_qty': 24,
+                'product_uom': kit.uom_id.id,
+                'location_id': stock_location.id,
+                'location_dest_id': customer_location.id,
+                'product_packaging_id': packaging.id,
+            })],
+        })
+        delivery.action_confirm()
+        delivery.move_ids.quantity = 20
+        delivery.move_ids.picked = True
+        delivery.button_validate()
+        self.assertTrue(delivery.state, 'done')
+        self.assertEqual(delivery.move_ids.move_line_ids.product_packaging_qty, 12)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storage “P1”:
    - UoM: Kg

- Create a storable “Kit 1”:
    - UoM: unit
    - BoM:
        - 1 Kg of P1

- Create a delivery order for 1 unit of Kit 1
- Mark it as to do
- Set the quantity of P1 to 1kg
- try to print

Problem:
A traceback is triggered because we try to convert 1kg to unit:

```
odoo.addons.base.models.ir_qweb.QWebException: Error while render the
template
UserError: L'unité de mesure kg définie sur la ligne de commande
n'appartient pas à la même catégorie que l'unité de mesure unités
définie sur le produit. Veuillez corriger l'unité de mesure définie
sur la ligne de commande ou sur le produit, elles doivent appartenir à
la même catégorie.
Template: stock.stock_report_delivery_has_serial_move_line
```

opw-4619140
