### PR TITLE
[FIX] hr_recruitment: give fallback value for refusal reason in applicant

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -39,7 +39,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
             if applicants and not wizard.single_applicant_email:
                 wizard.applicant_without_email = "%s\n%s" % (
                     _("You can't select Send email option.\nThe email will not be sent to the following applicant(s) as they don't have an email address:"),
-                    ",\n".join([i.partner_name or i.display_name for i in applicants])
+                    ",\n".join([i.partner_name or i.display_name or '' for i in applicants])
                 )
             else:
                 wizard.applicant_without_email = False


### PR DESCRIPTION
Currently, a traceback is occurring when trying to refuse an application.

To reproduce this issue:

1) Install `hr_recruitment`
2) Open any job position
3) Create a new application record
4) Don't give any values and click on refuse button

Error:- 
```
TypeError: sequence item 0: expected str instance, bool found
```

This issue was occurring because of the refactoring from the below commit

https://github.com/odoo/odoo/pull/169955/commits/e9bad7ebc795c34052a667a227c2103aa58fb861

When the user clicks on the refuse button, `_compute_applicant_without_email` 
method triggers with the applicant as a new origin object.

Partner_name is not a required field and the applicant is a new origin object, 
So indeed we won't get any value for `display_name` or `partner_name`.

This leads to the above traceback from the below line

https://github.com/odoo/odoo/blob/1a1354727f965b018374aa2001b0bb7f981d1cc1/addons/hr_recruitment/wizard/applicant_refuse_reason.py#L38-L42

sentry-6409185730
