### PR TITLE
[FIX] account: remove failing module from l10n standalone test

### DIFF
--- a/addons/account/tests/test_account_all_l10n.py
+++ b/addons/account/tests/test_account_all_l10n.py
@@ -32,6 +32,7 @@ def test_all_l10n(env):
         ('name', '=like', 'l10n_%'),
         ('state', '=', 'uninstalled'),
         '!', ('name', '=like', 'l10n_hk_hr%'),  #failling for obscure reason
+        '!', ('name', '=like', 'l10n_es_%'),  # certificate expired on 2025-03-15 runbot error 161068
     ])
     with patch.object(AccountChartTemplate, 'try_loading', try_loading_patch):
         l10n_mods.button_immediate_install()


### PR DESCRIPTION
The test is failing due to an expired certificate, removing the module from tests for now.
