### PR TITLE
[FIX] l10n_es: prevent error when upgrading module

### DIFF
--- a/addons/l10n_es/data/product_data.xml
+++ b/addons/l10n_es/data/product_data.xml
@@ -3,7 +3,7 @@
     <record id="product_dua_valuation_21" model="product.product">
         <field name="name">DUA VAT Valuation 21%</field>
         <field name="default_code">DUA21</field>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="True"/>
@@ -11,7 +11,7 @@
     <record id="product_dua_valuation_10" model="product.product">
         <field name="name">DUA VAT Valuation 10%</field>
         <field name="default_code">DUA10</field>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="True"/>
@@ -19,7 +19,7 @@
     <record id="product_dua_valuation_4" model="product.product">
         <field name="name">DUA VAT Valuation 4%</field>
         <field name="default_code">DUA4</field>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="True"/>


### PR DESCRIPTION
This error occurs when a user deletes product category  `services` and upgrades the module `l10n_es`.

Steps to reproduce

- Install module `l10n_es`.
- Open `Product Categories` from `Configuration`.
- Delete Services.
- Now Upgrade module  `l10n_es`.

`ParseError: while parsing /home/odoo/src/odoo/saas-18.2/addons/l10n_es/data /product_data.xml:3, somewhere inside
<record id=product_dua_valuation_21 model=product.product>
        <field name=name>DUA VAT Valuation 21%</field>
        <field name=default_code>DUA21</field>
        <field name=categ_id ref=product.product_category_services/>
        <field name=type>service</field>
        <field name=sale_ok eval=False/>
        <field name=purchase_ok eval=True/>
    </record>`

This error occurs when the system tries to find `product.product_category_services` from `ref` but it has already been deleted.

This commit resolves the error by preventing the system from raising an error if the referenced category has been deleted. Instead, it safely returns None,

sentry - 6404111714

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
