### PR TITLE
[FIX] web_tour: return unload for helper action

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -64,18 +64,18 @@ export class TourAutomatic {
                             await step.checkForUndeterminisms(trigger, delayToCheckUndeterminisms);
                         }
                         this.previousStepIsJustACheck = !step.hasAction;
+                        const result = await step.doAction();
                         if (this.debugMode) {
-                            console.log(step.element);
+                            console.log(trigger);
                             if (step.skipped) {
                                 console.log("This step has been skipped");
                             } else {
                                 console.log("This step has run successfully");
                             }
                             console.groupEnd();
-                        }
-                        const result = await step.doAction();
-                        if (step.pause && this.debugMode) {
-                            await this.pause();
+                            if (step.pause) {
+                                await this.pause();
+                            }
                         }
                         tourState.setCurrentIndex(step.index + 1);
                         return result;

--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -80,20 +80,16 @@ export class TourStepAutomatic extends TourStep {
     }
 
     /**
-     * When return true, macro stops.
-     * @returns {Boolean}
+     * When return null or false, macro continues.
      */
     async doAction() {
-        let result = false;
-        if (!this.skipped) {
-            // TODO: Delegate the following routine to the `ACTION_HELPERS` in the macro module.
+        if (this.skipped) {
+            return;
+        }
+        return await callWithUnloadCheck(async () => {
             const actionHelper = new TourHelpers(this.element);
-
             if (typeof this.run === "function") {
-                const willUnload = await callWithUnloadCheck(async () => {
-                    await this.run.call({ anchor: this.element }, actionHelper);
-                });
-                result = willUnload && "will unload";
+                await this.run.call({ anchor: this.element }, actionHelper);
             } else if (typeof this.run === "string") {
                 for (const todo of this.run.split("&&")) {
                     const m = String(todo)
@@ -102,8 +98,7 @@ export class TourStepAutomatic extends TourStep {
                     await actionHelper[m.groups?.action](m.groups?.arguments);
                 }
             }
-        }
-        return result;
+        });
     }
 
     /**


### PR DESCRIPTION
If an action is defined in a step with a string (and therefore is an action that comes from tour_helpers) there is no check on the beforeUnload event that is done. In this commit, we fix this.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
