### PR TITLE
[FIX] l10n_din5008: Fix overlapping adresses

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -72,13 +72,13 @@
                                         <span>|</span> <span t-field="company.country_id.name"/>
                                     </t>
                                     <hr class="company_invoice_line" />
-                                    <div t-if="address">
+                                    <span t-if="address">
                                         <t t-out="address"/>
-                                    </div>
-                                    <div t-else="fallback_address">
+                                    </span>
+                                    <span t-else="fallback_address">
                                         <t t-out="fallback_address"
                                            t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' />
-                                    </div>
+                                    </span>
                                 </div>
                             </td>
                             <td t-if="din5008_document_information">


### PR DESCRIPTION
The aim of this commit is to fix a display bug where the shipping adress is overlapping the address element when too many address lines are present

Steps to reproduce:
- Install l10n_din5008_sale
- Configure the document to use the din5008 layout
- Create a UK customer with all the adress fields filled + phone
- Create a quotation for that customer and Print the PDF Quote

opw-4575257

![image](https://github.com/user-attachments/assets/8e14964d-59ee-4bcd-990e-87ffe1684bd8)
Becomes 
![image](https://github.com/user-attachments/assets/35670160-ad5c-44e2-9b8e-1cdba1c75e65)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
