### PR TITLE
[FIX] l10n_de: handle account move missing delivery date value

### DIFF
--- a/addons/l10n_de/models/account_move.py
+++ b/addons/l10n_de/models/account_move.py
@@ -1,15 +1,7 @@
-from odoo import models, api
+from odoo import models, api, fields
 
 class AccountMove(models.Model):
     _inherit = 'account.move'
-
-    @api.depends('invoice_date')
-    def _compute_delivery_date(self):
-        # EXTENDS 'account'
-        super()._compute_delivery_date()
-        for move in self:
-            if move.invoice_date and move.country_code == 'DE' and not move.delivery_date:
-                move.delivery_date = move.invoice_date
 
     @api.depends('country_code', 'move_type')
     def _compute_show_delivery_date(self):
@@ -22,5 +14,5 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         for move in self:
             if move.country_code == 'DE' and move.is_sale_document() and not move.delivery_date:
-                move.delivery_date = move.invoice_date
+                move.delivery_date = move.invoice_date or fields.Date.context_today(self)
         return super()._post(soft)

--- a/addons/l10n_de/tests/__init__.py
+++ b/addons/l10n_de/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_account_move
 from . import test_audit_trail

--- a/addons/l10n_de/tests/test_account_move.py
+++ b/addons/l10n_de/tests/test_account_move.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo import fields, Command
+from freezegun import freeze_time
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestAccountMoveDE(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref='de_skr03'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'Helmut',
+            'country_id': cls.env.ref('base.de').id,
+        })
+
+    @freeze_time('2025-01-01')
+    def test_missing_invoice_delivery_date(self):
+        ''' Test that confirming an Account Move sets a value for delivery_date if none present
+        '''
+        move = self.env['account.move'].with_context(company_id=self.company_data['company'].id).create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner.id,
+            'invoice_line_ids': [Command.create({
+                'quantity': 1.0,
+                'price_unit': 1000.0,
+            })],
+        })
+        move.action_post()
+        self.assertEqual(fields.Date.from_string('2025-01-01'), move.invoice_date)
+        self.assertEqual(fields.Date.from_string('2025-01-01'), move.delivery_date)


### PR DESCRIPTION
Issue
-----
For a German company, when confirming an invoice for an order the
delivery date (of the invoice) gets set to the invoice date, even when one was
manually provided beforehand.

Steps to reproduce
-----
- Install Sales, Inventory, Purchase and German localization
- Switch to a German company
- Create a product
- Create a Sale Order for the product & confirm it
- Validate the linked Delivery
- Go back to the SO & create a (draft) Invoice
- Set a delivery date & confirm the Invoice

-> The delivery date changed to the invoice date

Cause
-----
When posting, we set the invoice date if no value was provided. This triggers
compute_delivery_date because it is overridden in the German localization to
depend on the invoice_date field. The override is present because delivery_date
is a legal requirement for the German localization.

However, forcing a value for invoice_date is also handled in the _post override
of the localization. We can just remove it.

This creates a problem of there being no value for delivery_date if invoice_date
is also False. This is because _post sets delivery_date = invoice_date before
calling the logic that forces a value for invoice_date. We should thus provide a
fallback value.

-----
Ticket:
opw-4599301