### PR TITLE
[FIX] l10n_vn_edi_viettel: signs on credit notes

### DIFF
--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -695,15 +695,15 @@ class AccountMove(models.Model):
                 'unitPrice': line.price_unit * sign,
                 'quantity': line.quantity,
                 # This amount should be without discount applied.
-                'itemTotalAmountWithoutTax': line.currency_id.round(line.price_unit * line.quantity) * sign,
+                'itemTotalAmountWithoutTax': line.currency_id.round(line.price_unit * line.quantity),
                 # In Vietnam a line will always have only one tax.
                 # Values are either: -2 (no tax), -1 (not declaring/paying taxes), 0,5,8,10 (the tax %)
                 # Most use cases will be -2 or a tax percentage, so we limit the support to these.
                 'taxPercentage': line.tax_ids and line.tax_ids[0].amount or -2,
-                'taxAmount': (line.price_total - line.price_subtotal) * sign,
+                'taxAmount': (line.price_total - line.price_subtotal),
                 'discount': line.discount,
-                'itemTotalAmountAfterDiscount': line.price_subtotal * sign,
-                'itemTotalAmountWithTax': line.price_total * sign,
+                'itemTotalAmountAfterDiscount': line.price_subtotal,
+                'itemTotalAmountWithTax': line.price_total,
             }
             if line.display_type in code_map:
                 item_information['selection'] = code_map[line.display_type]

--- a/addons/l10n_vn_edi_viettel/tests/test_edi.py
+++ b/addons/l10n_vn_edi_viettel/tests/test_edi.py
@@ -197,10 +197,10 @@ class TestVNEDI(AccountTestInvoicingCommon):
         # 2. Check the itemInfo to ensure that the values make sense
         expected = {
             'unitPrice': -100.0,
-            'itemTotalAmountWithoutTax': -100.0,
-            'taxAmount': -10.0,
-            'itemTotalAmountWithTax': -110.0,
-            'adjustmentTaxAmount': -10.0,
+            'itemTotalAmountWithoutTax': 100.0,
+            'taxAmount': 10.0,
+            'itemTotalAmountWithTax': 110.0,
+            'adjustmentTaxAmount': 10.0,
             'isIncreaseItem': False,
         }
         actual = json_data['itemInfo'][0]

--- a/doc/cla/individual/phuctranfxvn.md
+++ b/doc/cla/individual/phuctranfxvn.md
@@ -1,0 +1,11 @@
+Vietnam, 2025-03-17
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Phuc Tran Thanh phuctran.fx.vn@gmail.com https://github.com/phuctranfxvn


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Viettel SInvoice will automatically change the signs of the amount values (except for unit price) we sent for credit notes (on accounts with data validation step). So the "right" values will appear in the portal. Currently (before the commit) the values have the wrong sign in the portal (because they are changed but we sent the right ones already).
- We need to retain the original signs of those values when submitting them to SInvoice.

Current behavior before PR:
- All the amount values, including `itemTotalAmountWithoutTax`, `taxAmount`, `itemTotalAmountAfterDiscount` and `itemTotalAmountWithTax` are sent to Viettel SInvoice in negative values for credit note. Viettel SInvoice changes the sign of these values to positive (which is not correct for credit note).

Desired behavior after PR is merged:
- Only the sign of `unitPrice` is changed when we send the credit note to SInvoice.

**Note:**
- The signs will not automatically be changed for accounts with data validation step removed. So this commit will break credit notes for them (since the signs are not automatically adjusted but our values have the wrong signs).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
