### PR TITLE
[FIX] point_of_sale, *: self invoicing portal

### DIFF
--- a/addons/l10n_ar_pos/views/templates.xml
+++ b/addons/l10n_ar_pos/views/templates.xml
@@ -12,7 +12,7 @@
         </xpath>
 
         <!-- If the user is NOT log in we should hide the partner form, this one lost functionality because the get my invoice button is not shown and then the partner info is never save. In they want they can sign up and fill data from there -->
-        <xpath expr="//div[hasclass('o_portal_details')]" position="attributes">
+        <xpath expr="//div[hasclass('o_customer_address_fill')]" position="attributes">
             <attribute name="t-if">pos_order.company_id.country_code != 'AR'</attribute>
         </xpath>
         <xpath expr="//div[@id='get_info_div']" position="attributes">

--- a/addons/l10n_pe_pos/views/templates.xml
+++ b/addons/l10n_pe_pos/views/templates.xml
@@ -16,7 +16,7 @@
         <!-- If the user is NOT logged in we should hide the partner form, this one lost functionality
         because the get my invoice button is not shown and then the partner info is never saved. In they
         want they can sign up and fill data from there -->
-        <xpath expr="//div[hasclass('o_portal_details')]" position="attributes">
+        <xpath expr="//div[hasclass('o_customer_address_fill')]" position="attributes">
             <attribute name="t-if" add="(pos_order.company_id.country_code != 'PE')" separator="and" />
         </xpath>
         <xpath expr="//div[@id='get_info_div']" position="attributes">

--- a/addons/point_of_sale/static/tests/pos/tours/pos_self_invoicing_portal_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_self_invoicing_portal_tour.js
@@ -1,0 +1,81 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("invoicePoSOrderWithSelfInvocing", {
+    steps: () => [
+        {
+            trigger: "input[name='pos_reference']",
+            run: "edit 2500-002-00002",
+        },
+        {
+            trigger: ".o_portal_wrap input[name='date_order']",
+            run: function () {
+                const date_order = luxon.DateTime.now();
+                document.querySelector(".o_portal_wrap input[name='date_order']").value =
+                    date_order.toFormat("yyyy-MM-dd");
+            },
+        },
+        {
+            trigger: ".o_portal_wrap input[name='ticket_code']",
+            run: "edit inPoS",
+        },
+        {
+            trigger: ".o_portal_wrap button:contains('Request Invoice')",
+            run: "click",
+        },
+        {
+            trigger: ".o_portal_wrap input[name='name']",
+            run: "edit Anant Parmar",
+        },
+        {
+            trigger: ".o_portal_wrap input[name='phone']",
+            run: "edit +911234567890",
+        },
+        {
+            trigger: ".o_portal_wrap input[name='email']",
+            run: "edit test@test.com",
+        },
+        {
+            trigger: ".o_portal_wrap input[name='street']",
+            run: "edit 131, Satyamcity society",
+        },
+        {
+            trigger: ".o_portal_wrap input[name='street2']",
+            run: "edit opposite new rto office",
+        },
+        {
+            trigger: ".o_portal_wrap input[name='city']",
+            run: "edit palanpur",
+        },
+        {
+            trigger: ".o_portal_wrap input[name='zip']",
+            run: "edit 385001",
+        },
+        {
+            trigger: ".o_portal_wrap select[name='country_id']",
+            run: function () {
+                const countrySelect = document.querySelector("select[name='country_id']");
+                if (Array.from(countrySelect.classList).includes("d-none")) {
+                    throw new Error("The language selector must not be hidden.");
+                }
+                countrySelect.value = "233";
+            },
+        },
+        {
+            trigger: ".o_portal_wrap select[name='state_id']",
+            run: function () {
+                const stateSelect = document.querySelector("select[name='state_id']");
+                if (Array.from(stateSelect.classList).includes("d-none")) {
+                    throw new Error("The language selector must not be hidden.");
+                }
+                stateSelect.value = "19";
+            },
+        },
+        {
+            trigger: ".o_portal_wrap button:contains('Get my invoice')",
+            run: "click",
+        },
+        {
+            trigger: ".rounded.text-bg-success.fw-normal.badge",
+        },
+    ],
+});

--- a/addons/point_of_sale/views/pos_ticket_view.xml
+++ b/addons/point_of_sale/views/pos_ticket_view.xml
@@ -6,7 +6,7 @@
         <t t-call="portal.portal_layout">
             <t t-set="no_breadcrumbs" t-value="True"/>
             <div class="row justify-content-md-center">
-                <form method="post" target="_self" t-att-action="'/pos/ticket/validate'" onsubmit="$('button:submit').attr('disabled', 'disabled')">
+                <form method="post" target="_self" t-att-action="'/pos/ticket/validate'" onsubmit="$('button:submit').attr('disabled', 'disabled')" class="address_autoformat">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                     <input type="hidden" name="access_token" t-att-value="access_token"/>
                     <div class="col-12 col-md-6 mt-4 offset-md-3">
@@ -92,7 +92,7 @@
                                     <h4>Please enter your billing information <small class="text-muted">or</small> <a role="button" t-att-href="'/web/login?redirect=/pos/ticket/validate?access_token=%s' % access_token" style="margin-top: -11px"> Sign in</a>:</h4>
                                 </div>
                             </div>
-                            <div class="row o_portal_details">
+                            <div class="row o_customer_address_fill">
                                 <div class="col-lg-12">
                                     <div class="row">
                                         <t t-call="portal.address_form_fields"/>
@@ -148,7 +148,7 @@
                             </div>
                             <h2>Invoice Request</h2>
                             <hr class="mt-1 mb-0"/>
-                            <div class="row o_portal_details">
+                            <div class="row">
                                 <div class="col-lg-12">
                                     <div class="row">
                                         <div t-attf-class="col-12 mb-6 col-xl-8">

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -774,7 +774,7 @@ class CustomerPortal(Controller):
     @route(
         '/my/address/country_info/<model("res.country"):country>',
         type='jsonrpc',
-        auth='user',
+        auth='public',
         methods=['POST'],
         website=True,
         readonly=True,

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -979,10 +979,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
             ], limit=1)
         return super()._get_default_country(order_sudo=order_sudo, **kwargs)
 
-    @route(auth='public')
-    def portal_address_country_info(self, *args, **kwargs):
-        return super().portal_address_country_info(*args, **kwargs)
-
     @route(
         '/shop/address/submit', type='http', methods=['POST'], auth='public', website=True,
         sitemap=False


### PR DESCRIPTION
*: l10n_ar_pos, l10n_pe_pos, portal, website_sale

Issue 1:
==========
Steps:
-----------
- Install point_of_sale.
- Open a PoS Register.
- Process an order until the receipt screen.
- Scan the QR for self-invoicing.

Issue:
-----------
- A traceback occurs when trying to access a value from a `null` reference.

Cause:
-----------
- The `o_portal_details` class was included in the rendered template, even when the country selection was unavailable.

FIX:
----------
- Removed the unrelated o_portal_details class from the template to prevent the error.

Issue 2:
==========
Steps:
----------
- Install point_of_sale.
- Open a PoS Register.
- Process an order until the receipt screen.
- Scan the QR for self-invoicing with public user.
- Attempt to generate an invoice for a country where state selection is required for the invoice.

Issue:
----------
- The invoice is not generated due to missing state selection.

Cause:
----------
- The state selection field was not available, even when required for invoicing.

FIX:
----------
- Ensured the state field is displayed when required based on the selected country.
- Applied `address_autoformat` and `o_customer_address_fill` classes to dynamically update the field based on country selection.
- Changed authentication for the `/my/address/country_info/<model("res.country"):country>` route from `user` to `publi`c to allow public users to retrieve country-specific address formats.


task-4649241

Related PR:
- Enterprise: https://github.com/odoo/enterprise/pull/81639