### PR TITLE
[FIX] portal,website_sale: redirection to HTML content

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1179,7 +1179,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         """
         order_sudo = request.website.sale_get_order()
         if redirection := self._check_cart(order_sudo):
-            return redirection
+            return json.dumps({'redirectUrl': redirection.location})
 
         partner_sudo, address_type = self._prepare_address_update(
             order_sudo, partner_id=partner_id and int(partner_id), address_type=address_type
@@ -1258,7 +1258,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         self._handle_extra_form_data(extra_form_data, address_values)
 
         return json.dumps({
-            'successUrl': callback,
+            'redirectUrl': callback,
         })
 
     def _prepare_address_update(self, order_sudo, partner_id=None, address_type=None):

--- a/addons/website_sale/static/src/js/address.js
+++ b/addons/website_sale/static/src/js/address.js
@@ -206,8 +206,8 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
                 '/shop/address/submit',
                 new FormData(this.addressForm),
             )
-            if (result.successUrl) {
-                window.location = result.successUrl;
+            if (result.redirectUrl) {
+                window.location = result.redirectUrl;
             } else {
                 // Highlight missing/invalid form values
                 document.querySelectorAll('.is-invalid').forEach(element => {


### PR DESCRIPTION
When submitting the new address, the `post` method from the `http` service is called. This method expects a response in JSON. The problem arises when a redirection occurs during that call, then the returned content might be of another type which triggers an error. For example, it is possible to be redirected to the `/shop/cart` page if the cart is not valid.

Steps to reproduce:
- Add a product to your cart
- Then head over to the address form during checkout.
- Before confirming your address, in another tab, open the backend and remove every order line in your cart.
- Then back on the previous tab, confirm your address.
- You can observe an error in the console:

```
SyntaxError: Unexpected token '<', ..."
        <!DOCTYPE "... is not valid JSON
```

This commit fixes this issue by sending the redirection URL in the result of `shop_address_submit` and lets the client handle the redirection.

This commit also renames the `successUrl` value to `redirectUrl` to make it more clear that it is not necessarily a success URL any more, but the next location URL for the user, ie. redirect.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
