### PR TITLE
[IMP] views: allow decoration-bg on fields

### DIFF
--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -260,6 +260,12 @@
             <rng:optional><rng:attribute name="decoration-primary"/></rng:optional>
             <rng:optional><rng:attribute name="decoration-success"/></rng:optional>
             <rng:optional><rng:attribute name="decoration-warning"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-danger"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-info"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-muted"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-primary"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-success"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-warning"/></rng:optional>
             <rng:optional><rng:attribute name="kanban_view_ref" /></rng:optional>
             <rng:optional>
                 <rng:attribute name="force_save">

--- a/odoo/addons/base/rng/list_view.rng
+++ b/odoo/addons/base/rng/list_view.rng
@@ -45,6 +45,12 @@
             <rng:optional><rng:attribute name="decoration-primary"/></rng:optional>
             <rng:optional><rng:attribute name="decoration-success"/></rng:optional>
             <rng:optional><rng:attribute name="decoration-warning"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-danger"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-info"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-muted"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-primary"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-success"/></rng:optional>
+            <rng:optional><rng:attribute name="decoration-bg-warning"/></rng:optional>
             <rng:optional><rng:attribute name="sample"/></rng:optional>
             <rng:optional><rng:attribute name="action"/></rng:optional>
             <rng:optional><rng:attribute name="type"/></rng:optional>


### PR DESCRIPTION
The current validation only allows decoration-color attributes on fields on list views. The decoration-bg-color attributes
are working as expected but are not in allowed in the rng yet. 

Adding the attributes to the rng.