### PR TITLE
[FIX] hr_expense: fix expense team approver can't use the OCR

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -445,7 +445,7 @@ class HrExpense(models.Model):
                 raise UserError(_('You cannot delete a posted or approved expense.'))
 
     def write(self, vals):
-        if 'state' in vals and (not self.user_has_groups('hr_expense.group_hr_expense_manager') and vals['state'] != 'reported' and
+        if 'state' in vals and (not self.user_has_groups('hr_expense.group_hr_expense_manager') and vals['state'] not in ('draft', 'reported') and
         any(expense.state == 'draft' for expense in self)):
             raise UserError(_("You don't have the rights to bypass the validation process of this expense."))
         expense_to_previous_sheet = {}


### PR DESCRIPTION
When an employee with the "Team approver" role was using the digitization feature on an expense, a user error would be raised when clicking on the "Refresh" button.

This is related to commit 92284e7 which added an access right check when writing on the `state` field of the expense. After this commit, only expense managers are allowed to write the state field (except for the "Submit" state).

Since the OCR is resetting the expense state to draft it was raising this access right check. Writing the state to "Draft" should also be allowed as it's obviously not bypassing the validation process.

[opw-4613260](https://www.odoo.com/odoo/49/tasks/4613260)