### PR TITLE
[IMP] mail: composer reply to message is preserved

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -5,12 +5,7 @@ import { AutoresizeInput } from "@mail/core/common/autoresize_input";
 import { CountryFlag } from "@mail/core/common/country_flag";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
-import {
-    useHover,
-    useMessageEdition,
-    useMessageHighlight,
-    useMessageToReplyTo,
-} from "@mail/utils/common/hooks";
+import { useHover, useMessageEdition, useMessageHighlight } from "@mail/utils/common/hooks";
 import { isEventHandled } from "@web/core/utils/misc";
 
 import { Component, toRaw, useChildSubEnv, useRef, useState } from "@odoo/owl";
@@ -49,7 +44,6 @@ export class ChatWindow extends Component {
         this.store = useService("mail.store");
         this.messageEdition = useMessageEdition();
         this.messageHighlight = useMessageHighlight();
-        this.messageToReplyTo = useMessageToReplyTo();
         this.state = useState({
             actionsMenuOpened: false,
             jumpThreadPresent: 0,

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -102,13 +102,13 @@
                     <t t-component="threadActions.activeAction.component" t-props="{ ...threadActions.activeAction.componentProps, thread }"/>
                 </div>
                 <t t-elif="thread">
-                    <Thread isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/>
+                    <Thread isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage" messageEdition="messageEdition"/>
                     <div t-if="thread.hasOtherMembersTyping" class="d-flex bg-view position-relative">
                         <div class="o-mail-ChatWindow-typing d-flex px-2 position-absolute bottom-0 start-0 w-100 bg-view align-items-center">
                             <Typing channel="thread" size="'medium'"/>
                         </div>
                     </div>
-                    <Composer composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
+                    <Composer composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
                 </t>
             </t>
         </div>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -45,7 +45,6 @@ const EDIT_CLICK_TYPE = {
 /**
  * @typedef {Object} Props
  * @property {import("models").Composer} composer
- * @property {import("@mail/utils/common/hooks").MessageToReplyTo} messageToReplyTo
  * @property {import("@mail/utils/common/hooks").MessageEdition} [messageEdition]
  * @property {'compact'|'normal'|'extended'} [mode] default: 'normal'
  * @property {'message'|'note'|false} [type] default: false
@@ -75,7 +74,6 @@ export class Composer extends Component {
     static props = [
         "composer",
         "autofocus?",
-        "messageToReplyTo?",
         "onCloseFullComposerCallback?",
         "onDiscardCallback?",
         "onPostCallback?",
@@ -181,12 +179,12 @@ export class Composer extends Component {
             () => [this.props.autofocus + this.props.composer.autofocus, this.props.placeholder]
         );
         useEffect(
-            (rThread, cThread) => {
-                if (cThread && cThread.eq(rThread)) {
+            () => {
+                if (this.props.composer.replyToMessage) {
                     this.props.composer.autofocus++;
                 }
             },
-            () => [this.props.messageToReplyTo?.thread, this.props.composer.thread]
+            () => [this.props.composer.replyToMessage]
         );
         useEffect(
             () => {
@@ -315,7 +313,7 @@ export class Composer extends Component {
     }
 
     get thread() {
-        return this.props.messageToReplyTo?.message?.thread ?? this.props.composer.thread ?? null;
+        return this.props.composer.replyToMessage?.thread ?? this.props.composer.thread ?? null;
     }
 
     get allowUpload() {
@@ -599,7 +597,7 @@ export class Composer extends Component {
                 } else {
                     this.clear();
                 }
-                this.props.messageToReplyTo?.cancel();
+                this.props.composer.replyToMessage = undefined;
                 this.onCloseFullComposerCallback();
                 this.state.isFullComposerOpen = false;
                 // Use another event bus so that no message is sent to the
@@ -689,7 +687,7 @@ export class Composer extends Component {
             mentionedChannels: composer.mentionedChannels || [],
             mentionedPartners: composer.mentionedPartners || [],
             cannedResponseIds: composer.cannedResponses.map((c) => c.id),
-            parentId: this.props.messageToReplyTo?.message?.id,
+            parentId: this.props.composer.replyToMessage?.id,
         };
     }
 
@@ -722,7 +720,7 @@ export class Composer extends Component {
         }
         this.suggestion?.clearRawMentions();
         this.suggestion?.clearCannedResponses();
-        this.props.messageToReplyTo?.cancel();
+        this.props.composer.replyToMessage = undefined;
         this.props.composer.emailAddSignature = true;
         this.props.composer.thread.additionalRecipients = [];
     }
@@ -795,19 +793,26 @@ export class Composer extends Component {
 
     saveContent() {
         const composer = toRaw(this.props.composer);
-        const saveContentToLocalStorage = (text, emailAddSignature) => {
-            const config = {
-                emailAddSignature,
-                text,
-            };
-            browser.localStorage.setItem(composer.localId, JSON.stringify(config));
+        const saveContentToLocalStorage = ({ text, emailAddSignature, replyToMessageId }) => {
+            browser.localStorage.setItem(
+                composer.localId,
+                JSON.stringify({
+                    emailAddSignature,
+                    replyToMessageId,
+                    text,
+                })
+            );
         };
         if (this.state.isFullComposerOpen) {
             this.fullComposerBus.trigger("SAVE_CONTENT", {
                 onSaveContent: saveContentToLocalStorage,
             });
         } else {
-            saveContentToLocalStorage(composer.text, true);
+            saveContentToLocalStorage({
+                text: composer.text,
+                emailAddSignature: true,
+                replyToMessageId: composer.replyToMessage?.id,
+            });
         }
     }
 
@@ -818,6 +823,11 @@ export class Composer extends Component {
             if (config.text) {
                 composer.emailAddSignature = config.emailAddSignature;
                 composer.text = config.text;
+            }
+            if (Number.isInteger(config.replyToMessageId)) {
+                composer.replyToMessage = this.store["mail.message"].insert(
+                    config.replyToMessageId
+                );
             }
         } catch {
             browser.localStorage.removeItem(composer.localId);

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -31,14 +31,14 @@
             <div t-if="showComposerAvatar" class="o-mail-Composer-sidebarMain flex-shrink-0">
                 <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
             </div>
-            <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
-                <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">
-                    Replying to <b t-esc="props.messageToReplyTo.message.author?.name ?? props.messageToReplyTo.message.email_from"/>
+            <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.replyToMessage">
+                <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.composer.replyToMessage, props.composer.thread)">
+                    Replying to <b t-esc="props.composer.replyToMessage.author?.name ?? props.composer.replyToMessage.email_from"/>
                 </span>
-                <span t-if="props.messageToReplyTo.message.thread.notEq(props.composer.thread)">
-                    on: <b><t t-esc="props.messageToReplyTo.message.thread.displayName"/></b>
+                <span t-if="props.composer.replyToMessage.thread.notEq(props.composer.thread)">
+                    on: <b><t t-esc="props.composer.replyToMessage.thread.displayName"/></b>
                 </span>
-                <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => props.messageToReplyTo.cancel()"/>
+                <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => (props.composer.replyToMessage = undefined)"/>
             </div>
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended or props.composer.message }">
                 <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border shadow-sm border-secondary rounded-3"

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -46,12 +46,7 @@ composerActionsRegistry
             return "";
         },
         condition: (component) =>
-            (component.props.mode !== "extended" && !component.props.composer.message) ||
-            (component.props.messageToReplyTo?.message &&
-                component.props.composer.thread.notEq(
-                    component.props.messageToReplyTo.message.thread
-                )) ||
-            (component.props.composer.message && component.ui.isSmall),
+            !component.env.inChatter && (!component.props.composer.message || component.ui.isSmall),
         disabledCondition: (component) => component.isSendButtonDisabled,
         icon: "fa fa-paper-plane-o",
         name(component) {

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -5,6 +5,7 @@ export class Composer extends Record {
 
     clear() {
         this.attachments.length = 0;
+        this.replyToMessage = undefined;
         this.text = "";
         Object.assign(this.selection, {
             start: 0,
@@ -32,6 +33,7 @@ export class Composer extends Record {
     forceCursorMove;
     isFocused = false;
     autofocus = 0;
+    replyToMessage = Record.one("mail.message");
 }
 
 Composer.register();

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -48,7 +48,6 @@ import { discussComponentRegistry } from "./discuss_component_registry";
  * @property {boolean} [highlighted]
  * @property {function} [onParentMessageClick]
  * @property {import("models").Message} message
- * @property {import("@mail/utils/common/hooks").MessageToReplyTo} [messageToReplyTo]
  * @property {boolean} [squashed]
  * @property {import("models").Thread} [thread]
  * @property {ReturnType<import('@mail/core/common/message_search_hook').useMessageSearch>} [messageSearch]
@@ -86,7 +85,6 @@ export class Message extends Component {
         "onParentMessageClick?",
         "message",
         "messageEdition?",
-        "messageToReplyTo?",
         "previousMessage?",
         "squashed?",
         "thread?",
@@ -203,10 +201,7 @@ export class Message extends Component {
             "o-card p-2 mt-2 border border-secondary": this.props.asCard,
             "pt-1": !this.props.asCard,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,
-            "o-selected": this.props.messageToReplyTo?.isSelected(
-                this.props.thread,
-                this.props.message
-            ),
+            "o-selected": this.props.thread?.composer.replyToMessage?.eq(this.props.message),
             "o-squashed": this.props.squashed,
             "mt-1":
                 !this.props.squashed &&
@@ -214,10 +209,7 @@ export class Message extends Component {
                 !this.env.messageCard &&
                 !this.props.asCard,
             "px-2": this.props.isInChatWindow,
-            "opacity-50": this.props.messageToReplyTo?.isNotSelected(
-                this.props.thread,
-                this.props.message
-            ),
+            "opacity-50": this.props.thread?.composer.replyToMessage?.notEq(this.props.message),
             "o-actionMenuMobileOpen": this.state.actionMenuMobileOpen,
             "o-editing": this.state.isEditing,
         };
@@ -465,7 +457,6 @@ export class Message extends Component {
                 thread: this.props.thread,
                 isFirstMessage: this.props.isFirstMessage,
                 messageEdition: this.props.messageEdition,
-                messageToReplyTo: this.props.messageToReplyTo,
                 openReactionMenu: () => this.openReactionMenu(),
                 state: this.state,
             },

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.js
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.js
@@ -11,7 +11,6 @@ export class MessageActionMenuMobile extends Component {
         "thread?",
         "isFirstMessage?",
         "messageEdition?",
-        "messageToReplyTo?",
         "openReactionMenu?",
         "state",
     ];

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -52,7 +52,11 @@ messageActionsRegistry
         onClick: (component) => {
             const message = toRaw(component.props.message);
             const thread = toRaw(component.props.thread);
-            component.props.messageToReplyTo.toggle(thread, message);
+            if (message.eq(thread.composer.replyToMessage)) {
+                thread.composer.replyToMessage = undefined;
+            } else {
+                thread.composer.replyToMessage = message;
+            }
         },
         sequence: (component) => (component.props.thread?.eq(component.store.inbox) ? 55 : 20),
     })

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -33,7 +33,6 @@ const PRESENT_MESSAGE_THRESHOLD = 10;
  * @property {number} [jumpPresent=0]
  * @property {number} [jumpToNewMessage=0]
  * @property {import("@mail/utils/common/hooks").MessageEdition} [messageEdition]
- * @property {import("@mail/utils/common/hooks").MessageToReplyTo} [messageToReplyTo]
  * @property {"asc"|"desc"} [order="asc"]
  * @property {import("models").Thread} thread
  * @property {string} [searchTerm]
@@ -49,7 +48,6 @@ export class Thread extends Component {
         "jumpToNewMessage?",
         "thread",
         "messageEdition?",
-        "messageToReplyTo?",
         "order?",
         "scrollRef?",
         "showEmptyMessage?",

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -29,7 +29,6 @@
                         message="msg"
                         previousMessage="prevMsg"
                         registerMessageRef="registerMessageRef"
-                        messageToReplyTo="props.messageToReplyTo"
                         squashed="isSquashed(msg, prevMsg)"
                         onParentMessageClick.bind="() => msg.parentMessage and env.messageHighlight?.highlightMessage(msg.parentMessage, props.thread)"
                         thread="props.thread"

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -6,11 +6,7 @@ import { Thread } from "@mail/core/common/thread";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { DiscussSidebar } from "@mail/core/public_web/discuss_sidebar";
-import {
-    useMessageEdition,
-    useMessageHighlight,
-    useMessageToReplyTo,
-} from "@mail/utils/common/hooks";
+import { useMessageEdition, useMessageHighlight } from "@mail/utils/common/hooks";
 
 import {
     Component,
@@ -52,7 +48,6 @@ export class Discuss extends Component {
         this.store = useService("mail.store");
         this.messageHighlight = useMessageHighlight();
         this.messageEdition = useMessageEdition();
-        this.messageToReplyTo = useMessageToReplyTo();
         this.contentRef = useRef("content");
         this.root = useRef("root");
         this.state = useState({ jumpThreadPresent: 0 });

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -93,8 +93,8 @@
                     <t name="core-content">
                         <t t-if="thread">
                             <div class="o-mail-Discuss-threadContainer d-flex flex-column flex-grow-1">
-                                <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/></t>
-                                <Composer t-if="thread.model !== 'mail.box' or thread.eq(messageToReplyTo.thread)" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onDiscardCallback="() => messageToReplyTo.cancel()" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="messageToReplyTo?.message ? (messageToReplyTo.message.is_note ? 'note' : 'message') : undefined"/>
+                                <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition"/></t>
+                                <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.is_note ? 'note' : 'message') : undefined"/>
                             </div>
                             <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-Discuss-panelContainer h-100 border-start border-secondary flex-shrink-0">
                                 <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
@@ -38,7 +38,7 @@ const composerPatch = {
     },
     async sendGifMessage(gif) {
         await this._sendMessage(gif.url, {
-            parentId: this.props.messageToReplyTo?.message?.id,
+            parentId: this.props.composer.replyToMessage?.id,
         });
     },
 };

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -462,55 +462,6 @@ export function useMessageEdition() {
     return state;
 }
 
-/**
- * @typedef {Object} MessageToReplyTo
- * @property {function} cancel
- * @property {function} isNotSelected
- * @property {function} isSelected
- * @property {import("models").Message|null} message
- * @property {import("models").Thread|null} thread
- * @property {function} toggle
- * @returns {MessageToReplyTo}
- */
-export function useMessageToReplyTo() {
-    return useState({
-        cancel() {
-            Object.assign(this, { message: null, thread: null });
-        },
-        /**
-         * @param {import("models").Thread} thread
-         * @param {import("models").Message} message
-         * @returns {boolean}
-         */
-        isNotSelected(thread, message) {
-            return thread.eq(this.thread) && message.notEq(this.message);
-        },
-        /**
-         * @param {import("models").Thread} thread
-         * @param {import("models").Message} message
-         * @returns {boolean}
-         */
-        isSelected(thread, message) {
-            return thread.eq(this.thread) && message.eq(this.message);
-        },
-        /** @type {import("models").Message|null} */
-        message: null,
-        /** @type {import("models").Thread|null} */
-        thread: null,
-        /**
-         * @param {import("models").Thread} thread
-         * @param {import("models").Message} message
-         */
-        toggle(thread, message) {
-            if (message.eq(this.message)) {
-                this.cancel();
-            } else {
-                Object.assign(this, { message, thread });
-            }
-        },
-    });
-}
-
 export function useSequential() {
     let inProgress = false;
     let nextFunction;

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -24,9 +24,9 @@ export class HtmlComposerMessageField extends HtmlMailField {
                 this.editor.editable.after(elContent);
                 // TODO: the following legacy regex may not have the desired effect as it
                 // agglomerates multiple newLines together.
-                const textValue = elContent.innerText.replace(/(\t|\n)+/g, "\n");
+                const text = elContent.innerText.replace(/(\t|\n)+/g, "\n");
                 elContent.remove();
-                ev.detail.onSaveContent(textValue, emailAddSignature);
+                ev.detail.onSaveContent({ text, emailAddSignature });
             });
         }
     }

--- a/addons/mail/static/tests/core/search_highlight.test.js
+++ b/addons/mail/static/tests/core/search_highlight.test.js
@@ -164,6 +164,7 @@ test("Display highligthed search in Discuss", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message");
     await click("button[title='Search Messages']");
     await insertText(".o_searchview_input", "empty");
     triggerHotkey("Enter");
@@ -183,6 +184,7 @@ test("Display multiple highligthed search in Discuss", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message");
     await click("button[title='Search Messages']");
     await insertText(".o_searchview_input", "not empty");
     triggerHotkey("Enter");

--- a/addons/mail/static/tests/discuss/search_discuss.test.js
+++ b/addons/mail/static/tests/discuss/search_discuss.test.js
@@ -51,6 +51,7 @@ test("Search a message", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message");
     await click("button[title='Search Messages']");
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");
@@ -70,6 +71,7 @@ test("Search should be hightlighted", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message");
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");
@@ -90,6 +92,7 @@ test("Search a starred message", async () => {
     });
     await start();
     await openDiscuss("mail.box_starred");
+    await contains(".o-mail-Message");
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");
@@ -110,6 +113,7 @@ test("Search a message in inbox", async () => {
     });
     await start();
     await openDiscuss("mail.box_inbox");
+    await contains(".o-mail-Message");
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");
@@ -168,6 +172,7 @@ test("Search a message in 60 messages should return 30 message first", async () 
     }
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message", { count: 30 });
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");
@@ -192,6 +197,7 @@ test("Scrolling to the bottom should load more searched message", async () => {
     }
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message", { count: 30 });
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");
@@ -244,6 +250,7 @@ test("Search a message containing round brackets", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message");
     await click("button[title='Search Messages']");
     await insertText(".o_searchview_input", "(message");
     triggerHotkey("Enter");


### PR DESCRIPTION
When composing a message in Discuss, the composer state is preserved when removing the thread / message views and also on page reload.

Before this commit, some state of composer were not persistently saved, such as the reply-to message. The most notable reason comes from the feature being defined as a component hook, therefore it was coupled to the thread / message being viewed.

This commit fixes the issue by saving the reply-to message in JS models rather than component hooks, similarly to rest of composer state, so that this is persistently saved in RAM like the rest of composer state.

Also take into account the recovery of composer when closing the tab and reopening later or with page reload, again similarly to how the text content of composer is persistently saved.

Task-4593206