### PR TITLE
[FIX] event: fix cron after_sub

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -425,7 +425,7 @@ You receive this email because you are:
             # event-based: todo / attendee-based: running until event is not done
             '|',
             ('mail_done', '=', False),
-            '&', ('interval_type', '=', 'after_sub'), ('event_id.date_end', '<', self.env.cr.now()),
+            '&', ('interval_type', '=', 'after_sub'), ('event_id.date_end', '>', self.env.cr.now()),
         ])
 
         for scheduler in schedulers:


### PR DESCRIPTION
Until now, the after_sub are only sent after the start of the event
