### PR TITLE
[IMP] point_of_sale: improve preparation printer configuration

### DIFF
--- a/addons/point_of_sale/models/pos_printer.py
+++ b/addons/point_of_sale/models/pos_printer.py
@@ -16,6 +16,7 @@ class PosPrinter(models.Model):
     proxy_ip = fields.Char('Proxy IP Address', help="The IP Address or hostname of the Printer's hardware proxy")
     product_categories_ids = fields.Many2many('pos.category', 'printer_category_rel', 'printer_id', 'category_id', string='Printed Product Categories')
     company_id = fields.Many2one('res.company', string='Company', required=True, default=lambda self: self.env.company)
+    pos_config_ids = fields.Many2many('pos.printer', 'pos_config_printer_rel', 'printer_id', 'config_id')
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -205,6 +205,15 @@ class ResConfigSettings(models.TransientModel):
             'context': {'pos_config_open_modal': True, 'pos_config_create_mode': True},
         }
 
+    def action_pos_printer_dialog(self):
+        return {
+            'view_mode': 'form',
+            'res_model': 'pos.printer',
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'res_id': False,
+        }
+
     def pos_open_ui(self):
         if self._context.get('pos_config_id'):
             pos_config_id = self._context['pos_config_id']

--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -41,10 +41,10 @@
         <field name="model">pos.printer</field>
         <field name="arch" type="xml">
             <list string="Preparation Printers">
-                <field name="company_id" invisible="1" />
                 <field name="name" />
-                <field name="proxy_ip" />
                 <field name="product_categories_ids" widget="many2many_tags"/>
+                <field name="proxy_ip" optional="hide"/>
+                <field name="company_id" optional="hide"/>
             </list>
         </field>
     </record>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -407,12 +407,20 @@
                             <setting string="Preparation Printers" help="Print orders at the kitchen, at the bar, etc." id="is_order_printer">
                                 <field name="pos_is_order_printer"/>
                                 <div class="content-group" invisible="not pos_is_order_printer">
-                                    <div class="mt16">
-                                        <label string="Printers" for="pos_printer_ids" class="o_light_label"/>
+                                    <div class="mt16 mb-1">
+                                        <label string="Printers" for="pos_printer_ids" class="o_light_label me-2"/>
                                         <field name="pos_printer_ids" widget="many2many_tags"/>
                                     </div>
                                     <div>
-                                        <button name="%(point_of_sale.action_pos_printer_form)d" icon="oi-arrow-right" type="action" string="Printers" class="btn-link"/>
+                                        <button name="action_pos_printer_dialog"
+                                            context="{'default_pos_config_ids': [pos_config_id]}"
+                                            icon="oi-arrow-right"
+                                            type="object"
+                                            string="Add Printer"
+                                            class="btn-link"/>
+                                    </div>
+                                    <div>
+                                        <button name="%(point_of_sale.action_pos_printer_form)d" icon="oi-arrow-right" type="action" string="Manage Printers" class="btn-link"/>
                                     </div>
                                 </div>
                             </setting>


### PR DESCRIPTION
This commit allows users to quickly add a preparation printer, making the configuration process more efficient. Additionally, 'proxy' and 'company' columns  have been hidden in the preparation printer view to enhance usability.

task - 4510616

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
