### PR TITLE
[FIX] l10n_{ar,cl}: missing custom header margin

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -3,7 +3,7 @@
 
     <!-- this header can be used on any Argentinean report, to be useful some variables should be passed -->
     <template id="custom_header">
-        <div>
+        <div class="mb-3">
             <div class="row">
                 <div name="left-upper-side" class="col-5" t-if="not pre_printed_report">
                     <img t-if="o.company_id.logo" t-att-src="image_data_uri(o.company_id.logo)" style="max-height: 45px;" alt="Logo"/>

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -13,7 +13,7 @@
             <t t-call="l10n_cl.custom_footer"/>
         </t>
 
-        <div>
+        <div class="mb-3">
             <div class="row">
                 <div name="left-upper-side" class="col-8">
                     <img t-if="o.company_id.logo" t-att-src="image_data_uri(o.company_id.logo)"


### PR DESCRIPTION
latam document layouts with custom headers don't have any bottom margin. All default layouts use `<ul>` for the header, which by default has 1em bottom margin. When we replace these headers with our custom ones with just a plain `<div>` which has no bottom margin by deafult, we end up in a situation where in HTML preview, the body is glued to the header in `l10n_ar`, which also looks off comapred to PDF preview.

How to reproduce:
- Create a DB
- Install Accounting
- Install AR localization
- Move to "(AR) Responsable Inscripto" company
- Switch Document Layout to "Bubble" format
- Create an invoice with B2B customer. It will make sure the Document Type switches to "(1) INVOICES A".
- Make sure the Journal is "Electronic Invoice"
- Validate the invoice
- Click on Preview button
- In parallel generate a PDF report of the invoice too

You will see that on the PDF report the header looks nice because of the existing spacing, but on preview it looks glued to the header

opw-4411237