### PR TITLE
[FIX] phone_validation: typo in fallback import

### DIFF
--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -120,7 +120,7 @@ except ImportError:
             _phonenumbers_lib_warning = True
         return number
 
-    def phone_get_region_code_for_number(number):
+    def phone_get_region_data_for_number(number):
         return {
             'code': '',
             'national_number': '',


### PR DESCRIPTION
Before this commit, since the introduction of the
`phone_get_region_data_for_number` function (2d027ad), there was a fallback in case the import failed.

However, the fallback method had an incorrect name.
