### PR TITLE
[IMP] mail:  registering main components via services

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -85,4 +85,10 @@ export class ChatHub extends Component {
     }
 }
 
-registry.category("main_components").add("mail.ChatHub", { Component: ChatHub });
+export const chatHubService = {
+    dependencies: ["bus.monitoring_service", "mail.store", "ui"],
+    start() {
+        registry.category("main_components").add("mail.ChatHub", { Component: ChatHub });
+    },
+};
+registry.category("services").add("mail.chat_hub", chatHubService);

--- a/addons/mail/static/src/discuss/call/common/call_invitations.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitations.js
@@ -17,4 +17,12 @@ export class CallInvitations extends Component {
     }
 }
 
-registry.category("main_components").add("discuss.CallInvitations", { Component: CallInvitations });
+export const callInvitationsService = {
+    dependencies: ["discuss.rtc", "mail.store"],
+    start() {
+        registry
+            .category("main_components")
+            .add("discuss.CallInvitations", { Component: CallInvitations });
+    },
+};
+registry.category("services").add("discuss.call_invitations", callInvitationsService);

--- a/addons/mail/static/src/discuss/core/public_web/bus_connection_alert.js
+++ b/addons/mail/static/src/discuss/core/public_web/bus_connection_alert.js
@@ -16,4 +16,12 @@ export class BusConnectionAlert extends Component {
     }
 }
 
-registry.category("main_components").add("bus.connection_alert", { Component: BusConnectionAlert });
+export const connectionAlertService = {
+    dependencies: ["bus.monitoring_service", "mail.store"],
+    start() {
+        registry
+            .category("main_components")
+            .add("bus.connection_alert", { Component: BusConnectionAlert });
+    },
+};
+registry.category("services").add("bus.connection_alert", connectionAlertService);


### PR DESCRIPTION
When we create a public root, we do:
- Create env
- Wait for services to load
- Create `MainComponentsContainer`

In a usual scenario, all the services are started in the second step above, so when we create the MainComponentsContainer, all the services we need are already
 available. The problem with the lazy loading chatter bundle is that one of the
 services in the second step is responsible for loading that bundle. So while
 the lazy bundle is loading, new services and main components are being added to
 the registry.

The steps could become like this:
- Create env
- Wait for services to start
- Start loading chatter bundle
- Lazy services (from chatter bundle) are not yet completely started
- Main components of the lazy bundle are added to the registry
- Lazy services are completely started

It might cause a crash due to unavailable services when the main components are added depends on the timing of the deployment of the lazy services.

This PR defines a new service for each main component that are added through the
 chatter bundle to ensure that main components are registered when their
 dependent services are deployed.

backport of odoo/odoo#201504

Related to: odoo/enterprise#81462
