### PR TITLE
[16.0][FIX] base: Do not apply ustr() to the exception obtained when sending a message

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -732,7 +732,7 @@ class IrMailServer(models.Model):
         except smtplib.SMTPServerDisconnected:
             raise
         except Exception as e:
-            params = (ustr(smtp_server), e.__class__.__name__, ustr(e))
+            params = (ustr(smtp_server), e.__class__.__name__, e)
             msg = _("Mail delivery failed via SMTP server '%s'.\n%s: %s", *params)
             _logger.info(msg)
             raise MailDeliveryException(_("Mail Delivery Failed"), msg)


### PR DESCRIPTION
Do not apply `ustr()` to the exception obtained when sending a message

Example use case:
- Sending a message and adding an attached .eml file

```
File "/usr/local/lib/python3.10/site-packages/werkzeug/wrappers/response.py", line 327, in set_data
     value = value.encode(self.charset)
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 6547-6548: surrogates not allowed
```

The message must be processed, otherwise <ins>all subsequent messages will be blocked</ins>.

**Before**
![antes](https://github.com/user-attachments/assets/adaeebe4-58c9-4744-b703-bc66534d7bcc)

**After**
![despues](https://github.com/user-attachments/assets/bc8bac79-8524-463a-bb77-e373c02721ba)

Already solved in 18.0 indirectly since https://github.com/odoo/odoo/commit/41464b5896c00679a8f8ac4faba6bd6f1b11876d

Ping @pedrobaeza 

@Tecnativa TT55423

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
