### PR TITLE
[FIX] product: wrong supplier code

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -232,13 +232,19 @@ class ProductProduct(models.Model):
 
     @api.depends_context('partner_id')
     def _compute_product_code(self):
+        read_access = self.env['ir.model.access'].check('product.supplierinfo', 'read', False)
         for product in self:
             product.code = product.default_code
-            if self.env['ir.model.access'].check('product.supplierinfo', 'read', False):
+            if read_access:
                 for supplier_info in product.seller_ids:
                     if supplier_info.partner_id.id == product._context.get('partner_id'):
+                        if supplier_info.product_id and supplier_info.product_id != product:
+                            # Supplier info specific for another variant.
+                            continue
                         product.code = supplier_info.product_code or product.default_code
-                        break
+                        if product == supplier_info.product_id:
+                            # Supplier info specific for this variant.
+                            break
 
     @api.depends_context('partner_id')
     def _compute_partner_ref(self):

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -60,6 +60,20 @@ class TestVariants(ProductVariantsCommon):
         self.assertEqual({True}, set(v.is_product_variant for v in variants),
                          'Product variants are variants')
 
+    def test_variants_pricelist_code(self):
+        vendor = self.env['res.partner'].create({'name': 'Bidou', 'email': 'bidou@odoo.com'})
+        codes = ['bidou-red', 'bidou-green', 'bidou-blue']
+        self.env['product.supplierinfo'].create([{
+            'partner_id': vendor.id,
+            'product_tmpl_id': self.product_template_sofa.id,
+            'product_id': product.id,
+            'product_code': code,
+        } for product, code in zip(self.product_template_sofa.product_variant_ids, codes)])
+        variants = self.product_template_sofa.product_variant_ids.with_context(partner_id=vendor.id)
+        self.assertEqual(variants[0].code, codes[0], "sofa red should have code bidou-red")
+        self.assertEqual(variants[1].code, codes[1], "sofa green should have code bidou-green")
+        self.assertEqual(variants[2].code, codes[2], "sofa blue should have code bidou-blue")
+
     def test_variants_creation_mono(self):
         test_template = self.env['product.template'].create({
             'name': 'Sofa',


### PR DESCRIPTION
Issue
=====
When product's code is computed, which is depend of the product's suppliers since each supplier can have a specific code, the first supplier is taken regardless if this supplier info is specific to another product variant which can cause to use the wrong code if there is multiple supplier with the same vendor but for different variants of the same product template.

How to reproduce
================
1. Install Puchase and Barcode;
2. Create a product with at least 2 variants;
3. In the "Purchase" tab of this product, add two vendor pricelists with the same vendor but each for a different product variant and each with a different code;
4. Go in Purchase, create a new RFQ for this vendor, add a PO line for each variant and confirm the order;
5. Go in Barcode and open the PO's receipt -> You can see both lines have the same vendor's code (from the first pricelist) regardless the pricelist's product variant.

Cause of the issue
==================
In `_compute_product_code`, it uses the first product (template) supplier info regardless the product variant.

Solution
========
In `_compute_product_code`, we skip a supplier info if it concerns another variant, and we break the supplier info loop only if it concerns the current product variant.

Miscellaneous
=============
The check of the `product.supplierinfo` `read` access right is moved outside of the loop so it is done only one time.

[OPW-4589073](https://www.odoo.com/odoo/project/49/tasks/4589073)