### PR TITLE
[IMP] point_of_sale: maintain product screen's product sequence

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -58,7 +58,7 @@ class ProductTemplate(models.Model):
         return [
             'id', 'display_name', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name', 'list_price', 'is_favorite',
             'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'tracking', 'type', 'service_tracking', 'is_storable',
-            'write_date','color', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_variant_ids',
+            'write_date', 'color', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_variant_ids', 'sequence',
         ]
 
     def _load_pos_data(self, data):

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2196,6 +2196,22 @@ export class PosStore extends WithLazyGetterTrap {
 
         list = list
             .filter((product) => !excludedProductIds.includes(product.id) && product.canBeDisplayed)
+            .sort((a, b) => {
+                // Sort in the same order as what we receive (look _load_product_with_domain)
+                if (a.sequence !== b.sequence) {
+                    return a.sequence - b.sequence;
+                }
+                if (a.default_code !== b.default_code) {
+                    if (!b.default_code) {
+                        return -1;
+                    }
+                    if (!a.default_code) {
+                        return 1;
+                    }
+                    return a.default_code.localeCompare(b.default_code);
+                }
+                return a.name.localeCompare(b.name);
+            })
             .slice(0, 100);
 
         return searchWord !== ""


### PR DESCRIPTION
Before this commit, the second and onwards view of the product screen will pull and sort products by the data stored in IndexedDB. The first load of the product screen sorts based on a SQL query, whose sorting may be lost on sequential loads of the product screen.

This change maintains the sort sequence to 'product.template' when loading the product screen when IndexedDB exists in the browser.

opw-4584724

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
