### PR TITLE
[FIX] point_of_sale: prevent IndexedDB errors on local data access

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -80,6 +80,9 @@ export default class IndexedDB {
     }
 
     create(storeName, arrData) {
+        if (!arrData?.length) {
+            return;
+        }
         return this.promises(storeName, arrData, "put");
     }
 
@@ -123,6 +126,9 @@ export default class IndexedDB {
     }
 
     delete(storeName, uuids) {
+        if (!uuids?.length) {
+            return;
+        }
         return this.promises(storeName, uuids, "delete");
     }
 }

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -101,7 +101,10 @@ export class PosData extends Reactive {
         // This method initializes indexedDB with all models loaded into the PoS. The default key is ID.
         // But some models have another key configured in data_service_options.js. These models are
         // generally those that can be created in the frontend.
-        const models = Object.keys(relations).map((model) => {
+        const allModelNames = Array.from(
+            new Set([...Object.keys(relations), ...Object.keys(this.opts.databaseTable)])
+        );
+        const models = allModelNames.map((model) => {
             const key = this.opts.databaseTable[model]?.key || "id";
             return [key, model];
         });


### PR DESCRIPTION
Previously, tables defined in DataServiceOptions but missing from relations were not created, causing failures when reading local data via `getLocalDataFromIndexedDB`. Additionally, empty delete or add operations triggered unnecessary transactions.

This fix addresses these issues by:
- Ensuring all missing tables are correctly created.
- Avoiding unnecessary transactions caused by empty delete/add operations.

