### PR TITLE
[FIX] l10n_in_withholding: fix invisible field runbot error

### DIFF
--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
@@ -34,7 +34,7 @@
                         <page string="TDS Tax Details">
                             <field name="withhold_line_ids">
                                 <list editable="bottom">
-                                    <field name="currency_id" column_invisible="True"/>
+                                    <field name="currency_id" column_invisible="True"/> <!-- used to display the currency symbol -->
                                     <field name="tax_id" domain="[('l10n_in_tds_tax_type', '=', l10n_in_tds_tax_type)]"/>
                                     <field name="base" sum="Total Base" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                                     <field name="amount" sum="Total Amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>


### PR DESCRIPTION
In this commit-
We fix the [runbot error](https://runbot.odoo.com/runbot/build/76662614)
```py
Please indicate why the always invisible fields are present in the view, or remove the field tag.
Addon: 'l10n_in_withholding'
   View: tds_entry_view_form
      Fields:
         <field name="currency_id" column_invisible="True"/>
```



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
