### PR TITLE
[FIX] repair: RO stop onchange of location after confirm

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -192,7 +192,7 @@ class Repair(models.Model):
             if (repair.product_id and repair.lot_id and repair.lot_id.product_id != repair.product_id) or not repair.product_id:
                 repair.lot_id = False
 
-    @api.depends('user_id', 'company_id')
+    @api.depends('company_id')
     def _compute_picking_type_id(self):
         picking_type_by_company = self._get_picking_type()
         for ro in self:

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -490,6 +490,26 @@ class TestRepair(common.TransactionCase):
         ], limit=1)
         self.assertEqual(repair.move_ids[0].location_dest_id, location_dest_id)
 
+    def test_no_recompute_location_when_change_user_after_confirm(self):
+        user1 = self.env['res.users'].create({
+            'name': 'A User',
+            'login': 'a_user',
+            'email': 'a@user.com',
+        })
+        repair_order = self._create_simple_repair_order()
+        repair_order.location_id = self.stock_location_14
+        repair_order.recycle_location_id = self.stock_location_14
+        repair_order.action_validate()
+        repair_order.user_id = user1
+        self.assertEqual(repair_order.location_id, self.stock_location_14)
+        self.assertEqual(repair_order.recycle_location_id, self.stock_location_14)
+        repair_order.action_repair_start()
+        repair_order.action_repair_end()
+        with Form(repair_order) as ro_form:
+            ro_form.user_id = user1
+        self.assertEqual(repair_order.location_id, self.stock_location_14)
+        self.assertEqual(repair_order.recycle_location_id, self.stock_location_14)
+
     def test_purchase_price_so_create_from_repair(self):
         """
         Test that the purchase price is correctly set on the SO line,


### PR DESCRIPTION
**Problem:**
On a repair order, if the user is changed it changes the location (and recycled parts destination location) to the default one.
Additionally, when the order is confirmed, there is no way to change manually the location. The problematic use case is that if you first confirm the RO and then change the user, it will trigger a change of the location that you won't be able to revert manually.

**Steps to reproduce:**
- enable location in DB
- create a new repair order
- change the location and recycled parts destination location
- confirm the repair order
- change the responsible user

**Current Behavior:**
The location and recycled parts destination location fields values are changed to the default value for this operation type.

**Expected Behavior:**
The values of those fields shouldn't change after the repair order is confirmed.

**Cause of the issue:**
The _compute_picking_type_id depends on "user_id" and is therefore triggered when the user is changed
https://github.com/odoo/odoo/blob/1445d5adabf8eabe83e842c214655a74434bad4d/addons/repair/models/repair.py#L196
This triggers the _compute_location_id and _compute_recycle_location_id methods because they depend on
"picking_type_id"
https://github.com/odoo/odoo/blob/fa41c1d50f10ebab08437557ee863348a63de2c0/addons/repair/models/repair.py#L204
This happens regardless of whether the repair order has been confirmed.
Because the list of compute methods to be triggered when user_id is changed is computed all at once before
running them, adding an if statement at the beginning of _compute_picking_type_id (preventing the change
of value of picking_type_id if the state is not "draft") would not prevent _compute_location_id and
_compute_recycle_location_id to run.
Putting an if statement at the beginning of _compute_location_id and _compute_recycle_location_id
to prevent the change when the state is not in "draft" is not a good fix either. That's because
we wouldn't know if the computation is triggered by a change of user or a change of picking_type_id
(in which case we want the computation to run)

**Fix:**
I removed the 'user_id' dependency on _compute_picking_type_id


opw-4555293
