### PR TITLE
[FIX] point_of_sale: ensure missing products are loaded before showing

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -708,7 +708,7 @@ export class PosStore extends Reactive {
         if (!missingProductIds.size) {
             return;
         }
-        this._addProducts([...missingProductIds], false);
+        await this._addProducts([...missingProductIds], false);
     }
     async _loadMissingPricelistItems(products) {
         if (!products.length) {


### PR DESCRIPTION
It would fail to display lines containing missing products. This occurred because the product loading process could initiated after the orderlines were created, leading to missing product and preventing the orderlines from being added to the order.

opw-4638640

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
