### PR TITLE
[FIX] sale_timesheet: make timesheet entries editable in reversed invoice

### DIFF
--- a/addons/sale_timesheet/models/__init__.py
+++ b/addons/sale_timesheet/models/__init__.py
@@ -9,3 +9,4 @@ from . import project_update
 from . import sale_order
 from . import res_config_settings
 from . import project_sale_line_employee_map
+from . import account_move_reversal

--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -85,6 +85,17 @@ class AccountMove(models.Model):
                 timesheets = self.env['account.analytic.line'].sudo().search(domain)
                 timesheets.write({'timesheet_invoice_id': line.move_id.id})
 
+    def action_post(self):
+        result = super().action_post()
+        credit_notes = self.filtered(lambda move: move.move_type == 'out_refund' and move.reversed_entry_id)
+        timesheets_sudo = self.env['account.analytic.line'].sudo().search([
+            ('timesheet_invoice_id', 'in', credit_notes.reversed_entry_id.ids),
+            ('so_line', 'in', credit_notes.invoice_line_ids.sale_line_ids.ids),
+            ('project_id', '!=', False),
+        ])
+        timesheets_sudo.write({'timesheet_invoice_id': False})
+        return result
+
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'

--- a/addons/sale_timesheet/models/account_move_reversal.py
+++ b/addons/sale_timesheet/models/account_move_reversal.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class AccountMoveReversal(models.TransientModel):
+    _inherit = 'account.move.reversal'
+
+    def reverse_moves(self):
+        result = super().reverse_moves()
+        if self.refund_method == 'cancel':
+            moves = self.move_ids.filtered(lambda m: m.move_type == 'out_invoice')
+            timesheets_sudo = self.env['account.analytic.line'].sudo().search([
+                ('timesheet_invoice_id', 'in', moves.ids),
+            ])
+            if timesheets_sudo:
+                timesheets_sudo.write({'timesheet_invoice_id': False})
+        return result

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -902,6 +902,104 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         self.assertEqual(10, sale_order_line_template_1.project_id.allocated_hours)
         self.assertEqual(5, sale_order_line_template_2.project_id.allocated_hours)
 
+    def test_linked_timesheet_after_invoice_reversal(self):
+        """Test that uneditable timesheet entries aren't linked to a reversed invoice form"""
+
+        # Full refund credit note
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'partner_invoice_id': self.partner_a.id,
+            'partner_shipping_id': self.partner_a.id,
+            'pricelist_id': self.company_data['default_pricelist'].id,
+        })
+        so_line = self.env['sale.order.line'].create({
+            'product_id': self.product_delivery_timesheet2.id,
+            'product_uom_qty': 1,
+            'order_id': sale_order.id,
+        })
+        sale_order.action_confirm()
+        task = so_line.task_id
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Test Invoice Reversal',
+            'project_id': task.project_id.id,
+            'task_id': task.id,
+            'unit_amount': 5,
+            'employee_id': self.employee_user.id,
+        })
+        invoice = sale_order._create_invoices()[0]
+        invoice.action_post()
+        self.assertEqual(timesheet.timesheet_invoice_id, invoice, "Timesheet should be linked to the invoice")
+
+        reversal_wizard = self.env['account.move.reversal'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids
+        ).create({
+            'reason': 'full refund',
+            'refund_method': 'cancel',
+            'journal_id': invoice.journal_id.id,
+        })
+        reversal_wizard.reverse_moves()
+        self.assertFalse(timesheet.timesheet_invoice_id, "Timesheet should not be linked to the invoice after reversal")
+        timesheet.write({'unit_amount': 7})
+        self.assertEqual(timesheet.unit_amount, 7, "It Should be possible to edit timesheet after invoice reversal")
+
+        # Partial refund credit note
+        sale_order2 = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'partner_invoice_id': self.partner_a.id,
+            'partner_shipping_id': self.partner_a.id,
+            'pricelist_id': self.company_data['default_pricelist'].id,
+        })
+        so_line1 = self.env['sale.order.line'].create({
+            'product_id': self.product_delivery_timesheet2.id,
+            'product_uom_qty': 1,
+            'order_id': sale_order2.id,
+        })
+        so_line2 = self.env['sale.order.line'].create({
+            'product_id': self.product_delivery_timesheet3.id,
+            'product_uom_qty': 1,
+            'order_id': sale_order2.id,
+        })
+        sale_order2.action_confirm()
+        task1 = so_line1.task_id
+        task2 = so_line2.task_id
+        timesheet1 = self.env['account.analytic.line'].create({
+            'name': 'Timesheet Task 1',
+            'project_id': task1.project_id.id,
+            'task_id': task1.id,
+            'unit_amount': 5,
+            'employee_id': self.employee_user.id,
+        })
+        timesheet2 = self.env['account.analytic.line'].create({
+            'name': 'Timesheet Task 2',
+            'project_id': task2.project_id.id,
+            'task_id': task2.id,
+            'unit_amount': 5,
+            'employee_id': self.employee_user.id,
+        })
+        invoice2 = sale_order2._create_invoices()[0]
+        invoice2.action_post()
+        self.assertEqual(timesheet1.timesheet_invoice_id, invoice2, "Timesheet1 should be linked to the invoice")
+        self.assertEqual(timesheet2.timesheet_invoice_id, invoice2, "Timesheet2 should be linked to the invoice")
+
+        refund_wizard = self.env['account.move.reversal'].with_context(
+            active_model='account.move',
+            active_ids=invoice2.ids
+        ).create({
+            'reason': 'partial refund',
+            'refund_method': 'refund',
+            'journal_id': invoice2.journal_id.id,
+        })
+        refund_action = refund_wizard.reverse_moves()
+        credit_note = self.env['account.move'].browse(refund_action['res_id'])
+        invoice_line_to_remove = credit_note.invoice_line_ids.filtered(
+            lambda line: line.sale_line_ids.id == so_line2.id
+        )
+        invoice_line_to_remove.unlink()
+        credit_note.action_post()
+        self.assertFalse(timesheet1.timesheet_invoice_id, "Timesheet1 should be cleared after partial refund of its task")
+        self.assertEqual(timesheet2.timesheet_invoice_id, invoice2, "Timesheet2 should still be linked to the original invoice")
+
 
 class TestSaleTimesheetView(TestCommonTimesheet):
     def test_get_view_timesheet_encode_uom(self):


### PR DESCRIPTION
**Issue:**
Timesheet entries linked to reversed invoices are uneditable.

**Steps to reproduce:**
 - Create a service product invoiced by timesheets, and create a project & task.
 - In Sales, create a new quotation with the product.
 - Confirm the quotation, click on the task, and create a timesheet entry.
 - Create an invoice from the quotation.
 - Confirm the invoice, add a credit note, and reverse the invoice.
 - Go to the reversed invoice and access the timesheet through recorded hours.

the timesheet entry is uneditable, even though the invoice is reversed.

opw-4633121