### PR TITLE
[FIX] point_of_sale in _loadMissingProducts we must wait _addProducts…

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -708,7 +708,7 @@ export class PosStore extends Reactive {
         if (!missingProductIds.size) {
             return;
         }
-        this._addProducts([...missingProductIds], false);
+        await this._addProducts([...missingProductIds], false);
     }
     async _loadMissingPricelistItems(products) {
         if (!products.length) {


### PR DESCRIPTION
… as it async function too

Description of the issue/feature this PR addresses:
in some cases when try to load an order and some products not loaded yet, not all products are shown on the ticket screen
Current behavior before PR:
sometimes not all products are shown on the ticket screen
Desired behavior after PR is merged:
all products are shown on the ticket screen for paid orders



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
