### PR TITLE
[FIX] pos_self_order: Ensure correct translations on self-order screens

### DIFF
--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -26,7 +26,7 @@ class PosSelfKiosk(http.Controller):
                 }
             )
 
-    @http.route("/pos-self/data/<config_id>", type='json', auth='public')
+    @http.route("/pos-self/data/<config_id>", type='json', auth='public', website=True)
     def get_self_ordering_data(self, config_id=None, access_token=None, table_identifier=None):
         pos_config, _, _ = self._verify_entry_access(config_id, access_token, table_identifier)
         data = pos_config.load_self_data()

--- a/addons/pos_self_order/models/ir_http.py
+++ b/addons/pos_self_order/models/ir_http.py
@@ -19,8 +19,21 @@ class IrHttp(models.AbstractModel):
     # This override works around the issue.
     @api.model
     def get_nearest_lang(self, lang_code: str) -> str:
-        if lang_code and '/pos-self/' in request.httprequest.path:
-            config_id_match = re.search(r'/pos-self/(\d+)', request.httprequest.path)
+        if not lang_code:
+            return super().get_nearest_lang(lang_code)
+
+        referer_url = request.httprequest.headers.get('Referer', '')
+        path = request.httprequest.path
+
+        if '/pos-self/' in path:
+            path_with_config = path
+        elif '/website/translations' in path and '/pos-self/' in referer_url:
+            path_with_config = referer_url
+        else:
+            path_with_config = None
+
+        if path_with_config:
+            config_id_match = re.search(r'/pos-self(?:/data)?/(\d+)', path_with_config)
             if config_id_match:
                 pos_config = request.env['pos.config'].sudo().browse(int(config_id_match[1]))
                 if pos_config.self_ordering_available_language_ids:

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -133,7 +133,14 @@ registry.category("web_tour.tours").add("self_order_language_changes", {
     steps: () => [
         LandingPage.checkLanguageSelected("English"),
         LandingPage.checkCountryFlagShown("us"),
-        Utils.openLanguageSelector(),
-        Utils.checkLanguageIsAvailable("French"),
+
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Test Product"),
+        ...ProductPage.clickCancel(),
+
+        ...Utils.changeLanguage("French"),
+
+        Utils.clickBtn("Commander maintenant"),
+        ProductPage.clickProduct("Produit Test"),
     ],
 });

--- a/addons/pos_self_order/static/tests/tours/utils/common.js
+++ b/addons/pos_self_order/static/tests/tours/utils/common.js
@@ -55,3 +55,19 @@ export function openLanguageSelector() {
         run: "click",
     };
 }
+
+export function changeLanguage(language) {
+    return [
+        openLanguageSelector(),
+        {
+            content: `Check that the language is available`,
+            trigger: `.self_order_language_popup .btn:contains(${language})`,
+            in_modal: false,
+            run: "click",
+        },
+        {
+            content: `Check that the language changed`,
+            trigger: `.self_order_language_selector:contains(${language})`,
+        },
+    ];
+}

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -61,6 +61,15 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
 
     def test_self_order_language_changes(self):
         self.env['res.lang']._activate_lang('fr_FR')
+
+        product = self.env['product.product'].create({
+            'name': "Test Product",
+            'list_price': 100,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+        product.with_context(lang='fr_FR').name = "Produit Test"
+
         self.pos_config.write({
             'self_ordering_available_language_ids': [Command.link(lang.id) for lang in self.env['res.lang'].search([])],
             'self_ordering_takeaway': False,
@@ -68,6 +77,11 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
             'self_ordering_pay_after': 'each'
         })
 
+        link = self.env['pos_self_order.custom_link'].search(
+            [('pos_config_ids', '=', self.pos_config.id), ('name', '=', 'Order Now')]
+        )
+        link.with_context(lang='fr_FR').name = "Commander maintenant"
+
         self.pos_config.with_user(self.pos_user).open_ui()
         self_route = self.pos_config._get_self_order_route()
-        self.start_tour(self_route, "self_order_language_changes")
+        self.start_tour(self_route, 'self_order_language_changes')


### PR DESCRIPTION
The self-ordering kiosk does not correctly display translations for product names and other UI elements when switching languages. Some elements remain in English or the database language, even when translations are available.  

### Steps to Reproduce  

1. Open **Point of Sale** and navigate to **Configuration > Settings**.  
2. Select a POS configuration that has **Kiosk/Self-ordering** enabled.  
3. Add additional languages to the Kiosk and save the changes.  
4. Open a product available in the Kiosk POS and add translations for its name.  
5. Start a new Kiosk session, switch to the Kiosk window, and change the language.  
6. Notice that product names and other UI elements remain in English instead of switching to the selected language.  

### Cause  

- The `/pos-self/data/<config_id>` route was missing `website=True`, preventing it from receiving the correct frontend language setting.  
- Adding `website=True` fixes this issue, allowing the POS frontend to receive the correct language.  

### Secondary Issue

- After adding `website=True`, another problem emerged when the **website module** is installed.  
- In this case, the available languages were taken from the **website settings** instead of the **POS settings**.  
- This means that if the website only supports English but the POS Kiosk supports both English and French, switching the Kiosk language to French would fail. The system would always revert to English because language validation was still based on website settings rather than POS settings.  

### Solution  

1. **Fix the original issue** by adding `website=True` to ensure the POS self-ordering system receives the correct language.  
2. **Work around the secondary issue** by checking the **Referer** header to determine if the request comes from a POS self-ordering session.  
3. **Ensure language validation is based on POS settings**, not website settings, by retrieving available languages from the POS configuration when necessary.  

This solution follows a similar approach to the fix in **cd69a32503f4dcd11851908e2c983e1d49a1c2a8**, but in this case, the problematic route (`/website/translations`) is not strictly POS-related. Therefore, we must check the referer to extract the correct POS information.


opw-4557569
opw-4471819
opw-4436306
