### PR TITLE
[FIX] payment: payment link url amount shows bad rounding

### DIFF
--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -3,6 +3,7 @@
 from werkzeug import urls
 
 from odoo import _, api, fields, models
+from odoo.tools.float_utils import float_repr
 
 from odoo.addons.payment import utils as payment_utils
 
@@ -63,7 +64,7 @@ class PaymentLinkWizard(models.TransientModel):
             related_document = self.env[payment_link.res_model].browse(payment_link.res_id)
             base_url = related_document.get_base_url()  # Don't generate links for the wrong website
             url_params = {
-                'amount': self.amount,
+                'amount': float_repr(self.amount, self.currency_id.decimal_places),
                 'access_token': self._get_access_token(),
                 **self._get_additional_link_values(),
             }


### PR DESCRIPTION
Before this change, sometimes round(i, 2) != float_round(i, 2), which leads a bad float representation visible in the url. This happens on many such values like 6.14.

opw-4601734


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
