### PR TITLE
[FIX] account_peppol: ignore archived edi users

### DIFF
--- a/addons/account_edi_proxy_client/models/res_company.py
+++ b/addons/account_edi_proxy_client/models/res_company.py
@@ -6,4 +6,4 @@ from odoo import fields, models
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    account_edi_proxy_client_ids = fields.One2many('account_edi_proxy_client.user', inverse_name='company_id')
+    account_edi_proxy_client_ids = fields.One2many('account_edi_proxy_client.user', inverse_name='company_id', context={'active_test': True})

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -102,6 +102,22 @@ class TestPeppolParticipant(TransactionCase):
         yield self
         self.env.context = previous_context
 
+    def test_ignore_archived_edi_users(self):
+        wizard = self.env['peppol.registration'].create(self._get_participant_vals())
+        wizard.button_peppol_sender_registration()
+
+        self.env['account_edi_proxy_client.user'].create([{
+            'active': False,
+            'id_client': f'client-demo',
+            'company_id': self.env.company.id,
+            'edi_identification': f'client-demo',
+            'private_key_id': self.env['certificate.key'].sudo()._generate_rsa_private_key(self.env.company).id,
+            'refresh_token': False,
+            'proxy_type': 'peppol',
+            'edi_mode': 'demo',
+        }])
+        self.env.company.with_context(active_test=False).partner_id.button_account_peppol_check_partner_endpoint()
+
     def test_create_participant_missing_data(self):
         # creating a participant without eas/endpoint/document should not be possible
         wizard = self.env['peppol.registration'].create({


### PR DESCRIPTION
In lots of places within peppol we suppose that we only have one edi user, but we can end up in a situation where this is not the case by archiving a user. In some cases, where there is `active_test = False`, we can end up in a situation with a traceback because there are multiple edi users if you count archived users

Steps to reproduce:
- Select company BE Company CoA
- Open Settings > Accounting > PEPPOL Electronic Invoicing
- Activate Electronic Invoicing (if is not activated)
- Go to Accounting / Configuration / EDI Proxy Users
- Select the unique record (demo2peppol)
- Edit the id_client of the record to another one (this must need Odoo Studio or Odoo Inspector > Write > {"id_client": "another"})
- Go to tree view of EDI Proxy Users
- Archive it
- Open Settings > Accounting > PEPPOL Electronic Invoicing
- Remove from PEPPOL (archived record will not be deleted)
- Activate Electronic Invoicing Again (now you have one record active and another not)
- Go to Contacts > Search "BE Company CoA" > Select Contact
- Go to Accounting Tab > Customer Invoices section > Enable eInvoice Format (BIS Billing 3.0)
- Go to Contact & Addresses Tab
- Try to add a new Contact type (error while saving)

opw-4572074