### PR TITLE
[FIX] website, web_editor: fix the addition of data-snippet tag

### DIFF
--- a/addons/website/views/snippets/s_accordion_image.xml
+++ b/addons/website/views/snippets/s_accordion_image.xml
@@ -9,7 +9,7 @@
                     <h2 class="h3-fs">Top questions answered</h2>
                     <p class="lead">In this section, you can address common questions efficiently.</p>
                     <p><br/></p>
-                    <t t-call="website.s_accordion">
+                    <t t-snippet-call="website.s_accordion">
                         <t t-set="extra_classes" t-valuef="accordion-flush"/>
                     </t>
                 </div>


### PR DESCRIPTION
Since [1], the data-snippet tag was added for each t-call which was not the desired behavior. This commit fix this to restrain the addition of the data-snippet tag only for t-snippet-call.

[1]: https://github.com/odoo/odoo/commit/6d5c741820cb69f7619e2cf49bce1457b2cd1efd
