### PR TITLE
[IMP] payment{_stripe}: support meses sin intereses

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -2128,6 +2128,28 @@
         />
     </record>
 
+    <record id="payment_method_msi" model="payment.method">
+        <field name="name">Meses Sin Intereses</field>
+        <field name="code">msi</field>
+        <field name="sequence">1000</field>
+        <field name="active">False</field>
+        <field name="image" type="base64" file="payment/static/img/card.png"/>
+        <field name="support_tokenization">True</field>
+        <field name="support_express_checkout">True</field>
+        <field name="support_manual_capture">partial</field>
+        <field name="support_refund">partial</field>
+        <field name="supported_country_ids"
+               eval="[Command.set([
+                         ref('base.mx'),
+                     ])]"
+        />
+        <field name="supported_currency_ids"
+               eval="[Command.set([
+                         ref('base.MXN'),
+                     ])]"
+        />
+    </record>
+
     <record id="payment_method_multibanco" model="payment.method">
         <field name="name">Multibanco</field>
         <field name="code">multibanco</field>

--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -350,6 +350,7 @@
                          ref('payment.payment_method_klarna'),
                          ref('payment.payment_method_mobile_pay'),
                          ref('payment.payment_method_multibanco'),
+                         ref('payment.payment_method_msi'),
                          ref('payment.payment_method_p24'),
                          ref('payment.payment_method_paynow'),
                          ref('payment.payment_method_paypal'),

--- a/addons/payment_stripe/const.py
+++ b/addons/payment_stripe/const.py
@@ -31,6 +31,7 @@ PAYMENT_METHODS_MAPPING = {
     'clearpay': 'afterpay_clearpay',
     'cash_app_pay': 'cashapp',
     'mobile_pay': 'mobilepay',
+    'msi': 'card',
     'unknown': 'card',  # For express checkout.
 }
 

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -131,6 +131,8 @@ class PaymentTransaction(models.Model):
                 self.payment_method_code, self.payment_method_code
             ),
         }
+        if self.payment_method_code == 'msi':
+            setup_intent_payload['payment_method_options[card][installments][enabled]'] = True
         if self.currency_id.name in const.INDIAN_MANDATES_SUPPORTED_CURRENCIES:
             setup_intent_payload.update(**self._stripe_prepare_mandate_options())
         return setup_intent_payload
@@ -156,6 +158,9 @@ class PaymentTransaction(models.Model):
             'expand[]': 'payment_method',
             **stripe_utils.include_shipping_address(self),
         }
+        if payment_method_type == 'msi':
+            payment_intent_payload['payment_method_options[card][installments][enabled]'] = True
+            payment_intent_payload['payment_method'] = 'pm_card_mx'
         if self.operation in ['online_token', 'offline']:
             if not self.token_id.stripe_payment_method:  # Pre-SCA token, migrate it.
                 self.token_id._stripe_sca_migrate_customer()


### PR DESCRIPTION
When the amount of a purchase is big, it may we a good incentive to allow customers paying in several installments. Stripe supports some "Buy now pay later" options (Klarna, ... ) but in Mexico, this features is standard in all banks:

> Installments (meses sin intereses) is a feature of consumer credit
> cards in Mexico that allows customers to split purchases over multiple
> billing statements. You receive payment as if it were a normal one-
> time charge, with fees deducted, and the customer's bank handles
> collecting the money over time.

It's very popular as the retailer get all the money at once and ths bank of the customer is in charge of collecting installments.

This commit is work in progress as PaymentIntent does not support MSI yet (even though the Stripe support says it does ^^).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
