### PR TITLE
[FIX] web: prevent web_read crash when res_id without res_model

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -180,9 +180,14 @@ class Base(models.AbstractModel):
                     if not record[field_name]:
                         continue
 
+                    record_values = values_by_id[record.id]
+
                     if field.type == 'reference':
                         co_record = record[field_name]
                     else:  # field.type == 'many2one_reference'
+                        if not record[field.model_field]:
+                            record_values[field_name] = False
+                            continue
                         co_record = self.env[record[field.model_field]].browse(record[field_name])
 
                     if 'context' in field_spec:
@@ -203,8 +208,6 @@ class Base(models.AbstractModel):
                         # not actually read the records so we do not know if they exist.
                         # This ensures the record actually exists
                         co_record_exists = co_record.exists()
-
-                    record_values = values_by_id[record.id]
 
                     if not co_record_exists:
                         record_values[field_name] = False

--- a/odoo/addons/test_new_api/tests/test_unity_read.py
+++ b/odoo/addons/test_new_api/tests/test_unity_read.py
@@ -763,6 +763,28 @@ class TestUnityRead(TransactionCase):
             }
         ])
 
+    def test_reference_id_without_model(self):
+        self.course.m2o_reference_model = False
+        read = self.course.web_read(
+            {
+                'm2o_reference_id':
+                    {
+                        'fields':
+                            {
+                                'display_name': {},
+                                'write_date': {},
+                            },
+                    },
+                'm2o_reference_model': {}
+            })
+        self.assertEqual(read, [
+            {
+                'id': self.course.id,
+                'm2o_reference_id': False,
+                'm2o_reference_model': False,
+            }
+        ])
+
     def test_reference_with_deleted_record(self):
         self.lesson_day1.unlink()
         read = self.course.web_read(


### PR DESCRIPTION
Having a record with set res_id but no res_model doesn't mean much, but we can consider, in web_read, that it means that there is no related record to avoid crashes.

opw-4527152
