### PR TITLE
[FIX] analytic: Fix AutoComplete value prop type issue

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
@@ -42,7 +42,7 @@
                                     <AutoComplete
                                         id="dist_tag.id.toString()"
                                         placeholder="'Search Analytic Account'"
-                                        value="dist_tag.analytic_account_name"
+                                        value="dist_tag.analytic_account_name || ''"
                                         sources="sourcesAnalyticAccount(plan.id)"
                                         autoSelect="true"
                                         onSelect.alike="(option, params) => this.onSelect(option, params, dist_tag)"


### PR DESCRIPTION
- Ensure value prop in AutoComplete component is always a string.
- Convert dist_tag.analytic_account_name to a string to prevent OwlError.

Description of the issue/feature this PR addresses:
The AutoComplete component was throwing an OwlError due to the value prop not being a string.

Current behavior before PR:
The value prop in AutoComplete received dist_tag.analytic_account_name, which could be undefined or another non-string type, causing an error.

Desired behavior after PR is merged:
The value prop is now explicitly converted to a string, preventing errors and ensuring proper functionality of the AutoComplete component.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
