### PR TITLE
[IMP] event: order default mail schedules with older first

### DIFF
--- a/addons/event/models/event_type.py
+++ b/addons/event/models/event_type.py
@@ -19,12 +19,14 @@ class EventType(models.Model):
                   'interval_unit': 'hours',
                   'interval_type': 'before_event',
                   'template_ref': 'mail.template, %i' % self.env.ref('event.event_reminder').id,
+                  'sequence': 12,
                  }),
                 (0, 0,
                  {'interval_nbr': 3,
                   'interval_unit': 'days',
                   'interval_type': 'before_event',
                   'template_ref': 'mail.template, %i' % self.env.ref('event.event_reminder').id,
+                  'sequence': 11,
                  })]
 
     def _default_question_ids(self):


### PR DESCRIPTION
Before this commit, the default mail schedules for an event are created without providing a specific sequence, while ordering these by scheduled dates would make more sense.
This commit adds a sequence such that the first reminder (3 days before the event) is shown before the last one (1 hour before).