### PR TITLE
[FIX] point_of_sale: use localhost for proxy display

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
@@ -1,5 +1,5 @@
 import { reactive } from "@odoo/owl";
-import { deduceUrl, getOnNotified } from "@point_of_sale/utils";
+import { getOnNotified } from "@point_of_sale/utils";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { _t } from "@web/core/l10n/translation";
@@ -26,7 +26,7 @@ export const CustomerDisplayDataService = {
             const intervalId = setInterval(async () => {
                 try {
                     const response = await fetch(
-                        `${deduceUrl(session.proxy_ip)}/hw_proxy/customer_facing_display`,
+                        `http://localhost:8069/hw_proxy/customer_facing_display`,
                         {
                             method: "POST",
                             headers: {


### PR DESCRIPTION
Before this commit, if an IoT connected customer
display was activated without a valid HTTPS
certificate, it would fail as the IoT box
would not trust accessing its own endpoint, due
to the request using https://<iot_box_ip>.

After this commit, the proxy display instead
uses http://localhost, so the certificate is not
requirec and the customer display functions as
expected.

task-4648702

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
