### PR TITLE
[FIX] mail: non deterministic subscription test

### DIFF
--- a/addons/mail/static/src/core/web/thread_service_patch.js
+++ b/addons/mail/static/src/core/web/thread_service_patch.js
@@ -190,7 +190,7 @@ patch(ThreadService.prototype, {
     },
     /** @override */
     open(thread, replaceNewMessageChatWindow, options) {
-        if (thread.model === "discuss.channel") {
+        if (thread.model === "discuss.channel" && !thread.selfMember) {
             this.store.env.services["bus_service"].addChannel(thread.busChannel);
         }
         if (!this.store.discuss.isActive && !this.ui.isSmall) {

--- a/addons/mail/static/tests/discuss/core/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/discuss_tests.js
@@ -2,19 +2,22 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
+import { Command } from "@mail/../tests/helpers/command";
 import { start } from "@mail/../tests/helpers/test_utils";
 
 import { assertSteps, click, contains, insertText, step } from "@web/../tests/utils";
 import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
-import { patchDate } from "@web/../tests/helpers/utils";
+import { patchDate, triggerHotkey } from "@web/../tests/helpers/utils";
 
 QUnit.module("discuss");
 
 QUnit.test("Member list and settings menu are exclusive", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const later = luxon.DateTime.now().plus({ seconds: 2 });
+    patchDate(later.year, later.month, later.day, later.hour, later.minute, later.second);
     const { openDiscuss } = await start();
-    openDiscuss(channelId);
+    await openDiscuss(channelId);
     await click("[title='Show Member List']");
     await contains(".o-discuss-ChannelMemberList");
     await click("[title='Show Call Settings']");
@@ -22,58 +25,73 @@ QUnit.test("Member list and settings menu are exclusive", async () => {
     await contains(".o-discuss-ChannelMemberList", { count: 0 });
 });
 
+QUnit.test("subscribe to known partner presences", async () => {
+    patchWebsocketWorkerWithCleanup({
+        _sendToServer({ event_name, data }) {
+            if (event_name === "subscribe") {
+                step(`subscribe - [${data.channels}]`);
+            }
+        },
+    });
+    const pyEnv = await startServer();
+    const bobPartnerId = pyEnv["res.partner"].create({
+        name: "Bob",
+        user_ids: [Command.create({ name: "bob" })],
+    });
+    const later = luxon.DateTime.now().plus({ seconds: 2 });
+    patchDate(later.year, later.month, later.day, later.hour, later.minute, later.second);
+    const { openDiscuss } = await start();
+    await openDiscuss();
+    const expectedPresences = [
+        `odoo-presence-res.partner_${pyEnv.odoobotId}`,
+        `odoo-presence-res.partner_${pyEnv.currentPartnerId}`,
+    ];
+    await assertSteps([`subscribe - [${expectedPresences.join(",")}]`]);
+    await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
+    await insertText(".o-discuss-ChannelSelector input", "bob");
+    await click(".o-discuss-ChannelSelector-suggestion");
+    await triggerHotkey("Enter");
+    expectedPresences.push(`odoo-presence-res.partner_${bobPartnerId}`);
+    await assertSteps([`subscribe - [${expectedPresences.join(",")}]`]);
+});
+
 QUnit.test("bus subscription is refreshed when channel is joined", async () => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create([{ name: "General" }, { name: "Sales" }]);
     patchWebsocketWorkerWithCleanup({
-        _sendToServer({ event_name, data }) {
+        _sendToServer({ event_name }) {
             if (event_name === "subscribe") {
-                step(`subscribe - ${JSON.stringify(data.channels)}`);
+                step("subscribe");
             }
         },
     });
     const later = luxon.DateTime.now().plus({ seconds: 2 });
     patchDate(later.year, later.month, later.day, later.hour, later.minute, later.second);
-    const { env, openDiscuss } = await start();
-    const expectedSubscribes = [];
-    for (const { type, id } of env.services["mail.store"].imStatusTrackedPersonas) {
-        const model = type === "partner" ? "res.partner" : "mail.guest";
-        expectedSubscribes.unshift(`"odoo-presence-${model}_${id}"`);
-    }
+    const { openDiscuss } = await start();
     await openDiscuss();
-    await assertSteps([`subscribe - [${expectedSubscribes.join(",")}]`]);
+    await assertSteps(["subscribe"]);
     await click(".o-mail-DiscussSidebar i[title='Add or join a channel']");
     await insertText(".o-discuss-ChannelSelector input", "new channel");
     await click(".o-discuss-ChannelSelector-suggestion");
-    const [newChannel] = pyEnv["discuss.channel"].searchRead([["name", "=", "new channel"]]);
-    expectedSubscribes.unshift(`"discuss.channel_${newChannel.id}"`);
-    await assertSteps([
-        `subscribe - [${expectedSubscribes.join(",")}]`,
-        `subscribe - [${expectedSubscribes.join(",")}]`, // 1 is enough. The 2 comes from technical details (1: from channel_join, 2: from channel open), 2nd covers shadowing
-    ]);
+    await assertSteps(["subscribe"]);
 });
 
 QUnit.test("bus subscription is refreshed when channel is left", async () => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({ name: "General" });
     patchWebsocketWorkerWithCleanup({
-        _sendToServer({ event_name, data }) {
+        _sendToServer({ event_name }) {
             if (event_name === "subscribe") {
-                step(`subscribe - ${JSON.stringify(data.channels)}`);
+                step("subscribe");
             }
         },
     });
     const later = luxon.DateTime.now().plus({ seconds: 2 });
     patchDate(later.year, later.month, later.day, later.hour, later.minute, later.second);
-    const { env, openDiscuss } = await start();
-    const imStatusChannels = [];
-    for (const { type, id } of env.services["mail.store"].imStatusTrackedPersonas) {
-        const model = type === "partner" ? "res.partner" : "mail.guest";
-        imStatusChannels.unshift(`"odoo-presence-${model}_${id}"`);
-    }
-    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
+    const { openDiscuss } = await start();
+    await assertSteps(["subscribe"]);
     await openDiscuss();
     await assertSteps([]);
     await click("[title='Leave this channel']");
-    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
+    await assertSteps(["subscribe"]);
 });


### PR DESCRIPTION
Before this PR, the `bus subscription is refreshed when channel is joined` test was sometimes failing.

Since [1], opening a thread *always* result in a bus subscription being issued (the channel is added to the bus channels as a string). This is not required: bus subscriptions are based on user's channels (see `ir_websocket@_build_bus_channel_list`). When a new channel is added, the client subscribes again (see `toggleBusSubscription`).

Channels should only be added explictly when a channel the user is not a member of is opened. This addition causes a race condition between `toggleBusSubscription` and the explicit addition of the channel, resulting in a non deterministic behavior.

This PR fixes this issue: channel is only added when required, which is not the case in this test thus solving the issue.

fixes runbot-106895

[1]: https://github.com/odoo/odoo/pull/174473

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
