### PR TITLE
[FIX] pos_loyalty: not apply points change in backend if order is draft

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -136,7 +136,10 @@ patch(PaymentScreen.prototype, {
                 })
                 .map(([key, value]) => [key, omit(value, "appliedRules")])
         );
-        if (Object.keys(couponData || {}).length > 0) {
+        if (
+            Object.keys(couponData || {}).length > 0 &&
+            !["draft", "cancel"].includes(order.state)
+        ) {
             const payload = await this.pos.data.call("pos.order", "confirm_coupon_programs", [
                 order.id,
                 couponData,

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -567,3 +567,24 @@ registry.category("web_tour.tours").add("RefundRulesProduct", {
             ProductScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_points_applied_in_backend", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("product_a", "1"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAA Test Partner"),
+            PosLoyalty.claimReward("5% on your order"),
+            PosLoyalty.orderTotalIs("95"),
+
+            Chrome.createFloatingOrder(),
+            ProductScreen.addOrderline("product_a", "1"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("BBB Test Partner"),
+            PosLoyalty.claimReward("5% on your order"),
+            PosLoyalty.orderTotalIs("95"),
+            PosLoyalty.finalizeOrder("Cash", "95"),
+        ].flat(),
+});


### PR DESCRIPTION
Currently, when having multiple orders opened, when validating one, the points will be granted for all opened orders.

Steps to reproduce:
-------------------
* Have a loyalty progam with
 * 1point per $ spent
 * 5% on order in exchange of 200 points
* Have 2 customers A and B with 300 each on their loyalty card
* Open pos shop
* On the order, select customer A, add items and select the reward
* Open a new floating order, do the same but for customer B
* Pay the order related to customer B
* Go in the backend and check the loyalty card of customer A
> Observation: Point have been modifyed
* Back in the shop, pay order related to cusotmer A
* Go in the backend and check the loyalty card of customer A
> Observation: points have been modifyed twice

Why the fix:
------------
Only processed orders should modify the points available on the loyalty card in the backend.

opw-4539274