### PR TITLE
[FIX] project: remove unknown and duplicated CSS rule

### DIFF
--- a/addons/project/static/src/components/done_checkmark/task_done_checkmark.scss
+++ b/addons/project/static/src/components/done_checkmark/task_done_checkmark.scss
@@ -6,7 +6,6 @@ a.o_todo_done_button {
     }
 
     &.done_button_enabled {
-        text-color: $o-success;
         @include o-hover-text-color($o-success, $gray-400);
         &:hover:before {
             content: "\f05d";


### PR DESCRIPTION
This commit removes the `text-color` CSS property... which actually doesn't exist and should have been `color`... which in return was already set.