### PR TITLE
[FIX] mail: remove focus state from composer on unmount

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -17,6 +17,7 @@ import {
     Component,
     markup,
     onMounted,
+    onWillUnmount,
     useChildSubEnv,
     useEffect,
     useRef,
@@ -172,6 +173,9 @@ export class Composer extends Component {
         );
         onMounted(() => {
             this.ref.el.scrollTo({ top: 0, behavior: "instant" });
+        });
+        onWillUnmount(() => {
+            this.props.composer.isFocused = false;
         });
     }
 


### PR DESCRIPTION
If a chat window is closed with the escape key while the composer is focused, the focus out event is never triggered and the focus flag of the composer is never reset.

When this flag is kept, new messages received in this channel are automatically marked as read, even if the messages are not actually visible.

task-4643664