### PR TITLE
[REF] web: form renderer no longer needs useBounceButton

### DIFF
--- a/addons/web/static/src/views/form/form_renderer.js
+++ b/addons/web/static/src/views/form/form_renderer.js
@@ -10,7 +10,6 @@ import { ButtonBox } from "@web/views/form/button_box/button_box";
 import { InnerGroup, OuterGroup } from "@web/views/form/form_group/form_group";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { useViewCompiler } from "@web/views/view_compiler";
-import { useBounceButton } from "@web/views/view_hook";
 import { Widget } from "@web/views/widgets/widget";
 import { FormCompiler } from "./form_compiler";
 import { FormLabel } from "./form_label";
@@ -67,9 +66,6 @@ export class FormRenderer extends Component {
         this.state = useState({}); // Used by Form Compiler
         this.templates = useViewCompiler(Compiler || FormCompiler, templates);
         useSubEnv({ model: record.model });
-        useBounceButton(useRef("compiled_view_root"), (target) => {
-            return !record.isInEdition && !!target.closest(".oe_title, .o_inner_group");
-        });
         this.uiService = useService("ui");
         this.onResize = useDebounced(this.render, 200);
         onMounted(() => browser.addEventListener("resize", this.onResize));


### PR DESCRIPTION
This hook was used to make the "Edit" button bounce when the user clicked on the form, which was readonly, to indicate him that he first needed to switch it into edition. This is useless since we dropped the readonly mode in form views (for a while now).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
