### PR TITLE
[FIX] account: invalid context key when creating attachment

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -35,9 +35,9 @@ export class AccountFileUploader extends Component {
             mimetype: file.type,
             datas: file.data,
         };
-        const [att_id] = await this.orm.create("ir.attachment", [att_data], {
-            context: { ...this.extraContext, ...this.env.searchModel.context },
-        });
+        // clean the context to ensure the `create` call doesn't fail from unknown `default_*` context
+        const cleanContext = Object.fromEntries(Object.entries(this.env.searchModel.context).filter(([key]) => !key.startsWith('default_')));
+        const [att_id] = await this.orm.create("ir.attachment", [att_data], {context: cleanContext});
         this.attachmentIdsToProcess.push(att_id);
     }
 


### PR DESCRIPTION
Step to reproduce:

- install accounting
- in the dashboard searchbar, add a `Group By` with value `type`
- go to vendor bills view from the dashboard
- upload any file

Error:

Wrong value for `ir.attachment.type`: 'purchase'

Expected:

The upload process should go on without any error

Explanation:

in the `onFileUploaded` hook for vendor bills AccountFileUploader JS component, we included all context when we are creating the `ir.attachment` object. The group-by we added earlier are thus also added as `default_type` in the context.

But when creating a record, the ORM checks for all `default_*` key in the context and try to use it as additional values for the created record. Since the key-value combination `type` and `purchase` is not valid in an `ir.attachment` record, it throws this error.

Solution:

Before passing the context, we have to make sure to clean all the `default_*` contexts to avoid these kind of behaviors. In python, usually we use `clean_context` method before calling `create`. But since this is in JS, we manually filter all key-value item that starts with "default_" in the context object.

opw-4512697
