### PR TITLE
[FIX] core: allow duplicate groupby spec in _read_group

### DIFF
--- a/odoo/addons/test_read_group/tests/test_private_read_group.py
+++ b/odoo/addons/test_read_group/tests/test_private_read_group.py
@@ -709,3 +709,13 @@ class TestPrivateReadGroup(common.TransactionCase):
             self.env["test_read_group.order.line"].read_group(
                 [], ["order_id"], "order_id", orderby="order_id DESC"
             )
+
+    def test_duplicate_arguments(self):
+        Model = self.env['test_read_group.aggregate']
+        Model.create({'key': 1, 'value': 5})
+        self.assertEqual(
+            Model._read_group([], groupby=['key', 'key'], aggregates=['value:sum', 'value:sum', 'key:sum']),
+            [
+                (1, 1, 5, 5, 1),
+            ],
+        )

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1916,7 +1916,7 @@ class BaseModel(metaclass=MetaModel):
         sql_order, sql_extra_groupby, fnames_used = self._read_group_orderby(order, groupby_terms, query)
         fnames_to_flush.update(fnames_used)
 
-        groupby_terms = list(groupby_terms.values())
+        groupby_terms = [groupby_terms[spec] for spec in groupby]
 
         query_parts = [
             SQL("SELECT %s", SQL(", ").join(groupby_terms + select_terms)),


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/103510 , _read_group raises a StopIteration error if there are duplicate groupby specifications. This is because `groupby_terms` has become a `dict` which doesn't allow duplication but we are still looping on the `groupby` list to retrieve columns, leading to raise a StopIteration error when we try to retrieve the last column.

Fix this by creating `groupby_terms` with `groupby` instead of values from the dict.