### PR TITLE
[IMP] point_of_sale: remove unit price on basic receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -34,7 +34,7 @@
                             <i class="fa fa-tag pe-1"/><em><t t-esc="discount" />% </em> discount off on <t t-esc="env.utils.formatCurrency(line.allPrices.priceWithTaxBeforeDiscount)"/>
                         </t>
                     </li>
-                    <li class="price-per-unit" t-if="props.mode == 'receipt' || line.price_type !== 'original'">
+                    <li class="price-per-unit" t-if="(props.mode == 'receipt' and !props.basic_receipt) || line.price_type !== 'original'">
                         <t t-if="line.price !== 0">
                             <i class="fa fa-money center pe-1"/>
                             <t t-esc="formatCurrency(line.unitDisplayPrice)" />


### PR DESCRIPTION
In this commit,
=====
Removed the unit price from the basic receipt.
It will only be visible in two scenarios:
1. In the pos cart (If we change the price manually)
2. In standard receipt

task - 4643039


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
