### PR TITLE
[IMP] html_editor: avoid generating static CSS in loops

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
@@ -11,23 +11,28 @@ $embedded-toc-bg--active: #1ba1e4;
     background-color: $o-gray-100;
     & .o_embedded_toc_content {
         background-color: $o-view-background-color;
-        @for $depth from 0 through 5 {
-            a.o_embedded_toc_link_depth_#{$depth} {
-                padding-left: calc(5px + Min(30px, 10%) * #{$depth});
-                font-family: $font-family-base !important;
-                border-radius: 5px;
-                min-height: $line-height-base * $font-size-base;
-                border: transparent;
 
-                &:hover {
-                    background-color: rgba($embedded-toc-bg--active, 0.2);
-                    text-decoration: none;
-                }
+        a[class*="o_embedded_toc_link_depth_"] {
+            font-family: $font-family-base !important;
+            border-radius: 5px;
+            min-height: $line-height-base * $font-size-base;
+            border: transparent;
+
+            &:hover {
+                background-color: rgba($embedded-toc-bg--active, 0.2);
+                text-decoration: none;
             }
 
-            a.o_embedded_toc_link_depth_0 {
-                // initial 5px padding to give some space to first level
-                padding-left: 5px;
+        }
+
+        a.o_embedded_toc_link_depth_0 {
+            // initial 5px padding to give some space to first level
+            padding-left: 5px;
+        }
+
+        @for $depth from 1 through 5 {
+            a.o_embedded_toc_link_depth_#{$depth} {
+                padding-left: calc(5px + Min(30px, 10%) * #{$depth});
             }
         }
     }


### PR DESCRIPTION
This commit avoids to generate the same CSS rules for each iteration of
the loop instead of setting them once, letting only the rules that
actually depends on the loop to be generated during iteration.