### PR TITLE
[IMP] base: add ISO options for date-based sequences

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -213,7 +213,8 @@ class IrSequence(models.Model):
 
             sequences = {
                 'year': '%Y', 'month': '%m', 'day': '%d', 'y': '%y', 'doy': '%j', 'woy': '%W',
-                'weekday': '%w', 'h24': '%H', 'h12': '%I', 'min': '%M', 'sec': '%S'
+                'weekday': '%w', 'h24': '%H', 'h12': '%I', 'min': '%M', 'sec': '%S',
+                'isoyear': '%G', 'isoy': '%g', 'isoweek': '%V',
             }
             res = {}
             for key, format in sequences.items():

--- a/odoo/addons/base/views/ir_sequence_views.xml
+++ b/odoo/addons/base/views/ir_sequence_views.xml
@@ -38,7 +38,7 @@
                                 <field name="number_next_actual" string="Next Number"/>
                             </list>
                         </field>
-                        <group col="3" string="Legend (for prefix, suffix)">
+                        <group col="4" string="Legend (for prefix, suffix)">
                             <group>
                                 <span colspan="2">Current Year with Century: %%(year)s</span>
                                 <span colspan="2">Current Year without Century: %%(y)s</span>
@@ -55,6 +55,11 @@
                                 <span colspan="2">Hour 00->12: %%(h12)s</span>
                                 <span colspan="2">Minute: %%(min)s</span>
                                 <span colspan="2">Second: %%(sec)s</span>
+                            </group>
+                            <group>
+                                <span colspan="2">ISO 8601 Week Year with Century: %%(isoyear)s</span>
+                                <span colspan="2">ISO 8601 Week Year without Century: %%(isoy)s</span>
+                                <span colspan="2">ISO 8601 Week Number: %%(isoweek)s</span>
                             </group>
                         </group>
                         <group invisible="not use_date_range">


### PR DESCRIPTION
Steps
-----
1. Configure the sale order sequence to use `%(woy)s` as suffix;
2. confirm a new sale order in 2025.

Issue
-----
The week number used in the generated name is off by one from the expected ISO 8061 week number.

Cause
-----
The date interpolation used for sequences, passes `%W` to `strftime` to get the week of the year. This uses a non-standard method, starting with the first monday located in the year (2025-01-06)[^1].

The ISO 8061 method starts counting from whatever week has January 4 in it (i.e. first week with at least 4 days), with weeks starting on Monday (2024-12-30).
To get this result from `strftime`, `%V` needs to be used in the format string.

Solution
--------
In order to not break existing week-based sequences, add ISO 8061-based format specifications alongside the current ones:

- ISO 8061 week number `%V` → `%(isoweek)s`
- ISO 8061 week-based year w/ century `%G` → `%(isoyear)s`
- ISO 8061 week-based year w/out century `%g` → `%(isoy)s`


opw-4606876

[^1]: https://www.man7.org/linux/man-pages/man3/strftime.3.html