### PR TITLE
[FIX] mrp,uom: wrong productModel

### DIFF
--- a/addons/hr_timesheet/views/project_update_views.xml
+++ b/addons/hr_timesheet/views/project_update_views.xml
@@ -20,7 +20,7 @@
                 <b id="tasks_stats" position='after'>
                     <field name="display_timesheet_stats" invisible="1"/>
                     <div class="o_pupdate_kanban_width" invisible="not display_timesheet_stats">
-                        <field name="timesheet_time"/><span invisible="not allocated_time"> / <field name="allocated_time"/></span> <field name="uom_id" widget="many2one_uom" no_open="1"/><span invisible="not allocated_time"> (<field name="timesheet_percentage"/>%)</span>
+                        <field name="timesheet_time"/><span invisible="not allocated_time"> / <field name="allocated_time"/></span> <field name="uom_id" no_open="1"/><span invisible="not allocated_time"> (<field name="timesheet_percentage"/>%)</span>
                     </div>
                 </b>
             </field>

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2608,6 +2608,11 @@ class TestTourBoM(HttpCase):
             'product_qty': 1,
             'type': 'normal',
         })
+        # This product is not directly used in py tests but needed to run tours without demo data.
+        cls.component = cls.env['product.product'].create({
+            'name': 'compo test',
+            'is_storable': True,
+        })
 
     def test_mrp_bom_product_catalog(self):
         grp_uom = self.env.ref('uom.group_uom')

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2608,9 +2608,12 @@ class TestTourBoM(HttpCase):
             'product_qty': 1,
             'type': 'normal',
         })
-    
-    def test_mrp_bom_product_catalog(self):
 
+    def test_mrp_bom_product_catalog(self):
+        grp_uom = self.env.ref('uom.group_uom')
+        group_user = self.env.ref('base.group_user')
+        group_user.write({'implied_ids': [Command.link(grp_uom.id)]})
+        self.env.user.write({'groups_id': [Command.link(grp_uom.id)]})
         self.assertEqual(len(self.bom.bom_line_ids), 0)
 
         url = f'/odoo/action-mrp.mrp_bom_form_action/{self.bom.id}'

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -444,7 +444,7 @@
                     <field name="product_tag_ids" widget="many2many_tags" readonly="1" optional="hide"/>
                     <field name="additional_product_tag_ids" widget="many2many_tags" optional="hide"/>
                     <field name="type" optional="hide" readonly="1"/>
-                    <field name="uom_id" widget="many2one_uom" groups="uom.group_uom" optional="show" readonly="1"/>
+                    <field name="uom_id" groups="uom.group_uom" optional="show" readonly="1"/>
                     <field name="product_tmpl_id" readonly="1" column_invisible="True"/>
                     <field name="active" column_invisible="True"/>
                 </list>

--- a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
+++ b/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
@@ -13,6 +13,16 @@ import { UomAutoComplete } from "@uom/components/uom_autocomplete/uom_autocomple
 import { roundPrecision } from "@web/core/utils/numbers";
 import { onWillUpdateProps } from "@odoo/owl";
 
+function _getProductRelatedModel() {
+    const field = this.props.record.fields[this.props.productField];
+    // The widget is either used alongisde a product related field or either used in a product view.
+    let resModel = field?.relation || this.props.record.resModel;
+    if (!["product.product", "product.template"].includes(resModel)) {
+        throw new Error(`The widget '${this.constructor.name}' (field '${this.props.name}') needs a 'product.product' or 'product.template' field. '${this.props.productField}' is used but is related to '${field?.relation}' model.`);
+    }
+    return resModel;
+}
+
 export class Many2XUomTagsAutocomplete extends Many2XAutocomplete {
     static components = {
         ...Many2XAutocomplete.components,
@@ -97,6 +107,11 @@ export class Many2ManyUomTagsField extends Many2ManyTagsFieldColorEditable {
         productField: "product_id",
         quantityField: "product_uom_qty",
     }
+
+    async setup() {
+        super.setup();
+        this.productModel = _getProductRelatedModel.call(this);
+    }
 }
 
 export class Many2OneUomField extends Many2OneField {
@@ -115,7 +130,12 @@ export class Many2OneUomField extends Many2OneField {
         productField: "product_id",
         quantityField: "product_uom_qty",
     }
-}   
+
+    async setup() {
+        super.setup();
+        this.productModel = _getProductRelatedModel.call(this);
+    }
+}
 
 export const many2ManyUomTagsField = {
     ...many2ManyTagsFieldColorEditable,

--- a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.xml
+++ b/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.xml
@@ -2,14 +2,14 @@
 <templates xml:space="preserve">
     <t t-name="uom.Many2ManyUomTagsField" t-inherit="web.Many2ManyTagsField">
         <xpath expr="//Many2XAutocomplete" position="attributes">
-            <attribute name="productModel">["product.template", "product.product"].includes(this.props.record.resModel) ? this.props.record.resModel : "product.product"</attribute>
+            <attribute name="productModel">this.productModel</attribute>
             <attribute name="productId">["product.template", "product.product"].includes(this.props.record.resModel) ? (this.props.record.resId || 0) : this.props.record.data[this.props.productField][0] || 0</attribute>
             <attribute name="productQuantity">this.props.record.data[this.props.quantityField]</attribute>
         </xpath>
     </t>
     <t t-name="uom.Many2OneUomField" t-inherit="web.Many2OneField">
         <xpath expr="//Many2XAutocomplete" position="attributes">
-            <attribute name="productModel">["product.template", "product.product"].includes(this.props.record.resModel) ? this.props.record.resModel : "product.product"</attribute>
+            <attribute name="productModel">this.productModel</attribute>
             <attribute name="productId">["product.template", "product.product"].includes(this.props.record.resModel) ? (this.props.record.resId || 0) : this.props.record.data[this.props.productField][0] || 0</attribute>
             <attribute name="productQuantity">this.props.record.data[this.props.quantityField]</attribute>
         </xpath>


### PR DESCRIPTION
Issue
=====
In the `mrp_bom_form_view` BoM form view, the `many2one_uom` field widget use the field `product_tmpl_id` as its `product_field` which is related to `product.template` model.
The issue is, in the `uom.Many2OneUomField` template, we define the `productModel` attribute by looking at the **record's model**: if it's `product.template`, we use it, otherwise we use `product.product`.
Here, the model is `mrp.bom`, so `product.product` is used.
That leads to an issue in `Many2XUomTagsAutocomplete` `updateReferenceUnit` because we search for a `product.product` with the id of a `product.template`. If it exists a product variant with this id, the error is not visible because we use the UoM reference of the wrong product but all works good. But if there is no product variant for this id, there is a traceback.

How to reproduce
================
- Install MRP;
- Enable Units of Measure;
- Open a BoM form view;
- Select a Product (`product.template` field) with an id where no `product.product` exists with this exact same id -> Traceback.

Fix
===
To fix this issue, we removed the condition in the template and get the model on the field itself in the `setup`. If the field model is not `product.product` or `product.template`, we throw an error.
The same change is done for both `Many2XUomTagsAutocomplete` and `Many2ManyUomTagsField` since they follow the same logic.

Also, the test/tour `test_mrp_bom_product_catalog` was sometime affected by this issue, now the UoM setting is always active for this test to minimize the chance to got an nondeterministic error.

Runbot build error: 135062