### PR TITLE
[FIX] hr_expense: prevent access error when checking vendor bill warning

### DIFF
--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -41,7 +41,7 @@ class AccountMove(models.Model):
             move.show_commercial_partner_warning = (
                     move.commercial_partner_id == self.env.company.partner_id
                     and move.move_type == 'in_invoice'
-                    and move.partner_id.employee_ids
+                    and move.partner_id.sudo().employee_ids
             )
 
     # Expenses can be written on journal other than purchase, hence don't include them in the constraint check


### PR DESCRIPTION
When a user tries to access a vendor bill where the vendor is their own company, Odoo displays a warning indicating that the user is trying to invoice themselves. To determine whether to show this warning, we check if the partner has any related `employee_ids`.

However, if the user does not have the `"Employees / Officer: Manage all employees"` access rights, they cannot check the `employee_ids`, leading to an access error when opening the vendor bill.

Steps to Reproduce:
1. Create a vendor bill where the vendor is set to your own company.
2. Try to access the vendor bill with a user who does not have `"Employees / Officer: Manage all employees"` access rights. Issue: An error occurs because the user lacks permission to check the related `employee_ids` for the vendor.
Refer to this [video](https://drive.google.com/file/d/1hIUTbNYhZxT4aOtNq8XE1z7uy7K_HJM1/view) for clearer steps.
opw-4539017

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
