### PR TITLE
[FIX] l10n_es_website_sale: only require VAT/NIF on invoice address

### DIFF
--- a/addons/l10n_es_website_sale/__init__.py
+++ b/addons/l10n_es_website_sale/__init__.py
@@ -1,1 +1,2 @@
 from . import controllers
+from . import models

--- a/addons/l10n_es_website_sale/controllers/main.py
+++ b/addons/l10n_es_website_sale/controllers/main.py
@@ -4,11 +4,21 @@ from odoo.http import request
 
 class L10nESWebsiteSale(WebsiteSale):
 
+    def _get_mandatory_billing_address_fields(self, country_sudo):
+        """Require VAT/NIF for Spanish customers in billing addresses on Spanish e-commerce."""
+        field_names = super()._get_mandatory_billing_address_fields(country_sudo)
+
+        if request.website.sudo().company_id.country_code == country_sudo.code == 'ES':
+            field_names |= {'vat'}
+
+        return field_names
+
     def _get_mandatory_address_fields(self, country_sudo):
+        """Require State for Spanish customers on Spanish e-commerce."""
         field_names = super()._get_mandatory_address_fields(country_sudo)
 
         if request.website.sudo().company_id.country_code == country_sudo.code == 'ES':
-            field_names.update(('vat', 'state_id'))
+            field_names |= {'state_id'}
 
         return field_names
 

--- a/addons/l10n_es_website_sale/models/__init__.py
+++ b/addons/l10n_es_website_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import website

--- a/addons/l10n_es_website_sale/models/website.py
+++ b/addons/l10n_es_website_sale/models/website.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    def _display_partner_b2b_fields(self):
+        """ Spanish localization must always display b2b fields """
+        self.ensure_one()
+        return self.company_id.country_id.code == "ES" or super()._display_partner_b2b_fields()


### PR DESCRIPTION
**How to reproduce?**

1. Have `l10n_es` installed with `website_sale` and make sure the website with e-commerce belongs to the Spanish company.
2. Create a contact with a Spanish parent company having a VAT number.
3. Add a delivery address to this contact.
4. Create a portal user for this contact.
5. Log in with the portal user on the website, add a product to the cart and try to check out by filling out any remaining delivery address fields and trying to continue.

**Observed behavior**

An error is raised because it can't find some missing required fields.

**Intended behavior**

No error should be raised, because the delivery address should not require these fields.

The bug was introduced in [this commit].

This fix makes sure that
- the fields `vat` and `state` are only required on the invoicing address,
- the "display B2B fields" option is automatically enabled for Spanish companies since the `vat` field is required on the invoicing address.

[opw-4610111](https://www.odoo.com/odoo/project.task/4610111)

[this commit]: https://github.com/odoo/odoo/commit/c63dcc3156235203e9a91a13c44001ecb99a1ffa