### PR TITLE
[IMP] im_livechat: stricter access to live chat channels for operators

### DIFF
--- a/addons/im_livechat/security/ir.model.access.csv
+++ b/addons/im_livechat/security/ir.model.access.csv
@@ -2,7 +2,7 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_livechat_channel_public,im_livechat.channel,model_im_livechat_channel,base.group_public,1,0,0,0
 access_livechat_channel_portal,im_livechat.channel,model_im_livechat_channel,base.group_portal,1,0,0,0
 access_livechat_channel_employee,im_livechat.channel,model_im_livechat_channel,base.group_user,1,0,0,0
-access_livechat_channel_user,im_livechat.channel.user,model_im_livechat_channel,im_livechat_group_user,1,1,1,0
+access_livechat_channel_user,im_livechat.channel.user,model_im_livechat_channel,im_livechat_group_user,1,0,0,0
 access_livechat_channel_manager,im_livechat.channel.manager,model_im_livechat_channel,im_livechat_group_manager,1,1,1,1
 access_livechat_support_report_channel,im_livechat.report.channel,model_im_livechat_report_channel,im_livechat_group_manager,1,0,0,0
 access_livechat_support_report_operator,im_livechat.report.operator,model_im_livechat_report_operator,im_livechat_group_manager,1,0,0,0

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_discuss_channel
 from . import test_cors_livechat
 from . import test_get_discuss_channel
 from . import test_get_operator
+from . import test_im_livechat_channel
 from . import test_im_livechat_report
 from . import test_im_livechat_support_page
 from . import test_js

--- a/addons/im_livechat/tests/test_im_livechat_channel.py
+++ b/addons/im_livechat/tests/test_im_livechat_channel.py
@@ -1,0 +1,21 @@
+from odoo.tests import new_test_user, tagged
+from odoo.exceptions import AccessError
+from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
+
+
+@tagged("-at_install", "post_install")
+class TestImLivechatChannel(TestImLivechatCommon):
+    def test_user_cant_join_livechat_channel(self):
+        bob_user = new_test_user(self.env, "bob_user", groups="base.group_user")
+        with self.assertRaises(AccessError):
+            self.livechat_channel.with_user(bob_user).action_join()
+
+    def test_operator_join_leave_livechat_channel(self):
+        bob_operator = new_test_user(
+            self.env, "bob_user", groups="base.group_user,im_livechat.im_livechat_group_user"
+        )
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+        self.livechat_channel.with_user(bob_operator).action_join()
+        self.assertIn(bob_operator, self.livechat_channel.user_ids)
+        self.livechat_channel.with_user(bob_operator).action_quit()
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -29,7 +29,10 @@
                         <t t-name="menu">
                             <div class="container">
                                 <a type="object" name="action_view_rating" class="dropdown-item" role="menuitem">Ratings</a>
-                                <a type="open" class="dropdown-item" role="menuitem">Configure Channel</a>
+                                <a type="open" class="dropdown-item" role="menuitem">
+                                    <span groups="im_livechat.im_livechat_group_manager">Configure Channel</span>
+                                    <span groups="!im_livechat.im_livechat_group_manager">View Channel</span>
+                                </a>
                             </div>
                         </t>
                         <t t-name="card" class="p-0 row g-0">
@@ -44,7 +47,7 @@
                                     </div>
                                     <div>
                                         <button t-if="record.are_you_inside.raw_value" name="action_quit" type="object" class="btn btn-primary">Leave</button>
-                                        <button t-else="" name="action_join" type="object" class="btn btn-secondary">Join</button>
+                                        <button t-else="" name="action_join" type="object" class="btn btn-secondary" groups="im_livechat.im_livechat_group_user">Join</button>
                                     </div>
                                 </div>
                                 <footer class="pt-0">
@@ -117,7 +120,7 @@
                                         Operators that do not show any activity In Odoo for more than 30 minutes will be considered as disconnected.
                                     </p>
                             </page>
-                            <page string="Options" name="options">
+                            <page string="Options" name="options" groups="im_livechat.im_livechat_group_manager">
                                 <group>
                                     <group string="Livechat Button">
                                         <field name="button_text" string="Notification text" help="Text to display on the notification"/>
@@ -146,11 +149,11 @@
                                     </group>
                                 </group>
                             </page>
-                            <page string="Channel Rules" name="channel_rules">
+                            <page string="Channel Rules" name="channel_rules" groups="im_livechat.im_livechat_group_manager">
                                 <field name="rule_ids" colspan="2"/>
                                 <div class="text-muted" colspan="2">Define rules for your live support channel. You can apply an action for the given URL, and per country.<br />To identify the country, GeoIP must be installed on your server, otherwise, the countries of the rule will not be taken into account.</div>
                             </page>
-                            <page string="Widget" name="configuration_widget">
+                            <page string="Widget" name="configuration_widget" groups="im_livechat.im_livechat_group_manager">
                                 <div class="alert alert-warning mt4 mb16" role="alert" invisible="web_page">
                                     Save your Channel to get your configuration widget.
                                 </div>


### PR DESCRIPTION
With this commit live chat users will be restricted from making new live chat channels and editing them.

task-4603688
