### PR TITLE
[IMP] hr_holidays: avoid generating static CSS in loops

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_renderer.scss
@@ -21,13 +21,13 @@
             border-radius: $border-radius-pill;
         }
 
+        .fc-dayGridMonth-view .fc-day.fc-day-today[class*="hr_mandatory_day_"] {
+            --o-cw-bg: var(--mandatory-day-color);
+        }
+
         @for $size from 1 through length($o-colors) {
             .hr_mandatory_day_#{$size - 1} {
                 --mandatory-day-color: #{nth($o-colors, $size)};
-            }
-
-            .fc-dayGridMonth-view .fc-day.fc-day-today.hr_mandatory_day_#{$size - 1} {
-                --o-cw-bg: var(--mandatory-day-color);
             }
         }
 


### PR DESCRIPTION
This commit avoids to generate the same CSS rules for each iteration of
the loop instead of setting them once, letting only the rules that
actually depends on the loop to be generated during iteration.

