### PR TITLE
[FIX] html_editor: prevent traceback in resetFromPeer

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
@@ -739,10 +739,15 @@ export class CollaborationOdooPlugin extends Plugin {
         if (!applied) {
             return;
         }
-        this.dependencies.selection.setSelection({
-            anchorNode: this._getNodeFromIndexPath(anchorNodeIndexPath),
-            anchorOffset,
-        });
+        const anchorNode = this._getNodeFromIndexPath(anchorNodeIndexPath);
+        if (
+            this.dependencies.selection.isSelectionInEditable({ anchorNode, focusNode: anchorNode })
+        ) {
+            this.dependencies.selection.setSelection({
+                anchorNode,
+                anchorOffset,
+            });
+        }
         this.historySyncFinished = true;
         // In case there are steps received in the meantime, process them.
         if (this.historyStepsBuffer.length) {


### PR DESCRIPTION
Purpose of this PR:

- Check `isSelectionInEditable` before `setSelection` to avoid error when selection is outside the editor.

task-4639982

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
