### PR TITLE
[FIX] delivery_*_rest: update settings for delivery connectors

### DIFF
--- a/addons/sale/views/res_config_settings_views.xml
+++ b/addons/sale/views/res_config_settings_views.xml
@@ -261,12 +261,12 @@
                         </div>
                         <div class="col-12 col-lg-6 o_setting_box" id="ups">
                             <div class="o_setting_left_pane">
-                                <field name="module_delivery_ups" widget="upgrade_boolean"/>
                             </div>
                             <div class="o_setting_right_pane">
-                                <label for="module_delivery_ups"/>
+                                <div class="o_form_label">UPS Connector</div>
                                 <div class="text-muted">
-                                    Compute shipping costs and ship with UPS
+                                    Compute shipping costs and ship with UPS<br/>
+                                    <strong>(please go to Home>Apps to install)</strong>
                                 </div>
                                 <div class="content-group">
                                     <div id="sale_delivery_ups"/>
@@ -275,12 +275,12 @@
                         </div>
                         <div class="col-12 col-lg-6 o_setting_box" id="shipping_costs_dhl">
                             <div class="o_setting_left_pane">
-                                <field name="module_delivery_dhl" widget="upgrade_boolean"/>
                             </div>
                             <div class="o_setting_right_pane">
-                                <label for="module_delivery_dhl"/>
+                                <div class="o_form_label">DHL Connector</div>
                                 <div class="text-muted">
-                                    Compute shipping costs and ship with DHL
+                                    Compute shipping costs and ship with DHL<br/>
+                                    <strong>(please go to Home>Apps to install)</strong>
                                 </div>
                                 <div class="content-group">
                                     <div id="sale_delivery_dhl"></div>
@@ -289,12 +289,12 @@
                         </div>
                         <div class="col-12 col-lg-6 o_setting_box" id="shipping_costs_fedex">
                             <div class="o_setting_left_pane">
-                                <field name="module_delivery_fedex" widget="upgrade_boolean"/>
                             </div>
                             <div class="o_setting_right_pane">
-                                <label for="module_delivery_fedex"/>
+                                <div class="o_form_label">FedEx Connector</div>
                                 <div class="text-muted">
-                                    Compute shipping costs and ship with FedEx
+                                    Compute shipping costs and ship with FedEx<br/>
+                                    <strong>(please go to Home>Apps to install)</strong>
                                 </div>
                                 <div class="content-group">
                                     <div id="sale_delivery_fedex"/>
@@ -303,12 +303,12 @@
                         </div>
                         <div class="col-12 col-lg-6 o_setting_box" id="shipping_costs_usps">
                             <div class="o_setting_left_pane">
-                                <field name="module_delivery_usps" widget="upgrade_boolean"/>
                             </div>
                             <div class="o_setting_right_pane">
-                                <label for="module_delivery_usps"/>
+                                <div class="o_form_label">USPS Connector</div>
                                 <div class="text-muted">
-                                    Compute shipping costs and ship with USPS
+                                    Compute shipping costs and ship with USPS<br/>
+                                    <strong>(please go to Home>Apps to install)</strong>
                                 </div>
                                 <div class="content-group">
                                     <div id="sale_delivery_usps"/>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -173,13 +173,13 @@
                         <div class="row mt16 o_settings_container" name="product_setting_container">
                             <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_ups">
                                 <div class="o_setting_left_pane">
-                                    <field name="module_delivery_ups" widget="upgrade_boolean"/>
                                 </div>
                                 <div class="o_setting_right_pane">
-                                    <label for="module_delivery_ups"/>
+                                    <div class="o_form_label">UPS Connector</div>
                                     <a href="https://www.odoo.com/documentation/16.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                     <div class="text-muted">
-                                        Compute shipping costs and ship with UPS
+                                        Compute shipping costs and ship with UPS<br/>
+                                        <strong>(please go to Home>Apps to install)</strong>
                                     </div>
                                     <div class="content-group">
                                         <div id="stock_delivery_ups"/>
@@ -188,13 +188,13 @@
                             </div>
                             <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_dhl">
                                 <div class="o_setting_left_pane">
-                                    <field name="module_delivery_dhl" widget="upgrade_boolean"/>
                                 </div>
                                 <div class="o_setting_right_pane">
-                                    <label for="module_delivery_dhl"/>
+                                    <div class="o_form_label">DHL Connector</div>
                                     <a href="https://www.odoo.com/documentation/16.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                     <div class="text-muted">
-                                        Compute shipping costs and ship with DHL
+                                        Compute shipping costs and ship with DHL<br/>
+                                        <strong>(please go to Home>Apps to install)</strong>
                                     </div>
                                     <div class="content-group">
                                         <div id="stock_delivery_dhl"/>
@@ -203,13 +203,13 @@
                             </div>
                             <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_fedex">
                                 <div class="o_setting_left_pane">
-                                    <field name="module_delivery_fedex" widget="upgrade_boolean"/>
                                 </div>
                                 <div class="o_setting_right_pane">
-                                    <label for="module_delivery_fedex"/>
+                                    <div class="o_form_label">FedEx Connector</div>
                                     <a href="https://www.odoo.com/documentation/16.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                     <div class="text-muted">
-                                        Compute shipping costs and ship with FedEx
+                                        Compute shipping costs and ship with FedEx<br/>
+                                        <strong>(please go to Home>Apps to install)</strong>
                                     </div>
                                     <div class="content-group">
                                         <div id="stock_delivery_fedex"/>
@@ -218,13 +218,13 @@
                             </div>
                             <div class="col-12 col-lg-6 o_setting_box" id="compute_shipping_costs_usps">
                                 <div class="o_setting_left_pane">
-                                    <field name="module_delivery_usps" widget="upgrade_boolean"/>
                                 </div>
                                 <div class="o_setting_right_pane">
-                                    <label for="module_delivery_usps"/>
+                                    <div class="o_form_label">USPS Connector</div>
                                     <a href="https://www.odoo.com/documentation/16.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                     <div class="text-muted">
-                                        Compute shipping costs and ship with USPS
+                                        Compute shipping costs and ship with USPS<br/>
+                                        <strong>(please go to Home>Apps to install)</strong>
                                     </div>
                                     <div class="content-group">
                                         <div id="stock_delivery_usps"/>

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -265,45 +265,45 @@
                     </div>
                     <div class="col-12 col-lg-6 o_setting_box" id="ups_provider_setting">
                         <div class="o_setting_left_pane">
-                            <field name="module_delivery_ups" widget="upgrade_boolean"/>
                         </div>
                         <div class="o_setting_right_pane">
-                            <label string="UPS" for="module_delivery_ups"/>
+                            <div class="o_form_label">UPS</div>
                             <div class="text-muted" id="website_delivery_ups">
-                                Compute shipping costs and ship with UPS
+                                Compute shipping costs and ship with UPS<br/>
+                                <strong>(please go to Home>Apps to install)</strong>
                             </div>
                         </div>
                     </div>
                     <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_dhl_setting">
                         <div class="o_setting_left_pane">
-                            <field name="module_delivery_dhl" widget="upgrade_boolean"/>
                         </div>
                         <div class="o_setting_right_pane">
-                            <label string="DHL Express Connector" for="module_delivery_dhl"/>
+                            <div class="o_form_label">DHL</div>
                             <div class="text-muted" id="website_delivery_dhl">
-                                Compute shipping costs and ship with DHL
+                                Compute shipping costs and ship with DHL<br/>
+                                <strong>(please go to Home>Apps to install)</strong>
                             </div>
                         </div>
                     </div>
                     <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_fedex_setting">
                         <div class="o_setting_left_pane">
-                            <field name="module_delivery_fedex" widget="upgrade_boolean"/>
                         </div>
                         <div class="o_setting_right_pane">
-                            <label string="FedEx" for="module_delivery_fedex"/>
+                            <div class="o_form_label">FedEx</div>
                             <div class="text-muted" id="website_delivery_fedex">
-                                Compute shipping costs and ship with FedEx
+                                Compute shipping costs and ship with FedEx<br/>
+                                <strong>(please go to Home>Apps to install)</strong>
                             </div>
                         </div>
                     </div>
                     <div class="col-12 col-lg-6 o_setting_box" id="shipping_provider_usps_setting">
                         <div class="o_setting_left_pane">
-                            <field name="module_delivery_usps" widget="upgrade_boolean"/>
                         </div>
                         <div class="o_setting_right_pane">
-                            <label string="USPS" for="module_delivery_usps"/>
+                            <div class="o_form_label">USPS</div>
                             <div class="text-muted" id="website_delivery_usps">
-                                Compute shipping costs and ship with USPS
+                                Compute shipping costs and ship with USPS<br/>
+                                <strong>(please go to Home>Apps to install)</strong>
                             </div>
                         </div>
                     </div>

--- a/addons/website_sale_delivery/views/res_config_settings_views.xml
+++ b/addons/website_sale_delivery/views/res_config_settings_views.xml
@@ -12,27 +12,6 @@
                     </div>
                 </div>
             </div>
-            <div id="website_delivery_dhl" position="after">
-                <div class="content-group">
-                    <div class="mt8" attrs="{'invisible': [('module_delivery_dhl', '=', False)]}">
-                        <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="DHL Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'dhl'}"/>
-                    </div>
-                </div>
-            </div>
-            <div id="website_delivery_fedex" position="after">
-                <div class="content-group">
-                    <div class="mt8" attrs="{'invisible': [('module_delivery_fedex', '=', False)]}">
-                        <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="FedEx Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'fedex'}"/>
-                    </div>
-                </div>
-            </div>
-            <div id="website_delivery_usps" position="after">
-                <div class="content-group">
-                    <div class="mt8" attrs="{'invisible': [('module_delivery_usps', '=', False)]}">
-                        <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="USPS Shipping Methods" class="btn-link" context="{'search_default_delivery_type': 'usps'}"/>
-                    </div>
-                </div>
-            </div>
             <div id="website_delivery_bpost" position="after">
                 <div class="content-group">
                     <div class="mt8" attrs="{'invisible': [('module_delivery_bpost', '=', False)]}">


### PR DESCRIPTION
We have recently introduced several new versions of the delivery connectors, based on the newer REST APIs introduced by the shipping companies (USPS, FedEx, UPS, DHL).

However, in the settings we still link with installation checkboxes to the old modules.

To avoid confusion for the user, we remove these checkboxes and refer the user to the Apps menu instead for manual installation of the preferred shipping connector. In the apps menu, we clarify that these new modules are only compatible with the new REST APIs, and we also hide the legacy modules by default by making them application: False.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
