### PR TITLE
[FIX] web_editor, website: make sure o_dirty ignores class whitespaces

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -510,7 +510,7 @@ export class Wysiwyg extends Component {
             plugins: options.editorPlugins,
             direction: options.direction || localization.direction || 'ltr',
             collaborationClientAvatarUrl: this._getCollaborationClientAvatarUrl(),
-            renderingClasses: ["o_dirty", "o_transform_removal", "oe_edited_link", "o_menu_loading", "o_draggable", "o_link_in_selection"],
+            renderingClasses: ["o_dirty", "o_transform_removal", "oe_edited_link", "o_menu_loading", "o_draggable", "o_link_in_selection", "o_we_force_no_transition"],
             dropImageAsAttachment: options.dropImageAsAttachment,
             foldSnippets: !!options.foldSnippets,
             useResponsiveFontSizes: options.useResponsiveFontSizes,

--- a/addons/website/static/tests/tours/website_no_dirty_page.js
+++ b/addons/website/static/tests/tours/website_no_dirty_page.js
@@ -96,6 +96,13 @@ registerWebsitePreviewTour('website_no_dirty_page', {
             sel.collapse(el, 0);
             el.focus();
         },
+    }, {
+        content: "Add useless space at the end of the snippet class attribute, then click on it",
+        trigger: ":iframe .s_text_image",
+        async run(actions) {
+            this.anchor.setAttribute("class", this.anchor.getAttribute("class") + " ");
+            return actions.click();
+        },
     },
 ]));
 

--- a/addons/website_blog/static/src/js/options.js
+++ b/addons/website_blog/static/src/js/options.js
@@ -108,6 +108,10 @@ options.registry.BlogPostTagSelection = options.Class.extend({
             return;
         }
         this.tagIDs = JSON.parse(widgetValue).map(tag => tag.id);
+
+        // FIXME there should be a better way to indicate the page is dirty
+        // (this is supposed to be automatic).
+        this.$target[0].closest('[data-res-model="blog.post"]')?.classList.add('o_dirty');
     },
     /**
      * @see this.selectClass for params
@@ -139,6 +143,10 @@ options.registry.BlogPostTagSelection = options.Class.extend({
         // after createTag. This would reset the tagIds to the value before
         // adding the newly created tag. It therefore needs to be prevented.
         this._preventNextSetTagsCall = true;
+
+        // FIXME there should be a better way to indicate the page is dirty
+        // (this is supposed to be automatic).
+        this.$target[0].closest('[data-res-model="blog.post"]')?.classList.add('o_dirty');
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Before this commit, there was a bug that could be reproduced this way:
- Add a whitespace at the end of the class attribute of the footer main snippet (e.g. by using the HTML editor)
- Enter edit mode
- Click on the footer
- Discard the editor => Bug: a popup shows up saying you are about to lose changes... while
   you did not make any.

This commit fixes that specific issue, also extending the test that was introduced at [1], although as advertised many "no changes" flow are still marking the page as dirty (e.g. just hovering any editor panel option).

Note that there seems to be a deeper issue (although with no real breaking consequences) with the code surrounding this (see inline code comments), hopefully we won't have to care about this once the new HTML editor lands in master.

[1]: https://github.com/odoo/odoo/commit/8e1bce010be2df8bd7144364fcbbe509d0441695
