### PR TITLE
[FIX] purchase: do not overwrite PO when processing xml bill

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -410,6 +410,10 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
 
+        if self.line_ids.purchase_line_id.order_id:
+            # Bill is already associated with a purchase order
+            return
+
         method, matched_po_lines, matched_inv_lines = self._match_purchase_orders(
             po_references, partner_id, amount_total, from_ocr, timeout
         )

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -708,6 +708,19 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
 @tagged('post_install', '-at_install')
 class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
 
+    def test_no_overwrite(self):
+        po_a = self.init_purchase(confirm=True, partner=self.partner_a, products=[self.product_order])
+        po_b = self.init_purchase(confirm=True, partner=self.partner_a, products=[self.product_order])
+        po_b.order_line.qty_received = 1
+        po_b.action_create_invoice()
+        bill = po_b.invoice_ids
+
+        bill._find_and_set_purchase_orders(
+            [], bill.partner_id.id, bill.amount_total)
+
+        self.assertTrue(bill.id in po_b.invoice_ids.ids)
+        self.assertFalse(bill.id in po_a.invoice_ids.ids)
+
     def test_total_match_via_partner(self):
         po = self.init_purchase(confirm=True, partner=self.partner_a, products=[self.product_order])
         invoice = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order])


### PR DESCRIPTION
Currently in MX localization we process xml bills representing a CFDI
and update the bill accordingly. However, we might relink the bill with
a wrong PO in case a similar one exists

Steps to reproduce:
- With an MX Company setup
- Create a PO [PO1] with [Partner] and a line and confirm it
- Create an identical PO [PO2], confirm it, receive and create bill
  (Note: the bill is currently associated with PO2)
- In the bill upload the corresponding xml bill

Issue: After uploading the document, the bill will be associated to PO1

This occurs because in case of CFDI xml bills we process the attachment
and update the bill even if some lines already exists.
The system tries to find a PO to associate with the bill even if it's
already linked with one, looking for a purchase order not yet invoiced
with same partner and amount.
If one is found, the bill will be associated with this PO

opw-4521106