### PR TITLE
[FIX] web: tagline color on invoice preview

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -884,7 +884,7 @@
                         color: <t t-esc='primary'/>;
                     }
 
-                    .o_company_tagline {
+                    .o_company_tagline * {
                         color: <t t-esc='primary'/>
                     }
             <t t-if="layout == 'web.external_layout_boxed'">


### PR DESCRIPTION
Steps to reproduce:
 - open the general settings
 - open the "Configure Document Layout" in the "Companies" section
 - suggestion: set a strong visible color for the primary color
 - write a tagline -> the tagline now has the color set previously as expected
 - change the font size of the tagline to header 3 -> the color of the tagline in the preview is reset to black

Issue arise because the color gets overridden by generic style

opw-4572819

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
