### PR TITLE
[IMP] web: datetime_picker: improve and simplify date selection

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -512,7 +512,6 @@ export class DateTimePicker extends Component {
             isSelectStart: false,
             isSelectEnd: false,
             isHighlighted: isInRange(this.state.hoveredDate, range),
-            isCurrent: false,
         };
 
         if (this.props.range) {
@@ -521,9 +520,6 @@ export class DateTimePicker extends Component {
                 result.isSelectStart = !selectStart || isInRange(selectStart, range);
                 result.isSelectEnd = !selectEnd || isInRange(selectEnd, range);
             }
-            result.isCurrent =
-                !isOutOfRange &&
-                (isInRange(this.values[0], range) || isInRange(this.values[1], range));
         } else {
             result.isSelectStart = result.isSelectEnd = result.isSelected;
         }
@@ -535,15 +531,16 @@ export class DateTimePicker extends Component {
      * @param {DateTimePickerProps} props
      */
     getTimeValues(props) {
-        const timeValues = this.values.map((val, index) =>
-            new Time({
-                hour:
-                    index === 1 && !this.values[1]
-                        ? (val || DateTime.local()).hour + 1
-                        : (val || DateTime.local()).hour,
-                minute: val?.minute || 0,
-                second: val?.second || 0,
-            })
+        const timeValues = this.values.map(
+            (val, index) =>
+                new Time({
+                    hour:
+                        index === 1 && !this.values[1]
+                            ? (val || DateTime.local()).hour + 1
+                            : (val || DateTime.local()).hour,
+                    minute: val?.minute || 0,
+                    second: val?.second || 0,
+                })
         );
 
         if (props.range) {

--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -11,63 +11,37 @@
     }
 
     // Day
-
-    .o_date_item_cell {
-        position: relative;
-        border-radius: 0;
-    }
-
-    .o_current,
     .o_selected {
         color: $o-component-active-color;
-    }
-
-    .o_selected:not(.o_select_start):not(.o_select_end) {
         background: $o-component-active-bg;
     }
 
-    .o_current,
-    .o_highlighted,
     .o_select_start,
     .o_select_end {
-        &:before {
-            content: "";
-            position: absolute;
-            box-shadow: inset 0 0 0 1px $o-component-active-border;
-            width: 100%;
-            aspect-ratio: 1;
-            border-radius: 100%;
-            z-index: 1;
-        }
+        --selected-day-color: #{mix(lighten($o-component-active-border, 10%), $o-component-active-bg, 15%)};
+        --percent: calc(100% / sqrt(2));
+        background:
+            #{$o-component-active-bg}
+            radial-gradient(
+                circle,
+                var(--selected-day-color) 0% var(--percent),
+                transparent var(--percent) 100%
+            )
+        ;
     }
 
-    .o_select_start,
-    .o_select_end {
-        &:before {
-            background: mix(lighten($o-component-active-border, 10%), $o-component-active-bg, 15%);
-        }
-
-        &:after {
-            content: "";
-            position: absolute;
-            background: transparent;
-            width: 50%;
-            aspect-ratio: 1/2;
-        }
-
-        &:not(.o_select_end):after {
-            right: 0;
-            background: $o-component-active-bg;
-        }
-
-        &:not(.o_select_start):after {
-            right: 50%;
-            background: $o-component-active-bg;
-        }
+    .o_select_start {
+        border-top-left-radius: 50%;
+        border-bottom-left-radius: 50%;
     }
 
-    .o_today span {
-        border-bottom: 0.2em solid $danger;
+    .o_select_end  {
+        border-top-right-radius: 50%;
+        border-bottom-right-radius: 50%;
+    }
+
+    .o_today {
+        color: $o-brand-primary;
     }
 
     // Grids
@@ -111,7 +85,6 @@
     .o_cell_md {
         aspect-ratio: 1;
         @include media-breakpoint-up(md) {
-            padding: 0.4rem;
             width: var(--DateTimePicker__Cell-size-md);
             height: var(--DateTimePicker__Cell-size-md);
         }

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -29,24 +29,22 @@
                                 <div class="o_date_item_cell o_out_of_range o_cell_md" />
                             </t>
                             <t t-else="">
-                                <button
-                                    class="o_date_item_cell o_datetime_button o_center o_cell_md btn p-1 border-0 fw-normal"
-                                    tabindex="-1"
+                                <div
+                                    class="o_date_item_cell o_datetime_button o_center o_cell_md"
                                     t-att-class="{
                                         'o_selected': arInfo.isSelected,
                                         o_select_start: arInfo.isSelectStart,
                                         o_select_end: arInfo.isSelectEnd,
                                         o_highlighted: arInfo.isHighlighted,
-                                        o_current: arInfo.isCurrent,
-                                        o_today: itemInfo.includesToday,
+                                        'o_today fw-bolder text-decoration-underline': itemInfo.includesToday,
                                         [itemInfo.extraClass]: true,
                                     }"
                                     t-att-disabled="!itemInfo.isValid"
                                     t-on-pointerenter="() => (state.hoveredDate = itemInfo.range[0])"
                                     t-on-click="() => this.zoomOrSelect(itemInfo)"
                                 >
-                                    <span t-esc="itemInfo.label" class="z-1" />
-                                </button>
+                                    <t t-esc="itemInfo.label" />
+                                </div>
                             </t>
                         </t>
                     </t>
@@ -81,9 +79,8 @@
         <div class="o_date_item_picker d-grid">
             <t t-foreach="items" t-as="itemInfo" t-key="itemInfo.id">
                 <t t-set="arInfo" t-value="getActiveRangeInfo(itemInfo)" />
-                <button
-                    class="o_date_item_cell o_datetime_button btn o_center o_cell_lg btn p-1 border-0"
-                    tabindex="-1"
+                <div
+                    class="o_date_item_cell o_datetime_button o_center o_cell_lg"
                     t-att-class="{
                         o_selected: arInfo.isSelected,
                         o_select_start: arInfo.isSelectStart,
@@ -94,8 +91,8 @@
                     t-att-disabled="!itemInfo.isValid"
                     t-on-click="() => this.zoomOrSelect(itemInfo)"
                 >
-                    <span t-esc="itemInfo.label" class="z-1" />
-                </button>
+                    <t t-esc="itemInfo.label" />
+                </div>
             </t>
         </div>
     </t>


### PR DESCRIPTION
- Remove unused ´isCurrent´ This was probably used when the input wasn't automatically updated. Historically, we had to click on the "apply" button to apply the change.

- Simplify css rules for rounded backgrounds This avoids staking context (z-index, position) and pseudo-elements.

- Use of Odoo color for the current day See ´border-bottom´ / ´text-decoration´

- Remove rounded colored border for date selection

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
