### PR TITLE
[FIX] stock_dropshipping: Be consequent with new picking type code

### DIFF
--- a/addons/stock_dropshipping/models/res_company.py
+++ b/addons/stock_dropshipping/models/res_company.py
@@ -62,12 +62,7 @@ class ResCompany(models.Model):
     def create_missing_dropship_picking_type(self):
         company_ids = self.env['res.company'].search([])
         company_has_dropship_picking_type = (
-            self.env['stock.picking.type']
-            .search([
-                ('default_location_src_id.usage', '=', 'supplier'),
-                ('default_location_dest_id.usage', '=', 'customer'),
-            ])
-            .mapped('company_id')
+            self.env['stock.picking.type'].search([("code", "=", "dropship")]).company_id
         )
         company_todo_picking_type = company_ids - company_has_dropship_picking_type
         company_todo_picking_type._create_dropship_picking_type()


### PR DESCRIPTION
In this version, the picking type code `dropship` has been introduced to differentiate incoming types from this one (ref: 1547d66585a4b57cd3b747f28b7514dbd9d7bef8), but the search for missing companies without this new type is still being done with the old criteria of the source and target location.

Let's change this to use the new picking type code.

@Tecnativa