### PR TITLE
[IMP] project_purchase: add non-invoiced purchase order to profitability

### DIFF
--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -198,7 +198,7 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
         })
         purchase_order.button_confirm()
         self.assertEqual(purchase_order.invoice_status, 'to invoice')
-        # no section "purchase_order" should appear as no purchase order is invoiced, the total should be updated,
+        # The section "purchase_order" should appear as the purchase order is validated, the total should be updated,
         # the "other_purchase_costs" shouldn't change, as we don't take into
         # account bills from purchase orders, as those are already taken into calculations
         # from the purchase orders (in "purchase_order" section)
@@ -210,8 +210,12 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
                     'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.1,
-                },
-                {
+                },{
+                    'id': 'purchase_order',
+                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['purchase_order'],
+                    'to_bill': -self.product_order.standard_price * analytic_contribution,
+                    'billed': 0.0,
+                }, {
                     'id': 'other_purchase_costs',
                     'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_purchase_costs'],
                     'to_bill': 0.0,
@@ -220,7 +224,7 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
                                 self.service_deliver.standard_price) * analytic_contribution,
                 }],
                 'total': {
-                    'to_bill': 0.0,
+                    'to_bill': -self.product_order.standard_price * analytic_contribution,
                     'billed': -(2 * self.product_a.standard_price +
                                 2 * self.product_b.standard_price -
                                 self.service_deliver.standard_price) * analytic_contribution - 150.1,
@@ -341,9 +345,14 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
         self.assertDictEqual(
             self.project._get_profitability_items(False)['costs'],
             {
-                'data': [],
+                'data': [{
+                    'id': 'purchase_order',
+                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['purchase_order'],
+                    'to_bill': -(self.product_order.standard_price * (analytic_ratios["project_ratio"] / 100)),
+                    'billed': 0.0,
+                }],
                 'total': {
-                    'to_bill': 0.0,
+                    'to_bill': -(self.product_order.standard_price * (analytic_ratios["project_ratio"] / 100)),
                     'billed': 0.0,
                 },
             },
@@ -496,15 +505,19 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
         purchase_order_foreign.button_confirm()
         self.assertEqual(purchase_order_foreign.invoice_status, 'to invoice')
 
-        # No section "purchase_order" should appear because no purchase order is invoiced, the total should be updated,
+        # The section "purchase_order" should appear because the purchase order is validated, the total should be updated,
         # but the "other_purchase_costs" shouldn't change, as we don't take into
         # account bills from purchase orders in this section.
         items = project._get_profitability_items(with_action=False)['costs']
-        self.assertEqual('other_purchase_costs', items['data'][0]['id'])
-        self.assertEqual(project._get_profitability_sequence_per_invoice_type()['other_purchase_costs'], items['data'][0]['sequence'])
-        self.assertEqual(0.0, items['data'][0]['to_bill'])
-        self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6, items['data'][0]['billed'], 2), 0)
-        self.assertEqual(0.0, items['total']['to_bill'])
+        self.assertEqual('purchase_order', items['data'][0]['id'])
+        self.assertEqual(project._get_profitability_sequence_per_invoice_type()['purchase_order'], items['data'][0]['sequence'])
+        self.assertEqual(0.0, items['data'][0]['billed'])
+        self.assertEqual(float_compare(-self.product_order.standard_price * analytic_contribution * 0.6, items['data'][0]['to_bill'], 2), 0)
+        self.assertEqual('other_purchase_costs', items['data'][1]['id'])
+        self.assertEqual(project._get_profitability_sequence_per_invoice_type()['other_purchase_costs'], items['data'][1]['sequence'])
+        self.assertEqual(0.0, items['data'][1]['to_bill'])
+        self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6, items['data'][1]['billed'], 2), 0)
+        self.assertEqual(float_compare(- self.product_order.standard_price * analytic_contribution * 0.6, items['total']['to_bill'], 2), 0)
         self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6, items['total']['billed'], 2), 0)
 
         # create a new purchase order
@@ -528,13 +541,18 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
         })
         purchase_order.button_confirm()
         self.assertEqual(purchase_order.invoice_status, 'to invoice')
-        # Again, no section "purchase_order" should appear because no purchase order is invoiced.
+
+        # The section "purchase_order" should be updated with the new po values.
         items = project._get_profitability_items(with_action=False)['costs']
-        self.assertEqual('other_purchase_costs', items['data'][0]['id'])
-        self.assertEqual(project._get_profitability_sequence_per_invoice_type()['other_purchase_costs'], items['data'][0]['sequence'])
-        self.assertEqual(0.0, items['data'][0]['to_bill'])
-        self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6, items['data'][0]['billed'], 2), 0)
-        self.assertEqual(0.0, items['total']['to_bill'])
+        self.assertEqual('purchase_order', items['data'][0]['id'])
+        self.assertEqual(project._get_profitability_sequence_per_invoice_type()['purchase_order'], items['data'][0]['sequence'])
+        self.assertEqual(0.0, items['data'][0]['billed'])
+        self.assertEqual(float_compare(-self.product_order.standard_price * analytic_contribution * 3.6, items['data'][0]['to_bill'], 2), 0)
+        self.assertEqual('other_purchase_costs', items['data'][1]['id'])
+        self.assertEqual(project._get_profitability_sequence_per_invoice_type()['other_purchase_costs'], items['data'][1]['sequence'])
+        self.assertEqual(0.0, items['data'][1]['to_bill'])
+        self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6, items['data'][1]['billed'], 2), 0)
+        self.assertEqual(float_compare(- self.product_order.standard_price * analytic_contribution * 3.6    , items['total']['to_bill'], 2), 0)
         self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6, items['total']['billed'], 2), 0)
 
         self._create_invoice_for_po(purchase_order)
@@ -544,13 +562,13 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
         items = project._get_profitability_items(with_action=False)['costs']
         self.assertEqual('purchase_order', items['data'][0]['id'])
         self.assertEqual(project._get_profitability_sequence_per_invoice_type()['purchase_order'], items['data'][0]['sequence'])
-        self.assertEqual(0.0, items['data'][0]['to_bill'])
+        self.assertEqual(float_compare(-self.product_order.standard_price * analytic_contribution * 0.6, items['data'][0]['to_bill'], 2), 0)
         self.assertEqual(float_compare(-self.product_order.standard_price * analytic_contribution * 3, items['data'][0]['billed'], 2), 0)
         self.assertEqual('other_purchase_costs', items['data'][1]['id'])
         self.assertEqual(project._get_profitability_sequence_per_invoice_type()['other_purchase_costs'], items['data'][1]['sequence'])
         self.assertEqual(0.0, items['data'][1]['to_bill'])
         self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6, items['data'][1]['billed'], 2), 0)
-        self.assertEqual(0.0, items['total']['to_bill'])
+        self.assertEqual(float_compare(-self.product_order.standard_price * analytic_contribution * 0.6, items['total']['to_bill'], 2), 0)
         self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6 - self.product_order.standard_price * analytic_contribution * 3, items['total']['billed'], 2), 0)
 
         self._create_invoice_for_po(purchase_order_foreign)


### PR DESCRIPTION
This commit's purpose is to take advantage of the 'project' field of purchase order to take into account the purchase order that are not invoiced in the project profitability. This used to to be computed with the account.move.line linked to purchase.order.line.

branch - master

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
