### PR TITLE
[FIX] account: set correct links between invoices and payments

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -220,6 +220,11 @@ class AccountMove(models.Model):
         column2='payment_id',
         copy=False,
     )
+    reconciled_payment_ids = fields.Many2many('account.payment', string="Reconciled Payments",
+        compute='_compute_reconciled_payment_ids',
+        search='_search_reconciled_payment_ids',
+        help='Payments that have been reconciled with this invoice.'
+    )
     payment_count = fields.Integer(compute='_compute_payment_count')
 
     # === Statement fields === #
@@ -1145,7 +1150,7 @@ class AccountMove(models.Model):
             move.amount_residual_signed = total_residual
             move.amount_total_in_currency_signed = abs(move.amount_total) if move.move_type == 'entry' else -(sign * move.amount_total)
 
-    @api.depends('amount_residual', 'move_type', 'state', 'company_id', 'matched_payment_ids.state')
+    @api.depends('amount_residual', 'move_type', 'state', 'company_id', 'reconciled_payment_ids.state')
     def _compute_payment_state(self):
         groups = self.grouped(lambda move:
             'legacy' if move.payment_state == 'invoicing_legacy' else
@@ -1257,10 +1262,10 @@ class AccountMove(models.Model):
             )
         return super()._field_to_sql(alias, fname, query=query, flush=flush)
 
-    @api.depends('matched_payment_ids')
+    @api.depends('reconciled_payment_ids')
     def _compute_payment_count(self):
         for invoice in self:
-            invoice.payment_count = len(invoice.matched_payment_ids)
+            invoice.payment_count = len(invoice.reconciled_payment_ids)
 
     @api.depends('invoice_payment_term_id', 'invoice_date', 'currency_id', 'amount_total_in_currency_signed', 'invoice_date_due')
     def _compute_needed_terms(self):
@@ -2100,6 +2105,43 @@ class AccountMove(models.Model):
         for move in self:
             move.next_payment_date = min([line.payment_date for line in move.line_ids.filtered(lambda l: l.payment_date and not l.reconciled)], default=False)
 
+    @api.depends('line_ids.matched_debit_ids', 'line_ids.matched_credit_ids', 'matched_payment_ids')
+    def _compute_reconciled_payment_ids(self):
+        ''' Retrieve the payments reconciled to the invoices through the reconciliation (account.partial.reconcile) '''
+        self.env['account.payment'].flush_model(fnames=['move_id'])
+        self.env['account.move'].flush_model(fnames=['move_type'])
+        self.env['account.move.line'].flush_model(fnames=['move_id', 'account_id'])
+        self.env['account.partial.reconcile'].flush_model(fnames=['debit_move_id', 'credit_move_id'])
+        self.env['account.account'].flush_model(fnames=['account_type'])
+
+        invoice_payment_links = dict(self.env.execute_query(SQL(
+            """
+            SELECT
+                invoice.id,
+                ARRAY_AGG(DISTINCT payment.id) AS payment_ids
+            FROM account_payment payment
+            JOIN account_move move ON move.id = payment.move_id
+            JOIN account_move_line line ON line.move_id = move.id
+            JOIN account_partial_reconcile part ON
+                part.debit_move_id = line.id
+                OR
+                part.credit_move_id = line.id
+            JOIN account_move_line counterpart_line ON
+                part.debit_move_id = counterpart_line.id
+                OR
+                part.credit_move_id = counterpart_line.id
+            JOIN account_move invoice ON invoice.id = counterpart_line.move_id
+            JOIN account_account account ON account.id = line.account_id
+            WHERE account.account_type IN ('asset_receivable', 'liability_payable')
+                AND invoice.id IN %(invoice_ids)s
+                AND line.id != counterpart_line.id
+            GROUP BY invoice.id, invoice.move_type
+            """,
+            invoice_ids=tuple(self.ids),
+        ))) if self.ids else {}
+        for move in self:
+            move.reconciled_payment_ids = self.env['account.payment'].browse(invoice_payment_links.get(move.id)) | move.matched_payment_ids
+
     def _search_next_payment_date(self, operator, value):
         if operator not in ('=', '<', '<='):
             raise UserError(self.env._('Operation not supported'))
@@ -2113,6 +2155,13 @@ class AccountMove(models.Model):
         field = 'name' if 'like' in operator else 'id'
         journal_groups = self.env['account.journal.group'].search([(field, operator, value)])
         return [('journal_id', 'not in', journal_groups.excluded_journal_ids.ids)]
+
+    def _search_reconciled_payment_ids(self, operator, value):
+        if operator not in ('in', '='):
+            return NotImplemented
+        payment_ids = self.env['account.payment'].browse(value).reconciled_invoice_ids.ids
+        return [('id', 'in', payment_ids)]
+
     # -------------------------------------------------------------------------
     # INVERSE METHODS
     # -------------------------------------------------------------------------
@@ -5181,7 +5230,8 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
 
     def open_payments(self):
-        return self.matched_payment_ids._get_records_action(name=_("Payments"))
+        payments = self.reconciled_payment_ids
+        return payments._get_records_action(name=_("Payments"))
 
     def open_reconcile_view(self):
         return self.line_ids.open_reconcile_view()

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -149,6 +149,7 @@ class AccountPayment(models.Model):
     )
     reconciled_invoice_ids = fields.Many2many('account.move', string="Reconciled Invoices",
         compute='_compute_stat_buttons_from_reconciliation',
+        search='_search_reconciled_invoice_ids',
         help="Invoices whose journal items have been reconciled with these payments.")
     reconciled_invoices_count = fields.Integer(string="# Reconciled Invoices",
         compute="_compute_stat_buttons_from_reconciliation")
@@ -409,7 +410,7 @@ class AccountPayment(models.Model):
             if payment.journal_id.company_id not in payment.company_id.parent_ids:
                 payment.company_id = (payment.journal_id.company_id or self.env.company)._accessible_branches()[:1]
 
-    @api.depends('invoice_ids.payment_state', 'move_id.line_ids.amount_residual')
+    @api.depends('reconciled_invoice_ids.payment_state', 'move_id.line_ids.amount_residual')
     def _compute_state(self):
         payments_is_matched_to_recompute = self.env['account.payment']
         for payment in self:
@@ -423,7 +424,10 @@ class AccountPayment(models.Model):
                     if move.company_currency_id.is_zero(sum(liquidity.mapped('amount_residual'))) or not any(liquidity.account_id.mapped('reconcile')) else
                     'in_process'
                 )
-            if payment.state == 'in_process' and payment.invoice_ids and all(invoice.payment_state == 'paid' for invoice in payment.invoice_ids):
+            if (
+                payment.state == 'in_process' and payment.reconciled_invoice_ids and
+                all(invoice.payment_state == 'paid' for invoice in payment.reconciled_invoice_ids)
+            ):
                 # The access to invoice.payment_state will trigger a flush_model on account_payment.is_matched in its compute.
                 # This flush will then trigger _compute_reconciliation_status. However, the payment.state will then be changed by this next line of code.
                 # As the _compute_reconciliation_status was already tiggered once, we have to force the recompute after the payment state has been updated,
@@ -753,6 +757,12 @@ class AccountPayment(models.Model):
             # Uses payment._origin.id to handle records in edition/existing records and 0 for new records
             payment.duplicate_payment_ids = payment_to_duplicate_move.get(payment._origin.id, self.env['account.payment'])
 
+    def _search_reconciled_invoice_ids(self, operator, value):
+        if operator not in ('in', '='):
+            return NotImplemented
+        move_ids = self.env['account.move'].browse(value).reconciled_payment_ids.ids
+        return [('id', 'in', move_ids)]
+
     def _fetch_duplicate_reference(self, matching_states=('draft', 'in_process')):
         """ Retrieve move ids for possible duplicates of payments. Duplicates moves:
         - Have the same partner_id, amount and date as the payment
@@ -929,7 +939,7 @@ class AccountPayment(models.Model):
         self.move_id.filtered(lambda m: m.state != 'draft').button_draft()
         self.move_id.unlink()
 
-        linked_invoices = self.invoice_ids
+        linked_invoices = self.reconciled_invoice_ids
         res = super().unlink()
         self.env.add_to_compute(linked_invoices._fields['payment_state'], linked_invoices)
         return res
@@ -1120,7 +1130,7 @@ class AccountPayment(models.Model):
         :return:    An action on account.move.
         '''
         self.ensure_one()
-        return (self.invoice_ids | self.reconciled_invoice_ids).with_context(
+        return self.reconciled_invoice_ids.with_context(
             create=False
         )._get_records_action(
             name=_("Paid Invoices"),

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -194,6 +194,19 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                 "Amount currency of %s is incorrect" % account.name,
             )
 
+    def create_move_payment(self, move, payment_amount, with_outstanding_account=False):
+        payment = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=move.ids,
+        ).create({
+            'amount': payment_amount,
+            'payment_method_line_id':
+                self.company_data['default_journal_bank'].inbound_payment_method_line_ids.filtered_domain([
+                    ('payment_account_id', '!=' if with_outstanding_account else "=", False),
+                ])[0].id,
+        })._create_payments()
+        return payment
+
     # -------------------------------------------------------------------------
     # Test creation of account.partial.reconcile/account.full.reconcile
     # during the reconciliation.
@@ -5486,19 +5499,6 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
         })
         with patch.object(self.env.registry['account.move'], '_get_invoice_in_payment_state', return_value='in_payment'):
-            def create_move_payment(move, payment_amount, with_outstanding_account=False):
-                payment = self.env['account.payment.register'].with_context(
-                    active_model='account.move',
-                    active_ids=move.ids
-                ).create({
-                    'amount': payment_amount,
-                    'payment_method_line_id': self.company_data['default_journal_bank'].inbound_payment_method_line_ids.filtered_domain([
-                        ('payment_account_id', '!=' if with_outstanding_account else "=", False),
-                    ])[0].id,
-                })._create_payments()
-                self.assertEqual(payment.state, 'in_process')
-                return payment
-
             def reconcile_move(move, transaction_amount, balance=None, date='2023-09-30', currency=None, lines_filter=None):
                 lines_filter = lines_filter or (lambda l: l.account_id.account_type in ('asset_receivable', 'liability_payable'))
                 move_line = move.line_ids.filtered(lines_filter)[0]
@@ -5508,16 +5508,20 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                 amls.reconcile()
 
             vendor_bill = self.init_invoice(move_type='in_invoice', amounts=[1000], post=True)
-            payment = create_move_payment(vendor_bill, 10)
+            payment = self.create_move_payment(vendor_bill, 10)
+            self.assertEqual(payment.state, 'in_process')
             reconcile_move(vendor_bill, -12)
             self.assertEqual(payment.state, 'in_process')
             reconcile_move(vendor_bill, -10)
             self.assertEqual(payment.state, 'paid')
 
             customer_invoice = self.init_invoice(move_type='out_invoice', amounts=[400], post=True)
-            payment1 = create_move_payment(customer_invoice, 200)
-            payment2 = create_move_payment(customer_invoice, 50)
-            payment3 = create_move_payment(customer_invoice, 10)
+            payment1 = self.create_move_payment(customer_invoice, 200)
+            self.assertEqual(payment1.state, 'in_process')
+            payment2 = self.create_move_payment(customer_invoice, 50)
+            self.assertEqual(payment2.state, 'in_process')
+            payment3 = self.create_move_payment(customer_invoice, 10)
+            self.assertEqual(payment3.state, 'in_process')
             reconcile_move(customer_invoice, 50)
             self.assertEqual(payment1.state, 'in_process')
             self.assertEqual(payment2.state, 'paid')
@@ -5525,9 +5529,12 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
             foreign_currency = self.other_currency_2
             customer_invoice_foreign = self.init_invoice(move_type='out_invoice', amounts=[200], post=True, currency=foreign_currency)
-            payment1 = create_move_payment(customer_invoice_foreign, 30)
-            payment2 = create_move_payment(customer_invoice_foreign, 60)
-            payment3 = create_move_payment(customer_invoice_foreign, 15)
+            payment1 = self.create_move_payment(customer_invoice_foreign, 30)
+            self.assertEqual(payment1.state, 'in_process')
+            payment2 = self.create_move_payment(customer_invoice_foreign, 60)
+            self.assertEqual(payment2.state, 'in_process')
+            payment3 = self.create_move_payment(customer_invoice_foreign, 15)
+            self.assertEqual(payment3.state, 'in_process')
             reconcile_move(customer_invoice_foreign, 30, 15)
             self.assertEqual(payment1.state, 'paid')
             self.assertEqual(payment2.state, 'in_process')
@@ -5535,17 +5542,22 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
             foreign_currency2 = self.other_currency
             customer_invoice_different_currencies = self.init_invoice(move_type='out_invoice', amounts=[100], post=True)
-            payment1 = create_move_payment(customer_invoice_different_currencies, 5)
-            payment2 = create_move_payment(customer_invoice_different_currencies, 10)
-            payment3 = create_move_payment(customer_invoice_different_currencies, 20)
+            payment1 = self.create_move_payment(customer_invoice_different_currencies, 5)
+            self.assertEqual(payment1.state, 'in_process')
+            payment2 = self.create_move_payment(customer_invoice_different_currencies, 10)
+            self.assertEqual(payment2.state, 'in_process')
+            payment3 = self.create_move_payment(customer_invoice_different_currencies, 20)
+            self.assertEqual(payment3.state, 'in_process')
             reconcile_move(customer_invoice_different_currencies, 10, currency=foreign_currency2)
             self.assertEqual(payment1.state, 'paid')
             self.assertEqual(payment2.state, 'in_process')
             self.assertEqual(payment3.state, 'in_process')
 
             customer_invoice_outstanding = self.init_invoice(move_type='out_invoice', amounts=[300], post=True)
-            payment1 = create_move_payment(customer_invoice_outstanding, 12, True)
-            payment2 = create_move_payment(customer_invoice_outstanding, 12)
+            payment1 = self.create_move_payment(customer_invoice_outstanding, 12, True)
+            self.assertEqual(payment1.state, 'in_process')
+            payment2 = self.create_move_payment(customer_invoice_outstanding, 12)
+            self.assertEqual(payment2.state, 'in_process')
             reconcile_move(customer_invoice_outstanding, 12)
             reconcile_move(customer_invoice_outstanding, 12)
             self.assertEqual(payment1.state, 'in_process')
@@ -5609,6 +5621,22 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         # Cannot change other fields
         with self.assertRaisesRegex(UserError, "You can just change some non legal fields"):
             receivable_lines.currency_id = self.other_currency
+
+    def test_links_between_move_and_payment(self):
+        """
+        Test links between move and payment, via account.partial.reconcile and account_move__account_payment
+        In the context of an outstanding account
+        """
+        invoice_outstanding = self.init_invoice(move_type='out_invoice', amounts=[300], post=True)
+        payment = self.create_move_payment(invoice_outstanding, 300, True)
+
+        # Link still exists if payment is reset to draft
+        self.assertEqual(payment.reconciled_invoice_ids, invoice_outstanding)
+        payment.action_draft()
+        # The link is not destroyed as the account_move__account_payment many2many link still exists
+        self.assertEqual(payment.reconciled_invoice_ids, invoice_outstanding)
+        payment.action_post()
+        self.assertEqual(payment.reconciled_invoice_ids, invoice_outstanding)
 
     def test_reconciliation_currency_exchange_matching_number(self):
         """

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -653,12 +653,12 @@ class TestAccountPayment(AccountTestInvoicingCommon, MailCommon):
         }])
         invoice_1.action_post()
         register_payment_and_assert_state(invoice_1, 100.0, is_community=True)
-        self.assertTrue(invoice_1.matched_payment_ids.move_id)
+        self.assertTrue(invoice_1.reconciled_payment_ids.move_id)
 
         invoice_2 = invoice_1.copy()
         invoice_2.action_post()
         register_payment_and_assert_state(invoice_2, 100.0, is_community=False)
-        self.assertFalse(invoice_2.matched_payment_ids.move_id)
+        self.assertFalse(invoice_2.reconciled_payment_ids.move_id)
 
     def test_payment_confirmation_with_bank_outstanding_account(self):
         """ Ensures that when the outstanding account of the payment method is set to a bank,

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -871,7 +871,7 @@
                                     class="oe_stat_button"
                                     icon="fa-bars"
                                     type="object"
-                                    invisible="not matched_payment_ids">
+                                    invisible="not payment_count">
                                     <field name="payment_count" string="Payments" widget="statinfo"/>
                             </button>
                             <button name="open_reconcile_view"

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -578,7 +578,7 @@ class AccountPaymentRegister(models.TransientModel):
     def _compute_actionable_errors(self):
         for wizard in self:
             actionable_errors = {}
-            if unpaid_matched_payments := wizard.line_ids.move_id.matched_payment_ids.filtered(lambda p: p.state == 'in_process'):
+            if unpaid_matched_payments := wizard.line_ids.move_id.reconciled_payment_ids.filtered(lambda p: p.state == 'in_process'):
                 actionable_errors['unpaid_matched_payments'] = {
                     'message': self.env._("There are payments in progress. Make sure you don't pay twice."),
                     'action_text': self.env._("Check them"),

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -252,7 +252,7 @@ class AccountEdiXmlCII(models.AbstractModel):
         template_values['tax_basis_total_amount'] = tax_details['base_amount_currency']
         template_values['tax_total_amount'] = tax_details['tax_amount_currency']
 
-        if self.env['account.payment']._fields.get('sdd_mandate_id') and invoice.matched_payment_ids.sdd_mandate_id:
+        if self.env['account.payment']._fields.get('sdd_mandate_id') and invoice.reconciled_payment_ids.sdd_mandate_id:
             template_values['payment_means_code'] = PAYMENT_MEAN_CODES['SEPA direct debit']
         else:
             template_values['payment_means_code'] = PAYMENT_MEAN_CODES['Payment to bank account']


### PR DESCRIPTION
[FIX] account: set correct links between invoices and payments
The problematic found case was the following:
- Create an invoice and register a payment for it, using the wizard,
with a journal having an outstanding account set
- Use the smart button on the invoice form view to open the payment and
reset it back to draft
- Duplicate the payment, confirm the new one and reconcile it with the
invoice

=> If we go back to the invoice form, the smart button linking payments
is now redirecting to the 1st payment, that's in draft state, instead of
the second confirmed one.

This is because there can be 2 types of links between payments and
invoices:
- When there's no journal entry for payment, the link is done via the
Many2many table 'account_move__account_payment'.
- When there's a journal entry, the link is done via the table
'account.partial.reconcile'.

Before this commit, the button on the invoice form view was based on
account_move__account_payment and wasn't looking at all at
account.partial.reconcile as one would expect.

To solve that, we now look at reconciled_payment_ids that is computed
as the union of account_move__account_payment and
account.partial.reconcile.

Task-4613193
Runbot: https://runbot.odoo.com/runbot/bundle/18-0-outstanding-double-link-roto-354130