### PR TITLE
[FIX] discuss: fix SFU fallback connections

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -176,10 +176,11 @@ class Network {
      * not setting it will remove the track from the server
      */
     async updateUpload(type, track) {
-        await Promise.all([
-            this.p2p.updateUpload(type, track),
-            this.sfu?.updateUpload(type, track),
-        ]);
+        const proms = [this.p2p.updateUpload(type, track)];
+        if (this.sfu?.state === "connected") {
+            proms.push(this.sfu.updateUpload(type, track));
+        }
+        await Promise.all(proms);
     }
     /**
      * Stop or resume the consumption of tracks from the other call participants.
@@ -1031,7 +1032,7 @@ export class Rtc extends Record {
     }
 
     async _handleSfuClientStateChange({ detail: { state, cause } }) {
-        this.log(this.localSession, "SFU connection state changed", { state, cause });
+        this.log(this.localSession, `connection state change: ${state}`, { state, cause });
         this.localSession.connectionState = state;
         switch (state) {
             case this.SFU_CLIENT_STATE.AUTHENTICATED:
@@ -1288,7 +1289,7 @@ export class Rtc extends Record {
     buildSnapshot() {
         const server = {};
         if (this.state.connectionType === CONNECTION_TYPES.SERVER) {
-            server.info = this.serverInfo;
+            server.info = toRaw(this.serverInfo);
             server.state = this.sfuClient?.state;
             server.errors = this.sfuClient?.errors.map((error) => error.message);
         }
@@ -1974,6 +1975,8 @@ export const rtcService = {
                     return;
                 }
                 if (rtc.serverInfo?.channelUUID === serverInfo.channelUUID) {
+                    // we clear peers as inbound p2p connections may still be active
+                    rtc.p2pService.removeALlPeers();
                     // no reason to swap if the server is the same, if at some point we want to force a swap
                     // there should be an explicit flag in the event payload.
                     return;


### PR DESCRIPTION
Before this commit,

* The p2p service could still attempt to recover
peer to peer connections despite having swapped to a SFU.
* Dumping logs in SFU mode would cause a traceback due to
not being able to copy proxies.
* `updateUpload()` can be called when the SFU is not ready (for p2p
connection), it is not an issue as it is called when the SFU state
changes but it logs an error and bloats the logs.

This commit also changes the formatting of the connection state change
event of the SFU logging to be the same as the p2p connection state
change logging.

