### PR TITLE
[FIX] l10n_jo_edi: Remove deprecated mobile fallback

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -415,7 +415,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
             'accounting_customer_party_vals': {
                 'party_vals': self._get_empty_party_vals() if is_refund else self._get_partner_party_vals(customer, role='customer'),
                 'accounting_contact': {
-                    'telephone': '' if is_refund else invoice.partner_id.phone or invoice.partner_id.mobile,
+                    'telephone': '' if is_refund else invoice.partner_id.phone,
                 },
             },
             'seller_supplier_party_vals': {


### PR DESCRIPTION
Since https://github.com/odoo/enterprise/commit/555de9b336f0538439d6e2977984573bf2b4fc28 the `mobile` field has been removed.

This fix eliminates its usage as a fallback.

Steps to reproduce
1. Install `l10n_jo_edi`
2. Create a partner without a mobile number
3. Generate and validate an invoice
4. Attempt to send it to JoFatura

You'll get:
```
AttributeError: 'res.partner' object has no attribute 'mobile'
```
