### PR TITLE
Reopen  [FIX] payment_paypal: Allow the provider to work without delivery addresses

### DIFF
--- a/addons/payment_paypal/models/payment_provider.py
+++ b/addons/payment_paypal/models/payment_provider.py
@@ -55,7 +55,10 @@ class PaymentProvider(models.Model):
         :return: None
         :raise UserError: If the base URL is not in HTTPS.
         """
-        base_url = self.get_base_url()
+        # When hosted on premise with docker, Odoo use the docker host name instead of the base_url variable
+        base_url = self.env['ir.config_parameter'].sudo().get_param('payment.paypal.base_url')
+        if not base_url:
+            base_url = self.get_base_url()
         if 'localhost' in base_url:
             raise UserError(
                 "PayPal: " + _("You must have an HTTPS connection to generate a webhook.")

--- a/addons/payment_paypal/models/payment_transaction.py
+++ b/addons/payment_paypal/models/payment_transaction.py
@@ -58,6 +58,23 @@ class PaymentTransaction(models.Model):
         :return: The requested payload to create a Paypal order.
         :rtype: dict
         """
+
+        # Sometimes it's unnecessary to add all those information because we skipped the address.
+        simple_paypal_payload = self.env['ir.config_parameter'].sudo().get_param('payment.paypal.simple_payload')
+
+        if simple_paypal_payload:
+            _logger.info("Using simple payload with paypal")
+            return {
+            'intent': 'CAPTURE',
+            'purchase_units': [{
+                'reference_id': self.reference,
+                'amount': {
+                    'currency_code': self.currency_id.name,
+                    'value': self.amount
+                }
+            }],
+        }
+
         country_code = self.partner_country_id.code or self.company_id.country_id.code
         partner_first_name, partner_last_name = payment_utils.split_partner_name(self.partner_name)
         payload = {

--- a/doc/cla/corporate/olive007.md
+++ b/doc/cla/corporate/olive007.md
@@ -1,0 +1,15 @@
+Philippines, 2025-03-17
+
+Devolive OÜ agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Olivier SECRET public@devo.live https://github.com/oliveOO7
+
+List of contributors:
+
+Olivier SECRET public@devo.live https://github.com/oliveOO7


### PR DESCRIPTION

Why are you closing the pull request #201982 ?
First, the module 'website_skip_hide_addresses' isn't the only to require a payload without address.
Second, there is also the issue about the url used to generate the webhook.
Third I can't reopen the pull request since I don't have the right.

