### PR TITLE
[FIX] account_edi_ubl_cii: import missing partner fields

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -335,14 +335,14 @@ class AccountEdiCommon(models.AbstractModel):
 
         return invoice
 
-    def _import_retrieve_and_fill_partner(self, invoice, name, phone, mail, vat, country_code=False):
+    def _import_retrieve_and_fill_partner(self, invoice, name, phone, mail, vat, country_code=False, street=False, street2=False, city=False, zip_code=False):
         """ Retrieve the partner, if no matching partner is found, create it (only if he has a vat and a name)
         """
         invoice.partner_id = self.env['account.edi.format'] \
             .with_company(invoice.company_id) \
             ._retrieve_partner(name=name, phone=phone, mail=mail, vat=vat)
         if not invoice.partner_id and name and vat:
-            partner_vals = {'name': name, 'email': mail, 'phone': phone}
+            partner_vals = {'name': name, 'email': mail, 'phone': phone, 'street': street, 'street2': street2, 'zip': zip_code, 'city': city}
             country = self.env.ref(f'base.{country_code.lower()}', raise_if_not_found=False) if country_code else False
             if country:
                 partner_vals['country_id'] = country.id

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -598,7 +598,12 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         name = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:Name', tree) or \
             self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:RegistrationName', tree)
         country_code = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cac:Country//cbc:IdentificationCode', tree)
-        self._import_retrieve_and_fill_partner(invoice, name=name, phone=phone, mail=mail, vat=vat, country_code=country_code)
+        street = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:StreetName', tree)
+        street2 = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:AdditionalStreetName', tree)
+        city = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:CityName', tree)
+        zip_code = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:PostalZone', tree)
+
+        self._import_retrieve_and_fill_partner(invoice, name=name, phone=phone, mail=mail, vat=vat, country_code=country_code, street=street, street2=street2, city=city, zip_code=zip_code)
 
         # ==== currency_id ====
 


### PR DESCRIPTION
Currently when the user upload an e-invoice in compatible format,
accounting information will be extracted to automatically create the
bill and associated records.
While creating the parnter, however, only basic information is filled in
(name, vat, email, phone, country), leaving out the address

Steps to reproduce:
- Import an xml bill with complete partner info
Issue: Only some partner fields are imported

opw-4488308