### PR TITLE
[FIX] mail: do not always show triangle warning on self call card

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -87,9 +87,9 @@ export class CallParticipantCard extends Component {
             return false;
         }
         if (this.rtc.state.connectionType === CONNECTION_TYPES.SERVER) {
-            return this.rtcSession.eq(this.rtc?.selfSession);
+            return this.rtcSession.eq(this.rtc.state.selfSession);
         } else {
-            return this.rtcSession.notEq(this.rtc?.selfSession);
+            return this.rtcSession.notEq(this.rtc.state.selfSession);
         }
     }
 


### PR DESCRIPTION
Before this commit, when making or joining a discuss call with up to 2 participants, it was always showing a warning icon in the top-right corner of the self card.

This happened because the code to show connection issue on card filters on self session: warning icon on other sessions in P2P, and on self card when using SFU server.

This was using `rtc.selfSession` to compare sessions, but this is correct only starting from 17.4. In 17.0, the `selfSession` is stored in `rtc.state.selfSession`. Because of this typo, the warning icon is always displayed on self card in P2P.

This commit fixes the issue by using `rtc.state.selfSession`. Note that SFU branching for conditionally showing the icon was also wrong. This made it never show the triangle warning icon. This is also fixed by this commit.

Before
<img width="2261" alt="Screenshot 2025-03-17 at 11 36 07" src="https://github.com/user-attachments/assets/b11272b2-df95-4470-b9e5-ec6bd643b153" />

After
<img width="2265" alt="Screenshot 2025-03-17 at 11 36 32" src="https://github.com/user-attachments/assets/f00a4978-d8cd-4201-a629-02618e71f381" />

