### PR TITLE
[IMP] l10n_be_codabox: remove limitation for accountant

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~17.4+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 13:11+0000\n"
-"PO-Revision-Date: 2025-02-10 13:11+0000\n"
+"POT-Creation-Date: 2025-03-03 11:38+0000\n"
+"PO-Revision-Date: 2025-03-03 11:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19820,11 +19820,6 @@ msgid "Footer text displayed at the bottom of all reports."
 msgstr ""
 
 #. module: base
-#: model:ir.module.module,summary:base.module_l10n_be_codabox
-msgid "For Accounting Firms"
-msgstr ""
-
-#. module: base
 #: model:ir.model.fields,help:base.field_ir_actions_server__value
 #: model:ir.model.fields,help:base.field_ir_cron__value
 msgid ""
@@ -34230,9 +34225,8 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_be_codabox
 msgid ""
-"This module allows Accounting Firms to connect to CodaBox\n"
-"and automatically import CODA and SODA statements for their clients in Odoo.\n"
-"The connection must be done by the Accounting Firm.\n"
+"This module allows connection to CodaBox and automatically imports CODA and "
+"SODA statements in Odoo."
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fr.po
+++ b/odoo/addons/base/i18n/fr.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~17.4+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 13:11+0000\n"
-"PO-Revision-Date: 2024-07-16 09:15+0000\n"
+"POT-Creation-Date: 2025-03-03 11:38+0000\n"
+"PO-Revision-Date: 2025-03-03 11:38+0000\n"
 "Last-Translator: Manon Rondou, 2025\n"
 "Language-Team: French (https://app.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -25026,10 +25026,6 @@ msgstr "Alimentation/Hospitalité"
 msgid "Footer text displayed at the bottom of all reports."
 msgstr "Pied de page de tous les rapports."
 
-#. module: base
-#: model:ir.module.module,summary:base.module_l10n_be_codabox
-msgid "For Accounting Firms"
-msgstr "Pour les cabinets comptables"
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_actions_server__value
@@ -41312,13 +41308,11 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_be_codabox
 msgid ""
-"This module allows Accounting Firms to connect to CodaBox\n"
-"and automatically import CODA and SODA statements for their clients in Odoo.\n"
-"The connection must be done by the Accounting Firm.\n"
+"This module allows connection to CodaBox and automatically imports CODA and "
+"SODA statements in Odoo."
 msgstr ""
-"Ce module permet aux cabinets comptables de se connecter à la CodaBox\n"
-"et d'importer automatiquement les relevés CODA et SODA de leurs clients dans Odoo.\n"
-"La connexion doit être effectuée par le cabinet comptable.\n"
+"Ce module permet de se connecter à CodaBox et d'importer automatiquement "
+"les déclarations CODA et SODA dans Odoo."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_sale_fedex

--- a/odoo/addons/base/i18n/nl.po
+++ b/odoo/addons/base/i18n/nl.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~17.4+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 13:11+0000\n"
-"PO-Revision-Date: 2024-07-16 09:15+0000\n"
+"POT-Creation-Date: 2025-03-03 11:38+0000\n"
+"PO-Revision-Date: 2025-03-03 11:38+0000\n"
 "Last-Translator: Manon Rondou, 2025\n"
 "Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
 "MIME-Version: 1.0\n"
@@ -24983,11 +24983,6 @@ msgid "Footer text displayed at the bottom of all reports."
 msgstr "Voettekst, weergegeven aan de onderzijde van alle rapportages."
 
 #. module: base
-#: model:ir.module.module,summary:base.module_l10n_be_codabox
-msgid "For Accounting Firms"
-msgstr "Voor Accountantskantoren"
-
-#. module: base
 #: model:ir.model.fields,help:base.field_ir_actions_server__value
 #: model:ir.model.fields,help:base.field_ir_cron__value
 msgid ""
@@ -41186,13 +41181,11 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_be_codabox
 msgid ""
-"This module allows Accounting Firms to connect to CodaBox\n"
-"and automatically import CODA and SODA statements for their clients in Odoo.\n"
-"The connection must be done by the Accounting Firm.\n"
+"This module allows connection to CodaBox and automatically imports CODA and "
+"SODA statements in Odoo."
 msgstr ""
-"Dit module stelt Accountantskantoren in staat om verbinding te maken met CodaBox\n"
-"en automatisch CODA- en SODA-afschriften te importeren voor hun klanten in Odoo.\n"
-"De verbinding moet worden gemaakt door het Accountantskantoor.\n"
+"Deze module maakt een verbinding met CodaBox mogelijk en importeert "
+"automatisch CODA- en SODA-overzichten in Odoo."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_sale_fedex


### PR DESCRIPTION
### Before

Codabox used to require a fiduciary VAT and the VAT of a company (managed by the fiduciary) in order to connect to their services. 
- Access to Codabox was limited to companies with an accounting firm with a VAT number assigned


### Now

Codabox gives the opportunity for companies to directly connect (without being a fiduciary/ being managed by one). This is through the same port as before, just receiving two identical  VAT numbers.  

- Module summary, descriptions and other texts are updated to generalize 

- Companies without an accounting firm can access the Codabox configuration settings

task - 4460499