### PR TITLE
[FIX] core: allow to fail fast accross multiple suites

### DIFF
--- a/odoo/tests/result.py
+++ b/odoo/tests/result.py
@@ -84,8 +84,8 @@ class OdooTestResult(object):
         self.had_failure = False
         self.stats = collections.defaultdict(Stat)
         self.global_report = global_report
-        self.shouldStop = False
-        
+        self.shouldStop = self.global_report and self.global_report.shouldStop or False
+
     def total_errors_count(self):
         result = self.errors_count + self.failures_count
         if self.global_report:


### PR DESCRIPTION
In #195395, the following test suite should first check if the global_result is already stopped



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
