### PR TITLE
[FIX] pos_self_order: display the ui in selected language

### DIFF
--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -52,7 +52,7 @@ class PosSelfKiosk(http.Controller):
 
         company = pos_config_sudo.company_id
         user = pos_config_sudo.self_ordering_default_user_id
-        pos_config = pos_config_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids)
+        pos_config = pos_config_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids, lang=request.cookies.get('frontend_lang'))
 
         if not pos_config:
             raise werkzeug.exceptions.NotFound()


### PR DESCRIPTION
Before this commit, the interface was always shown in the default language. This fix ensures that the UI is displayed according to the user’s selected language.

task-4609518





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
