### PR TITLE
[FIX] spreadsheet: correctly update field matching

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_global_filter_plugin.js
@@ -134,15 +134,13 @@ export class PivotCoreGlobalFilterPlugin extends OdooCorePlugin {
      * @param {Record<string,FieldMatching>} pivotFieldMatches
      */
     _setPivotFieldMatching(filterId, pivotFieldMatches) {
-        const pivots = { ...this.pivots };
         for (const [pivotId, fieldMatch] of Object.entries(pivotFieldMatches)) {
             const pivot = this.getters.getPivotCoreDefinition(pivotId);
             if (pivot.type !== "ODOO") {
                 continue;
             }
-            this.pivots[pivotId].fieldMatching[filterId] = fieldMatch;
+            this.history.update("pivots", pivotId, "fieldMatching", filterId, fieldMatch);
         }
-        this.history.update("pivots", pivots);
     }
 
     _onFilterDeletion(filterId) {
@@ -159,13 +157,10 @@ export class PivotCoreGlobalFilterPlugin extends OdooCorePlugin {
     _addPivot(id, fieldMatching = undefined) {
         const pivot = this.getters.getPivotCoreDefinition(id);
         if (pivot.type === "ODOO") {
-            const pivots = { ...this.pivots };
-            const model = pivot.model;
-            pivots[id] = {
+            this.history.update("pivots", id, {
                 id,
-                fieldMatching: fieldMatching || this.getters.getFieldMatchingForModel(model),
-            };
-            this.history.update("pivots", pivots);
+                fieldMatching: fieldMatching || this.getters.getFieldMatchingForModel(pivot.model),
+            });
         }
     }
 

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -30,6 +30,8 @@ import {
     setCellContent,
     setCellFormat,
     setGlobalFilterValue,
+    undo,
+    redo,
 } from "@spreadsheet/../tests/helpers/commands";
 import {
     assertDateDomainEqual,
@@ -2615,4 +2617,47 @@ test("Updating the list domain should keep the global filter domain", async () =
     expect(computedDomain.toString()).toBe(
         `["&", ("date", ">=", "2022-01-01"), ("date", "<=", "2022-12-31")]`
     );
+});
+
+test("Undo/Redo of global filter update", async () => {
+    const { model, pivotId } = await createSpreadsheetWithPivot();
+    const filter = {
+        id: "43",
+        type: "date",
+        label: "This Year",
+        rangeType: "fixedPeriod",
+        defaultValue: "this_year",
+        defaultsToCurrentPeriod: true,
+    };
+    await addGlobalFilter(model, filter, {
+        pivot: { [pivotId]: { chain: "date", type: "date", offset: 0 } },
+    });
+    expect(model.getters.getPivotFieldMatching(pivotId, filter.id)).toEqual({
+        chain: "date",
+        type: "date",
+        offset: 0,
+    });
+    model.dispatch("EDIT_GLOBAL_FILTER", {
+        filter,
+        pivot: {
+            [pivotId]: { chain: "date", type: "date", offset: -1 },
+        },
+    });
+    expect(model.getters.getPivotFieldMatching(pivotId, filter.id)).toEqual({
+        chain: "date",
+        type: "date",
+        offset: -1,
+    });
+    undo(model);
+    expect(model.getters.getPivotFieldMatching(pivotId, filter.id)).toEqual({
+        chain: "date",
+        type: "date",
+        offset: 0,
+    });
+    redo(model);
+    expect(model.getters.getPivotFieldMatching(pivotId, filter.id)).toEqual({
+        chain: "date",
+        type: "date",
+        offset: -1,
+    });
 });


### PR DESCRIPTION
Before this commit, the field matching of the pivots was changed in place instead of using `this.history`, which caused issues with the undo/redo.

Task: 4646822

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
