### PR TITLE
[IMP] im_livechat: add 'Live Chat' stat button on res partner form

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -28,6 +28,7 @@ Help your customers with this chat, and analyse their feedback.
         'views/chatbot_script_step_views.xml',
         'views/chatbot_script_views.xml',
         "views/discuss_channel_views.xml",
+        "views/res_partner_views.xml",
         "views/im_livechat_channel_views.xml",
         "views/im_livechat_channel_templates.xml",
         "views/im_livechat_chatbot_templates.xml",

--- a/addons/im_livechat/views/res_partner_views.xml
+++ b/addons/im_livechat/views/res_partner_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_partner_form" model="ir.ui.view">
+            <field name="name">res.partner.view.buttons</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form" />
+            <field name="priority" eval="20"/>
+            <field name="arch" type="xml">
+                <div name="button_box" position="inside">
+                    <button
+                        groups="im_livechat.im_livechat_group_user"
+                        class="oe_stat_button"
+                        type="object"
+                        name="action_view_livechat_sessions"
+                        invisible="not livechat_channel_count"
+                        icon="fa-comments"
+                        title="Live Chat History"
+                    >
+                        <field string="Live Chat" name="livechat_channel_count" widget="statinfo"/>
+                    </button>
+                </div>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Purpose of this PR:

- Add 'Live Chat' button in the res partner form view.
- Appears next to the 'Chats' button (if the WhatsApp module is installed).
- Visible only when the partner has at least one live chat conversation.
- Opens a kanban view showing all live chat conversations for the partner (clicking on a conversation opens Discuss).
- Accessible only to users with 'Live Chat > User' access rights.

task-[4607506](https://www.odoo.com/odoo/project/1519/tasks/4607506)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
