### PR TITLE
[IMP] core: apply monkeypatches lazily

### DIFF
--- a/odoo/_monkeypatches/__init__.py
+++ b/odoo/_monkeypatches/__init__.py
@@ -1,8 +1,13 @@
 # ruff: noqa: F401, PLC0415
 # ignore import not at top of the file
+import functools
+import importlib
 import os
+import sys
 import time
-from .evented import patch_evented
+from types import SimpleNamespace
+
+from .evented import patch_module as patch_evented
 
 
 def set_timezone_utc():
@@ -11,29 +16,65 @@ def set_timezone_utc():
         time.tzset()
 
 
-def patch_all():
+class PatchImportHook:
+    """Register hooks that are run on import."""
+
+    def __init__(self):
+        self.hooks = {}
+
+    def add_hook(self, fullname: str, hook):
+        """Register a hook after a module is loaded.
+        If already loaded, run hook immediately."""
+        self.hooks[fullname] = hook
+        if fullname in sys.modules:
+            hook()
+
+    def find_spec(self, fullname, path=None, target=None):
+        hook = self.hooks.get(fullname)
+        if hook is None:
+            return  # let python use another import hook to import this fullname
+
+        # skip all finders before this one
+        idx = sys.meta_path.index(self)
+        for finder in sys.meta_path[idx + 1:]:
+            spec = finder.find_spec(fullname, path, target)
+            if spec is not None:
+                # we found a spec, change the loader
+
+                def exec_module(module, exec_module=spec.loader.exec_module):
+                    res = exec_module(module)
+                    hook()
+                    return res
+
+                spec.loader = SimpleNamespace(create_module=spec.loader.create_module, exec_module=exec_module)
+                return spec
+        raise ImportError(f"Could not load the module {fullname!r} to patch")
+
+
+HOOK_IMPORT = PatchImportHook()
+sys.meta_path.insert(0, HOOK_IMPORT)
+
+
+def patch_init():
     patch_evented()
     set_timezone_utc()
 
-    from .codecs import patch_codecs
-    patch_codecs()
-    from .email import patch_email
-    patch_email()
-    from .mimetypes import patch_mimetypes
-    patch_mimetypes()
-    from .pytz import patch_pytz
-    patch_pytz()
-    from .literal_eval import patch_literal_eval
-    patch_literal_eval()
-    from .num2words import patch_num2words
-    patch_num2words()
-    from .stdnum import patch_stdnum
-    patch_stdnum()
-    from .urllib3 import patch_urllib3
-    patch_urllib3()
-    from .werkzeug_urls import patch_werkzeug
-    patch_werkzeug()
-    from .zeep import patch_zeep
-    patch_zeep()
-    from .win32 import patch_win32
-    patch_win32()
+    def patch_module(name):
+        """Load and apply monkeypatches.
+
+        For a module name, run the equivalent to::
+
+            from . import {name} as x
+            x.patch_{name}()
+        """
+        module = importlib.import_module(f'.{name}', __name__)
+        func = getattr(module, 'patch_module')
+        func()
+
+    patch_module('codecs')
+    patch_module('win32')
+    for name in (
+        'ast', 'email', 'mimetypes', 'num2words', 'pytz', 'stdnum', 'urllib3',
+        'werkzeug', 'zeep',
+    ):
+        HOOK_IMPORT.add_hook(name, functools.partial(patch_module, name))

--- a/odoo/_monkeypatches/ast.py
+++ b/odoo/_monkeypatches/ast.py
@@ -28,5 +28,5 @@ def literal_eval(expr):
     return orig_literal_eval(expr)
 
 
-def patch_literal_eval():
+def patch_module():
     ast.literal_eval = literal_eval

--- a/odoo/_monkeypatches/codecs.py
+++ b/odoo/_monkeypatches/codecs.py
@@ -5,7 +5,7 @@ import re
 import babel.core
 
 
-def patch_codecs():
+def patch_module():
     # ---------------------------------------------------------
     # some charset are known by Python under a different name
     # ---------------------------------------------------------

--- a/odoo/_monkeypatches/email.py
+++ b/odoo/_monkeypatches/email.py
@@ -1,7 +1,7 @@
 from email._policybase import _PolicyBase
 
 
-def patch_email():
+def patch_module():
     def policy_clone(self, **kwargs):
         for arg in kwargs:
             if arg.startswith("_") or "__" in arg:

--- a/odoo/_monkeypatches/evented.py
+++ b/odoo/_monkeypatches/evented.py
@@ -10,7 +10,7 @@ import sys
 odoo.evented = False
 
 
-def patch_evented():
+def patch_module():
     if odoo.evented or not (len(sys.argv) > 1 and sys.argv[1] == 'gevent'):
         return
     sys.argv.remove('gevent')

--- a/odoo/_monkeypatches/mimetypes.py
+++ b/odoo/_monkeypatches/mimetypes.py
@@ -1,7 +1,7 @@
 import mimetypes
 
 
-def patch_mimetypes():
+def patch_module():
     # if extension is already knows, the new definition will remplace the existing one
     # Add potentially missing (older ubuntu) font mime types
     mimetypes.add_type('application/font-woff', '.woff')

--- a/odoo/_monkeypatches/num2words.py
+++ b/odoo/_monkeypatches/num2words.py
@@ -971,7 +971,7 @@ class NumberToWords_BG(Num2Word_Base):
         return ret_minus + ''.join(ret)
 
 
-def patch_num2words():
+def patch_module():
     try:
         import num2words  # noqa: PLC0415
     except ImportError:

--- a/odoo/_monkeypatches/pytz.py
+++ b/odoo/_monkeypatches/pytz.py
@@ -122,7 +122,7 @@ _tz_mapping = {
 original_pytz_timezone = pytz.timezone
 
 
-def patch_pytz():
+def patch_module():
     def timezone(name):
         if name not in pytz.all_timezones_set and name in _tz_mapping:
             name = _tz_mapping[name]

--- a/odoo/_monkeypatches/stdnum.py
+++ b/odoo/_monkeypatches/stdnum.py
@@ -48,7 +48,7 @@ def new_get_soap_client(wsdlurl, timeout=30):
     return _soap_clients[(wsdlurl, timeout)]
 
 
-def patch_stdnum():
+def patch_module():
     try:
         from stdnum import util
     except ImportError:

--- a/odoo/_monkeypatches/urllib3.py
+++ b/odoo/_monkeypatches/urllib3.py
@@ -8,5 +8,5 @@ def pool_init(self, *args, **kwargs):
     self.pool_classes_by_scheme = {**self.pool_classes_by_scheme}
 
 
-def patch_urllib3():
+def patch_module():
     PoolManager.__init__ = pool_init

--- a/odoo/_monkeypatches/werkzeug.py
+++ b/odoo/_monkeypatches/werkzeug.py
@@ -1040,8 +1040,8 @@ def url_join(
     return url_unparse((scheme, netloc, path, query, fragment))
 
 
-def patch_werkzeug():
-    from ..tools.json import scriptsafe  # noqa: PLC0415
+def patch_module():
+    from odoo.tools.json import scriptsafe
     Request.json_module = Response.json_module = scriptsafe
 
     FileStorage.save = lambda self, dst, buffer_size=(1 << 20): copyfileobj(self.stream, dst, buffer_size)

--- a/odoo/_monkeypatches/win32.py
+++ b/odoo/_monkeypatches/win32.py
@@ -5,7 +5,7 @@ import time
 import datetime
 
 
-def patch_win32():
+def patch_module():
     if not hasattr(locale, 'D_FMT'):
         locale.D_FMT = 1
 

--- a/odoo/_monkeypatches/zeep.py
+++ b/odoo/_monkeypatches/zeep.py
@@ -2,7 +2,7 @@ from zeep.xsd import visitor
 from zeep.xsd.const import xsd_ns
 
 
-def patch_zeep():
+def patch_module():
     # see https://github.com/mvantellingen/python-zeep/issues/1185
     if visitor.tags.notation.localname != 'notation':
         visitor.tags.notation = xsd_ns('notation')

--- a/odoo/init.py
+++ b/odoo/init.py
@@ -12,7 +12,7 @@ assert sys.version_info > MIN_PY_VERSION, f"Outdated python version detected, Od
 # required to do as early as possible for evented and timezone
 # ----------------------------------------------------------
 from . import _monkeypatches
-_monkeypatches.patch_all()
+_monkeypatches.patch_init()
 
 # ----------------------------------------------------------
 # Shortcuts

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -473,7 +473,7 @@ mods = ['parser', 'relativedelta', 'rrule', 'tz']
 for mod in mods:
     __import__('dateutil.%s' % mod)
 # make sure to patch pytz before exposing
-from odoo._monkeypatches.pytz import patch_pytz  # noqa: E402, F401
+from odoo._monkeypatches.pytz import patch_module as patch_pytz  # noqa: E402, F401
 patch_pytz()
 
 datetime = wrap_module(__import__('datetime'), ['date', 'datetime', 'time', 'timedelta', 'timezone', 'tzinfo', 'MAXYEAR', 'MINYEAR'])


### PR DESCRIPTION
Create an import hook that can patch libraries at the time they are imported. This allows to register patches at initialization, but delay the execution until the point the module is needed.

When executing simple cli tools that don't need to load everything, we can skip monkeypatching all used libraries.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
