### PR TITLE
[FIX] point_of_sale: update tmpl. attr. values w/o POS access

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -58,16 +58,16 @@ class ProductTemplate(models.Model):
         for template in self:
             archived_product = self.env['product.product'].search([('product_tmpl_id', '=', template.id), ('active', '=', False)], limit=1)
             if archived_product:
-                combo_choices_to_delete = self.env['pos.combo.line'].search([
+                combo_choices_to_delete = self.env['pos.combo.line'].sudo().search([
                     ('product_id', '=', archived_product.id)
                 ])
                 if combo_choices_to_delete:
                     # Delete old combo line
                     combo_ids = combo_choices_to_delete.mapped('combo_id')
-                    combo_choices_to_delete.unlink()
+                    combo_choices_to_delete.sudo().unlink()
                     # Create new combo line (one for each new variant) in each combo
                     new_variants = template.product_variant_ids.filtered(lambda v: v.active)
-                    self.env['pos.combo.line'].create([
+                    self.env['pos.combo.line'].sudo().create([
                         {
                             'product_id': variant.id,
                             'combo_id': combo_id.id,

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -22,3 +22,4 @@ from . import test_js
 from . import test_report_pos_order
 from . import test_report_session
 from . import test_res_config_settings
+from . import test_stock_product_updates

--- a/addons/point_of_sale/tests/test_stock_product_updates.py
+++ b/addons/point_of_sale/tests/test_stock_product_updates.py
@@ -1,0 +1,98 @@
+import odoo
+
+from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+from odoo.addons.product.tests.common import TestProductCommon
+from odoo.fields import Command
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestStockProductUpdates(TestPoSCommon, TestProductCommon):
+
+    def setUp(self):
+        super(TestStockProductUpdates, self).setUp()
+        self.config = self.basic_config
+        self.inventory_admin_without_pos = self.env['res.users'].create({
+            'name': 'Inventory Admin (No POS access)',
+            'login': 'inventory_admin_without_pos',
+            'groups_id': [Command.set([self.ref('stock.group_stock_manager')])],
+        })
+        self.full_admin = self.env['res.users'].create({
+            'name': 'Full Admin',
+            'login': 'full_admin',
+            'groups_id': [
+                Command.set(
+                    [self.ref('stock.group_stock_manager'),
+                     self.ref('point_of_sale.group_pos_manager')]
+                )],
+        })
+        self.product_template = self.env['product.template'].create({
+            'name': 'Odoo Juice',
+        })
+
+    def test_change_variant_ids(self):
+        """
+        Ensure user access to create, then links and unlink attribute values 
+        from a product template.
+        
+        Specifically, this test makes sure that these users can create
+        and delete attribute values from a product template, especially when
+        a product variant has been used in a way that would prevent it from 
+        being unlinked (e.g. if it has been used in a stock lot):
+        - Inventory + POS admin
+        - Inventory admin (No POS access)
+        
+        Whether or not a product.product record has been used in a stock lot
+        impacts whether it will be archived or completely deleted when its 
+        attribute value is unlinked from the product template.
+        """
+        drink_size_attr = self.env['product.attribute'].create({'name': 'Size'})
+        attr_value_sm = self.env['product.attribute.value'].with_user(self.full_admin).create({
+            'name': 'sm',
+            'attribute_id': drink_size_attr.id,
+        })
+        attr_value_md = self.env['product.attribute.value'].with_user(self.full_admin).create({
+            'name': 'md',
+            'attribute_id': drink_size_attr.id,
+        })
+        self.product_template.with_user(self.full_admin).attribute_line_ids = [(0, 0, {
+            'attribute_id': drink_size_attr.id,
+            'value_ids': [
+                Command.link(attr_value_sm.id),
+                Command.link(attr_value_md.id), 
+            ],
+        })]
+        
+        md_product = self.env['product.product'].search([
+            ('product_tmpl_id', '=', self.product_template.id),
+            ('product_template_variant_value_ids.product_attribute_value_id', '=', attr_value_md.id),
+        ])
+        
+        # Create a stock lot for the "md" product variant. This should prevent
+        # the product variant from being deleted when the attribute value is
+        # unlinked from the product template; it should be archived instead.
+        self.env['stock.lot'].create({
+            'name': 'Lot 1',
+            'product_id': md_product.id,
+        })
+        self.product_template.attribute_line_ids[0].with_user(self.full_admin).value_ids = [
+            Command.unlink(attr_value_md.id),
+        ]
+            
+        # Check that the "md" product variant is archived, not deleted. This is
+        # important because we need to be able to read, unlink, and create 
+        # pos.combo.line records in the case that a product variant is archived.
+        self.assertFalse(md_product.active)
+            
+        # Now as the inventory admin without POS access, try to create and link
+        # the "lg" attribute value to the product template.
+        attr_value_lg = self.env['product.attribute.value'].with_user(self.inventory_admin_without_pos).create({
+            'name': 'lg',
+            'attribute_id': drink_size_attr.id,
+        })
+        self.product_template.attribute_line_ids[0].with_user(self.inventory_admin_without_pos).value_ids = [
+            Command.link(attr_value_lg.id),
+        ]
+        # Finally, ensure that unlinking works without access failure.
+        self.product_template.attribute_line_ids[0].with_user(self.inventory_admin_without_pos).value_ids = [
+            Command.unlink(attr_value_lg.id),
+        ]
+        


### PR DESCRIPTION
This PR addresses an access rights issue when an Inventory admin, specifically without POS access, tries to edit the variant attributes on a product template. 

In its current state, this user will witness an access error related to `pos.combo.line` records when they add or remove an attribute value.

This PR fixes this by introducing `.sudo()` access when interacting with the `pos.combo.line` model during this process.

opw-4553416