### PR TITLE
[FIX] project: display `Private` in whole many2one field content

### DIFF
--- a/addons/project/static/src/components/project_many2one_field/project_many2one_field.js
+++ b/addons/project/static/src/components/project_many2one_field/project_many2one_field.js
@@ -12,9 +12,10 @@ export class ProjectMany2OneField extends Component {
     get m2oProps() {
         const props = computeM2OProps(this.props);
         const { record } = this.props;
+        props.cssClass = "w-100";
         if (!record.data.project_id && !record._isRequired("project_id")) {
             props.placeholder = _t("Private");
-            props.cssClass = "private_placeholder";
+            props.cssClass += " private_placeholder";
         }
         return props;
     }

--- a/addons/project/static/src/components/project_many2one_field/project_many2one_field.xml
+++ b/addons/project/static/src/components/project_many2one_field/project_many2one_field.xml
@@ -2,8 +2,9 @@
 
     <t t-name="project.ProjectMany2OneField">
         <div class="d-flex align-items-center gap-1">
-            <Many2One t-props="m2oProps" cssClass="'w-100'"/>
-            <t t-if="props.readonly and !props.record.data.parent_id and !props.record.data.project_id">
+            <t t-set="isPrivateTask" t-value="props.readonly and !props.record.data.parent_id and !props.record.data.project_id"/>
+            <Many2One t-if="!isPrivateTask" t-props="m2oProps"/>
+            <t t-if="isPrivateTask">
                 <span class="text-danger fst-italic text-muted">
                     <i class="fa fa-lock"></i> Private
                 </span>

--- a/addons/project/static/tests/project_task_project_many2one_field.test.js
+++ b/addons/project/static/tests/project_task_project_many2one_field.test.js
@@ -1,0 +1,41 @@
+import { expect, test } from "@odoo/hoot";
+
+import { mountView } from "@web/../tests/web_test_helpers";
+
+import { defineProjectModels } from "./project_models";
+
+defineProjectModels();
+
+test("ProjectMany2one: project.task form view with private task", async () => {
+    await mountView({
+        resModel: "project.task",
+        resId: 3,
+        type: "form",
+        arch: `
+            <form>
+                <field name="name"/>
+                <field name="project_id" widget="project"/>
+            </form>
+        `,
+    });
+    expect("div[name='project_id'] .o_many2one").toHaveClass("o_many2one private_placeholder w-100");
+    expect("div[name='project_id'] .o_many2one input").toHaveAttribute("placeholder", "Private");
+});
+
+test("ProjectMany2one: project.task list view", async () => {
+    await mountView({
+        resModel: "project.task",
+        type: "list",
+        arch: `
+            <list>
+                <field name="name"/>
+                <field name="project_id" widget="project"/>
+            </list>
+        `,
+    });
+    expect("div[name='project_id']").toHaveCount(3);
+    expect("div[name='project_id'] .o_many2one").toHaveCount(2);
+    expect("div[name='project_id'] i.fa-lock").toHaveCount(1);
+    expect("div[name='project_id'] span.text-danger.fst-italic.text-muted").toHaveCount(1);
+    expect("div[name='project_id'] span.text-danger.fst-italic.text-muted").toHaveText("Private");
+});


### PR DESCRIPTION
Before this commit, the `Private` value is displayed next to value of `project_id` field when the task is considered as private task (task with no project set) and so in list view, the `Private` text is not displayed correctly in the cell.

This commit makes sure the many2one component is not displayed when the Many2oneField component for project_id field is in readonly and the task is a private one.

task-4653868
