### PR TITLE
[IMP] core: reduce target fields of _check_company() for write().

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -285,6 +285,7 @@ class Lead(models.Model):
             team = self.env['crm.team']._get_default_team_id(user_id=user.id, domain=team_domain)
             if lead.team_id != team:
                 lead.team_id = team.id
+        self._origin._check_company(['team_id'])
 
     @api.depends('user_id', 'team_id', 'partner_id')
     def _compute_company_id(self):

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -45,8 +45,9 @@ class StockPickingType(models.Model):
     @api.depends('default_location_src_id', 'default_location_dest_id')
     def _compute_warehouse_id(self):
         super()._compute_warehouse_id()
-        if self.default_location_src_id.usage == 'supplier' and self.default_location_dest_id.usage == 'customer':
-            self.warehouse_id = False
+        for picking_type in self:
+            if picking_type.default_location_src_id.usage == 'supplier' and picking_type.default_location_dest_id.usage == 'customer':
+                picking_type.warehouse_id = False
 
 
 class StockLot(models.Model):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -541,7 +541,7 @@ class Users(models.Model):
                         pass
 
     @api.constrains('company_id', 'company_ids', 'active')
-    def _check_company(self):
+    def _check_company_inconsistencies(self):
         for user in self.filtered(lambda u: u.active):
             if user.company_id not in user.company_ids:
                 raise ValidationError(


### PR DESCRIPTION
If we write() on only one relational field with check_company=True, _check_company() is called without argument, which means that we will check for company inconsistency on all fields of the models.

This can cause errors during upgrade for unmodified fields. Also, it's actually inefficient since the `_check_company` may generate SQL queries for X2many or for company dependent fields for no reason.

