### PR TITLE
[FIX] l10n_es_edi_tbai: NIE is also autonomo

### DIFF
--- a/addons/l10n_es_edi_tbai/models/res_company.py
+++ b/addons/l10n_es_edi_tbai/models/res_company.py
@@ -163,4 +163,4 @@ class ResCompany(models.Model):
 
     def _l10n_es_freelancer(self):
         self.ensure_one()
-        return self.vat and re.fullmatch(r"(ES)?\d{8}[A-Z]", self.vat) or False
+        return self.vat and re.fullmatch(r"(ES)?(\d{8}[A-Z]|[X-Z].*)", self.vat) or False


### PR DESCRIPTION
In order to determine if the vat provided is for an autonomo (freelancer) or a juridical person (company), we checked 8 digits and a letter for the freelancer, but NIEs that start with X/Y/Z are also freelancers, so we added that option in the regex.

opw-4616635

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
