### PR TITLE
[FIX] sale: sudo compute amount invoiced

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -212,7 +212,11 @@ class SaleOrder(models.Model):
     amount_tax = fields.Monetary(string="Taxes", store=True, compute='_compute_amounts')
     amount_total = fields.Monetary(string="Total", store=True, compute='_compute_amounts', tracking=4)
     amount_to_invoice = fields.Monetary(string="Amount to invoice", store=True, compute='_compute_amount_to_invoice')
-    amount_invoiced = fields.Monetary(string="Already invoiced", compute='_compute_amount_invoiced')
+    amount_invoiced = fields.Monetary(
+        string="Already invoiced",
+        compute='_compute_amount_invoiced',
+        compute_sudo=True,  # compute `amount_invoiced` in sudo like the stored `amount_*` fields
+    )
 
     invoice_count = fields.Integer(string="Invoice Count", compute='_get_invoiced')
     invoice_ids = fields.Many2many(


### PR DESCRIPTION
Versions
--------
- 17.0+

Enterprise PR: https://github.com/odoo/enterprise/pull/81461

Steps
-----
1. Have a internal user with only Sales: Own Documents access;
2. assign the user to a subscription;
3. as admin, create an invoice for the subscription;
4. assign yoursel as salesman on the invoice;
5. confirm the invoice;
6. log in as the other user;
7. try to create an invoice for the subscription assigned to you.

Issue
-----
Access error.

Cause
-----
Unlike the the other `_compute_amount_*` methods of sale.order, `_compute_amount_invoiced` isn't computed with `sudo`.

This isn't an issue when just using `sale`, as it's computed with only sale order fields, but if an override attempts to check `invoice_ids`, it will throw an error if it has an invoice you don't have access to.

Solution
--------
In `sale`:
- The bring the compute method in line with other `_compute_amount_*` methods, add `compute_sudo=True` to the `amount_invoiced` field.

In `sale_subscription`:
- Add a test to prevent regression.

opw-4554639