### PR TITLE
[FIX] stock_landed_costs: set correct landed cost from catalog

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -51,6 +51,13 @@ class AccountMove(models.Model):
         posted.sudo().landed_costs_ids.reconcile_landed_cost()
         return posted
 
+    def _update_order_line_info(self, product_id, quantity, **kwargs):
+        price_unit = super()._update_order_line_info(product_id, quantity, **kwargs)
+        move_line = self.line_ids.filtered(lambda line: line.product_id.id == product_id)
+        if move_line:
+            move_line.is_landed_costs_line = move_line.product_id.landed_cost_ok
+        return price_unit
+
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs.py
@@ -217,3 +217,24 @@ class TestStockLandedCosts(TestStockLandedCostsCommon):
             landed_cost_aml = bill.invoice_line_ids.filtered(lambda l: l.product_id == self.landed_cost)
             self.assertEqual(bill.state, 'posted', 'Incorrect value with valuation %s' % valuation)
             self.assertEqual(landed_cost_aml.account_id, account, 'Incorrect value with valuation %s' % valuation)
+
+    def test_landed_cost_in_move_line(self):
+        """
+        Tests that a move line created through the catalog gives the right landed cost
+        """
+        self.landed_cost.landed_cost_ok = True
+        account_move = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id
+        })
+        account_move._update_order_line_info(
+            product_id=self.landed_cost.id,
+            quantity=1
+        )
+        self.assertTrue(account_move.invoice_line_ids.is_landed_costs_line, "The landed cost should appear in the move line.")
+        account_move._update_order_line_info(
+            product_id=self.product.id,
+            quantity=1
+        )
+        move_line_no_landed = account_move.line_ids.filtered(lambda line: line.product_id == self.product)
+        self.assertFalse(move_line_no_landed.is_landed_costs_line, "The landed cost should not be set to True.")


### PR DESCRIPTION
**Problem:**
When adding a product that has the landed cost setting activated
to a Vendor Bill, the landed cost checkbox was not checked, thus
the product was not registered with a landed cost in the Vendor
Bill. Adding the product straight from the vendor bill worked fine.

**Steps to reproduce:**
- Make a product with a landed cost.
- Make a new vendor bill and go to the catalog from the Invoice Lines tab.
- Search for your product and add it to the Vendor Bill.
- Return to the Vendor Bill and see that the landed cost is not checked.

**Cause of the issue:**
The field is_landed_costs_line is set in an onchange function,
thus when adding a product from the catalog the said function
is not triggered and the is_landed_costs_line is not applied.
https://github.com/odoo/odoo/blob/01058b94d860ab508bc2c013af5fe887e08247d9/addons/stock_landed_costs/models/account_move.py#L61-L66

**Fix:**
An override of the create function was added to add the
correct landed cost even when the onchange function is
not called. With the onchange function and the create
function, this ensures that the is_landed_costs_line
will be set correctly regardless of where it is created
from.

opw-4521391