### PR TITLE
[FIX] hr_expense: display categ_id on product form view.

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -521,6 +521,7 @@
                                        help="When the cost of an expense product is different than 0, then the user using this product won't be able to change the amount of the expense, only the quantity. Use a cost different than 0 for expense categories funded by the company at fixed cost like allowances for mileage, per diem, accommodation or meal."/>
                                 <field name="uom_id" groups="uom.group_uom" options="{'no_create': True}"/>
                                 <field name="uom_po_id" invisible="1"/>
+                                <field name="categ_id"/>
                                 <label for="default_code"/>
                                 <div>
                                     <field name="default_code"/>


### PR DESCRIPTION
Use Case: if user set accounting setting at category level, he can not set the category when creating expense and has to go to the main product form view to put the correct category.

**Description of the issue/feature this PR addresses:**
- Create an expense
- on the expense form view, create an new expense category

**Current behavior before PR:**
- in the expense category form view (that is product.template), it is not possible to set the the categ_id field. As a result, if accountant set account on categ level, he has to open the product in another form.


**Desired behavior after PR is merged:**
- possibility to select a category.
- 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
