### PR TITLE
[FIX] l10n_in_ewaybill: correct the wrongly placed comment

### DIFF
--- a/addons/l10n_in_ewaybill/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill/views/l10n_in_ewaybill_views.xml
@@ -68,11 +68,7 @@
                         </group>
                     </group>
                     <group name="partners" string="Address Details">
-                    <!--
-                    We require account_move_id in the view it to
-                    compute the Billing and Shipping partners if the
-                    field is removed the compute won't work as expected -->
-                    <field name="account_move_id" invisible="1"/>
+                    <field name="account_move_id" invisible="1"/> <!-- To compute the Billing and Shipping partners -->
                         <group>
                             <field name="partner_bill_from_id"
                                    force_save="1"


### PR DESCRIPTION
this commit intends to resolve the [runbot error](https://runbot.odoo.com/runbot/build/76665319)

The comment already existed for the invisible field but the comment was not correctly placed in this commit we fix that

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
