### PR TITLE
[IMP] point_of_sale: displaying online order details on KOT

### DIFF
--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -15,7 +15,7 @@
                         <t t-else="">Dine In</t>
                     </t>
                 </div>
-                <div style="font-size: 78%;">
+                <div class="o-employee-name" style="font-size: 78%;">
                     <span><t t-esc="changes.config_name"/> : <t t-esc="changes.time"/></span><br/>
                     <span>By: <t t-esc="changes.employee_name"/></span>
                 </div>

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1723,10 +1723,9 @@ export class PosStore extends Reactive {
         }
     }
 
-    async getRenderedReceipt(order, title, lines, fullReceipt = false, diningModeUpdate) {
+    getPrintingChanges(order, diningModeUpdate) {
         const time = DateTime.now().toFormat("HH:mm");
-
-        const printingChanges = {
+        return {
             table_name: order.table_id ? order.table_id.table_number : "",
             config_name: order.config.name,
             time: time,
@@ -1736,10 +1735,12 @@ export class PosStore extends Reactive {
             order_note: order.general_note,
             diningModeUpdate: diningModeUpdate,
         };
+    }
 
+    async getRenderedReceipt(order, title, lines, fullReceipt = false, diningModeUpdate) {
         const receipt = renderToElement("point_of_sale.OrderChangeReceipt", {
             operational_title: title,
-            changes: printingChanges,
+            changes: this.getPrintingChanges(order, diningModeUpdate),
             changedlines: lines,
             fullReceipt: fullReceipt,
         });


### PR DESCRIPTION
Following this commit :
- getRenderedReceipt method is optimised to pass dynamic values.
- o-employee-name class has been added for applying xpath.
Enterprise PR: https://github.com/odoo/enterprise/pull/81559

task-4633156