### PR TITLE
[FIX] mrp_account: take the right value for byproduct unbuild valuation

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -60,7 +60,7 @@ class StockMove(models.Model):
         price_unit_map = {
             move.id: (
                 move.unbuild_id.mo_id.move_finished_ids.stock_valuation_layer_ids.filtered(
-                    lambda svl: svl.product_id == move.unbuild_id.mo_id.product_id
+                    lambda svl: svl.product_id == move.product_id
                 )[0].unit_cost,
                 move.company_id.currency_id.round,
             )


### PR DESCRIPTION
Steps to reproduce:
- Create two products, both in AVCO cost method
- Create another product with a standard_price of 100
- Create a bom to produce an AVCO product and has the other one as byproduct. Also use the last one as component
- Create a MO for 1 unit of that bom and produce it
- Unbuild the MO

Issue:
The valuation layer created for the byproduct in the unbuild will use the value of the main product of the MO instead of its counterpart.

opw-4623337

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
