### PR TITLE
[FIX] google_account, google_calendar: use google_account for calendar sync

### DIFF
--- a/addons/google_account/models/google_service.py
+++ b/addons/google_account/models/google_service.py
@@ -90,6 +90,19 @@ class GoogleService(models.AbstractModel):
             error_msg = _("Something went wrong during your token generation. Maybe your Authorization Code is invalid or already expired")
             raise self.env['res.config.settings'].get_config_warning(error_msg)
 
+    def _refresh_google_token(self, service, rtoken):
+        ICP = self.env['ir.config_parameter'].sudo()
+
+        headers = {"content-type": "application/x-www-form-urlencoded"}
+        data = {
+            'refresh_token': rtoken,
+            'client_id': self._get_client_id(service),
+            'client_secret': _get_client_secret(ICP, service),
+            'grant_type': 'refresh_token',
+        }
+        dummy, response, dummy = self._do_request(GOOGLE_TOKEN_ENDPOINT, params=data, headers=headers, method='POST', preuri='')
+        return response.get('access_token'), response.get('expires_in')
+
     @api.model
     def _do_request(self, uri, params=None, headers=None, method='POST', preuri=GOOGLE_API_BASE_URL, timeout=TIMEOUT):
         """ Execute the request to Google API. Return a tuple ('HTTP_CODE', 'HTTP_RESPONSE')
@@ -114,7 +127,7 @@ class GoogleService(models.AbstractModel):
         else:
             _log_params = (params or {}).copy()
         if _log_params.get('client_secret'):
-            _log_params['client_secret'] = _log_params['client_secret'][0:4] + 'x' * 12
+            _log_params['client_secret'] = str(_log_params['client_secret'])[0:4] + 'x' * 12
 
         _logger.debug("Uri: %s - Type : %s - Headers: %s - Params : %s!", uri, method, headers, _log_params)
 

--- a/addons/google_calendar/models/res_users_settings.py
+++ b/addons/google_calendar/models/res_users_settings.py
@@ -6,7 +6,7 @@ import requests
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.addons.google_account.models.google_service import GOOGLE_TOKEN_ENDPOINT
+
 
 class ResUsersSettings(models.Model):
     _inherit = "res.users.settings"
@@ -50,26 +50,11 @@ class ResUsersSettings(models.Model):
 
     def _refresh_google_calendar_token(self):
         self.ensure_one()
-        get_param = self.env['ir.config_parameter'].sudo().get_param
-        client_id = get_param('google_calendar_client_id')
-        client_secret = get_param('google_calendar_client_secret')
-
-        if not client_id or not client_secret:
-            raise UserError(_("The account for the Google Calendar service is not configured."))
-
-        headers = {"content-type": "application/x-www-form-urlencoded"}
-        data = {
-            'refresh_token': self.sudo().google_calendar_rtoken,
-            'client_id': client_id,
-            'client_secret': client_secret,
-            'grant_type': 'refresh_token',
-        }
 
         try:
-            _dummy, response, _dummy = self.env['google.service']._do_request(GOOGLE_TOKEN_ENDPOINT, params=data, headers=headers, method='POST', preuri='')
-            ttl = response.get('expires_in')
+            access_token, ttl = self.env['google.service']._refresh_google_token('calendar', self.sudo().google_calendar_rtoken)
             self.sudo().write({
-                'google_calendar_token': response.get('access_token'),
+                'google_calendar_token': access_token,
                 'google_calendar_token_validity': fields.Datetime.now() + timedelta(seconds=ttl),
             })
         except requests.HTTPError as error:


### PR DESCRIPTION
Before this commit, the `refresh_token` handling was done in the `calendar`
module,   even though it relates to token management and should therefore be
handled by `google_account`, which manages tokens and requests to Google.

This also fixes the call to `get_param('google_calendar_client_secret')`, which should use the correct helper `_get_client_secret`, as it may be monkey-patched by another module.
