### PR TITLE
[IMP] project: display closed tasks as past event in tasks calendar view

### DIFF
--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_common/project_task_calendar_common_renderer.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_common/project_task_calendar_common_renderer.js
@@ -1,0 +1,21 @@
+import { patch } from "@web/core/utils/patch";
+import { CalendarCommonRenderer } from "@web/views/calendar/calendar_common/calendar_common_renderer";
+
+export function patchCommonRenderer(CommonRenderer) {
+    patch(CommonRenderer.prototype, {
+        eventClassNames(info) {
+            const classesToAdd = super.eventClassNames(info);
+            const { event } = info;
+            const record = this.props.model.records[event.id];
+            const { state, is_closed } = record.rawRecord;
+            const isTaskClosed = is_closed !== undefined ? is_closed : ['1_done', '1_canceled'].includes(state);
+            if (isTaskClosed) {
+                classesToAdd.push("o_past_event");
+            }
+            return classesToAdd;
+        },
+    });
+}
+
+export class ProjectTaskCalendarCommonRenderer extends CalendarCommonRenderer { }
+patchCommonRenderer(ProjectTaskCalendarCommonRenderer);

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_renderer.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_renderer.js
@@ -1,0 +1,13 @@
+import { CalendarRenderer } from "@web/views/calendar/calendar_renderer";
+import { ProjectTaskCalendarCommonRenderer } from "./project_task_calendar_common/project_task_calendar_common_renderer";
+import { ProjectTaskCalendarYearRenderer } from "./project_task_calendar_year/project_task_calendar_year_renderer";
+
+export class ProjectTaskCalendarRenderer extends CalendarRenderer {
+    static components = {
+        ...CalendarRenderer.components,
+        day: ProjectTaskCalendarCommonRenderer,
+        week: ProjectTaskCalendarCommonRenderer,
+        month: ProjectTaskCalendarCommonRenderer,
+        year: ProjectTaskCalendarYearRenderer,
+    };
+}

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_view.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_view.js
@@ -2,10 +2,12 @@ import { registry } from "@web/core/registry";
 import { calendarView } from "@web/views/calendar/calendar_view";
 import { ProjectTaskCalendarController } from "./project_task_calendar_controller";
 import { ProjectTaskCalendarModel } from "./project_task_calendar_model";
+import { ProjectTaskCalendarRenderer } from "./project_task_calendar_renderer";
 
 export const projectTaskCalendarView = {
     ...calendarView,
     Controller: ProjectTaskCalendarController,
     Model: ProjectTaskCalendarModel,
+    Renderer: ProjectTaskCalendarRenderer,
 };
 registry.category("views").add("project_task_calendar", projectTaskCalendarView);

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_year/project_task_calendar_year_renderer.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_year/project_task_calendar_year_renderer.js
@@ -1,0 +1,5 @@
+import { CalendarYearRenderer } from "@web/views/calendar/calendar_year/calendar_year_renderer";
+import { patchCommonRenderer } from "../project_task_calendar_common/project_task_calendar_common_renderer";
+
+export class ProjectTaskCalendarYearRenderer extends CalendarYearRenderer {}
+patchCommonRenderer(CalendarYearRenderer);

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -90,6 +90,7 @@ export class ProjectTask extends models.Model {
     date_deadline = fields.Datetime({ string: "Stop Date" });
     depend_on_ids = fields.Many2many({ relation: "project.task" });
     closed_depend_on_count = fields.Integer();
+    is_closed = fields.Boolean();
 
     _records = [
         {

--- a/addons/project/static/tests/project_task_calendar.test.js
+++ b/addons/project/static/tests/project_task_calendar.test.js
@@ -111,3 +111,43 @@ test("test task_stage_with_state_selection widget with editable state", async ()
     await animationFrame();
     expect(".o-dropdown .o_status").toHaveStyle({ color: "rgb(0, 136, 24)" });
 });
+
+test("Display closed tasks as past event", async () => {
+    ProjectTask._records.push({
+        id: 2,
+        name: "Task-2",
+        date_deadline: "2024-01-09 07:00:00",
+        create_date: "2024-01-03 12:00:00",
+        project_id: 1,
+        stage_id: 1,
+        state: "1_done",
+        user_ids: [],
+        display_name: "Task-2",
+    });
+    ProjectTask._records.push({
+        id: 3,
+        name: "Task-3",
+        date_deadline: "2024-01-09 07:00:00",
+        create_date: "2024-01-03 12:00:00",
+        project_id: 1,
+        stage_id: 1,
+        state: "1_canceled",
+        user_ids: [],
+        display_name: "Task-3",
+    });
+    ProjectTask._records.push({
+        id: 4,
+        name: "Task-4",
+        date_deadline: "2024-01-09 07:00:00",
+        create_date: "2024-01-03 12:00:00",
+        project_id: 1,
+        stage_id: 1,
+        state: "1_canceled",
+        user_ids: [],
+        display_name: "Task-4",
+        is_closed: true,
+    });
+    await mountView(calendarMountParams);
+    expect(".o_event").toHaveCount(4);
+    expect(".o_event.o_past_event").toHaveCount(3);
+})


### PR DESCRIPTION
Before this commit, when the user removes the `Open Tasks` filter in the calendar view of tasks, the closed tasks have the same rendering than the open ones which could be difficult for the user to see the ones still open in the calendar view.

This commit customizes a bit the calendar view of tasks to consider the closed tasks as past event to reduce the opacity for those tasks. By doing that, the user can easily differentiate the open tasks with the closed ones.

task-4647219
