### PR TITLE
[FIX] auth_signup, web: signup with captcha w/o error message


### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -7,6 +7,7 @@ from werkzeug.urls import url_encode
 from odoo import http, tools, _
 from odoo.addons.auth_signup.models.res_users import SignupError
 from odoo.addons.web.controllers.home import ensure_db, Home, SIGN_UP_REQUEST_PARAMS, LOGIN_SUCCESSFUL_PARAMS
+from odoo.addons.web.models.res_users import SKIP_CAPTCHA_LOGIN
 from odoo.addons.base_setup.controllers.main import BaseSetup
 from odoo.exceptions import UserError
 from odoo.http import request
@@ -58,6 +59,7 @@ class AuthSignupHome(Home):
                 template = request.env.ref('auth_signup.mail_template_user_signup_account_created', raise_if_not_found=False)
                 if user_sudo and template:
                     template.sudo().send_mail(user_sudo.id, force_send=True)
+                request.update_context(skip_captcha_login=SKIP_CAPTCHA_LOGIN)
                 return self.web_login(*args, **kw)
             except UserError as e:
                 qcontext['error'] = e.args[0]
@@ -89,6 +91,7 @@ class AuthSignupHome(Home):
             try:
                 if qcontext.get('token'):
                     self.do_signup(qcontext)
+                    request.update_context(skip_captcha_login=SKIP_CAPTCHA_LOGIN)
                     return self.web_login(*args, **kw)
                 else:
                     login = qcontext.get('login')

--- a/addons/web/models/res_users.py
+++ b/addons/web/models/res_users.py
@@ -1,7 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
+from odoo.http import request
 from odoo.osv import expression
+
+SKIP_CAPTCHA_LOGIN = object()
 
 
 class ResUsers(models.Model):
@@ -27,4 +30,6 @@ class ResUsers(models.Model):
         self.ensure_one()
 
     def _should_captcha_login(self, credential):
+        if request and request.env.context.get('skip_captcha_login') is SKIP_CAPTCHA_LOGIN:
+            return False
         return credential['type'] == 'password'


### PR DESCRIPTION
Scenario: activate recaptcha, do a signup (or reset password)

Result: the signup is done, but we see an error "The reCaptcha token is
invalid." and reload the /web/signup form.

Issue:

In a0651c364be58a98e209ee413c1a9c79c72d874d the captcha validation on
login was done inside the method. But when creating a new account, we
were bypassing the login captcha check (that was already done on the
/web/signup or /web/reset_password route).

Fix: bypass the login captcha check by using a context key.

Note: without the fix, the modified test would fail with:

  AssertionError: '/web/login?redirect=%2Fweb%2Flogin_successful%3Faccount_created%3DTrue'
  not found in 'http://127.0.0.1:41811/web/signup'

opw-4641916