### PR TITLE
[FIX] account: SEPA payment missing partner_bank_id value

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -788,11 +788,15 @@ class AccountPaymentRegister(models.TransientModel):
             'company_id': self.company_id.id,
             'currency_id': batch_values['source_currency_id'],
             'partner_id': batch_values['partner_id'],
-            'partner_bank_id': partner_bank_id,
             'payment_method_line_id': payment_method_line.id,
             'destination_account_id': batch_result['lines'][0].account_id.id,
             'write_off_line_vals': [],
         }
+
+        # In case it is false, we don't add it to the create vals so that
+        # _compute_partner_bank_id is executed at payment creation
+        if partner_bank_id:
+            payment_vals['partner_bank_id'] = partner_bank_id
 
         total_amount, mode = self._get_total_amount_using_same_currency(batch_result)
         currency = self.env['res.currency'].browse(batch_values['source_currency_id'])


### PR DESCRIPTION
Description of the issue this commit addresses:

When registering a SEPA payment, it is possible to get a UserError telling you
to validate therecipient bank account while it is validated.

---

Steps to reproduce:

1. Install account.
2. Activate SEPA Credit Transfer (SCT) in the settings.
3. On the Bank journal's settings, input an account number.
4. Make sure the accounts used for the transfer authorize sending money.
5. Create a move in the misc journal with multiple lines and distinct partners.
6. Post the move. Go in the journal entries. Select it. "Register Payment".
7. Change the Payment Method for SEPA Credit Transfer. "Create Payments".
8. A UserError shows up.

---

Desired behavior after this commit is merged:

No UserError shows up, the payments are created.

---

Note on the fix:

The error happened because one of the condition for raising the UserError is a
value of a record in a many2one relation which is a stored computed field. As
the payment is created with a list of values, the compute method is not
triggered and the many2one remains empty while it should not.

This fix makes sure the partner_bank_id is only put in the payment values once
it has been computed to avoid keeping it false.

---

opw-4518374

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
