### PR TITLE
[IMP] core: reduce target fields of _check_company() for write()

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4033,7 +4033,6 @@ class BaseModel(metaclass=MetaModel):
         determine_inverses = defaultdict(list)      # {inverse: fields}
         fnames_modifying_relations = []
         protected = set()
-        check_company = False
         for fname, value in vals.items():
             field = self._fields.get(fname)
             if not field:
@@ -4063,8 +4062,6 @@ class BaseModel(metaclass=MetaModel):
                     # forcing its value to be recomputed once dependencies are
                     # up-to-date.
                     protected.update(self.pool.field_computed.get(field, [field]))
-            if fname == 'company_id' or (field.relational and field.check_company):
-                check_company = True
 
         # force the computation of fields that are computed with some assigned
         # fields, but are not assigned themselves
@@ -4150,8 +4147,8 @@ class BaseModel(metaclass=MetaModel):
             # validate inversed fields
             real_recs._validate_fields(inverse_fields)
 
-        if check_company and self._check_company_auto:
-            self._check_company()
+        if self._check_company_auto:
+            self._check_company(list(vals))
         return True
 
     def _write(self, vals: ValuesType) -> None:


### PR DESCRIPTION
If we write() on only one relational field with check_company=True, _check_company() is called without argument, which means that we will check for company inconsistency on all fields of the models.

This can cause errors during upgrade for unmodified fields. Also, it's actually inefficient since the `_check_company` may generate SQL queries for X2many or for company dependent fields for no reason.