### PR TITLE
[FIX] point_of_sale: make sure deleted lines are removed from indexedDB

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -352,13 +352,13 @@ export class PosData extends Reactive {
 
         const ignore = Object.keys(this.opts.databaseTable);
         for (const model of Object.keys(this.relations)) {
-            if (ignore.includes(model)) {
-                continue;
-            }
-
             this.models[model].addEventListener("delete", (params) => {
                 this.indexedDB.delete(model, [params.key]);
             });
+
+            if (ignore.includes(model)) {
+                continue;
+            }
 
             this.models[model].addEventListener("update", (params) => {
                 const record = this.models[model].get(params.id).raw;

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -7,6 +7,8 @@ import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Utils from "@point_of_sale/../tests/pos/tours/utils/common";
 import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
+import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
+import { refresh, negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("ChromeTour", {
     checkDelay: 50,
@@ -189,5 +191,33 @@ registry.category("web_tour.tours").add("test_tracking_number_closing_session", 
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_indexed_db_draft_order", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.0"),
+            refresh(),
+            inLeftSide(ProductScreen.orderLineHas("Desk Organizer", "1")),
+            ProductScreen.clickDisplayedProduct("Desk Pad", true, "1.0"),
+            refresh(),
+            inLeftSide([
+                ...ProductScreen.orderLineHas("Desk Organizer", "1"),
+                ...ProductScreen.orderLineHas("Desk Pad", "1"),
+                ...ProductScreen.clickLine("Desk Pad"),
+                Numpad.click("⌫"),
+                ...ProductScreen.selectedOrderlineHasDirect("Desk Pad", "0", "0"),
+                Numpad.click("⌫"),
+                ...ProductScreen.orderLineHas("Desk Pad").map(negateStep),
+            ]),
+            refresh(),
+            inLeftSide([
+                ...ProductScreen.orderLineHas("Desk Organizer", "1"),
+                ...ProductScreen.orderLineHas("Desk Pad").map(negateStep),
+            ]),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1799,6 +1799,10 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.assertAlmostEqual(order.amount_total, invoice.amount_total, places=2, msg="Order and Invoice amounts do not match.")
 
+    def test_indexed_db_draft_order(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_indexed_db_draft_order', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
When an orderline is deleted, it wasn't being removed from the indexedDB. This commit ensures that deleted orderlines are also removed from the local storage, maintaining data integrity in the POS.

opw-4626344

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
