### PR TITLE
[FIX] html_editor: remove text align shortcuts

### DIFF
--- a/addons/html_editor/static/src/main/align/align_plugin.js
+++ b/addons/html_editor/static/src/main/align/align_plugin.js
@@ -34,12 +34,6 @@ export class AlignPlugin extends Plugin {
                 run: () => this.setAlignment("justify"),
             },
         ],
-        shortcuts: [
-            { hotkey: "control+shift+l", commandId: "alignLeft" },
-            { hotkey: "control+shift+e", commandId: "alignCenter" },
-            { hotkey: "control+shift+r", commandId: "alignRight" },
-            { hotkey: "control+shift+j", commandId: "justify" },
-        ],
         toolbar_items: [
             {
                 id: "alignment",

--- a/addons/html_editor/static/tests/align.test.js
+++ b/addons/html_editor/static/tests/align.test.js
@@ -1,5 +1,4 @@
 import { describe, test } from "@odoo/hoot";
-import { press } from "@odoo/hoot-dom";
 import { testEditor } from "./_helpers/editor";
 import { alignCenter, justify, alignLeft, alignRight } from "./_helpers/user_actions";
 
@@ -85,15 +84,6 @@ describe("left", () => {
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: left;">a[]b</h1></div>',
         });
     });
-
-    test("should left align a container with shortcut", async () => {
-        await testEditor({
-            contentBefore: '<div style="text-align: center;"><p>a[]b</p></div>',
-            stepFunction: () => press(["ctrl", "shift", "l"]),
-            contentAfter:
-                '<div style="text-align: center;"><p style="text-align: left;">a[]b</p></div>',
-        });
-    });
 });
 
 describe("center", () => {
@@ -167,15 +157,6 @@ describe("center", () => {
             stepFunction: alignCenter,
             contentAfter:
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: center;">a[]b</h1></div>',
-        });
-    });
-
-    test("should center align a container with shortcut", async () => {
-        await testEditor({
-            contentBefore: '<div style="text-align: left;"><p>a[]b</p></div>',
-            stepFunction: () => press(["ctrl", "shift", "e"]),
-            contentAfter:
-                '<div style="text-align: left;"><p style="text-align: center;">a[]b</p></div>',
         });
     });
 });
@@ -253,14 +234,6 @@ describe("right", () => {
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: right;">a[]b</h1></div>',
         });
     });
-    test("should right align a container with shortcut", async () => {
-        await testEditor({
-            contentBefore: '<div style="text-align: left;"><p>a[]b</p></div>',
-            stepFunction: () => press(["ctrl", "shift", "r"]),
-            contentAfter:
-                '<div style="text-align: left;"><p style="text-align: right;">a[]b</p></div>',
-        });
-    });
 });
 
 describe("justify", () => {
@@ -334,15 +307,6 @@ describe("justify", () => {
             stepFunction: justify,
             contentAfter:
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: justify;">a[]b</h1></div>',
-        });
-    });
-
-    test("should justify align a container with shortcut", async () => {
-        await testEditor({
-            contentBefore: '<div style="text-align: right;"><p>a[]b</p></div>',
-            stepFunction: () => press(["ctrl", "shift", "j"]),
-            contentAfter:
-                '<div style="text-align: right;"><p style="text-align: justify;">a[]b</p></div>',
         });
     });
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

This commit removes the text alignment shortcuts introduces in commit [1](https://github.com/odoo/odoo/commit/5e06eba56427a8c58bb503d160a8df815d2d8b9a) as they conflicted with certain browsers shortcuts. For example, Ctrl+Shift+R, which was assigned to align text to the right, is commonly used for a hard reload in browsers.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
