### PR TITLE
[PERF] stock: speedup get_orderpoint_action

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -414,7 +414,7 @@ class StockWarehouseOrderpoint(models.Model):
         rounding = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         # Group orderpoint by product-location
         orderpoint_by_product_location = self.env['stock.warehouse.orderpoint']._read_group(
-            [('id', 'in', orderpoints.ids)],
+            [('id', 'in', orderpoints.ids), ('product_id', 'in', product_ids)],
             ['product_id', 'location_id', 'qty_to_order:sum'],
             ['product_id', 'location_id'], lazy=False)
         orderpoint_by_product_location = {
@@ -433,7 +433,7 @@ class StockWarehouseOrderpoint(models.Model):
 
         # With archived ones to avoid `product_location_check` SQL constraints
         orderpoint_by_product_location = self.env['stock.warehouse.orderpoint'].with_context(active_test=False)._read_group(
-            [('id', 'in', orderpoints.ids)],
+            [('id', 'in', orderpoints.ids), ('product_id', 'in', product_ids)],
             ['product_id', 'location_id', 'ids:array_agg(id)'],
             ['product_id', 'location_id'], lazy=False)
         orderpoint_by_product_location = {


### PR DESCRIPTION
### Description:

When opening the replenishment view, the locations are checked to find if some products need to be refilled. If one product needs to be refilled, it will check if an orderpoint already exists, otherwise, it will create it. The issue is that the checks are currently done on all the orderpoints, even the ones not related to the product. The performances are worsened by the compute on `qty_to_order` triggered on all the orderpoints.

### Fix:

To fix that, we can add a leaf to the domain so that we only retrieve the orderpoints related to the products that need to be refilled. This will reduce the number of records on which we call the `qty_to_order` compute.

### Benchmark (in 18):

| # of orderpoint | Before | After |
| --------------- | ------ | ----- |
|           44145 |   6:52 |    6s |
|           22145 |   3:38 |    6s |

### Reference:

opw-4618887