### PR TITLE
[IMP] im_livechat: restrict live chat operators from accessing chatbots

### DIFF
--- a/addons/im_livechat/security/ir.model.access.csv
+++ b/addons/im_livechat/security/ir.model.access.csv
@@ -13,8 +13,8 @@ access_livechat_channel_rule_user,im_livechat.channel.rule,model_im_livechat_cha
 access_livechat_channel_rule_manager,im_livechat.channel.rule,model_im_livechat_channel_rule,im_livechat_group_manager,1,1,1,1
 access_livechat_expertise_internal_user,im_livechat.expertise.internal.user,model_im_livechat_expertise,base.group_user,1,0,0,0
 access_livechat_expertise_livechat_manager,im_livechat.expertise.manager,model_im_livechat_expertise,im_livechat_group_manager,1,1,1,1
-access_chatbot_script_user,chatbot.script.user,model_chatbot_script,im_livechat_group_user,1,1,1,1
-access_chatbot_script_step_user,chatbot.script.step.user,model_chatbot_script_step,im_livechat_group_user,1,1,1,1
+access_chatbot_script_user,chatbot.script.user,model_chatbot_script,im_livechat_group_manager,1,1,1,1
+access_chatbot_script_step_user,chatbot.script.step.user,model_chatbot_script_step,im_livechat_group_manager,1,1,1,1
 access_chatbot_script_answer,chatbot.script.answer,model_chatbot_script_answer,,0,0,0,0
-access_chatbot_script_answer_user,chatbot.script.answer.user,model_chatbot_script_answer,im_livechat_group_user,1,1,1,1
-access_chatbot_message_user,chatbot.script.user,model_chatbot_message,im_livechat_group_user,1,1,1,1
+access_chatbot_script_answer_user,chatbot.script.answer.user,model_chatbot_script_answer,im_livechat_group_manager,1,1,1,1
+access_chatbot_message_user,chatbot.script.user,model_chatbot_message,im_livechat_group_manager,1,1,1,1

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -74,7 +74,7 @@
                         <field name="rating_count" invisible="1"/>
                         <div class="oe_button_box" name="button_box">
                             <button class="oe_stat_button" type="object" name="action_view_chatbot_scripts" icon="fa-android"
-                                invisible="chatbot_script_count == 0">
+                                invisible="chatbot_script_count == 0" groups="im_livechat.im_livechat_group_manager">
                                 <field string="Chatbots" name="chatbot_script_count" widget="statinfo"/>
                             </button>
                             <button class="oe_stat_button" type="action" invisible="nbr_channel == 0" name="%(discuss_channel_action_from_livechat_channel)d" icon="fa-comments">
@@ -304,7 +304,7 @@
             name="Chatbots"
             parent="livechat_config"
             action="chatbot_script_action"
-            groups="im_livechat_group_user"
+            groups="im_livechat_group_manager"
             sequence="20"/>
 
     </data>

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -116,8 +116,8 @@ class TestLivechatChatbotUI(TestGetOperatorCommon, TestWebsiteLivechatCommon, Ch
         self.start_tour("/", "website_livechat_chatbot_after_reload_tour")
 
     def test_chatbot_test_page_tour(self):
-        bob_operator = tests.new_test_user(self.env, login="bob_user", groups="im_livechat.im_livechat_group_user,base.group_user")
-        self.livechat_channel.user_ids += bob_operator
+        bob_manager = tests.new_test_user(self.env, login="bob_user", groups="im_livechat.im_livechat_group_manager,base.group_user")
+        self.livechat_channel.user_ids += bob_manager
         test_page_url = f"/chatbot/{'-'.join(self.chatbot_script.title.split(' '))}-{self.chatbot_script.id}/test"
         self.start_tour(test_page_url, "website_livechat_chatbot_test_page_tour", login="bob_user")
 


### PR DESCRIPTION
This commit restricts live chat operators from accessing, creating, editing and deleting chatbots.
Those operations are restricted to live chat managers.

task-4603688