### PR TITLE
[FIX] web: kanban: no crash when opening record after d&d

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -147,6 +147,10 @@ export class KanbanController extends Component {
         });
         useSetupView({
             rootRef: this.rootRef,
+            beforeLeave: () => {
+                // wait for potential pending write operations (e.g. records being moved)
+                return this.model.mutex.getUnlockedDef();
+            },
             getGlobalState: () => {
                 return {
                     resIds: this.model.root.records.map((rec) => rec.resId), // WOWL: ask LPE why?


### PR DESCRIPTION
In a grouped kanban view (e.g. project tasks), especially on a slow network, quickly move several records from a column to another, and click on a record to open it.

Before this commit, we switched to the opened record directly, without waiting for the ongoing rpcs (web_save, resequence), for each moved record. However, the `async` protection in the orm service prevent destroyed components from doing rpcs. As a consequence, a crash can occur if some moved records could not be saved before leaving the kanban view.

This commit ensures that we wait for all those operations to be done before leaving the kanban view. That way, all moved records are properly saved, and no crash occurs.

Issue reported on our prod.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
