### PR TITLE
[IMP] core: allow running upgrade scripts unconditionally

### DIFF
--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -62,6 +62,8 @@ def report_configuration():
     _logger.info('addons paths: %s', odoo.addons.__path__)
     if config.get('upgrade_path'):
         _logger.info('upgrade path: %s', config['upgrade_path'])
+    if config.get('pre_upgrade_scripts'):
+        _logger.info('extra upgrade scripts: %s', config['pre_upgrade_scripts'])
     host = config['db_host'] or os.environ.get('PGHOST', 'default')
     port = config['db_port'] or os.environ.get('PGPORT', 'default')
     user = config['db_user'] or os.environ.get('PGUSER', 'default')

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -419,6 +419,9 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
         if not graph:
             _logger.critical('module base cannot be loaded! (hint: verify addons-path)')
             raise ImportError('Module `base` cannot be loaded! (hint: verify addons-path)')
+        if update_module and tools.config['update']:
+            for pyfile in tools.config['pre_upgrade_scripts'].split(','):
+                odoo.modules.migration.exec_script(cr, graph['base'].installed_version, pyfile, 'base', 'pre')
 
         if update_module and odoo.tools.table_exists(cr, 'ir_model_fields'):
             # determine the fields which are currently translated in the database

--- a/odoo/modules/migration.py
+++ b/odoo/modules/migration.py
@@ -166,27 +166,26 @@ class MigrationManager(object):
         versions = _get_migration_versions(pkg, stage)
         for version in versions:
             if compare(version):
-                strfmt = {'addon': pkg.name,
-                          'stage': stage,
-                          'version': stageformat[stage] % version,
-                          }
-
                 for pyfile in _get_migration_files(pkg, version, stage):
-                    name, ext = os.path.splitext(os.path.basename(pyfile))
-                    if ext.lower() != '.py':
-                        continue
-                    mod = None
-                    try:
-                        mod = load_script(pyfile, name)
-                        _logger.info('module %(addon)s: Running migration %(version)s %(name)s' % dict(strfmt, name=mod.__name__))
-                        migrate = mod.migrate
-                    except ImportError:
-                        _logger.exception('module %(addon)s: Unable to load %(stage)s-migration file %(file)s' % dict(strfmt, file=pyfile))
-                        raise
-                    except AttributeError:
-                        _logger.error('module %(addon)s: Each %(stage)s-migration file must have a "migrate(cr, installed_version)" function' % strfmt)
-                    else:
-                        migrate(self.cr, installed_version)
-                    finally:
-                        if mod:
-                            del mod
+                    exec_script(self.cr, installed_version, pyfile, pkg.name, stage, stageformat[stage] % version)
+
+def exec_script(cr, installed_version, pyfile, addon, stage, version=None):
+    version = version or installed_version
+    name, ext = os.path.splitext(os.path.basename(pyfile))
+    if ext.lower() != '.py':
+        return
+    mod = None
+    try:
+        mod = load_script(pyfile, name)
+        _logger.info('module %(addon)s: Running migration %(version)s %(name)s' % dict(locals(), name=mod.__name__))
+        migrate = mod.migrate
+    except ImportError:
+        _logger.exception('module %(addon)s: Unable to load %(stage)s-migration file %(file)s' % dict(locals(), file=pyfile))
+        raise
+    except AttributeError:
+        _logger.error('module %(addon)s: Each %(stage)s-migration file must have a "migrate(cr, installed_version)" function' % locals())
+    else:
+        migrate(cr, installed_version)
+    finally:
+        if mod:
+            del mod


### PR DESCRIPTION
Upgrade scripts are run only when there is an update of the module version. This is not flexible enough. After a major upgrade developers need to upgrade their custom modules. Unfortunately the tools in `upgrade-util` repo that modify modules (`merge_module`, `rename_module`, ...) should be done before loading base module. The latter is already upgraded after a major upgrade thus no upgrade scripts are run for it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
