### PR TITLE
[IMP] hr_timesheet: improve timesheet visible for portal when set as a customer

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -327,7 +327,9 @@ class AccountAnalyticLine(models.Model):
             # Then, he is internal user, and we take the domain for this current user
             return self.env['ir.rule']._compute_domain(self._name)
         return [
+            '|',
             ('message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
+            ('partner_id', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
             ('project_id.privacy_visibility', '=', 'portal'),
         ]
 

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -53,8 +53,9 @@
             <field name="domain_force">[
                 ('user_id', '=', user.id),
                 ('project_id', '!=', False),
-                '|',
+                '|', '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('partner_id', '=', user.partner_id.id),
                     ('message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
@@ -65,9 +66,10 @@
             <field name="model_id" ref="analytic.model_account_analytic_line" />
             <field name="domain_force">[
                 ('project_id', '!=', False),
-                '|',
+                '|', '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('message_partner_ids', 'in', [user.partner_id.id]),
+                    ('partner_id', '=', user.partner_id.id),
             ]</field>
             <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]" />
         </record>

--- a/addons/hr_timesheet/tests/test_portal_timesheet.py
+++ b/addons/hr_timesheet/tests/test_portal_timesheet.py
@@ -68,3 +68,46 @@ class TestPortalTimesheet(TestProjectSharingCommon):
                 self.assertEqual(view_id, form_view_id)
             elif view_type == 'kanban':
                 self.assertEqual(view_id, kanban_view_id)
+
+    def test_timesheet_visibility_portal(self):
+        """
+        Steps:
+        1. Retrieve the domain that determines timesheet visibility for the portal user.
+        2. Create an employee linked to the project user.
+        3. Create a timesheet entry associated with a specific project and task.
+        4. Assign the portal user as the partner on the task.
+        5. Search for timesheets using the retrieved domain.
+        6. Verify that the created timesheet is visible to the portal user.
+        7. Remove the portal user as the partner of the task.
+        8. Search for timesheets again using the same domain.
+        9. Verify that the timesheet is no longer visible to the portal user.
+        10. Assign the portal user as the partner of the project.
+        11. Search for timesheets again using the same domain.
+        12. Verify that the timesheet is now visible to the portal user.
+        """
+        AnalyticLineModel = self.env['account.analytic.line']
+        timesheet_domain = AnalyticLineModel.with_user(self.user_portal)._timesheet_get_portal_domain()
+
+        employee = self.env['hr.employee'].create({
+            'name': 'Project User Employee',
+            'user_id': self.user_projectuser.id,
+        })
+
+        timesheet_entry = AnalyticLineModel.create({
+            'name': 'Timesheet',
+            'project_id': self.project_cows.id,
+            'task_id': self.task_cow.id,
+            'employee_id': employee.id,
+        })
+
+        self.task_cow.write({'partner_id': self.user_portal.partner_id.id})
+        timesheets = AnalyticLineModel.search(timesheet_domain)
+        self.assertIn(timesheet_entry.id, timesheets.ids, "Portal user should see the timesheet when set as the partner on the task.")
+
+        self.task_cow.write({'partner_id': False})
+        timesheets = AnalyticLineModel.search(timesheet_domain)
+        self.assertNotIn(timesheet_entry.id, timesheets.ids, "Portal user should not see the timesheet when not assigned as the task's partner.")
+
+        self.project_cows.write({'partner_id': self.user_portal.partner_id.id})
+        timesheets = AnalyticLineModel.search(timesheet_domain)
+        self.assertIn(timesheet_entry.id, timesheets.ids, "Portal user should see the timesheet when set as the project’s partner.")


### PR DESCRIPTION
this commit enhance the visibility of timesheet entries for the portal user. Now when a portal user is a customer or follower of a project or task, they can see all the timesheet entries related to the particular task or project.

and additionally also after this commit if timesheet user is set as follower or customer on the project or task they can able to see the timesheet entries related to them.

Why are we doing this?
In saas-18.2, when a message was sent, the customer was automatically added as a follower, allowing them to view the timesheet entry. However, in saas-18.2, the automatic addition of followers has been removed, so now we have to add the followers manually. With this commit, we are using the customer's user to ensure they can easily view the timesheet entry without needing to add them as a follower.

task - 4586667





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
