### PR TITLE
[FIX] point_of_sale: save data while terminal installation

### DIFF
--- a/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.js
+++ b/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.js
@@ -17,6 +17,7 @@ export class PosPaymentProviderCards extends Component {
         this.container = useRef("cards_container");
         this.state = useState({
             providers: [],
+            disabled: false,
         });
 
         onWillStart(async () => {
@@ -51,13 +52,22 @@ export class PosPaymentProviderCards extends Component {
     }
 
     async installModule(moduleId) {
-        const result = await this.orm.call("ir.module.module", "button_immediate_install", [
-            moduleId,
-        ]);
-
-        if (result) {
-            window.location.reload();
+        const recordSave = await this.props.record.save();
+        if (!recordSave) {
+            return;
         }
+        this.state.disabled = true;
+        await this.orm
+            .call("ir.module.module", "button_immediate_install", [moduleId])
+            .then((result) => {
+                this.state.disabled = false;
+                if (result) {
+                    window.location.reload();
+                }
+            })
+            .finally(() => {
+                this.state.disabled = false;
+            });
     }
 
     async setupProvider(moduleId) {

--- a/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.xml
+++ b/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.xml
@@ -12,8 +12,8 @@
                 </div>
                 <div class="d-flex flex-column justify-content-between w-100">
                     <span class="mb-0 fs-6 fw-bold" t-esc="provider.provider" />
-                    <button t-if="provider.state === 'uninstalled'" t-on-click="() => this.installModule(provider.id)" class="btn btn-sm btn-primary ms-auto align-self-end">Install</button>
-                    <button t-else="" t-on-click="() => this.setupProvider(provider.id)" class="btn btn-sm btn-secondary ms-auto align-self-end">Setup</button>
+                    <button t-if="provider.state === 'uninstalled'" t-on-click="() => this.installModule(provider.id)" class="btn btn-sm btn-primary ms-auto align-self-end" t-att-disabled="state.disabled">Activate</button>
+                    <button t-else="" t-on-click="() => this.setupProvider(provider.id)" class="btn btn-sm btn-secondary ms-auto align-self-end" t-att-disabled="state.disabled">Setup</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
In this commit, save the record when we install the payment terminal from the form widget.

Steps:
---
- Go to payment method config 
- Click on new 
- Journal = bank & Integration = terminal 
- Select a payment provider to download
- the page refreshes and loses the data that is configured

task - 4653445



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
