### PR TITLE
[FIX] l10n_in_ewaybill: fix compute `content` without dependency

### DIFF
--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -251,8 +251,12 @@ class L10nInEwaybill(models.Model):
             ewaybill.is_ship_to_editable = not is_incoming and not is_overseas
 
     def _compute_content(self):
+        dependent_fields = self._get_ewaybill_dependencies()
         for ewaybill in self:
-            ewaybill_json = ewaybill._ewaybill_generate_direct_json()
+            if any(ewaybill[d_field] for d_field in dependent_fields):
+                ewaybill_json = ewaybill._ewaybill_generate_direct_json()
+            else:
+                ewaybill_json = {}
             ewaybill.content = base64.b64encode(json.dumps(ewaybill_json).encode())
 
     @api.depends('name', 'state')


### PR DESCRIPTION
runbot error-https://runbot.odoo.com/odoo/runbot.build.error/115298




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
