### PR TITLE
[IMP] website_livechat: restrict lc operators from editing visitors

### DIFF
--- a/addons/website_livechat/security/ir.model.access.csv
+++ b/addons/website_livechat/security/ir.model.access.csv
@@ -2,5 +2,5 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_im_livechat_channel_public_public,im_livechat.channel.public,im_livechat.model_im_livechat_channel,base.group_public,1,0,0,0
 access_im_livechat_channel_public_portal,im_livechat.channel.public,im_livechat.model_im_livechat_channel,base.group_portal,1,0,0,0
 access_im_livechat_channel_public_employee,im_livechat.channel.public,im_livechat.model_im_livechat_channel,base.group_user,1,0,0,0
-access_website_visitor_livechat_users,website.visitor.livechat.users,model_website_visitor,im_livechat.im_livechat_group_user,1,1,0,0
+access_website_visitor_livechat_users,website.visitor.livechat.users,model_website_visitor,im_livechat.im_livechat_group_user,1,0,0,0
 access_website_track_livechat_users,website.track.livechat.users,website.model_website_track,im_livechat.im_livechat_group_user,1,0,0,0


### PR DESCRIPTION
This commit restricts live chat operators from editing website visitors fields.

task-4603688
