### PR TITLE
[FIX] account: Fix sending invoice by email to other contacts

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -524,11 +524,12 @@ class AccountMoveSend(models.AbstractModel):
 
         self._generate_dynamic_reports(moves_data)
 
-        for move, move_data in [(move, move_data) for move, move_data in moves_data.items() if move.partner_id.email]:
+        for move, move_data in moves_data.items():
             mail_template = move_data['mail_template']
             mail_lang = move_data['mail_lang']
             mail_params = self._get_mail_params(move, move_data)
-            if not mail_params:
+            valid_mail_contacts = self.env['res.partner'].browse(move_data['mail_partner_ids'] + move.partner_id.ids).filtered('email')
+            if not mail_params or not valid_mail_contacts:
                 continue
 
             if move_data.get('proforma_pdf_attachment'):


### PR DESCRIPTION
If the invoice partner has no email address set, you can't send out the invoice by email to other contacts. Check email for contacts in the mail_partner_ids field instead of invoice partner and send to emails existed.

opw-4624587


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
