### PR TITLE
[FIX] project: hide color picker for portal users in shared tasks

### DIFF
--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -79,8 +79,8 @@
                                     </a>
                                     <div class="dropdown-menu" role="menu">
                                         <a t-if="widget.editable" role="menuitem" type="edit" class="dropdown-item">Edit</a>
-                                        <div role="separator" class="dropdown-divider"></div>
-                                        <ul class="oe_kanban_colorpicker" data-field="color"/>
+                                        <div invisible="1" role="separator" class="dropdown-divider"></div>
+                                        <ul invisible="1" class="oe_kanban_colorpicker" data-field="color"/>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Steps to reproduce:

- Install `project`
- Create a new `project` and `tasks` within it.
- Share the project with the portal user with edit access mode.

Issue:

- The color picker is not accessible through the portal.

Fix:

- Hide the color picker for portal users when editing color in shared tasks.

task-4495861






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
