### PR TITLE
[FIX] account: fix gap in sequence warning for branches

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -124,23 +124,33 @@ class account_journal(models.Model):
 
     def _query_has_sequence_holes(self):
         self.env['account.move'].flush_model(['journal_id', 'date', 'sequence_prefix', 'sequence_number', 'state'])
+        # A branch company is locked when the parent is locked.
+        # Parent companies of the journal company can not add moves to the journal.
+        # Thus it is good enough to consider all moves in the journal after the journal company lockdate.
+        # This way we find all holes that can still be corrected.
+        to_check = self.grouped(lambda j: j.company_id.fiscalyear_lock_date)
         queries = []
-        for company in self.env.companies:
+        for lock_date, journals in to_check.items():
+            # We add the companies to the query to benefit from index `account_move_journal_id_company_id_idx`
+            journal_company_ids = journals.company_id.ids
+            companies = self.env['res.company'].sudo().search([
+                ('id', 'child_of', journal_company_ids),
+            ])
             queries.append(SQL(
                 """
                     SELECT move.journal_id,
                            move.sequence_prefix
                       FROM account_move move
                      WHERE move.journal_id = ANY(%(journal_ids)s)
-                       AND move.company_id = %(company_id)s
+                       AND move.company_id = ANY(%(company_ids)s)
                        AND (move.state = 'posted' OR (move.state = 'draft' AND move.name != '/'))
                        AND %(fiscalyear_lock_date_clause)s
                   GROUP BY move.journal_id, move.sequence_prefix
                     HAVING COUNT(*) != MAX(move.sequence_number) - MIN(move.sequence_number) + 1
                 """,
-                journal_ids=self.ids,
-                company_id=company.id,
-                fiscalyear_lock_date_clause=SQL('move.date > %s', lock_date) if (lock_date := company.fiscalyear_lock_date) else SQL('TRUE')
+                journal_ids=journals.ids,
+                company_ids=companies.ids,
+                fiscalyear_lock_date_clause=SQL('move.date > %s', lock_date) if lock_date else SQL('TRUE'),
             ))
         self.env.cr.execute(SQL(' UNION ALL '.join(['%s'] * len(queries)), *queries))
         return self.env.cr.fetchall()


### PR DESCRIPTION
There are currently 2 issues with the "Gaps in the sequence" warning on journals in the accounting dashboard.

(1)
Sequence check per company issue:
We query and thus do the the sequence check only on the moves of a single company. This e.g. fails though in the following case (all moves in the same journal)
```
move0: company_A
move1: company_B
move2: company_A
```
The query for company_A will find a gap between move0 and move2. But there is no gap (it just belongs to a different company).

(2)
Lockdate per company issue:
 Consider the case that the child company is already locked but the parent is not.
E.g
```
move0: parent company
move1: child company (move is locked)
move2: parent company
```
We would find a gap for the parent company.

The "right" lock date to use for a journal is the lock date of the journal company:
  * A branch company is locked when the parent is locked.
  * Parent companies of the journal company can not add moves to the journal. So we will find all holes that can still be corrected.

After this commit we query per lock date (instead of per company). In each query we check all the journals restricted by the same lock date.

This solves both issues:
(1) is solved since query all moves independent of the company
(2) is not an issue since we use the "right" lock date (see reasoning above)

opw-4548453