### PR TITLE
[FIX] website_sale_collect: remove override and fix zipcode type

### DIFF
--- a/addons/website_sale_collect/controllers/main.py
+++ b/addons/website_sale_collect/controllers/main.py
@@ -22,6 +22,7 @@ class WebsiteSaleCollect(WebsiteSale):
                 order_sudo.partner_shipping_id.zip
                 or res.get('selected_wh_location', {}).get('zip_code')
                 or request.geoip.postal.code
+                or ''  # String expected for the widget.
             )
         return res
 

--- a/addons/website_sale_collect/static/src/js/website_sale.js
+++ b/addons/website_sale_collect/static/src/js/website_sale.js
@@ -13,21 +13,4 @@ WebsiteSale.include({
         Component.env.bus.trigger('updateCombinationInfo', combination);
         return res;
     },
-
-    /**
-     * Override of `_updateRootProduct` to skip the quantity check and allow adding a product to the
-     * cart via the configurator when Click and Collect is activated.
-     *
-     * @override
-     * @private
-     * @param {HTMLFormElement} form - The form in which the product is.
-     *
-     * @returns {void}
-     */
-    _updateRootProduct(form) {
-        this._super(...arguments);
-        this.rootProduct.isClickAndCollectActive = Boolean(
-            form.querySelector('.o_click_and_collect_availability')
-        );
-    },
 })


### PR DESCRIPTION
Props validation in debug mode failed as they were removed in
fw commit https://github.com/odoo/odoo/commit/d940fa55c465afa11fa443745f8f5a0081c8cfe3.
Fallback to an empty string for zipcode as it is expected in the
widget.