### PR TITLE
[FIX] web: access error on dialog form view

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -222,7 +222,11 @@ export class FormController extends Component {
 
         onError((error) => {
             const suggestedCompany = error.cause?.data?.context?.suggested_company;
-            if (error.cause?.data?.name === "odoo.exceptions.AccessError" && suggestedCompany) {
+            if (
+                error.cause?.data?.name === "odoo.exceptions.AccessError" &&
+                suggestedCompany &&
+                !this.env.inDialog
+            ) {
                 this.env.pushStateBeforeReload();
                 const activeCompanyIds = this.companyService.activeCompanyIds;
                 activeCompanyIds.push(suggestedCompany.id);


### PR DESCRIPTION
- On a view with a company-dependent field with a `many2many_tags` widget, where the `edit_tags` option is set to `true`;
- Click on a tag;
- Change the company;
- Save the tag;
- Open the same tag again;

A traceback error is displayed. This error occurs because, since [1], when loading the form view the access errors are handled, the company is added to the selected companies and the record is reloaded. The issue is that this cannot be done with a dialog form view, not only is an unreachable action service function is called, but also the dialog is not reopened when reloading.

In this commit, we fix this by showing the access error.
