### PR TITLE
[FIX] mrp_account: post labor entry once

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -105,7 +105,7 @@ class MrpProduction(models.Model):
             for line in account_move.line_ids[:-1]:
                 workorders[line.account_id].time_ids.write({'account_move_line_id': line.id})
 
-    def button_mark_done(self):
-        res = super().button_mark_done()
-        self._post_labour()
+    def _post_inventory(self, cancel_backorder=False):
+        res = super()._post_inventory(cancel_backorder=cancel_backorder)
+        self.filtered(lambda mo: mo.state == 'done')._post_labour()
         return res

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -619,6 +619,42 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
             {'credit': 0.00, 'debit': 0.01},
         ])
 
+    def test_labor_cost_over_consumption(self):
+        """ Test the labour accounting entries creation is independent of consumption variation"""
+        self.workcenter.write({'costs_hour': 20})
+        self.bom.operation_ids = [Command.create({
+            'name': 'work',
+            'workcenter_id': self.workcenter.id,
+            'time_cycle': 5,
+            'sequence': 1,
+        })]
+        production = self.env['mrp.production'].create({
+            'bom_id': self.bom.id,
+            'product_qty': 1,
+        })
+        production.action_confirm()
+        production.workorder_ids.duration = 60
+
+        production.qty_producing = 1
+
+        # overconsume one component to get a warning wizard
+        production.move_raw_ids[0].quantity += 2
+
+        action = production.button_mark_done()
+        consumption_warning = Form(self.env['mrp.consumption.warning'].with_context(**action['context'])).save()
+        consumption_warning.action_confirm()
+
+        mo_aml = self.env['account.move.line'].search([('name', 'like', production.name)])
+        self.assertEqual(len(mo_aml), 6, "2 Labour + 2 finished product + 2 for the components")
+        self.assertRecordValues(mo_aml, [
+            {'name': production.name + ' - Labour', 'debit': 0.0, 'credit': 20.0},
+            {'name': production.name + ' - Labour', 'debit': 20.0, 'credit': 0.0},
+            {'name': production.name + ' - ' + self.product_A.name, 'debit': 0.0, 'credit': 10.0},
+            {'name': production.name + ' - ' + self.product_A.name, 'debit': 10.0, 'credit': 0.0},
+            {'name': production.name + ' - ' + self.product_B.name, 'debit': 0.0, 'credit': 10.0},
+            {'name': production.name + ' - ' + self.product_B.name, 'debit': 10.0, 'credit': 0.0},
+        ])
+
     def test_labor_cost_balancing_with_cost_share(self):
         """ Same test as test_labor_cost_balancing, however, instead of having the worcenter_cost to 0.05,
         we have it at 0.01, and it is the cost_share that bring it back to 0.005 before rounding it back up to 0.01.


### PR DESCRIPTION
By overriding `button_mark_done` to post labor entries, multiples entries could be posted in case of action returned (overconsumption wizard for instance) before the actual validation.
This commit change the override by `_post_inventory()` which is called only once per validation.

opw: 4571535
opw: 4532096

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
