### PR TITLE
[FIX] point_of_sale: proper handling of caba taxes

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -10,6 +10,18 @@ class AccountMove(models.Model):
     pos_order_ids = fields.One2many('pos.order', 'account_move')
     pos_payment_ids = fields.One2many('pos.payment', 'account_move_id')
 
+    def _compute_always_tax_exigible(self):
+        super()._compute_always_tax_exigible()
+        # The pos closing move does not create caba entries (anymore); we set the tax values directly on the closing move.
+        # (But there may still be old closing moves that used caba entries from previous versions.)
+        relevant_moves = self.filtered(lambda move: not (move.always_tax_exigible or move.tax_cash_basis_created_move_ids))
+        if not relevant_moves:
+            return
+        sessions = self.env['pos.session'].with_context(active_test=False).search([
+            ('move_id', 'in', relevant_moves.ids),
+        ])
+        sessions.move_id.always_tax_exigible = True
+
     def _stock_account_get_last_step_stock_moves(self):
         stock_moves = super(AccountMove, self)._stock_account_get_last_step_stock_moves()
         for invoice in self.filtered(lambda x: x.move_type == 'out_invoice'):

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1172,14 +1172,9 @@ class PosSession(models.Model):
         # may arise in 'Round Globally'.
         check_refund = lambda x: x.qty * x.price_unit < 0
         is_refund = check_refund(order_line)
-        tax_data = tax_ids.compute_all(price_unit=price, quantity=abs(order_line.qty), currency=self.currency_id, is_refund=is_refund, fixed_multiplicator=sign)
-        taxes = tax_data['taxes']
-        # For Cash based taxes, use the account from the repartition line immediately as it has been paid already
-        for tax in taxes:
-            tax_rep = self.env['account.tax.repartition.line'].browse(tax['tax_repartition_line_id'])
-            tax['account_id'] = tax_rep.account_id.id
+        tax_data = tax_ids.compute_all(price_unit=price, quantity=abs(order_line.qty), currency=self.currency_id, is_refund=is_refund, fixed_multiplicator=sign, include_caba_tags=True)
         date_order = order_line.order_id.date_order
-        taxes = [{'date_order': date_order, **tax} for tax in taxes]
+        taxes = [{'date_order': date_order, **tax} for tax in tax_data['taxes']]
         return {
             'date_order': order_line.order_id.date_order,
             'income_account_id': get_income_account(order_line).id,


### PR DESCRIPTION
We do not create create caba moves anymore for PoS session closing moves.
(See commits 2f62d5c0d78371be70586c79cb2b5931e733b042 and 66e3696b4f06c657ff71af30178f0ac69d552632)

But now there are 2 issues when using (only) caba taxes in a PoS session.
  (1) The closing move does not appear on the tax report.
  (2) The closing move line do not get the right tax tags (they do not have any).

Issue (1) is solved by making pos closing moves `always_tax_exigible`.
(In case they did not creat cash basis entries; for backwards compatibility).

Issue (2) is solved by telling the tax computation for the lines to include caba taxes
(instead of just changing the account to be the "final" account and not
the caba transition account).

opw-4355124