### PR TITLE
[FIX] mrp: assign production_id to smls with no reservation

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -599,6 +599,8 @@ class StockMove(models.Model):
 
     def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
         vals = super()._prepare_move_line_vals(quantity, reserved_quant)
+        if self.raw_material_production_id:
+            vals['production_id'] = self.raw_material_production_id.id
         if self.production_id.product_tracking == 'lot' and self.product_id == self.production_id.product_id:
             vals['lot_id'] = self.production_id.lot_producing_id.id
         return vals

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -261,6 +261,13 @@ class TestWarehouseMrp(common.TestMrpCommon):
         self.assertEqual(backorder.state, 'done')
         self.assertEqual(mo.move_raw_ids.move_line_ids.mapped('quantity_product_uom'), [20, 80])
 
+    def test_produce_with_zero_available_qty(self):
+        """ Test that producing with 0 qty_available for the component
+        still links the stock.move.line to the production order. """
+        mo, *_ = self.generate_mo()
+        mo.button_mark_done()
+        self.assertEqual(mo.move_raw_ids.move_line_ids.production_id, mo)
+
 class TestKitPicking(common.TestMrpCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
When producing a MO with components and the components don't have any available quantity, there are no direct link between the MO and the stock move lines of its move_raw_ids. This causes issues when filtering on MO in the Moves History report.

This is because the link is only done at the reservation of the SMLs, which can't happen without available qty.

This fix ensures that the MO is added at the SML creation.

opw-4545828

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
