### PR TITLE
[FIX] iot_box_image: sparse-checkout to prepare for 18.3

### DIFF
--- a/addons/iot_box_image/build_image.sh
+++ b/addons/iot_box_image/build_image.sh
@@ -76,6 +76,7 @@ if [ ! -d $CLONE_DIR ]; then
     git config core.sparsecheckout true
     echo "addons/web
 addons/hw_*
+addons/iot_base
 addons/iot_box_image/configuration
 addons/point_of_sale/tools/posbox/configuration
 odoo/


### PR DESCRIPTION
In saas-18.3 we added base module for IoT modules, but this module was not part of the sparse-checkout on IoT Box images, leading to odoo not starting after a checkout.
