### PR TITLE
[FIX] l10n_ar: Validation error raised at creation on trial

### DIFF
--- a/addons/l10n_ar/models/account_chart_template.py
+++ b/addons/l10n_ar/models/account_chart_template.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, api, _
+from odoo.exceptions import ValidationError
 from odoo.addons.account.models.chart_template import template
 
 
@@ -32,9 +33,15 @@ class AccountChartTemplate(models.AbstractModel):
                 'country_id': self.env['res.country'].search([('code', '=', 'AR')]).id,
                 'tax_calculation_rounding_method': 'round_globally',
             })
-            # set CUIT identification type (which is the argentinean vat) in the created company partner instead of
-            # the default VAT type.
-            company.partner_id.l10n_latam_identification_type_id = self.env.ref('l10n_ar.it_cuit')
+
+            current_identification_type = company.partner_id.l10n_latam_identification_type_id
+            try:
+                # set CUIT identification type (which is the argentinean vat) in the created company partner instead of
+                # the default VAT type.
+                company.partner_id.l10n_latam_identification_type_id = self.env.ref('l10n_ar.it_cuit')
+            except ValidationError:
+                # put back previous value if we could not validate the CUIT
+                company.partner_id.l10n_latam_identification_type_id = current_identification_type
 
         res = super()._load(template_code, company, install_demo,force_create)
 


### PR DESCRIPTION
### Steps to reproduce:
- Create a new DB on odoo.com/trial with Argentinean localization, and your Odoo email.
- After installation, a validation is raised: "Invalid length for CUIT".

### Here is what happens:
1. When creating a new company, the enrich function tries to complete data. 
If you created the database with an `odoo.com` email for example, the Company will be filled with a Belgian VAT.
https://github.com/odoo/odoo/blob/5bb57a916d3069cd609e07d401dd3b4c39f85954/addons/partner_autocomplete/models/res_company.py#L23-L28

2. The l10n_ar is then installed, and the CUIT will be set as the default identification. https://github.com/odoo/odoo/blob/9a44bc80a5f8bd1cfcb05a3a9f4abdbd67228488/addons/l10n_ar/models/account_chart_template.py#L37

3. Finally, the validation is triggered by the modification above. Obviously the Belgian VAT is not compatible with the CUIT format, which leads to a User Error.
https://github.com/odoo/odoo/blob/4c1d2025118b98e89c131a32d46015d9c6a3b032/addons/l10n_ar/models/res_partner.py#L56-L57

Note: to reproduce in local, you have to add IAP credits.

### Solution:
Solution:
When installing the l10n_ar package, let's only set CUIT as a default if the validation passes.

opw-4609583
