### PR TITLE
[FIX] mrp{,_workorder}: run procurement when adding component on an MO

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -435,7 +435,7 @@ class StockMove(models.Model):
             # when updating consumed qty need to update related pickings
             # context no_procurement means we don't want the qty update to modify stock i.e create new pickings
             # ex. when spliting MO to backorders we don't want to move qty from pre prod to stock in 2/3 step config
-            self.filtered(lambda m: m.raw_material_production_id.state == 'confirmed')._run_procurement(old_demand)
+            self.filtered(lambda m: m.raw_material_production_id.state in ('confirmed', 'progress', 'to_close'))._run_procurement(old_demand)
         return res
 
     def _run_procurement(self, old_qties=False):


### PR DESCRIPTION
### Steps to reproduce:

- In the settings, enable multi-step routes.
- Set Warehouse to 2-step Manufacturing
- Create a BoM with an operation and one move raw: 1 x COMP
- Create confirm, plan and **start** an MO with that bom.
- Through Shop Floor, on your operation > Wheel > add components
- Set the quantity of COMP to 10 instead of 1.
#### > In the backend, observe that the picking Stock -> Pre-Prod has not been updated

### Cause of the issue:

Adding a product already referenced as a raw material via the catalog will trigger a call of the `_update_order_line_info` which will update the demand of the move raw:
https://github.com/odoo/odoo/blob/38821f7ffae0aa15c10f3e6972b01aafade6bc60/addons/mrp/models/mrp_production.py#L2895-L2898 https://github.com/odoo/odoo/blob/38821f7ffae0aa15c10f3e6972b01aafade6bc60/addons/mrp/models/mrp_production.py#L2913-L2914 If you did not start the MO, this would run the procurement to update the demand and thus update the picking:
https://github.com/odoo/odoo/blob/38821f7ffae0aa15c10f3e6972b01aafade6bc60/addons/mrp/models/stock_move.py#L434-L438 However, since the MO was started the state of the MO is 'in_progress' instead of 'confirmed'.

Note:

The issue was not reproducible before 18.0. Since adding a component was done via a call that would create and confirm a new move (hence running the procurements):
https://github.com/odoo/enterprise/blob/b3febe5a1afd5c1c8fd598db95e8c58fa4131563/mrp_workorder/wizard/additional_product.py#L63-L68

Enterprise: https://github.com/odoo/enterprise/pull/81361

opw-4638371
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
