### PR TITLE
[IMP] stock: deduplicate locs and whs before creating domain

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -395,8 +395,10 @@ class StockWarehouseOrderpoint(models.Model):
 
         # recompute virtual_available with lead days
         today = fields.datetime.now().replace(hour=23, minute=59, second=59)
-        for (days, loc), product_ids in ploc_per_day.items():
-            products = self.env['product.product'].browse(product_ids)
+        product_ids = set()
+        location_ids = set()
+        for (days, loc), prod_ids in ploc_per_day.items():
+            products = self.env['product.product'].browse(prod_ids)
             qties = products.with_context(
                 location=loc.id,
                 to_date=today + relativedelta.relativedelta(days=days)
@@ -404,13 +406,14 @@ class StockWarehouseOrderpoint(models.Model):
             for (product, qty) in zip(products, qties):
                 if float_compare(qty['virtual_available'], 0, precision_rounding=product.uom_id.rounding) < 0:
                     to_refill[(qty['id'], loc.id)] = qty['virtual_available']
+                    product_ids.add(qty['id'])
+                    location_ids.add(loc.id)
             products.invalidate_recordset()
         if not to_refill:
             return action
 
         # Remove incoming quantity from other origin than moves (e.g RFQ)
-        product_ids, location_ids = zip(*to_refill)
-        qty_by_product_loc, dummy = self.env['product.product'].browse(product_ids)._get_quantity_in_progress(location_ids=location_ids)
+        qty_by_product_loc = self.env['product.product'].browse(list(product_ids))._get_quantity_in_progress(location_ids=list(location_ids))[0]
         rounding = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         # Group orderpoint by product-location
         orderpoint_by_product_location = self.env['stock.warehouse.orderpoint']._read_group(


### PR DESCRIPTION
Otherwise, it will create massive domains, which may exhaust the memory available to PG:

```
 Traceback (most recent call last):
   File "/home/odoo/src/odoo/18.0/odoo/tools/safe_eval.py", line 397, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
   File "ir.actions.server(364,)", line 5, in <module>
   File "/home/odoo/src/odoo/18.0/addons/stock/models/stock_orderpoint.py", line 257, in action_open_orderpoints
    return self._get_orderpoint_action()
   File "/home/odoo/src/odoo/18.0/addons/stock/models/stock_orderpoint.py", line 500, in _get_orderpoint_action
    qty_by_product_loc, dummy = self.env['product.product'].browse(product_ids)._get_quantity_in_progress(location_ids=location_ids)
   File "/home/odoo/src/odoo/18.0/addons/purchase_stock/models/product.py", line 50, in _get_quantity_in_progress
    groups = self.env['purchase.order.line'].sudo()._read_group(domain,
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 1989, in _read_group
    row_values = self.env.execute_query(query.select(*groupby_terms.values(), *select_terms))
   File "/home/odoo/src/odoo/18.0/odoo/api.py", line 978, in execute_query
    self.cr.execute(query)
   File "/home/odoo/src/odoo/18.0/odoo/sql_db.py", line 572, in execute
    return self._cursor.execute(*args, **kwargs)
   File "/home/odoo/src/odoo/18.0/odoo/sql_db.py", line 354, in execute
    res = self._obj.execute(query, params)
 psycopg2.errors.SyntaxError: memory exhausted at or near "("
LINE 1: ...((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((...
                                                             ^
```

upg-2461663

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
