### PR TITLE
[FIX] pos_loyalty: PosLoyaltyTour2 tour

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -121,7 +121,8 @@ registry.category("web_tour.tours").add("PosLoyaltyTour2", {
             PosLoyalty.hasRewardLine("90% on the cheapest product", "-4.59"),
             // set quantity to 18
             // free qty stays the same since the amount of points on the card only allows for 4 free products
-            ProductScreen.clickNumpad("⌫", "8"),
+            //TODO: The following step should works with ProductScreen.clickNumpad("⌫", "8"),
+            ProductScreen.clickNumpad("⌫", "⌫", "1", "8"),
             PosLoyalty.hasRewardLine("10% on your order", "-6.68"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-20.40"),
             // scan the code again and check notification


### PR DESCRIPTION
This commit fixes an undeterministic behavior error in POS. Changing the number of products with "⌫", "8" does not recalculate the number of free products. To recalculate, you must type "⌫", "⌫", "1", "8".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
