### PR TITLE
[FIX] website_slides: prevent publish navbar & refine loading

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -486,6 +486,7 @@
     var Fullscreen = SlideCoursePage.extend({
         events: Object.assign({}, SlideCoursePage.prototype.events, {
             'click .o_wslides_fs_toggle_sidebar': '_onClickToggleSidebar',
+            'click .o_wslides_fs_exit_fullscreen': '_onClickExitFullScreen',
         }),
         custom_events: Object.assign({}, SlideCoursePage.prototype.custom_events, {
             'change_slide': '_onChangeSlideRequest',
@@ -526,6 +527,17 @@
             const backendNavEl = document.querySelector('.o_frontend_to_backend_nav');
             if (backendNavEl) {
                 backendNavEl.remove();
+            }
+            document.addEventListener('keydown', function (event) {
+                if (event.key === "Escape") {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    return false;
+                }
+            }, true);
+            const o_web_client = window.parent.document.querySelector(".o_web_client");
+            if (o_web_client) {
+                o_web_client.classList.toggle("o_website_fullscreen", true);
             }
             return this._super.apply(this, arguments).then(function () {
                 return self._onChangeSlide(); // trigger manually once DOM ready, since slide content is not rendered server side
@@ -786,6 +798,20 @@
         _onClickToggleSidebar: function (ev){
             ev.preventDefault();
             this._toggleSidebar();
+        },
+        /**
+         * Called when the Exit FullScreen will click
+         *
+         * @private
+         */
+        _onClickExitFullScreen: function (ev){
+            var slideSlug = this.get('slide').slug;
+            var newUrl = `/slides/slide/${slideSlug}`;
+            history.pushState(null, '', newUrl);
+            const o_web_client = window.parent.document.querySelector(".o_web_client");
+            if (o_web_client) {
+                o_web_client.classList.remove("o_website_fullscreen");
+            }
         },
         /**
          * Toggles sidebar visibility.

--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -75,9 +75,6 @@
                                         <div class="toast-header">
                                             <i class="fa fa-circle-o-notch fa-spin me-2"/><b>Loading...</b>
                                         </div>
-                                        <div class="toast-body p-0">
-                                            <img class="img-fluid w-100" t-att-src="website.image_url(slide, 'image_256')"/>
-                                        </div>
                                     </div>
                                 </div>
                                 <canvas id="PDFViewerCanvas" class="mx-auto" style="display: none;"></canvas>

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -45,7 +45,7 @@
                         <i class="fa fa-share-alt"/>
                         <span class="d-none d-md-inline-block ms-2">Share</span>
                     </a>
-                    <a class="d-flex align-items-center px-3 o_wslides_fs_exit_fullscreen" t-attf-href="/slides/slide/#{slug(slide)}" title="Exit Fullscreen">
+                    <a class="d-flex align-items-center px-3 o_wslides_fs_exit_fullscreen" href="#" title="Exit Fullscreen">
                         <i class="fa fa-sign-out"/><span class="d-none d-md-inline-block ms-1">Exit Fullscreen</span>
                     </a>
                     <a class="d-flex align-items-center px-3" t-attf-href="/slides/#{slug(slide.channel_id)}" title="Back to course">


### PR DESCRIPTION
Steps to reproduce:
1. All three PDF contents are unpublished.
2. Preview the first content and publish it.
3. After publishing, stay on the preview page.
4. Click on the second content to publish it.
5. The content appears as published but hasn't been updated after the first one was published.

Technical Reason:
The Slides sidebar content is only meant to be displayed in full-screen mode, there is no link between it and the Publish/Unpublish button.

After this commit:
Hide the main navbar in fullscreen mode and remove the image showing while loading, displaying only the loading text.

Task-4464984