### PR TITLE
[IMP] hw_posbox_homepage: connecting loading state

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -27,6 +27,7 @@ class ConnectionManager(Thread):
         self.pairing_code_expired = False
         self.pairing_code_expires = 0
         self.pairing_code_count = 0
+        self.new_database_url = False
         requests.packages.urllib3.disable_warnings()
 
     def run(self):
@@ -90,11 +91,14 @@ class ConnectionManager(Thread):
                 self._try_print_pairing_code()
 
     def _connect_to_server(self, url, token, db_uuid, enterprise_code):
+        self.new_database_url = url
         # Save DB URL and token
         helpers.save_conf_server(url, token, db_uuid, enterprise_code)
         # Notify the DB, so that the kanban view already shows the IoT Box
         manager.send_all_devices()
-        # Restart to checkout the git branch, get a certificate, load the IoT handlers...
+        # Switch git branch before restarting, this avoids restarting twice
+        helpers.check_git_branch()
+        # Restart to get a certificate, load the IoT handlers...
         helpers.odoo_restart(2)
 
     def _try_print_pairing_code(self):

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -276,6 +276,7 @@ def save_conf_server(url, token, db_uuid, enterprise_code):
         'db_uuid': db_uuid,
         'enterprise_code': enterprise_code,
     })
+    get_odoo_server_url.cache_clear()
 
 
 def generate_password():

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -167,6 +167,7 @@ class IotBoxOwlHomePage(http.Controller):
             'devices': grouped_devices,
             'server_status': odoo_server_url,
             'pairing_code': connection_manager.pairing_code,
+            'new_database_url': connection_manager.new_database_url,
             'pairing_code_expired': connection_manager.pairing_code_expired and not odoo_server_url,
             'six_terminal': six_terminal,
             'is_access_point_up': platform.system() == 'Linux' and wifi.is_access_point(),

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -3,6 +3,8 @@ import { DEVICE_ICONS } from "./components/dialog/DeviceDialog.js";
 
 const { Component, mount, xml, useState } = owl;
 
+const STATUS_POLL_DELAY_MS = 5000;
+
 class StatusPage extends Component {
     static props = {};
 
@@ -11,9 +13,6 @@ class StatusPage extends Component {
         this.icons = DEVICE_ICONS;
 
         this.loadInitialData();
-        setInterval(() => {
-            this.loadInitialData();
-        }, 10000);
     }
 
     async loadInitialData() {
@@ -24,6 +23,7 @@ class StatusPage extends Component {
         } catch {
             console.warn("Error while fetching data");
         }
+        setTimeout(() => this.loadInitialData(), STATUS_POLL_DELAY_MS);
     }
 
     get accessPointSsid() {
@@ -31,10 +31,18 @@ class StatusPage extends Component {
     }
 
     static template = xml`
-    <div t-if="!state.loading" class="container-fluid">
-        <div class="text-center pt-5">
-            <img class="odoo-logo" src="/web/static/img/logo2.png" alt="Odoo logo"/>
+    <div class="text-center pt-5">
+        <img class="odoo-logo" src="/web/static/img/logo2.png" alt="Odoo logo"/>
+    </div>
+    <div t-if="state.loading || state.data.new_database_url" class="position-fixed top-0 start-0 vh-100 w-100 justify-content-center align-items-center d-flex flex-column gap-5">
+        <div class="spinner-border">
+            <span class="visually-hidden">Loading...</span>
         </div>
+        <span t-if="state.data.new_database_url" class="fs-4">
+            Connecting to <t t-out="state.data.new_database_url"/>, please wait
+        </span>
+    </div>
+    <div t-else="" class="container-fluid">
         <!-- QR Codes shown on status page -->
         <div class="qr-code-box">
             <div class="status-display-box qr-code">
@@ -117,6 +125,10 @@ class StatusPage extends Component {
                         <tr>
                             <td class="col-3"><i class="me-1 fa fa-fw fa-id-card"/>Name</td>
                             <td class="col-3" t-out="state.data.hostname"/>
+                        </tr>
+                        <tr t-if="state.data.odoo_server_url">
+                            <td class="col-3"><i class="me-1 fa fa-fw fa-database"/>Database</td>
+                            <td class="col-3" t-out="state.data.odoo_server_url"/>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
Before this commit, when pairing an IoT box with
a database, there was no indication that the
process had started, or that it was successful

After this commit, a loading state has been added
as soon as pairing is started, as well as a new
status item showing the currently connected DB.

task-4603262

![image](https://github.com/user-attachments/assets/f6f91541-28f5-4dc2-bed6-16454f76ffba)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
