### PR TITLE
[FIX] google_address_autocomplete: log warning instead error

### DIFF
--- a/addons/google_address_autocomplete/controllers/google_address_autocomplete.py
+++ b/addons/google_address_autocomplete/controllers/google_address_autocomplete.py
@@ -101,14 +101,14 @@ class AutoCompleteController(http.Controller):
         try:
             results = self._call_google_route("/autocomplete/json", params)
         except (TimeoutError, ValueError) as e:
-            _logger.error(e)
+            _logger.warning(e)
             return {
                 'results': [],
                 'session_id': session_id
             }
 
         if results.get('error_message'):
-            _logger.error(results['error_message'])
+            _logger.warning(results['error_message'])
 
         results = results.get('predictions', [])
 
@@ -136,11 +136,11 @@ class AutoCompleteController(http.Controller):
         try:
             results = self._call_google_route("/details/json", params)
         except (TimeoutError, ValueError) as e:
-            _logger.error(e)
+            _logger.warning(e)
             return {'address': None}
 
         if results.get('error_message'):
-            _logger.error(results['error_message'])
+            _logger.warning(results['error_message'])
 
         try:
             html_address = results['result']['adr_address']


### PR DESCRIPTION
Currently in Google Address Autocomplete, a logger prints an error in the log; however, this error is coming from the external API.

error: `This API project is not authorized to use this API.`

This commit will use logger warnings instead of errors since this is not an error in the codebase.

sentry-6407824887


