### PR TITLE
[FIX] web: safe_eval with context for user filters domains

### DIFF
--- a/addons/web/controllers/json.py
+++ b/addons/web/controllers/json.py
@@ -262,7 +262,7 @@ def get_default_domain(model, action, context, eval_context):
     for ir_filter in model.env['ir.filters'].get_filters(model._name, action._origin.id):
         if ir_filter['is_default']:
             # user filters, static parsing only
-            default_domain = ast.literal_eval(ir_filter['domain'])
+            default_domain = safe_eval(ir_filter['domain'], eval_context)
             break
     else:
         def filters_from_context():


### PR DESCRIPTION
"/json" path not work if the current domain contains dynamic data like "uid", replace ast evaluation by safe_eval to pass the context

Steps:
- Open sales
- Save current filter as a custom default filter
    - My quotations: [("user_id", "=", uid)]
- Switch to json path

Actual result:
- Internal server error

Expected result:
- No error, json data is loaded with the domain

opw-4648527