### PR TITLE
[IMP] web_editor: enhance the design of install buttons

### DIFF
--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -252,7 +252,7 @@ export class AddSnippetDialog extends Component {
                     snippetPreviewWrapEl.classList.add("o_snippet_preview_install");
                     clonedSnippetEl.dataset.moduleId = snippet.moduleId;
                     const installBtnEl = document.createElement("button");
-                    installBtnEl.classList.add("o_snippet_preview_install_btn", "btn", "text-white", "rounded-1", "mx-auto", "p-2", "bottom-50");
+                    installBtnEl.classList.add("o_snippet_preview_install_btn", "btn", "text-white", "rounded-1", "mx-auto", "p-2", "bottom-50", "shadow");
                     installBtnEl.innerText = _t("Install %s", snippet.displayName);
                     snippetPreviewWrapEl.appendChild(installBtnEl);
                 }

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -5201,8 +5201,11 @@ class SnippetsMenu extends Component {
             body: markup(`${escape(bodyText)}\n<a href="${linkUrl}" target="_blank">${escape(linkText)}</a>`),
             confirm: async () => {
                 try {
-                    await this.orm.call("ir.module.module", "button_immediate_install", [[moduleID]]);
+                    this._execWithLoadingEffect(async () => {
+                        await this.orm.call("ir.module.module", "button_immediate_install", [[moduleID]]);
+                    }, "both");
                     this.invalidateSnippetCache = true;
+                    this.dialog.closeAll(); // Close the "add snippet" dialog.
                     this._onSaveRequest({
                         data: {
                             reloadWebClient: true,

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -396,7 +396,7 @@
                 &.o_snippet_install {
                     .btn.o_install_btn {
                         z-index: 1;
-                        @include o-position-absolute($top: 10px);
+                        @include o-position-absolute($top: 10px, $right: 2px, $left: 2px);
                         @include text-truncate();
                     }
 

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -198,7 +198,7 @@
                                             <span class="oe_snippet_thumbnail_title"><t t-out="snippet.displayName"/></span>
                                         </t>
                                         <t t-if="snippet.installable">
-                                            <button class="btn btn-primary o_install_btn w-100" t-on-click="_onInstallBtnClick">Install</button>
+                                            <button class="btn btn-primary o_install_btn rounded-0 shadow" t-on-click="_onInstallBtnClick">Install</button>
                                         </t>
                                     </div>
                                     <t t-if="snippet.isCustom and !snippet.renaming">


### PR DESCRIPTION
-- **Commit 1** --

This commit slightly improves the design of the "Install" buttons in the snippet menu in website edit mode. These buttons appear when only "Website" is installed and allow installing a new app to make the snippet available.

- Add slight left and right padding to the buttons.
- Remove rounded corners.
- Add a shadow for better contrast.

#### Preview
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/9aa40484-a11b-4216-8e99-01ef8fe5ab58) | ![image](https://github.com/user-attachments/assets/6358c7cc-a136-4d30-994d-26864b0ec33e) |

task-4434981

------

-- **Commit 2** --

Steps to reproduce:

- Enter edit mode with only "Website" installed.
- Click on the "Add to Cart Button" snippet in the snippet menu.
- Click on "Confirm" in the dialog to install the module.
- Bug: During installation, it is possible to make changes on the page.

This commit adds a loader during module installation to prevent users
from modifying the page. It also closes the "Add Snippet" dialog when
installing a module from it.