### PR TITLE
[FIX] purchase,purchase_stock: 0 price automated RFQ no pricelist

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -596,9 +596,8 @@ class PurchaseOrderLine(models.Model):
         product_taxes = product_id.supplier_taxes_id.filtered(lambda x: x.company_id in company_id.parent_ids)
         taxes = po.fiscal_position_id.map_tax(product_taxes)
 
-        price_unit = seller.price if seller else product_id.standard_price
         price_unit = self.env['account.tax']._fix_tax_included_price_company(
-            price_unit, product_taxes, taxes, company_id)
+            seller.price, product_taxes, taxes, company_id) if seller else 0
         if price_unit and seller and po.currency_id and seller.currency_id != po.currency_id:
             price_unit = seller.currency_id._convert(
                 price_unit, po.currency_id, po.company_id, po.date_order or fields.Date.today())

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -450,7 +450,7 @@ class TestReplenishWizard(TestStockCommon):
         ])[-1]
 
         self.assertEqual(last_po_id.partner_id, vendor)
-        self.assertEqual(last_po_id.order_line.price_unit, 60)
+        self.assertEqual(last_po_id.order_line.price_unit, 0)
 
     def test_correct_supplier(self):
         self.env['stock.warehouse'].search([], limit=1).reception_steps = 'two_steps'


### PR DESCRIPTION
**Problem**: 
When a RFQ is created automatically (MTO, reordering rule, manual replenish) for a product which has a different currency in general information (next to cost) and in the vendor line (in the pruchase tab).
If the conditions of the vendors pricelists aren't met (ex not enough quantity) the price on the RFQ will be the cost from the "general information tab" and the currency will come from the vendor in the purchase tab. This could be an issue especially if there's a high exchange rate between the currencies. 

**Steps to reproduce**:
- in settings, activate another currency (ex:kr)
- create a new product
- set the product type as "storable product"
- set a cost in the general information tab and a currency (ex:1000kr)
- in the inventory tab set the route as "Buy"
- in the pruchase tab add a vendor line, with a vendor name, a quantity (ex:10) and a price in another currency (ex:8$)
- click on the replenish button and set a quantity below the minimum quantity of the vendor line you just created

**Current behavior**:
A RFQ is created, with a price equal to the cost set in general information and the currency of the vendor in the purchase tab (here:1000$).

**Expected behavior**:
When the conditions of the vendor's pricelist aren't met the price should be 0 and the currency should be the one of the vendor

**Fix**:
I reversed the changes made in this commit
https://github.com/odoo/odoo/pull/158650/commits/caf4974b770b3295faebdaab5014a879760ccd67 and adapted the test
Now, if the seller variable is empty (which happens when no pricelist is matched), the price is set to zero
https://github.com/odoo/odoo/blob/953eb7cc241e290e3e5d1ef19048213a206a1947/addons/purchase/models/purchase_order_line.py#L599

opw-4547212
