### PR TITLE
[FIX] im_livechat: fix hover highlight for channels kanban burger menu

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -33,10 +33,8 @@
                     <field name="image_128"/>
                     <templates>
                         <t t-name="kanban-menu">
-                            <div class="container">
-                                <a type="object" name="action_view_rating" class="dropdown-item" role="menuitem">Ratings</a>
-                                <a type="open" class="dropdown-item" role="menuitem">Configure Channel</a>
-                            </div>
+                            <a type="object" name="action_view_rating" class="dropdown-item" role="menuitem">Ratings</a>
+                            <a type="open" class="dropdown-item" role="menuitem">Configure Channel</a>
                         </t>
                         <t t-name="kanban-box">
                             <div class="oe_kanban_global_click px-4" t-att-class="{'o-livechat-ChannelKanban-highlighted': record.available_operator_ids.raw_value.length > 0}">


### PR DESCRIPTION
Remove the extra space around the menu items in the hamberger menu in the channels kanban view

task-4630807

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
