### PR TITLE
[FIX] purchase: include bill in purchase matching

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -141,7 +141,7 @@ class AccountMove(models.Model):
             'name': _("Purchase Matching"),
             'res_model': 'purchase.bill.line.match',
             'domain': [
-                ('partner_id', '=', self.partner_id.id),
+                ('partner_id', 'in', (self.partner_id | self.partner_id.commercial_partner_id).ids),
                 ('company_id', 'in', self.env.company.ids),
                 ('account_move_id', 'in', [self.id, False]),
             ],


### PR DESCRIPTION
**Problem:**
When clicking the button Purchase Matching, in a Vendor Bill, if
the vendor is an individual but has a company, the bill will not
appear below the Purchase Orders. If the vendor is an individual
without a company, the Purchase Matching button will display
everything like it should.

**Steps to reproduce:**
- Make a Purchase Order, the vendor has to be an individual with a company.
- Create a bill for the same product and vendor.
- Use the Purchase Matching button on the bill.
- The bill is not displayed, but the Purchase Orders are.

**Cause of the issue:**
https://github.com/odoo/odoo/blob/cc9e7cb92f1a6237a496b9acabd93506a8724a62/addons/purchase/models/account_invoice.py#L143-L144
The partner_id for the Purchase Orders are the current individual
vendor, but we are trying to match it with the partner_id of an
Account Move Line, which is set to be the commercial partner of
the individual, meaning the company, as seen below.
https://github.com/odoo/odoo/blob/9e9e992698946b75212040ca0ff812194200a8bf/addons/account/models/account_move_line.py#L481-L483
On the matching table, we use the partner of the Account Move Line,
and this is the why filtering on the individual doesn't give any
result, if we wanted some we would need to filter on the company.
https://github.com/odoo/odoo/blob/45533a1c6a70a3b86cf744a0f950c92d8a99afcf/addons/purchase/models/purchase_bill_line_match.py#L109

**Fix:**
The domain was updated to take both the individual and the
commercial partner (the company). This ensures that the bill
will be found even in we are dealing with an individual that
is in a company.

opw-4577643