### PR TITLE
[FIX] web_editor: display module name in install snippet dialog

### DIFF
--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -109,9 +109,10 @@ class IrQWeb(models.AbstractModel):
             if not module or module.state == 'installed':
                 return []
             name = el.attrib.get('string') or 'Snippet'
-            div = '<div name="%s" data-oe-type="snippet" data-module-id="%s" data-oe-thumbnail="%s"><section/></div>' % (
+            div = '<div name="%s" data-oe-type="snippet" data-module-id="%s" data-module-display-name="%s" data-oe-thumbnail="%s"><section/></div>' % (
                 escape(pycompat.to_text(name)),
                 module.id,
+                module.display_name,
                 escape(pycompat.to_text(thumbnail))
             )
             self._append_text(div, compile_context)

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -4014,17 +4014,23 @@ var SnippetsMenu = Widget.extend({
         var self = this;
         var $snippet = $(ev.currentTarget).closest('[data-module-id]');
         var moduleID = $snippet.data('moduleId');
-        var name = $snippet.attr('name');
+        var moduleDisplayName = $snippet[0].dataset.moduleDisplayName;
         new Dialog(this, {
-            title: _.str.sprintf(_t("Install %s"), name),
+            title: _.str.sprintf(_t("Install %s"), `"${moduleDisplayName}"`),
             size: 'medium',
-            $content: $('<div/>', {text: _.str.sprintf(_t("Do you want to install the %s App?"), name)}).append(
+            $content: $('<div/>', {text: _.str.sprintf(_t("Do you want to install the %s App?"), `"${moduleDisplayName}"`)}).append(
                 $('<a/>', {
                     target: '_blank',
                     href: '/web#id=' + encodeURIComponent(moduleID) + '&view_type=form&model=ir.module.module&action=base.open_module_tree',
                     text: _t("More info about this app."),
                     class: 'ml4',
-                })
+                }).prepend(
+                    $('<i/>', {
+                        class: 'fa fa-arrow-right me-1'
+                    })
+                ).prepend(
+                    $('<br/>')
+                )
             ),
             buttons: [{
                 text: _t("Save and Install"),
@@ -4044,7 +4050,7 @@ var SnippetsMenu = Widget.extend({
                     }).guardedCatch(reason => {
                         reason.event.preventDefault();
                         this.close();
-                        const message = sprintf(Markup(_t("Could not install module <strong>%s</strong>")), name);
+                        const message = sprintf(Markup(_t("Could not install module <strong>%s</strong>")), moduleDisplayName);
                         self.displayNotification({
                             message: message,
                             type: 'danger',


### PR DESCRIPTION
Steps to reproduce:

- Install the Website.
- Enter edit mode.
- Click on the "Add to Cart Button" snippet in the snippet menu.
- Bug: The message displayed in the dialog is "Do you want to install the Add to Cart Button app?". This is incorrect; the app name should be the module name instead of the snippet name.

This commit displays the module name as expected and slightly enhances the design of the dialog (line break before the link + add an arrow icon before the link to the app info).

#### Preview
| Before |
|--------|
| ![image](https://github.com/user-attachments/assets/aa8a31d6-49e0-4679-a281-1d58b88214c1) |

| After |
|--------|
| ![image](https://github.com/user-attachments/assets/2f175136-2cc5-4b3d-a995-095ead92303b) |

task-4434981
