### PR TITLE
[IMP] core: improve code of Domain optimizations

### DIFF
--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -472,7 +472,7 @@ class TestHrEmployee(TestHrCommon):
         domain = Domain([
             ('name', '=', 'Test Employee'),
             ('active', '=', True)
-        ])._optimize(self.env['hr.employee'])
+        ]).optimize(self.env['hr.employee'])
         with self.assertNoLogs('odoo.domains'):
             self.assertEqual(
                 employee.ids,

--- a/odoo/addons/base/models/res_groups.py
+++ b/odoo/addons/base/models/res_groups.py
@@ -237,7 +237,7 @@ class ResGroups(models.Model):
 
     def _search_all_implied_by_ids(self, operator, value):
         """ Compute the search on the reflexive transitive closure of implied_by_ids. """
-        assert isinstance(value, (int, list, tuple))
+        assert isinstance(value, (int, Collection))
 
         if isinstance(value, int):
             value = [value]

--- a/odoo/addons/base/models/res_groups.py
+++ b/odoo/addons/base/models/res_groups.py
@@ -237,7 +237,7 @@ class ResGroups(models.Model):
 
     def _search_all_implied_by_ids(self, operator, value):
         """ Compute the search on the reflexive transitive closure of implied_by_ids. """
-        assert isinstance(value, (int, Collection))
+        assert isinstance(value, (int, list, tuple))
 
         if isinstance(value, int):
             value = [value]

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -2625,7 +2625,7 @@ class TestPrettifyDomain(BaseCase):
 
 class TestAnyfy(TransactionCase):
     def _test_combine_anies(self, domain, expected):
-        anyfied_domain = list(Domain(domain)._optimize(self.env['res.partner']))
+        anyfied_domain = list(Domain(domain).optimize(self.env['res.partner']))
         return self.assertEqual(anyfied_domain, expected,
                                 f'\nFor initial domain: {domain}\nBecame: {anyfied_domain}')
 

--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -587,6 +587,14 @@ class TestDomainOptimize(TransactionCase):
     def test_condition_optimize_date(self):
         model = self.env['test_new_api.mixed']
         self.assertEqual(
+            Domain('date', '=', date(2024, 1, 5)).optimize(model),
+            Domain('date', '=', date(2024, 1, 5)),
+        )
+        self.assertEqual(
+            Domain('date', '=', datetime(2024, 1, 5, 12, 0, 0)).optimize(model),
+            Domain('date', '=', date(2024, 1, 5)),
+        )
+        self.assertEqual(
             Domain('date', '=', '2024-01-05').optimize(model),
             Domain('date', '=', date(2024, 1, 5)),
         )
@@ -612,6 +620,10 @@ class TestDomainOptimize(TransactionCase):
 
     def test_condition_optimize_datetime(self):
         model = self.env['test_new_api.mixed']
+        self.assertEqual(
+            Domain('moment', '=', datetime(2024, 1, 5)).optimize(model),
+            Domain('moment', '=', datetime(2024, 1, 5)),
+        )
         self.assertEqual(
             Domain('moment', '=', '2024-01-05').optimize(model),
             Domain('moment', '=', datetime(2024, 1, 5)),

--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -455,7 +455,7 @@ class TestDomainOptimize(TransactionCase):
         domain = Domain('id', 'in', range(5)).optimize(model)
         self.assertIsInstance(domain.value, OrderedSet)
         domain = Domain('id', 'in', [9, 99]).optimize(model)
-        self.assertIsInstance(domain.value, list)
+        self.assertIsInstance(domain.value, OrderedSet)
         self.assertIs(domain.optimize(model), domain, "Idempotent")
 
         self.assertEqual(

--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -398,8 +398,8 @@ class TestDomainOptimize(TransactionCase):
 
     def test_bool_optimize(self):
         model = self.env['test_new_api.mixed']
-        self.assertIs(Domain.TRUE._optimize(model), Domain.TRUE)
-        self.assertIs(Domain.FALSE._optimize(model), Domain.FALSE)
+        self.assertIs(Domain.TRUE.optimize(model), Domain.TRUE)
+        self.assertIs(Domain.FALSE.optimize(model), Domain.FALSE)
 
     def test_condition_build(self):
         # the terms do not change during the build of the condition
@@ -417,24 +417,24 @@ class TestDomainOptimize(TransactionCase):
     def test_condition_optimize_optimal(self):
         model = self.env['test_new_api.mixed']
         domain = self.number_domain
-        self.assertIs(domain._optimize(model), domain, "Domain is already optimized")
+        self.assertIs(domain.optimize(model), domain, "Domain is already optimized")
 
     def test_condition_optimize_invalid_field(self):
         model = self.env['test_new_api.mixed']
         domain = Domain("xxx_inexisting", "=", False)
         with self.assertRaises(ValueError):
             # fields must be validated
-            domain._optimize(model)
+            domain.optimize(model)
 
     def test_condition_optimize_search(self):
         model = self.env['test_new_api.bar']
         foo = model.foo.create({"name": "ok"})
         self.assertEqual(
-            Domain('foo', '=', foo.id)._optimize_for_sql(model),
-            Domain('name', 'in', ["ok"])._optimize(model),
+            Domain('foo', '=', foo.id).optimize(model, full=True),
+            Domain('name', 'in', ["ok"]).optimize(model),
         )
         self.assertEqual(
-            Domain('foo', 'in', foo.browse().ids)._optimize(model),
+            Domain('foo', 'in', foo.browse().ids).optimize(model),
             Domain.FALSE,
             "search should be further optimized",
         )
@@ -442,28 +442,28 @@ class TestDomainOptimize(TransactionCase):
     def test_condition_optimize_traverse(self):
         model = self.env['test_new_api.mixed']
         self.assertEqual(
-            Domain('currency_id.id', '>', 5)._optimize(model),
+            Domain('currency_id.id', '>', 5).optimize(model),
             Domain('currency_id', 'any', Domain('id', '>', 5)),
         )
         self.assertEqual(
-            (~Domain('currency_id.id', '>', 5))._optimize(model),
+            (~Domain('currency_id.id', '>', 5)).optimize(model),
             Domain('currency_id', 'not any', Domain('id', '>', 5)),
         )
 
     def test_condition_optimize_in(self):
         model = self.env['test_new_api.mixed']
-        domain = Domain('id', 'in', range(5))._optimize(model)
+        domain = Domain('id', 'in', range(5)).optimize(model)
         self.assertIsInstance(domain.value, OrderedSet)
-        domain = Domain('id', 'in', [9, 99])._optimize(model)
+        domain = Domain('id', 'in', [9, 99]).optimize(model)
         self.assertIsInstance(domain.value, list)
-        self.assertIs(domain._optimize(model), domain, "Idempotent")
+        self.assertIs(domain.optimize(model), domain, "Idempotent")
 
         self.assertEqual(
-            Domain('id', 'in', [])._optimize(model),
+            Domain('id', 'in', []).optimize(model),
             Domain.FALSE,
         )
         self.assertEqual(
-            Domain('id', 'not in', [])._optimize(model),
+            Domain('id', 'not in', []).optimize(model),
             Domain.TRUE,
         )
 
@@ -471,65 +471,65 @@ class TestDomainOptimize(TransactionCase):
         model = self.env['test_new_api.mixed']
 
         domain = Domain('currency_id', 'any', model.currency_id._search([]))
-        self.assertIs(domain._optimize(model), domain, "Idempotent with a Query value")
+        self.assertIs(domain.optimize(model), domain, "Idempotent with a Query value")
 
         self.assertEqual(
-            Domain('currency_id', 'any', Domain.FALSE)._optimize(model),
+            Domain('currency_id', 'any', Domain.FALSE).optimize(model),
             Domain.FALSE,
         )
         self.assertEqual(
-            Domain('currency_id', 'not any', Domain.FALSE)._optimize(model),
+            Domain('currency_id', 'not any', Domain.FALSE).optimize(model),
             Domain.TRUE,
         )
         self.assertEqual(
-            Domain('currency_id', 'any', Domain('id', 'not in', []))._optimize(model),
+            Domain('currency_id', 'any', Domain('id', 'not in', [])).optimize(model),
             Domain('currency_id', 'any', Domain.TRUE),
             "optimize the domain"
         )
 
-        domain = Domain('currency_id', 'any', Domain('id', 'in', [1]))._optimize(model)
-        self.assertIs(domain._optimize(model), domain, "Idempotent")
+        domain = Domain('currency_id', 'any', Domain('id', 'in', [1])).optimize(model)
+        self.assertIs(domain.optimize(model), domain, "Idempotent")
 
     def test_condition_optimize_any_non_relational(self):
         model = self.env['test_new_api.mixed']
         domain = Domain('number', 'any', Domain('id', '>', 0))
         with self.assertRaises(ValueError):
-            domain._optimize(model)
+            domain.optimize(model)
 
     def test_condition_optimize_any_id(self):
         model = self.env['test_new_api.mixed']
         self.assertEqual(
-            Domain('id', 'any', self.number_domain)._optimize(model),
+            Domain('id', 'any', self.number_domain).optimize(model),
             self.number_domain,
         )
         self.assertEqual(
-            Domain('id', 'not any', self.number_domain)._optimize(model),
-            (~self.number_domain)._optimize(model),
+            Domain('id', 'not any', self.number_domain).optimize(model),
+            (~self.number_domain).optimize(model),
         )
 
     def test_condition_optimize_like(self):
         model = self.env['test_new_api.message']
         domain = Domain('name', 'like', 'ok')
         self.assertIs(
-            domain._optimize(model),
+            domain.optimize(model),
             domain, "Idempotent"
         )
 
         self.assertEqual(
-            Domain('name', 'like', '')._optimize(model),
+            Domain('name', 'like', '').optimize(model),
             Domain.TRUE, "Matching anything"
         )
         self.assertEqual(
-            Domain('name', 'not like', '')._optimize(model),
+            Domain('name', 'not like', '').optimize(model),
             Domain.FALSE, "Matching nothing"
         )
         self.assertEqual(
-            Domain('name', '=like', '')._optimize(model),
-            Domain('name', '=', False)._optimize(model),
+            Domain('name', '=like', '').optimize(model),
+            Domain('name', '=', False).optimize(model),
             "Matching empty string only"
         )
         self.assertEqual(
-            Domain('name', 'like', 5)._optimize(model),
+            Domain('name', 'like', 5).optimize(model),
             Domain('name', 'like', "5"),
             "Convert to str type for like matching"
         )
@@ -537,16 +537,16 @@ class TestDomainOptimize(TransactionCase):
     def test_condition_optimize_like_relational(self):
         model = self.env['test_new_api.message']
         self.assertEqual(
-            Domain('discussion', 'like', '')._optimize(model),
+            Domain('discussion', 'like', '').optimize(model),
             Domain('discussion', '!=', False),
             "Matching anything in relation",
         )
         query = model.discussion._search([('display_name', 'like', 'ok')])
-        domain = Domain('discussion', 'like', 'ok')._optimize_for_sql(model)
+        domain = Domain('discussion', 'like', 'ok').optimize(model, full=True)
         self.assertEqual(domain.operator, 'any')
         self.assertEqual(domain.value.select().code, query.select().code)
 
-        domain = Domain('discussion', 'not like', 'ok')._optimize_for_sql(model)
+        domain = Domain('discussion', 'not like', 'ok').optimize(model, full=True)
         self.assertEqual(
             domain.operator, 'not any',
             f"Always use positive operator when searching on display_name; in {domain}"
@@ -556,106 +556,106 @@ class TestDomainOptimize(TransactionCase):
         model = self.env['test_new_api.message']
         is_important = Domain('important', 'in', OrderedSet([True]))
         self.assertIs(
-            is_important._optimize(model),
+            is_important.optimize(model),
             is_important, "Idempotent optimization"
         )
         self.assertEqual(
-            Domain('important', '=', True)._optimize(model),
+            Domain('important', '=', True).optimize(model),
             Domain('important', '=', True),
         )
         self.assertEqual(
-            len(list(Domain('important', 'not in', [True, False])._optimize(model).iter_conditions())),
+            len(list(Domain('important', 'not in', [True, False]).optimize(model).iter_conditions())),
             1, "the condition should not be reduced to a constant"
         )
         self.assertEqual(
-            Domain('important', 'not in', [True, False])._optimize_for_sql(model),
+            Domain('important', 'not in', [True, False]).optimize(model, full=True),
             Domain.FALSE,
         )
         self.assertEqual(
-            Domain('important', 'in', [True, "yes"])._optimize(model),
+            Domain('important', 'in', [True, "yes"]).optimize(model),
             is_important,
         )
         self.assertEqual(
-            Domain('important', 'in', ["yes"])._optimize(model),
+            Domain('important', 'in', ["yes"]).optimize(model),
             is_important,
         )
         self.assertEqual(
-            Domain('important', 'in', [0, 2])._optimize_for_sql(model),
+            Domain('important', 'in', [0, 2]).optimize(model, full=True),
             Domain.TRUE,
         )
 
     def test_condition_optimize_date(self):
         model = self.env['test_new_api.mixed']
         self.assertEqual(
-            Domain('date', '=', '2024-01-05')._optimize(model),
+            Domain('date', '=', '2024-01-05').optimize(model),
             Domain('date', '=', date(2024, 1, 5)),
         )
         self.assertEqual(
-            Domain('date', '=like', '2024%')._optimize(model),
+            Domain('date', '=like', '2024%').optimize(model),
             Domain('date', '=like', '2024%'),
         )
         self.assertEqual(
-            Domain('date', '>', '2024-01-01')._optimize(model),
+            Domain('date', '>', '2024-01-01').optimize(model),
             Domain('date', '>', date(2024, 1, 1)),
         )
         self.assertEqual(
-            Domain('date', '>', False)._optimize(model),
+            Domain('date', '>', False).optimize(model),
             Domain.FALSE,
         )
         self.assertEqual(
-            Domain('date', 'not in', ['2024-01-05', date(2023, 1, 1)])._optimize(model),
+            Domain('date', 'not in', ['2024-01-05', date(2023, 1, 1)]).optimize(model),
             Domain('date', 'not in', OrderedSet([date(2024, 1, 5), date(2023, 1, 1)])),
         )
 
         with self.assertRaises(ValueError):
-            Domain('date', '>', 'hello')._optimize(model)
+            Domain('date', '>', 'hello').optimize(model)
 
     def test_condition_optimize_datetime(self):
         model = self.env['test_new_api.mixed']
         self.assertEqual(
-            Domain('moment', '=', '2024-01-05')._optimize(model),
+            Domain('moment', '=', '2024-01-05').optimize(model),
             Domain('moment', '=', datetime(2024, 1, 5)),
         )
         self.assertEqual(
-            Domain('moment', '=like', '2024%')._optimize(model),
+            Domain('moment', '=like', '2024%').optimize(model),
             Domain('moment', '=like', '2024%'),
         )
         self.assertEqual(
-            Domain('moment', '>', '2024-01-01 10:00:00')._optimize(model),
+            Domain('moment', '>', '2024-01-01 10:00:00').optimize(model),
             Domain('moment', '>', datetime(2024, 1, 1, 10)),
         )
         self.assertEqual(
-            Domain('moment', '>', '2024-01-01')._optimize(model),
+            Domain('moment', '>', '2024-01-01').optimize(model),
             Domain('moment', '>=', datetime(2024, 1, 2)),
         )
         self.assertEqual(
-            Domain('moment', '<', '2024-01-01')._optimize(model),
+            Domain('moment', '<', '2024-01-01').optimize(model),
             Domain('moment', '<', datetime(2024, 1, 1)),
         )
         self.assertEqual(
-            Domain('moment', '<=', '2024-01-01')._optimize(model),
+            Domain('moment', '<=', '2024-01-01').optimize(model),
             Domain('moment', '<', datetime(2024, 1, 2)),
         )
         self.assertEqual(
-            Domain('moment', '>', False)._optimize(model),
+            Domain('moment', '>', False).optimize(model),
             Domain.FALSE,
         )
         self.assertEqual(
-            Domain('moment', 'not in', ['2024-01-05', datetime(2023, 1, 1)])._optimize(model),
+            Domain('moment', 'not in', ['2024-01-05', datetime(2023, 1, 1)]).optimize(model),
             Domain('moment', 'not in', OrderedSet([datetime(2024, 1, 5), datetime(2023, 1, 1)])),
         )
 
         with self.assertRaises(ValueError):
-            Domain('moment', '>', 'hello')._optimize(model)
+            Domain('moment', '>', 'hello').optimize(model)
 
     def test_condition_optimize_maybe_eq(self):
         model = self.env['test_new_api.mixed']
         self.assertEqual(
-            Domain('number', '=?', 5)._optimize(model),
-            Domain('number', '=', 5)._optimize(model),
+            Domain('number', '=?', 5).optimize(model),
+            Domain('number', '=', 5).optimize(model),
         )
         self.assertEqual(
-            Domain('number', '=?', 0)._optimize(model),
+            Domain('number', '=?', 0).optimize(model),
             Domain.TRUE,
         )
 
@@ -664,11 +664,11 @@ class TestDomainOptimize(TransactionCase):
         categ = model.create({'name': 'parent'})
         categ_child = model.create({'name': 'child', 'parent': categ.id})
         self.assertEqual(
-            Domain('id', 'child_of', categ.ids)._optimize_for_sql(model),
+            Domain('id', 'child_of', categ.ids).optimize(model, full=True),
             Domain('parent_path', '=like', f"{categ.parent_path}%"),
         )
         self.assertEqual(
-            Domain('id', 'parent_of', categ_child.ids)._optimize_for_sql(model),
+            Domain('id', 'parent_of', categ_child.ids).optimize(model, full=True),
             Domain('id', 'in', OrderedSet([categ_child.id, categ.id])),
         )
 
@@ -698,7 +698,7 @@ class TestDomainOptimize(TransactionCase):
                 Domain('date', '!=', False),
                 Domain('number', '<', 99),
                 Domain('comment1', 'like', 'ok'),
-            ])._optimize(model),
+            ]).optimize(model),
             Domain.AND([
                 Domain('comment1', 'like', 'ok'),
                 Domain('date', '!=', False),
@@ -722,37 +722,37 @@ class TestDomainOptimize(TransactionCase):
         ]:
             field_type = model._fields[field_name].type
             m2o = field_type == 'many2one'
-            left = left._optimize_for_sql(model[field_name])
-            right = right._optimize_for_sql(model[field_name])
+            left = left.optimize(model[field_name], full=True)
+            right = right.optimize(model[field_name], full=True)
 
             with self.subTest(field_type=field_type):
                 self.assertEqual(
-                    (Domain(field_name, 'any', left) | Domain(field_name, 'any', right))._optimize_for_sql(model),
+                    (Domain(field_name, 'any', left) | Domain(field_name, 'any', right)).optimize(model, full=True),
                     Domain(field_name, 'any', left | right),
                 )
                 self.assertEqual(
-                    (Domain(field_name, 'any', left) & Domain(field_name, 'any', right))._optimize_for_sql(model),
+                    (Domain(field_name, 'any', left) & Domain(field_name, 'any', right)).optimize(model, full=True),
                     Domain(field_name, 'any', left & right) if m2o
                     else Domain(field_name, 'any', left) & Domain(field_name, 'any', right),
                 )
                 query = model[field_name]._search([])
                 self.assertEqual(
-                    (Domain(field_name, 'any', left) | Domain(field_name, 'any', query) | Domain(field_name, 'any', right))._optimize_for_sql(model),
+                    (Domain(field_name, 'any', left) | Domain(field_name, 'any', query) | Domain(field_name, 'any', right)).optimize(model, full=True),
                     Domain(field_name, 'any', left | right) | Domain(field_name, 'any', query),
                     "Don't merge query with domains",
                 )
                 self.assertEqual(
-                    (Domain(field_name, 'not any', left) | Domain(field_name, 'not any', right))._optimize_for_sql(model),
+                    (Domain(field_name, 'not any', left) | Domain(field_name, 'not any', right)).optimize(model, full=True),
                     Domain(field_name, 'not any', left & right) if m2o
                     else Domain(field_name, 'not any', left) | Domain(field_name, 'not any', right),
                 )
                 self.assertEqual(
-                    (Domain(field_name, 'not any', left) & Domain(field_name, 'not any', right))._optimize_for_sql(model),
+                    (Domain(field_name, 'not any', left) & Domain(field_name, 'not any', right)).optimize(model, full=True),
                     Domain(field_name, 'not any', left | right),
                 )
 
                 self.assertEqual(
-                    (Domain(field_name, 'any', left) | Domain(field_name, 'not any', right))._optimize_for_sql(model),
+                    (Domain(field_name, 'any', left) | Domain(field_name, 'not any', right)).optimize(model, full=True),
                     (Domain(field_name, 'any', left) | Domain(field_name, 'not any', right)),
                     "Do not merge any and not any",
                 )
@@ -760,6 +760,6 @@ class TestDomainOptimize(TransactionCase):
     def test_nary_optimize_same(self):
         model = self.env['test_new_api.mixed']
         self.assertEqual(
-            (self.number_domain & self.number_domain)._optimize(model),
+            (self.number_domain & self.number_domain).optimize(model),
             self.number_domain
         )

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -817,7 +817,8 @@ class DomainCondition(Domain):
             if not field.search:
                 _logger.error("Non-stored field %s cannot be searched.", field, stack_info=_logger.isEnabledFor(logging.DEBUG))
                 return _TRUE_DOMAIN
-            domain = field.determine_domain(model, self.operator, self.value)
+            value = list(self.value) if isinstance(self.value, OrderedSet) else self.value
+            domain = field.determine_domain(model, self.operator, value)
             return Domain(domain)
 
         # optimizations based on operator

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -164,7 +164,7 @@ class OptimizationLevel(enum.IntEnum):
     """Indicator whether the domain was optimized."""
     NONE = 0
     BASIC = enum.auto()
-    FOR_SQL = enum.auto()
+    FULL = enum.auto()
 
 
 MAX_OPTIMIZE_ITERATIONS = 1000
@@ -379,7 +379,7 @@ class Domain:
         and non-stored fields (using their search method) to transform the
         conditions.
         """
-        level = OptimizationLevel.FOR_SQL if full else OptimizationLevel.BASIC
+        level = OptimizationLevel.FULL if full else OptimizationLevel.BASIC
         if self._opt_level >= level:
             return self
 
@@ -417,7 +417,7 @@ class DomainBool(Domain):
         """Create a constant domain."""
         self = object.__new__(cls)
         self.value = value
-        self._opt_level = OptimizationLevel.FOR_SQL
+        self._opt_level = OptimizationLevel.FULL
         return self
 
     def __eq__(self, other):
@@ -577,14 +577,13 @@ class DomainNary(Domain):
     def _optimize(self, model: BaseModel, full: bool) -> Domain:
         # optimize children
         children = self._flatten(child.optimize(model, full=full) for child in self.children)
-        level = OptimizationLevel.FOR_SQL if full else OptimizationLevel.BASIC
         size = len(children)
         if size > 1:
             # sort children in order to ease their grouping by field and operator
             children.sort(key=_optimize_nary_sort_key)
             # run optimizations until some merge happens
-            for merge in _CONDITION_MERGE_OPTIMIZATIONS:
-                children = list(merge(type(self), model, level, children))
+            for merge in _MERGE_OPTIMIZATIONS:
+                children = list(merge(type(self), children, model))
                 if len(children) < size:
                     break
         return self.apply(children)
@@ -785,16 +784,18 @@ class DomainCondition(Domain):
             return DomainCondition(field.name, 'any', sub_domain)
 
         # optimizations based on operator
-        for opt in _CONDITION_OPTIMIZATIONS_BY_OPERATOR[self.operator]:
-            domain = opt(self, model)
-            if domain != self:
-                return domain
+        for opt in _OPTIMIZATIONS_BY_OPERATOR[self.operator]:
+            if opt.level == OptimizationLevel.BASIC:
+                domain = opt(self, model)
+                if domain != self:
+                    return domain
 
         # optimizations based on field type
-        for opt in _CONDITION_OPTIMIZATIONS_BY_FIELD_TYPE[field.type]:
-            domain = opt(self, model)
-            if domain != self:
-                return domain
+        for opt in _OPTIMIZATIONS_BY_FIELD_TYPE[field.type]:
+            if opt.level == OptimizationLevel.BASIC:
+                domain = opt(self, model)
+                if domain != self:
+                    return domain
 
         if not full:
             return self
@@ -820,16 +821,18 @@ class DomainCondition(Domain):
             return Domain(domain)
 
         # optimizations based on operator
-        for opt in _CONDITION_OPTIMIZATIONS_FOR_SQL_BY_OPERATOR[self.operator]:
-            domain = opt(self, model)
-            if domain != self:
-                return domain
+        for opt in _OPTIMIZATIONS_BY_OPERATOR[self.operator]:
+            if opt.level == OptimizationLevel.FULL:
+                domain = opt(self, model)
+                if domain != self:
+                    return domain
 
         # optimizations based on field type
-        for opt in _CONDITION_OPTIMIZATIONS_FOR_SQL_BY_FIELD_TYPE[field.type]:
-            domain = opt(self, model)
-            if domain != self:
-                return domain
+        for opt in _OPTIMIZATIONS_BY_FIELD_TYPE[field.type]:
+            if opt.level == OptimizationLevel.FULL:
+                domain = opt(self, model)
+                if domain != self:
+                    return domain
 
         # final checks
         if self.operator not in STANDARD_CONDITION_OPERATORS:
@@ -849,11 +852,36 @@ ANY_TYPES = (Domain, Query, SQL)
 
 if typing.TYPE_CHECKING:
     ConditionOptimization = Callable[[DomainCondition, BaseModel], Domain]
-_CONDITION_OPTIMIZATIONS_BY_OPERATOR: dict[str, list[ConditionOptimization]] = collections.defaultdict(list)
-_CONDITION_OPTIMIZATIONS_BY_FIELD_TYPE: dict[str, list[ConditionOptimization]] = collections.defaultdict(list)
-_CONDITION_OPTIMIZATIONS_FOR_SQL_BY_OPERATOR: dict[str, list[ConditionOptimization]] = collections.defaultdict(list)
-_CONDITION_OPTIMIZATIONS_FOR_SQL_BY_FIELD_TYPE: dict[str, list[ConditionOptimization]] = collections.defaultdict(list)
-_CONDITION_MERGE_OPTIMIZATIONS: list[Callable[[type[DomainNary], BaseModel, OptimizationLevel, Iterable[Domain]], Iterable[Domain]]] = list()
+    MergeOptimization = Callable[[type[DomainNary], Iterable[Domain], BaseModel], Iterable[Domain]]
+
+_OPTIMIZATIONS_BY_OPERATOR: dict[str, list[ConditionOptimization]] = collections.defaultdict(list)
+_OPTIMIZATIONS_BY_FIELD_TYPE: dict[str, list[ConditionOptimization]] = collections.defaultdict(list)
+_MERGE_OPTIMIZATIONS: list[MergeOptimization] = list()
+
+
+def operator_optimization(operators: Collection[str], level: OptimizationLevel = OptimizationLevel.BASIC):
+    """Register a condition operator optimization for (condition, model)"""
+    assert operators, "Missing operator to register"
+    CONDITION_OPERATORS.update(operators)
+
+    def register(optimization: ConditionOptimization):
+        optimization.level = level
+        for operator in operators:
+            _OPTIMIZATIONS_BY_OPERATOR[operator].append(optimization)
+        return optimization
+
+    return register
+
+
+def field_type_optimization(field_types: Collection[str], level: OptimizationLevel = OptimizationLevel.BASIC):
+    """Register a condition optimization by field type for (condition, model)"""
+    def register(optimization: ConditionOptimization):
+        optimization.level = level
+        for field_type in field_types:
+            _OPTIMIZATIONS_BY_FIELD_TYPE[field_type].append(optimization)
+        return optimization
+
+    return register
 
 
 def _optimize_nary_sort_key(domain: Domain) -> tuple[str, str, str]:
@@ -889,7 +917,7 @@ def _optimize_nary_sort_key(domain: Domain) -> tuple[str, str, str]:
         return '~', '', domain.OPERATOR
 
 
-def nary_optimization(optimization: Callable[[type[DomainNary], BaseModel, OptimizationLevel, Iterable[Domain]], Iterable[Domain]]):
+def nary_optimization(optimization: MergeOptimization):
     """Register an optimization to a list of children of an nary domain.
 
     The function will take an iterable containing optimized children of a
@@ -905,11 +933,11 @@ def nary_optimization(optimization: Callable[[type[DomainNary], BaseModel, Optim
     then sorts them by (field, operator_type, operator) where operator type
     groups similar operators together.
     """
-    _CONDITION_MERGE_OPTIMIZATIONS.append(optimization)
+    _MERGE_OPTIMIZATIONS.append(optimization)
     return optimization
 
 
-def nary_condition_optimization(*, operators: Collection[str], field_condition: Callable[[Field], bool] | None = None):
+def nary_condition_optimization(operators: Collection[str], field_types: Collection[str] | None = None):
     """Register an optimization for condition children of an nary domain.
 
     The function will take a list of domain conditions of the same field and
@@ -920,50 +948,26 @@ def nary_condition_optimization(*, operators: Collection[str], field_condition: 
     NOTE: if you want to merge different operators, register for
     `operator=CONDITION_OPERATORS` and find conditions that you want to merge.
     """
-    def register(optimization: Callable[[type[DomainNary], BaseModel, list[DomainCondition]], Iterable[Domain]]):
+    def grouping_key(domain):
+        return domain.field_expr if isinstance(domain, DomainCondition) and domain.operator in operators else None
+
+    def register(optimization: Callable[[type[DomainNary], list[DomainCondition], BaseModel], Iterable[Domain]]):
         @nary_optimization
-        def optimizer(cls, model, level, conditions: Iterable[Domain]):
-            for (field_expr, apply_operator), conds in itertools.groupby(
-                conditions, lambda c: (c.field_expr, True) if isinstance(c, DomainCondition) and c.operator in operators else ('', False)
-            ):
-                if (
-                    apply_operator
-                    and (field_condition is None or (
-                        (field := model._fields.get(field_expr)) is not None and field_condition(field)
-                    ))
-                ):
-                    list_conds: list[DomainCondition] = list(conds)  # type: ignore[arg-type]
-                    if len(list_conds) > 1:
-                        yield from optimization(cls, model, list_conds)
+        def optimizer(cls, domains, model):
+            # group domains by field_expr
+            for field_expr, doms in itertools.groupby(domains, grouping_key):
+                if field_expr:
+                    conditions = list(doms)
+                    if len(conditions) > 1 and (
+                        field_types is None or conditions[0]._field(model).type in field_types
+                    ):
+                        yield from optimization(cls, conditions, model)
                     else:
-                        yield from list_conds
+                        yield from conditions
                 else:
-                    yield from conds
+                    yield from doms
         return optimization
-    return register
 
-
-def operator_optimization(operators: Collection[str], level: OptimizationLevel = OptimizationLevel.BASIC):
-    """Register a condition operator optimization for (condition, model)"""
-    assert operators, "Missing operator to register"
-    CONDITION_OPERATORS.update(operators)
-
-    def register(optimization: Callable[[DomainCondition, BaseModel], Domain]):
-        optimizations = _CONDITION_OPTIMIZATIONS_BY_OPERATOR if level <= OptimizationLevel.BASIC else _CONDITION_OPTIMIZATIONS_FOR_SQL_BY_OPERATOR
-        for operator in operators:
-            optimizations[operator].append(optimization)
-        return optimization
-    return register
-
-
-def field_type_optimization(field_types: Collection[str], level: OptimizationLevel = OptimizationLevel.BASIC):
-    """Register a condition optimization by field type for (condition, model)"""
-
-    def register(optimization: Callable[[DomainCondition, BaseModel], Domain]):
-        optimizations = _CONDITION_OPTIMIZATIONS_BY_FIELD_TYPE if level <= OptimizationLevel.BASIC else _CONDITION_OPTIMIZATIONS_FOR_SQL_BY_FIELD_TYPE
-        for field_type in field_types:
-            optimizations[field_type].append(optimization)
-        return optimization
     return register
 
 
@@ -1040,17 +1044,16 @@ def _operator_equal_as_in(condition, _):
     Validation for some types and translate collection into 'in'.
     """
     value = condition.value
-    operator = 'in' if condition.operator == '=' else 'not in'
-    if isinstance(value, COLLECTION_TYPES):
-        # TODO make a warning or equality against a collection
-        if not value:  # views sometimes use ('user_ids', '!=', []) to indicate the user is set
-            _logger.debug("The domain condition %r should compare with False.", condition)
-            value = OrderedSet([False])
-        else:
-            _logger.debug("The domain condition %r should use the 'in' or 'not in' operator.", condition)
-            value = OrderedSet(value)
-    else:
+    if not isinstance(value, COLLECTION_TYPES):
         return condition
+    operator = 'in' if condition.operator == '=' else 'not in'
+    # TODO make a warning or equality against a collection
+    if not value:  # views sometimes use ('user_ids', '!=', []) to indicate the user is set
+        _logger.debug("The domain condition %r should compare with False.", condition)
+        value = OrderedSet([False])
+    else:
+        _logger.debug("The domain condition %r should use the 'in' or 'not in' operator.", condition)
+        value = OrderedSet(value)
     return DomainCondition(condition.field_expr, operator, value)
 
 
@@ -1059,9 +1062,9 @@ def _optimize_in_list(condition, _):
     """Make sure the value is a collection or use 'any' operator"""
     value = condition.value
     if isinstance(value, ANY_TYPES):
-        return DomainCondition(condition.field_expr, 'any' if condition.operator == 'in' else 'not any', value)
+        operator = 'any' if condition.operator == 'in' else 'not any'
+        return DomainCondition(condition.field_expr, operator, value)
     if not value:
-        # empty, return a boolean
         return _FALSE_DOMAIN if condition.operator == 'in' else _TRUE_DOMAIN
     if not isinstance(value, COLLECTION_TYPES):
         # TODO show warning, note that condition.field_expr in ('group_ids', 'user_ids') gives a lot of them
@@ -1090,21 +1093,14 @@ def _optimize_in_required(condition, model):
 def _optimize_any_domain(condition, model):
     """Make sure the value is an optimized domain (or Query or SQL)"""
     value = condition.value
-    if isinstance(value, Domain):
-        domain = value
-    elif isinstance(value, ANY_TYPES):
+    if isinstance(value, ANY_TYPES) and not isinstance(value, Domain):
         return condition
-    else:
-        domain = Domain(value)
+    domain = Domain(value)
     field = condition._field(model)
     if field.name == 'id':
-        """
-        id ANY domain  <=>  domain
-        id NOT ANY domain  <=>  ~domain
-        """
-        if condition.operator == 'not any':
-            domain = ~domain
-        return domain
+        # id ANY domain  <=>  domain
+        # id NOT ANY domain  <=>  ~domain
+        return domain if condition.operator == 'any' else ~domain
     # get the model to optimize with
     try:
         comodel = model.env[field.comodel_name]
@@ -1114,11 +1110,11 @@ def _optimize_any_domain(condition, model):
     # const if the domain is empty, the result is a constant
     # if the domain is True, we keep it as is
     if domain.is_false():
-        return Domain(condition.operator == 'not any')
+        return _FALSE_DOMAIN if condition.operator == 'any' else _TRUE_DOMAIN
     return DomainCondition(condition.field_expr, condition.operator, domain)
 
 
-@operator_optimization(['any', 'not any'], OptimizationLevel.FOR_SQL)
+@operator_optimization(['any', 'not any'], OptimizationLevel.FULL)
 def _optimize_any_domain_for_sql(condition, model):
     domain = condition.value
     if not isinstance(domain, Domain):
@@ -1153,7 +1149,7 @@ def _optimize_like_str(condition, model):
     return DomainCondition(condition.field_expr, condition.operator, str(value))
 
 
-@field_type_optimization(['many2one', 'one2many', 'many2many'], OptimizationLevel.FOR_SQL)
+@field_type_optimization(['many2one', 'one2many', 'many2many'], OptimizationLevel.FULL)
 def _optimize_relational_name_search(condition, model):
     """Search using display_name; see _value_to_ids."""
     operator = condition.operator
@@ -1222,24 +1218,22 @@ def _optimize_boolean_in(condition, model):
     return DomainCondition(condition.field_expr, operator, value)
 
 
-@field_type_optimization(['boolean'], OptimizationLevel.FOR_SQL)
+@field_type_optimization(['boolean'], OptimizationLevel.FULL)
 def _optimize_boolean_in_all(condition, model):
     """b in [True, False]  =>  True"""
     if isinstance(condition.value, COLLECTION_TYPES) and set(condition.value) == {False, True}:
         # tautology is simplified to a boolean
         # note that this optimization removes fields (like active) from the domain
-        # so we do this only on FOR_SQL level to avoid removing it from sub-domains
+        # so we do this only on FULL level to avoid removing it from sub-domains
         return Domain(condition.operator == 'in')
     return condition
 
 
 def _value_to_date(value):
     # check datetime first, because it's a subclass of date
-    if isinstance(value, SQL):
-        return value
     if isinstance(value, datetime):
         return value.date()
-    if isinstance(value, date) or value is False:
+    if isinstance(value, (SQL, date)) or value is False:
         return value
     if isinstance(value, str):
         # TODO can we use fields.Date.to_date? same for datetime
@@ -1273,9 +1267,7 @@ def _optimize_type_date(condition, _):
 
 
 def _value_to_datetime(value):
-    if isinstance(value, SQL):
-        return value, False
-    if isinstance(value, datetime) or value is False:
+    if isinstance(value, (SQL, datetime)) or value is False:
         return value, False
     if isinstance(value, str):
         return datetime.fromisoformat(value), len(value) == 10
@@ -1340,7 +1332,7 @@ def _optimize_type_binary_attachment(condition, model):
     return condition
 
 
-@operator_optimization(['parent_of', 'child_of'], OptimizationLevel.FOR_SQL)
+@operator_optimization(['parent_of', 'child_of'], OptimizationLevel.FULL)
 def _operator_hierarchy(condition, model):
     """Transform a hierarchy operator into a simpler domain.
 
@@ -1446,15 +1438,19 @@ def _operator_parent_of_domain(comodel: BaseModel, parent):
 # --------------------------------------------------
 
 
-@nary_condition_optimization(operators=('any',), field_condition=lambda f: f.type == 'many2one')
-def _optimize_merge_many2one_any(cls, model, conditions):
-    """Merge domains of 'any' conditions for many2one fields.
+@nary_condition_optimization(['any'], ['many2one', 'one2many', 'many2many'])
+def _optimize_merge_any(cls, conditions, model):
+    """Merge domains of 'any' conditions for relational fields.
 
     This will lead to a smaller number of sub-queries which are equivalent.
     Example:
 
-        a.f = 8 and a.g = 5  <=>  a any (f = 8 and g = 5)
+        a any (f = 8) or a any (g = 5)  <=>  a any (f = 8 or g = 5)     (for all fields)
+        a any (f = 8) and a any (g = 5)  <=>  a any (f = 8 and g = 5)   (for many2one fields only)
     """
+    field = conditions[0]._field(model)
+    if field.type != 'many2one' and cls is DomainAnd:
+        return conditions
     merge_conditions, other_conditions = partition(lambda c: isinstance(c.value, Domain), conditions)
     if len(merge_conditions) < 2:
         return conditions
@@ -1463,16 +1459,19 @@ def _optimize_merge_many2one_any(cls, model, conditions):
     return [DomainCondition(field_expr, 'any', sub_domain), *other_conditions]
 
 
-@nary_condition_optimization(operators=('not any',), field_condition=lambda f: f.type == 'many2one')
-def _optimize_merge_many2one_not_any(cls, model, conditions):
-    """Merge domains of 'not any' conditions for many2one fields.
+@nary_condition_optimization(['not any'], ['many2one', 'one2many', 'many2many'])
+def _optimize_merge_not_any(cls, conditions, model):
+    """Merge domains of 'not any' conditions for relational fields.
 
     This will lead to a smaller number of sub-queries which are equivalent.
     Example:
 
-        a not any f = 1 or a not any g = 5 => a not any (f = 1 and g = 5)
-        a not any f = 1 and a not any g = 5 => a not any (f = 1 or g = 5)
+        a not any (f = 1) or a not any (g = 5) => a not any (f = 1 and g = 5)   (for many2one fields only)
+        a not any (f = 1) and a not any (g = 5) => a not any (f = 1 or g = 5)   (for all fields)
     """
+    field = conditions[0]._field(model)
+    if field.type != 'many2one' and cls is DomainOr:
+        return conditions
     merge_conditions, other_conditions = partition(lambda c: isinstance(c.value, Domain), conditions)
     if len(merge_conditions) < 2:
         return conditions
@@ -1481,41 +1480,8 @@ def _optimize_merge_many2one_not_any(cls, model, conditions):
     return [DomainCondition(field_expr, 'not any', sub_domain), *other_conditions]
 
 
-@nary_condition_optimization(operators=('any',), field_condition=lambda f: f.type.endswith('2many'))
-def _optimize_merge_x2many_any(cls, model, conditions):
-    """Merge domains of 'any' conditions for x2many fields.
-
-    This will lead to a smaller number of sub-queries which are equivalent.
-    Example:
-
-        a.f = 8 or a.g = 5  <=>  a any (f = 8 or g = 5)
-
-    Note that the following cannot be optimized as multiple instances can
-    satisfy conditions:
-
-        a.f = 8 and a.g = 5
-    """
-    if cls is DomainAnd:
-        return conditions
-    return _optimize_merge_many2one_any(cls, model, conditions)
-
-
-@nary_condition_optimization(operators=('not any',), field_condition=lambda f: f.type.endswith('2many'))
-def _optimize_merge_x2many_not_any(cls, model, conditions):
-    """Merge domains of 'not any' conditions for x2many fields.
-
-    This will lead to a smaller number of sub-queries which are equivalent.
-    Example:
-
-        a not any f = 1 and a not any g = 5  <=>  a not any (f = 1 or g = 5)
-    """
-    if cls is DomainOr:
-        return conditions
-    return _optimize_merge_many2one_not_any(cls, model, conditions)
-
-
 @nary_optimization
-def _optimize_same_conditions(cls, model, level, conditions: Iterable[Domain]):
+def _optimize_same_conditions(cls, conditions, model):
     """Merge (adjacent) conditions that are the same.
 
     Quick optimization for some conditions, just compare if we have the same

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -723,7 +723,7 @@ class _RelationalMulti(_Relational[M], typing.Generic[M]):
             return query
         if isinstance(value, Query):
             # add the field_domain to the query
-            domain = field_domain._optimize_for_sql(comodel)
+            domain = field_domain.optimize(comodel, full=True)
             if not domain.is_true():
                 # TODO should clone/copy Query value
                 value.add_where(domain._to_sql(comodel, value.table, value))

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4849,7 +4849,7 @@ class BaseModel(metaclass=MetaModel):
         ):
             domain &= Domain(self._active_name, '=', True)
 
-        domain = domain._optimize_for_sql(self)
+        domain = domain.optimize(self, full=True)
         if domain.is_false():
             return self.browse()._as_query()
         query = Query(self.env, self._table, self._table_sql)
@@ -4880,7 +4880,7 @@ class BaseModel(metaclass=MetaModel):
         domain = self.env['ir.rule']._compute_domain(self._name, mode)
         if not domain.is_true():
             model = self.sudo()
-            domain = domain._optimize_for_sql(model)
+            domain = domain.optimize(model, full=True)
             query.add_where(domain._to_sql(model, query.table, query))
 
     def _order_to_sql(self, order: str, query: Query, alias: (str | None) = None,
@@ -5021,7 +5021,7 @@ class BaseModel(metaclass=MetaModel):
             sec_domain = Domain.TRUE
         else:
             sec_domain = self.env['ir.rule']._compute_domain(self._name, 'read')
-            sec_domain = sec_domain._optimize_for_sql(self.sudo())
+            sec_domain = sec_domain.optimize(self.sudo(), full=True)
 
         # build the query
         if sec_domain.is_false() or (not limit and limit is not None and limit is not False):

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -266,7 +266,7 @@ def domain_combine_anies(domain, model):
     conditions have been combined in order to generate less subqueries.
     """
     warnings.warn("Since 19.0, use Domain() object", DeprecationWarning)
-    return orm_domains.Domain(domain)._optimize(model)
+    return orm_domains.Domain(domain).optimize(model)
 
 
 def prettify_domain(domain, pre_indent=0):
@@ -443,7 +443,7 @@ class expression(object):
 
         # normalize and prepare the expression for parsing
         domain = orm_domains.Domain(domain)
-        domain = domain._optimize_for_sql(self.root_model)
+        domain = domain.optimize(self.root_model, full=True)
         self.expression = domain
 
         # this object handles all the joins


### PR DESCRIPTION
This introduces a few improvements:
- introduce public method `optimize()` to replace `_optimize()` and `_optimize_for_sql()`; the boolean parameter `full` makes the distinction between basic and advanced optimization;
- add the attribute `_opt_level` on all `Domain` objects: all optimized domains are flagged with the corresponding optimization level;
- simplify the determination of the fixpoint of optimizations;
- a few extra code simplifications.