### PR TITLE
[IMP] website: allow to not use default 3rd list

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -244,10 +244,18 @@ class Website(models.Model):
     def _compute_blocked_third_party_domains(self):
         for website in self:
             custom_list = website.sudo().custom_blocked_third_party_domains
+
+            full_list = DEFAULT_BLOCKED_THIRD_PARTY_DOMAINS
             if custom_list:
-                full_list = f'{DEFAULT_BLOCKED_THIRD_PARTY_DOMAINS}\n{custom_list}'
-            else:
-                full_list = DEFAULT_BLOCKED_THIRD_PARTY_DOMAINS
+                # Note: each line of the custom list is already ensured to not
+                # have leading or trailing whitespaces.
+                lines = custom_list.splitlines()
+                custom_domains = '\n'.join([line for line in lines if line[0] != '#'])
+                if lines[0].startswith("#ignore_default"):
+                    full_list = custom_domains
+                else:
+                    full_list += f"\n{custom_domains}"
+
             website.blocked_third_party_domains = full_list
 
     def _get_blocked_third_party_domains_list(self):

--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -504,7 +504,7 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
      */
     _onAcceptClick(ev) {
         const isFullConsent = ev.target.id === "cookies-consent-all";
-        this.cookieValue = `{"required": true, "optional": ${isFullConsent}}`;
+        this.cookieValue = `{"required": true, "optional": ${isFullConsent}, "ts": ${Date.now()}}`;
         if (isFullConsent) {
             document.dispatchEvent(new Event("optionalCookiesAccepted"));
         }

--- a/addons/website/wizard/blocked_third_party_domains.py
+++ b/addons/website/wizard/blocked_third_party_domains.py
@@ -12,17 +12,29 @@ class BlockedThirdPartyDomains(models.TransientModel):
     content = fields.Text(default=lambda s: s.env['website'].get_current_website().custom_blocked_third_party_domains)
 
     def action_save(self):
-        domains = set()
+        # Can't be a set since we want to keep comment order, this will just
+        # ignore people adding the same domain multiple times.
+        domains = []
         if self.content:
-            for domain in self.content.split('\n'):
+            for line in self.content.split('\n'):
+                domain = line.strip().lower()
+                if not domain:
+                    continue
+
+                if domain[0] == '#':
+                    # Allow a line to start with '#' indicating a comment (also
+                    # see #ignore_default).
+                    domains.append(domain)
+                    continue
+
                 try:
                     # Remove protocol, path and query + check that domain is
                     # valid.
-                    domain = parse_url(domain.strip().lower()).host
+                    domain = parse_url(domain).host
                 except LocationParseError:
                     raise ValidationError(_("The following domain is not valid:") + '\n' + domain)
                 if domain:
-                    domains.add(domain)
+                    domains.append(domain)
 
         self.env['website'].get_current_website().custom_blocked_third_party_domains = '\n'.join(domains)
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
By default, you cannot choose which third parties to block, you can just add to the default list.

After this commit, you can use the 'magic key' `#ignore_default`  to define your own list.
