### PR TITLE
[FIX] l10n_fr_account: Fix module auto install

### DIFF
--- a/addons/l10n_fr_account/__manifest__.py
+++ b/addons/l10n_fr_account/__manifest__.py
@@ -4,6 +4,7 @@
     'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/france.html',
     'icon': '/account/static/description/l10n.png',
     'version': '2.1',
+    'countries': ['fr'],
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 This is the module to manage the accounting chart for France in Odoo.
@@ -33,7 +34,7 @@ configuration of their taxes and fiscal positions manually.
         'account',
         'l10n_fr',
     ],
-    'auto_install': ['account', 'l10n_fr'],
+    'auto_install': ['account'],
     'data': [
         'data/account_chart_template_data.xml',
         'data/account_data.xml',


### PR DESCRIPTION
Previously, the auto_install flag was set on both
account and l10n_fr, preventing proper installation of the fiscal localization package.

Now, the fiscal localization package is correctly
installed when a French company is created and the account module is installed.

opw-4630911


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
