### PR TITLE
[IMP] web: add support for :indeterminate state in CheckBox component

### DIFF
--- a/addons/web/static/src/core/checkbox/checkbox.js
+++ b/addons/web/static/src/core/checkbox/checkbox.js
@@ -51,6 +51,10 @@ export class CheckBox extends Component {
             type: String,
             optional: true,
         },
+        indeterminate: {
+            type: Boolean,
+            optional: true,
+        },
     };
 
     setup() {

--- a/addons/web/static/src/core/checkbox/checkbox.xml
+++ b/addons/web/static/src/core/checkbox/checkbox.xml
@@ -10,6 +10,7 @@
             t-att-disabled="props.disabled"
             t-att-checked="props.value"
             t-att-name="props.name"
+            t-att-indeterminate="props.indeterminate"
             t-on-change="onChange"
         />
         <label t-att-for="props.id or id" class="form-check-label">

--- a/addons/web/static/tests/core/checkbox.test.js
+++ b/addons/web/static/tests/core/checkbox.test.js
@@ -133,3 +133,16 @@ test("toggling through multiple ways", async () => {
     expect(`.o-checkbox input`).not.toBeChecked();
     expect.verifySteps(["true", "false", "true", "false"]);
 });
+
+test("checkbox with props indeterminate", async () => {
+    class Parent extends Component {
+        static components = { CheckBox };
+        static props = {};
+        static template = xml`<CheckBox indeterminate="true" />`;
+    }
+
+    await mountWithCleanup(Parent);
+
+    expect(`.o-checkbox input`).toHaveCount(1);
+    expect(`.o-checkbox input`).toBeChecked({ indeterminate: true });
+});


### PR DESCRIPTION
This commit adds support for the "indeterminate" state of the
`input[type=checkbox]` in the Checkbox component.

For example, a "select all/deselect all" checkbox may be in the
indeterminate state when some but not all of its sub-controls are
checked.

Reference:
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/indeterminate
- https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate
