### PR TITLE
[REF] test_lint: check create() overrides

### DIFF
--- a/addons/crm/models/calendar.py
+++ b/addons/crm/models/calendar.py
@@ -36,8 +36,8 @@ class CalendarEvent(models.Model):
                     event.is_highlighted = True
 
     @api.model_create_multi
-    def create(self, vals):
-        events = super(CalendarEvent, self).create(vals)
+    def create(self, vals_list):
+        events = super().create(vals_list)
         for event in events:
             if event.opportunity_id and not event.activity_ids:
                 event.opportunity_id.log_meeting(event)

--- a/addons/gamification/models/gamification_karma_rank.py
+++ b/addons/gamification/models/gamification_karma_rank.py
@@ -33,8 +33,8 @@ class GamificationKarmaRank(models.Model):
             rank.rank_users_count = requests_mapped_data.get(rank.id, 0)
 
     @api.model_create_multi
-    def create(self, values_list):
-        res = super().create(values_list)
+    def create(self, vals_list):
+        res = super().create(vals_list)
         if any(res.mapped('karma_min')) > 0:
             users = self.env['res.users'].sudo().search([('karma', '>=', max(min(res.mapped('karma_min')), 1))])
             if users:

--- a/addons/gamification/models/gamification_karma_tracking.py
+++ b/addons/gamification/models/gamification_karma_tracking.py
@@ -48,16 +48,16 @@ class GamificationKarmaTracking(models.Model):
             karma.origin_ref_model_name = karma.origin_ref._name
 
     @api.model_create_multi
-    def create(self, values_list):
+    def create(self, vals_list):
         # fill missing old value with current user karma
         users = self.env['res.users'].browse([
             values['user_id']
-            for values in values_list
+            for values in vals_list
             if 'old_value' not in values and values.get('user_id')
         ])
         karma_per_users = {user.id: user.karma for user in users}
 
-        for values in values_list:
+        for values in vals_list:
             if 'old_value' not in values and values.get('user_id'):
                 values['old_value'] = karma_per_users[values['user_id']]
 
@@ -65,7 +65,7 @@ class GamificationKarmaTracking(models.Model):
                 values['new_value'] = values['old_value'] + values['gain']
                 del values['gain']
 
-        return super().create(values_list)
+        return super().create(vals_list)
 
     @api.model
     def _consolidate_cron(self):

--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -68,8 +68,8 @@ class ResUsers(models.Model):
             self.browse(user_id)['{}_badge'.format(level)] = count
 
     @api.model_create_multi
-    def create(self, values_list):
-        res = super().create(values_list)
+    def create(self, vals_list):
+        res = super().create(vals_list)
 
         self._add_karma_batch({
             user: {
@@ -78,7 +78,7 @@ class ResUsers(models.Model):
                 'origin_ref': f'res.users,{self.env.uid}',
                 'reason': _('User Creation'),
             }
-            for user, vals in zip(res, values_list)
+            for user, vals in zip(res, vals_list)
             if vals.get('karma')
         })
 

--- a/addons/hr_presence/models/res_config_settings.py
+++ b/addons/hr_presence/models/res_config_settings.py
@@ -1,12 +1,12 @@
-
-from odoo import models
+from odoo import api, models
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    def create(self, vals):
-        configs = super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        configs = super().create(vals_list)
         if any(config.hr_presence_control_ip or config.hr_presence_control_email for config in configs):
             self.env['hr.employee.base']._check_presence()
         return configs

--- a/addons/hr_timesheet/models/res_company.py
+++ b/addons/hr_timesheet/models/res_company.py
@@ -33,8 +33,8 @@ class ResCompany(models.Model):
             raise ValidationError(_('The Internal Project of a company should be in that company.'))
 
     @api.model_create_multi
-    def create(self, values):
-        company = super().create(values)
+    def create(self, vals_list):
+        company = super().create(vals_list)
         # use sudo as the user could have the right to create a company
         # but not to create a project. On the other hand, when the company
         # is created, it is not in the allowed_company_ids on the env

--- a/addons/mail/models/mail_blacklist.py
+++ b/addons/mail/models/mail_blacklist.py
@@ -22,11 +22,11 @@ class MailBlacklist(models.Model):
     )
 
     @api.model_create_multi
-    def create(self, values):
+    def create(self, vals_list):
         # First of all, extract values to ensure emails are really unique (and don't modify values in place)
         new_values = []
         all_emails = []
-        for value in values:
+        for value in vals_list:
             email = tools.email_normalize(value.get('email'))
             if not email:
                 raise UserError(_('Invalid email address “%s”', value['email']))

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -125,9 +125,9 @@ class MailMail(models.Model):
         return [('body_html', operator, value)]
 
     @api.model_create_multi
-    def create(self, values_list):
+    def create(self, vals_list):
         # notification field: if not set, set if mail comes from an existing mail.message
-        for values in values_list:
+        for values in vals_list:
             if 'is_notification' not in values and values.get('mail_message_id'):
                 values['is_notification'] = True
             if values.get('scheduled_date'):
@@ -135,10 +135,10 @@ class MailMail(models.Model):
                 values['scheduled_date'] = parsed_datetime.replace(tzinfo=None) if parsed_datetime else False
             else:
                 values['scheduled_date'] = False  # void string crashes
-        new_mails = super(MailMail, self).create(values_list)
+        new_mails = super().create(vals_list)
 
         new_mails_w_attach = self.env['mail.mail']
-        for mail, values in zip(new_mails, values_list):
+        for mail, values in zip(new_mails, vals_list):
             if values.get('attachment_ids'):
                 new_mails_w_attach += mail
         if new_mails_w_attach:

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -597,9 +597,9 @@ class MailMessage(models.Model):
         return self.browse()
 
     @api.model_create_multi
-    def create(self, values_list):
+    def create(self, vals_list):
         tracking_values_list = []
-        for values in values_list:
+        for values in vals_list:
             if 'email_from' not in values:  # needed to compute reply_to
                 _author_id, email_from = self.env['mail.thread']._message_compute_author(values.get('author_id'), email_from=None, raise_on_email=False)
                 values['email_from'] = email_from
@@ -640,7 +640,7 @@ class MailMessage(models.Model):
             # delegate creation of tracking after the create as sudo to avoid access rights issues
             tracking_values_list.append(values.pop('tracking_value_ids', False))
 
-        messages = super().create(values_list)
+        messages = super().create(vals_list)
 
         # link back attachments to records, to filter out attachments linked to
         # the same records as the message (considered as ok if message is ok)
@@ -648,9 +648,9 @@ class MailMessage(models.Model):
         attachments_tocheck = self.env['ir.attachment']
         doc_to_attachment_ids = defaultdict(set)
         if all(isinstance(command, int) or command[0] in (4, 6)
-               for values in values_list
+               for values in vals_list
                for command in values['attachment_ids']):
-            for values in values_list:
+            for values in vals_list:
                 message_attachment_ids = set()
                 for command in values['attachment_ids']:
                     if isinstance(command, int):
@@ -680,7 +680,7 @@ class MailMessage(models.Model):
         if attachments_tocheck:
             attachments_tocheck.check('read')
 
-        for message, values, tracking_values_cmd in zip(messages, values_list, tracking_values_list):
+        for message, values, tracking_values_cmd in zip(messages, vals_list, tracking_values_list):
             if tracking_values_cmd:
                 vals_lst = [dict(cmd[2], mail_message_id=message.id) for cmd in tracking_values_cmd if len(cmd) == 3 and cmd[0] == 0]
                 other_cmd = [cmd for cmd in tracking_values_cmd if len(cmd) != 3 or cmd[0] != 0]

--- a/addons/mail/models/mail_presence.py
+++ b/addons/mail/models/mail_presence.py
@@ -40,8 +40,9 @@ class MailPresence(models.Model):
         "A mail presence must have a user or a guest.",
     )
 
-    def create(self, values):
-        presences = super().create(values)
+    @api.model_create_multi
+    def create(self, vals_list):
+        presences = super().create(vals_list)
         presences._send_presence()
         return presences
 

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -91,8 +91,8 @@ class MailRenderMixin(models.AbstractModel):
         return name in ['render_engine', 'render_options'] or super()._valid_field_parameter(field, name)
 
     @api.model_create_multi
-    def create(self, values_list):
-        record = super().create(values_list)
+    def create(self, vals_list):
+        record = super().create(vals_list)
         if self._unrestricted_rendering:
             # If the rendering is unrestricted (e.g. mail.template),
             # check the user is part of the mail editor group to create a new template if the template is dynamic

--- a/addons/mail_group/models/mail_group_message.py
+++ b/addons/mail_group/models/mail_group_message.py
@@ -87,8 +87,8 @@ class MailGroupMessage(models.Model):
                 raise AccessError(_('The record of the message should be the group.'))
 
     @api.model_create_multi
-    def create(self, values_list):
-        for vals in values_list:
+    def create(self, vals_list):
+        for vals in vals_list:
             if not vals.get('mail_message_id'):
                 vals.update({
                     'res_id': vals.get('mail_group_id'),
@@ -100,7 +100,7 @@ class MailGroupMessage(models.Model):
                     if field in vals
                     and field in self.env['mail.thread']._get_message_create_valid_field_names()
                 }).id
-        return super(MailGroupMessage, self).create(values_list)
+        return super().create(vals_list)
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default)

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -159,7 +159,7 @@ class CardCampaign(models.Model):
             campaign.res_model = preview_model or campaign.res_model or 'res.partner'
 
     @api.model_create_multi
-    def create(self, create_vals):
+    def create(self, vals_list):
         utm_source = self.env.ref('marketing_card.utm_source_marketing_card', raise_if_not_found=False)
         link_trackers = self.env['link.tracker'].sudo().create([
             {
@@ -168,12 +168,12 @@ class CardCampaign(models.Model):
                 'source_id': utm_source.id if utm_source else None,
                 'label': f"marketing_card_campaign_{vals.get('name', '')}_{fields.Datetime.now()}",
             }
-            for vals in create_vals
+            for vals in vals_list
         ])
         return super().create([{
             **vals,
             'link_tracker_id': link_tracker_id,
-        } for vals, link_tracker_id in zip(create_vals, link_trackers.ids)])
+        } for vals, link_tracker_id in zip(vals_list, link_trackers.ids)])
 
     def write(self, vals):
         link_tracker_vals = {}

--- a/addons/mass_mailing/models/mailing_trace.py
+++ b/addons/mass_mailing/models/mailing_trace.py
@@ -125,11 +125,11 @@ class MailingTrace(models.Model):
             trace.display_name = f'{trace.trace_type}: {trace.mass_mailing_id.name} ({trace.id})'
 
     @api.model_create_multi
-    def create(self, values_list):
-        for values in values_list:
+    def create(self, vals_list):
+        for values in vals_list:
             if 'mail_mail_id' in values:
                 values['mail_mail_id_int'] = values['mail_mail_id']
-        return super(MailingTrace, self).create(values_list)
+        return super().create(vals_list)
 
     def action_view_contact(self):
         self.ensure_one()

--- a/addons/mass_mailing_sms/models/mailing_trace.py
+++ b/addons/mass_mailing_sms/models/mailing_trace.py
@@ -59,11 +59,11 @@ class MailingTrace(models.Model):
             sms_trace.sms_id = sms_trace.sms_id_int
 
     @api.model_create_multi
-    def create(self, values_list):
-        for values in values_list:
+    def create(self, vals_list):
+        for values in vals_list:
             if values.get('trace_type') == 'sms' and not values.get('sms_code'):
                 values['sms_code'] = self._get_random_code()
-        return super(MailingTrace, self).create(values_list)
+        return super().create(vals_list)
 
     def _get_random_code(self):
         """ Generate a random code for trace. Uniqueness is not really necessary

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -521,8 +521,8 @@ class MrpWorkorder(models.Model):
         return res
 
     @api.model_create_multi
-    def create(self, values):
-        res = super().create(values)
+    def create(self, vals_list):
+        res = super().create(vals_list)
 
         # resequence the workorders if necessary
         for mo in res.mapped('production_id'):

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -40,8 +40,8 @@ class StockMoveLine(models.Model):
                 return expression.OR([[('production_id.picking_type_id', operator, value)], res])
 
     @api.model_create_multi
-    def create(self, values):
-        res = super(StockMoveLine, self).create(values)
+    def create(self, vals_list):
+        res = super().create(vals_list)
         for line in res:
             # If the line is added in a done production, we need to map it
             # manually to the produced move lines in order to see them in the

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -312,8 +312,8 @@ class PaymentProvider(models.Model):
     #=== CRUD METHODS ===#
 
     @api.model_create_multi
-    def create(self, values_list):
-        providers = super().create(values_list)
+    def create(self, vals_list):
+        providers = super().create(vals_list)
         providers._check_required_if_provider()
         if any(provider.state != 'disabled' for provider in providers):
             self._toggle_post_processing_cron()

--- a/addons/payment/models/payment_token.py
+++ b/addons/payment/models/payment_token.py
@@ -45,8 +45,8 @@ class PaymentToken(models.Model):
     #=== CRUD METHODS ===#
 
     @api.model_create_multi
-    def create(self, values_list):
-        for values in values_list:
+    def create(self, vals_list):
+        for values in vals_list:
             if 'provider_id' in values:
                 provider = self.env['payment.provider'].browse(values['provider_id'])
 
@@ -55,7 +55,7 @@ class PaymentToken(models.Model):
             else:
                 pass  # Let psycopg warn about the missing required field.
 
-        return super().create(values_list)
+        return super().create(vals_list)
 
     @api.model
     def _get_specific_create_values(self, provider_code, values):

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -160,8 +160,8 @@ class PaymentTransaction(models.Model):
     #=== CRUD METHODS ===#
 
     @api.model_create_multi
-    def create(self, values_list):
-        for values in values_list:
+    def create(self, vals_list):
+        for values in vals_list:
             provider = self.env['payment.provider'].browse(values['provider_id'])
 
             if not values.get('reference'):
@@ -188,7 +188,7 @@ class PaymentTransaction(models.Model):
             # Include provider-specific create values
             values.update(self._get_specific_create_values(provider.code, values))
 
-        txs = super().create(values_list)
+        txs = super().create(vals_list)
 
         # Monetary fields are rounded with the currency at creation time by the ORM. Sometimes, this
         # can lead to inconsistent string representation of the amounts sent to the providers.

--- a/addons/payment_adyen/models/payment_provider.py
+++ b/addons/payment_adyen/models/payment_provider.py
@@ -43,10 +43,10 @@ class PaymentProvider(models.Model):
     #=== CRUD METHODS ===#
 
     @api.model_create_multi
-    def create(self, values_list):
-        for values in values_list:
+    def create(self, vals_list):
+        for values in vals_list:
             self._adyen_extract_prefix_from_api_url(values)
-        return super().create(values_list)
+        return super().create(vals_list)
 
     def write(self, values):
         self._adyen_extract_prefix_from_api_url(values)

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -26,8 +26,8 @@ class PaymentProvider(models.Model):
         string="Enable QR Codes", help="Enable the use of QR-codes when paying by wire transfer.")
 
     @api.model_create_multi
-    def create(self, values_list):
-        providers = super().create(values_list)
+    def create(self, vals_list):
+        providers = super().create(vals_list)
         providers.filtered(lambda p: p.custom_mode == 'wire_transfer').pending_msg = None
         return providers
 

--- a/addons/phone_validation/models/phone_blacklist.py
+++ b/addons/phone_validation/models/phone_blacklist.py
@@ -23,7 +23,7 @@ class PhoneBlacklist(models.Model):
     )
 
     @api.model_create_multi
-    def create(self, values):
+    def create(self, vals_list):
         """ Create new (or activate existing) blacklisted numbers.
                 A. Note: Attempt to create a number that already exists, but is non-active, will result in its activation.
                 B. Note: If the number already exists and it's active, it will be added to returned set, (it won't be re-created)
@@ -32,7 +32,7 @@ class PhoneBlacklist(models.Model):
         # Extract and sanitize numbers, ensuring uniques
         to_create = []
         done = set()
-        for value in values:
+        for value in vals_list:
             try:
                 sanitized_value = self.env.user._phone_format(number=value['number'], raise_exception=True)
             except UserError as err:

--- a/addons/portal_rating/models/rating_rating.py
+++ b/addons/portal_rating/models/rating_rating.py
@@ -14,10 +14,10 @@ class RatingRating(models.Model):
     publisher_datetime = fields.Datetime("Commented on", readonly=True)
 
     @api.model_create_multi
-    def create(self, values_list):
-        for values in values_list:
+    def create(self, vals_list):
+        for values in vals_list:
             self._synchronize_publisher_values(values)
-        ratings = super().create(values_list)
+        ratings = super().create(vals_list)
         if any(rating.publisher_comment for rating in ratings):
             ratings._check_synchronize_publisher_values()
         return ratings

--- a/addons/pos_mercado_pago/models/pos_payment_method.py
+++ b/addons/pos_mercado_pago/models/pos_payment_method.py
@@ -1,6 +1,6 @@
 import logging
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, UserError
 
 from .mercado_pago_pos_request import MercadoPagoPosRequest
@@ -118,8 +118,9 @@ class PosPaymentMethod(models.Model):
 
         return records
 
-    def create(self, vals):
-        records = super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
 
         for record in records:
             if record.mp_bearer_token:

--- a/addons/pos_viva_com/models/pos_payment_method.py
+++ b/addons/pos_viva_com/models/pos_payment_method.py
@@ -180,9 +180,9 @@ class PosPaymentMethod(models.Model):
 
         return record
 
-
-    def create(self, vals):
-        records = super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
 
         for record in records:
             if record.viva_com_merchant_id and record.viva_com_api_key:

--- a/addons/sale_purchase/models/sale_order_line.py
+++ b/addons/sale_purchase/models/sale_order_line.py
@@ -41,8 +41,8 @@ class SaleOrderLine(models.Model):
     # --------------------------
 
     @api.model_create_multi
-    def create(self, values):
-        lines = super(SaleOrderLine, self).create(values)
+    def create(self, vals_list):
+        lines = super().create(vals_list)
         # Do not generate purchase when expense SO line since the product is already delivered
         lines.filtered(
             lambda line: line.state == 'sale' and not line.is_expense

--- a/addons/sales_team/models/crm_team_member.py
+++ b/addons/sales_team/models/crm_team_member.py
@@ -141,7 +141,7 @@ class CrmTeamMember(models.Model):
     # ------------------------------------------------------------
 
     @api.model_create_multi
-    def create(self, values_list):
+    def create(self, vals_list):
         """ Specific behavior implemented on create
 
           * mono membership mode: other user memberships are automatically
@@ -155,10 +155,10 @@ class CrmTeamMember(models.Model):
         """
         is_membership_multi = self.env['ir.config_parameter'].sudo().get_param('sales_team.membership_multi', False)
         if not is_membership_multi:
-            self._synchronize_memberships(values_list)
+            self._synchronize_memberships(vals_list)
         return super(CrmTeamMember, self.with_context(
             mail_create_nosubscribe=True
-        )).create(values_list)
+        )).create(vals_list)
 
     def write(self, values):
         """ Specific behavior about active. If you change user_id / team_id user

--- a/addons/stock_fleet/models/stock_picking_batch.py
+++ b/addons/stock_fleet/models/stock_picking_batch.py
@@ -62,6 +62,8 @@ class StockPickingBatch(models.Model):
                 batch.used_volume_percentage = 100 * (batch.estimated_shipping_volume / batch.vehicle_volume_capacity)
 
     # CRUD
+
+    @api.model_create_multi
     def create(self, vals_list):
         batches = super().create(vals_list)
         batches.order_on_zip()

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -421,6 +421,7 @@ class SurveyQuestion(models.Model):
                 new_question.triggering_answer_ids = old_question.triggering_answer_ids
         return new_questions
 
+    @api.model_create_multi
     def create(self, vals_list):
         questions = super().create(vals_list)
         questions.filtered(

--- a/odoo/addons/test_lint/tests/test_override_signatures.py
+++ b/odoo/addons/test_lint/tests/test_override_signatures.py
@@ -33,7 +33,7 @@ methods_to_sanitize = {
     if not method_name.startswith('_')
 } - {
     # Not yet sanitized...
-    'write', 'create', 'default_get', 'init'
+    'write', 'create', 'default_get'
 }
 
 
@@ -133,6 +133,9 @@ class TestLintOverrideSignatures(LintCase):
             for method_name, _ in inspect.getmembers(model_cls, inspect.isroutine):
                 if method_name not in methods_to_sanitize:
                     # TODO sanitize all methods
+                    continue
+                if method_name == 'init' and model_name == 'ir.config_parameter':
+                    # TODO refactor ir.config_parameter
                     continue
 
                 # Find the original function definition

--- a/odoo/addons/test_lint/tests/test_override_signatures.py
+++ b/odoo/addons/test_lint/tests/test_override_signatures.py
@@ -33,7 +33,7 @@ methods_to_sanitize = {
     if not method_name.startswith('_')
 } - {
     # Not yet sanitized...
-    'write', 'create', 'default_get'
+    'write', 'default_get'
 }
 
 


### PR DESCRIPTION
Check that the `create` method is properly overridden.

Forgetting to add `@api.model_create_multi` makes most methods unusable over RPC and does not work with a dict parameter.

odoo/enterprise#81599
odoo/documentation#12527


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
