### PR TITLE
[FIX] l10n_*: remove countries from the manifest

### DIFF
--- a/addons/l10n_sa_pos/__manifest__.py
+++ b/addons/l10n_sa_pos/__manifest__.py
@@ -3,7 +3,6 @@
 {
     'name': 'Saudi Arabia - Point of Sale',
     'category': 'Accounting/Localizations/Point of Sale',
-    'countries': ['sa'],
     'description': """
 Saudi Arabia POS Localization
 ===========================================================


### PR DESCRIPTION
After https://github.com/odoo/odoo/pull/144586, the modules other than base localization module should not have the `countries` key defined in their manifest.

The issue happens because `countries` key works similar to auto-install and it can lead to unwanted installation of the module.

As there was no check implemented, for some modules this key was used accidentally and caused issues with auto-install.

This commit removes this field from the manifest of the modules that could have this problem to avoid the issue.

Also in https://github.com/odoo/odoo/pull/201526 a linting test is proposed to avoid having the same issue in the future.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
