### PR TITLE
[FIX] mail, test_mail: display followers of another company

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3460,7 +3460,9 @@ class MailThread(models.AbstractModel):
                 'display_name': follower.display_name,
                 'email': follower.email,
                 'is_active': follower.is_active,
-                'partner': follower.partner_id.mail_partner_format()[follower.partner_id],
+                # sudo: res.partner - can read partners of found followers, in particular allows
+                # by-passing multi-company ACL for portal partners
+                'partner': follower.partner_id.sudo().mail_partner_format()[follower.partner_id],
             } for follower in self.message_follower_ids]
         if 'suggestedRecipients' in request_list:
             res['suggestedRecipients'] = self._message_get_suggested_recipients()[self.id]


### PR DESCRIPTION
- have a follower with a portal partner linked to a specific company
  "portal" user is important here because internal users don't have multi-company rule.
- view the chatter with a user which has no access to that company
- the chatter is currently locked by an ACL error

The follower should be displayed instead.

task-4648765