### PR TITLE
[FIX] point_of_sale: added custom_attr field in addComboLine

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -2269,6 +2269,7 @@ export class Order extends PosModel {
                     comboParent,
                     comboLine: line.comboLine,
                     attribute_value_ids: line.attribute_value_ids,
+                    attribute_custom_values: line.comboLine?.configuration?.attribute_custom_values,
                     extras: {price_type: "manual"},
                 }
             );

--- a/addons/point_of_sale/static/tests/tours/PosComboTour.js
+++ b/addons/point_of_sale/static/tests/tours/PosComboTour.js
@@ -123,3 +123,17 @@ registry.category("web_tour.tours").add("PosComboChangeFP", {
         ProductScreen.isShown(),
     ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_combo_with_custom_attribute", {
+    test: true,
+    steps: () => [
+        ProductScreen.confirmOpeningPopup(),
+        ProductScreen.clickDisplayedProduct("Custom Attr Combo"),
+        combo.select("Custom Attr Product"),
+        ProductConfigurator.fillCustomAttribute("asf"),
+        ProductConfigurator.confirmAttributes(),
+        combo.confirm(),
+        ...inLeftSide(Order.hasLine({productName: "Custom Attr Product (Custom Value: asf)"})),
+        ProductScreen.isShown(),
+    ].flat(),
+});

--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -1,3 +1,5 @@
+from odoo.fields import Command
+
 def setup_pos_combo_items(self):
     tax10 = self.env["account.tax"].create(
         {
@@ -257,5 +259,51 @@ def setup_pos_combo_items(self):
             "combo_ids": [
                 (6, 0, [self.desks_combo.id, self.chairs_combo.id, self.desk_accessories_combo.id])
             ],
+        }
+    )
+
+    #Create Combo with custom attribute
+    custom_attribute = self.env['product.attribute'].create({
+        'name': 'Custom Attribute',
+        'display_type': 'radio',
+        'create_variant': 'no_variant',
+        'value_ids': [
+                Command.create({'name': 'Custom Value', 'is_custom': True}),
+        ]
+    })
+
+    self.product_tmpl_with_custom_attr = self.env["product.template"].create(
+        {
+            "name": "Custom Attr Product",
+            "available_in_pos": True,
+            "attribute_line_ids": [
+                Command.create({
+                    'attribute_id': custom_attribute.id,
+                    'value_ids': [Command.set(custom_attribute.value_ids.ids)],
+                })
+            ],
+        }
+    )
+
+    custom_combo_line = self.env["pos.combo.line"].create(
+        {
+            "product_id": self.product_tmpl_with_custom_attr.product_variant_id.id,
+            "combo_price": 100,
+        }
+    )
+
+    custom_combo = self.env["pos.combo"].create({
+        "name": "Attr Combo",
+        "combo_line_ids": custom_combo_line.ids,
+    })
+
+    self.combo_product_with_custom_attr = self.env["product.product"].create(
+        {
+            "available_in_pos": True,
+            "list_price": 40,
+            "name": "Custom Attr Combo",
+            "type": "combo",
+            "categ_id": self.env.ref("product.product_category_2").id,
+            "combo_ids": custom_combo.ids,
         }
     )

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1343,6 +1343,11 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertAlmostEqual(order.amount_total, invoice.amount_total, places=2, msg="Order and Invoice amounts do not match.")
 
 
+    def test_combo_with_custom_attribute(self):
+        setup_pos_combo_items(self)
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_combo_with_custom_attribute', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Steps to reproduce the bug:
- Install POS
- Create an attribute with a custom value (entered by user)
- Create a product with this attribute in attr lines & custom value
- Create a combo product with comboLine linked to this product
- Order this combo from the shop session
- OrderLine will be created without the user-entered value

Issue:
The `addComboLines` function in the Order model does not include custom values in the options when adding a product to the order. `set_orderline_options` applies order options, but since the options do not contain custom attribute values for combo products, they are not applied, causing the attribute value to be missing.

opw-4587765

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
