### PR TITLE
[IMP] utils: Optimize `unique` using `dict` instead of `set`

### DIFF
--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1218,12 +1218,7 @@ def unique(it: Iterable[T]) -> Iterator[T]:
     :param Iterable it:
     :rtype: Iterator
     """
-    seen = set()
-    for e in it:
-        if e not in seen:
-            seen.add(e)
-            yield e
-
+    return iter(dict.fromkeys(it))
 
 def submap(mapping: Mapping[K, T], keys: Iterable[K]) -> Mapping[K, T]:
     """


### PR DESCRIPTION
Use `dict` instead of `set` in `unique` for performance.
- Memory: The load factor for scaling up is 2/3 for `dict` and 3/5 for `set`, meaning `dict` does not always consume more memory than `set`. Also in our use cases, `unique` is never early stopped, so pre-generating the `dict` is not an issue.
- Performance: `dict.fromkeys` assigns values in C, making it significantly faster than using `set.add` in Python.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
