### PR TITLE
[FIX] account: fix encrypted original bill with PyPDF2 2.12.1

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -2,9 +2,14 @@
 from collections import OrderedDict
 from zlib import error as zlib_error
 try:
-    from PyPDF2.errors import PdfStreamError, PdfReadError
+    from PyPDF2.errors import PdfReadError
 except ImportError:
-    from PyPDF2.utils import PdfStreamError, PdfReadError
+    from PyPDF2.utils import PdfReadError
+
+try:
+    from PyPDF2.errors import DependencyError
+except ImportError:
+    DependencyError = NotImplementedError
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
@@ -33,7 +38,7 @@ class IrActionsReport(models.Model):
                     record = self.env[attachment.res_model].browse(attachment.res_id)
                     try:
                         stream = pdf.add_banner(stream, record.name, logo=True)
-                    except (ValueError, PdfStreamError, PdfReadError, TypeError, zlib_error, NotImplementedError):
+                    except (ValueError, PdfReadError, TypeError, zlib_error, NotImplementedError, DependencyError):
                         record._message_log(body=_(
                             "There was an error when trying to add the banner to the original PDF.\n"
                             "Please make sure the source file is valid."


### PR DESCRIPTION
**Steps to reproduce:**
- Use version 2.12.1 of PyPDF2 as required if python version > 3.10
- Install Accounting
- Upload an encrypted PDF as a bill
- Go to the bills list view
- Select the uploaded bill
- Print "Original Bills"

**Issue:**
A traceback is raised:
"PyPDF2.errors.DependencyError: PyCryptodome is required for AES algorithm"

**Cause:**
When printing the original bill, we try to add a banner on the PDF.
If the PDF is encrypted, PyPDF2 (2.12.1) will only try to decrypt it if "PyCryptodome" library is installed.
Otherwise, it will raise a "DependencyError", which is not handled in the "except" clause.
As "PyCryptodome" library is not part of Odoo requirements, we should handle the raised "DependencyError".

**Solution:**
Try to import "DependencyError" from "PyPDF2.errors" and catch that exception when adding the banner to the PDF.
Our own "DependencyError" exception should be created because version 1.26.0 of PyPDF2 doesn't declare "DependencyError" and therefore the import will fail.
"NotImplementedError" is used instead in version 1.26.0 and is already handled.

opw-4634417




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
