### PR TITLE
[FIX] l10n_fr_pos_cert: fix numpad visibility glitch

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderSummary.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderSummary.xml
@@ -3,7 +3,7 @@
     <t t-name="l10n_fr_pos_cert.OrderSummary" t-inherit="point_of_sale.OrderSummary" t-inherit-mode="extension">
 		<xpath expr="//Orderline" position="inside" >
             <t t-if="pos.is_french_country() !== false and line.price_type === 'manual'">
-                <li class="info">
+                <li class="info pe-none">
                     Old unit price:
                     <span class="oldPrice">
                         <s>


### PR DESCRIPTION
Steps:
------
- Install `l10n_fr_pos_cert`
- Open a PoS session, and add a combo product, orderlines corresponding to the combo procuts will be added
- Hide the numpad by clicking on the selected orderline.
- Choose a random orderline, and click on the text "Old unit price"

-> Observe that the numpad will appear and then disappear immediately.

Reason:
-------
When clicking the text "Old unit price", two click events are dispatched, those running the click handler twice, the first time it selects the orderline and hence show the numpad, and the second time, it unselects that same orderline, hiding the numpad.

Fix:
----
We disable the pointer-events on the "Old unit price" text, making it unclickable, more precisely, preventing it from being a `target` of a click event. With that change, the click handler (aka `clickLink` [1]) will only run once.

[1]: https://github.com/odoo/odoo/blob/8fb7e5fd304697aebcce085602a5f3a1ecaf757a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml#L9

opw-4636261