### PR TITLE
[FIX] web: fallback on classic footer if no tag line

### DIFF
--- a/addons/l10n_hu_edi/views/report_templates.xml
+++ b/addons/l10n_hu_edi/views/report_templates.xml
@@ -38,15 +38,15 @@
         </xpath>
 
         <!-- support for custom footer -->
-        <div class="o_footer_content row border-top pt-2" position="attributes">
+        <xpath expr="//div[hasclass('o_footer_content')]" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
-        </div>
-        <div class="o_footer_content row border-top pt-2" position="after">
-            <div class="o_footer_content row border-top pt-2"
-                 t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
-                <t t-out="custom_footer"/>
+        </xpath>
+        <xpath expr="//div[hasclass('o_footer_content')]" position="after">
+            <div class="o_footer_content border-top pt-2" t-attf-class="{{'d-flex' if is_html_empty(company.report_header) else 'row' }}"
+                    t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
+                    <t t-out="custom_footer"/>
             </div>
-        </div>
+        </xpath>
     </template>
 
     <template id="external_layout_boxed" inherit_id="web.external_layout_boxed" >
@@ -61,15 +61,15 @@
         </xpath>
 
         <!-- support for custom footer -->
-        <div class="o_footer_content row border-top pt-2" position="attributes">
+        <xpath expr="//div[hasclass('o_footer_content')]" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
-        </div>
-        <div class="o_footer_content row border-top pt-2" position="after">
-            <div class="o_footer_content row border-top pt-2"
+        </xpath>
+        <xpath expr="//div[hasclass('o_footer_content')]" position="after">
+            <div class="o_footer_content border-top pt-2" t-attf-class="{{'d-flex' if is_html_empty(company.report_header) else 'row' }}"
                  t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
                 <t t-out="custom_footer"/>
             </div>
-        </div>
+        </xpath>
     </template>
 
     <template id="external_layout_striped" inherit_id="web.external_layout_striped" >

--- a/addons/l10n_latam_invoice_document/views/report_templates.xml
+++ b/addons/l10n_latam_invoice_document/views/report_templates.xml
@@ -38,15 +38,15 @@
         </xpath>
 
         <!-- support for custom footer -->
-        <div class="o_footer_content row border-top pt-2" position="attributes">
+        <xpath expr="//div[hasclass('o_footer_content')]" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
-        </div>
-        <div class="o_footer_content row border-top pt-2" position="after">
-            <div class="o_footer_content row border-top pt-2"
+        </xpath>
+        <xpath expr="//div[hasclass('o_footer_content')]" position="after">
+            <div class="o_footer_content border-top pt-2" t-attf-class="{{'d-flex' if is_html_empty(company.report_header) else 'row' }}"
                  t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
-        </div>
+        </xpath>
     </template>
 
     <template id="external_layout_boxed" inherit_id="web.external_layout_boxed" >
@@ -61,15 +61,15 @@
         </xpath>
 
         <!-- support for custom footer -->
-        <div class="o_footer_content row border-top pt-2" position="attributes">
+        <xpath expr="//div[hasclass('o_footer_content')]" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
-        </div>
-        <div class="o_footer_content row border-top pt-2" position="after">
-            <div class="o_footer_content row border-top pt-2"
+        </xpath>
+        <xpath expr="//div[hasclass('o_footer_content')]" position="after">
+            <div class="o_footer_content border-top pt-2" t-attf-class="{{'d-flex' if is_html_empty(company.report_header) else 'row' }}"
                  t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
-        </div>
+        </xpath>
     </template>
 
     <template id="external_layout_striped" inherit_id="web.external_layout_striped" >

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -406,14 +406,14 @@
         </div>
 
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}">
-            <div class="o_footer_content row border-top pt-2">
-                <div class="col-8">
+            <div class="o_footer_content" t-attf-class="{{'d-flex' if is_html_empty(company.report_header) else 'row' }} o_footer_content border-top pt-2">
+                <div t-attf-class="{{'flex-grow-1' if is_html_empty(company.report_header) else 'col-8'}} {{'me-2' if is_html_empty(company.report_header) and report_type == 'pdf' else ''}}">
                     <span t-field="company.report_footer"/>
                 </div>
-                <div class="col-4 text-end">
-                    <strong t-if="company.report_header" t-field="company.report_header" class="o_company_tagline">Company tagline</strong>
+                <div t-attf-class="{{'' if is_html_empty(company.report_header) else 'col-4'}} text-end">
+                    <strong t-if="not is_html_empty(company.report_header)" t-field="company.report_header" class="o_company_tagline">Company tagline</strong>
                     <span t-if="report_type == 'pdf' and display_name_in_footer" class="text-muted" t-out="str(o.name) + ', '">(document name)</span>
-                    <span t-if="report_type == 'pdf'" class="text-muted">Page <span class="page"/> / <span class="topage"/></span>
+                    <span t-if="report_type == 'pdf'" t-attf-class="text-muted {{'text-nowrap' if is_html_empty(company.report_header) else ''}}">Page <span class="page"/> / <span class="topage"/></span>
                 </div>
             </div>
         </div>
@@ -465,14 +465,14 @@
         </div>
 
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'mt-auto'}}">
-            <div class="o_footer_content row border-top pt-2">
-                <div class="col-8">
+            <div class="o_footer_content" t-attf-class="{{'d-flex' if is_html_empty(company.report_header) else 'row' }} o_footer_content border-top pt-2">
+                <div t-attf-class="{{'flex-grow-1' if is_html_empty(company.report_header) else 'col-8'}} {{'me-2' if is_html_empty(company.report_header) and report_type == 'pdf' else ''}}">
                     <span t-field="company.report_footer"/>
                 </div>
-                <div class="col-4 text-end">
-                    <strong t-if="company.report_header" t-field="company.report_header" class="o_company_tagline">Company tagline</strong>
+                <div t-attf-class="{{'' if is_html_empty(company.report_header) else 'col-4'}} text-end">
+                    <strong t-if="not is_html_empty(company.report_header)" t-field="company.report_header" class="o_company_tagline">Company tagline</strong>
                     <span t-if="report_type == 'pdf' and display_name_in_footer" class="text-muted" t-out="str(o.name) + ', '">(document name)</span>
-                    <span t-if="report_type == 'pdf'" class="text-muted">Page <span class="page"/> / <span class="topage"/></span>
+                    <span t-if="report_type == 'pdf'" t-attf-class="text-muted {{'text-nowrap' if is_html_empty(company.report_header) else ''}}">Page <span class="page"/> / <span class="topage"/></span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
commit https://github.com/odoo/odoo/commit/695b429d09887debe1a58e92abfd7e738350061d
reworked the footer style but on boxed and bold if there is
no tag line, it uses a col-8 that let a big empty space.

Also it uses a wrong t-if condition on an html field.
It should use is_html_empty since the field could
contains empty tags (<br>)

Fallback on standard template for report without report_header

We keep a duplicate of class and t-attf-class in order to have
a valid override of the template

Fix l10n template to reduce the xpath and match the fix.
Keeping the o_footer_content in both class for override and
t-attf-class since `ir_qweb.py:def _compile_directive_att` ignore
class attribute when t-attf-class is set

opw-4618652
