### PR TITLE
[FIX] html editor: selection normalization around noneditables

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -44,6 +44,7 @@ import { CTYPES } from "../utils/content_types";
 import { withSequence } from "@html_editor/utils/resource";
 import { compareListTypes } from "@html_editor/main/list/utils";
 import { hasTouch, isBrowserChrome } from "@web/core/browser/feature_detection";
+import { normalizeDeepCursorPosition, normalizeFakeBR } from "@html_editor/utils/selection";
 
 /**
  * @typedef {Object} RangeLike
@@ -112,6 +113,24 @@ export class DeletePlugin extends Plugin {
         this.findNextPosition = this.makeFindPositionFn("forward");
     }
 
+    /**
+     * @param {EditorSelection} selection
+     * @returns {Range}
+     */
+    getNormalizedRange(selection) {
+        let { startContainer, startOffset, endContainer, endOffset, isCollapsed } = selection;
+        for (const normalizer of [normalizeDeepCursorPosition, normalizeFakeBR]) {
+            [startContainer, startOffset] = normalizer(startContainer, startOffset);
+            [endContainer, endOffset] = isCollapsed
+                ? [startContainer, startOffset]
+                : normalizer(endContainer, endOffset);
+        }
+        const range = this.document.createRange();
+        range.setStart(startContainer, startOffset);
+        range.setEnd(endContainer, endOffset);
+        return range;
+    }
+
     // --------------------------------------------------------------------------
     // commands
     // --------------------------------------------------------------------------
@@ -123,14 +142,11 @@ export class DeletePlugin extends Plugin {
         // @todo @phoenix: handle non-collapsed selection around a ZWS
         // see collapseIfZWS
 
-        // Normalize selection
-        selection = this.dependencies.selection.setSelection(selection);
-
-        if (selection.isCollapsed) {
+        let range = this.getNormalizedRange(selection);
+        if (range.collapsed || !closestElement(range.commonAncestorContainer).isContentEditable) {
             return;
         }
-
-        let range = this.adjustRange(selection, [
+        range = this.adjustRange(range, [
             this.expandRangeToIncludeNonEditables,
             this.includeEndOrStartBlock,
             this.fullyIncludeLinks,
@@ -174,8 +190,10 @@ export class DeletePlugin extends Plugin {
      * @param {"character"|"word"|"line"} granularity
      */
     deleteBackward(selection, granularity) {
-        // Normalize selection
-        const { endContainer, endOffset } = this.dependencies.selection.setSelection(selection);
+        const { endContainer, endOffset } = this.getNormalizedRange(selection);
+        if (!closestElement(endContainer).isContentEditable) {
+            return;
+        }
 
         let range = this.getRangeForDelete(endContainer, endOffset, "backward", granularity);
 
@@ -203,8 +221,10 @@ export class DeletePlugin extends Plugin {
      * @param {"character"|"word"|"line"} granularity
      */
     deleteForward(selection, granularity) {
-        // Normalize selection
-        const { startContainer, startOffset } = this.dependencies.selection.setSelection(selection);
+        const { startContainer, startOffset } = this.getNormalizedRange(selection);
+        if (!closestElement(startContainer).isContentEditable) {
+            return;
+        }
 
         let range = this.getRangeForDelete(startContainer, startOffset, "forward", granularity);
 

--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -901,8 +901,11 @@ export class DeletePlugin extends Plugin {
         return range;
     }
 
-    // Expand the range to fully include all contentEditable=False elements.
     /**
+     * Expand the range to fully include all contentEditable=False elements.
+     * This scenario happens when the range has one end inside a non-editable
+     * element and the other end outside of it.
+     *
      * @param {Range} range
      * @returns {Range}
      */
@@ -911,15 +914,7 @@ export class DeletePlugin extends Plugin {
         const isNonEditable = (node) => !isContentEditable(node);
         const startUneditable = findFurthest(startContainer, commonAncestor, isNonEditable);
         if (startUneditable) {
-            // @todo @phoenix: Review this spec. I suggest this instead (no block merge after removing):
-            // startContainer = startUneditable.parentElement;
-            // startOffset = childNodeIndex(startUneditable);
-            const leaf = previousLeaf(startUneditable);
-            if (leaf) {
-                range.setStart(leaf, nodeSize(leaf));
-            } else {
-                range.setStart(commonAncestor, 0);
-            }
+            range.setStartBefore(startUneditable);
         }
         const endUneditable = findFurthest(endContainer, commonAncestor, isNonEditable);
         if (endUneditable) {

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -219,6 +219,7 @@ export class FormatPlugin extends Plugin {
 
     // @todo phoenix: refactor this method.
     _formatSelection(formatName, { applyStyle, formatProps } = {}) {
+        this.dependencies.selection.selectAroundNonEditable();
         // note: does it work if selection is in opposite direction?
         const selection = this.dependencies.split.splitSelection();
         if (typeof applyStyle === "undefined") {

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -19,7 +19,6 @@ import { Plugin } from "../plugin";
 import { DIRECTIONS, endPos, leftPos, nodeSize, rightPos } from "../utils/position";
 import {
     getAdjacentCharacter,
-    normalizeCursorPosition,
     normalizeDeepCursorPosition,
     normalizeFakeBR,
     normalizeNotEditableNode,
@@ -527,10 +526,10 @@ export class SelectionPlugin extends Plugin {
             throw new Error("Selection is not in editor");
         }
         const isCollapsed = anchorNode === focusNode && anchorOffset === focusOffset;
-        [focusNode, focusOffset] = normalizeCursorPosition(focusNode, focusOffset, "right");
+        [focusNode, focusOffset] = normalizeSelfClosingElement(focusNode, focusOffset, "right");
         [anchorNode, anchorOffset] = isCollapsed
             ? [focusNode, focusOffset]
-            : normalizeCursorPosition(anchorNode, anchorOffset, "left");
+            : normalizeSelfClosingElement(anchorNode, anchorOffset, "left");
         if (normalize) {
             // normalize selection
             [anchorNode, anchorOffset] = normalizeDeepCursorPosition(anchorNode, anchorOffset);

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -22,6 +22,8 @@ import {
     normalizeCursorPosition,
     normalizeDeepCursorPosition,
     normalizeFakeBR,
+    normalizeNotEditableNode,
+    normalizeSelfClosingElement,
 } from "../utils/selection";
 import { isElement } from "../utils/dom_info";
 import { closestScrollableY } from "@web/core/utils/scrolling";
@@ -175,6 +177,7 @@ function scrollToSelection(selection) {
  * @property { SelectionPlugin['setCursorEnd'] } setCursorEnd
  * @property { SelectionPlugin['setCursorStart'] } setCursorStart
  * @property { SelectionPlugin['setSelection'] } setSelection
+ * @property { SelectionPlugin['selectAroundNonEditable'] } selectAroundNonEditable
  */
 
 export class SelectionPlugin extends Plugin {
@@ -198,6 +201,7 @@ export class SelectionPlugin extends Plugin {
         "focusEditable",
         // "collapseIfZWS",
         "isSelectionInEditable",
+        "selectAroundNonEditable",
     ];
     resources = {
         user_commands: { id: "selectAll", run: this.selectAll.bind(this) },
@@ -340,16 +344,8 @@ export class SelectionPlugin extends Plugin {
                 // inside a protected zone.
                 return this.activeSelection;
             }
-            [anchorNode, anchorOffset] = normalizeCursorPosition(
-                anchorNode,
-                anchorOffset,
-                direction ? "left" : "right"
-            );
-            [focusNode, focusOffset] = normalizeCursorPosition(
-                focusNode,
-                focusOffset,
-                direction ? "right" : "left"
-            );
+            [anchorNode, anchorOffset] = normalizeSelfClosingElement(anchorNode, anchorOffset);
+            [focusNode, focusOffset] = normalizeSelfClosingElement(focusNode, focusOffset);
             const [startContainer, startOffset, endContainer, endOffset] =
                 direction === DIRECTIONS.RIGHT
                     ? [anchorNode, anchorOffset, focusNode, focusOffset]
@@ -926,5 +922,28 @@ export class SelectionPlugin extends Plugin {
         if (selection) {
             selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
         }
+    }
+
+    /**
+     * @returns {EditorSelection}
+     */
+    selectAroundNonEditable() {
+        // Get up-to-date selection
+        const { editableSelection } = this.getSelectionData();
+        // Avoid setting the selection if it's not inside an uneditable element
+        const isInUneditable = (node) => !!closestElement(node, (elem) => !elem.isContentEditable);
+        let { startContainer: start, endContainer: end } = editableSelection;
+        if (!(isInUneditable(start) || (end !== start && isInUneditable(end)))) {
+            return editableSelection;
+        }
+        // Normalize both sides
+        let { startOffset, endOffset, direction } = editableSelection;
+        [start, startOffset] = normalizeNotEditableNode(start, startOffset, "left");
+        [end, endOffset] = normalizeNotEditableNode(end, endOffset, "right");
+        // Set the new selection
+        const [anchorNode, anchorOffset, focusNode, focusOffset] = direction
+            ? [start, startOffset, end, endOffset]
+            : [end, endOffset, start, startOffset];
+        return this.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
     }
 }

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -191,6 +191,7 @@ export class ColorPlugin extends Plugin {
      * @param {boolean} [previewMode=false] true - apply color in preview mode
      */
     _applyColor(color, mode, previewMode = false) {
+        this.dependencies.selection.selectAroundNonEditable();
         if (this.delegateTo("color_apply_overrides", color, mode, previewMode)) {
             return;
         }

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -11,6 +11,7 @@ import { rpc } from "@web/core/network/rpc";
 import { MediaDialog } from "./media_dialog/media_dialog";
 import { rightPos } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 const MEDIA_SELECTOR = `${ICON_SELECTOR} , .o_image, .media_iframe_video`;
 
@@ -63,6 +64,7 @@ export class MediaPlugin extends Plugin {
         clean_handlers: this.clean.bind(this),
         clean_for_save_handlers: ({ root }) => this.cleanForSave(root),
         normalize_handlers: this.normalizeMedia.bind(this),
+        selectionchange_handlers: this.selectAroundIcon.bind(this),
 
         unsplittable_node_predicates: isIconElement, // avoid merge
 
@@ -341,6 +343,15 @@ export class MediaPlugin extends Plugin {
             delete el.dataset.bgSrc;
         } else {
             el.setAttribute("src", newAttachmentSrc);
+        }
+    }
+
+    /**
+     * @param {import("@html_editor/core/selection_plugin").SelectionData} param0
+     */
+    selectAroundIcon({ editableSelection: { anchorNode, isCollapsed } }) {
+        if (isCollapsed && closestElement(anchorNode, isIconElement)) {
+            this.dependencies.selection.selectAroundNonEditable();
         }
     }
 }

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -3,6 +3,7 @@ import { closestElement, selectElements } from "@html_editor/utils/dom_traversal
 import { leftPos, rightPos } from "@html_editor/utils/position";
 import { QWebPicker } from "./qweb_picker";
 import { isElement } from "@html_editor/utils/dom_info";
+import { withSequence } from "@html_editor/utils/resource";
 
 const isUnsplittableQWebElement = (node) =>
     isElement(node) &&
@@ -26,7 +27,7 @@ export class QWebPlugin extends Plugin {
     static dependencies = ["overlay", "protectedNode", "selection"];
     resources = {
         /** Handlers */
-        selectionchange_handlers: this.onSelectionChange.bind(this),
+        selectionchange_handlers: withSequence(8, this.onSelectionChange.bind(this)),
         clean_handlers: this.clearDataAttributes.bind(this),
         clean_for_save_handlers: ({ root }) => {
             this.clearDataAttributes(root);

--- a/addons/html_editor/static/src/utils/selection.js
+++ b/addons/html_editor/static/src/utils/selection.js
@@ -173,9 +173,12 @@ function updateCursorBeforeMove(destParent, destIndex, node, cursor) {
     } else if (cursor.node === node.parentNode) {
         const childIndex = childNodeIndex(node);
         // Update cursor at origin
-        if (cursor.offset === childIndex) {
-            // Keep pointing to the moved node
+        if (cursor.offset === childIndex && cursor.offset === 0) {
+            // Keep cursor before the moved node if it's the first child before the move
             [cursor.node, cursor.offset] = [destParent, destIndex];
+        } else if (cursor.offset === childIndex + 1 && cursor.offset === nodeSize(cursor.node)) {
+            // Keep cursor after the moved node if it's the last child before the move
+            [cursor.node, cursor.offset] = [destParent, destIndex + 1];
         } else if (cursor.offset > childIndex) {
             cursor.offset -= 1;
         }

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -144,8 +144,8 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     await press(["ctrl", "a"]);
     await animationFrame();
     expect(getContent(el)).toBe(
-        `[<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
-                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+        `<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">[💡</i>
                 <div class="w-100 px-3" contenteditable="true">
                     <p><br></p>
                 </div>
@@ -187,7 +187,7 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     );
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        '[<div data-oe-role="status" contenteditable="false" role="status">a</div><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd]</p>'
+        '<div data-oe-role="status" contenteditable="false" role="status">[a</div><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd]</p>'
     );
 
     await press("Backspace");

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -2012,7 +2012,7 @@ describe("Selection not collapsed", () => {
                     deleteBackward(editor);
                 },
                 contentAfter: unformat(`
-                        <p>before[]after</p>`),
+                        <p>before</p><p>[]after</p>`),
             });
         });
 

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -472,7 +472,7 @@ describe("Selection collapsed", () => {
             });
         });
 
-        test.todo("should not delete in contenteditable=false", async () => {
+        test("should not delete in contenteditable=false", async () => {
             await testEditor({
                 contentBefore: `<p contenteditable="false">ab[]cdef</p>`,
                 stepFunction: deleteBackward,
@@ -2040,7 +2040,7 @@ describe("Selection not collapsed", () => {
             });
         });
 
-        test.todo("should not delete in contenteditable=false 1", async () => {
+        test("should not delete in contenteditable=false 1", async () => {
             await testEditor({
                 contentBefore: `<p contenteditable="false">ab[cd]ef</p>`,
                 stepFunction: deleteBackward,
@@ -2048,7 +2048,7 @@ describe("Selection not collapsed", () => {
             });
         });
 
-        test.todo("should not delete in contenteditable=false 2", async () => {
+        test("should not delete in contenteditable=false 2", async () => {
             await testEditor({
                 contentBefore: `<div contenteditable="false">
                                     <p>a[b</p>

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -1584,7 +1584,6 @@ describe("Selection not collapsed", () => {
         });
     });
 
-    // @todo @phoenix: review this spec. It should not merge, like the test above.
     test("should extend the range to fully include contenteditable=false that are partially selected at the start of the range", async () => {
         await testEditor({
             contentBefore: unformat(`
@@ -1597,7 +1596,7 @@ describe("Selection not collapsed", () => {
                 deleteForward(editor);
             },
             contentAfter: unformat(`
-                    <p>before[]after</p>`),
+                    <p>before</p><p>[]after</p>`),
         });
     });
 

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -165,7 +165,13 @@ test("Can spin an icon", async () => {
 });
 
 test("Can set icon color", async () => {
-    await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
+    const { el } = await setupEditor(`<p><span class="fa fa-glass"></span></p>`);
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
     await waitFor(".o-we-toolbar");
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-select-color-foreground");

--- a/addons/html_editor/static/tests/list/normalization.test.js
+++ b/addons/html_editor/static/tests/list/normalization.test.js
@@ -98,7 +98,7 @@ describe("Inlines and blocks in list item", () => {
                 <ul>
                     <li>
                         <h1>abc</h1>
-                        <p>abc[<i>def</i></p>]
+                        <p>abc[<i>def</i>]</p>
                     </li>
                 </ul>
             `),

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { press, queryFirst, queryOne } from "@odoo/hoot-dom";
+import { press, queryFirst } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { Component, xml } from "@odoo/owl";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
@@ -216,16 +216,6 @@ test("restore a selection when you are not in the editable shouldn't move the fo
     const cursors = editor.shared.selection.preserveSelection();
     cursors.restore();
     expect("input.test").toBeFocused();
-});
-
-test("set a collapse selection in a contenteditable false should move it after this node", async () => {
-    const { el, editor } = await setupEditor(`<p>ab<span contenteditable="false">cd</span>ef</p>`);
-    editor.shared.selection.setSelection({
-        anchorNode: queryOne("span[contenteditable='false']"),
-        anchorOffset: 1,
-    });
-    editor.shared.selection.focusEditable();
-    expect(getContent(el)).toBe(`<p>ab<span contenteditable="false">cd</span>[]ef</p>`);
 });
 
 test("preserveSelection's restore should always set the selection, even if it's the same as the current one", async () => {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1080,5 +1080,11 @@ describe("toolbar open and close on user interaction", () => {
             await advanceTime(500);
             expect(".o-we-toolbar").toHaveCount(1);
         });
+
+        test("toolbar should not open with a collapsed selection inside a contenteditable=false", async () => {
+            await setupEditor(`<div contenteditable="false"><p>[]test</p></div>`);
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(0);
+        });
     });
 });


### PR DESCRIPTION
A little guide to this PR:

**[FIX] html_editor: toolbar shown on collapsed selection in uneditable**
- removes normalization around non-editables on `makeActiveSelection`, but leaves `setSelection` untouched.
- fixes a bug reported in the html_builder (see https://pad.odoo.com/p/mysterious-egg-builder-editor-bug)
- to test this, one should cherry-pick this commit into `odoo-dev/master-mysterious-egg`. Here it is, as of 13/03/2025: `odoo-dev/master-mysterious-egg-rcdl-3` ([runbot bundle](https://runbot.odoo.com/runbot/bundle/master-mysterious-egg-rcdl-3-348950), or try directly [this](https://76547856-master.runbot251.odoo.com/odoo/action-205)).
- it will only take effect on htm_builder once this is fw-ported to master and odoo-dev/master-mysterious-egg rebased to odoo/master 

**[FIX] html_editor: selection preservation around moved nodes**
- prerequisite for the following commit

**[FIX] html_editor: delete in uneditable zone**
- what the task 4242213 is originally about
- 3 "todo" tests now passing! :partying_face: 

================
So far, so good, no spec changes, no breaking tests.
Now it gets a little wild (possibly better for master?). Either way, no API changes, thus suitable for stable.

**[FIX] html_editor: asymmetric range adjustment around non-editables**
- prerequisite for the next one

**[FIX] html_editor: normalization around non-editables on setSelection**
- finishes the job started by the first commit and removes the normalization step also from `setSelection`. A dream come true???

task-4242213
