### PR TITLE
[FIX] web: bypass SCSS error notification in blank iframes

### DIFF
--- a/addons/web/static/src/core/errors/scss_error_dialog.js
+++ b/addons/web/static/src/core/errors/scss_error_dialog.js
@@ -7,6 +7,10 @@ const scssErrorNotificationService = {
     dependencies: ["notification"],
     start(env, { notification }) {
         const origin = getOrigin();
+        // Iframe with src "about:blank" origin isn't a valid base URL.
+        if (browser.location.origin === "null") {
+            return;
+        }
         const assets = [...document.styleSheets].filter((sheet) => {
             return (
                 sheet.href?.includes("/web") &&


### PR DESCRIPTION
The `scssErrorNotificationService` uses the `browser.location.origin` as base url for a check. In the case of an iframe with `src="about:blank"`, the origin is `"null"`, which isn't a valid base URL and throws a TypeError.
In such a case anyway, any sheet's origin would be different from the iframe's, so we just bypass the error service entirely.