### PR TITLE
[FIX] l10n_ro_edi: fix EDI checkbox in send wizard

### DIFF
--- a/addons/account/static/src/css/account.css
+++ b/addons/account/static/src/css/account.css
@@ -62,3 +62,13 @@
 .o_field_account_resequence_widget {
     width: 100%;
 }
+
+.o_field_account_json_checkboxes {
+    div.form-check {
+        display: inline-block;
+    }
+
+    i.fa {
+        margin-left: 2px;
+    }
+}

--- a/addons/l10n_ro_edi/wizard/account_move_send_wizard.py
+++ b/addons/l10n_ro_edi/wizard/account_move_send_wizard.py
@@ -9,5 +9,5 @@ class AccountMoveSendWizard(models.TransientModel):
         for wizard in self:
             checkboxes = wizard.extra_edi_checkboxes or {}
             if 'ro_edi' not in checkboxes and wizard.move_id.l10n_ro_edi_state == 'invoice_sent':
-                readonly_checkbox = {'checked': False, 'readonly': True, 'label': _("Send E-Factura to SPV"), 'question_circle': _("You can't send now. Invoice is waiting for an answer.")}
+                readonly_checkbox = {'ro_spv': {'checked': False, 'readonly': True, 'label': _("Send E-Factura to SPV"), 'question_circle': _("You can't send now. Invoice is waiting for an answer.")}}
                 wizard.extra_edi_checkboxes = {**checkboxes, **readonly_checkbox}


### PR DESCRIPTION
**Steps to reproduce:**
(To reproduce the issue, we have to simulate a case where "E-Factura Status" is "Sent".
This can be done by editing "account_move_form_inherit_l10n_ro_edi" view and setting "l10n_ro_edi_state" field visible and editable.)
- Install Accounting and l10n_ro_edi
- Switch to a Romanian company (e.g. RO Company)
- Create an invoice
- Set "E-Factura Status" to "Sent"
- Confirm it
- Try to send the invoice

**Issue:**
1) A traceback is raised when trying to generate the extra EDI checkbox for the "Print & Send" wizard.

2) Once the first issue fixed, the "Send E-Factura to SPV" option will be displayed in the "Print & Send" wizard with a warning tooltip button.
The tooltip button will be displayed on another line, which misaligns the "Send E-Factura to SPV" option with the other ones.

**Cause:**
This specific code:
```py
return [checkbox_key for checkbox_key, checkbox_vals in json_checkboxes.items()
        if checkbox_vals['checked']]
```
fails because there is no key associated to the data dict for the Romanian EDI checkbox.

opw-4630524




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
