### PR TITLE
[FIX] website_sale: pricelist update in express checkout

### DIFF
--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -182,7 +182,7 @@ class Delivery(WebsiteSale):
             # Pricelists are recomputed every time the partner is changed. We don't want to
             # recompute the price with another pricelist at this state since the customer has
             # already accepted the amount and validated the payment.
-            with request.env.protecting(['pricelist_id'], order_sudo):
+            with request.env.protecting([order_sudo._fields['pricelist_id']], order_sudo):
                 order_sudo.partner_id = new_partner_sudo
         elif order_sudo.partner_shipping_id.name.endswith(order_sudo.name):
             order_sudo.partner_shipping_id.write(partial_delivery_address)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1570,7 +1570,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             new_partner_sudo = self._create_new_address(
                 billing_address, address_type='billing', use_same=False, order_sudo=order_sudo,
             )
-            with request.env.protecting(['pricelist_id'], order_sudo):
+            with request.env.protecting([order_sudo._fields['pricelist_id']], order_sudo):
                 order_sudo.partner_id = new_partner_sudo
 
             # Add the new partner as follower of the cart


### PR DESCRIPTION
During express checkout flows, we don't want to update the pricelist or recompute the prices as the user already accepted an amount.

Nevertheless, recent commit 495de30cd273be87ea1a72dcb7bd0376acd6df8e updated the code to use the right orm api to prevent the recomputation, but in a wrong way. The field must be given as is, not as a field name.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
