### PR TITLE
[FIX] analytic: adapt analytic line columns when plan's parent changes

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -175,39 +175,42 @@ class AccountAnalyticAccount(models.Model):
                 account.credit = data_credit.get(account.id, 0.0)
                 account.balance = account.credit - account.debit
 
+    def _update_accounts_in_analytic_lines(self, new_fname, current_fname, accounts):
+        if current_fname != new_fname:
+            domain = [
+                (new_fname, 'not in', accounts.ids + [False]),
+                (current_fname, 'in', accounts.ids),
+            ]
+            if self.env['account.analytic.line'].sudo().search_count(domain, limit=1):
+                list_view = self.env.ref('analytic.view_account_analytic_line_tree', raise_if_not_found=False)
+                raise RedirectWarning(
+                    message=_("Whoa there! Making this change would wipe out your current data. Let's avoid that, shall we?"),
+                    action={
+                        'res_model': 'account.analytic.line',
+                        'type': 'ir.actions.act_window',
+                        'domain': domain,
+                        'target': 'new',
+                        'views': [(list_view and list_view.id, 'list')]
+                    },
+                    button_text=_("See them"),
+                )
+            self.env.cr.execute(SQL(
+                """
+                UPDATE account_analytic_line
+                   SET %(new_fname)s = %(current_fname)s,
+                       %(current_fname)s = NULL
+                 WHERE %(current_fname)s = ANY(%(account_ids)s)
+                """,
+                new_fname=SQL.identifier(new_fname),
+                current_fname=SQL.identifier(current_fname),
+                account_ids=accounts.ids,
+            ))
+            self.env['account.analytic.line'].invalidate_model()
+
     def write(self, vals):
         if vals.get('plan_id'):
             new_fname = self.env['account.analytic.plan'].browse(vals['plan_id'])._column_name()
-            for account in self:
-                current_fname = account.plan_id._column_name()
-                if current_fname != new_fname:
-                    domain = [
-                        (new_fname, 'not in', (account.id, False)),
-                        (current_fname, '=', account.id),
-                    ]
-                    if self.env['account.analytic.line'].sudo().search_count(domain, limit=1):
-                        list_view = self.env.ref('analytic.view_account_analytic_line_tree', raise_if_not_found=False)
-                        raise RedirectWarning(
-                            message=_("Whoa there! Moving this account would wipe out your current data. Let's avoid that, shall we?"),
-                            action={
-                                'res_model': 'account.analytic.line',
-                                'type': 'ir.actions.act_window',
-                                'domain': domain,
-                                'target': 'new',
-                                'views': [(list_view and list_view.id, 'list')]
-                            },
-                            button_text=_("See them"),
-                        )
-                    self.env.cr.execute(SQL(
-                        """
-                        UPDATE account_analytic_line
-                           SET %(new_fname)s = %(account_id)s,
-                               %(current_fname)s = NULL
-                         WHERE %(current_fname)s = %(account_id)s
-                        """,
-                        new_fname=SQL.identifier(new_fname),
-                        current_fname=SQL.identifier(current_fname),
-                        account_id=account.id,
-                    ))
-                    self.env['account.analytic.line'].invalidate_model()
+            for plan, accounts in self.grouped('plan_id').items():
+                current_fname = plan._column_name()
+                self._update_accounts_in_analytic_lines(new_fname, current_fname, accounts)
         return super().write(vals)

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -290,6 +290,30 @@ class AccountAnalyticPlan(models.Model):
                     'index': True,
                 })
 
+    def write(self, vals):
+        new_parent = self.env['account.analytic.plan'].browse(vals.get('parent_id'))
+        plan2previous_parent = {plan: plan.parent_id for plan in self if plan.parent_id}
+        if 'parent_id' in vals and new_parent:
+            # Update accounts in analytic lines before _sync_plan_column() unlinks child plan's column
+            for plan in self:
+                self.env['account.analytic.account']._update_accounts_in_analytic_lines(
+                    new_fname=new_parent._column_name(),
+                    current_fname=plan._column_name(),
+                    accounts=plan.account_ids,
+                )
+
+        res = super().write(vals)
+
+        if 'parent_id' in vals and not new_parent:
+            # Update accounts in analytic lines after _sync_plan_column() creates the new column
+            for plan, previous_parent in plan2previous_parent.items():
+                self.env['account.analytic.account']._update_accounts_in_analytic_lines(
+                    new_fname=plan._column_name(),
+                    current_fname=previous_parent._column_name(),
+                    accounts=plan.account_ids,
+                )
+        return res
+
 
 class AccountAnalyticApplicability(models.Model):
     _name = 'account.analytic.applicability'

--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -275,3 +275,42 @@ class TestAnalyticAccount(TransactionCase):
             plan_1_col: False,
             plan_2_col: self.analytic_account_1.id,
         }])
+
+    def test_change_parent_plan(self):
+        """Changing the parent of a plan updates account columns of the analytic lines."""
+        plan_1_col = self.analytic_plan_1._column_name()
+        plan_2_col = self.analytic_plan_2._column_name()
+        line = self.env['account.analytic.line'].create({
+            'name': 'test',
+            plan_1_col: self.analytic_account_1.id,
+        })
+
+        # Setting a parent plan should lead to the line having analytic_account_1 under Plan 2
+        self.analytic_plan_1.parent_id = self.analytic_plan_2
+        self.assertRecordValues(line, [{
+            plan_2_col: self.analytic_account_1.id,
+        }])
+        # plan_1_col should no longer be a field of the analytic line
+        self.assertNotIn(plan_1_col, line)
+
+        # Removing the parent plan should fully reverse the analytic line
+        self.analytic_plan_1.parent_id = False
+        self.assertRecordValues(line, [{
+            plan_1_col: self.analytic_account_1.id,
+            plan_2_col: False,
+        }])
+
+    def test_change_parent_plan_conflict(self):
+        """
+        Test case where changing the parent plan leads to more than one account under the same
+        plan in an analytic line.
+        """
+        plan_1_col = self.analytic_plan_1._column_name()
+        plan_2_col = self.analytic_plan_2._column_name()
+        self.env['account.analytic.line'].create({
+            'name': 'test',
+            plan_1_col: self.analytic_account_1.id,
+            plan_2_col: self.analytic_account_2.id,
+        })
+        with self.assertRaisesRegex(RedirectWarning, "Making this change would wipe out"):
+            self.analytic_plan_1.parent_id = self.analytic_plan_2


### PR DESCRIPTION
To replicate:
1. With `accountant` installed, activate Analytic Accounting in the Settings
2. Create an Analytic Plan with an Analytic Account
3. Create an Analytic Item with any amount, using the created account.
4. Verify that the Analytic Account has a balance associated to it.
5. Returning to the Analytic Plan, set a parent plan.
6. The Analytic Account has no balance associated to it, and the Analytic Item does not have the account anywhere.

When changing the parent plan of an Analytic Plan, this change is not propagated correctly to the analytic items using the now child plan's accounts.

This commit will update the lines using accounts from the now child plan, setting the accounts in the correct plan column if possible. If there are lines that already have a different account in the new parent plan column, a RedirectWarning is shown.

opw-4607129

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
