### PR TITLE
[FIX] base: fix inherited views domain

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -622,15 +622,11 @@ actual arch.
     @api.model
     def _get_inheriting_views_domain(self):
         """ Return a domain to filter the sub-views to inherit from. """
-        base_domain =  [('active', '=', True)]
         tree_cut_off_view = self.env.context.get("ir_ui_view_tree_cut_off_view")
         if not tree_cut_off_view:
-            return base_domain
-        cut_off_domain = [
-            "|", ("priority", "<", tree_cut_off_view.priority),
-            "&", ("priority", "=", tree_cut_off_view.priority), ("id", "<", tree_cut_off_view.id)
-        ]
-        return expression.AND([base_domain, cut_off_domain])
+            return [('active', '=', True)]
+        else:
+            return ['|', ('active', '=', True), ('id','=', tree_cut_off_view.id)]
 
     @api.model
     def _get_filter_xmlid_query(self):
@@ -935,8 +931,11 @@ actual arch.
         # pushed at the other end of the queue, so that they are applied after
         # all extensions have been applied.
         queue = collections.deque(sorted(hierarchy[self], key=lambda v: v.mode))
+        tree_cut_off_view = self.env.context.get("ir_ui_view_tree_cut_off_view")
         while queue:
             view = queue.popleft()
+            if view == tree_cut_off_view:
+                break
             arch = etree.fromstring(view.arch or '<data/>')
             if view.env.context.get('inherit_branding'):
                 view.inherit_branding(arch)

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -494,6 +494,32 @@ class TestViewInheritance(ViewCase):
             'active': False,
         })
 
+        child_view3 = self.View.create({
+            'model': self.model,
+            'name': "child_view",
+            'arch': """<data>
+                        <xpath expr="//div[hasclass('parasite')]" position="inside" >
+                            <div class="invalid" />
+                        </xpath>
+                    </data>""",
+            'inherit_id': base_view.id,
+            'priority': 7,
+            'active': False,
+        })
+
+        child_view4 = self.View.create({
+            'model': self.model,
+            'name': "child_view",
+            'arch': """<data>
+                        <xpath expr="//div[hasclass('parasite')]" position="inside" >
+                            <div class="valid" />
+                        </xpath>
+                    </data>""",
+            'inherit_id': child_applied.id,
+            'priority': 5,
+            'active': True,
+        })
+
         # Assert that accessing invalid_locators does not cause database writes.
         actual_queries = []
         with contextmanager(lambda: self._patchExecute(actual_queries))():
@@ -503,6 +529,8 @@ class TestViewInheritance(ViewCase):
 
         self.assertEqual(child_view.invalid_locators, [{'tag': 'xpath', 'attrib': {'expr': "//div[hasclass('parasite')]", 'position': 'inside'}, 'sourceline': 8}])
         self.assertEqual(child_view2.invalid_locators, [{'tag': 'field', 'attrib': {'name': 'user_id', 'position': 'after'}, 'sourceline': 5}])
+        self.assertEqual(child_view3.invalid_locators, [{'tag': 'xpath', 'attrib': {'expr': "//div[hasclass('parasite')]", 'position': 'inside'}, 'sourceline': 2}])
+        self.assertEqual(child_view4.invalid_locators, False)
 
 class TestApplyInheritanceSpecs(ViewCase):
     """ Applies a sequence of inheritance specification nodes to a base


### PR DESCRIPTION
When computing invalid view locators, the combined arch is constructed using views having a lower priority or equal priority with a lower id. This domain will not fetch parent views if the parent has a higher priority. The domain was intended only to exclude lower priority siblings to preserve the order, but it should include all parents regardless of priority.

**Description of the issue/feature this PR addresses:**
example on runbot:
view `pos_enterprise.res_config_settings_view_form` has priority 15, it inherits `point_of_sale.res_config_settings_view_form` which has priority 95. The enterprise view and all its children are marked with red showing invalid locators.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
