### PR TITLE
[FIX] base_automation: multiple records computation

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -365,7 +365,7 @@ class BaseAutomation(models.Model):
             if automation.trigger == "on_create_or_write":
                 automation.trigger_field_ids |= automation._get_filter_domain_fields()
                 continue
-            self._onchange_trigger()
+            automation._onchange_trigger()
 
     @api.depends('model_id')
     def _compute_trigger(self):
@@ -373,6 +373,7 @@ class BaseAutomation(models.Model):
 
     @api.onchange('trigger')
     def _onchange_trigger(self):
+        self.ensure_one()
         field = (
             self._get_trigger_specific_field()
             if self.trigger not in TIME_TRIGGERS


### PR DESCRIPTION
Steps:
- Try to compute trigger_field_ids for multiple record

Actual result:
- Singleton error for _onchange_trigger

Expected result:
- No error
- _onchange_trigger is call as ensure one

opw-4650807

Caused by: https://github.com/odoo/odoo/pull/189772