### PR TITLE
[FIX] account: allow invoice email when recipient is not partner

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -524,7 +524,11 @@ class AccountMoveSend(models.AbstractModel):
 
         self._generate_dynamic_reports(moves_data)
 
-        for move, move_data in [(move, move_data) for move, move_data in moves_data.items() if move.partner_id.email]:
+        for move, move_data in [
+            (move, move_data)
+            for move, move_data in moves_data.items()
+            if move.partner_id.email or move_data.get('mail_partner_ids')
+        ]:
             mail_template = move_data['mail_template']
             mail_lang = move_data['mail_lang']
             mail_params = self._get_mail_params(move, move_data)


### PR DESCRIPTION
On manual sending an invoice email via wizard, if the invoice partner has no email, and another recipient is set as recipient, no mail is sent. This was caused by a check only allowing emails to be sent for invoices with partners having an email.

Task: opw-4604810