### PR TITLE
[IMP] web: remove unused CSS rule in CommandPalette

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.scss
+++ b/addons/web/static/src/core/commands/command_palette.scss
@@ -21,10 +21,6 @@
                 background-color: inherit;
                 padding: 0.5rem 1.3em;
                 display: flex;
-                > icon {
-                    position: relative;
-                    top: 0.4em;
-                }
             }
             a {
                 text-decoration: none;


### PR DESCRIPTION
This selector was targeted to the CommandPalette used by Knowledge, but actually the `<icon>` tag (sic) is never a direct child of the `.o_command_hotkey` (there is a span in-between).

As the visual aspect is still OK without it, this commit simply removes those rules.