### PR TITLE
[FIX] account: fix traceback when the user removes the date value

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -624,7 +624,8 @@ class AccountMove(models.Model):
     def _compute_hide_post_button(self):
         for record in self:
             record.hide_post_button = record.state != 'draft' \
-                or record.auto_post != 'no' and record.date > fields.Date.context_today(record)
+                or record.auto_post != 'no' and \
+                record.date and record.date > fields.Date.context_today(record)
 
     @api.depends('journal_id')
     def _compute_company_id(self):


### PR DESCRIPTION
Currently, a traceback is occurs when the user tries to remove the date value, while creating a Bill.

To reproduce this issue:

1) Install account
2) Create a Bills record from vendors
3) Change the `Auto-Post` value to `at date` from `other info` 
4) Now remove the `Accounting Date`

Error:-
```
TypeError: '>' not supported between instances of 'bool' and 'datetime.date'
```

When the user removed the date value, a compute method will be triggered
 in which a comparison is done between the record date and the today value.

However, the user removed the record's date value,
which leads to the above traceback from the below line

https://github.com/odoo/odoo/blob/2adabe7321f26e67eea9853460948cbd4ac10a4a/addons/account/models/account_move.py#L626-L627

sentry-6402545255

