### PR TITLE
[FIX] web: allow to have the same field as group by and progressbar

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -818,11 +818,19 @@ class Base(models.AbstractModel):
 
         result = defaultdict(lambda: dict.fromkeys(progress_bar['colors'], 0))
         domain = AND([domain, [(progress_bar['field'], 'in', list(progress_bar['colors']))]])
+        groupby = [group_by]
+        if progress_bar['field'] != group_by:
+            groupby.append(progress_bar['field'])
 
-        for main_group, field_value, count in self._read_group(
-            domain, [group_by, progress_bar['field']], ['__count'],
+        for group in self._read_group(
+            domain, groupby, ['__count'],
         ):
+            main_group = group[0]
+            count = group[-1]
             group_by_value = str(adapt(main_group))
+            field_value = group_by_value
+            if len(groupby) == 2:
+                field_value = group[1]
             result[group_by_value][field_value] += count
 
         return result


### PR DESCRIPTION
Before this commit, when the user group by `Status` in the kanban view of `project.project` model, he got a traceback because the iterator in the `_read_group` stops 1 iterator before expected. The reason is because the progressbar field is the same than the one used for the main group by (the columns displayed in the kanban view) and the result of the read_group for the `read_progress_bar` returns a tuple with 2 elements instead of 3 elements.

This commit fixes the issue by checking if the progressbar field is the same than the one used for the main group by if yes then only the main group by is given to the `groupby` parameter of `_read_group` method.

Steps to reproduce the issues:
-----------------------------
0. Install Project app
1. Create one project (if there is no one)
2. Go back to the kanban view of `project.project` model
3. Group by `Status`

Expected Behavior:
-----------------
The projects should be grouped by `Status` without any issues.

Current Behavior:
----------------
A traceback is occurred in `read_progress_bar` rpc call.

opw-4652127
