### PR TITLE
[FIX] account: fix invoice portal iframe's height

### DIFF
--- a/addons/account/static/src/interactions/account_sidebar.js
+++ b/addons/account/static/src/interactions/account_sidebar.js
@@ -32,8 +32,9 @@ export class AccountSidebar extends Sidebar {
      */
     updateIframeSize() {
         const wrapwrapEl = this.invoiceHTMLEl.contentDocument.querySelector("div#wrapwrap");
-        this.invoiceHTMLEl.style.height = 0;
-        this.invoiceHTMLEl.style.height = wrapwrapEl.scrollHeight;
+        // Set it to 0 first to handle the case where scrollHeight is too big for its content.
+        this.invoiceHTMLEl.height = 0;
+        this.invoiceHTMLEl.height = wrapwrapEl.scrollHeight;
         // scroll to the right place after iframe resize
         const isAnchor = /^#[\w-]+$/.test(window.location.hash)
         if (!isAnchor) {


### PR DESCRIPTION
With the conversion from public widgets to interactions in [1], the iframe containing the invoice preview in portal was not properly assigned its height.

Steps to reproduce:
- Go to Accounting → Customer → Invoices
- open any invoice and click on Preview. => The invoice is not displayed in a usable format.

[1]: https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba

opw-4633795