### PR TITLE
[FIX] sale: sudo check invoices on cancel

### DIFF
--- a/addons/sale/wizard/sale_order_cancel.py
+++ b/addons/sale/wizard/sale_order_cancel.py
@@ -41,6 +41,7 @@ class SaleOrderCancel(models.TransientModel):
     display_invoice_alert = fields.Boolean(
         string="Invoice Alert",
         compute='_compute_display_invoice_alert',
+        compute_sudo=True,
     )
 
     @api.depends('order_id')


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have a internal user with only Sales: Own Documents access;
2. assign them as salesperson to a sales order with two lines;
3. create an draft invoice for one line;
4. assign admin as salesperson on the invoice;
5. as user, create a draft invoice for the other line (optional);
6. as user, cancel the sales order.

Issue
-----
If no second draft invoice was created, there's no warning displayed that a draft invoice exists.

If one was created, trying to cancel will say you're not allowed to read journal entries.

You are supposed to get an error when trying to modify journal entries.

Cause
-----
The cancel wizard doesn't check the order's invoices using sudo.

Solution
--------
Check the order's invoices using sudo.

opw-4554639