### PR TITLE
[IMP] l10n_lu: 2025 VAT report an coa updates

### DIFF
--- a/addons/l10n_lu/data/account.account.template.csv
+++ b/addons/l10n_lu/data/account.account.template.csv
@@ -490,9 +490,9 @@ lu_2011_account_642,642,"Indemnities, damages and interest",expense,FALSE,lu_201
 lu_2020_account_6431,6431,Attendance fees,expense,FALSE,lu_2011_chart_1
 lu_2020_account_6432,6432,"Director's fees",expense,FALSE,lu_2011_chart_1
 lu_2020_account_6438,6438,Other similar remuneration,expense,FALSE,lu_2011_chart_1
-lu_2020_account_64411,64411,Book value of yielded intangible fixed assets,expense,FALSE,lu_2011_chart_1
+lu_2020_account_64411,64411,Book value of intangible fixed assets disposed of,expense,FALSE,lu_2011_chart_1
 lu_2020_account_64412,64412,Disposal proceeds of intangible fixed assets,expense,FALSE,lu_2011_chart_1
-lu_2020_account_64421,64421,Book value of yielded tangible fixed assets,expense,FALSE,lu_2011_chart_1
+lu_2020_account_64421,64421,Book value of tangible fixed assets disposed of,expense,FALSE,lu_2011_chart_1
 lu_2020_account_64422,64422,Disposal proceeds of tangible fixed assets,expense,FALSE,lu_2011_chart_1
 lu_2011_account_6451,6451,Trade receivables,expense,FALSE,lu_2011_chart_1
 lu_2011_account_6452,6452,Amounts owed by affiliated undertakings,expense,FALSE,lu_2011_chart_1
@@ -525,15 +525,15 @@ lu_2020_account_65213,65213,Participating interests,expense,FALSE,lu_2011_chart_
 lu_2020_account_65214,65214,Amounts owed by undertakings with which the undertaking is linked by virtue of participating interests,expense,FALSE,lu_2011_chart_1
 lu_2020_account_65215,65215,Securities held as fixed assets,expense,FALSE,lu_2011_chart_1
 lu_2020_account_65216,65216,"Loans, deposits and claims held as fixed assets",expense,FALSE,lu_2011_chart_1
-lu_2020_account_652211,652211,Book value of yielded shares in affiliated undertakings,expense,FALSE,lu_2011_chart_1
+lu_2020_account_652211,652211,Book value of shares in affiliated undertakings disposed of,expense,FALSE,lu_2011_chart_1
 lu_2020_account_652212,652212,Disposal proceeds of shares in affiliated undertakings,expense,FALSE,lu_2011_chart_1
-lu_2020_account_652221,652221,Book value of yielded amounts owed by affiliated undertakings,expense,FALSE,lu_2011_chart_1
+lu_2020_account_652221,652221,Book value of amounts owed by affiliated undertakings disposed of,expense,FALSE,lu_2011_chart_1
 lu_2020_account_652222,652222,Disposal proceeds of amounts owed by affiliated undertakings,expense,FALSE,lu_2011_chart_1
-lu_2020_account_652231,652231,Book value of yielded participating interests,expense,FALSE,lu_2011_chart_1
+lu_2020_account_652231,652231,Book value of participating interests disposed of,expense,FALSE,lu_2011_chart_1
 lu_2020_account_652232,652232,Disposal proceeds of participating interests,expense,FALSE,lu_2011_chart_1
-lu_2020_account_652241,652241,Book value of yielded amounts owed by undertakings with which the undertaking is linked by virtue of participating interests,expense,FALSE,lu_2011_chart_1
+lu_2020_account_652241,652241,Book value of amounts owed by undertakings with which the undertaking is linked by virtue of participating interests disposed of,expense,FALSE,lu_2011_chart_1
 lu_2020_account_652242,652242,Disposal proceeds of amounts owed by undertakings with which the undertaking is linked by virtue of participating interests,expense,FALSE,lu_2011_chart_1
-lu_2020_account_652251,652251,Book value of yielded securities held as fixed assets,expense,FALSE,lu_2011_chart_1
+lu_2020_account_652251,652251,Book value of securities held as fixed assets disposed of,expense,FALSE,lu_2011_chart_1
 lu_2020_account_652252,652252,Disposal proceeds of securities held as fixed assets,expense,FALSE,lu_2011_chart_1
 lu_2020_account_652261,652261,"Book value of yielded loans, deposits and claims held as fixed assets",expense,FALSE,lu_2011_chart_1
 lu_2020_account_652262,652262,"Disposal proceeds of loans, deposits and claims held as fixed assets",expense,FALSE,lu_2011_chart_1

--- a/addons/l10n_lu/data/account.group.template.csv
+++ b/addons/l10n_lu/data/account.group.template.csv
@@ -613,10 +613,10 @@ account_group_6432,6432,,"Director's fees",l10n_lu.lu_2011_chart_1
 account_group_6438,6438,,"Other similar remuneration",l10n_lu.lu_2011_chart_1
 account_group_644,644,,"Loss on disposal of intangible and tangible fixed assets",l10n_lu.lu_2011_chart_1
 account_group_6441,6441,,"Loss on disposal of intangible fixed assets",l10n_lu.lu_2011_chart_1
-account_group_64411,64411,,"Book value of yielded intangible fixed assets",l10n_lu.lu_2011_chart_1
+account_group_64411,64411,,"Book value of intangible fixed assets disposed of",l10n_lu.lu_2011_chart_1
 account_group_64412,64412,,"Disposal proceeds of intangible fixed assets",l10n_lu.lu_2011_chart_1
 account_group_6442,6442,,"Loss on disposal of tangible fixed assets",l10n_lu.lu_2011_chart_1
-account_group_64421,64421,,"Book value of yielded tangible fixed assets",l10n_lu.lu_2011_chart_1
+account_group_64421,64421,,"Book value of tangible fixed assets disposed of",l10n_lu.lu_2011_chart_1
 account_group_64422,64422,,"Disposal proceeds of tangible fixed assets",l10n_lu.lu_2011_chart_1
 account_group_645,645,,"Losses on bad debts",l10n_lu.lu_2011_chart_1
 account_group_6451,6451,,"Trade receivables",l10n_lu.lu_2011_chart_1
@@ -661,19 +661,19 @@ account_group_65215,65215,,"Securities held as fixed assets",l10n_lu.lu_2011_cha
 account_group_65216,65216,,"Loans, deposits and claims held as fixed assets",l10n_lu.lu_2011_chart_1
 account_group_6522,6522,,"Loss on disposal of financial fixed assets",l10n_lu.lu_2011_chart_1
 account_group_65221,65221,,"Loss on disposal of shares in affiliated undertakings",l10n_lu.lu_2011_chart_1
-account_group_652211,652211,,"Book value of yielded shares in affiliated undertakings",l10n_lu.lu_2011_chart_1
+account_group_652211,652211,,"Book value of shares in affiliated undertakings disposed of",l10n_lu.lu_2011_chart_1
 account_group_652212,652212,,"Disposal proceeds of shares in affiliated undertakings",l10n_lu.lu_2011_chart_1
 account_group_65222,65222,,"Loss on disposal of amounts owed by affiliated undertakings",l10n_lu.lu_2011_chart_1
-account_group_652221,652221,,"Book value of yielded amounts owed by affiliated undertakings",l10n_lu.lu_2011_chart_1
+account_group_652221,652221,,"Book value of amounts owed by affiliated undertakings disposed of",l10n_lu.lu_2011_chart_1
 account_group_652222,652222,,"Disposal proceeds of amounts owed by affiliated undertakings",l10n_lu.lu_2011_chart_1
 account_group_65223,65223,,"Loss on disposal of participating interests",l10n_lu.lu_2011_chart_1
-account_group_652231,652231,,"Book value of yielded participating interests",l10n_lu.lu_2011_chart_1
+account_group_652231,652231,,"Book value of participating interests disposed of",l10n_lu.lu_2011_chart_1
 account_group_652232,652232,,"Disposal proceeds of participating interests",l10n_lu.lu_2011_chart_1
 account_group_65224,65224,,"Loss on disposal of amounts owed by undertakings with which the undertaking is linked by virtue of participating interests",l10n_lu.lu_2011_chart_1
-account_group_652241,652241,,"Book value of yielded amounts owed by undertakings with which the undertaking is linked by virtue of participating interests",l10n_lu.lu_2011_chart_1
+account_group_652241,652241,,"Book value of amounts owed by undertakings with which the undertaking is linked by virtue of participating interests disposed of",l10n_lu.lu_2011_chart_1
 account_group_652242,652242,,"Disposal proceeds of amounts owed by undertakings with which the undertaking is linked by virtue of participating interests",l10n_lu.lu_2011_chart_1
 account_group_65225,65225,,"Loss on disposal of securities held as fixed assets",l10n_lu.lu_2011_chart_1
-account_group_652251,652251,,"Book value of yielded securities held as fixed assets",l10n_lu.lu_2011_chart_1
+account_group_652251,652251,,"Book value of securities held as fixed assets disposed of",l10n_lu.lu_2011_chart_1
 account_group_652252,652252,,"Disposal proceeds of securities held as fixed assets",l10n_lu.lu_2011_chart_1
 account_group_65226,65226,,"Loss on disposal of loans, deposits and claims held as fixed assets",l10n_lu.lu_2011_chart_1
 account_group_652261,652261,,"Book value of yielded loans, deposits and claims held as fixed assets",l10n_lu.lu_2011_chart_1

--- a/addons/l10n_lu/data/account_tax_report_line.xml
+++ b/addons/l10n_lu/data/account_tax_report_line.xml
@@ -71,7 +71,7 @@
                     <record id="account_tax_report_line_1b_exemptions_deductible_amounts" model="account.report.line">
                         <field name="name">021 - Exemptions and deductible amounts</field>
                         <field name="code">LUTAX_021</field>
-                        <field name="aggregation_formula">LUTAX_014.balance + LUTAX_457.balance + LUTAX_015.balance + LUTAX_016.balance + LUTAX_017.balance + LUTAX_018.balance + LUTAX_423.balance + LUTAX_424.balance + LUTAX_226.balance + LUTAX_019.balance + LUTAX_419.balance</field>
+                        <field name="aggregation_formula">LUTAX_014.balance + LUTAX_457.balance + LUTAX_015.balance + LUTAX_016.balance + LUTAX_017.balance + LUTAX_018.balance + LUTAX_423.balance + LUTAX_424.balance + LUTAX_226.balance + LUTAX_019.balance + LUTAX_419.balance + LUTAX_481.balance + LUTAX_482.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_1b_1_intra_community_goods_pi_vat" model="account.report.line">
                                 <field name="name">457 - Intra-Community supply of goods to persons identified for VAT purposes in another Member State (MS)</field>
@@ -173,7 +173,7 @@
                                 </field>
                             </record>
                             <record id="account_tax_report_line_1b_6_d_supplies_other_referred" model="account.report.line">
-                                <field name="name">019 - Supplies other than referred to in 018 and 423 or 424</field>
+                                <field name="name">019 - Other supplies carried out (for which the place of supply is) abroad</field>
                                 <field name="code">LUTAX_019</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_1b_6_d_supplies_other_referred_tag" model="account.report.expression">
@@ -191,6 +191,30 @@
                                         <field name="label">balance</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">419</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_8_supplies_carried_out_domestic" model="account.report.line">
+                                <field name="name">481 - Supplies carried out within the scope of the domestic SME scheme of article 57bis (7)</field>
+                                <field name="code">LUTAX_481</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_8_supplies_carried_out_domestic_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_9_supplies_carried_out_cross_border" model="account.report.line">
+                                <field name="name">482 - Supplies carried out within the scope of the cross-border SME scheme of article 57 quater</field>
+                                <field name="code">LUTAX_482</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_9_supplies_carried_out_cross_border_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable</field>
                                     </record>
                                 </field>
                             </record>

--- a/addons/l10n_lu/i18n_extra/de.po
+++ b/addons/l10n_lu/i18n_extra/de.po
@@ -17,136 +17,163 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-IC-EX
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-IC-EX
 msgid " EX-IC-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_V-ART-43_60b
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_V-ART-43_60b
 msgid "0-E-Art.43&60b"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_V-ART-44_56q
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_V-ART-44_56q
 msgid "0-E-Art.44&56q"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-PA-0
 msgid "0-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-PA-0
 msgid "0-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-0
 msgid "0-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-EC-0
 msgid "0-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-EC-0
 msgid "0-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-EC-0
 msgid "0-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-EC-0
 msgid "0-EC-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-EC-0
 msgid "0-EC-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-EC-Tab
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-EC-Tab
 msgid "0-EC-ST-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-IC-0
 msgid "0-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-IC-0
 msgid "0-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-IC-0
 msgid "0-IC-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-IC-0
 msgid "0-IC-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-IC-Tab
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-IC-Tab
 msgid "0-IC-ST-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-TR-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-TR-0
 msgid "0-ICT-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-PA-0
 msgid "0-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-PA-0
 msgid "0-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-PA-0
 msgid "0-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-PA-0
 msgid "0-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_SANS
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_SANS
 msgid "0-P-Tax-Free"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-PA-0
 msgid "0-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-PA-0
 msgid "0-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_SANS_sale
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_SANS_sale
 msgid "0-S-Tax-Free"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-PA-Tab
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-PA-Tab
 msgid "0-ST-G"
 msgstr ""
@@ -157,19 +184,9 @@ msgid "012 - Overall turnover"
 msgstr "012 - Gesamtumsatz"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
-msgid "014"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014 - Exports"
 msgstr "014 - Ausfuhren"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
-msgid "015"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
@@ -177,19 +194,9 @@ msgid "015 - Other exemptions"
 msgstr "015 - Andere Befreiungen"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
-msgid "016"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016 - Other exemptions"
 msgstr "016 - Andere Befreiungen"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
-msgid "017"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
@@ -201,27 +208,18 @@ msgstr ""
 "Steuerlagers gemeinsam mit den Verbrauchsteuern erhoben wurde"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
-msgid "018"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
 msgid ""
 "018 - Supply, subsequent to intra-Community acquisitions of goods, in the "
 "context of triangular transactions, when the customer identified,..."
 msgstr ""
-"018 - An innergemeinschaftliche Erwerbe anschließende Lieferungen im Rahmen von "
-"Dreiecksgeschäften..."
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
-msgid "019"
-msgstr ""
+"018 - An innergemeinschaftliche Erwerbe anschließende Lieferungen im Rahmen "
+"von Dreiecksgeschäften..."
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
-msgid "019 - Supplies other than referred to in 018 and 423 or 424"
+msgid ""
+"019 - Other supplies carried out (for which the place of supply is) abroad"
 msgstr "019 - Andere im Ausland getätigte (steuerpflichtige) Umsätze"
 
 #. module: l10n_lu
@@ -235,19 +233,9 @@ msgid "022 - Taxable turnover"
 msgstr "022 - Steuerpflichtiger Umsatz"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
-msgid "031"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031 - base 3%"
 msgstr "031 - Besteuerungsgrundlage 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
-msgid "033"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
@@ -260,11 +248,6 @@ msgid "037 - Breakdown of taxable turnover – base"
 msgstr "037 - Steuerpflichtiger Umsatz: Aufteilung - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
-msgid "040"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040 - tax 3%"
 msgstr "040 - MwSt. 3%"
@@ -275,11 +258,6 @@ msgid "046 - Breakdown of taxable turnover – tax"
 msgstr "046 - Steuerpflichtiger Umsatz: Aufteilung - MwSt."
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
-msgid "049"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049 - base 3%"
 msgstr "049 - Besteuerungsgrundlage 3%"
@@ -287,12 +265,9 @@ msgstr "049 - Besteuerungsgrundlage 3%"
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
 msgid "051 - Intra-Community acquisitions of goods – base"
-msgstr "051 - Innergemeinschaftliche Erwerbe von Gegenständen - Besteuerungsgrundlage"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
-msgid "054"
 msgstr ""
+"051 - Innergemeinschaftliche Erwerbe von Gegenständen - "
+"Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
@@ -305,19 +280,9 @@ msgid "056 - Intra-Community acquisitions of goods – tax"
 msgstr "056 - Innergemeinschaftliche Erwerbe von Gegenständen - MwSt."
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
-msgid "059"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059 - for business purposes: base 3%"
 msgstr "059 - für Zwecke des Unternehmens: Besteuerungsgrundlage 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
-msgid "063"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
@@ -330,19 +295,9 @@ msgid "065 - Importation of goods – base"
 msgstr "065 - Einfuhren von Gegenständen - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
-msgid "068"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068 - for business purposes: tax 3%"
 msgstr "068 - für Zwecke des Unternehmens: MwSt. 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
-msgid "073"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
@@ -355,21 +310,11 @@ msgid "076 - Total tax due"
 msgstr "076 - Gesamtbetrag der Steuer"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
-msgid "090"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090 - Due in respect of the application of goods for business purposes"
 msgstr ""
 "090 - Erklärte Mehrwertsteuer für die Zuordnung von Gegenständen zu Zwecken "
 "des Unternehmens"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
-msgid "092"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
@@ -387,29 +332,26 @@ msgid ""
 "094 - relating to transactions which are exempt pursuant to articles 44 and "
 "56quater"
 msgstr ""
-"094 - Nicht abziehbare Vorsteuer betreffend die gemäß Art. 44 und Art. 56quater "
-"steuerfreien Umsätze"
+"094 - Nicht abziehbare Vorsteuer betreffend die gemäß Art. 44 und Art. "
+"56quater steuerfreien Umsätze"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
 msgid ""
-"095 - where the deductible proportion determined in accordance to article 50 "
-"is applied"
+"095 - where the deductible proportion determined in accordance to article 50"
+" is applied"
 msgstr ""
 "095 - Nicht abziehbare Vorsteuer in Anwendung der in Art. 50 vorgesehenen "
 "Prorata-Regel"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
-msgid "096"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
 msgid ""
 "096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and "
 "56ter-2(7) (when applying the margin scheme)"
-msgstr "096 - Nicht abziehbare Vorsteuer in Anwendung von Art. 56ter-1/7 und 56ter-2/7 "
+msgstr ""
+"096 - Nicht abziehbare Vorsteuer in Anwendung von Art. 56ter-1/7 und "
+"56ter-2/7 "
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
@@ -437,6 +379,217 @@ msgid "105 - Exceeding amount"
 msgstr "105 - Überschuss"
 
 #. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-ECP-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-ECP-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VP-PA-13
+msgid "13%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-13
+msgid "13-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-13
+msgid "13-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-13
+msgid "13-EC(P)-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-13
+msgid "13-EC(P)-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-13
+msgid "13-EC(P)-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-13
+msgid "13-EC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-13
+msgid "13-EC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-13
+msgid "13-EC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-13
+msgid "13-EC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-13
+msgid "13-EC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-13
+msgid "13-EC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-13
+msgid "13-IC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-13
+msgid "13-IC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-13
+msgid "13-IC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-13
+msgid "13-IC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-13
+msgid "13-IC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-13
+msgid "13-IC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-13
+msgid "13-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-13
+msgid "13-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-13
+msgid "13-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-13
+msgid "13-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-13
+msgid "13-S-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-13
+msgid "13-S-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-14
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-14
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-14
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-14
@@ -464,131 +617,371 @@ msgid "14%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-14
 msgid "14-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-14
 msgid "14-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-14
 msgid "14-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-14
 msgid "14-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-14
 msgid "14-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-14
 msgid "14-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-14
 msgid "14-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-14
 msgid "14-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-14
 msgid "14-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-14
 msgid "14-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-14
 msgid "14-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-14
 msgid "14-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-14
 msgid "14-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-14
 msgid "14-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-14
 msgid "14-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-14
 msgid "14-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-14
 msgid "14-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-14
 msgid "14-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-14
 msgid "14-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-14
 msgid "14-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-14
 msgid "14-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-14
 msgid "14-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-14
 msgid "14-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
-msgid "152"
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
+msgid "152 - Acquisitions, in the context of triangular transactions – base"
+msgstr ""
+"152 - Im Rahmen von Dreiecksgeschäften getätigte Erwerbe - "
+"Besteuerungsgrundlage"
+
+#. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_ATN_sale_16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_ATN_sale_16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-ECP-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-ECP-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VP-PA-16
+msgid "16%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
-msgid "152 - Acquisitions, in the context of triangular transactions – base"
-msgstr "152 - Im Rahmen von Dreiecksgeschäften getätigte Erwerbe - Besteuerungsgrundlage"
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_ATN_sale_16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_ATN_sale_16
+msgid "16-ATN"
+msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-16
+msgid "16-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-16
+msgid "16-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-16
+msgid "16-EC(P)-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-16
+msgid "16-EC(P)-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-16
+msgid "16-EC(P)-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-16
+msgid "16-EC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-16
+msgid "16-EC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-16
+msgid "16-EC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-16
+msgid "16-EC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-16
+msgid "16-EC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-16
+msgid "16-EC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-16
+msgid "16-IC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-16
+msgid "16-IC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-16
+msgid "16-IC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-16
+msgid "16-IC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-16
+msgid "16-IC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-16
+msgid "16-IC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-16
+msgid "16-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-16
+msgid "16-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-16
+msgid "16-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-16
+msgid "16-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-16
+msgid "16-S-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-16
+msgid "16-S-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_ATN_sale
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-17
@@ -596,6 +989,7 @@ msgstr "152 - Im Rahmen von Dreiecksgeschäften getätigte Erwerbe - Besteuerung
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-EC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-IC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-PA-17
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_ATN_sale
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-EC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-ECP-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-IC-17
@@ -616,123 +1010,147 @@ msgid "17%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_ATN_sale
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_ATN_sale
+msgid "17-ATN"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-17
 msgid "17-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-17
 msgid "17-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-17
 msgid "17-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-17
 msgid "17-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-17
 msgid "17-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-17
 msgid "17-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-17
 msgid "17-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-17
 msgid "17-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-17
 msgid "17-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-17
 msgid "17-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-17
 msgid "17-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-17
 msgid "17-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-17
 msgid "17-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-17
 msgid "17-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-17
 msgid "17-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-17
 msgid "17-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-17
 msgid "17-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-17
 msgid "17-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-17
 msgid "17-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-17
 msgid "17-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-17
 msgid "17-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-17
 msgid "17-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-17
 msgid "17-S-S"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_exempt
-msgid "194"
 msgstr ""
 
 #. module: l10n_lu
@@ -741,41 +1159,24 @@ msgid "194 - base exempt"
 msgstr "194 - Besteuerungsgrundlage steuerbefreit"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
-msgid "195"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195 - for business purposes: base exempt"
-msgstr "195 - für Zwecke des Unternehmens: Besteuerungsgrundlage steuerbefreit"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
-msgid "196"
 msgstr ""
+"195 - für Zwecke des Unternehmens: Besteuerungsgrundlage steuerbefreit"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196 - for non-business purposes: base exempt"
-msgstr "196 - für unternehmensfremde Zwecke: Besteuerungsgrundlage steuerbefreit"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
-msgid "226"
 msgstr ""
+"196 - für unternehmensfremde Zwecke: Besteuerungsgrundlage steuerbefreit"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
 msgid ""
 "226 - Supplies carried out within the scope of the special arrangement of "
 "art. 56sexies"
-msgstr "226 - Im Rahmen der Sonderregelung von Artikel 56sexies getätigte Umsätze"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
-msgid "227"
 msgstr ""
+"226 - Im Rahmen der Sonderregelung von Artikel 56sexies getätigte Umsätze"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
@@ -783,126 +1184,144 @@ msgid "227 - Special arrangement for tax suspension: adjustment"
 msgstr "227 - Sonderregelung zur Steueraussetzung: Berichtigung"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
-msgid "228"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228 - Adjusted tax - special arrangement for tax suspension"
 msgstr "228 - Berichtigte Steuer - Sonderregelung zur Steueraussetzung"
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-PA-3
 msgid "3-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-PA-3
 msgid "3-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-3
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-3
 msgid "3-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-3
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-3
 msgid "3-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-3
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-3
 msgid "3-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-EC-3
 msgid "3-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-EC-3
 msgid "3-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-EC-3
 msgid "3-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-EC-3
 msgid "3-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-EC-3
 msgid "3-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-EC-3
 msgid "3-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-IC-3
 msgid "3-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-IC-3
 msgid "3-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-IC-3
 msgid "3-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-IC-3
 msgid "3-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-IC-3
 msgid "3-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-IC-3
 msgid "3-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-PA-3
 msgid "3-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-PA-3
 msgid "3-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-PA-3
 msgid "3-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-PA-3
 msgid "3-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-PA-3
 msgid "3-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-PA-3
 msgid "3-S-S"
 msgstr ""
@@ -915,37 +1334,27 @@ msgstr "407 - Einfuhren von Gegenständen - MwSt."
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
 msgid ""
-"409 - Supply of services for which the customer is liable for the payment of "
-"VAT – base"
+"409 - Supply of services for which the customer is liable for the payment of"
+" VAT – base"
 msgstr ""
-"409 - Vom Empfänger als Steuerschuldner zu erklärende Dienstleistungen "
-" - Besteuerungsgrundlage"
+"409 - Vom Empfänger als Steuerschuldner zu erklärende Dienstleistungen  - "
+"Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
 msgid ""
-"410 - Supply of services for which the customer is liable for the payment of "
-"VAT – tax"
+"410 - Supply of services for which the customer is liable for the payment of"
+" VAT – tax"
 msgstr ""
-"410 - Vom Empfänger als Steuerschuldner zu erklärende Dienstleistungen "
-" - MwSt."
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
-msgid "419"
-msgstr ""
+"410 - Vom Empfänger als Steuerschuldner zu erklärende Dienstleistungen  - "
+"MwSt."
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
 msgid ""
-"419 - Inland supplies for which the customer is liable for the payment of VAT"
-msgstr ""
-"419 - Umsätze im Inland, für die der Empfänger Steuerschuldner ist"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
-msgid "423"
-msgstr ""
+"419 - Inland supplies for which the customer is liable for the payment of "
+"VAT"
+msgstr "419 - Umsätze im Inland, für die der Empfänger Steuerschuldner ist"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
@@ -956,21 +1365,11 @@ msgstr ""
 "Zwecke der MwSt. erfasst und Steuerschuldner ist, nicht steuerbefreit sind"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
-msgid "424"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424 - exempt in the MS where the customer is identified"
 msgstr ""
-"424 - Dienstleistungen, die im Mitgliedstaat des Empfängers, "
-"der dort für Zwecke der MwSt. erfasst ist, steuerbefreit sind"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
-msgid "431"
-msgstr ""
+"424 - Dienstleistungen, die im Mitgliedstaat des Empfängers, der dort für "
+"Zwecke der MwSt. erfasst ist, steuerbefreit sind"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
@@ -978,19 +1377,9 @@ msgid "431 - not exempt within the territory: base 3%"
 msgstr "431 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
-msgid "432"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432 - not exempt within the territory: tax 3%"
 msgstr "432 - nicht steuerbefreit im Inland: MwSt. 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
-msgid "435"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
@@ -1003,50 +1392,30 @@ msgid "436 - base"
 msgstr "436 - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
-msgid "441"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441 - not established or residing within the Community: base 3%"
 msgstr ""
-"441 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
-msgid "442"
-msgstr ""
+"441 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442 - not established or residing within the Community: tax 3%"
 msgstr ""
-"442 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: MwSt. 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
-msgid "445"
-msgstr ""
+"442 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: MwSt. 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445 - not established or residing within the Community: exempt"
 msgstr ""
-"445 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: steuerbefreit"
+"445 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: steuerbefreit"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
 msgid "454 - Total Sales / Receipts"
 msgstr "454 - Gesamtbetrag der Entgelte"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
-msgid "455"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
@@ -1057,44 +1426,25 @@ msgstr ""
 "unternehmensfremde Zwecke"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
-msgid "456"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456 - Non-business use of goods and supply of services free of charge"
 msgstr "456 - Erbringung von Dienstleistungen für unternehmensfremde Zwecke"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
-msgid "457"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
 msgid ""
-"457 - Intra-Community supply of goods to persons identified for VAT purposes "
-"in another Member State (MS)"
+"457 - Intra-Community supply of goods to persons identified for VAT purposes"
+" in another Member State (MS)"
 msgstr ""
-"457 - Innergemeinschaftliche Lieferungen an Personen, die eine Id.-Nummer in "
-"einem anderen Mitgliedstaat besitzen"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
-msgid "458"
-msgstr ""
+"457 - Innergemeinschaftliche Lieferungen an Personen, die eine Id.-Nummer in"
+" einem anderen Mitgliedstaat besitzen"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458 - Invoiced by other taxable persons for goods or services supplied"
-msgstr "458 - Von anderen Steuerpflichtigen für Warenlieferungen und "
-"Dienstleistungen in Rechnung gestellte Mehrwertsteuer"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
-msgid "459"
 msgstr ""
+"458 - Von anderen Steuerpflichtigen für Warenlieferungen und "
+"Dienstleistungen in Rechnung gestellte Mehrwertsteuer"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
@@ -1104,19 +1454,9 @@ msgstr ""
 "Erwerbe von Gegenständen"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
-msgid "460"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460 - Due or paid in respect of importation of goods"
 msgstr "460 - Erklärte oder bezahlte Mehrwertsteuer für eingeführte Waren"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
-msgid "461"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
@@ -1139,16 +1479,13 @@ msgid "464 - tax"
 msgstr "464 - MwSt."
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
-msgid "471"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid ""
 "471 - Telecommunications services, radio and television broadcasting "
 "services..."
-msgstr "471 - Telekommunikationsdienstleistungen, Rundfunk- und Fernsehdienstleistungen..."
+msgstr ""
+"471 - Telekommunikationsdienstleistungen, Rundfunk- und "
+"Fernsehdienstleistungen..."
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
@@ -1156,8 +1493,159 @@ msgid "472 - Other sales / receipts"
 msgstr "472 - Andere Umsätze / Erträge"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
-msgid "701"
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_8_supplies_carried_out_domestic
+msgid ""
+"481 - Supplies carried out within the scope of the domestic SME scheme of "
+"article 57bis (7)"
+msgstr ""
+"481 - Im Rahmen der nationalen Sonderregelung für Kleinunternehmer gemäβ Artikel "
+"57bis getätigte Umsätze (17)"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_9_supplies_carried_out_cross_border
+msgid ""
+"482 - Supplies carried out within the scope of the cross-border SME scheme "
+"of article 57 quater"
+msgstr ""
+"482 - Im Rahmen der grenzüberschreitenden Sonderregelung für Kleinunternehmer "
+"gemäβ Artikel 57quater getätigte Umsätze"
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-7
+msgid "7-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-7
+msgid "7-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-7
+msgid "7-EC(P)-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-7
+msgid "7-EC(P)-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-7
+msgid "7-EC(P)-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-7
+msgid "7-EC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-7
+msgid "7-EC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-7
+msgid "7-EC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-7
+msgid "7-EC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-7
+msgid "7-EC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-7
+msgid "7-EC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-7
+msgid "7-IC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-7
+msgid "7-IC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-7
+msgid "7-IC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-7
+msgid "7-IC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-7
+msgid "7-IC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-7
+msgid "7-IC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-7
+msgid "7-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-7
+msgid "7-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-7
+msgid "7-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-7
+msgid "7-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-7
+msgid "7-S-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-7
+msgid "7-S-S"
 msgstr ""
 
 #. module: l10n_lu
@@ -1166,19 +1654,9 @@ msgid "701 - base 17%"
 msgstr "701 - Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
-msgid "702"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702 - tax 17%"
 msgstr "702 - MwSt. 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
-msgid "703"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
@@ -1186,19 +1664,9 @@ msgid "703 - base 14%"
 msgstr "703 - Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
-msgid "704"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704 - tax 14%"
 msgstr "704 - MwSt. 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
-msgid "705"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
@@ -1206,19 +1674,9 @@ msgid "705 - base 8%"
 msgstr "705 - Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
-msgid "706"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706 - tax 8%"
 msgstr "706 - MwSt. 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
-msgid "711"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
@@ -1226,19 +1684,9 @@ msgid "711 - base 17%"
 msgstr "711 - Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
-msgid "712"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712 - tax 17%"
 msgstr "712 - MwSt. 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
-msgid "713"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
@@ -1246,19 +1694,9 @@ msgid "713 - base 14%"
 msgstr "713 - Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
-msgid "714"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714 - tax 14%"
 msgstr "714 - MwSt. 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
-msgid "715"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
@@ -1266,19 +1704,9 @@ msgid "715 - base 8%"
 msgstr "715 - Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
-msgid "716"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716 - tax 8%"
 msgstr "716 - MwSt. 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
-msgid "719"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
@@ -1290,19 +1718,9 @@ msgstr ""
 "gemeinsam mit den Verbrauchsteuern erhoben wird"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
-msgid "721"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721 - for business purposes: base 17%"
 msgstr "721 - für Zwecke des Unternehmens: Besteuerungsgrundlage 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
-msgid "722"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
@@ -1310,19 +1728,9 @@ msgid "722 - for business purposes: tax 17%"
 msgstr "722 - für Zwecke des Unternehmens: MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
-msgid "723"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723 - for business purposes: base 14%"
 msgstr "723 - für Zwecke des Unternehmens: Besteuerungsgrundlage 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
-msgid "724"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
@@ -1330,29 +1738,14 @@ msgid "724 - for business purposes: tax 14%"
 msgstr "724 - für Zwecke des Unternehmens: MwSt. 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
-msgid "725"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725 - for business purposes: base 8%"
 msgstr "725 - für Zwecke des Unternehmens: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
-msgid "726"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
 msgstr "726 - für Zwecke des Unternehmens: MwSt. 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
-msgid "729"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
@@ -1364,19 +1757,9 @@ msgstr ""
 "gemeinsam mit den Verbrauchsteuern erhoben wird"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
-msgid "731"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731 - for non-business purposes: base 17%"
 msgstr "731 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
-msgid "732"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
@@ -1384,19 +1767,9 @@ msgid "732 - for non-business purposes: tax 17%"
 msgstr "732 - für unternehmensfremde Zwecke: MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
-msgid "733"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733 - for non-business purposes: base 14%"
 msgstr "733 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
-msgid "734"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
@@ -1404,19 +1777,9 @@ msgid "734 - for non-business purposes: tax 14%"
 msgstr "734 - für unternehmensfremde Zwecke: MwSt. 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
-msgid "735"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735 - for non-business purposes: base 8%"
 msgstr "735 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
-msgid "736"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
@@ -1424,19 +1787,9 @@ msgid "736 - for non-business purposes: tax 8%"
 msgstr "736 - für unternehmensfremde Zwecke: MwSt. 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
-msgid "741"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741 - not exempt within the territory: base 17%"
 msgstr "741 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
-msgid "742"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
@@ -1444,19 +1797,9 @@ msgid "742 - not exempt within the territory: tax 17%"
 msgstr "742 - nicht steuerbefreit im Inland: MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
-msgid "743"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743 - not exempt within the territory: base 14%"
 msgstr "743 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
-msgid "744"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
@@ -1464,19 +1807,9 @@ msgid "744 - not exempt within the territory: tax 14%"
 msgstr "744 - nicht steuerbefreit im Inland: MwSt. 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
-msgid "745"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745 - not exempt within the territory: base 8%"
 msgstr "745 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
-msgid "746"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
@@ -1484,113 +1817,65 @@ msgid "746 - not exempt within the territory: tax 8%"
 msgstr "746 - nicht steuerbefreit im Inland: MwSt. 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
-msgid "751"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751 - not established or residing within the Community: base 17%"
 msgstr ""
-"751 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
-msgid "752"
-msgstr ""
+"751 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752 - not established or residing within the Community: tax 17%"
 msgstr ""
-"752 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: MwSt. 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
-msgid "753"
-msgstr ""
+"752 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: MwSt. 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753 - not established or residing within the Community: base 14%"
 msgstr ""
-"753 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
-msgid "754"
-msgstr ""
+"753 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754 - not established or residing within the Community: tax 14%"
 msgstr ""
-"754 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: MwSt. 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
-msgid "755"
-msgstr ""
+"754 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: MwSt. 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755 - not established or residing within the Community: base 8%"
 msgstr ""
-"755 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
-msgid "756"
-msgstr ""
+"755 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756 - not established or residing within the Community: tax 8%"
-msgstr "756 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: MwSt. 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
-msgid "761"
 msgstr ""
+"756 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: MwSt. 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761 - suppliers established within the territory: base 17%"
 msgstr ""
-"761 - erbracht an den Erklärenden von im Inland ansässigen Steuerpflichtigen: "
-"Besteuerungsgrundlage 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
-msgid "762"
-msgstr ""
+"761 - erbracht an den Erklärenden von im Inland ansässigen "
+"Steuerpflichtigen: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762 - suppliers established within the territory: tax 17%"
-msgstr "762 - erbracht an den Erklärenden von im Inland ansässigen "
-"Steuerpflichtigen: MwSt. 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
-msgid "763"
 msgstr ""
+"762 - erbracht an den Erklärenden von im Inland ansässigen "
+"Steuerpflichtigen: MwSt. 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763 - base 8%"
 msgstr "763 - Besteuerungsgrundlage 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
-msgid "764"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
@@ -1613,7 +1898,8 @@ msgid ""
 "767 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - base"
 msgstr ""
-"767 - Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - Besteuerungsgrundlage"
+"767 - Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - "
+"Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
@@ -1624,202 +1910,152 @@ msgstr ""
 "768 - Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - MwSt."
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_17
+msgid "769 - base 17%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_17
+msgid "770 - tax 17%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-8
 msgid "8-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-8
 msgid "8-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-8
 msgid "8-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-8
 msgid "8-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-8
 msgid "8-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-8
 msgid "8-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-8
 msgid "8-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-8
 msgid "8-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-8
 msgid "8-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-8
 msgid "8-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-8
 msgid "8-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-8
 msgid "8-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-8
 msgid "8-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-8
 msgid "8-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-8
 msgid "8-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-8
 msgid "8-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-8
 msgid "8-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-8
 msgid "8-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-8
 msgid "8-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-8
 msgid "8-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-8
 msgid "8-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-8
 msgid "8-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-8
 msgid "8-S-S"
 msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_16
-msgid "921 - for business purposes: base 16%"
-msgstr "921 - für Zwecke des Unternehmens: Besteuerungsgrundlage 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_13
-msgid "923 - for business purposes: base 13%"
-msgstr "923 - für Zwecke des Unternehmens: Besteuerungsgrundlage 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_7
-msgid "925 - for business purposes: base 7%"
-msgstr "925 - für Zwecke des Unternehmens: Besteuerungsgrundlage 7%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_16
-msgid "931 - for non-business purposes: base 16%"
-msgstr "931 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_13
-msgid "933 - for non-business purposes: base 13%"
-msgstr "933 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_7
-msgid "935 - for non-business purposes: base 7%"
-msgstr "935 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 7%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_16
-msgid "941 - not exempt within the territory: base 16%"
-msgstr "941 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_13
-msgid "943 - not exempt within the territory: base 13%"
-msgstr "943 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_7
-msgid "945 - not exempt within the territory: base 7%"
-msgstr "945 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 7%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_16
-msgid "951 - not established or residing within the Community: base 16%"
-msgstr ""
-"951 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_13
-msgid "953 - not established or residing within the Community: base 13%"
-msgstr ""
-"953 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_7
-msgid "955 - not established or residing within the Community: base 7%"
-msgstr ""
-"955 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 7%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_16
-msgid "961 - suppliers established within the territory: base 16%"
-msgstr ""
-"961 - erbracht an den Erklärenden von im Inland ansässigen Steuerpflichtigen: "
-"Besteuerungsgrundlage 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_7
-msgid "963 - base 7%"
-msgstr "963 - Besteuerungsgrundlage 7%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_7
-msgid "964 - tax 7%"
-msgstr "964 - MwSt. 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_16
@@ -1827,24 +2063,24 @@ msgid "901 - base 16%"
 msgstr "901 - Besteuerungsgrundlage 16%"
 
 #. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_13
-msgid "903 - base 13%"
-msgstr "903 - Besteuerungsgrundlage 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_7
-msgid "905 - base 7%"
-msgstr "905 - Besteuerungsgrundlage 7%"
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_16
 msgid "902 - tax 16%"
 msgstr "902 - MwSt. 16%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_13
+msgid "903 - base 13%"
+msgstr "903 - Besteuerungsgrundlage 13%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_13
 msgid "904 - tax 13%"
 msgstr "904 - MwSt. 13%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_7
+msgid "905 - base 7%"
+msgstr "905 - Besteuerungsgrundlage 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_7
@@ -1857,19 +2093,14 @@ msgid "911 - base 16%"
 msgstr "911 - Besteuerungsgrundlage 16%"
 
 #. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_13
-msgid "913 - base 13%"
-msgstr "913 - Besteuerungsgrundlage 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_7
-msgid "915 - base 7%"
-msgstr "915 - Besteuerungsgrundlage 7%"
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_16
 msgid "912 - tax 16%"
 msgstr "912 - MwSt. 16%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_13
+msgid "913 - base 13%"
+msgstr "913 - Besteuerungsgrundlage 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_13
@@ -1877,9 +2108,19 @@ msgid "914 - tax 13%"
 msgstr "914 - MwSt. 13%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_7
+msgid "915 - base 7%"
+msgstr "915 - Besteuerungsgrundlage 7%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_7
 msgid "916 - tax 7%"
 msgstr "916 - MwSt. 7%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_16
+msgid "921 - for business purposes: base 16%"
+msgstr "921 - für Zwecke des Unternehmens: Besteuerungsgrundlage 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_16
@@ -1887,9 +2128,19 @@ msgid "922 - for business purposes: tax 16%"
 msgstr "922 - für Zwecke des Unternehmens: MwSt. 16%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_13
+msgid "923 - for business purposes: base 13%"
+msgstr "923 - für Zwecke des Unternehmens: Besteuerungsgrundlage 13%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_13
 msgid "924 - for business purposes: tax 13%"
 msgstr "924 - für Zwecke des Unternehmens: MwSt. 13%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_7
+msgid "925 - for business purposes: base 7%"
+msgstr "925 - für Zwecke des Unternehmens: Besteuerungsgrundlage 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_7
@@ -1897,9 +2148,19 @@ msgid "926 - for business purposes: tax 7%"
 msgstr "926 - für Zwecke des Unternehmens: MwSt. 7%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_16
+msgid "931 - for non-business purposes: base 16%"
+msgstr "931 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 16%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_16
 msgid "932 - for non-business purposes: tax 16%"
 msgstr "932 - für unternehmensfremde Zwecke: MwSt. 16%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_13
+msgid "933 - for non-business purposes: base 13%"
+msgstr "933 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_13
@@ -1907,9 +2168,19 @@ msgid "934 - for non-business purposes: tax 13%"
 msgstr "934 - für unternehmensfremde Zwecke: MwSt. 13%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_7
+msgid "935 - for non-business purposes: base 7%"
+msgstr "935 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 7%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_7
 msgid "936 - for non-business purposes: tax 7%"
 msgstr "936 - für unternehmensfremde Zwecke: MwSt. 7%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_16
+msgid "941 - not exempt within the territory: base 16%"
+msgstr "941 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_16
@@ -1917,9 +2188,19 @@ msgid "942 - not exempt within the territory: tax 16%"
 msgstr "942 - nicht steuerbefreit im Inland: MwSt. 16%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_13
+msgid "943 - not exempt within the territory: base 13%"
+msgstr "943 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 13%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_13
 msgid "944 - not exempt within the territory: tax 13%"
 msgstr "944 - nicht steuerbefreit im Inland: MwSt. 13%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_7
+msgid "945 - not exempt within the territory: base 7%"
+msgstr "945 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_7
@@ -1927,64 +2208,114 @@ msgid "946 - not exempt within the territory: tax 7%"
 msgstr "946 - nicht steuerbefreit im Inland: MwSt. 7%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_16
+msgid "951 - not established or residing within the Community: base 16%"
+msgstr ""
+"951 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: Besteuerungsgrundlage 16%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_16
 msgid "952 - not established or residing within the Community: tax 16%"
 msgstr ""
-"952 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: MwSt. 16%"
+"952 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: MwSt. 16%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_13
+msgid "953 - not established or residing within the Community: base 13%"
+msgstr ""
+"953 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: Besteuerungsgrundlage 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_13
 msgid "954 - not established or residing within the Community: tax 13%"
 msgstr ""
-"954 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: MwSt. 13%"
+"954 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: MwSt. 13%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_7
+msgid "955 - not established or residing within the Community: base 7%"
+msgstr ""
+"955 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: Besteuerungsgrundlage 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_7
 msgid "956 - not established or residing within the Community: tax 7%"
 msgstr ""
-"956 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
-"in der Gemeinschaft ansässig sind: MwSt. 7%"
+"956 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht in der "
+"Gemeinschaft ansässig sind: MwSt. 7%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_16
+msgid "961 - suppliers established within the territory: base 16%"
+msgstr ""
+"961 - erbracht an den Erklärenden von im Inland ansässigen "
+"Steuerpflichtigen: Besteuerungsgrundlage 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_16
 msgid "962 - suppliers established within the territory: tax 16%"
-msgstr "962 - erbracht an den Erklärenden von im Inland ansässigen "
+msgstr ""
+"962 - erbracht an den Erklärenden von im Inland ansässigen "
 "Steuerpflichtigen: MwSt. 16%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_7
+msgid "963 - base 7%"
+msgstr "963 - Besteuerungsgrundlage 7%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_7
+msgid "964 - tax 7%"
+msgstr "964 - MwSt. 7%"
+
+#. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46128
+#: model:account.group,name:l10n_lu.2_account_group_46128
 #: model:account.group.template,name:l10n_lu.account_group_46128
 msgid "ACD - Other amounts payable"
 msgstr "ACD - Sonstige Verbindlichkeiten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42148
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42148
+#: model:account.group,name:l10n_lu.2_account_group_42148
 #: model:account.group.template,name:l10n_lu.account_group_42148
 msgid "ACD - Other amounts receivable"
 msgstr "ACD - Sonstige Verbindlichkeiten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_46148
 #: model:account.account.template,name:l10n_lu.lu_2020_account_46148
+#: model:account.group,name:l10n_lu.2_account_group_46148
 #: model:account.group.template,name:l10n_lu.account_group_46148
 msgid "AED - Other debts"
 msgstr ""
 "Steuerverwaltung - Indirekte Steuern (AED) - Sonstige Verbindlichkeiten"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_635
 #: model:account.group.template,name:l10n_lu.account_group_635
 msgid "AVA and FVA on receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65112
+#: model:account.group,name:l10n_lu.2_account_group_65112
 #: model:account.group.template,name:l10n_lu.account_group_65112
 msgid "AVA on amounts owed by affiliated undertakings"
 msgstr "ZWb von Forderungen gegen verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6352
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6352
+#: model:account.group,name:l10n_lu.2_account_group_6352
 #: model:account.group.template,name:l10n_lu.account_group_6352
 msgid ""
 "AVA on amounts owed by affiliated undertakings and undertakings with which "
@@ -1994,7 +2325,9 @@ msgstr ""
 "ein Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65114
+#: model:account.group,name:l10n_lu.2_account_group_65114
 #: model:account.group.template,name:l10n_lu.account_group_65114
 msgid ""
 "AVA on amounts owed by undertakings with which the undertaking is linked by "
@@ -2004,13 +2337,17 @@ msgstr ""
 "besteht"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_63313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_63313
+#: model:account.group,name:l10n_lu.2_account_group_63313
 #: model:account.group.template,name:l10n_lu.account_group_63313
 msgid "AVA on buildings"
 msgstr "ZWb von Bauten / Gebäuden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6322
+#: model:account.group,name:l10n_lu.2_account_group_6322
 #: model:account.group.template,name:l10n_lu.account_group_6322
 msgid ""
 "AVA on concessions, patents, licences, trademarks and similar rights and "
@@ -2020,13 +2357,17 @@ msgstr ""
 "Rechten und Werten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6321
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6321
+#: model:account.group,name:l10n_lu.2_account_group_6321
 #: model:account.group.template,name:l10n_lu.account_group_6321
 msgid "AVA on development costs"
 msgstr "ZWb von Entwicklungskosten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6324
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6324
+#: model:account.group,name:l10n_lu.2_account_group_6324
 #: model:account.group.template,name:l10n_lu.account_group_6324
 msgid "AVA on down payments and intangible fixed assets under development"
 msgstr ""
@@ -2034,19 +2375,25 @@ msgstr ""
 "Entwicklung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6334
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6334
+#: model:account.group,name:l10n_lu.2_account_group_6334
 #: model:account.group.template,name:l10n_lu.account_group_6334
 msgid "AVA on down payments and tangible fixed assets under development"
 msgstr "ZWb von geleisteten Anzahlungen und Anlagen im Bau"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6345
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6345
+#: model:account.group,name:l10n_lu.2_account_group_6345
 #: model:account.group.template,name:l10n_lu.account_group_6345
 msgid "AVA on down payments on inventories"
 msgstr "ZWb von geleisteten Anzahlungen auf Vorräte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6313
+#: model:account.group,name:l10n_lu.2_account_group_6313
 #: model:account.group.template,name:l10n_lu.account_group_6313
 msgid ""
 "AVA on expenses for capital increases and various operations (mergers, "
@@ -2056,88 +2403,113 @@ msgstr ""
 "Spaltungen und Umwandlungen)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6511
 #: model:account.group.template,name:l10n_lu.account_group_6511
 msgid "AVA on financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_63314
 #: model:account.account.template,name:l10n_lu.lu_2020_account_63314
+#: model:account.group,name:l10n_lu.2_account_group_63314
 #: model:account.group.template,name:l10n_lu.account_group_63314
 msgid "AVA on fixtures and fittings-out of buildings"
 msgstr "ZWb von Einrichtungen von Bauten/Gebäuden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_63312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_63312
+#: model:account.group,name:l10n_lu.2_account_group_63312
 #: model:account.group.template,name:l10n_lu.account_group_63312
 msgid "AVA on fixtures and fittings-out of land"
 msgstr "ZWb von Erschließungen von Grundstücken"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_631
 #: model:account.group.template,name:l10n_lu.account_group_631
 msgid "AVA on formation expenses and similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6323
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6323
+#: model:account.group,name:l10n_lu.2_account_group_6323
 #: model:account.group.template,name:l10n_lu.account_group_6323
 msgid "AVA on goodwill acquired for consideration"
 msgstr ""
 "ZWb vom Geschäfts- oder Firmenwert, soweit er entgeltlich erworben wurde"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_632
 #: model:account.group.template,name:l10n_lu.account_group_632
 msgid "AVA on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_634
 #: model:account.group.template,name:l10n_lu.account_group_634
 msgid "AVA on inventories"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6343
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6343
+#: model:account.group,name:l10n_lu.2_account_group_6343
 #: model:account.group.template,name:l10n_lu.account_group_6343
 msgid "AVA on inventories of goods"
 msgstr "ZWb von Erzeugnissen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6344
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6344
+#: model:account.group,name:l10n_lu.2_account_group_6344
 #: model:account.group.template,name:l10n_lu.account_group_6344
 msgid "AVA on inventories of merchandise and other goods for resale"
 msgstr "ZWb von Waren und zum Verkauf bestimmten Gütern/Vermögensgegenständen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6341
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6341
+#: model:account.group,name:l10n_lu.2_account_group_6341
 #: model:account.group.template,name:l10n_lu.account_group_6341
 msgid "AVA on inventories of raw materials and consumables"
 msgstr "ZWb von Roh-, Hilfs- und Betriebsstoffen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6342
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6342
+#: model:account.group,name:l10n_lu.2_account_group_6342
 #: model:account.group.template,name:l10n_lu.account_group_6342
 msgid "AVA on inventories of work and contracts in progress"
 msgstr "ZWb von unfertigen Erzeugnissen und in Arbeit befindlichen Aufträgen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_63311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_63311
+#: model:account.group,name:l10n_lu.2_account_group_63311
 #: model:account.group.template,name:l10n_lu.account_group_63311
 msgid "AVA on land"
 msgstr "ZWb von Grundstücken  "
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6331
 #: model:account.group.template,name:l10n_lu.account_group_6331
 msgid ""
 "AVA on land, fittings-out and buildings and FVA on investment properties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6314
+#: model:account.group,name:l10n_lu.2_account_group_6314
 #: model:account.group.template,name:l10n_lu.account_group_6314
 msgid "AVA on loan-issuance expenses"
 msgstr "ZWb von Emissionskosten von Anleihen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65116
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65116
+#: model:account.group,name:l10n_lu.2_account_group_65116
 #: model:account.group.template,name:l10n_lu.account_group_65116
 msgid "AVA on loans, deposits and claims held as fixed assets"
 msgstr ""
@@ -2145,7 +2517,9 @@ msgstr ""
 "Anlagevermögens"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6333
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6333
+#: model:account.group,name:l10n_lu.2_account_group_6333
 #: model:account.group.template,name:l10n_lu.account_group_6333
 msgid ""
 "AVA on other fixtures and fittings, tools and equipment (including rolling "
@@ -2154,71 +2528,96 @@ msgstr ""
 "ZWb von anderen Anlagen, Betriebs- und Geschäftsausstattung und Fuhrpark"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6353
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6353
+#: model:account.group,name:l10n_lu.2_account_group_6353
 #: model:account.group.template,name:l10n_lu.account_group_6353
 msgid "AVA on other receivables"
 msgstr "ZWb von sonstigen Forderungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6318
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6318
+#: model:account.group,name:l10n_lu.2_account_group_6318
 #: model:account.group.template,name:l10n_lu.account_group_6318
 msgid "AVA on other similar expenses"
 msgstr "ZWb von sonstigen vergleichbaren Kosten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65318
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65318
+#: model:account.group,name:l10n_lu.2_account_group_65318
 #: model:account.group.template,name:l10n_lu.account_group_65318
 msgid "AVA on other transferable securities"
 msgstr "ZWb von sonstigen Wertpapieren"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65312
+#: model:account.group,name:l10n_lu.2_account_group_65312
 #: model:account.group.template,name:l10n_lu.account_group_65312
 msgid "AVA on own shares or own corporate units"
 msgstr "ZWb von eigenen Aktien oder Anteilen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65113
+#: model:account.group,name:l10n_lu.2_account_group_65113
 #: model:account.group.template,name:l10n_lu.account_group_65113
 msgid "AVA on participating interests"
 msgstr "ZWb von Anteilen  "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6332
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6332
+#: model:account.group,name:l10n_lu.2_account_group_6332
 #: model:account.group.template,name:l10n_lu.account_group_6332
 msgid "AVA on plant and machinery"
 msgstr "ZWb von technischen Anlagen und Maschinen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65115
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65115
+#: model:account.group,name:l10n_lu.2_account_group_65115
 #: model:account.group.template,name:l10n_lu.account_group_65115
 msgid "AVA on securities held as fixed assets"
 msgstr "ZWb von Wertpapieren des Anlagevermögens"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6311
+#: model:account.group,name:l10n_lu.2_account_group_6311
 #: model:account.group.template,name:l10n_lu.account_group_6311
 msgid "AVA on set-up and start-up costs"
-msgstr "ZWb von Gründungs- und Errichtungskosten (Rechts- und Beratungskosten)"
+msgstr ""
+"ZWb von Gründungs- und Errichtungskosten (Rechts- und Beratungskosten)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65311
+#: model:account.group,name:l10n_lu.2_account_group_65111
+#: model:account.group,name:l10n_lu.2_account_group_65311
 #: model:account.group.template,name:l10n_lu.account_group_65111
 #: model:account.group.template,name:l10n_lu.account_group_65311
 msgid "AVA on shares in affiliated undertakings"
 msgstr "ZWb von Anteilen an verbundenen Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65313
+#: model:account.group,name:l10n_lu.2_account_group_65313
 #: model:account.group.template,name:l10n_lu.account_group_65313
 msgid ""
-"AVA on shares in undertakings with which the undertaking is linked by virtue "
-"of participating interests"
+"AVA on shares in undertakings with which the undertaking is linked by virtue"
+" of participating interests"
 msgstr ""
-"ZWb von Anteilen an Unternehmen, mit denen ein Beteiligungsverhältnis besteht"
+"ZWb von Anteilen an Unternehmen, mit denen ein Beteiligungsverhältnis "
+"besteht"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_633
 #: model:account.group.template,name:l10n_lu.account_group_633
 msgid ""
 "AVA on tangible fixed assets and fair value adjustments (FVA) on investment "
@@ -2226,17 +2625,21 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6351
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6351
+#: model:account.group,name:l10n_lu.2_account_group_6351
 #: model:account.group.template,name:l10n_lu.account_group_6351
 msgid "AVA on trade receivables"
 msgstr "ZWb von Forderungen aus Lieferungen und Leistungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6531
 #: model:account.group.template,name:l10n_lu.account_group_6531
 msgid "AVA on transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106142
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106142
 msgid "Accident insurance"
 msgstr "Unfallversicherung"
@@ -2247,126 +2650,163 @@ msgid "Account Chart Template"
 msgstr "Kontenplanvorlage"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_106
 #: model:account.group.template,name:l10n_lu.account_group_106
 msgid "Account of the owner or the co-owners"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61342
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61342
+#: model:account.group,name:l10n_lu.2_account_group_61342
 #: model:account.group.template,name:l10n_lu.account_group_61342
 msgid "Accounting, tax consulting, auditing and similar fees"
 msgstr "Buchführungs-, Steuerberatungs- und Prüfungskosten und ähnliche"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_16121
 #: model:account.account.template,name:l10n_lu.lu_2020_account_16121
 msgid "Acquired against payment (except Goodwill)"
 msgstr "Entgeltlich erworben (Firmenwert nicht inbegriffen)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_771
 #: model:account.account.template,name:l10n_lu.lu_2011_account_771
+#: model:account.group,name:l10n_lu.2_account_group_771
 #: model:account.group.template,name:l10n_lu.account_group_771
 msgid "Adjustments of corporate income tax (CIT)"
 msgstr "Erstattung der Körperschaftssteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_773
 #: model:account.account.template,name:l10n_lu.lu_2011_account_773
+#: model:account.group,name:l10n_lu.2_account_group_773
 #: model:account.group.template,name:l10n_lu.account_group_773
 msgid "Adjustments of foreign income taxes"
 msgstr "Erstattung der ausländischen Ertragssteuern"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_783
 #: model:account.account.template,name:l10n_lu.lu_2011_account_783
+#: model:account.group,name:l10n_lu.2_account_group_783
 #: model:account.group.template,name:l10n_lu.account_group_783
 msgid "Adjustments of foreign taxes"
 msgstr "Erstattung der ausländischen Steuern"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_77
 #: model:account.group.template,name:l10n_lu.account_group_77
 msgid "Adjustments of income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_772
 #: model:account.account.template,name:l10n_lu.lu_2011_account_772
+#: model:account.group,name:l10n_lu.2_account_group_772
 #: model:account.group.template,name:l10n_lu.account_group_772
 msgid "Adjustments of municipal business tax (MBT)"
 msgstr "Erstattung der Gewerbesteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_781
 #: model:account.account.template,name:l10n_lu.lu_2011_account_781
+#: model:account.group,name:l10n_lu.2_account_group_781
 #: model:account.group.template,name:l10n_lu.account_group_781
 msgid "Adjustments of net wealth tax (NWT)"
-msgstr "Erstattung der Vermögenssteuer"
+msgstr "Erstattung der Vermögensteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_788
 #: model:account.account.template,name:l10n_lu.lu_2011_account_788
+#: model:account.group,name:l10n_lu.2_account_group_788
 #: model:account.group.template,name:l10n_lu.account_group_788
 msgid "Adjustments of other taxes"
 msgstr "Erstattung sonstiger Steuern"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_78
 #: model:account.group.template,name:l10n_lu.account_group_78
 msgid "Adjustments of other taxes not included in the previous caption"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_782
 #: model:account.account.template,name:l10n_lu.lu_2011_account_782
+#: model:account.group,name:l10n_lu.2_account_group_782
 #: model:account.group.template,name:l10n_lu.account_group_782
 msgid "Adjustments of subscription tax"
 msgstr "Erstattung der Abgeltungssteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42111
+#: model:account.group,name:l10n_lu.2_account_group_42111
 #: model:account.group.template,name:l10n_lu.account_group_42111
 msgid "Advances and down payments"
 msgstr "Vorschüsse und geleistete Anzahlungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_659
 #: model:account.group.template,name:l10n_lu.account_group_659
 msgid "Allocations to financial provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6591
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6591
+#: model:account.group,name:l10n_lu.2_account_group_6591
 #: model:account.group.template,name:l10n_lu.account_group_6591
 msgid "Allocations to financial provisions - affiliated undertakings"
 msgstr "Zuführungen zu finanziellen Rückstellungen - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6592
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6592
+#: model:account.group,name:l10n_lu.2_account_group_6592
 #: model:account.group.template,name:l10n_lu.account_group_6592
 msgid "Allocations to financial provisions - other"
 msgstr "Zuführungen zu finanziellen Rückstellungen - sonstige"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6492
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6492
+#: model:account.group,name:l10n_lu.2_account_group_6492
 #: model:account.group.template,name:l10n_lu.account_group_6492
 msgid "Allocations to operating provisions"
 msgstr "Zuführungen zu betrieblichen Rückstellungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_649
 #: model:account.group.template,name:l10n_lu.account_group_649
 msgid "Allocations to provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_679
 #: model:account.account.template,name:l10n_lu.lu_2020_account_679
+#: model:account.group,name:l10n_lu.2_account_group_679
 #: model:account.group.template,name:l10n_lu.account_group_679
 msgid "Allocations to provisions for deferred taxes"
 msgstr "Zuführungen zu Rückstellungen für Steuern"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6491
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6491
+#: model:account.group,name:l10n_lu.2_account_group_6491
 #: model:account.group.template,name:l10n_lu.account_group_6491
 msgid "Allocations to tax provisions"
 msgstr "Zuführungen zu Steuerrückstellungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_647
 #: model:account.account.template,name:l10n_lu.lu_2011_account_647
+#: model:account.group,name:l10n_lu.2_account_group_647
 #: model:account.group.template,name:l10n_lu.account_group_647
 msgid "Allocations to tax-exempt capital gains"
 msgstr "Zuführungen zu Sonderposten mit Rücklageanteil"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_653
 #: model:account.group.template,name:l10n_lu.account_group_653
 msgid ""
 "Allocations to value adjustment (AVA) and fair-value adjustments (FVA) on "
@@ -2374,6 +2814,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_63
 #: model:account.group.template,name:l10n_lu.account_group_63
 msgid ""
 "Allocations to value adjustments (AVA) and fair value adjustments (FVA) on "
@@ -2382,6 +2823,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_651
 #: model:account.group.template,name:l10n_lu.account_group_651
 msgid ""
 "Allocations to value adjustments (AVA) and fair-value adjustments (FVA) of "
@@ -2389,11 +2831,22 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_232
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6452
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75112
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65212
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6452
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75112
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75212
+#: model:account.group,name:l10n_lu.2_account_group_232
+#: model:account.group,name:l10n_lu.2_account_group_411
+#: model:account.group,name:l10n_lu.2_account_group_6452
+#: model:account.group,name:l10n_lu.2_account_group_65212
+#: model:account.group,name:l10n_lu.2_account_group_75212
+#: model:account.group,name:l10n_lu.2_account_group_75222
 #: model:account.group.template,name:l10n_lu.account_group_232
 #: model:account.group.template,name:l10n_lu.account_group_411
 #: model:account.group.template,name:l10n_lu.account_group_6452
@@ -2404,6 +2857,7 @@ msgid "Amounts owed by affiliated undertakings"
 msgstr "Forderungen gegen verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_41
 #: model:account.group.template,name:l10n_lu.account_group_41
 msgid ""
 "Amounts owed by affiliated undertakings and by undertakings with which the "
@@ -2411,19 +2865,25 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4112
 #: model:account.group.template,name:l10n_lu.account_group_4112
 msgid ""
 "Amounts owed by affiliated undertakings receivable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4111
 #: model:account.group.template,name:l10n_lu.account_group_4111
 msgid "Amounts owed by affiliated undertakings receivable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4212
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4222
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4222
+#: model:account.group,name:l10n_lu.2_account_group_4212
+#: model:account.group,name:l10n_lu.2_account_group_4222
 #: model:account.group.template,name:l10n_lu.account_group_4212
 #: model:account.group.template,name:l10n_lu.account_group_4222
 msgid ""
@@ -2434,11 +2894,13 @@ msgstr ""
 "Unternehmen)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4217
 #: model:account.group.template,name:l10n_lu.account_group_4217
 msgid "Amounts owed by the Social Security and other social bodies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75114
 msgid ""
 "Amounts owed by undertakings with which the company is linked by virtue of "
@@ -2447,10 +2909,20 @@ msgstr ""
 "Forderungen gegen Unternehmen, mit denen ein Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_234
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6453
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65214
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75214
 #: model:account.account.template,name:l10n_lu.lu_2011_account_234
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6453
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65214
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75214
+#: model:account.group,name:l10n_lu.2_account_group_234
+#: model:account.group,name:l10n_lu.2_account_group_412
+#: model:account.group,name:l10n_lu.2_account_group_6453
+#: model:account.group,name:l10n_lu.2_account_group_65214
+#: model:account.group,name:l10n_lu.2_account_group_75214
+#: model:account.group,name:l10n_lu.2_account_group_75224
 #: model:account.group.template,name:l10n_lu.account_group_234
 #: model:account.group.template,name:l10n_lu.account_group_412
 #: model:account.group.template,name:l10n_lu.account_group_6453
@@ -2464,6 +2936,7 @@ msgstr ""
 "Forderungen gegen Unternehmen, mit denen ein Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4121
 #: model:account.group.template,name:l10n_lu.account_group_4121
 msgid ""
 "Amounts owed by undertakings with which the undertaking is linked by virtue "
@@ -2471,21 +2944,25 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_194
 #: model:account.group.template,name:l10n_lu.account_group_194
 msgid "Amounts owed to credit institutions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_451
 #: model:account.group.template,name:l10n_lu.account_group_451
 msgid "Amounts payable to affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4512
 #: model:account.group.template,name:l10n_lu.account_group_4512
 msgid "Amounts payable to affiliated undertakings after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_45
 #: model:account.group.template,name:l10n_lu.account_group_45
 msgid ""
 "Amounts payable to affiliated undertakings and to undertakings with which "
@@ -2493,13 +2970,18 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4511
 #: model:account.group.template,name:l10n_lu.account_group_4511
 msgid "Amounts payable to affiliated undertakings within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4713
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4723
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4713
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4723
+#: model:account.group,name:l10n_lu.2_account_group_4713
+#: model:account.group,name:l10n_lu.2_account_group_4723
 #: model:account.group.template,name:l10n_lu.account_group_4713
 #: model:account.group.template,name:l10n_lu.account_group_4723
 msgid "Amounts payable to directors, managers, statutory auditors and similar"
@@ -2508,8 +2990,12 @@ msgstr ""
 "ähnlichen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4712
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4722
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4712
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4722
+#: model:account.group,name:l10n_lu.2_account_group_4712
+#: model:account.group,name:l10n_lu.2_account_group_4722
 #: model:account.group.template,name:l10n_lu.account_group_4712
 #: model:account.group.template,name:l10n_lu.account_group_4722
 msgid ""
@@ -2520,14 +3006,19 @@ msgstr ""
 "gegnüber verbundenen Unternehmen)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4714
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4724
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4714
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4724
+#: model:account.group,name:l10n_lu.2_account_group_4714
+#: model:account.group,name:l10n_lu.2_account_group_4724
 #: model:account.group.template,name:l10n_lu.account_group_4714
 #: model:account.group.template,name:l10n_lu.account_group_4724
 msgid "Amounts payable to staff"
 msgstr "Verbindlichkeiten gegenüber dem Personal"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_452
 #: model:account.group.template,name:l10n_lu.account_group_452
 msgid ""
 "Amounts payable to undertakings with which the undertaking is linked by "
@@ -2535,6 +3026,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4522
 #: model:account.group.template,name:l10n_lu.account_group_4522
 msgid ""
 "Amounts payable to undertakings with which the undertaking is linked by "
@@ -2542,6 +3034,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4521
 #: model:account.group.template,name:l10n_lu.account_group_4521
 msgid ""
 "Amounts payable to undertakings with which the undertaking is linked by "
@@ -2549,35 +3042,50 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4122
 #: model:account.group.template,name:l10n_lu.account_group_4122
 msgid "Amounts receivable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60813
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60813
+#: model:account.group,name:l10n_lu.2_account_group_60813
 #: model:account.group.template,name:l10n_lu.account_group_60813
 msgid "Architects' and engineers' fees"
 msgstr "Honorare für Architekten und Ingenieure"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6431
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6431
+#: model:account.group,name:l10n_lu.2_account_group_6431
 #: model:account.group.template,name:l10n_lu.account_group_6431
 msgid "Attendance fees"
 msgstr "Sitzungsgeld"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_643
 #: model:account.group.template,name:l10n_lu.account_group_643
 msgid "Attendance fees, director's fees and similar remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_743
 #: model:account.account.template,name:l10n_lu.lu_2011_account_743
+#: model:account.group,name:l10n_lu.2_account_group_743
 #: model:account.group.template,name:l10n_lu.account_group_743
 msgid "Attendance fees, director's fees and similar remunerations"
 msgstr "Sitzungsgeld, Tantiemen und vergleichbare Erträge"
 
 #. module: l10n_lu
+#: model:account.report.column,name:l10n_lu.tax_report_balance
+msgid "Balance"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61333
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61333
+#: model:account.group,name:l10n_lu.2_account_group_61333
 #: model:account.group.template,name:l10n_lu.account_group_61333
 msgid ""
 "Bank account charges and bank commissions (included custody fees on "
@@ -2587,99 +3095,173 @@ msgstr ""
 "inbegriffen)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7552
 #: model:account.group.template,name:l10n_lu.account_group_7552
 msgid "Bank and similar interest"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6552
 #: model:account.group.template,name:l10n_lu.account_group_6552
 msgid "Banking and similar interest"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6133
 #: model:account.group.template,name:l10n_lu.account_group_6133
 msgid "Banking and similar services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65521
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65521
+#: model:account.group,name:l10n_lu.2_account_group_65521
 #: model:account.group.template,name:l10n_lu.account_group_65521
 msgid "Banking interest on current accounts"
 msgstr "Kontozinsen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65522
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65522
+#: model:account.group,name:l10n_lu.2_account_group_65522
 #: model:account.group.template,name:l10n_lu.account_group_65522
 msgid "Banking interest on financing operations"
 msgstr "Bankzinsen auf Finanzoperationen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5131
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5131
+#: model:account.group,name:l10n_lu.2_account_group_5131
 #: model:account.group.template,name:l10n_lu.account_group_5131
 msgid "Banks and CCP : available balance"
 msgstr "Kreditinstitute und CCP : Guthaben"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5132
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5132
+#: model:account.group,name:l10n_lu.2_account_group_5132
 #: model:account.group.template,name:l10n_lu.account_group_5132
 msgid "Banks and CCP : overdraft"
 msgstr "Kreditinstitute und CCP : Überziehungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_513
 #: model:account.group.template,name:l10n_lu.account_group_513
 msgid "Banks and postal cheques accounts (CCP)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6467
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6467
+#: model:account.group,name:l10n_lu.2_account_group_6467
 #: model:account.group.template,name:l10n_lu.account_group_6467
 msgid "Bar licence tax"
 msgstr "Getränkesteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62111
+#: model:account.group,name:l10n_lu.2_account_group_62111
 #: model:account.group.template,name:l10n_lu.account_group_62111
 msgid "Base wages"
 msgstr "Grundlöhne"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62115
+#: model:account.account,name:l10n_lu.2_lu_2011_account_746
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62115
 #: model:account.account.template,name:l10n_lu.lu_2011_account_746
+#: model:account.group,name:l10n_lu.2_account_group_62115
+#: model:account.group,name:l10n_lu.2_account_group_746
 #: model:account.group.template,name:l10n_lu.account_group_62115
 #: model:account.group.template,name:l10n_lu.account_group_746
 msgid "Benefits in kind"
 msgstr "Sachleistungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_442
 #: model:account.group.template,name:l10n_lu.account_group_442
 msgid "Bills of exchange payable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4422
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4422
+#: model:account.group,name:l10n_lu.2_account_group_4422
 #: model:account.group.template,name:l10n_lu.account_group_4422
 msgid "Bills of exchange payable after more than one year"
 msgstr ""
-"Durch Handelswechsel entstandene Verbindlichkeiten (Schuldwechsel) mit einer "
-"Restlaufzeit von mehr als einem Jahr"
+"Durch Handelswechsel entstandene Verbindlichkeiten (Schuldwechsel) mit einer"
+" Restlaufzeit von mehr als einem Jahr"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4421
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4421
+#: model:account.group,name:l10n_lu.2_account_group_4421
 #: model:account.group.template,name:l10n_lu.account_group_4421
 msgid "Bills of exchange payable within one year"
 msgstr ""
-"Durch Handelswechsel entstandene Verbindlichkeiten (Schuldwechsel) mit einer "
-"Restlaufzeit von bis zu einem Jahr"
+"Durch Handelswechsel entstandene Verbindlichkeiten (Schuldwechsel) mit einer"
+" Restlaufzeit von bis zu einem Jahr"
 
 #. module: l10n_lu
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652221
-#: model:account.account.template,name:l10n_lu.lu_2020_account_752221
 #: model:account.group.template,name:l10n_lu.account_group_652221
+msgid "Book value of amounts owed by affiliated undertakings disposed of"
+msgstr "Buchwert der verkauften Forderungen gegen verbundene Unternehmen"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652241
+#: model:account.group.template,name:l10n_lu.account_group_652241
+msgid ""
+"Book value of amounts owed by undertakings with which the undertaking is "
+"linked by virtue of participating interests disposed of"
+msgstr ""
+"Buchwert der verkauften Forderungen gegen Unternehmen, mit denen ein "
+"Beteiligungsverhältnis besteht"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_64411
+#: model:account.group.template,name:l10n_lu.account_group_64411
+msgid "Book value of intangible fixed assets disposed of"
+msgstr "Buchwert der verkauften immateriellen Anlagewerte"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652231
+#: model:account.group.template,name:l10n_lu.account_group_652231
+msgid "Book value of participating interests disposed of"
+msgstr "Buchwert der verkauften Anteile"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652251
+#: model:account.group.template,name:l10n_lu.account_group_652251
+msgid "Book value of securities held as fixed assets disposed of"
+msgstr "Buchwert der verkauften Wertpapiere des Anlagevermögens"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652211
+#: model:account.group.template,name:l10n_lu.account_group_652211
+msgid "Book value of shares in affiliated undertakings disposed of"
+msgstr "Buchwert der verkauften Beteiligungen an verbundenen Unternehmen"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_64421
+#: model:account.group.template,name:l10n_lu.account_group_64421
+msgid "Book value of tangible fixed assets disposed of"
+msgstr "Buchwert der verkauften materiellen Anlagewerte"
+
+#. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652221
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752221
+#: model:account.account.template,name:l10n_lu.lu_2020_account_752221
+#: model:account.group,name:l10n_lu.2_account_group_652221
+#: model:account.group,name:l10n_lu.2_account_group_752221
 #: model:account.group.template,name:l10n_lu.account_group_752221
 msgid "Book value of yielded amounts owed by affiliated undertakings"
 msgstr "Buchwert der verkauften Forderungen gegen verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_752241
 #: model:account.group.template,name:l10n_lu.account_group_752241
 msgid ""
 "Book value of yielded amounts owed by undertakings with which the "
@@ -2687,9 +3269,10 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652241
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652241
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752241
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752241
-#: model:account.group.template,name:l10n_lu.account_group_652241
+#: model:account.group,name:l10n_lu.2_account_group_652241
 msgid ""
 "Book value of yielded amounts owed by undertakings with which the "
 "undertaking is linked by virtue of participating interests"
@@ -2698,16 +3281,22 @@ msgstr ""
 "Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_64411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74411
-#: model:account.group.template,name:l10n_lu.account_group_64411
+#: model:account.group,name:l10n_lu.2_account_group_64411
+#: model:account.group,name:l10n_lu.2_account_group_74411
 #: model:account.group.template,name:l10n_lu.account_group_74411
 msgid "Book value of yielded intangible fixed assets"
 msgstr "Buchwert der verkauften immateriellen Anlagewerte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652261
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752261
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652261
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752261
+#: model:account.group,name:l10n_lu.2_account_group_652261
+#: model:account.group,name:l10n_lu.2_account_group_752261
 #: model:account.group.template,name:l10n_lu.account_group_652261
 #: model:account.group.template,name:l10n_lu.account_group_752261
 msgid "Book value of yielded loans, deposits and claims held as fixed assets"
@@ -2716,41 +3305,56 @@ msgstr ""
 "Forderungen des Umlaufvermögens"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652231
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652231
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752231
-#: model:account.group.template,name:l10n_lu.account_group_652231
+#: model:account.group,name:l10n_lu.2_account_group_652231
+#: model:account.group,name:l10n_lu.2_account_group_752231
 #: model:account.group.template,name:l10n_lu.account_group_752231
 msgid "Book value of yielded participating interests"
 msgstr "Buchwert der verkauften Anteile"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652251
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652251
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752251
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752251
-#: model:account.group.template,name:l10n_lu.account_group_652251
+#: model:account.group,name:l10n_lu.2_account_group_652251
+#: model:account.group,name:l10n_lu.2_account_group_752251
 #: model:account.group.template,name:l10n_lu.account_group_752251
 msgid "Book value of yielded securities held as fixed assets"
 msgstr "Buchwert der verkauften Wertpapiere des Anlagevermögens"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752211
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752211
-#: model:account.group.template,name:l10n_lu.account_group_652211
+#: model:account.group,name:l10n_lu.2_account_group_652211
+#: model:account.group,name:l10n_lu.2_account_group_752211
 #: model:account.group.template,name:l10n_lu.account_group_752211
 msgid "Book value of yielded shares in affiliated undertakings"
 msgstr "Buchwert der verkauften Beteiligungen an verbundenen Unternehmen"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_64421
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64421
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74421
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74421
-#: model:account.group.template,name:l10n_lu.account_group_64421
+#: model:account.group,name:l10n_lu.2_account_group_64421
+#: model:account.group,name:l10n_lu.2_account_group_74421
 #: model:account.group.template,name:l10n_lu.account_group_74421
 msgid "Book value of yielded tangible fixed assets"
 msgstr "Buchwert der verkauften materiellen Anlagewerte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61112
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61221
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61411
+#: model:account.group,name:l10n_lu.2_account_group_2213
+#: model:account.group,name:l10n_lu.2_account_group_61112
+#: model:account.group,name:l10n_lu.2_account_group_61221
+#: model:account.group,name:l10n_lu.2_account_group_61411
 #: model:account.group.template,name:l10n_lu.account_group_2213
 #: model:account.group.template,name:l10n_lu.account_group_61112
 #: model:account.group.template,name:l10n_lu.account_group_61221
@@ -2759,287 +3363,381 @@ msgid "Buildings"
 msgstr "Bauten/Gebäude"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60763
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60763
+#: model:account.group,name:l10n_lu.2_account_group_60763
 #: model:account.group.template,name:l10n_lu.account_group_60763
 msgid "Buildings for resale"
 msgstr "Zum Verkauf bestimmte Bauten/Gebäude"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_22131
 #: model:account.group.template,name:l10n_lu.account_group_22131
 msgid "Buildings in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22132
+#: model:account.group,name:l10n_lu.2_account_group_22132
 #: model:account.group.template,name:l10n_lu.account_group_22132
 msgid "Buildings in foreign countries"
 msgstr "Bauten / Gebäude im Ausland"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_314
+#: model:account.group,name:l10n_lu.2_account_group_314
 #: model:account.group.template,name:l10n_lu.account_group_314
 msgid "Buildings under construction"
 msgstr "Im Bau befindliche Bauten / Gebäude"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61523
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61523
+#: model:account.group,name:l10n_lu.2_account_group_61523
 #: model:account.group.template,name:l10n_lu.account_group_61523
 msgid "Business assignments"
 msgstr "Dienstreisen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6144
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6144
+#: model:account.group,name:l10n_lu.2_account_group_6144
 #: model:account.group.template,name:l10n_lu.account_group_6144
 msgid "Business risk insurance"
 msgstr "Versicherung für betriebliche Risiken"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10629
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10629
 msgid "Business share in private expenses"
 msgstr "Gewerblicher Anteil an privaten Ausgaben"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6
 #: model:account.group.template,name:l10n_lu.account_group_6
 msgid "CHARGES ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461212
+#: model:account.group,name:l10n_lu.2_account_group_461212
 #: model:account.group.template,name:l10n_lu.account_group_461212
 msgid "CIT - Tax payable"
 msgstr "Körperschaftssteuer - Zu zahlende Steuerschuld"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6711
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6711
+#: model:account.group,name:l10n_lu.2_account_group_6711
 #: model:account.group.template,name:l10n_lu.account_group_6711
 msgid "CIT - current financial year"
 msgstr "KSt - laufendes Geschäftsjahr"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6712
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6712
+#: model:account.group,name:l10n_lu.2_account_group_6712
 #: model:account.group.template,name:l10n_lu.account_group_6712
 msgid "CIT - previous financial years"
 msgstr "KSt - vorhergehende Geschäftsjahre"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_115
 #: model:account.account.template,name:l10n_lu.lu_2011_account_115
+#: model:account.group,name:l10n_lu.2_account_group_115
 #: model:account.group.template,name:l10n_lu.account_group_115
 msgid "Capital contribution without issue of shares"
 msgstr "Kapitaleinlagen ohne Ausgabe von Anteilen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7473
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7473
+#: model:account.group,name:l10n_lu.2_account_group_16
+#: model:account.group,name:l10n_lu.2_account_group_7473
 #: model:account.group.template,name:l10n_lu.account_group_16
 #: model:account.group.template,name:l10n_lu.account_group_7473
 msgid "Capital investment subsidies"
 msgstr "Investitionszuschüsse"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_104
 #: model:account.account.template,name:l10n_lu.lu_2020_account_104
+#: model:account.group,name:l10n_lu.2_account_group_104
 #: model:account.group.template,name:l10n_lu.account_group_104
 msgid "Capital of individual companies, corporate partnerships and similar"
 msgstr ""
 "Kapital von Einzelkaufleuten, Personenhandelsgesellschaften und ähnlichen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_72
 #: model:account.group.template,name:l10n_lu.account_group_72
 msgid "Capitalised production"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106166
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106166
 msgid "Car"
 msgstr "Fahrzeug"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_51
 #: model:account.group.template,name:l10n_lu.account_group_51
 msgid "Cash at bank, in postal cheques accounts, cheques and in hand"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_516
 #: model:account.account.template,name:l10n_lu.lu_2020_account_516
+#: model:account.group,name:l10n_lu.2_account_group_516
 #: model:account.group.template,name:l10n_lu.account_group_516
 msgid "Cash in hand"
 msgstr "Kassenbestand"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10611
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10611
 msgid "Cash withdrawals (daily life)"
 msgstr "Barentnahmen (Lebenshaltungskosten)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6222
+#: model:account.group,name:l10n_lu.2_account_group_6222
 #: model:account.group.template,name:l10n_lu.account_group_6222
 msgid "Casual workers"
 msgstr "Gelegenheitsarbeitskräfte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61515
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61515
+#: model:account.group,name:l10n_lu.2_account_group_61515
 #: model:account.group.template,name:l10n_lu.account_group_61515
 msgid "Catalogues, printed materials and publications"
 msgstr "Kataloge, Drucksachen und Veröffentlichungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7121
+#: model:account.group,name:l10n_lu.2_account_group_7121
 #: model:account.group.template,name:l10n_lu.account_group_7121
 msgid "Change in inventories of finished goods"
 msgstr "Bestandsveränderung von fertigen Erzeugnissen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_712
 #: model:account.group.template,name:l10n_lu.account_group_712
 msgid "Change in inventories of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_71
 #: model:account.group.template,name:l10n_lu.account_group_71
 msgid "Change in inventories of goods and of work in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7123
+#: model:account.group,name:l10n_lu.2_account_group_7123
 #: model:account.group.template,name:l10n_lu.account_group_7123
 msgid "Change in inventories of residual goods"
 msgstr "Bestandsveränderung von Restprodukten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7122
+#: model:account.group,name:l10n_lu.2_account_group_7122
 #: model:account.group.template,name:l10n_lu.account_group_7122
 msgid "Change in inventories of semi-finished goods"
 msgstr "Bestandsveränderung von Zwischenprodukten"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_711
 #: model:account.group.template,name:l10n_lu.account_group_711
 msgid "Change in inventories of work and contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7111
+#: model:account.group,name:l10n_lu.2_account_group_7111
 #: model:account.group.template,name:l10n_lu.account_group_7111
 msgid "Change in inventories of work in progress"
 msgstr "Bestandsveränderung von unfertigen Erzeugnissen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7114
+#: model:account.group,name:l10n_lu.2_account_group_7114
 #: model:account.group.template,name:l10n_lu.account_group_7114
 msgid "Change in inventories: buildings under construction"
 msgstr "Bestandsveränderung von im Bau befindlichen Bauten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7112
+#: model:account.group,name:l10n_lu.2_account_group_7112
 #: model:account.group.template,name:l10n_lu.account_group_7112
 msgid "Change in inventories: contracts in progress - goods"
-msgstr "Bestandsveränderung von in Arbeit befindlichen Aufträgen - Erzeugnisse"
+msgstr ""
+"Bestandsveränderung von in Arbeit befindlichen Aufträgen - Erzeugnisse"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7113
+#: model:account.group,name:l10n_lu.2_account_group_7113
 #: model:account.group.template,name:l10n_lu.account_group_7113
 msgid "Change in inventories: contracts in progress - services"
 msgstr ""
 "Bestandsveränderung von in Arbeit befindlichen Aufträgen - Dienstleistungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_607
 #: model:account.group.template,name:l10n_lu.account_group_607
 msgid "Changes in inventory"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6073
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6073
+#: model:account.group,name:l10n_lu.2_account_group_6073
 #: model:account.group.template,name:l10n_lu.account_group_6073
 msgid "Changes in inventory of consumable materials and supplies"
 msgstr "Bestandsveränderungen an Hilfs- und Betriebsstoffen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6076
 #: model:account.group.template,name:l10n_lu.account_group_6076
 msgid "Changes in inventory of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6074
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6074
+#: model:account.group,name:l10n_lu.2_account_group_6074
 #: model:account.group.template,name:l10n_lu.account_group_6074
 msgid "Changes in inventory of packaging"
 msgstr "Bestandsveränderungen an Verpackungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6071
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6071
+#: model:account.group,name:l10n_lu.2_account_group_6071
 #: model:account.group.template,name:l10n_lu.account_group_6071
 msgid "Changes in inventory of raw materials"
 msgstr "Bestandsveränderungen an Rohstoffen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62412
+#: model:account.group,name:l10n_lu.2_account_group_62412
 #: model:account.group.template,name:l10n_lu.account_group_62412
 msgid "Changes to provisions for complementary pensions"
 msgstr "Zuführung zu Rückstellungen für Zusatzrenten"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_652
 #: model:account.group.template,name:l10n_lu.account_group_652
 msgid "Charges and loss of disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_61334
 #: model:account.group.template,name:l10n_lu.account_group_61334
 msgid "Charges for electronic means of paiment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61334
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61334
 msgid "Charges for electronic means of payment"
 msgstr "Gebühren auf elektronische Bezahlungsmittel"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6521
 #: model:account.group.template,name:l10n_lu.account_group_6521
 msgid "Charges of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106152
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106152
 msgid "Child benefit office"
 msgstr "Familienzulagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6165
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6165
+#: model:account.group,name:l10n_lu.2_account_group_6165
 #: model:account.group.template,name:l10n_lu.account_group_6165
 msgid "Collective staff transportation"
 msgstr "Beförderungen von Personal"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6131
+#: model:account.account,name:l10n_lu.2_lu_2020_account_705
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6131
 #: model:account.account.template,name:l10n_lu.lu_2020_account_705
+#: model:account.group,name:l10n_lu.2_account_group_6131
+#: model:account.group,name:l10n_lu.2_account_group_705
 #: model:account.group.template,name:l10n_lu.account_group_6131
 #: model:account.group.template,name:l10n_lu.account_group_705
 msgid "Commissions and brokerage fees"
 msgstr "Provisionen und Maklergebühren"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7453
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7453
+#: model:account.group,name:l10n_lu.2_account_group_7453
 #: model:account.group.template,name:l10n_lu.account_group_7453
 msgid "Compensatory allowances"
 msgstr "Ausgleichszahlungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6241
 #: model:account.group.template,name:l10n_lu.account_group_6241
 msgid "Complementary pensions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62415
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62415
+#: model:account.group,name:l10n_lu.2_account_group_62415
 #: model:account.group.template,name:l10n_lu.account_group_62415
 msgid "Complementary pensions paid by the employer"
 msgstr "Ausgezahlte betriebliche Zusatzrente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2235
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2235
+#: model:account.group,name:l10n_lu.2_account_group_2235
 #: model:account.group.template,name:l10n_lu.account_group_2235
 msgid "Computer equipment"
 msgstr "IT-Ausstattung "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21221
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6411
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72121
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70311
+#: model:account.group,name:l10n_lu.2_account_group_21211
+#: model:account.group,name:l10n_lu.2_account_group_21221
+#: model:account.group,name:l10n_lu.2_account_group_6411
+#: model:account.group,name:l10n_lu.2_account_group_70311
+#: model:account.group,name:l10n_lu.2_account_group_72121
+#: model:account.group,name:l10n_lu.2_account_group_7411
 #: model:account.group.template,name:l10n_lu.account_group_21211
 #: model:account.group.template,name:l10n_lu.account_group_21221
 #: model:account.group.template,name:l10n_lu.account_group_6411
@@ -3050,6 +3748,9 @@ msgid "Concessions"
 msgstr "Konzessionen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1612
+#: model:account.group,name:l10n_lu.2_account_group_212
+#: model:account.group,name:l10n_lu.2_account_group_7212
 #: model:account.group.template,name:l10n_lu.account_group_1612
 #: model:account.group.template,name:l10n_lu.account_group_212
 #: model:account.group.template,name:l10n_lu.account_group_7212
@@ -3058,41 +3759,62 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_312
+#: model:account.group,name:l10n_lu.2_account_group_312
 #: model:account.group.template,name:l10n_lu.account_group_312
 msgid "Contracts in progress - goods"
 msgstr "In Arbeit befindlichen Aufträge - Waren"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_313
+#: model:account.group,name:l10n_lu.2_account_group_313
 #: model:account.group.template,name:l10n_lu.account_group_313
 msgid "Contracts in progress - services"
 msgstr "In Arbeit befindlichen Aufträge - Dienstleistungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_113
+#: model:account.group,name:l10n_lu.2_account_group_113
 #: model:account.group.template,name:l10n_lu.account_group_113
 msgid "Contribution premium"
 msgstr "Agio bei Einlagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6187
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6187
+#: model:account.group,name:l10n_lu.2_account_group_6187
 #: model:account.group.template,name:l10n_lu.account_group_6187
 msgid "Contributions to professional associations"
 msgstr "Beiträge für Berufsverbände"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_192
 #: model:account.group.template,name:l10n_lu.account_group_192
 msgid "Convertible debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212151
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212251
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64151
+#: model:account.account,name:l10n_lu.2_lu_2011_account_721251
+#: model:account.account,name:l10n_lu.2_lu_2011_account_74151
+#: model:account.account,name:l10n_lu.2_lu_2020_account_703151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212251
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_721251
 #: model:account.account.template,name:l10n_lu.lu_2011_account_74151
 #: model:account.account.template,name:l10n_lu.lu_2020_account_703151
+#: model:account.group,name:l10n_lu.2_account_group_212151
+#: model:account.group,name:l10n_lu.2_account_group_212251
+#: model:account.group,name:l10n_lu.2_account_group_64151
+#: model:account.group,name:l10n_lu.2_account_group_703151
+#: model:account.group,name:l10n_lu.2_account_group_721251
+#: model:account.group,name:l10n_lu.2_account_group_74151
 #: model:account.group.template,name:l10n_lu.account_group_212151
 #: model:account.group.template,name:l10n_lu.account_group_212251
 #: model:account.group.template,name:l10n_lu.account_group_64151
@@ -3103,157 +3825,212 @@ msgid "Copyrights and reproduction rights"
 msgstr "Urheber- und Reproduktionsrechte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42141
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42141
+#: model:account.group,name:l10n_lu.2_account_group_42141
 #: model:account.group.template,name:l10n_lu.account_group_42141
 msgid "Corporate income tax"
 msgstr "Körperschaftssteuer"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_46121
+#: model:account.group,name:l10n_lu.2_account_group_671
 #: model:account.group.template,name:l10n_lu.account_group_46121
 #: model:account.group.template,name:l10n_lu.account_group_671
 msgid "Corporate income tax (CIT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461211
+#: model:account.group,name:l10n_lu.2_account_group_461211
 #: model:account.group.template,name:l10n_lu.account_group_461211
 msgid "Corporate income tax - Tax accrual"
 msgstr "Körperschaftssteuer - Ermittelte Steuerschuld"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6182
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6182
+#: model:account.group,name:l10n_lu.2_account_group_6182
 #: model:account.group.template,name:l10n_lu.account_group_6182
 msgid "Costs of training, symposiums, seminars, conferences"
 msgstr "Kosten von Weiterbildungen, Kolloquien, Seminaren, Konferenzen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_16122
 #: model:account.account.template,name:l10n_lu.lu_2020_account_16122
 msgid "Created by the undertaking itself"
 msgstr "Vom Unternehmen selbst erstellt "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_67321
 #: model:account.account.template,name:l10n_lu.lu_2011_account_67321
+#: model:account.group,name:l10n_lu.2_account_group_67321
 #: model:account.group.template,name:l10n_lu.account_group_67321
 msgid "Current financial year"
 msgstr "Laufendes Geschäftsjahr"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4011
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4021
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4011
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4021
+#: model:account.group,name:l10n_lu.2_account_group_4011
+#: model:account.group,name:l10n_lu.2_account_group_4021
 #: model:account.group.template,name:l10n_lu.account_group_4011
 #: model:account.group.template,name:l10n_lu.account_group_4021
 msgid "Customers"
 msgstr "Kunden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_40111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_40111
 msgid "Customers (PoS)"
 msgstr "Kunden (POS)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4012
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4012
+#: model:account.group,name:l10n_lu.2_account_group_4012
 #: model:account.group.template,name:l10n_lu.account_group_4012
 msgid "Customers - Receivable bills of exchange"
 msgstr "Kunden - Einzutreibende Wechsel (Besitzwechsel)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4014
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4014
+#: model:account.group,name:l10n_lu.2_account_group_4014
 #: model:account.group.template,name:l10n_lu.account_group_4014
 msgid "Customers - Unbilled sales"
 msgstr "Noch auszustellende Rechnungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6145
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6145
+#: model:account.group,name:l10n_lu.2_account_group_6145
 #: model:account.group.template,name:l10n_lu.account_group_6145
 msgid "Customers credit insurance"
 msgstr "Forderungsausfallversicherung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4015
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4015
+#: model:account.group,name:l10n_lu.2_account_group_4015
 #: model:account.group.template,name:l10n_lu.account_group_4015
 msgid "Customers with a credit balance"
 msgstr "Kunden - Kreditorische Debitoren"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4025
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4025
+#: model:account.group,name:l10n_lu.2_account_group_4025
 #: model:account.group.template,name:l10n_lu.account_group_4025
 msgid "Customers with creditor balance"
 msgstr "Kreditorische Debitoren"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4215
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4215
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4613
+#: model:account.group,name:l10n_lu.2_account_group_4215
+#: model:account.group,name:l10n_lu.2_account_group_4613
 #: model:account.group.template,name:l10n_lu.account_group_4215
 #: model:account.group.template,name:l10n_lu.account_group_4613
 msgid "Customs and Excise Authority (ADA)"
 msgstr "Zoll- und Verbrauchssteuerverwaltung (ADA)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4
 #: model:account.group.template,name:l10n_lu.account_group_4
 msgid "DEBTORS AND CREDITORS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106154
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106154
 msgid "Death and other health insurance funds"
 msgstr "Sterbekasse oder sonstige Krankenzusatzversicherungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_19
 #: model:account.group.template,name:l10n_lu.account_group_19
 msgid "Debenture loans and amounts owed to credit institutions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5083
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5083
+#: model:account.group,name:l10n_lu.2_account_group_5083
 #: model:account.group.template,name:l10n_lu.account_group_5083
 msgid "Debenture loans and other notes issued and repurchased by the company"
 msgstr "Eigene Anleihen und sonstige eigene Schuldtitel"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_23521
 #: model:account.account.template,name:l10n_lu.lu_2011_account_23521
+#: model:account.group,name:l10n_lu.2_account_group_23521
 #: model:account.group.template,name:l10n_lu.account_group_23521
 msgid "Debentures"
 msgstr "Anleihen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_481
 #: model:account.account.template,name:l10n_lu.lu_2011_account_481
+#: model:account.group,name:l10n_lu.2_account_group_481
 #: model:account.group.template,name:l10n_lu.account_group_481
 msgid "Deferred charges (on one or more financial years)"
 msgstr "Abgegrenzte Aufwendungen (über ein oder mehrere Geschäfstjahre)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_48
 #: model:account.group.template,name:l10n_lu.account_group_48
 msgid "Deferred charges and income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_482
 #: model:account.account.template,name:l10n_lu.lu_2011_account_482
+#: model:account.group,name:l10n_lu.2_account_group_482
 #: model:account.group.template,name:l10n_lu.account_group_482
 msgid "Deferred income (on one or more financial years)"
 msgstr "Abgegrenzte Erträge (über ein oder mehrere Geschäfstjahre)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_183
 #: model:account.account.template,name:l10n_lu.lu_2011_account_183
+#: model:account.group,name:l10n_lu.2_account_group_183
 #: model:account.group.template,name:l10n_lu.account_group_183
 msgid "Deferred tax provisions"
 msgstr "Rückstellungen für latente Steuern"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_2362
 #: model:account.account.template,name:l10n_lu.lu_2020_account_2362
+#: model:account.group,name:l10n_lu.2_account_group_2362
 #: model:account.group.template,name:l10n_lu.account_group_2362
 msgid "Deposits and guarantees paid"
 msgstr "Geleistete Hinterlegungen und Kautionen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106192
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106192
 msgid "Deposits on private financial accounts"
 msgstr "Anlagen auf finanziellen Privatkonten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42187
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42287
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4717
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4727
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42187
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42287
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4717
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4727
+#: model:account.group,name:l10n_lu.2_account_group_42187
+#: model:account.group,name:l10n_lu.2_account_group_42287
+#: model:account.group,name:l10n_lu.2_account_group_4717
+#: model:account.group,name:l10n_lu.2_account_group_4727
 #: model:account.group.template,name:l10n_lu.account_group_42187
 #: model:account.group.template,name:l10n_lu.account_group_42287
 #: model:account.group.template,name:l10n_lu.account_group_4717
@@ -3262,15 +4039,23 @@ msgid "Derivative financial instruments"
 msgstr "Derivative Finanzinstrumente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221111
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221111
+#: model:account.group,name:l10n_lu.2_account_group_221111
 #: model:account.group.template,name:l10n_lu.account_group_221111
 msgid "Developed land"
 msgstr "Bebaute Grundstücke"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1611
 #: model:account.account.template,name:l10n_lu.lu_2011_account_211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7211
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1611
+#: model:account.group,name:l10n_lu.2_account_group_1611
+#: model:account.group,name:l10n_lu.2_account_group_211
+#: model:account.group,name:l10n_lu.2_account_group_7211
 #: model:account.group.template,name:l10n_lu.account_group_1611
 #: model:account.group.template,name:l10n_lu.account_group_211
 #: model:account.group.template,name:l10n_lu.account_group_7211
@@ -3278,70 +4063,91 @@ msgid "Development costs"
 msgstr "Entwicklungskosten"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4214
+#: model:account.group,name:l10n_lu.2_account_group_4612
 #: model:account.group.template,name:l10n_lu.account_group_4214
 #: model:account.group.template,name:l10n_lu.account_group_4612
 msgid "Direct Tax Authority (ACD)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6432
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6432
+#: model:account.group,name:l10n_lu.2_account_group_6432
 #: model:account.group.template,name:l10n_lu.account_group_6432
 msgid "Director's fees"
 msgstr "Tantiemen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6555
 #: model:account.group.template,name:l10n_lu.account_group_6555
 msgid "Discounts and charges on bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65551
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65551
+#: model:account.group,name:l10n_lu.2_account_group_65551
 #: model:account.group.template,name:l10n_lu.account_group_65551
 msgid "Discounts and charges on bills of exchange - affiliated undertakings"
 msgstr "Diskonte und Kosten von Handelswechsel - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65552
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65552
+#: model:account.group,name:l10n_lu.2_account_group_65552
 #: model:account.group.template,name:l10n_lu.account_group_65552
 msgid "Discounts and charges on bills of exchange - other"
 msgstr "Diskonte und Kosten von Handelswechsel - sonstige"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7555
 #: model:account.group.template,name:l10n_lu.account_group_7555
 msgid "Discounts on bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75551
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75551
+#: model:account.group,name:l10n_lu.2_account_group_75551
 #: model:account.group.template,name:l10n_lu.account_group_75551
 msgid "Discounts on bills of exchange - affiliated undertakings"
 msgstr "Diskonte auf Handelswechsel - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75552
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75552
+#: model:account.group,name:l10n_lu.2_account_group_75552
 #: model:account.group.template,name:l10n_lu.account_group_75552
 msgid "Discounts on bills of exchange - other"
 msgstr "Diskonte auf Handelswechsel - sonstige"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7556
 #: model:account.group.template,name:l10n_lu.account_group_7556
 msgid "Discounts received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75561
+#: model:account.group,name:l10n_lu.2_account_group_75561
 #: model:account.group.template,name:l10n_lu.account_group_75561
 msgid "Discounts received - affiliated undertakings"
 msgstr "Erhaltene Diskonten - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75562
+#: model:account.group,name:l10n_lu.2_account_group_75562
 #: model:account.group.template,name:l10n_lu.account_group_75562
 msgid "Discounts received - other"
 msgstr "Erhaltene Diskonten - sonstige"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752262
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752262
+#: model:account.group,name:l10n_lu.2_account_group_752262
 #: model:account.group.template,name:l10n_lu.account_group_752262
 msgid "Disposal proceed of loans, deposits and claims held as fixed assets"
 msgstr ""
@@ -3349,128 +4155,175 @@ msgstr ""
 "Forderungen des Anlagevermögens"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652222
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752222
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652222
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752222
+#: model:account.group,name:l10n_lu.2_account_group_652222
+#: model:account.group,name:l10n_lu.2_account_group_752222
 #: model:account.group.template,name:l10n_lu.account_group_652222
 #: model:account.group.template,name:l10n_lu.account_group_752222
 msgid "Disposal proceeds of amounts owed by affiliated undertakings"
 msgstr "Veräußerungswert der Forderungen gegen verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652242
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752242
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652242
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752242
+#: model:account.group,name:l10n_lu.2_account_group_652242
+#: model:account.group,name:l10n_lu.2_account_group_752242
 #: model:account.group.template,name:l10n_lu.account_group_652242
 #: model:account.group.template,name:l10n_lu.account_group_752242
 msgid ""
-"Disposal proceeds of amounts owed by undertakings with which the undertaking "
-"is linked by virtue of participating interests"
+"Disposal proceeds of amounts owed by undertakings with which the undertaking"
+" is linked by virtue of participating interests"
 msgstr ""
 "Veräußerungswert der Forderungen gegen Unternehmen, mit denen ein "
 "Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64412
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_64412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74412
+#: model:account.group,name:l10n_lu.2_account_group_64412
+#: model:account.group,name:l10n_lu.2_account_group_74412
 #: model:account.group.template,name:l10n_lu.account_group_64412
 #: model:account.group.template,name:l10n_lu.account_group_74412
 msgid "Disposal proceeds of intangible fixed assets"
 msgstr "Verkaufserlös von immateriellen Anlagewerten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652262
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652262
+#: model:account.group,name:l10n_lu.2_account_group_652262
 #: model:account.group.template,name:l10n_lu.account_group_652262
 msgid "Disposal proceeds of loans, deposits and claims held as fixed assets"
 msgstr ""
-"Veräußerungswert der Ausleihungen, geleistete Hinterlegungen und Forderungen "
-"des Umlaufvermögens"
+"Veräußerungswert der Ausleihungen, geleistete Hinterlegungen und Forderungen"
+" des Umlaufvermögens"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652232
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752232
+#: model:account.group,name:l10n_lu.2_account_group_652232
+#: model:account.group,name:l10n_lu.2_account_group_752232
 #: model:account.group.template,name:l10n_lu.account_group_652232
 #: model:account.group.template,name:l10n_lu.account_group_752232
 msgid "Disposal proceeds of participating interests"
 msgstr "Veräußerungswert der Anteile"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652252
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752252
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652252
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752252
+#: model:account.group,name:l10n_lu.2_account_group_652252
+#: model:account.group,name:l10n_lu.2_account_group_752252
 #: model:account.group.template,name:l10n_lu.account_group_652252
 #: model:account.group.template,name:l10n_lu.account_group_752252
 msgid "Disposal proceeds of securities held as fixed assets"
 msgstr "Veräußerungswert der Wertpapiere des Anlagevermögens"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652212
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752212
+#: model:account.group,name:l10n_lu.2_account_group_652212
+#: model:account.group,name:l10n_lu.2_account_group_752212
 #: model:account.group.template,name:l10n_lu.account_group_652212
 #: model:account.group.template,name:l10n_lu.account_group_752212
 msgid "Disposal proceeds of shares in affiliated undertakings"
 msgstr "Veräußerungswert der Anteile an verbundenen Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64422
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_64422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74422
+#: model:account.group,name:l10n_lu.2_account_group_64422
+#: model:account.group,name:l10n_lu.2_account_group_74422
 #: model:account.group.template,name:l10n_lu.account_group_64422
 #: model:account.group.template,name:l10n_lu.account_group_74422
 msgid "Disposal proceeds of tangible fixed assets"
 msgstr "Verkaufserlös von materiellen Anlagewerten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6181
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6181
+#: model:account.group,name:l10n_lu.2_account_group_6181
 #: model:account.group.template,name:l10n_lu.account_group_6181
 msgid "Documentation"
 msgstr "Dokumentation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61516
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61516
+#: model:account.group,name:l10n_lu.2_account_group_61516
 #: model:account.group.template,name:l10n_lu.account_group_61516
 msgid "Donations"
 msgstr "Spenden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4013
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4013
+#: model:account.group,name:l10n_lu.2_account_group_4013
 #: model:account.group.template,name:l10n_lu.account_group_4013
 msgid "Doubtful or disputed customers"
 msgstr "Zweifelhafte oder strittige Kunden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_214
 #: model:account.account.template,name:l10n_lu.lu_2020_account_214
+#: model:account.group,name:l10n_lu.2_account_group_214
 #: model:account.group.template,name:l10n_lu.account_group_214
 msgid "Down payments and intangible fixed assets under development"
 msgstr ""
 "Geleistete Anzahlungen und immaterielle Vermögensgegenstände in Entwicklung"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_224
 #: model:account.group.template,name:l10n_lu.account_group_224
 msgid "Down payments and tangible fixed assets under development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_37
 #: model:account.account.template,name:l10n_lu.lu_2020_account_37
+#: model:account.group,name:l10n_lu.2_account_group_37
 #: model:account.group.template,name:l10n_lu.account_group_37
 msgid "Down payments on account on inventories"
 msgstr "Geleistete Anzahlungen auf Vorräte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_432
 #: model:account.account.template,name:l10n_lu.lu_2011_account_432
+#: model:account.group,name:l10n_lu.2_account_group_432
 #: model:account.group.template,name:l10n_lu.account_group_432
 msgid "Down payments received after more than one year"
 msgstr "Erhaltene Anzahlungen mit einer Restlaufzeit von mehr als einem Jahr"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_315
 #: model:account.group.template,name:l10n_lu.account_group_315
 msgid ""
 "Down payments received on inventories of work and on contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4311
+#: model:account.group,name:l10n_lu.2_account_group_4321
 #: model:account.group.template,name:l10n_lu.account_group_4311
 #: model:account.group.template,name:l10n_lu.account_group_4321
 msgid "Down payments received on orders"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_43
 #: model:account.group.template,name:l10n_lu.account_group_43
 msgid ""
 "Down payments received on orders as far as they are not deducted distinctly "
@@ -3478,12 +4331,17 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_431
 #: model:account.account.template,name:l10n_lu.lu_2011_account_431
+#: model:account.group,name:l10n_lu.2_account_group_431
 #: model:account.group.template,name:l10n_lu.account_group_431
 msgid "Down payments received within one year"
 msgstr "Erhaltene Anzahlungen mit einer Restlaufzeit von bis zu einem Jahr"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1922
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1932
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1942
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1922
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1932
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1942
@@ -3491,6 +4349,9 @@ msgid "Due and payable after more than one year"
 msgstr "Mit einer Restlaufzeit von mehr als einem Jahr"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1921
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1931
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1941
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1921
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1931
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1941
@@ -3498,89 +4359,111 @@ msgid "Due and payable within one year"
 msgstr "Mit einer Restlaufzeit von bis zu einem Jahr"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6463
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6463
+#: model:account.group,name:l10n_lu.2_account_group_6463
 #: model:account.group.template,name:l10n_lu.account_group_6463
 msgid "Duties on imported merchandise"
 msgstr "Zölle und Einfuhrabgaben"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1
 #: model:account.group.template,name:l10n_lu.account_group_1
 msgid "EQUITY, PROVISIONS AND FINANCIAL LIABILITIES ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_private_LU_IC
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_private_LU_IC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_private_LU_IC
 msgid "EU private"
 msgstr "EU privat"
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-0
 msgid "EX-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-0
 msgid "EX-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-EC-0
 msgid "EX-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-EC-0
 msgid "EX-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-EC-0
 msgid "EX-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-IC-0
 msgid "EX-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-IC-0
 msgid "EX-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-IC-0
 msgid "EX-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-IC-0
 msgid "EX-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60315
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61845
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60315
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61845
+#: model:account.group,name:l10n_lu.2_account_group_60315
+#: model:account.group,name:l10n_lu.2_account_group_61845
 #: model:account.group.template,name:l10n_lu.account_group_60315
 #: model:account.group.template,name:l10n_lu.account_group_61845
 msgid "Electricity"
 msgstr "Strom"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_105
 #: model:account.account.template,name:l10n_lu.lu_2011_account_105
+#: model:account.group,name:l10n_lu.2_account_group_105
 #: model:account.group.template,name:l10n_lu.account_group_105
 msgid "Endowment of branches"
 msgstr "Dotationskapital von Niederlassungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6464
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6464
+#: model:account.group,name:l10n_lu.2_account_group_6464
 #: model:account.group.template,name:l10n_lu.account_group_6464
 msgid "Excise duties on production and tax on consumption"
 msgstr "Verbrauchsabgaben aus der Produktion und Verbrauchssteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_203
 #: model:account.account.template,name:l10n_lu.lu_2011_account_203
+#: model:account.group,name:l10n_lu.2_account_group_203
 #: model:account.group.template,name:l10n_lu.account_group_203
 msgid ""
 "Expenses for increases in capital and for various operations (merger, "
@@ -3590,81 +4473,108 @@ msgstr ""
 "Vorgänge (Verschmelzungen, Spaltungen, Formwechsel)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_617
 #: model:account.group.template,name:l10n_lu.account_group_617
 msgid "External staff of the company"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6172
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6172
+#: model:account.group,name:l10n_lu.2_account_group_6172
 #: model:account.group.template,name:l10n_lu.account_group_6172
 msgid "External staff on secondment"
 msgstr "Ausgeliehenes Personal"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_EC
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_EC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_EC
 msgid "Extra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_5
 #: model:account.group.template,name:l10n_lu.account_group_5
 msgid "FINANCIAL ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2
 #: model:account.group.template,name:l10n_lu.account_group_2
 msgid "FORMATION EXPENSES AND FIXED ASSETS ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6512
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7512
+#: model:account.group,name:l10n_lu.2_account_group_6512
+#: model:account.group,name:l10n_lu.2_account_group_7512
 #: model:account.group.template,name:l10n_lu.account_group_6512
 #: model:account.group.template,name:l10n_lu.account_group_7512
 msgid "FVA on financial fixed assets"
 msgstr "AFV der Finanzanlagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_63315
+#: model:account.account,name:l10n_lu.2_lu_2020_account_73315
 #: model:account.account.template,name:l10n_lu.lu_2020_account_63315
 #: model:account.account.template,name:l10n_lu.lu_2020_account_73315
+#: model:account.group,name:l10n_lu.2_account_group_63315
+#: model:account.group,name:l10n_lu.2_account_group_73315
 #: model:account.group.template,name:l10n_lu.account_group_63315
 #: model:account.group.template,name:l10n_lu.account_group_73315
 msgid "FVA on investment properties"
 msgstr "AFV von Anlageimmobilien"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6354
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7354
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6354
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7354
+#: model:account.group,name:l10n_lu.2_account_group_6354
+#: model:account.group,name:l10n_lu.2_account_group_7354
 #: model:account.group.template,name:l10n_lu.account_group_6354
 #: model:account.group.template,name:l10n_lu.account_group_7354
 msgid "FVA on receivables from current assets"
 msgstr "AFV von Forderungen des Umlaufvermögens"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6532
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6532
+#: model:account.group,name:l10n_lu.2_account_group_6532
+#: model:account.group,name:l10n_lu.2_account_group_7532
 #: model:account.group.template,name:l10n_lu.account_group_6532
 #: model:account.group.template,name:l10n_lu.account_group_7532
 msgid "FVA on transferable securities"
 msgstr "AFV der Wertpapiere"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61336
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61336
+#: model:account.group,name:l10n_lu.2_account_group_61336
 #: model:account.group.template,name:l10n_lu.account_group_61336
 msgid "Factoring services"
 msgstr "Factoringgebühren"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7532
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7532
 msgid "Fair value adjustments on transferable securities"
 msgstr "AFV der Wertpapiere"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61513
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61513
+#: model:account.group,name:l10n_lu.2_account_group_61513
 #: model:account.group.template,name:l10n_lu.account_group_61513
 msgid "Fairs and exhibitions"
 msgstr "Messen und Ausstellungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_641
+#: model:account.group,name:l10n_lu.2_account_group_7031
 #: model:account.group.template,name:l10n_lu.account_group_641
 #: model:account.group.template,name:l10n_lu.account_group_7031
 msgid ""
@@ -3673,6 +4583,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_741
 #: model:account.group.template,name:l10n_lu.account_group_741
 msgid ""
 "Fees and royalties for concessions, patents, licences, trademarks and "
@@ -3680,177 +4591,229 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65
 #: model:account.group.template,name:l10n_lu.account_group_65
 msgid "Financial charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_23
 #: model:account.group.template,name:l10n_lu.account_group_23
 msgid "Financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75
 #: model:account.group.template,name:l10n_lu.account_group_75
 msgid "Financial income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6115
 #: model:account.group.template,name:l10n_lu.account_group_6115
 msgid "Financial leasing on movable property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6114
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6114
+#: model:account.group,name:l10n_lu.2_account_group_6114
 #: model:account.group.template,name:l10n_lu.account_group_6114
 msgid "Financial leasing on real property"
 msgstr "Immobilienfinanzierungsleasing"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_1882
 #: model:account.account.template,name:l10n_lu.lu_2011_account_1882
+#: model:account.group,name:l10n_lu.2_account_group_1882
 #: model:account.group.template,name:l10n_lu.account_group_1882
 msgid "Financial provisions"
 msgstr "Finanzielle Rückstellungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6481
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6481
+#: model:account.group,name:l10n_lu.2_account_group_6481
 #: model:account.group.template,name:l10n_lu.account_group_6481
 msgid "Fines, sanctions and penalties"
 msgstr "Steuer- und strafrechtliche Bußgelder"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106143
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106143
 msgid "Fire insurance"
 msgstr "Brandschutzversicherung"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2214
 #: model:account.group.template,name:l10n_lu.account_group_2214
 msgid "Fixtures and fitting-outs of buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22141
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22141
+#: model:account.group,name:l10n_lu.2_account_group_22141
 #: model:account.group.template,name:l10n_lu.account_group_22141
 msgid "Fixtures and fitting-outs of buildings in Luxembourg"
 msgstr "Einrichtung von Bauten / Gebäuden in Luxemburg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22142
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22142
+#: model:account.group,name:l10n_lu.2_account_group_22142
 #: model:account.group.template,name:l10n_lu.account_group_22142
 msgid "Fixtures and fitting-outs of buildings in foreign countries"
 msgstr "Einrichtung von Bauten / Gebäuden im Ausland"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22121
+#: model:account.group,name:l10n_lu.2_account_group_22121
 #: model:account.group.template,name:l10n_lu.account_group_22121
 msgid "Fixtures and fitting-outs of land in Luxembourg"
 msgstr "Erschließung von Grundstücken in Luxembourg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22122
+#: model:account.group,name:l10n_lu.2_account_group_22122
 #: model:account.group.template,name:l10n_lu.account_group_22122
 msgid "Fixtures and fitting-outs of land in foreign countries"
 msgstr "Erschließung von Grundstücken im Ausland"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2212
 #: model:account.group.template,name:l10n_lu.account_group_2212
 msgid "Fixtures and fittings-out of land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4622
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4622
+#: model:account.group,name:l10n_lu.2_account_group_4622
 #: model:account.group.template,name:l10n_lu.account_group_4622
 msgid "Foreign Social Security offices"
 msgstr "Ausländische Sozialversicherungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421811
+#: model:account.account,name:l10n_lu.2_lu_2020_account_46151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421811
 #: model:account.account.template,name:l10n_lu.lu_2020_account_46151
+#: model:account.group,name:l10n_lu.2_account_group_421811
+#: model:account.group,name:l10n_lu.2_account_group_46151
 #: model:account.group.template,name:l10n_lu.account_group_421811
 #: model:account.group.template,name:l10n_lu.account_group_46151
 msgid "Foreign VAT"
 msgstr "Ausländische MwSt"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_756
 #: model:account.group.template,name:l10n_lu.account_group_756
 msgid "Foreign currency exchange gains"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7561
+#: model:account.group,name:l10n_lu.2_account_group_7561
 #: model:account.group.template,name:l10n_lu.account_group_7561
 msgid "Foreign currency exchange gains - affiliated undertakings"
 msgstr "Wechselkursgewinne - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7562
+#: model:account.group,name:l10n_lu.2_account_group_7562
 #: model:account.group.template,name:l10n_lu.account_group_7562
 msgid "Foreign currency exchange gains - other"
 msgstr "Wechselkursgewinne - sonstige"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_656
 #: model:account.group.template,name:l10n_lu.account_group_656
 msgid "Foreign currency exchange losses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6561
+#: model:account.group,name:l10n_lu.2_account_group_6561
 #: model:account.group.template,name:l10n_lu.account_group_6561
 msgid "Foreign currency exchange losses - affiliated undertakings"
 msgstr "Wechselkursverluste - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6562
+#: model:account.group,name:l10n_lu.2_account_group_6562
 #: model:account.group.template,name:l10n_lu.account_group_6562
 msgid "Foreign currency exchange losses - other"
 msgstr "Wechselkursverluste - sonstige"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_673
 #: model:account.group.template,name:l10n_lu.account_group_673
 msgid "Foreign income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42172
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42172
+#: model:account.group,name:l10n_lu.2_account_group_42172
 #: model:account.group.template,name:l10n_lu.account_group_42172
 msgid "Foreign social security offices"
 msgstr "Ausländische Sozialversicherungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4615
 #: model:account.group.template,name:l10n_lu.account_group_4615
 msgid "Foreign tax authorities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_683
 #: model:account.account.template,name:l10n_lu.lu_2011_account_683
+#: model:account.group,name:l10n_lu.2_account_group_42181
+#: model:account.group,name:l10n_lu.2_account_group_683
 #: model:account.group.template,name:l10n_lu.account_group_42181
 #: model:account.group.template,name:l10n_lu.account_group_683
 msgid "Foreign taxes"
 msgstr "Ausländische Steuern"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_20
 #: model:account.group.template,name:l10n_lu.account_group_20
 msgid "Formation expenses and similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_755231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_755231
+#: model:account.group,name:l10n_lu.2_account_group_65411
 #: model:account.group.template,name:l10n_lu.account_group_65411
 msgid "From affiliated undertakings"
 msgstr "Forderungen gegen verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_755232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_755232
 msgid "From other"
 msgstr "Von sonstigen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65413
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65413
 msgid "From other receivables from current assets"
 msgstr "Sonstige Forderungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65412
+#: model:account.group,name:l10n_lu.2_account_group_65412
 #: model:account.group.template,name:l10n_lu.account_group_65412
 msgid ""
 "From undertakings with which the undertaking is linked by virtue of "
@@ -3859,11 +4822,13 @@ msgstr ""
 "Forderungen gegen Unternehmen, mit denen ein Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6031
 #: model:account.group.template,name:l10n_lu.account_group_6031
 msgid "Fuels, gas, water and electricity"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6184
 #: model:account.group.template,name:l10n_lu.account_group_6184
 msgid ""
 "Fuels, gas, water and electricity (not included in the production of goods "
@@ -3871,17 +4836,21 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106145
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106145
 msgid "Full coverage insurance"
 msgstr "Mehrgefahrenversicherung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2234
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2234
+#: model:account.group,name:l10n_lu.2_account_group_2234
 #: model:account.group.template,name:l10n_lu.account_group_2234
 msgid "Furniture"
 msgstr "Mobiliar"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_754
 #: model:account.group.template,name:l10n_lu.account_group_754
 msgid ""
 "Gain on disposal and other income from current receivables and transferable "
@@ -3889,104 +4858,133 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7522
 #: model:account.group.template,name:l10n_lu.account_group_7522
 msgid "Gain on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_744
 #: model:account.group.template,name:l10n_lu.account_group_744
 msgid "Gain on disposal of intangible and tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7441
 #: model:account.group.template,name:l10n_lu.account_group_7441
 msgid "Gain on disposal of intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7541
 #: model:account.group.template,name:l10n_lu.account_group_7541
 msgid "Gain on disposal of receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7542
 #: model:account.group.template,name:l10n_lu.account_group_7542
 msgid "Gain on disposal of transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60313
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61843
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60313
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61843
+#: model:account.group,name:l10n_lu.2_account_group_60313
+#: model:account.group,name:l10n_lu.2_account_group_61843
 #: model:account.group.template,name:l10n_lu.account_group_60313
 #: model:account.group.template,name:l10n_lu.account_group_61843
 msgid "Gas"
-msgstr "Gas"
+msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6121
+#: model:account.group,name:l10n_lu.2_account_group_6121
 #: model:account.group.template,name:l10n_lu.account_group_6121
 msgid ""
-"General subcontracting (not included in the production of goods and services)"
+"General subcontracting (not included in the production of goods and "
+"services)"
 msgstr ""
 "Allgemeine Zulieferung (nicht für Werklieferungen und -leistungen und "
 "sonstige Arbeiten)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106194
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106194
 msgid "Gifts and allowance to children"
 msgstr "Spenden und Zuwendungen an Kinder"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61514
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61514
+#: model:account.group,name:l10n_lu.2_account_group_61514
 #: model:account.group.template,name:l10n_lu.account_group_61514
 msgid "Gifts to customers"
 msgstr "Geschenke für Kunden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_213
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_213
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1613
+#: model:account.group,name:l10n_lu.2_account_group_1613
+#: model:account.group,name:l10n_lu.2_account_group_213
 #: model:account.group.template,name:l10n_lu.account_group_1613
 #: model:account.group.template,name:l10n_lu.account_group_213
 msgid "Goodwill acquired for consideration"
 msgstr "Geschäfts- oder Firmenwert, soweit er entgeltlich erworben wurde"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6556
 #: model:account.group.template,name:l10n_lu.account_group_6556
 msgid "Granted discounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65561
+#: model:account.group,name:l10n_lu.2_account_group_65561
 #: model:account.group.template,name:l10n_lu.account_group_65561
 msgid "Granted discounts - affiliated undertakings"
 msgstr "Gewährte Diskonten - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65562
+#: model:account.group,name:l10n_lu.2_account_group_65562
 #: model:account.group.template,name:l10n_lu.account_group_65562
 msgid "Granted discounts - other"
 msgstr "Gewährte Diskonten - sonstige"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_212152
 #: model:account.group.template,name:l10n_lu.account_group_212152
 msgid "Greenhous gas and similar emission quotas"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212152
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212152
 msgid "Greenhouse gas and similar emission quotas"
 msgstr "Kontigente für Treibhausgasemissionen und ähnliche"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6211
 #: model:account.group.template,name:l10n_lu.account_group_6211
 msgid "Gross wages"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106153
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106153
 msgid "Health insurance funds"
 msgstr "Krankenversicherungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106163
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106163
 msgid "Heating, gas, electricity"
 msgstr "Heizung, Gas, Strom"
@@ -4007,17 +5005,21 @@ msgid "III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)"
 msgstr "III. BERECHNUNG DER ABZIEHBAREN VORSTEUER"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7
 #: model:account.group.template,name:l10n_lu.account_group_7
 msgid "INCOME ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_3
 #: model:account.group.template,name:l10n_lu.account_group_3
 msgid "INVENTORIES ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6132
+#: model:account.group,name:l10n_lu.2_account_group_6132
 #: model:account.group.template,name:l10n_lu.account_group_6132
 msgid "IT services"
 msgstr "IT - Instandhaltung"
@@ -4028,125 +5030,157 @@ msgid "IV. TAX TO BE PAID OR TO BE RECLAIMED"
 msgstr "IV. BERECHNUNG DES ÜBERSCHUSSES"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62114
+#: model:account.group,name:l10n_lu.2_account_group_62114
 #: model:account.group.template,name:l10n_lu.account_group_62114
 msgid "Incentives, bonuses and commissions"
 msgstr "Gratifikationen, Prämien und Provisionen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_752
 #: model:account.group.template,name:l10n_lu.account_group_752
 msgid "Income and gain on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7521
 #: model:account.group.template,name:l10n_lu.account_group_7521
 msgid "Income from financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7442
 #: model:account.group.template,name:l10n_lu.account_group_7442
 msgid "Income of yielded tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106281
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106281
 msgid "Income tax"
 msgstr "Einkommenssteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106181
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106181
 msgid "Income tax paid"
 msgstr "Gezahlte Einkommenssteuer"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_67
 #: model:account.group.template,name:l10n_lu.account_group_67
 msgid "Income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_642
 #: model:account.account.template,name:l10n_lu.lu_2011_account_642
+#: model:account.group,name:l10n_lu.2_account_group_642
 #: model:account.group.template,name:l10n_lu.account_group_642
 msgid "Indemnities, damages and interest"
 msgstr "Entschädigungen, Schadensersatz und Zinsen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4216
 #: model:account.group.template,name:l10n_lu.account_group_4216
 msgid "Indirect Tax Authority (AED)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4614
 #: model:account.group.template,name:l10n_lu.account_group_4614
 msgid "Indirect tax authorities (AED)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_42162
+#: model:account.group,name:l10n_lu.2_account_group_46142
 #: model:account.group.template,name:l10n_lu.account_group_42162
 #: model:account.group.template,name:l10n_lu.account_group_46142
 msgid "Indirect taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6183
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6183
+#: model:account.group,name:l10n_lu.2_account_group_6183
 #: model:account.group.template,name:l10n_lu.account_group_6183
 msgid "Industrial and non-industrial waste treatment"
 msgstr "Abfallbeseitigung von Industrieabfällen und sonstigen Abfällen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10621
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10621
 msgid "Inheritance or donation"
 msgstr "Erbschaft oder Schenkung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106195
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106195
 msgid "Inheritance taxes and mutation tax due to death"
 msgstr "Erbschaftssteuern und Wechselsteuer durch Sterbefall"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62414
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62414
+#: model:account.group,name:l10n_lu.2_account_group_62414
 #: model:account.group.template,name:l10n_lu.account_group_62414
 msgid "Insolvency insurance premiums"
 msgstr "Beiträge zur Insolvenzversicherung"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6141
 #: model:account.group.template,name:l10n_lu.account_group_6141
 msgid "Insurance for assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7481
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7481
+#: model:account.group,name:l10n_lu.2_account_group_7481
 #: model:account.group.template,name:l10n_lu.account_group_7481
 msgid "Insurance indemnities"
 msgstr "Versicherungsentschädigungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6142
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6142
+#: model:account.group,name:l10n_lu.2_account_group_6142
 #: model:account.group.template,name:l10n_lu.account_group_6142
 msgid "Insurance on rented assets"
 msgstr "Versicherung für gemietete Vermögensgegenstände"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_614
 #: model:account.group.template,name:l10n_lu.account_group_614
 msgid "Insurance premiums"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_21
+#: model:account.group,name:l10n_lu.2_account_group_721
 #: model:account.group.template,name:l10n_lu.account_group_21
 #: model:account.group.template,name:l10n_lu.account_group_721
 msgid "Intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_655
 #: model:account.group.template,name:l10n_lu.account_group_655
 msgid "Interest and discounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75541
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75541
+#: model:account.group,name:l10n_lu.2_account_group_75541
 #: model:account.group.template,name:l10n_lu.account_group_75541
 msgid "Interest on amounts owed by affiliated undertakings"
 msgstr "Zinsen auf Forderungen gegen verbundene Unternehmen "
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7554
 #: model:account.group.template,name:l10n_lu.account_group_7554
 msgid ""
 "Interest on amounts owed by affiliated undertakings and undertakings with "
@@ -4154,7 +5188,9 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75542
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75542
+#: model:account.group,name:l10n_lu.2_account_group_75542
 #: model:account.group.template,name:l10n_lu.account_group_75542
 msgid ""
 "Interest on amounts owed by undertakings with which the undertaking is "
@@ -4164,82 +5200,107 @@ msgstr ""
 "Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75521
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75521
+#: model:account.group,name:l10n_lu.2_account_group_75521
 #: model:account.group.template,name:l10n_lu.account_group_75521
 msgid "Interest on bank accounts"
 msgstr "Kontozinsen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6551
 #: model:account.group.template,name:l10n_lu.account_group_6551
 msgid "Interest on debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65511
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65511
+#: model:account.group,name:l10n_lu.2_account_group_65511
 #: model:account.group.template,name:l10n_lu.account_group_65511
 msgid "Interest on debenture loans - affiliated undertakings"
 msgstr "Zinsen auf Anleihen - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65512
+#: model:account.group,name:l10n_lu.2_account_group_65512
 #: model:account.group.template,name:l10n_lu.account_group_65512
 msgid "Interest on debenture loans - other"
 msgstr "Zinsen auf Anleihen - sonstige"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65523
+#: model:account.group,name:l10n_lu.2_account_group_75523
 #: model:account.group.template,name:l10n_lu.account_group_65523
 #: model:account.group.template,name:l10n_lu.account_group_75523
 msgid "Interest on financial leases"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_655231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_655231
+#: model:account.group,name:l10n_lu.2_account_group_655231
 #: model:account.group.template,name:l10n_lu.account_group_655231
 msgid "Interest on financial leases - affiliated undertakings"
 msgstr "Zinsen auf Finanzierungsleasings - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_655232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_655232
+#: model:account.group,name:l10n_lu.2_account_group_655232
 #: model:account.group.template,name:l10n_lu.account_group_655232
 msgid "Interest on financial leases - other"
 msgstr "Zinsen auf Finanzierungsleasings - sonstige"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7558
 #: model:account.group.template,name:l10n_lu.account_group_7558
 msgid "Interest on other amounts receivable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75581
+#: model:account.group,name:l10n_lu.2_account_group_75581
 #: model:account.group.template,name:l10n_lu.account_group_75581
 msgid "Interest on other amounts receivable - affiliated undertakings"
 msgstr "Zinsen auf sonstigen Forderungen - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75582
+#: model:account.group,name:l10n_lu.2_account_group_75582
 #: model:account.group.template,name:l10n_lu.account_group_75582
 msgid "Interest on other amounts receivable - other"
 msgstr "Zinsen auf sonstigen Forderungen - sonstige"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6553
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6553
+#: model:account.group,name:l10n_lu.2_account_group_6553
 #: model:account.group.template,name:l10n_lu.account_group_6553
 msgid "Interest on trade payables"
 msgstr "Zinsen auf Verbindlichkeiten aus Lieferungen und Leistungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7553
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7553
+#: model:account.group,name:l10n_lu.2_account_group_7553
 #: model:account.group.template,name:l10n_lu.account_group_7553
 msgid "Interest on trade receivables"
 msgstr "Zinsen auf Handelsforderungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6558
 #: model:account.group.template,name:l10n_lu.account_group_6558
 msgid "Interest payable on other loans and debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65581
+#: model:account.group,name:l10n_lu.2_account_group_65581
 #: model:account.group.template,name:l10n_lu.account_group_65581
 msgid "Interest payable on other loans and debts - affiliated undertakings"
 msgstr ""
@@ -4247,18 +5308,23 @@ msgstr ""
 "Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65582
+#: model:account.group,name:l10n_lu.2_account_group_65582
 #: model:account.group.template,name:l10n_lu.account_group_65582
 msgid "Interest payable on other loans and debts - other"
 msgstr "Zinsen auf sonstige Ausleihungen und Verbindlichkeiten - sonstige"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65541
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65541
+#: model:account.group,name:l10n_lu.2_account_group_65541
 #: model:account.group.template,name:l10n_lu.account_group_65541
 msgid "Interest payable to affiliated undertakings"
 msgstr "Zinsen auf Verbindlichkeiten gegenüber verbundenen Unternehmen "
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6554
 #: model:account.group.template,name:l10n_lu.account_group_6554
 msgid ""
 "Interest payable to affiliated undertakings and undertakings with which the "
@@ -4266,7 +5332,9 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65542
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65542
+#: model:account.group,name:l10n_lu.2_account_group_65542
 #: model:account.group.template,name:l10n_lu.account_group_65542
 msgid ""
 "Interest payable to undertakings with which the undertaking is linked by "
@@ -4276,138 +5344,177 @@ msgstr ""
 "Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7452
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7452
+#: model:account.group,name:l10n_lu.2_account_group_7452
 #: model:account.group.template,name:l10n_lu.account_group_7452
 msgid "Interest subsidies"
 msgstr "Zinszuschüsse"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_15
 #: model:account.account.template,name:l10n_lu.lu_2011_account_15
+#: model:account.group,name:l10n_lu.2_account_group_15
 #: model:account.group.template,name:l10n_lu.account_group_15
 msgid "Interim dividends"
 msgstr "Vorabdividenden"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_517
 #: model:account.group.template,name:l10n_lu.account_group_517
 msgid "Internal transfers"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5172
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5172
+#: model:account.group,name:l10n_lu.2_account_group_5172
 #: model:account.group.template,name:l10n_lu.account_group_5172
 msgid "Internal transfers : credit balance"
 msgstr "Interne Transferkonten : Guthaben"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5171
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5171
+#: model:account.group,name:l10n_lu.2_account_group_5171
 #: model:account.group.template,name:l10n_lu.account_group_5171
 msgid "Internal transfers : debit balance"
 msgstr "Interne Transferkonten : Sollsaldo"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_IC
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_IC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_IC
 msgid "Intra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_363
 #: model:account.group.template,name:l10n_lu.account_group_363
 msgid "Inventories of buildings for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3631
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3631
+#: model:account.group,name:l10n_lu.2_account_group_3631
 #: model:account.group.template,name:l10n_lu.account_group_3631
 msgid "Inventories of buildings for resale in Luxembourg"
 msgstr "Vorräte an, zum Verkauf bestimmten, Bauten / Gebäuden in Luxemburg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3632
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3632
+#: model:account.group,name:l10n_lu.2_account_group_3632
 #: model:account.group.template,name:l10n_lu.account_group_3632
 msgid "Inventories of buildings for resale in foreign countries"
 msgstr "Vorräte an, zum Verkauf bestimmten, Bauten / Gebäuden im Ausland"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_303
 #: model:account.account.template,name:l10n_lu.lu_2020_account_303
+#: model:account.group,name:l10n_lu.2_account_group_303
 #: model:account.group.template,name:l10n_lu.account_group_303
 msgid "Inventories of consumable materials and supplies"
 msgstr "Vorräte an Hilfs-und Betriebsstoffen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_321
 #: model:account.account.template,name:l10n_lu.lu_2011_account_321
+#: model:account.group,name:l10n_lu.2_account_group_321
 #: model:account.group.template,name:l10n_lu.account_group_321
 msgid "Inventories of finished goods"
 msgstr "Vorräte an fertigen Erzeugnissen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_32
 #: model:account.group.template,name:l10n_lu.account_group_32
 msgid "Inventories of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_362
 #: model:account.group.template,name:l10n_lu.account_group_362
 msgid "Inventories of land for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3621
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3621
+#: model:account.group,name:l10n_lu.2_account_group_3621
 #: model:account.group.template,name:l10n_lu.account_group_3621
 msgid "Inventories of land for resale in Luxembourg"
 msgstr "Vorräte an, zum Verkauf bestimmten, Grundstücken in Luxemburg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3622
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3622
+#: model:account.group,name:l10n_lu.2_account_group_3622
 #: model:account.group.template,name:l10n_lu.account_group_3622
 msgid "Inventories of land for resale in foreign countries"
 msgstr "Vorräte an, zum Verkauf bestimmten, Grundstücken im Ausland"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_361
 #: model:account.account.template,name:l10n_lu.lu_2020_account_361
+#: model:account.group,name:l10n_lu.2_account_group_361
 #: model:account.group.template,name:l10n_lu.account_group_361
 msgid "Inventories of merchandise"
 msgstr "Vorräte an Waren"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_36
 #: model:account.group.template,name:l10n_lu.account_group_36
 msgid "Inventories of merchandises and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_304
 #: model:account.account.template,name:l10n_lu.lu_2020_account_304
+#: model:account.group,name:l10n_lu.2_account_group_304
 #: model:account.group.template,name:l10n_lu.account_group_304
 msgid "Inventories of packaging"
 msgstr "Vorräte an Verpackungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_301
 #: model:account.account.template,name:l10n_lu.lu_2011_account_301
+#: model:account.group,name:l10n_lu.2_account_group_301
 #: model:account.group.template,name:l10n_lu.account_group_301
 msgid "Inventories of raw materials"
 msgstr "Vorräte an Rohstoffen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_30
 #: model:account.group.template,name:l10n_lu.account_group_30
 msgid "Inventories of raw materials and consumables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_323
 #: model:account.account.template,name:l10n_lu.lu_2020_account_323
+#: model:account.group,name:l10n_lu.2_account_group_323
 #: model:account.group.template,name:l10n_lu.account_group_323
 msgid ""
 "Inventories of residual goods (waste, rejected and recuperable material)"
 msgstr "Vorräte an Restprodukten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_322
+#: model:account.group,name:l10n_lu.2_account_group_322
 #: model:account.group.template,name:l10n_lu.account_group_322
 msgid "Inventories of semi-finished goods"
 msgstr "Vorräte an Zwischenprodukten"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_31
 #: model:account.group.template,name:l10n_lu.account_group_31
 msgid "Inventories of work and contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4312
+#: model:account.group,name:l10n_lu.2_account_group_4322
 #: model:account.group.template,name:l10n_lu.account_group_4312
 #: model:account.group.template,name:l10n_lu.account_group_4322
 msgid ""
@@ -4415,187 +5522,255 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_311
+#: model:account.group,name:l10n_lu.2_account_group_311
 #: model:account.group.template,name:l10n_lu.account_group_311
 msgid "Inventories of work in progress"
 msgstr "Vorräte an unfertigen Erzeugnissen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2215
 #: model:account.group.template,name:l10n_lu.account_group_2215
 msgid "Investment properties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22151
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22151
+#: model:account.group,name:l10n_lu.2_account_group_22151
 #: model:account.group.template,name:l10n_lu.account_group_22151
 msgid "Investment properties in Luxembourg"
 msgstr "Anlageimmobilien in Luxembourg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22152
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22152
+#: model:account.group,name:l10n_lu.2_account_group_22152
 #: model:account.group.template,name:l10n_lu.account_group_22152
 msgid "Investment properties in foreign countries"
 msgstr "Anlageimmobilien im Ausland"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42131
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42131
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42231
+#: model:account.group,name:l10n_lu.2_account_group_42131
+#: model:account.group,name:l10n_lu.2_account_group_42231
 #: model:account.group.template,name:l10n_lu.account_group_42131
 #: model:account.group.template,name:l10n_lu.account_group_42231
 msgid "Investment subsidies"
 msgstr "Investitionszuschüsse"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_42171
+#: model:account.group,name:l10n_lu.2_account_group_4621
 #: model:account.group.template,name:l10n_lu.account_group_42171
 #: model:account.group.template,name:l10n_lu.account_group_4621
 msgid "Joint Social Security Centre (CCSS)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61111
+#: model:account.group,name:l10n_lu.2_account_group_2211
+#: model:account.group,name:l10n_lu.2_account_group_61111
 #: model:account.group.template,name:l10n_lu.account_group_2211
 #: model:account.group.template,name:l10n_lu.account_group_61111
 msgid "Land"
 msgstr "Grundstücke"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60762
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60762
+#: model:account.group,name:l10n_lu.2_account_group_60762
 #: model:account.group.template,name:l10n_lu.account_group_60762
 msgid "Land for resale"
 msgstr "Zum Verkauf bestimme Grundstücke"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_22111
 #: model:account.group.template,name:l10n_lu.account_group_22111
 msgid "Land in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22112
+#: model:account.group,name:l10n_lu.2_account_group_22112
 #: model:account.group.template,name:l10n_lu.account_group_22112
 msgid "Land in foreign countries"
 msgstr "Grundstücke im Ausland"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2241
 #: model:account.group.template,name:l10n_lu.account_group_2241
 msgid "Land, fitting-outs and buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22411
+#: model:account.group,name:l10n_lu.2_account_group_22411
 #: model:account.group.template,name:l10n_lu.account_group_22411
 msgid "Land, fitting-outs and buildings in Luxembourg"
 msgstr "Grundstücke, Erschließungen, Einrichtungen und Bauten in Luxemburg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22412
+#: model:account.group,name:l10n_lu.2_account_group_22412
 #: model:account.group.template,name:l10n_lu.account_group_22412
 msgid "Land, fitting-outs and buildings in foreign countries"
 msgstr "Grundstücke, Erschließungen, Einrichtungen und Bauten im Ausland"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7221
+#: model:account.group,name:l10n_lu.2_account_group_7221
 #: model:account.group.template,name:l10n_lu.account_group_7221
 msgid "Land, fittings and buildings"
 msgstr "Grundstücke, Erschließungen, Einrichtungen und Bauten"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_221
 #: model:account.group.template,name:l10n_lu.account_group_221
 msgid "Land, fixtures and fitting-outs and buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47162
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47262
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47162
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47262
+#: model:account.group,name:l10n_lu.2_account_group_47162
+#: model:account.group,name:l10n_lu.2_account_group_47262
 #: model:account.group.template,name:l10n_lu.account_group_47162
 #: model:account.group.template,name:l10n_lu.account_group_47262
 msgid "Lease debts"
 msgstr "Verbindlichkeiten aus Finanzierungsleasing"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_131
 #: model:account.account.template,name:l10n_lu.lu_2011_account_131
+#: model:account.group,name:l10n_lu.2_account_group_131
 #: model:account.group.template,name:l10n_lu.account_group_131
 msgid "Legal reserve"
 msgstr "Gesetzliche Rücklage"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61341
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61341
+#: model:account.group,name:l10n_lu.2_account_group_61341
 #: model:account.group.template,name:l10n_lu.account_group_61341
 msgid "Legal, litigation and similar fees"
 msgstr "Rechts- und Prozesskosten und ähnliche"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47163
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47263
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47163
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47263
+#: model:account.group,name:l10n_lu.2_account_group_47163
+#: model:account.group,name:l10n_lu.2_account_group_47263
 #: model:account.group.template,name:l10n_lu.account_group_47163
 #: model:account.group.template,name:l10n_lu.account_group_47263
 msgid "Life annuities"
 msgstr "Leibrenten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106141
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106141
 msgid "Life insurance"
 msgstr "Lebensversicherung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_486
 #: model:account.account.template,name:l10n_lu.lu_2011_account_486
+#: model:account.group,name:l10n_lu.2_account_group_486
 #: model:account.group.template,name:l10n_lu.account_group_486
 msgid "Linking accounts (branches) - Assets"
 msgstr "Verbindungskonten (Niederlassungen) - Aktiva"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_487
 #: model:account.account.template,name:l10n_lu.lu_2011_account_487
+#: model:account.group,name:l10n_lu.2_account_group_487
 #: model:account.group.template,name:l10n_lu.account_group_487
 msgid "Linking accounts (branches) - Liabilities"
 msgstr "Verbindungskonten (Niederlassungen) - Passiva"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60312
+#: model:account.group,name:l10n_lu.2_account_group_60312
 #: model:account.group.template,name:l10n_lu.account_group_60312
 msgid "Liquid fuels"
 msgstr "Flüssige Brennstoffe"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61842
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61842
+#: model:account.group,name:l10n_lu.2_account_group_61842
 #: model:account.group.template,name:l10n_lu.account_group_61842
 msgid "Liquid fuels (oil, motor fuel, etc.)"
 msgstr "Flüssige Brennsoffe"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2011_chart_1_liquidity_transfer
+#: model:account.account,name:l10n_lu.2_lu_2011_chart_1_liquidity_transfer
 msgid "Liquidity Transfer"
 msgstr "Liquiditätsübertragung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5084
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5084
+#: model:account.group,name:l10n_lu.2_account_group_5084
 #: model:account.group.template,name:l10n_lu.account_group_5084
 msgid "Listed debenture loans"
 msgstr "Anleihen - Notierte Wertpapiere"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_235111
 #: model:account.account.template,name:l10n_lu.lu_2020_account_235111
+#: model:account.group,name:l10n_lu.2_account_group_235111
 #: model:account.group.template,name:l10n_lu.account_group_235111
 msgid "Listed shares"
 msgstr "Notierte Aktien"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2236
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2236
+#: model:account.group,name:l10n_lu.2_account_group_2236
 #: model:account.group.template,name:l10n_lu.account_group_2236
 msgid "Livestock"
 msgstr "Viehbestand"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_204
 #: model:account.account.template,name:l10n_lu.lu_2011_account_204
+#: model:account.group,name:l10n_lu.2_account_group_204
 #: model:account.group.template,name:l10n_lu.account_group_204
 msgid "Loan issuances expenses"
 msgstr "Emissionskosten von Anleihen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_2361
 #: model:account.account.template,name:l10n_lu.lu_2020_account_2361
+#: model:account.group,name:l10n_lu.2_account_group_2361
 #: model:account.group.template,name:l10n_lu.account_group_2361
 msgid "Loans"
 msgstr "Ausleihungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41112
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41122
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41212
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41222
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45112
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45122
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45212
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41212
@@ -4604,6 +5779,14 @@ msgstr "Ausleihungen"
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45222
+#: model:account.group,name:l10n_lu.2_account_group_41112
+#: model:account.group,name:l10n_lu.2_account_group_41122
+#: model:account.group,name:l10n_lu.2_account_group_41212
+#: model:account.group,name:l10n_lu.2_account_group_41222
+#: model:account.group,name:l10n_lu.2_account_group_45112
+#: model:account.group,name:l10n_lu.2_account_group_45122
+#: model:account.group,name:l10n_lu.2_account_group_45212
+#: model:account.group,name:l10n_lu.2_account_group_45222
 #: model:account.group.template,name:l10n_lu.account_group_41112
 #: model:account.group.template,name:l10n_lu.account_group_41122
 #: model:account.group.template,name:l10n_lu.account_group_41212
@@ -4616,21 +5799,32 @@ msgid "Loans and advances"
 msgstr "Ausleihungen und geleistete Anzahlungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4716
+#: model:account.group,name:l10n_lu.2_account_group_4726
 #: model:account.group.template,name:l10n_lu.account_group_4716
 #: model:account.group.template,name:l10n_lu.account_group_4726
 msgid "Loans and similar debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61332
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61332
+#: model:account.group,name:l10n_lu.2_account_group_61332
 #: model:account.group.template,name:l10n_lu.account_group_61332
 msgid "Loans' issuance expenses"
 msgstr "Emissionskosten von Anleihen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75116
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65216
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75216
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75116
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65216
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75216
+#: model:account.group,name:l10n_lu.2_account_group_236
+#: model:account.group,name:l10n_lu.2_account_group_65216
+#: model:account.group,name:l10n_lu.2_account_group_75216
+#: model:account.group,name:l10n_lu.2_account_group_75226
 #: model:account.group.template,name:l10n_lu.account_group_236
 #: model:account.group.template,name:l10n_lu.account_group_65216
 #: model:account.group.template,name:l10n_lu.account_group_75216
@@ -4640,17 +5834,21 @@ msgstr ""
 "Ausleihungen, geleistete Hinterlegungen und Forderungen (Anlagevermögen)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2363
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2363
+#: model:account.group,name:l10n_lu.2_account_group_2363
 #: model:account.group.template,name:l10n_lu.account_group_2363
 msgid "Long-term receivables"
 msgstr "Forderungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65222
 #: model:account.group.template,name:l10n_lu.account_group_65222
 msgid "Loss on disposal of amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65224
 #: model:account.group.template,name:l10n_lu.account_group_65224
 msgid ""
 "Loss on disposal of amounts owed by undertakings with which the undertaking "
@@ -4658,31 +5856,37 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6522
 #: model:account.group.template,name:l10n_lu.account_group_6522
 msgid "Loss on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_644
 #: model:account.group.template,name:l10n_lu.account_group_644
 msgid "Loss on disposal of intangible and tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6441
 #: model:account.group.template,name:l10n_lu.account_group_6441
 msgid "Loss on disposal of intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65226
 #: model:account.group.template,name:l10n_lu.account_group_65226
 msgid "Loss on disposal of loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65223
 #: model:account.group.template,name:l10n_lu.account_group_65223
 msgid "Loss on disposal of participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_654
 #: model:account.group.template,name:l10n_lu.account_group_654
 msgid ""
 "Loss on disposal of receivables and transferable securities from current "
@@ -4690,37 +5894,45 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6541
 #: model:account.group.template,name:l10n_lu.account_group_6541
 msgid "Loss on disposal of receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65225
 #: model:account.group.template,name:l10n_lu.account_group_65225
 msgid "Loss on disposal of securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65221
 #: model:account.group.template,name:l10n_lu.account_group_65221
 msgid "Loss on disposal of shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6442
 #: model:account.group.template,name:l10n_lu.account_group_6442
 msgid "Loss on disposal of tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6542
 #: model:account.group.template,name:l10n_lu.account_group_6542
 msgid "Loss on disposal of transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_645
 #: model:account.group.template,name:l10n_lu.account_group_645
 msgid "Losses on bad debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6037
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6037
+#: model:account.group,name:l10n_lu.2_account_group_6037
 #: model:account.group.template,name:l10n_lu.account_group_6037
 msgid "Lubricants"
 msgstr "Schmiermittel"
@@ -4731,251 +5943,325 @@ msgid "Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_LU
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_LU
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_LU
 msgid "Luxembourgish Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461221
+#: model:account.group,name:l10n_lu.2_account_group_461221
 #: model:account.group.template,name:l10n_lu.account_group_461221
 msgid "MBT - Tax accrual"
 msgstr "Gewerbesteuer - Ermittelte Steuerschuld"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461222
+#: model:account.group,name:l10n_lu.2_account_group_461222
 #: model:account.group.template,name:l10n_lu.account_group_461222
 msgid "MBT - Tax payable"
 msgstr "Gewerbesteuer - Zu zahlende Steuerschuld"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6721
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6721
+#: model:account.group,name:l10n_lu.2_account_group_6721
 #: model:account.group.template,name:l10n_lu.account_group_6721
 msgid "MBT - current financial year"
 msgstr "GewSt - laufendes Geschäftsjahr"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6722
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6722
+#: model:account.group,name:l10n_lu.2_account_group_6722
 #: model:account.group.template,name:l10n_lu.account_group_6722
 msgid "MBT - previous financial years"
 msgstr "GewSt - vorhergehende Geschäftsjahre"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2222
+#: model:account.group,name:l10n_lu.2_account_group_2222
 #: model:account.group.template,name:l10n_lu.account_group_2222
 msgid "Machinery"
 msgstr "Maschinen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6032
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61854
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6032
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61854
+#: model:account.group,name:l10n_lu.2_account_group_6032
+#: model:account.group,name:l10n_lu.2_account_group_61854
 #: model:account.group.template,name:l10n_lu.account_group_6032
 #: model:account.group.template,name:l10n_lu.account_group_61854
 msgid "Maintenance supplies"
 msgstr "Pflegemittel"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_615211
 #: model:account.group.template,name:l10n_lu.account_group_615211
 msgid "Management (if appropriate owner and partner)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_615211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_615211
 msgid "Management (respectively owner and partner)"
 msgstr "Geschäftsleitung (Einzelunternehmer bzw. Gesellschafter)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6151
 #: model:account.group.template,name:l10n_lu.account_group_6151
 msgid "Marketing and advertising costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_615
 #: model:account.group.template,name:l10n_lu.account_group_615
 msgid "Marketing and communication costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60761
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60761
+#: model:account.group,name:l10n_lu.2_account_group_60761
 #: model:account.group.template,name:l10n_lu.account_group_60761
 msgid "Merchandise"
 msgstr "Waren"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_112
+#: model:account.group,name:l10n_lu.2_account_group_112
 #: model:account.group.template,name:l10n_lu.account_group_112
 msgid "Merger premium"
 msgstr "Agio bei Verschmelzungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_618
 #: model:account.group.template,name:l10n_lu.account_group_618
 msgid "Miscellaneous external charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6488
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6488
+#: model:account.group,name:l10n_lu.2_account_group_6488
 #: model:account.group.template,name:l10n_lu.account_group_6488
 msgid "Miscellaneous operating charges"
 msgstr "Sonstige betriebliche Aufwendungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7488
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7488
+#: model:account.group,name:l10n_lu.2_account_group_7488
 #: model:account.group.template,name:l10n_lu.account_group_7488
 msgid "Miscellaneous operating income"
 msgstr "Andere betriebliche Erträge"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4218
+#: model:account.group,name:l10n_lu.2_account_group_4228
 #: model:account.group.template,name:l10n_lu.account_group_4218
 #: model:account.group.template,name:l10n_lu.account_group_4228
 msgid "Miscellaneous receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221313
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221313
+#: model:account.group,name:l10n_lu.2_account_group_221313
 #: model:account.group.template,name:l10n_lu.account_group_221313
 msgid "Mixed-use buildings"
 msgstr "Mischnutzungsbauten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6036
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6036
+#: model:account.group,name:l10n_lu.2_account_group_6036
 #: model:account.group.template,name:l10n_lu.account_group_6036
 msgid "Motor fuels"
 msgstr "Treibstoffe"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2232
+#: model:account.group,name:l10n_lu.2_account_group_2232
 #: model:account.group.template,name:l10n_lu.account_group_2232
 msgid "Motor vehicles"
 msgstr "Transportfahrzeuge"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6466
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6466
+#: model:account.group,name:l10n_lu.2_account_group_6466
 #: model:account.group.template,name:l10n_lu.account_group_6466
 msgid "Motor-vehicle taxes"
 msgstr "Kfz-Steuern"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4611
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4611
+#: model:account.group,name:l10n_lu.2_account_group_4611
 #: model:account.group.template,name:l10n_lu.account_group_4611
 msgid "Municipal authorities"
 msgstr "Gemeindeverwaltungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42142
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42142
+#: model:account.group,name:l10n_lu.2_account_group_42142
+#: model:account.group,name:l10n_lu.2_account_group_672
 #: model:account.group.template,name:l10n_lu.account_group_42142
 #: model:account.group.template,name:l10n_lu.account_group_672
 msgid "Municipal business tax"
 msgstr "Gewerbesteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106284
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106284
+#: model:account.group,name:l10n_lu.2_account_group_46122
 #: model:account.group.template,name:l10n_lu.account_group_46122
 msgid "Municipal business tax (MBT)"
 msgstr "Gewerbesteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106183
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106183
 msgid "Municipal business tax - payment in arrears"
 msgstr "Gewerbesteuer - gezahlte Rückstände"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461231
+#: model:account.group,name:l10n_lu.2_account_group_461231
 #: model:account.group.template,name:l10n_lu.account_group_461231
 msgid "NWT - Tax accrual"
-msgstr "Vermögenssteuer - Ermittelte Steuerschuld"
+msgstr "Vermögensteuer - Ermittelte Steuerschuld"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461232
+#: model:account.group,name:l10n_lu.2_account_group_461232
 #: model:account.group.template,name:l10n_lu.account_group_461232
 msgid "NWT - Tax payable"
-msgstr "Vermögenssteuer - Zu zahlende Steuerschuld"
+msgstr "Vermögensteuer - Zu zahlende Steuerschuld"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6811
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6811
+#: model:account.group,name:l10n_lu.2_account_group_6811
 #: model:account.group.template,name:l10n_lu.account_group_6811
 msgid "NWT - current financial year"
 msgstr "VermSt - laufendes Geschäftsjahr"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6812
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6812
+#: model:account.group,name:l10n_lu.2_account_group_6812
 #: model:account.group.template,name:l10n_lu.account_group_6812
 msgid "NWT - previous financial years"
 msgstr "VermSt - vorhergehende Geschäftsjahre"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_70
 #: model:account.group.template,name:l10n_lu.account_group_70
 msgid "Net turnover"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42143
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42143
+#: model:account.group,name:l10n_lu.2_account_group_42143
 #: model:account.group.template,name:l10n_lu.account_group_42143
 msgid "Net wealth tax"
-msgstr "Vermögenssteuer"
+msgstr "Vermögensteuer"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_46123
+#: model:account.group,name:l10n_lu.2_account_group_681
 #: model:account.group.template,name:l10n_lu.account_group_46123
 #: model:account.group.template,name:l10n_lu.account_group_681
 msgid "Net wealth tax (NWT)"
-msgstr ""
+msgstr "Vermögensteuer (VermSt)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_193
 #: model:account.group.template,name:l10n_lu.account_group_193
 msgid "Non-convertible debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6462
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6462
+#: model:account.group,name:l10n_lu.2_account_group_6462
 #: model:account.group.template,name:l10n_lu.account_group_6462
 msgid "Non-refundable VAT"
 msgstr "Nicht erstattungsfähige Mehrwertsteuer (MwSt)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221312
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221312
+#: model:account.group,name:l10n_lu.2_account_group_221312
 #: model:account.group.template,name:l10n_lu.account_group_221312
 msgid "Non-residential buildings"
 msgstr "Zweckbauten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7099
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7099
+#: model:account.group,name:l10n_lu.2_account_group_7099
 #: model:account.group.template,name:l10n_lu.account_group_7099
 msgid "Not allocated rebates, discounts and refunds"
 msgstr "Nicht zugeordnete RPR"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_NO
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_NO
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_NO
 msgid "Not liable to VAT"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6135
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6135
+#: model:account.group,name:l10n_lu.2_account_group_6135
 #: model:account.group.template,name:l10n_lu.account_group_6135
 msgid "Notarial and similar fees"
 msgstr "Notarielle Beurkundungskosten und ähnliche"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6035
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6035
+#: model:account.group,name:l10n_lu.2_account_group_6035
 #: model:account.group.template,name:l10n_lu.account_group_6035
 msgid "Office and administrative supplies"
 msgstr "Büroausstattung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61851
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61851
+#: model:account.group,name:l10n_lu.2_account_group_61851
 #: model:account.group.template,name:l10n_lu.account_group_61851
 msgid "Office supplies"
 msgstr "Büromaterial"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75411
 msgid "On affiliated undertakings"
 msgstr "Forderungen gegen verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75413
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75413
 msgid "On other current receivables"
 msgstr "Sonstige Forderungen des Umlaufvermögens"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75412
 msgid ""
 "On undertakings with which the undertaking is linked by virtue of "
@@ -4984,26 +6270,44 @@ msgstr ""
 "Forderungen gegen Unternehmen, mit denen ein Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_1881
 #: model:account.account.template,name:l10n_lu.lu_2011_account_1881
+#: model:account.group,name:l10n_lu.2_account_group_1881
 #: model:account.group.template,name:l10n_lu.account_group_1881
 msgid "Operating provisions"
 msgstr "Betriebliche Rückstellungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42132
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42232
+#: model:account.group,name:l10n_lu.2_account_group_42132
+#: model:account.group,name:l10n_lu.2_account_group_42232
 #: model:account.group.template,name:l10n_lu.account_group_42132
 #: model:account.group.template,name:l10n_lu.account_group_42232
 msgid "Operating subsidies"
 msgstr "Betriebszuschüsse"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61418
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6228
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61128
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61158
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61228
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61858
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61418
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6228
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61128
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61158
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61228
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61858
+#: model:account.group,name:l10n_lu.2_account_group_61128
+#: model:account.group,name:l10n_lu.2_account_group_61158
+#: model:account.group,name:l10n_lu.2_account_group_61228
+#: model:account.group,name:l10n_lu.2_account_group_61418
+#: model:account.group,name:l10n_lu.2_account_group_61858
+#: model:account.group,name:l10n_lu.2_account_group_6228
 #: model:account.group.template,name:l10n_lu.account_group_61128
 #: model:account.group.template,name:l10n_lu.account_group_61158
 #: model:account.group.template,name:l10n_lu.account_group_61228
@@ -5014,132 +6318,171 @@ msgid "Other"
 msgstr "Sonstige"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106178
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106178
 msgid "Other acquisitions"
 msgstr "Sonstiger Erwerb"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61338
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61338
+#: model:account.group,name:l10n_lu.2_account_group_61338
 #: model:account.group.template,name:l10n_lu.account_group_61338
 msgid ""
 "Other banking and similar services (except interest and similar expenses)"
 msgstr "Sonstige Bankdienstleistungen (außer Zinsen und vergleichbare Kosten)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6218
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6218
+#: model:account.group,name:l10n_lu.2_account_group_6218
 #: model:account.group.template,name:l10n_lu.account_group_6218
 msgid "Other benefits"
 msgstr "Sonstige Zulagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221318
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221318
+#: model:account.group,name:l10n_lu.2_account_group_221318
 #: model:account.group.template,name:l10n_lu.account_group_221318
 msgid "Other buildings"
 msgstr "Sonstige Bauten / Gebäude"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_168
 #: model:account.account.template,name:l10n_lu.lu_2011_account_168
+#: model:account.group,name:l10n_lu.2_account_group_168
 #: model:account.group.template,name:l10n_lu.account_group_168
 msgid "Other capital investment subsidies"
 msgstr "Sonstige Kapitalsubventionen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_518
 #: model:account.account.template,name:l10n_lu.lu_2011_account_518
+#: model:account.group,name:l10n_lu.2_account_group_518
 #: model:account.group.template,name:l10n_lu.account_group_518
 msgid "Other cash amounts"
 msgstr "Sonstige Guthaben"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_708
 #: model:account.account.template,name:l10n_lu.lu_2020_account_708
+#: model:account.group,name:l10n_lu.2_account_group_708
 #: model:account.group.template,name:l10n_lu.account_group_708
 msgid "Other components of turnover"
 msgstr "Sonstige Umsatzerlöse"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6038
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6038
+#: model:account.group,name:l10n_lu.2_account_group_6038
 #: model:account.group.template,name:l10n_lu.account_group_6038
 msgid "Other consumable supplies"
 msgstr "Sonstige Betriebsstoffe"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106158
 msgid "Other contributions"
 msgstr "Sonstige Beiträge"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_47
 #: model:account.group.template,name:l10n_lu.account_group_47
 msgid "Other debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_472
 #: model:account.group.template,name:l10n_lu.account_group_472
 msgid "Other debts payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_471
 #: model:account.group.template,name:l10n_lu.account_group_471
 msgid "Other debts payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106248
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106248
 msgid "Other disposals"
 msgstr "Sonstige Übertragungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6468
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6468
+#: model:account.group,name:l10n_lu.2_account_group_6468
 #: model:account.group.template,name:l10n_lu.account_group_6468
 msgid "Other duties and taxes"
 msgstr "Sonstige Gebühren und Steuern"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_61
 #: model:account.group.template,name:l10n_lu.account_group_61
 msgid "Other external charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_658
 #: model:account.group.template,name:l10n_lu.account_group_658
 msgid "Other financial charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6581
+#: model:account.group,name:l10n_lu.2_account_group_6581
 #: model:account.group.template,name:l10n_lu.account_group_6581
 msgid "Other financial charges - affiliated undertakings"
 msgstr "Sonstige finanzielle Aufwendungen - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6582
+#: model:account.group,name:l10n_lu.2_account_group_6582
 #: model:account.group.template,name:l10n_lu.account_group_6582
 msgid "Other financial charges - other"
 msgstr "Sonstige finanzielle Aufwendungen - sonstige"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_758
 #: model:account.group.template,name:l10n_lu.account_group_758
 msgid "Other financial income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7581
+#: model:account.group,name:l10n_lu.2_account_group_7581
 #: model:account.group.template,name:l10n_lu.account_group_7581
 msgid "Other financial income - affiliated undertakings"
 msgstr "Sonstige finanzielle Erträge - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7582
+#: model:account.group,name:l10n_lu.2_account_group_7582
 #: model:account.group.template,name:l10n_lu.account_group_7582
 msgid "Other financial income - other"
 msgstr "Sonstige finanzielle Erträge - sonstige"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2238
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2238
+#: model:account.group,name:l10n_lu.2_account_group_2238
 #: model:account.group.template,name:l10n_lu.account_group_2238
 msgid "Other fixtures"
 msgstr "Sonstige Anlagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7223
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7333
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7223
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7333
+#: model:account.group,name:l10n_lu.2_account_group_7223
+#: model:account.group,name:l10n_lu.2_account_group_7333
 #: model:account.group.template,name:l10n_lu.account_group_7223
 #: model:account.group.template,name:l10n_lu.account_group_7333
 msgid ""
@@ -5148,7 +6491,10 @@ msgstr ""
 "Sonstige Anlagen, Betriebs- und Geschäftsausstattung (Fuhrpark inbegriffen)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2243
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2243
+#: model:account.group,name:l10n_lu.2_account_group_223
+#: model:account.group,name:l10n_lu.2_account_group_2243
 #: model:account.group.template,name:l10n_lu.account_group_223
 #: model:account.group.template,name:l10n_lu.account_group_2243
 msgid ""
@@ -5157,115 +6503,160 @@ msgstr ""
 "Sonstige Anlagen, Betriebs- und Geschäftsausstattung (Fuhrpark inbegriffen)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6738
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6738
+#: model:account.group,name:l10n_lu.2_account_group_6738
 #: model:account.group.template,name:l10n_lu.account_group_6738
 msgid "Other foreign income taxes"
 msgstr "Sonstige ausländische Steuern auf Einkommen und Erträge"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421818
+#: model:account.account,name:l10n_lu.2_lu_2020_account_46158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421818
 #: model:account.account.template,name:l10n_lu.lu_2020_account_46158
+#: model:account.group,name:l10n_lu.2_account_group_421818
+#: model:account.group,name:l10n_lu.2_account_group_46158
 #: model:account.group.template,name:l10n_lu.account_group_421818
 #: model:account.group.template,name:l10n_lu.account_group_46158
 msgid "Other foreign taxes"
 msgstr "Sonstige ausländische Steuern"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106168
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106168
 msgid "Other in kind withdrawals"
 msgstr "Sonstige Sachentnahmen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7548
 #: model:account.group.template,name:l10n_lu.account_group_7548
 msgid "Other income from transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421628
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461428
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421628
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461428
+#: model:account.group,name:l10n_lu.2_account_group_421628
+#: model:account.group,name:l10n_lu.2_account_group_461428
 #: model:account.group.template,name:l10n_lu.account_group_421628
 #: model:account.group.template,name:l10n_lu.account_group_461428
 msgid "Other indirect taxes"
 msgstr "Sonstige indirekte Steuern"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6148
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6148
+#: model:account.group,name:l10n_lu.2_account_group_6148
 #: model:account.group.template,name:l10n_lu.account_group_6148
 msgid "Other insurances"
 msgstr "Sonstige Versicherungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_755
 #: model:account.group.template,name:l10n_lu.account_group_755
 msgid "Other interest income from current assets and discounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221118
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221118
+#: model:account.group,name:l10n_lu.2_account_group_221118
 #: model:account.group.template,name:l10n_lu.account_group_221118
 msgid "Other land"
 msgstr "Sonstige Grundstücke"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47161
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47261
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47161
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47261
+#: model:account.group,name:l10n_lu.2_account_group_47161
+#: model:account.group,name:l10n_lu.2_account_group_47261
 #: model:account.group.template,name:l10n_lu.account_group_47161
 #: model:account.group.template,name:l10n_lu.account_group_47261
 msgid "Other loans"
 msgstr "Sonstige Ausleihungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4718
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4728
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4718
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4728
+#: model:account.group,name:l10n_lu.2_account_group_4718
+#: model:account.group,name:l10n_lu.2_account_group_4728
 #: model:account.group.template,name:l10n_lu.account_group_4718
 #: model:account.group.template,name:l10n_lu.account_group_4728
 msgid "Other miscellaneous debts"
 msgstr "Andere sonstige Verbindlichkeiten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6188
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6188
+#: model:account.group,name:l10n_lu.2_account_group_6188
 #: model:account.group.template,name:l10n_lu.account_group_6188
 msgid "Other miscellaneous external charges"
 msgstr "Andere sonstige externe Aufwendungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_648
 #: model:account.group.template,name:l10n_lu.account_group_648
 msgid "Other miscellaneous operating charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_748
 #: model:account.group.template,name:l10n_lu.account_group_748
 msgid "Other miscellaneous operating income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42188
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42288
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42188
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42288
+#: model:account.group,name:l10n_lu.2_account_group_42188
+#: model:account.group,name:l10n_lu.2_account_group_42288
 #: model:account.group.template,name:l10n_lu.account_group_42188
 #: model:account.group.template,name:l10n_lu.account_group_42288
 msgid "Other miscellaneous receivables"
 msgstr "Andere sonstige Forderungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5088
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5088
+#: model:account.group,name:l10n_lu.2_account_group_5088
 #: model:account.group.template,name:l10n_lu.account_group_5088
 msgid "Other miscellaneous transferable securities"
 msgstr "Andere sonstige Wertpapiere"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_64
 #: model:account.group.template,name:l10n_lu.account_group_64
 msgid "Other operating charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_74
 #: model:account.group.template,name:l10n_lu.account_group_74
 msgid "Other operating income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45118
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45128
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45218
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45228
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45118
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45218
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45228
+#: model:account.group,name:l10n_lu.2_account_group_45118
+#: model:account.group,name:l10n_lu.2_account_group_45128
+#: model:account.group,name:l10n_lu.2_account_group_45218
+#: model:account.group,name:l10n_lu.2_account_group_45228
 #: model:account.group.template,name:l10n_lu.account_group_45118
 #: model:account.group.template,name:l10n_lu.account_group_45128
 #: model:account.group.template,name:l10n_lu.account_group_45218
@@ -5274,49 +6665,72 @@ msgid "Other payables"
 msgstr "Sonstige Verbindlichkeiten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106148
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106148
 msgid "Other private insurance premiums"
 msgstr "Sonstige Beiträge für private Versicherungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61348
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61348
+#: model:account.group,name:l10n_lu.2_account_group_61348
 #: model:account.group.template,name:l10n_lu.account_group_61348
 msgid "Other professional fees"
 msgstr "Sonstige Honorare"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_188
 #: model:account.group.template,name:l10n_lu.account_group_188
 msgid "Other provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6088
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6088
+#: model:account.group,name:l10n_lu.2_account_group_6088
 #: model:account.group.template,name:l10n_lu.account_group_6088
 msgid "Other purchases included in the production of goods and services"
 msgstr "Sonstige bezogene Gutachten und Dienstleistungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61518
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61518
+#: model:account.group,name:l10n_lu.2_account_group_61518
 #: model:account.group.template,name:l10n_lu.account_group_61518
 msgid "Other purchases of advertising services"
 msgstr "Sonstige Werbung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6082
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6082
+#: model:account.group,name:l10n_lu.2_account_group_6082
 #: model:account.group.template,name:l10n_lu.account_group_6082
 msgid ""
 "Other purchases of material included in the production of goods and services"
 msgstr ""
-"Sonstige Einkäufe von Material, Ausstattungen, Ersatzteilen und Arbeiten für "
-"Werklieferungen und -leistungen"
+"Sonstige Einkäufe von Material, Ausstattungen, Ersatzteilen und Arbeiten für"
+" Werklieferungen und -leistungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41118
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41128
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41218
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41228
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42168
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6454
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41118
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41218
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41228
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42168
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6454
+#: model:account.group,name:l10n_lu.2_account_group_41118
+#: model:account.group,name:l10n_lu.2_account_group_41128
+#: model:account.group,name:l10n_lu.2_account_group_41218
+#: model:account.group,name:l10n_lu.2_account_group_41228
+#: model:account.group,name:l10n_lu.2_account_group_42
+#: model:account.group,name:l10n_lu.2_account_group_42168
+#: model:account.group,name:l10n_lu.2_account_group_6454
 #: model:account.group.template,name:l10n_lu.account_group_41118
 #: model:account.group.template,name:l10n_lu.account_group_41128
 #: model:account.group.template,name:l10n_lu.account_group_41218
@@ -5328,92 +6742,126 @@ msgid "Other receivables"
 msgstr "Sonstige Forderungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_422
 #: model:account.group.template,name:l10n_lu.account_group_422
 msgid "Other receivables after one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_421
 #: model:account.group.template,name:l10n_lu.account_group_421
 msgid "Other receivables within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64658
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64658
+#: model:account.group,name:l10n_lu.2_account_group_64658
 #: model:account.group.template,name:l10n_lu.account_group_64658
 msgid "Other registration fees, stamp duties and mortgage duties"
 msgstr "Sonstige Eintragungs- und Stempelgebühren und Hypothekensteuern"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6138
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6138
+#: model:account.group,name:l10n_lu.2_account_group_6138
 #: model:account.group.template,name:l10n_lu.account_group_6138
 msgid "Other remuneration of intermediaries and professional fees"
 msgstr "Sonstige Vermittlervergütungen und Honorare"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_1381
 #: model:account.account.template,name:l10n_lu.lu_2011_account_1381
+#: model:account.group,name:l10n_lu.2_account_group_1381
 #: model:account.group.template,name:l10n_lu.account_group_1381
 msgid "Other reserves available for distribution"
 msgstr "Sonstige freie Rücklagen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1382
 #: model:account.group.template,name:l10n_lu.account_group_1382
 msgid "Other reserves not available for distribution"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_138
 #: model:account.group.template,name:l10n_lu.account_group_138
 msgid "Other reserves, including fair-value reserve"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_128
+#: model:account.group,name:l10n_lu.2_account_group_128
 #: model:account.group.template,name:l10n_lu.account_group_128
 msgid "Other revaluation reserves"
 msgstr "Sonstige Neubewertungsrücklagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2358
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2358
+#: model:account.group,name:l10n_lu.2_account_group_2358
 #: model:account.group.template,name:l10n_lu.account_group_2358
 msgid "Other securities held as fixed assets"
 msgstr "Sonstige Wertpapiere des Anlagevermögens"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_23528
 #: model:account.account.template,name:l10n_lu.lu_2011_account_23528
+#: model:account.group,name:l10n_lu.2_account_group_23528
 #: model:account.group.template,name:l10n_lu.account_group_23528
 msgid "Other securities held as fixed assets (creditor's right)"
 msgstr "Sonstige Wertpapiere des Anlagevermögens (Forderungsrecht)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_23518
 #: model:account.account.template,name:l10n_lu.lu_2011_account_23518
+#: model:account.group,name:l10n_lu.2_account_group_23518
 #: model:account.group.template,name:l10n_lu.account_group_23518
 msgid "Other securities held as fixed assets (equity right)"
 msgstr "Sonstige Wertpapiere des Anlagevermögens (Eigentumsrecht)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47164
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47264
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47164
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47264
+#: model:account.group,name:l10n_lu.2_account_group_47168
+#: model:account.group,name:l10n_lu.2_account_group_47268
 #: model:account.group.template,name:l10n_lu.account_group_47168
 #: model:account.group.template,name:l10n_lu.account_group_47268
 msgid "Other similar debts"
 msgstr "Sonstige vergleichbare Verbindlichkeiten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_208
 #: model:account.account.template,name:l10n_lu.lu_2011_account_208
+#: model:account.group,name:l10n_lu.2_account_group_208
 #: model:account.group.template,name:l10n_lu.account_group_208
 msgid "Other similar expenses"
 msgstr "Sonstige ähnliche Kosten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6438
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6438
+#: model:account.group,name:l10n_lu.2_account_group_6438
 #: model:account.group.template,name:l10n_lu.account_group_6438
 msgid "Other similar remuneration"
 msgstr "Sonstige ähnliche Vergütungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64158
+#: model:account.account,name:l10n_lu.2_lu_2011_account_721258
+#: model:account.account,name:l10n_lu.2_lu_2011_account_74158
+#: model:account.account,name:l10n_lu.2_lu_2020_account_703158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_721258
 #: model:account.account.template,name:l10n_lu.lu_2011_account_74158
 #: model:account.account.template,name:l10n_lu.lu_2020_account_703158
+#: model:account.group,name:l10n_lu.2_account_group_64158
+#: model:account.group,name:l10n_lu.2_account_group_703158
+#: model:account.group,name:l10n_lu.2_account_group_721258
+#: model:account.group,name:l10n_lu.2_account_group_74158
 #: model:account.group.template,name:l10n_lu.account_group_64158
 #: model:account.group.template,name:l10n_lu.account_group_703158
 #: model:account.group.template,name:l10n_lu.account_group_721258
@@ -5422,28 +6870,38 @@ msgid "Other similar rights and assets"
 msgstr "Sonstige vergleichbare Rechte und Werte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212158
+#: model:account.group,name:l10n_lu.2_account_group_212158
 #: model:account.group.template,name:l10n_lu.account_group_212158
 msgid "Other similar rights and assets acquired for consideration"
 msgstr "Sonstige entgeltlich erworbene Rechte und Werte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212258
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212258
+#: model:account.group,name:l10n_lu.2_account_group_212258
 #: model:account.group.template,name:l10n_lu.account_group_212258
 msgid "Other similar rights and assets created by the undertaking itself"
 msgstr ""
 "Sonstige vergleichbare vom Unternehmen selbst erstellte Rechte und Werte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42178
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4628
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42178
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4628
+#: model:account.group,name:l10n_lu.2_account_group_42178
+#: model:account.group,name:l10n_lu.2_account_group_4628
 #: model:account.group.template,name:l10n_lu.account_group_42178
 #: model:account.group.template,name:l10n_lu.account_group_4628
 msgid "Other social bodies"
 msgstr "Sonstige Einrichtungen der sozialen Sicherheit"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6232
+#: model:account.group,name:l10n_lu.2_account_group_6232
 #: model:account.group.template,name:l10n_lu.account_group_6232
 msgid "Other social security costs (including illness, accidents, a.s.o.)"
 msgstr ""
@@ -5451,68 +6909,94 @@ msgstr ""
 "Arbeitsunfallversicherung)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106198
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106198
 msgid "Other special private withdrawals"
 msgstr "Sonstige besondere Privatentnahmen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_624
 #: model:account.group.template,name:l10n_lu.account_group_624
 msgid "Other staff expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6248
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6248
+#: model:account.group,name:l10n_lu.2_account_group_6248
 #: model:account.group.template,name:l10n_lu.account_group_6248
 msgid "Other staff expenses not mentioned above"
 msgstr "Sonstige nicht oben aufgeführte Personalaufwendungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_622
 #: model:account.group.template,name:l10n_lu.account_group_622
 msgid "Other staff remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42138
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42238
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42138
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42238
+#: model:account.group,name:l10n_lu.2_account_group_42138
+#: model:account.group,name:l10n_lu.2_account_group_42238
 #: model:account.group.template,name:l10n_lu.account_group_42138
 #: model:account.group.template,name:l10n_lu.account_group_42238
 msgid "Other subsidies"
 msgstr "Sonstige Zuschüsse"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7458
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7458
+#: model:account.group,name:l10n_lu.2_account_group_7458
 #: model:account.group.template,name:l10n_lu.account_group_7458
 msgid "Other subsidies for operating activities"
 msgstr "Sonstige Zuschüsse für die laufende Geschäftstätigkeit"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621128
+#: model:account.group,name:l10n_lu.2_account_group_621128
 #: model:account.group.template,name:l10n_lu.account_group_621128
 msgid "Other supplements"
 msgstr "Sonstige Zuschläge"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106288
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106288
 msgid "Other tax refunds"
 msgstr "Sonstige Steuerrückzahlungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106188
+#: model:account.account,name:l10n_lu.2_lu_2011_account_688
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106188
 #: model:account.account.template,name:l10n_lu.lu_2011_account_688
+#: model:account.group,name:l10n_lu.2_account_group_688
 #: model:account.group.template,name:l10n_lu.account_group_688
 msgid "Other taxes"
 msgstr "Sonstige Steuern"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_68
 #: model:account.group.template,name:l10n_lu.account_group_68
 msgid "Other taxes not included in the previous caption"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75488
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65428
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75318
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75428
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75488
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65428
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75318
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75428
+#: model:account.group,name:l10n_lu.2_account_group_508
+#: model:account.group,name:l10n_lu.2_account_group_65428
+#: model:account.group,name:l10n_lu.2_account_group_75428
+#: model:account.group,name:l10n_lu.2_account_group_75488
 #: model:account.group.template,name:l10n_lu.account_group_508
 #: model:account.group.template,name:l10n_lu.account_group_65428
 #: model:account.group.template,name:l10n_lu.account_group_75428
@@ -5521,28 +7005,41 @@ msgid "Other transferable securities"
 msgstr "Sonstige Wertpapiere"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6168
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6168
+#: model:account.group,name:l10n_lu.2_account_group_6168
 #: model:account.group.template,name:l10n_lu.account_group_6168
 msgid "Other transportation"
 msgstr "Sonstige Transporte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60814
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60814
+#: model:account.group,name:l10n_lu.2_account_group_60814
 #: model:account.group.template,name:l10n_lu.account_group_60814
 msgid "Outsourcing included in the production of goods and services"
 msgstr "Zulieferungen für Werklieferungen und -leistungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621123
+#: model:account.group,name:l10n_lu.2_account_group_621123
 #: model:account.group.template,name:l10n_lu.account_group_621123
 msgid "Overtime"
 msgstr "Überstunden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75482
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65422
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75312
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75422
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75482
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75312
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75422
+#: model:account.group,name:l10n_lu.2_account_group_65422
+#: model:account.group,name:l10n_lu.2_account_group_75422
+#: model:account.group,name:l10n_lu.2_account_group_75482
 #: model:account.group.template,name:l10n_lu.account_group_65422
 #: model:account.group.template,name:l10n_lu.account_group_75422
 #: model:account.group.template,name:l10n_lu.account_group_75482
@@ -5550,7 +7047,9 @@ msgid "Own shares or corporate units"
 msgstr "Eigene Aktien oder Anteile"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_502
 #: model:account.account.template,name:l10n_lu.lu_2011_account_502
+#: model:account.group,name:l10n_lu.2_account_group_502
 #: model:account.group.template,name:l10n_lu.account_group_502
 msgid "Own shares or own corporate units"
 msgstr "Eigene Aktien oder eigene Anteile"
@@ -5561,10 +7060,18 @@ msgid "PCMN Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_233
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75113
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65213
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75213
 #: model:account.account.template,name:l10n_lu.lu_2011_account_233
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75113
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65213
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75213
+#: model:account.group,name:l10n_lu.2_account_group_233
+#: model:account.group,name:l10n_lu.2_account_group_65213
+#: model:account.group,name:l10n_lu.2_account_group_75213
+#: model:account.group,name:l10n_lu.2_account_group_75223
 #: model:account.group.template,name:l10n_lu.account_group_233
 #: model:account.group.template,name:l10n_lu.account_group_65213
 #: model:account.group.template,name:l10n_lu.account_group_75213
@@ -5573,12 +7080,24 @@ msgid "Participating interests"
 msgstr "Anteile"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21212
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21222
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6412
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72122
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7412
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70312
+#: model:account.group,name:l10n_lu.2_account_group_21212
+#: model:account.group,name:l10n_lu.2_account_group_21222
+#: model:account.group,name:l10n_lu.2_account_group_6412
+#: model:account.group,name:l10n_lu.2_account_group_70312
+#: model:account.group,name:l10n_lu.2_account_group_72122
+#: model:account.group,name:l10n_lu.2_account_group_7412
 #: model:account.group.template,name:l10n_lu.account_group_21212
 #: model:account.group.template,name:l10n_lu.account_group_21222
 #: model:account.group.template,name:l10n_lu.account_group_6412
@@ -5589,19 +7108,27 @@ msgid "Patents"
 msgstr "Patente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10622
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10622
 msgid "Personal holdings"
 msgstr "Private Guthaben"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2221
+#: model:account.group,name:l10n_lu.2_account_group_2221
 #: model:account.group.template,name:l10n_lu.account_group_2221
 msgid "Plant"
 msgstr "Technische Anlagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2242
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2242
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7222
+#: model:account.group,name:l10n_lu.2_account_group_222
+#: model:account.group,name:l10n_lu.2_account_group_2242
+#: model:account.group,name:l10n_lu.2_account_group_7222
 #: model:account.group.template,name:l10n_lu.account_group_222
 #: model:account.group.template,name:l10n_lu.account_group_2242
 #: model:account.group.template,name:l10n_lu.account_group_7222
@@ -5609,133 +7136,176 @@ msgid "Plant and machinery"
 msgstr "Technische Anlagen und Maschinen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61531
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61531
+#: model:account.group,name:l10n_lu.2_account_group_61531
 #: model:account.group.template,name:l10n_lu.account_group_61531
 msgid "Postal charges"
 msgstr "Postgebühren"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6153
 #: model:account.group.template,name:l10n_lu.account_group_6153
 msgid "Postal charges and telecommunication costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62411
+#: model:account.group,name:l10n_lu.2_account_group_62411
 #: model:account.group.template,name:l10n_lu.account_group_62411
 msgid "Premiums for external pensions funds"
 msgstr "Beiträge für externe Rentenfonds"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_114
+#: model:account.group,name:l10n_lu.2_account_group_114
 #: model:account.group.template,name:l10n_lu.account_group_114
 msgid "Premiums on conversion of bonds into shares"
 msgstr "Agio bei der Umwandlung von Anleihen in Aktien"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61511
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61511
+#: model:account.group,name:l10n_lu.2_account_group_61511
 #: model:account.group.template,name:l10n_lu.account_group_61511
 msgid "Press advertising"
 msgstr "Annoncen und Inserate"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_67322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_67322
+#: model:account.group,name:l10n_lu.2_account_group_67322
 #: model:account.group.template,name:l10n_lu.account_group_67322
 msgid "Previous financial years"
 msgstr "Vorhergehende Geschäftsjahre"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106174
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106244
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106174
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106244
 msgid "Private buildings"
 msgstr "Private Gebäude"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106172
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106242
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106172
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106242
 msgid "Private car"
 msgstr "Privates Fahrzeug"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106171
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106241
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106171
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106241
 msgid "Private furniture"
 msgstr "Privates Mobiliar"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106173
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106173
 msgid "Private held securities"
 msgstr "Private Wertpapiere"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10623
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10623
 msgid "Private loans"
 msgstr "Private Ausleihungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10613
 msgid "Private share of medical services expenses"
 msgstr "Privater Anteil an den Krankheitskosten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106243
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106243
 msgid "Private shares / bonds"
 msgstr "Private Wertpapiere / Aktien"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7451
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7451
+#: model:account.group,name:l10n_lu.2_account_group_7451
 #: model:account.group.template,name:l10n_lu.account_group_7451
 msgid "Product subsidies"
 msgstr "Produktzuschüsse"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6134
 #: model:account.group.template,name:l10n_lu.account_group_6134
 msgid "Professional fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221112
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221112
+#: model:account.group,name:l10n_lu.2_account_group_221112
 #: model:account.group.template,name:l10n_lu.account_group_221112
 msgid "Property rights and similar"
 msgstr "Immobilien- / Eigentumsrechte auf Sachanlagen und ähnliche"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_18
 #: model:account.group.template,name:l10n_lu.account_group_18
 msgid "Provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_181
 #: model:account.account.template,name:l10n_lu.lu_2011_account_181
+#: model:account.group,name:l10n_lu.2_account_group_181
 #: model:account.group.template,name:l10n_lu.account_group_181
 msgid "Provisions for pensions and similar obligations"
 msgstr "Rückstellungen für Pensionen und ähnliche Verpflichtungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_182
 #: model:account.account.template,name:l10n_lu.lu_2020_account_182
+#: model:account.group,name:l10n_lu.2_account_group_182
 #: model:account.group.template,name:l10n_lu.account_group_182
 msgid "Provisions for taxation"
 msgstr "Steuerrückstellungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621122
+#: model:account.group,name:l10n_lu.2_account_group_621122
 #: model:account.group.template,name:l10n_lu.account_group_621122
 msgid "Public holidays"
 msgstr "Feiertagsarbeit"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6083
 #: model:account.group.template,name:l10n_lu.account_group_6083
 msgid "Purchase of greenhous gas and similar emission quotas"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6083
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6083
 msgid "Purchase of greenhouse gas and similar emission quotas"
 msgstr "Einkäufe von Kontigenten für Treibhausgasemissionen und ähnliche"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45121
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45221
+#: model:account.group,name:l10n_lu.2_account_group_45111
+#: model:account.group,name:l10n_lu.2_account_group_45121
+#: model:account.group,name:l10n_lu.2_account_group_45211
+#: model:account.group,name:l10n_lu.2_account_group_45221
 #: model:account.group.template,name:l10n_lu.account_group_45111
 #: model:account.group.template,name:l10n_lu.account_group_45121
 #: model:account.group.template,name:l10n_lu.account_group_45211
@@ -5744,64 +7314,83 @@ msgid "Purchases and services"
 msgstr "Käufe und Dienstleistungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6063
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6063
+#: model:account.group,name:l10n_lu.2_account_group_6063
 #: model:account.group.template,name:l10n_lu.account_group_6063
 msgid "Purchases of buildings for resale"
 msgstr "Einkäufe von zum Verkauf bestimmten Bauten/Gebäuden"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_603
 #: model:account.group.template,name:l10n_lu.account_group_603
 msgid "Purchases of consumable materials and supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_608
 #: model:account.group.template,name:l10n_lu.account_group_608
 msgid "Purchases of items included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6062
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6062
+#: model:account.group,name:l10n_lu.2_account_group_6062
 #: model:account.group.template,name:l10n_lu.account_group_6062
 msgid "Purchases of land for resale"
 msgstr "Einkäufe von zum Verkauf bestimmten Grundstücken"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6061
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6061
+#: model:account.group,name:l10n_lu.2_account_group_6061
 #: model:account.group.template,name:l10n_lu.account_group_6061
 msgid "Purchases of merchandise"
 msgstr "Einkäufe von Waren"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_606
 #: model:account.group.template,name:l10n_lu.account_group_606
 msgid "Purchases of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_604
 #: model:account.account.template,name:l10n_lu.lu_2020_account_604
+#: model:account.group,name:l10n_lu.2_account_group_604
 #: model:account.group.template,name:l10n_lu.account_group_604
 msgid "Purchases of packaging"
 msgstr "Einkäufe von Verpackungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_601
 #: model:account.account.template,name:l10n_lu.lu_2020_account_601
+#: model:account.group,name:l10n_lu.2_account_group_601
 #: model:account.group.template,name:l10n_lu.account_group_601
 msgid "Purchases of raw materials"
 msgstr "Einkäufe von Rohstoffen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7095
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7095
+#: model:account.group,name:l10n_lu.2_account_group_7095
 #: model:account.group.template,name:l10n_lu.account_group_7095
 msgid "RDR on commissions and brokerage fees"
 msgstr "RPR auf Kommissionen und Courtagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7098
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7098
+#: model:account.group,name:l10n_lu.2_account_group_7098
 #: model:account.group.template,name:l10n_lu.account_group_7098
 msgid "RDR on other components of turnover"
 msgstr "RPR auf sonstige Umsatzerlöse"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6098
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6098
+#: model:account.group,name:l10n_lu.2_account_group_6098
 #: model:account.group.template,name:l10n_lu.account_group_6098
 msgid "RDR on purchases included in the production of goods and services"
 msgstr ""
@@ -5809,7 +7398,9 @@ msgstr ""
 "Werklieferungen und -leistungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6093
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6093
+#: model:account.group,name:l10n_lu.2_account_group_6093
 #: model:account.group.template,name:l10n_lu.account_group_6093
 msgid "RDR on purchases of consumable materials and supplies"
 msgstr ""
@@ -5817,63 +7408,82 @@ msgstr ""
 "Betriebsstoffe"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6096
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6096
+#: model:account.group,name:l10n_lu.2_account_group_6096
 #: model:account.group.template,name:l10n_lu.account_group_6096
 msgid "RDR on purchases of merchandise and other goods for resale"
 msgstr ""
-"Erhaltene Rabatte, Preisnachlässe und Rückvergütungen auf Waren und sonstige "
-"zum Verkauf bestimmte Güter/Vermögensgegenstände"
+"Erhaltene Rabatte, Preisnachlässe und Rückvergütungen auf Waren und sonstige"
+" zum Verkauf bestimmte Güter/Vermögensgegenstände"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6094
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6094
+#: model:account.group,name:l10n_lu.2_account_group_6094
 #: model:account.group.template,name:l10n_lu.account_group_6094
 msgid "RDR on purchases of packaging"
-msgstr "Erhaltene Rabatte, Preisnachlässe und Rückvergütungen auf Verpackungen"
+msgstr ""
+"Erhaltene Rabatte, Preisnachlässe und Rückvergütungen auf Verpackungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6091
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6091
+#: model:account.group,name:l10n_lu.2_account_group_6091
 #: model:account.group.template,name:l10n_lu.account_group_6091
 msgid "RDR on purchases of raw materials"
 msgstr "Erhaltene Rabatte, Preisnachlässe und Rückvergütungen auf Rohstoffe"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7092
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7092
+#: model:account.group,name:l10n_lu.2_account_group_7092
 #: model:account.group.template,name:l10n_lu.account_group_7092
 msgid "RDR on sales of goods"
 msgstr "RPR auf Verkäufe von Erzeugnissen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7096
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7096
+#: model:account.group,name:l10n_lu.2_account_group_7096
 #: model:account.group.template,name:l10n_lu.account_group_7096
 msgid "RDR on sales of merchandise and other goods for resale"
 msgstr ""
-"RPR auf Verkäufe von Waren und zum Verkauf bestimmten Gütern/"
-"Vermögensgegenständen"
+"RPR auf Verkäufe von Waren und zum Verkauf bestimmten "
+"Gütern/Vermögensgegenständen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7094
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7094
+#: model:account.group,name:l10n_lu.2_account_group_7094
 #: model:account.group.template,name:l10n_lu.account_group_7094
 msgid "RDR on sales of packages"
 msgstr "RPR auf Verkäufe von Verpackungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7093
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7093
+#: model:account.group,name:l10n_lu.2_account_group_7093
 #: model:account.group.template,name:l10n_lu.account_group_7093
 msgid "RDR on sales of services"
 msgstr "RPR auf Verkäufe von Dienstleistungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_735
 #: model:account.group.template,name:l10n_lu.account_group_735
 msgid "RVA and FVA on receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75112
 #: model:account.group.template,name:l10n_lu.account_group_75112
 msgid "RVA on amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7352
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7352
+#: model:account.group,name:l10n_lu.2_account_group_7352
 #: model:account.group.template,name:l10n_lu.account_group_7352
 msgid ""
 "RVA on amounts owed by affiliated undertakings and undertakings with which "
@@ -5883,6 +7493,7 @@ msgstr ""
 "ein Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75114
 #: model:account.group.template,name:l10n_lu.account_group_75114
 msgid ""
 "RVA on amounts owed by undertakings with which the company is linked by "
@@ -5890,13 +7501,17 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73313
+#: model:account.group,name:l10n_lu.2_account_group_73313
 #: model:account.group.template,name:l10n_lu.account_group_73313
 msgid "RVA on buildings"
 msgstr "Wertaufholungen von Bauten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7322
+#: model:account.group,name:l10n_lu.2_account_group_7322
 #: model:account.group.template,name:l10n_lu.account_group_7322
 msgid ""
 "RVA on concessions, patents, licences, trademarks and similar rights and "
@@ -5906,13 +7521,17 @@ msgstr ""
 "ähnlichen Rechten und Werten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7321
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7321
+#: model:account.group,name:l10n_lu.2_account_group_7321
 #: model:account.group.template,name:l10n_lu.account_group_7321
 msgid "RVA on development costs"
 msgstr "Wertaufholungen von Entwicklungskosten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7324
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7324
+#: model:account.group,name:l10n_lu.2_account_group_7324
 #: model:account.group.template,name:l10n_lu.account_group_7324
 msgid "RVA on down payments and intangible fixed assets under development"
 msgstr ""
@@ -5920,64 +7539,83 @@ msgstr ""
 "Vermögensgegenständen in Entwicklung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7334
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7334
+#: model:account.group,name:l10n_lu.2_account_group_7334
 #: model:account.group.template,name:l10n_lu.account_group_7334
 msgid "RVA on down payments and tangible fixed assets under development"
 msgstr "Wertaufholungen von geleisteten Anzahlungen und Anlagen im Bau"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7345
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7345
+#: model:account.group,name:l10n_lu.2_account_group_7345
 #: model:account.group.template,name:l10n_lu.account_group_7345
 msgid "RVA on down payments on inventories"
 msgstr "Geleistete Anzahlungen auf Vorräte"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7511
 #: model:account.group.template,name:l10n_lu.account_group_7511
 msgid "RVA on financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73314
+#: model:account.group,name:l10n_lu.2_account_group_73314
 #: model:account.group.template,name:l10n_lu.account_group_73314
 msgid "RVA on fixtures and fittings-out of buildings"
 msgstr "Wertaufholungen von Einrichtungen von Bauten/Gebäuden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73312
+#: model:account.group,name:l10n_lu.2_account_group_73312
 #: model:account.group.template,name:l10n_lu.account_group_73312
 msgid "RVA on fixtures and fittings-out of land"
 msgstr "Wertaufholungen von Erschließungen von Grundstücken"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_732
 #: model:account.group.template,name:l10n_lu.account_group_732
 msgid "RVA on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_734
 #: model:account.group.template,name:l10n_lu.account_group_734
 msgid "RVA on inventories"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7343
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7343
+#: model:account.group,name:l10n_lu.2_account_group_7343
 #: model:account.group.template,name:l10n_lu.account_group_7343
 msgid "RVA on inventories of goods"
 msgstr "Erzeugnisse"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7344
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7344
+#: model:account.group,name:l10n_lu.2_account_group_7344
 #: model:account.group.template,name:l10n_lu.account_group_7344
 msgid "RVA on inventories of merchandise and other goods for resale"
 msgstr "Waren und sonstige zum Verkauf bestimmte Güter/Vermögensgegenstände "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7341
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7341
+#: model:account.group,name:l10n_lu.2_account_group_7341
 #: model:account.group.template,name:l10n_lu.account_group_7341
 msgid "RVA on inventories of raw materials and consumables"
 msgstr "Wertaufholungen von Roh-, Hilfs- und Betriebsstoffen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7342
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7342
+#: model:account.group,name:l10n_lu.2_account_group_7342
 #: model:account.group.template,name:l10n_lu.account_group_7342
 msgid "RVA on inventories of work and contracts in progress"
 msgstr ""
@@ -5985,13 +7623,16 @@ msgstr ""
 "Aufträgen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73311
+#: model:account.group,name:l10n_lu.2_account_group_73311
 #: model:account.group.template,name:l10n_lu.account_group_73311
 msgid "RVA on land"
 msgstr ""
 "Wertaufholungen von Grundstücken, Erschließungen, Einrichtungen und Bauten"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7331
 #: model:account.group.template,name:l10n_lu.account_group_7331
 msgid ""
 "RVA on land, fixtures and fittings-out and buildings and FVA on investment "
@@ -5999,56 +7640,69 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75116
 #: model:account.group.template,name:l10n_lu.account_group_75116
 msgid "RVA on loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7353
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7353
+#: model:account.group,name:l10n_lu.2_account_group_7353
 #: model:account.group.template,name:l10n_lu.account_group_7353
 msgid "RVA on other receivables"
 msgstr "Sonstige Forderungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75318
 #: model:account.group.template,name:l10n_lu.account_group_75318
 msgid "RVA on other transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75312
 #: model:account.group.template,name:l10n_lu.account_group_75312
 msgid "RVA on own shares or corporate units"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75113
 #: model:account.group.template,name:l10n_lu.account_group_75113
 msgid "RVA on participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7332
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7332
+#: model:account.group,name:l10n_lu.2_account_group_7332
 #: model:account.group.template,name:l10n_lu.account_group_7332
 msgid "RVA on plant and machinery"
 msgstr "Wertaufholungen von technischen Anlagen und Maschinen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75115
 #: model:account.group.template,name:l10n_lu.account_group_75115
 msgid "RVA on securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75111
+#: model:account.group,name:l10n_lu.2_account_group_75311
 #: model:account.group.template,name:l10n_lu.account_group_75111
 #: model:account.group.template,name:l10n_lu.account_group_75311
 msgid "RVA on shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75313
 #: model:account.group.template,name:l10n_lu.account_group_75313
 msgid ""
-"RVA on shares in undertakings with which the undertaking is linked by virtue "
-"of participating interests"
+"RVA on shares in undertakings with which the undertaking is linked by virtue"
+" of participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_733
 #: model:account.group.template,name:l10n_lu.account_group_733
 msgid ""
 "RVA on tangible fixed assets and fair value adjustments (FVA) on investment "
@@ -6056,23 +7710,29 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7351
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7351
+#: model:account.group,name:l10n_lu.2_account_group_7351
 #: model:account.group.template,name:l10n_lu.account_group_7351
 msgid "RVA on trade receivables"
 msgstr "Forderungen aus Lieferungen und Leistungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7531
 #: model:account.group.template,name:l10n_lu.account_group_7531
 msgid "RVA on transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6461
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6461
+#: model:account.group,name:l10n_lu.2_account_group_6461
 #: model:account.group.template,name:l10n_lu.account_group_6461
 msgid "Real property tax"
 msgstr "Grundsteuer"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_709
 #: model:account.group.template,name:l10n_lu.account_group_709
 msgid ""
 "Rebates, discounts and refunds (RDR) granted and not immediately deducted "
@@ -6080,14 +7740,17 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_609
 #: model:account.group.template,name:l10n_lu.account_group_609
 msgid ""
-"Rebates, discounts and refunds (RDR) received and not directly deducted from "
-"purchases"
+"Rebates, discounts and refunds (RDR) received and not directly deducted from"
+" purchases"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_619
 #: model:account.account.template,name:l10n_lu.lu_2011_account_619
+#: model:account.group,name:l10n_lu.2_account_group_619
 #: model:account.group.template,name:l10n_lu.account_group_619
 msgid "Rebates, discounts and refunds received on other external charges"
 msgstr ""
@@ -6095,268 +7758,346 @@ msgstr ""
 "Aufwendungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10627
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10627
 msgid "Received child benefit"
 msgstr "Erhaltene Familienzulagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4711
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4721
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4711
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4721
+#: model:account.group,name:l10n_lu.2_account_group_4711
+#: model:account.group,name:l10n_lu.2_account_group_4721
 #: model:account.group.template,name:l10n_lu.account_group_4711
 #: model:account.group.template,name:l10n_lu.account_group_4721
 msgid "Received deposits and guarantees"
 msgstr "Erhaltene Hinterlegungen und Kautionen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10625
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10625
 msgid "Received rents"
 msgstr "Mieteinnahmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10626
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10626
 msgid "Received wages or pensions"
 msgstr "Eingenommene Löhne oder Renten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61524
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61524
+#: model:account.group,name:l10n_lu.2_account_group_61524
 #: model:account.group.template,name:l10n_lu.account_group_61524
 msgid "Receptions and entertainment costs"
 msgstr "Bewirtungs- und Repräsentationskosten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106193
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106193
 msgid "Refund of private debts"
 msgstr "Rückzahlungen privater Schulden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6219
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6219
+#: model:account.group,name:l10n_lu.2_account_group_6219
 #: model:account.group.template,name:l10n_lu.account_group_6219
 msgid "Refunds on wages paid"
 msgstr "Erstattungen von gezahlten Löhnen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421621
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461421
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421621
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461421
+#: model:account.group,name:l10n_lu.2_account_group_421621
+#: model:account.group,name:l10n_lu.2_account_group_461421
 #: model:account.group.template,name:l10n_lu.account_group_421621
 #: model:account.group.template,name:l10n_lu.account_group_461421
 msgid "Registration duties"
 msgstr "Registriergebühren"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64651
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64651
+#: model:account.group,name:l10n_lu.2_account_group_64651
 #: model:account.group.template,name:l10n_lu.account_group_64651
 msgid "Registration fees"
 msgstr "Eintragungsgebühren"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6465
 #: model:account.group.template,name:l10n_lu.account_group_6465
 msgid "Registration fees, stamp duties and mortgage duties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61522
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61522
+#: model:account.group,name:l10n_lu.2_account_group_61522
 #: model:account.group.template,name:l10n_lu.account_group_61522
 msgid "Relocation expenses"
 msgstr "Umzugskosten des Unternehmens"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_613
 #: model:account.group.template,name:l10n_lu.account_group_613
 msgid "Remuneration of intermediaries and professional fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106162
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106162
 msgid "Rent"
 msgstr "Miete"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7032
 #: model:account.group.template,name:l10n_lu.account_group_7032
 msgid "Rental income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_742
 #: model:account.group.template,name:l10n_lu.account_group_742
 msgid "Rental income from ancillary activities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70322
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70322
+#: model:account.group,name:l10n_lu.2_account_group_70322
 #: model:account.group.template,name:l10n_lu.account_group_70322
 msgid "Rental income from movable property"
 msgstr "Mieterträge aus beweglichem Vermögen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70321
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70321
+#: model:account.group,name:l10n_lu.2_account_group_70321
 #: model:account.group.template,name:l10n_lu.account_group_70321
 msgid "Rental income from real property"
 msgstr "Mieterträge aus Immobilien"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7422
+#: model:account.group,name:l10n_lu.2_account_group_7422
 #: model:account.group.template,name:l10n_lu.account_group_7422
 msgid "Rental income on movable property"
 msgstr "Mieterträge aus beweglichem Vermögen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7421
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7421
+#: model:account.group,name:l10n_lu.2_account_group_7421
 #: model:account.group.template,name:l10n_lu.account_group_7421
 msgid "Rental income on real property"
 msgstr "Mieterträge aus Immobilien"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6112
 #: model:account.group.template,name:l10n_lu.account_group_6112
 msgid "Rents and operational leasing on movable property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6111
 #: model:account.group.template,name:l10n_lu.account_group_6111
 msgid "Rents and operationnal leasing for real property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_611
 #: model:account.group.template,name:l10n_lu.account_group_611
 msgid "Rents and service charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106191
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106191
 msgid "Repairs to private buildings"
 msgstr "Reparaturen an privaten Gebäuden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60812
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60812
+#: model:account.group,name:l10n_lu.2_account_group_60812
 #: model:account.group.template,name:l10n_lu.account_group_60812
 msgid "Research and development"
 msgstr "Forschung und Entwicklung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_13821
 #: model:account.account.template,name:l10n_lu.lu_2020_account_13821
+#: model:account.group,name:l10n_lu.2_account_group_13821
 #: model:account.group.template,name:l10n_lu.account_group_13821
 msgid "Reserve for net wealth tax (NWT)"
-msgstr "Vermögenssteuerrücklage"
+msgstr "Vermögensteuerrücklage"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_13
 #: model:account.group.template,name:l10n_lu.account_group_13
 msgid "Reserves"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_132
+#: model:account.group,name:l10n_lu.2_account_group_132
 #: model:account.group.template,name:l10n_lu.account_group_132
 msgid "Reserves for own shares or own corporate units"
 msgstr "Rücklagen für eigene Aktien oder eigene Anteile"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_13822
 #: model:account.account.template,name:l10n_lu.lu_2020_account_13822
+#: model:account.group,name:l10n_lu.2_account_group_13822
 #: model:account.group.template,name:l10n_lu.account_group_13822
 msgid "Reserves in application of fair value"
 msgstr "Rücklagen durch Anwendung des beizulegenden Zeitwerts (Fair Value)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_122
+#: model:account.group,name:l10n_lu.2_account_group_122
 #: model:account.group.template,name:l10n_lu.account_group_122
 msgid "Reserves in application of the equity method"
 msgstr "Rücklagen durch Anwendung der Kapitalanteilsmethode "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_13828
 #: model:account.account.template,name:l10n_lu.lu_2020_account_13828
+#: model:account.group,name:l10n_lu.2_account_group_13828
 #: model:account.group.template,name:l10n_lu.account_group_13828
 msgid "Reserves not available for distribution not mentioned above"
 msgstr "Gebundene Rücklagen welche nicht oben aufgelistet wurden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_133
 #: model:account.account.template,name:l10n_lu.lu_2011_account_133
+#: model:account.group,name:l10n_lu.2_account_group_133
 #: model:account.group.template,name:l10n_lu.account_group_133
 msgid "Reserves provided for by the articles of association"
 msgstr "Satzungsmäßige Rücklagen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221311
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221311
+#: model:account.group,name:l10n_lu.2_account_group_221311
 #: model:account.group.template,name:l10n_lu.account_group_221311
 msgid "Residential buildings"
 msgstr "Wohngebäude"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_142
 #: model:account.account.template,name:l10n_lu.lu_2011_account_142
+#: model:account.group,name:l10n_lu.2_account_group_142
 #: model:account.group.template,name:l10n_lu.account_group_142
 msgid "Result for the financial year"
 msgstr "Ergebnis des Geschäftsjahres"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_14
 #: model:account.group.template,name:l10n_lu.account_group_14
 msgid "Result for the financial year and results brought forward"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_141
 #: model:account.group.template,name:l10n_lu.account_group_141
 msgid "Results brought forward"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1412
+#: model:account.group,name:l10n_lu.2_account_group_1412
 #: model:account.group.template,name:l10n_lu.account_group_1412
 msgid "Results brought forward (assigned)"
 msgstr "Ergebnisvorträge (zugewiesen)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1411
+#: model:account.group,name:l10n_lu.2_account_group_1411
 #: model:account.group.template,name:l10n_lu.account_group_1411
 msgid "Results brought forward in the process of assignment"
 msgstr "Ergebnisvorträge in Zuweisung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2237
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2237
+#: model:account.group,name:l10n_lu.2_account_group_2237
 #: model:account.group.template,name:l10n_lu.account_group_2237
 msgid "Returnable packaging"
 msgstr "Wiederverwendbare Verpackungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_12
 #: model:account.group.template,name:l10n_lu.account_group_12
 msgid "Revaluation reserves"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_759
 #: model:account.group.template,name:l10n_lu.account_group_759
 msgid "Reversals of financial provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7591
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7591
+#: model:account.group,name:l10n_lu.2_account_group_7591
 #: model:account.group.template,name:l10n_lu.account_group_7591
 msgid "Reversals of financial provisions - affiliated undertakings"
 msgstr ""
 "Wertaufholungen von finanziellen Rückstellungen - verbundene Unternehmen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7592
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7592
+#: model:account.group,name:l10n_lu.2_account_group_7592
 #: model:account.group.template,name:l10n_lu.account_group_7592
 msgid "Reversals of financial provisions - other"
 msgstr "Wertaufholungen von finanziellen Rückstellungen - sonstige"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7492
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7492
+#: model:account.group,name:l10n_lu.2_account_group_7492
 #: model:account.group.template,name:l10n_lu.account_group_7492
 msgid "Reversals of operating provisions"
 msgstr "Wertaufholungen von betrieblichen Rückstellungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_749
 #: model:account.group.template,name:l10n_lu.account_group_749
 msgid "Reversals of provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_779
 #: model:account.account.template,name:l10n_lu.lu_2020_account_779
+#: model:account.group,name:l10n_lu.2_account_group_779
 #: model:account.group.template,name:l10n_lu.account_group_779
 msgid "Reversals of provisions for deferred taxes"
 msgstr "Auflösungen von Rückstellungen für Ertragssteuern"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7491
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7491
+#: model:account.group,name:l10n_lu.2_account_group_7491
 #: model:account.group.template,name:l10n_lu.account_group_7491
 msgid "Reversals of provisions for taxes"
 msgstr "Wertaufholungen von Steuerrückstellungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_747
 #: model:account.group.template,name:l10n_lu.account_group_747
 msgid ""
 "Reversals of temporarily not taxable capital gains and of investment "
@@ -6364,6 +8105,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_751
 #: model:account.group.template,name:l10n_lu.account_group_751
 msgid ""
 "Reversals of value adjustments (RVA) and fair-value adjustments (FVA) on "
@@ -6371,6 +8113,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_753
 #: model:account.group.template,name:l10n_lu.account_group_753
 msgid ""
 "Reversals of value adjustments (RVA) and fair-value adjustments (FVA) on "
@@ -6378,6 +8121,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_73
 #: model:account.group.template,name:l10n_lu.account_group_73
 msgid ""
 "Reversals of value adjustments (RVA) on intangible, tangible and current "
@@ -6385,10 +8129,18 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61123
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61153
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61223
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61153
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61223
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61412
+#: model:account.group,name:l10n_lu.2_account_group_61123
+#: model:account.group,name:l10n_lu.2_account_group_61153
+#: model:account.group,name:l10n_lu.2_account_group_61223
+#: model:account.group,name:l10n_lu.2_account_group_61412
 #: model:account.group.template,name:l10n_lu.account_group_61123
 #: model:account.group.template,name:l10n_lu.account_group_61153
 #: model:account.group.template,name:l10n_lu.account_group_61223
@@ -6397,95 +8149,128 @@ msgid "Rolling stock"
 msgstr "Fuhrpark"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_703001
 #: model:account.account.template,name:l10n_lu.lu_2020_account_703001
 msgid "Sale of Services"
 msgstr "Verkäufe von Dienstleistungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7063
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7063
+#: model:account.group,name:l10n_lu.2_account_group_7063
 #: model:account.group.template,name:l10n_lu.account_group_7063
 msgid "Sales of buildings for resale"
 msgstr "Verkäufe von zum Verkauf bestimmten Bauten/Gebäuden "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7021
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7021
+#: model:account.group,name:l10n_lu.2_account_group_7021
 #: model:account.group.template,name:l10n_lu.account_group_7021
 msgid "Sales of finished goods"
 msgstr "Verkäufe von fertigen Erzeugnissen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_702
 #: model:account.group.template,name:l10n_lu.account_group_702
 msgid "Sales of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7062
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7062
+#: model:account.group,name:l10n_lu.2_account_group_7062
 #: model:account.group.template,name:l10n_lu.account_group_7062
 msgid "Sales of land resale"
 msgstr "Verkäufe von zum Verkauf bestimmten Grundstücken"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7061
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7061
+#: model:account.group,name:l10n_lu.2_account_group_7061
 #: model:account.group.template,name:l10n_lu.account_group_7061
 msgid "Sales of merchandise"
 msgstr "Verkäufe von Waren"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_706
 #: model:account.group.template,name:l10n_lu.account_group_706
 msgid "Sales of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_704
 #: model:account.account.template,name:l10n_lu.lu_2011_account_704
+#: model:account.group,name:l10n_lu.2_account_group_704
 #: model:account.group.template,name:l10n_lu.account_group_704
 msgid "Sales of packaging"
 msgstr "Verkäufe von Verpackungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7023
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7023
+#: model:account.group,name:l10n_lu.2_account_group_7023
 #: model:account.group.template,name:l10n_lu.account_group_7023
 msgid "Sales of residual products"
 msgstr "Verkäufe von Restprodukten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7022
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7022
+#: model:account.group,name:l10n_lu.2_account_group_7022
 #: model:account.group.template,name:l10n_lu.account_group_7022
 msgid "Sales of semi-finished goods"
 msgstr "Verkäufe von Zwischenprodukten"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_703
 #: model:account.group.template,name:l10n_lu.account_group_703
 msgid "Sales of services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7039
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7039
+#: model:account.group,name:l10n_lu.2_account_group_7039
 #: model:account.group.template,name:l10n_lu.account_group_7039
 msgid "Sales of services in the course of completion"
 msgstr "Nicht ausgeführte Dienstleistungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7033
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7033
+#: model:account.group,name:l10n_lu.2_account_group_7033
 #: model:account.group.template,name:l10n_lu.account_group_7033
 msgid "Sales of services not mentioned above"
 msgstr "Dienstleistungen welche nicht oben erwähnt wurden"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7029
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7029
+#: model:account.group,name:l10n_lu.2_account_group_7029
 #: model:account.group.template,name:l10n_lu.account_group_7029
 msgid "Sales of work in progress"
 msgstr "Verkäufe von unfertigen Erzeugnissen "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61512
+#: model:account.group,name:l10n_lu.2_account_group_61512
 #: model:account.group.template,name:l10n_lu.account_group_61512
 msgid "Samples"
 msgstr "Muster"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75115
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65215
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75215
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75115
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65215
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75215
+#: model:account.group,name:l10n_lu.2_account_group_235
+#: model:account.group,name:l10n_lu.2_account_group_65215
+#: model:account.group,name:l10n_lu.2_account_group_75215
+#: model:account.group,name:l10n_lu.2_account_group_75225
 #: model:account.group.template,name:l10n_lu.account_group_235
 #: model:account.group.template,name:l10n_lu.account_group_65215
 #: model:account.group.template,name:l10n_lu.account_group_75215
@@ -6494,45 +8279,57 @@ msgid "Securities held as fixed assets"
 msgstr "Wertpapiere des Anlagevermögens"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2352
 #: model:account.group.template,name:l10n_lu.account_group_2352
 msgid "Securities held as fixed assets (creditor's right)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2351
 #: model:account.group.template,name:l10n_lu.account_group_2351
 msgid "Securities held as fixed assets (equity right)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6113
+#: model:account.group,name:l10n_lu.2_account_group_6113
 #: model:account.group.template,name:l10n_lu.account_group_6113
 msgid "Service charges and co-ownership expenses"
 msgstr "Mietnebenkosten und Miteigentumsgemeinschaftskosten"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6081
 #: model:account.group.template,name:l10n_lu.account_group_6081
 msgid "Services included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6122
 #: model:account.group.template,name:l10n_lu.account_group_6122
 msgid "Servicing, repairs and maintenance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_201
 #: model:account.account.template,name:l10n_lu.lu_2011_account_201
+#: model:account.group,name:l10n_lu.2_account_group_201
 #: model:account.group.template,name:l10n_lu.account_group_201
 msgid "Set-up and start-up costs"
 msgstr "Gründungs- und Einrichtungskosten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62116
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62116
+#: model:account.group,name:l10n_lu.2_account_group_62116
 #: model:account.group.template,name:l10n_lu.account_group_62116
 msgid "Severance pay"
 msgstr "Abfindungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_657
 #: model:account.account.template,name:l10n_lu.lu_2011_account_657
+#: model:account.group,name:l10n_lu.2_account_group_657
 #: model:account.group.template,name:l10n_lu.account_group_657
 msgid ""
 "Share in the losses of undertakings accounted for under the equity method"
@@ -6541,35 +8338,54 @@ msgstr ""
 "Kapitalgesellschaften)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_757
 #: model:account.account.template,name:l10n_lu.lu_2011_account_757
+#: model:account.group,name:l10n_lu.2_account_group_757
 #: model:account.group.template,name:l10n_lu.account_group_757
-msgid "Share of profit from undertakings accounted for under the equity method"
+msgid ""
+"Share of profit from undertakings accounted for under the equity method"
 msgstr "Gewinnanteil aus Unternehmungen (andere als Kapitalgesellschaften)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_111
+#: model:account.group,name:l10n_lu.2_account_group_111
 #: model:account.group.template,name:l10n_lu.account_group_111
 msgid "Share premium"
 msgstr "Ausgabeagio"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_11
 #: model:account.group.template,name:l10n_lu.account_group_11
 msgid "Share premium and similar premiums"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5081
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5081
+#: model:account.group,name:l10n_lu.2_account_group_5081
 #: model:account.group.template,name:l10n_lu.account_group_5081
 msgid "Shares - listed securities"
 msgstr "Aktien - Notierte Wertpapiere"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5082
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5082
+#: model:account.group,name:l10n_lu.2_account_group_5082
 #: model:account.group.template,name:l10n_lu.account_group_5082
 msgid "Shares - unlisted securities"
 msgstr "Aktien - Nicht notierte Wertpapiere"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_231
+#: model:account.account,name:l10n_lu.2_lu_2011_account_501
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75481
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65421
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75311
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75421
 #: model:account.account.template,name:l10n_lu.lu_2011_account_231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_501
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75111
@@ -6579,6 +8395,14 @@ msgstr "Aktien - Nicht notierte Wertpapiere"
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75211
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75311
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75421
+#: model:account.group,name:l10n_lu.2_account_group_231
+#: model:account.group,name:l10n_lu.2_account_group_501
+#: model:account.group,name:l10n_lu.2_account_group_65211
+#: model:account.group,name:l10n_lu.2_account_group_65421
+#: model:account.group,name:l10n_lu.2_account_group_75211
+#: model:account.group,name:l10n_lu.2_account_group_75221
+#: model:account.group,name:l10n_lu.2_account_group_75421
+#: model:account.group,name:l10n_lu.2_account_group_75481
 #: model:account.group.template,name:l10n_lu.account_group_231
 #: model:account.group.template,name:l10n_lu.account_group_501
 #: model:account.group.template,name:l10n_lu.account_group_65211
@@ -6591,6 +8415,7 @@ msgid "Shares in affiliated undertakings"
 msgstr "Anteile an verbundenen Unternehmen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65423
 #: model:account.group.template,name:l10n_lu.account_group_65423
 msgid ""
 "Shares in in undertakings with which the undertaking is linked by virtue of "
@@ -6598,11 +8423,19 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_503
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75483
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65423
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75313
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75423
 #: model:account.account.template,name:l10n_lu.lu_2011_account_503
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75483
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65423
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75313
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75423
+#: model:account.group,name:l10n_lu.2_account_group_503
+#: model:account.group,name:l10n_lu.2_account_group_75423
+#: model:account.group,name:l10n_lu.2_account_group_75483
 #: model:account.group.template,name:l10n_lu.account_group_503
 #: model:account.group.template,name:l10n_lu.account_group_75423
 #: model:account.group.template,name:l10n_lu.account_group_75483
@@ -6612,17 +8445,26 @@ msgid ""
 msgstr "Anteile an Unternehmen, mit denen ein Beteiligungsverhältnis besteht"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_2353
 #: model:account.account.template,name:l10n_lu.lu_2020_account_2353
+#: model:account.group,name:l10n_lu.2_account_group_2353
 #: model:account.group.template,name:l10n_lu.account_group_2353
 msgid "Shares of collective investment funds"
 msgstr "OPC Anteile"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_23511
 #: model:account.group.template,name:l10n_lu.account_group_23511
 msgid "Shares or corporate units"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_21215
+#: model:account.group,name:l10n_lu.2_account_group_21225
+#: model:account.group,name:l10n_lu.2_account_group_6415
+#: model:account.group,name:l10n_lu.2_account_group_70315
+#: model:account.group,name:l10n_lu.2_account_group_72125
+#: model:account.group,name:l10n_lu.2_account_group_7415
 #: model:account.group.template,name:l10n_lu.account_group_21215
 #: model:account.group.template,name:l10n_lu.account_group_21225
 #: model:account.group.template,name:l10n_lu.account_group_6415
@@ -6633,45 +8475,66 @@ msgid "Similar rights and assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61852
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61852
+#: model:account.group,name:l10n_lu.2_account_group_61852
 #: model:account.group.template,name:l10n_lu.account_group_61852
 msgid "Small equipment"
 msgstr "Kleines Werkzeug"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106151
 msgid "Social Security"
 msgstr "Sozialversicherungen (Pflegeversicherung)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42171
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4621
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42171
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4621
 msgid "Social Security office (CCSS)"
 msgstr "Sozialversicherungszentrum (CCSS)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_623
 #: model:account.group.template,name:l10n_lu.account_group_623
 msgid "Social security costs (employer's share)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_462
 #: model:account.group.template,name:l10n_lu.account_group_462
 msgid "Social security debts and other social securities offices"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6231
+#: model:account.group,name:l10n_lu.2_account_group_6231
 #: model:account.group.template,name:l10n_lu.account_group_6231
 msgid "Social security on pensions"
 msgstr "Soziale Aufwendungen für Renten "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21213
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21223
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6413
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72123
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7413
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21213
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21223
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6413
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7413
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70313
+#: model:account.group,name:l10n_lu.2_account_group_21213
+#: model:account.group,name:l10n_lu.2_account_group_21223
+#: model:account.group,name:l10n_lu.2_account_group_6413
+#: model:account.group,name:l10n_lu.2_account_group_70313
+#: model:account.group,name:l10n_lu.2_account_group_72123
+#: model:account.group,name:l10n_lu.2_account_group_7413
 #: model:account.group.template,name:l10n_lu.account_group_21213
 #: model:account.group.template,name:l10n_lu.account_group_21223
 #: model:account.group.template,name:l10n_lu.account_group_6413
@@ -6682,53 +8545,69 @@ msgid "Software licences"
 msgstr "Software- und Softwarepaketlizenzen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60311
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61841
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60311
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61841
+#: model:account.group,name:l10n_lu.2_account_group_60311
+#: model:account.group,name:l10n_lu.2_account_group_61841
 #: model:account.group.template,name:l10n_lu.account_group_60311
 #: model:account.group.template,name:l10n_lu.account_group_61841
 msgid "Solid fuels"
 msgstr "Feste Brennstoffe"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61517
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61517
+#: model:account.group,name:l10n_lu.2_account_group_61517
 #: model:account.group.template,name:l10n_lu.account_group_61517
 msgid "Sponsorship"
 msgstr "Sponsoring"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_615212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_615212
+#: model:account.group,name:l10n_lu.2_account_group_615212
 #: model:account.group.template,name:l10n_lu.account_group_615212
 msgid "Staff"
 msgstr "Personal"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4211
 #: model:account.group.template,name:l10n_lu.account_group_4211
 msgid "Staff - Advances and down payments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4221
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4221
+#: model:account.group,name:l10n_lu.2_account_group_4221
 #: model:account.group.template,name:l10n_lu.account_group_4221
 msgid "Staff - advances and down payments"
 msgstr "Personal - Vorschüsse und geleistete Anzahlungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_62
 #: model:account.group.template,name:l10n_lu.account_group_62
 msgid "Staff expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_621
 #: model:account.group.template,name:l10n_lu.account_group_621
 msgid "Staff remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_483
 #: model:account.group.template,name:l10n_lu.account_group_483
 msgid "State - Greenhous gas and similar emission quotas received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4715
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4715
+#: model:account.group,name:l10n_lu.2_account_group_4715
 #: model:account.group.template,name:l10n_lu.account_group_4715
 msgid ""
 "State - Greenhous gas and similar emission quotas to be returned or acquired"
@@ -6737,54 +8616,73 @@ msgstr ""
 "Treibhausgasemissionen und ähnliche"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_483
 #: model:account.account.template,name:l10n_lu.lu_2011_account_483
 msgid "State - Greenhouse gas and similar emission quotas received"
 msgstr "Staat - zugeteilte Kontigente für Treibhausgasemissionen und ähnliche"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4213
+#: model:account.group,name:l10n_lu.2_account_group_4223
 #: model:account.group.template,name:l10n_lu.account_group_4213
 #: model:account.group.template,name:l10n_lu.account_group_4223
 msgid "State - Subsidies to be received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6221
+#: model:account.group,name:l10n_lu.2_account_group_6221
 #: model:account.group.template,name:l10n_lu.account_group_6221
 msgid "Students"
 msgstr "Studentische Aushilfskräfte"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_612
 #: model:account.group.template,name:l10n_lu.account_group_612
 msgid "Subcontracting, servicing, repairs and maintenance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_101
 #: model:account.account.template,name:l10n_lu.lu_2011_account_101
+#: model:account.group,name:l10n_lu.2_account_group_101
 #: model:account.group.template,name:l10n_lu.account_group_101
 msgid "Subscribed capital"
 msgstr "Gezeichnetes Kapital "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_103
 #: model:account.account.template,name:l10n_lu.lu_2011_account_103
+#: model:account.group,name:l10n_lu.2_account_group_103
 #: model:account.group.template,name:l10n_lu.account_group_103
 msgid "Subscribed capital called but unpaid"
 msgstr "Gezeichnetes eingefordertes und nicht eingezahltes Kapital"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_102
 #: model:account.account.template,name:l10n_lu.lu_2011_account_102
+#: model:account.group,name:l10n_lu.2_account_group_102
 #: model:account.group.template,name:l10n_lu.account_group_102
 msgid "Subscribed capital not called"
 msgstr "Gezeichnetes nicht eingefordertes Kapital "
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_10
 #: model:account.group.template,name:l10n_lu.account_group_10
 msgid "Subscribed capital or branches' assigned capital and owner's account"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421622
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461422
+#: model:account.account,name:l10n_lu.2_lu_2011_account_682
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421622
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461422
 #: model:account.account.template,name:l10n_lu.lu_2011_account_682
+#: model:account.group,name:l10n_lu.2_account_group_421622
+#: model:account.group,name:l10n_lu.2_account_group_461422
+#: model:account.group,name:l10n_lu.2_account_group_682
 #: model:account.group.template,name:l10n_lu.account_group_421622
 #: model:account.group.template,name:l10n_lu.account_group_461422
 #: model:account.group.template,name:l10n_lu.account_group_682
@@ -6792,29 +8690,37 @@ msgid "Subscription tax"
 msgstr "Abgeltungssteuer"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_745
 #: model:account.group.template,name:l10n_lu.account_group_745
 msgid "Subsidies for operating activities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7454
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7454
+#: model:account.group,name:l10n_lu.2_account_group_7454
 #: model:account.group.template,name:l10n_lu.account_group_7454
 msgid "Subsidies in favour of employment development"
 msgstr "Zuschüsse zur Beschäftigungsförderung"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_161
 #: model:account.group.template,name:l10n_lu.account_group_161
 msgid "Subsidies on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1621
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1621
+#: model:account.group,name:l10n_lu.2_account_group_1621
 #: model:account.group.template,name:l10n_lu.account_group_1621
 msgid "Subsidies on land, fitting-outs and buildings"
 msgstr "Investitionszuschüsse auf Grundstücke, Erschließungen und Bauten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1623
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1623
+#: model:account.group,name:l10n_lu.2_account_group_1623
 #: model:account.group.template,name:l10n_lu.account_group_1623
 msgid ""
 "Subsidies on other fixtures, fittings, tools and equipment (including "
@@ -6824,57 +8730,77 @@ msgstr ""
 "Geschäftsausstattung (Fuhrpark inbegriffen)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1622
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1622
+#: model:account.group,name:l10n_lu.2_account_group_1622
 #: model:account.group.template,name:l10n_lu.account_group_1622
 msgid "Subsidies on plant and machinery"
 msgstr "Investitionszuschüsse auf Ttechnische Anlagen und Maschinen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_162
 #: model:account.group.template,name:l10n_lu.account_group_162
 msgid "Subsidies on tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621121
+#: model:account.group,name:l10n_lu.2_account_group_621121
 #: model:account.group.template,name:l10n_lu.account_group_621121
 msgid "Sunday"
 msgstr "Sonntagsarbeit"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_44111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_44121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_44111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_44121
+#: model:account.group,name:l10n_lu.2_account_group_44111
+#: model:account.group,name:l10n_lu.2_account_group_44121
 #: model:account.group.template,name:l10n_lu.account_group_44111
 #: model:account.group.template,name:l10n_lu.account_group_44121
 msgid "Suppliers"
 msgstr "Lieferanten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_44112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_44112
+#: model:account.group,name:l10n_lu.2_account_group_44112
 #: model:account.group.template,name:l10n_lu.account_group_44112
 msgid "Suppliers - invoices not yet received"
 msgstr "Lieferanten - Noch nicht erhaltene Rechnungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_44113
+#: model:account.account,name:l10n_lu.2_lu_2020_account_44123
 #: model:account.account.template,name:l10n_lu.lu_2020_account_44113
 #: model:account.account.template,name:l10n_lu.lu_2020_account_44123
+#: model:account.group,name:l10n_lu.2_account_group_44113
+#: model:account.group,name:l10n_lu.2_account_group_44123
 #: model:account.group.template,name:l10n_lu.account_group_44113
 #: model:account.group.template,name:l10n_lu.account_group_44123
 msgid "Suppliers with a debit balance"
 msgstr "Lieferanten - Debitorische Kreditoren"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6185
 #: model:account.group.template,name:l10n_lu.account_group_6185
 msgid "Supplies and small equipment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6186
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6186
+#: model:account.group,name:l10n_lu.2_account_group_6186
 #: model:account.group.template,name:l10n_lu.account_group_6186
 msgid "Surveillance and security charges"
 msgstr "Wach- und Sicherheitsdienste"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62117
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62117
+#: model:account.group,name:l10n_lu.2_account_group_62117
 #: model:account.group.template,name:l10n_lu.account_group_62117
 msgid "Survivor's pay"
 msgstr "Hinterbliebenenzuschuss"
@@ -6895,6 +8821,11 @@ msgid "TVA 12%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_13
+msgid "TVA 13%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.tax.group,name:l10n_lu.tax_group_14
 msgid "TVA 14%"
 msgstr ""
@@ -6902,6 +8833,11 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.group,name:l10n_lu.tax_group_15
 msgid "TVA 15%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_16
+msgid "TVA 16%"
 msgstr ""
 
 #. module: l10n_lu
@@ -6920,136 +8856,191 @@ msgid "TVA 6%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_7
+msgid "TVA 7%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.tax.group,name:l10n_lu.tax_group_8
 msgid "TVA 8%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60811
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60811
+#: model:account.group,name:l10n_lu.2_account_group_60811
 #: model:account.group.template,name:l10n_lu.account_group_60811
 msgid "Tailoring"
 msgstr "Lohnverarbeitung"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_22
+#: model:account.group,name:l10n_lu.2_account_group_722
 #: model:account.group.template,name:l10n_lu.account_group_22
 #: model:account.group.template,name:l10n_lu.account_group_722
 msgid "Tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report,name:l10n_lu.tax_report
+msgid "Tax Report"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_46
 #: model:account.group.template,name:l10n_lu.account_group_46
 msgid "Tax and social security debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_461
 #: model:account.group.template,name:l10n_lu.account_group_461
 msgid "Tax debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6733
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6733
+#: model:account.group,name:l10n_lu.2_account_group_6733
 #: model:account.group.template,name:l10n_lu.account_group_6733
 msgid "Taxes levied on non-resident undertakings"
 msgstr ""
 "Steuern, die durch die nicht gebietsansässige Unternehmen getragen wurden"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6732
 #: model:account.group.template,name:l10n_lu.account_group_6732
 msgid "Taxes levied on permanent establishments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_646
 #: model:account.group.template,name:l10n_lu.account_group_646
 msgid "Taxes, duties and similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61532
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61532
+#: model:account.group,name:l10n_lu.2_account_group_61532
 #: model:account.group.template,name:l10n_lu.account_group_61532
 msgid "Telecommunication costs"
 msgstr "Sonstige Telekommunikationskosten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106165
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106165
 msgid "Telephone"
 msgstr "Telefon"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_13823
 #: model:account.group.template,name:l10n_lu.account_group_13823
 msgid "Temporarily not taxable capital gains"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7471
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7471
+#: model:account.group,name:l10n_lu.2_account_group_7471
 #: model:account.group.template,name:l10n_lu.account_group_7471
 msgid "Temporarily not taxable capital gains not reinvested"
 msgstr "Sonderposten mit Rücklageanteil, nicht wiederangelegt"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7472
+#: model:account.account,name:l10n_lu.2_lu_2020_account_138232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7472
 #: model:account.account.template,name:l10n_lu.lu_2020_account_138232
+#: model:account.group,name:l10n_lu.2_account_group_138232
+#: model:account.group,name:l10n_lu.2_account_group_7472
 #: model:account.group.template,name:l10n_lu.account_group_138232
 #: model:account.group.template,name:l10n_lu.account_group_7472
 msgid "Temporarily not taxable capital gains reinvested"
 msgstr "Sonderposten mit Rücklageanteil, wiederangelegt"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_138231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_138231
+#: model:account.group,name:l10n_lu.2_account_group_138231
 #: model:account.group.template,name:l10n_lu.account_group_138231
 msgid "Temporarily not taxable capital gains to reinvest"
 msgstr "Sonderposten mit Rücklageanteil, zur Wiederanlage bestimmt"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_123
+#: model:account.group,name:l10n_lu.2_account_group_123
 #: model:account.group.template,name:l10n_lu.account_group_123
 msgid "Temporarily not taxable currency translation adjustments"
 msgstr "Rücklagen aus der Währungsumrechnung (unversteuert)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6171
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6171
+#: model:account.group,name:l10n_lu.2_account_group_6171
 #: model:account.group.template,name:l10n_lu.account_group_6171
 msgid "Temporary staff"
 msgstr "Aushilfskräfte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106144
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6146
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106144
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6146
+#: model:account.group,name:l10n_lu.2_account_group_6146
 #: model:account.group.template,name:l10n_lu.account_group_6146
 msgid "Third-party insurance"
 msgstr "Haftpflichtversicherung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2233
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2233
+#: model:account.group,name:l10n_lu.2_account_group_2233
 #: model:account.group.template,name:l10n_lu.account_group_2233
 msgid "Tools"
 msgstr "Werkzeuge"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_441
 #: model:account.group.template,name:l10n_lu.account_group_441
 msgid "Trade payables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4412
 #: model:account.group.template,name:l10n_lu.account_group_4412
 msgid "Trade payables after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_44
 #: model:account.group.template,name:l10n_lu.account_group_44
 msgid "Trade payables and bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4411
 #: model:account.group.template,name:l10n_lu.account_group_4411
 msgid "Trade payables within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41121
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41221
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6451
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6451
+#: model:account.group,name:l10n_lu.2_account_group_41111
+#: model:account.group,name:l10n_lu.2_account_group_41121
+#: model:account.group,name:l10n_lu.2_account_group_41211
+#: model:account.group,name:l10n_lu.2_account_group_41221
+#: model:account.group,name:l10n_lu.2_account_group_6451
 #: model:account.group.template,name:l10n_lu.account_group_41111
 #: model:account.group.template,name:l10n_lu.account_group_41121
 #: model:account.group.template,name:l10n_lu.account_group_41211
@@ -7059,32 +9050,47 @@ msgid "Trade receivables"
 msgstr "Verkäufe und Dienstleistungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_40
 #: model:account.group.template,name:l10n_lu.account_group_40
 msgid "Trade receivables (Receivables from sales and rendering of services)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_402
 #: model:account.group.template,name:l10n_lu.account_group_402
 msgid "Trade receivables due and payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_401
 #: model:account.group.template,name:l10n_lu.account_group_401
 msgid "Trade receivables due and payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6414
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6414
+#: model:account.group,name:l10n_lu.2_account_group_6414
 #: model:account.group.template,name:l10n_lu.account_group_6414
 msgid "Trademarks and franchise"
 msgstr "Warenzeichen und Franchising (Verkaufskonzession/Alleinverkaufsrecht)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21214
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21224
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72124
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7414
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21214
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21224
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72124
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7414
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70314
+#: model:account.group,name:l10n_lu.2_account_group_21214
+#: model:account.group,name:l10n_lu.2_account_group_21224
+#: model:account.group,name:l10n_lu.2_account_group_70314
+#: model:account.group,name:l10n_lu.2_account_group_72124
+#: model:account.group,name:l10n_lu.2_account_group_7414
 #: model:account.group.template,name:l10n_lu.account_group_21214
 #: model:account.group.template,name:l10n_lu.account_group_21224
 #: model:account.group.template,name:l10n_lu.account_group_70314
@@ -7094,133 +9100,181 @@ msgid "Trademarks and franchises"
 msgstr "Warenzeichen und Verkaufskonzession / Alleinverkaufsrecht"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_50
 #: model:account.group.template,name:l10n_lu.account_group_50
 msgid "Transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_484
 #: model:account.account.template,name:l10n_lu.lu_2011_account_484
+#: model:account.group,name:l10n_lu.2_account_group_484
 #: model:account.group.template,name:l10n_lu.account_group_484
 msgid "Transitory or suspense accounts - Assets"
 msgstr "Transitorische Konten - Aktiva"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_485
 #: model:account.account.template,name:l10n_lu.lu_2011_account_485
+#: model:account.group,name:l10n_lu.2_account_group_485
 #: model:account.group.template,name:l10n_lu.account_group_485
 msgid "Transitory or suspense accounts - Liabilities"
 msgstr "Transitorische Konten - Passiva"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6143
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6143
+#: model:account.group,name:l10n_lu.2_account_group_6143
 #: model:account.group.template,name:l10n_lu.account_group_6143
 msgid "Transport insurance"
 msgstr "Transportversicherung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2231
+#: model:account.group,name:l10n_lu.2_account_group_2231
 #: model:account.group.template,name:l10n_lu.account_group_2231
 msgid "Transportation and handling equipment"
 msgstr "Transport- und Wartungsmittel"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_616
 #: model:account.group.template,name:l10n_lu.account_group_616
 msgid "Transportation of goods and collective staff transportation"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6161
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6161
+#: model:account.group,name:l10n_lu.2_account_group_6161
 #: model:account.group.template,name:l10n_lu.account_group_6161
 msgid "Transportation of purchased goods"
 msgstr "Transporte von Einkäufen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6162
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6162
+#: model:account.group,name:l10n_lu.2_account_group_6162
 #: model:account.group.template,name:l10n_lu.account_group_6162
 msgid "Transportation of sold goods"
 msgstr "Transporte von Verkäufen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6152
 #: model:account.group.template,name:l10n_lu.account_group_6152
 msgid "Travel and entertainment expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_61521
 #: model:account.group.template,name:l10n_lu.account_group_61521
 msgid "Travel expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6099
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6099
+#: model:account.group,name:l10n_lu.2_account_group_6099
 #: model:account.group.template,name:l10n_lu.account_group_6099
 msgid "Unallocated RDR"
 msgstr "Nicht zugeordnete Rabatte, Preisnachlässe und Rückvergütungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5085
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5085
+#: model:account.group,name:l10n_lu.2_account_group_5085
 #: model:account.group.template,name:l10n_lu.account_group_5085
 msgid "Unlisted debenture loans"
 msgstr "Anleihen - Nicht notierte Wertpapiere"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_235112
 #: model:account.account.template,name:l10n_lu.lu_2020_account_235112
+#: model:account.group,name:l10n_lu.2_account_group_235112
 #: model:account.group.template,name:l10n_lu.account_group_235112
 msgid "Unlisted shares"
 msgstr "Nicht notierte Aktien"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_60
 #: model:account.group.template,name:l10n_lu.account_group_60
 msgid "Use of merchandise, raw and consumable materials"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461418
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461418
+#: model:account.group,name:l10n_lu.2_account_group_461418
 #: model:account.group.template,name:l10n_lu.account_group_461418
 msgid "VAT - Other payables"
 msgstr "MwSt - Sonstige Verbindlichkeiten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421618
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421618
+#: model:account.group,name:l10n_lu.2_account_group_421618
 #: model:account.group.template,name:l10n_lu.account_group_421618
 msgid "VAT - Other receivables"
 msgstr "MwSt - Sonstige Forderungen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421613
+#: model:account.group,name:l10n_lu.2_account_group_421613
 #: model:account.group.template,name:l10n_lu.account_group_421613
 msgid "VAT down payments made"
 msgstr "Geleistete Anzahlungen auf MwSt"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461413
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461413
+#: model:account.group,name:l10n_lu.2_account_group_461413
 #: model:account.group.template,name:l10n_lu.account_group_461413
 msgid "VAT down payments received"
 msgstr "Erhaltene Anzahlungen auf MwSt"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_421611
 #: model:account.account.template,name:l10n_lu.lu_2020_account_421611
+#: model:account.group,name:l10n_lu.2_account_group_421611
 #: model:account.group.template,name:l10n_lu.account_group_421611
 msgid "VAT paid and recoverable"
 msgstr "Vorsteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461412
+#: model:account.group,name:l10n_lu.2_account_group_461412
 #: model:account.group.template,name:l10n_lu.account_group_461412
 msgid "VAT payable"
 msgstr "Zu zahlende MwSt"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421612
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421612
+#: model:account.group,name:l10n_lu.2_account_group_421612
 #: model:account.group.template,name:l10n_lu.account_group_421612
 msgid "VAT receivable"
 msgstr "Zu erhaltende MwSt"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_461411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_461411
+#: model:account.group,name:l10n_lu.2_account_group_461411
 #: model:account.group.template,name:l10n_lu.account_group_461411
 msgid "VAT received"
 msgstr "Umsatzsteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4019
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4029
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41119
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41129
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41219
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41229
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42119
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42189
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42289
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4019
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4029
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41119
@@ -7230,6 +9284,15 @@ msgstr "Umsatzsteuer"
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42119
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42189
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42289
+#: model:account.group,name:l10n_lu.2_account_group_4019
+#: model:account.group,name:l10n_lu.2_account_group_4029
+#: model:account.group,name:l10n_lu.2_account_group_41119
+#: model:account.group,name:l10n_lu.2_account_group_41129
+#: model:account.group,name:l10n_lu.2_account_group_41219
+#: model:account.group,name:l10n_lu.2_account_group_41229
+#: model:account.group,name:l10n_lu.2_account_group_42119
+#: model:account.group,name:l10n_lu.2_account_group_42189
+#: model:account.group,name:l10n_lu.2_account_group_42289
 #: model:account.group.template,name:l10n_lu.account_group_4019
 #: model:account.group.template,name:l10n_lu.account_group_4029
 #: model:account.group.template,name:l10n_lu.account_group_41119
@@ -7243,39 +9306,49 @@ msgid "Value adjustments"
 msgstr "Wertberichtigungen"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_42161
+#: model:account.group,name:l10n_lu.2_account_group_46141
 #: model:account.group.template,name:l10n_lu.account_group_42161
 #: model:account.group.template,name:l10n_lu.account_group_46141
 msgid "Value-added tax (VAT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_62112
 #: model:account.group.template,name:l10n_lu.account_group_62112
 msgid "Wage supplements"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106161
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106161
 msgid "Wages"
 msgstr "Löhne "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106164
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106164
 msgid "Water"
 msgstr "Wasser"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60314
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60314
+#: model:account.group,name:l10n_lu.2_account_group_60314
 #: model:account.group.template,name:l10n_lu.account_group_60314
 msgid "Water and sewage"
 msgstr "Wasser und Abwasser"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61844
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61844
+#: model:account.group,name:l10n_lu.2_account_group_61844
 #: model:account.group.template,name:l10n_lu.account_group_61844
 msgid "Water and waste water"
 msgstr "Wasserversorgung und Abwasserbeseitigung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10612
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10612
 msgid "Withdrawals of merchandise, finished products and services (at cost)"
 msgstr ""
@@ -7283,72 +9356,101 @@ msgstr ""
 "Einstandspreisen)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62413
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62413
+#: model:account.group,name:l10n_lu.2_account_group_62413
 #: model:account.group.template,name:l10n_lu.account_group_62413
 msgid "Withholding tax on complementary pensions"
 msgstr "Einbehaltene Steuer auf Zusatzrenten"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46126
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42146
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46126
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42146
+#: model:account.group,name:l10n_lu.2_account_group_42146
+#: model:account.group,name:l10n_lu.2_account_group_46126
 #: model:account.group.template,name:l10n_lu.account_group_42146
 #: model:account.group.template,name:l10n_lu.account_group_46126
 msgid "Withholding tax on director's fees"
 msgstr "Einbehaltene Steuer auf Tantiemen"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46125
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42145
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46125
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42145
+#: model:account.group,name:l10n_lu.2_account_group_42145
+#: model:account.group,name:l10n_lu.2_account_group_46125
 #: model:account.group.template,name:l10n_lu.account_group_42145
 #: model:account.group.template,name:l10n_lu.account_group_46125
 msgid "Withholding tax on financial investment income"
 msgstr "Einbehaltene Kapitalertragsteuer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46124
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42144
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46124
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42144
+#: model:account.group,name:l10n_lu.2_account_group_42144
+#: model:account.group,name:l10n_lu.2_account_group_46124
 #: model:account.group.template,name:l10n_lu.account_group_42144
 #: model:account.group.template,name:l10n_lu.account_group_46124
 msgid "Withholding tax on wages and salaries"
 msgstr "Einbehaltene Steuer auf Gehälter und Löhne"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6731
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6731
+#: model:account.group,name:l10n_lu.2_account_group_6731
 #: model:account.group.template,name:l10n_lu.account_group_6731
 msgid "Withholding taxes"
 msgstr "Quellensteuern"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6034
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61853
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6034
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61853
+#: model:account.group,name:l10n_lu.2_account_group_6034
+#: model:account.group,name:l10n_lu.2_account_group_61853
 #: model:account.group.template,name:l10n_lu.account_group_6034
 #: model:account.group.template,name:l10n_lu.account_group_61853
 msgid "Work clothes"
 msgstr "Berufsbekleidung"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6033
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6033
+#: model:account.group,name:l10n_lu.2_account_group_6033
 #: model:account.group.template,name:l10n_lu.account_group_6033
 msgid "Workshop, factory and store supplies and small equipment"
 msgstr "Werkstatt-, Fabrik- und Ladenausstattung"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_16121
 #: model:account.group.template,name:l10n_lu.account_group_16121
 msgid "acquired against payment (except Goodwill)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2121
 #: model:account.group.template,name:l10n_lu.account_group_2121
 msgid "acquired for consideration (except Goodwill)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_16122
+#: model:account.group,name:l10n_lu.2_account_group_2122
 #: model:account.group.template,name:l10n_lu.account_group_16122
 #: model:account.group.template,name:l10n_lu.account_group_2122
 msgid "created by the undertaking itself"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1922
+#: model:account.group,name:l10n_lu.2_account_group_1932
+#: model:account.group,name:l10n_lu.2_account_group_1942
 #: model:account.group.template,name:l10n_lu.account_group_1922
 #: model:account.group.template,name:l10n_lu.account_group_1932
 #: model:account.group.template,name:l10n_lu.account_group_1942
@@ -7356,6 +9458,9 @@ msgid "due and payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1921
+#: model:account.group,name:l10n_lu.2_account_group_1931
+#: model:account.group,name:l10n_lu.2_account_group_1941
 #: model:account.group.template,name:l10n_lu.account_group_1921
 #: model:account.group.template,name:l10n_lu.account_group_1931
 #: model:account.group.template,name:l10n_lu.account_group_1941
@@ -7363,31 +9468,37 @@ msgid "due and payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_755231
 #: model:account.group.template,name:l10n_lu.account_group_755231
 msgid "from affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_755232
 #: model:account.group.template,name:l10n_lu.account_group_755232
 msgid "from other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65413
 #: model:account.group.template,name:l10n_lu.account_group_65413
 msgid "from other receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75411
 #: model:account.group.template,name:l10n_lu.account_group_75411
 msgid "on affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75413
 #: model:account.group.template,name:l10n_lu.account_group_75413
 msgid "on other current receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75412
 #: model:account.group.template,name:l10n_lu.account_group_75412
 msgid ""
 "on undertakings with which the undertaking is linked by virtue of "

--- a/addons/l10n_lu/i18n_extra/fr.po
+++ b/addons/l10n_lu/i18n_extra/fr.po
@@ -17,136 +17,163 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-IC-EX
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-IC-EX
 msgid " EX-IC-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_V-ART-43_60b
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_V-ART-43_60b
 msgid "0-E-Art.43&60b"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_V-ART-44_56q
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_V-ART-44_56q
 msgid "0-E-Art.44&56q"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-PA-0
 msgid "0-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-PA-0
 msgid "0-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-0
 msgid "0-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-EC-0
 msgid "0-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-EC-0
 msgid "0-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-EC-0
 msgid "0-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-EC-0
 msgid "0-EC-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-EC-0
 msgid "0-EC-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-EC-Tab
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-EC-Tab
 msgid "0-EC-ST-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-IC-0
 msgid "0-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-IC-0
 msgid "0-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-IC-0
 msgid "0-IC-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-IC-0
 msgid "0-IC-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-IC-Tab
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-IC-Tab
 msgid "0-IC-ST-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-TR-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-TR-0
 msgid "0-ICT-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-PA-0
 msgid "0-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-PA-0
 msgid "0-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-PA-0
 msgid "0-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-PA-0
 msgid "0-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_SANS
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_SANS
 msgid "0-P-Tax-Free"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-PA-0
 msgid "0-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-PA-0
 msgid "0-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_SANS_sale
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_SANS_sale
 msgid "0-S-Tax-Free"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-PA-Tab
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-PA-Tab
 msgid "0-ST-G"
 msgstr ""
@@ -157,19 +184,9 @@ msgid "012 - Overall turnover"
 msgstr "012 - Chiffre d'affaires global"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
-msgid "014"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014 - Exports"
 msgstr "014 - Exportations"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
-msgid "015"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
@@ -177,19 +194,9 @@ msgid "015 - Other exemptions"
 msgstr "015 - Autres exonérations"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
-msgid "016"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016 - Other exemptions"
 msgstr "016 - Autres exonérations"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
-msgid "017"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
@@ -197,13 +204,8 @@ msgid ""
 "017 - Manufactured tobacco whose VAT was collected at the source or at the "
 "exit of the tax..."
 msgstr ""
-"017 - Tabacs fabriqués dont la TVA a été perçue à la source respectivement "
-"à la sortie de l'entrepôt fiscal..."
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
-msgid "018"
-msgstr ""
+"017 - Tabacs fabriqués dont la TVA a été perçue à la source respectivement à"
+" la sortie de l'entrepôt fiscal..."
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
@@ -215,13 +217,9 @@ msgstr ""
 "triangulaires…"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
-msgid "019"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
-msgid "019 - Supplies other than referred to in 018 and 423 or 424"
+msgid ""
+"019 - Other supplies carried out (for which the place of supply is) abroad"
 msgstr "019 - Autres opérations réalisées (imposables) à l'étranger"
 
 #. module: l10n_lu
@@ -235,34 +233,19 @@ msgid "022 - Taxable turnover"
 msgstr "022 - Chiffre d'affaires imposable"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
-msgid "031"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031 - base 3%"
-msgstr "031 - base 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
-msgid "033"
 msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033 - base 0%"
-msgstr "033 - base 0%"
+msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
 msgid "037 - Breakdown of taxable turnover – base"
 msgstr "037 - Chiffre d'affaires imposable – base"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
-msgid "040"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
@@ -275,24 +258,14 @@ msgid "046 - Breakdown of taxable turnover – tax"
 msgstr "046 - Chiffre d'affaires imposable – taxe"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
-msgid "049"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049 - base 3%"
-msgstr "049 - base 3%"
+msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
 msgid "051 - Intra-Community acquisitions of goods – base"
 msgstr "051 - Acquisitions intracommunautaires de biens - base"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
-msgid "054"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
@@ -305,19 +278,9 @@ msgid "056 - Intra-Community acquisitions of goods – tax"
 msgstr "056 - Acquisitions intracommunautaires de biens - taxe"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
-msgid "059"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059 - for business purposes: base 3%"
 msgstr "059 - à des fins de l'entreprise: base 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
-msgid "063"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
@@ -330,19 +293,9 @@ msgid "065 - Importation of goods – base"
 msgstr "065 - Importations de biens - base"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
-msgid "068"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068 - for business purposes: tax 3%"
 msgstr "068 - à des fins de l'entreprise: taxe de 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
-msgid "073"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
@@ -355,19 +308,9 @@ msgid "076 - Total tax due"
 msgstr "076 - Total de la taxe en aval"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
-msgid "090"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090 - Due in respect of the application of goods for business purposes"
 msgstr "090 - Taxe déclarée pour l'affectation de biens à l'entreprise"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
-msgid "092"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
@@ -391,15 +334,10 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
 msgid ""
-"095 - where the deductible proportion determined in accordance to article 50 "
-"is applied"
+"095 - where the deductible proportion determined in accordance to article 50"
+" is applied"
 msgstr ""
 "095 - Taxe non déductible en application du prorata visé à l'article 50"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
-msgid "096"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
@@ -407,9 +345,8 @@ msgid ""
 "096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and "
 "56ter-2(7) (when applying the margin scheme)"
 msgstr ""
-"096 - Taxe non déductible en application des articles 56ter-1/7 et "
-"56ter-2/7 (en cas d'option pour le régime d'imposition de la marge "
-"bénéficiaire)"
+"096 - Taxe non déductible en application des articles 56ter-1/7 et 56ter-2/7"
+" (en cas d'option pour le régime d'imposition de la marge bénéficiaire)"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
@@ -437,6 +374,217 @@ msgid "105 - Exceeding amount"
 msgstr "105 - Excédent"
 
 #. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-ECP-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-ECP-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VP-PA-13
+msgid "13%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-13
+msgid "13-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-13
+msgid "13-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-13
+msgid "13-EC(P)-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-13
+msgid "13-EC(P)-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-13
+msgid "13-EC(P)-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-13
+msgid "13-EC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-13
+msgid "13-EC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-13
+msgid "13-EC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-13
+msgid "13-EC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-13
+msgid "13-EC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-13
+msgid "13-EC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-13
+msgid "13-IC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-13
+msgid "13-IC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-13
+msgid "13-IC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-13
+msgid "13-IC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-13
+msgid "13-IC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-13
+msgid "13-IC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-13
+msgid "13-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-13
+msgid "13-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-13
+msgid "13-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-13
+msgid "13-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-13
+msgid "13-S-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-13
+msgid "13-S-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-14
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-14
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-14
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-14
@@ -464,123 +612,141 @@ msgid "14%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-14
 msgid "14-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-14
 msgid "14-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-14
 msgid "14-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-14
 msgid "14-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-14
 msgid "14-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-14
 msgid "14-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-14
 msgid "14-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-14
 msgid "14-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-14
 msgid "14-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-14
 msgid "14-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-14
 msgid "14-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-14
 msgid "14-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-14
 msgid "14-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-14
 msgid "14-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-14
 msgid "14-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-14
 msgid "14-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-14
 msgid "14-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-14
 msgid "14-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-14
 msgid "14-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-14
 msgid "14-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-14
 msgid "14-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-14
 msgid "14-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-14
 msgid "14-S-S"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
-msgid "152"
 msgstr ""
 
 #. module: l10n_lu
@@ -589,6 +755,226 @@ msgid "152 - Acquisitions, in the context of triangular transactions – base"
 msgstr "152 - Acquisitions triangulaires – base"
 
 #. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_ATN_sale_16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_ATN_sale_16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-ECP-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-ECP-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VP-PA-16
+msgid "16%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_ATN_sale_16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_ATN_sale_16
+msgid "16-ATN"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-16
+msgid "16-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-16
+msgid "16-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-16
+msgid "16-EC(P)-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-16
+msgid "16-EC(P)-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-16
+msgid "16-EC(P)-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-16
+msgid "16-EC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-16
+msgid "16-EC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-16
+msgid "16-EC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-16
+msgid "16-EC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-16
+msgid "16-EC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-16
+msgid "16-EC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-16
+msgid "16-IC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-16
+msgid "16-IC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-16
+msgid "16-IC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-16
+msgid "16-IC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-16
+msgid "16-IC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-16
+msgid "16-IC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-16
+msgid "16-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-16
+msgid "16-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-16
+msgid "16-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-16
+msgid "16-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-16
+msgid "16-S-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-16
+msgid "16-S-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_ATN_sale
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-17
@@ -596,6 +982,7 @@ msgstr "152 - Acquisitions triangulaires – base"
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-EC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-IC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-PA-17
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_ATN_sale
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-EC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-ECP-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-IC-17
@@ -616,123 +1003,147 @@ msgid "17%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_ATN_sale
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_ATN_sale
+msgid "17-ATN"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-17
 msgid "17-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-17
 msgid "17-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-17
 msgid "17-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-17
 msgid "17-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-17
 msgid "17-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-17
 msgid "17-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-17
 msgid "17-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-17
 msgid "17-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-17
 msgid "17-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-17
 msgid "17-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-17
 msgid "17-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-17
 msgid "17-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-17
 msgid "17-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-17
 msgid "17-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-17
 msgid "17-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-17
 msgid "17-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-17
 msgid "17-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-17
 msgid "17-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-17
 msgid "17-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-17
 msgid "17-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-17
 msgid "17-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-17
 msgid "17-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-17
 msgid "17-S-S"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_exempt
-msgid "194"
 msgstr ""
 
 #. module: l10n_lu
@@ -741,29 +1152,14 @@ msgid "194 - base exempt"
 msgstr "194 - base exonérée"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
-msgid "195"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195 - for business purposes: base exempt"
 msgstr "195 - à des fins de l'entreprise: base exonérée"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
-msgid "196"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196 - for non-business purposes: base exempt"
 msgstr "196 - à des fins étrangères à l'entreprise: base exonérée"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
-msgid "226"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
@@ -775,19 +1171,9 @@ msgstr ""
 "56sexies"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
-msgid "227"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227 - Special arrangement for tax suspension: adjustment"
 msgstr "227 - Régime particulier suspensif: régularisation"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
-msgid "228"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
@@ -795,116 +1181,139 @@ msgid "228 - Adjusted tax - special arrangement for tax suspension"
 msgstr "228 - Taxe régularisée - régime particulier suspensif"
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-PA-3
 msgid "3-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-PA-3
 msgid "3-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-3
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-3
 msgid "3-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-3
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-3
 msgid "3-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-3
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-3
 msgid "3-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-EC-3
 msgid "3-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-EC-3
 msgid "3-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-EC-3
 msgid "3-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-EC-3
 msgid "3-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-EC-3
 msgid "3-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-EC-3
 msgid "3-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-IC-3
 msgid "3-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-IC-3
 msgid "3-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-IC-3
 msgid "3-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-IC-3
 msgid "3-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-IC-3
 msgid "3-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-IC-3
 msgid "3-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-PA-3
 msgid "3-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-PA-3
 msgid "3-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-PA-3
 msgid "3-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-PA-3
 msgid "3-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-PA-3
 msgid "3-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-PA-3
 msgid "3-S-S"
 msgstr ""
@@ -917,49 +1326,37 @@ msgstr "407 - Importations de biens - taxe"
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
 msgid ""
-"409 - Supply of services for which the customer is liable for the payment of "
-"VAT – base"
+"409 - Supply of services for which the customer is liable for the payment of"
+" VAT – base"
 msgstr ""
-"409 - Prestations de services à déclarer par le preneur redevable de la taxe "
-"- base"
+"409 - Prestations de services à déclarer par le preneur redevable de la taxe"
+" - base"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
 msgid ""
-"410 - Supply of services for which the customer is liable for the payment of "
-"VAT – tax"
+"410 - Supply of services for which the customer is liable for the payment of"
+" VAT – tax"
 msgstr ""
-"410 - Prestations de services à déclarer par le preneur redevable de la taxe "
-"- taxe"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
-msgid "419"
-msgstr ""
+"410 - Prestations de services à déclarer par le preneur redevable de la taxe"
+" - taxe"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
 msgid ""
-"419 - Inland supplies for which the customer is liable for the payment of VAT"
+"419 - Inland supplies for which the customer is liable for the payment of "
+"VAT"
 msgstr ""
-"419 - Opérations à l'intérieur du pays pour lesquelles le preneur est le redevable"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
-msgid "423"
-msgstr ""
+"419 - Opérations à l'intérieur du pays pour lesquelles le preneur est le "
+"redevable"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
 msgid ""
 "423 - not exempt in the MS where the customer is liable for payment of VAT"
 msgstr ""
-"423 - Prestations de services non exonérées dans l'Etat membre du preneur redevable"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
-msgid "424"
-msgstr ""
+"423 - Prestations de services non exonérées dans l'Etat membre du preneur "
+"redevable"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
@@ -967,29 +1364,14 @@ msgid "424 - exempt in the MS where the customer is identified"
 msgstr "424 - Prestations de services exonérées dans l'Etat membre du preneur"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
-msgid "431"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431 - not exempt within the territory: base 3%"
 msgstr "431 - non exonérées à l'intérieur du pays: base 3%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
-msgid "432"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432 - not exempt within the territory: tax 3%"
 msgstr "432 - non exonérées à l'intérieur du pays: tax 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
-msgid "435"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
@@ -1002,37 +1384,25 @@ msgid "436 - base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
-msgid "441"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441 - not established or residing within the Community: base 3%"
-msgstr "441 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: base 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
-msgid "442"
 msgstr ""
+"441 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: base 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442 - not established or residing within the Community: tax 3%"
-msgstr "442 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: tax 3%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
-msgid "445"
 msgstr ""
+"442 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: tax 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445 - not established or residing within the Community: exempt"
-msgstr "445 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: exonérées"
+msgstr ""
+"445 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: exonérées"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
@@ -1040,76 +1410,47 @@ msgid "454 - Total Sales / Receipts"
 msgstr "454 - Total Ventes / Recettes"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
-msgid "455"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
 msgid ""
 "455 - Application of goods for non-business use and for business purposes"
 msgstr ""
-"455 - Application de biens de l'utilisation privée et à des fins de l'entreprise"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
-msgid "456"
-msgstr ""
+"455 - Application de biens de l'utilisation privée et à des fins de "
+"l'entreprise"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456 - Non-business use of goods and supply of services free of charge"
-msgstr "456 - Prestations de services effectuées à des fins étrangères à "
-"l'entreprise"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
-msgid "457"
 msgstr ""
+"456 - Prestations de services effectuées à des fins étrangères à "
+"l'entreprise"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
 msgid ""
-"457 - Intra-Community supply of goods to persons identified for VAT purposes "
-"in another Member State (MS)"
+"457 - Intra-Community supply of goods to persons identified for VAT purposes"
+" in another Member State (MS)"
 msgstr ""
 "457 - Livraisons intracommunautaires de biens à des personnes identifiées à "
 "la TVA dans un autre État membre"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
-msgid "458"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458 - Invoiced by other taxable persons for goods or services supplied"
-msgstr "458 - Taxe facturée par d'autres assujettis pour des biens et des services fournis"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
-msgid "459"
 msgstr ""
+"458 - Taxe facturée par d'autres assujettis pour des biens et des services "
+"fournis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459 - Due in respect of intra-Community acquisitions of goods"
-msgstr "459 - Taxe déclarée ou payée sur des acquisitions intracommunautaires de biens"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
-msgid "460"
 msgstr ""
+"459 - Taxe déclarée ou payée sur des acquisitions intracommunautaires de "
+"biens"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460 - Due or paid in respect of importation of goods"
 msgstr "460 - Taxe déclarée ou payée sur des biens importés"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
-msgid "461"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
@@ -1132,17 +1473,11 @@ msgid "464 - tax"
 msgstr "464 - taxe"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
-msgid "471"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid ""
 "471 - Telecommunications services, radio and television broadcasting "
 "services..."
-msgstr ""
-"471 - Prestations de services de télécom., de radio et de tv..."
+msgstr "471 - Prestations de services de télécom., de radio et de tv..."
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
@@ -1150,8 +1485,159 @@ msgid "472 - Other sales / receipts"
 msgstr "472 - Autres Ventes / Recettes"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
-msgid "701"
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_8_supplies_carried_out_domestic
+msgid ""
+"481 - Supplies carried out within the scope of the domestic SME scheme of "
+"article 57bis (7)"
+msgstr ""
+"Opérations réalisées dans le cadre du régime de franchise national de "
+"l'article 57bis (17)"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_9_supplies_carried_out_cross_border
+msgid ""
+"482 - Supplies carried out within the scope of the cross-border SME scheme "
+"of article 57 quater"
+msgstr ""
+"482 - Opérations réalisées dans le cadre du régime de franchise transfrontalier"
+"de l’article 57quater"
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-7
+msgid "7-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-7
+msgid "7-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-7
+msgid "7-EC(P)-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-7
+msgid "7-EC(P)-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-7
+msgid "7-EC(P)-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-7
+msgid "7-EC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-7
+msgid "7-EC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-7
+msgid "7-EC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-7
+msgid "7-EC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-7
+msgid "7-EC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-7
+msgid "7-EC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-7
+msgid "7-IC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-7
+msgid "7-IC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-7
+msgid "7-IC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-7
+msgid "7-IC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-7
+msgid "7-IC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-7
+msgid "7-IC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-7
+msgid "7-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-7
+msgid "7-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-7
+msgid "7-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-7
+msgid "7-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-7
+msgid "7-S-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-7
+msgid "7-S-S"
 msgstr ""
 
 #. module: l10n_lu
@@ -1160,28 +1646,13 @@ msgid "701 - base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
-msgid "702"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702 - tax 17%"
 msgstr "702 - taxe 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
-msgid "703"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
 msgid "703 - base 14%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
-msgid "704"
 msgstr ""
 
 #. module: l10n_lu
@@ -1190,18 +1661,8 @@ msgid "704 - tax 14%"
 msgstr "704 - taxe 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
-msgid "705"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
 msgid "705 - base 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
-msgid "706"
 msgstr ""
 
 #. module: l10n_lu
@@ -1210,18 +1671,8 @@ msgid "706 - tax 8%"
 msgstr "706 - taxe 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
-msgid "711"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
 msgid "711 - base 17%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
-msgid "712"
 msgstr ""
 
 #. module: l10n_lu
@@ -1230,18 +1681,8 @@ msgid "712 - tax 17%"
 msgstr "712 - taxe 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
-msgid "713"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
 msgid "713 - base 14%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
-msgid "714"
 msgstr ""
 
 #. module: l10n_lu
@@ -1250,18 +1691,8 @@ msgid "714 - tax 14%"
 msgstr "714 - taxe 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
-msgid "715"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
 msgid "715 - base 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
-msgid "716"
 msgstr ""
 
 #. module: l10n_lu
@@ -1270,23 +1701,13 @@ msgid "716 - tax 8%"
 msgstr "716 - taxe 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
-msgid "719"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
 msgid ""
 "719 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
 msgstr ""
-"719 - de tabacs fabriqués dont la TVA est perçue à la sortie de "
-"l'entrepôt fiscal conjointement avec les accises"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
-msgid "721"
-msgstr ""
+"719 - de tabacs fabriqués dont la TVA est perçue à la sortie de l'entrepôt "
+"fiscal conjointement avec les accises"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
@@ -1294,19 +1715,9 @@ msgid "721 - for business purposes: base 17%"
 msgstr "721 - à des fins de l'entreprise: base 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
-msgid "722"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722 - for business purposes: tax 17%"
 msgstr "722 - à des fins de l'entreprise: taxe 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
-msgid "723"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
@@ -1314,19 +1725,9 @@ msgid "723 - for business purposes: base 14%"
 msgstr "723 - à des fins de l'entreprise: base 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
-msgid "724"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724 - for business purposes: tax 14%"
 msgstr "724 - à des fins de l'entreprise: taxe 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
-msgid "725"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
@@ -1334,19 +1735,9 @@ msgid "725 - for business purposes: base 8%"
 msgstr "725 - à des fins de l'entreprise: base 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
-msgid "726"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
 msgstr "726 - à des fins de l'entreprise: taxe 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
-msgid "729"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
@@ -1354,13 +1745,8 @@ msgid ""
 "729 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
 msgstr ""
-"729 - de tabacs fabriqués dont la TVA est perçue à la sortie de "
-"l'entrepôt fiscal conjointement avec les accises"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
-msgid "731"
-msgstr ""
+"729 - de tabacs fabriqués dont la TVA est perçue à la sortie de l'entrepôt "
+"fiscal conjointement avec les accises"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
@@ -1368,19 +1754,9 @@ msgid "731 - for non-business purposes: base 17%"
 msgstr "731 - à des fins étrangères à l'entreprise: base 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
-msgid "732"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732 - for non-business purposes: tax 17%"
 msgstr "732 - à des fins étrangères à l'entreprise: taxe 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
-msgid "733"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
@@ -1388,19 +1764,9 @@ msgid "733 - for non-business purposes: base 14%"
 msgstr "733 - à des fins étrangères à l'entreprise: base 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
-msgid "734"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734 - for non-business purposes: tax 14%"
 msgstr "734 - à des fins étrangères à l'entreprise: taxe 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
-msgid "735"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
@@ -1408,19 +1774,9 @@ msgid "735 - for non-business purposes: base 8%"
 msgstr "735 - à des fins étrangères à l'entreprise: base 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
-msgid "736"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736 - for non-business purposes: tax 8%"
 msgstr "736 - à des fins étrangères à l'entreprise: taxe 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
-msgid "741"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
@@ -1428,19 +1784,9 @@ msgid "741 - not exempt within the territory: base 17%"
 msgstr "741 - non exonérées à l'intérieur du pays: base 17%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
-msgid "742"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742 - not exempt within the territory: tax 17%"
 msgstr "742 - non exonérées à l'intérieur du pays: taxe 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
-msgid "743"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
@@ -1448,19 +1794,9 @@ msgid "743 - not exempt within the territory: base 14%"
 msgstr "743 - non exonérées à l'intérieur du pays: base 14%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
-msgid "744"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744 - not exempt within the territory: tax 14%"
 msgstr "744 - non exonérées à l'intérieur du pays: taxe 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
-msgid "745"
-msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
@@ -1468,116 +1804,69 @@ msgid "745 - not exempt within the territory: base 8%"
 msgstr "745 - non exonérées à l'intérieur du pays: base 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
-msgid "746"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746 - not exempt within the territory: tax 8%"
 msgstr "746 - non exonérées à l'intérieur du pays: taxe 8%"
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
-msgid "751"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751 - not established or residing within the Community: base 17%"
-msgstr "751 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: base 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
-msgid "752"
 msgstr ""
+"751 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: base 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752 - not established or residing within the Community: tax 17%"
-msgstr "752 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: taxe 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
-msgid "753"
 msgstr ""
+"752 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: taxe 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753 - not established or residing within the Community: base 14%"
-msgstr "753 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: base 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
-msgid "754"
 msgstr ""
+"753 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: base 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754 - not established or residing within the Community: tax 14%"
-msgstr "754 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: taxe 14%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
-msgid "755"
 msgstr ""
+"754 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: taxe 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755 - not established or residing within the Community: base 8%"
-msgstr "755 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: base 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
-msgid "756"
 msgstr ""
+"755 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: base 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756 - not established or residing within the Community: tax 8%"
-msgstr "756 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: taxe 8%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
-msgid "761"
 msgstr ""
+"756 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: taxe 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761 - suppliers established within the territory: base 17%"
-msgstr "761 - effectuées au déclarant par des assujettis établis "
-"à l'intérieur du pays: base 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
-msgid "762"
 msgstr ""
+"761 - effectuées au déclarant par des assujettis établis à l'intérieur du "
+"pays: base 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762 - suppliers established within the territory: tax 17%"
-msgstr "762 - effectuées au déclarant par des assujettis établis "
-"à l'intérieur du pays: taxe 17%"
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
-msgid "763"
 msgstr ""
+"762 - effectuées au déclarant par des assujettis établis à l'intérieur du "
+"pays: taxe 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763 - base 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
-msgid "764"
 msgstr ""
 
 #. module: l10n_lu
@@ -1601,7 +1890,8 @@ msgid ""
 "767 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - base"
 msgstr ""
-"767 - Livraisons de biens à déclarer par l'acquéreur redevable de la taxe - base"
+"767 - Livraisons de biens à déclarer par l'acquéreur redevable de la taxe - "
+"base"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
@@ -1609,215 +1899,160 @@ msgid ""
 "768 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - tax"
 msgstr ""
-"768 - Livraisons de biens à déclarer par l'acquéreur redevable de la taxe - taxe"
+"768 - Livraisons de biens à déclarer par l'acquéreur redevable de la taxe - "
+"taxe"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_17
+msgid "769 - base 17%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_17
+msgid "770 - tax 17%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-8
 msgid "8-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-8
 msgid "8-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-8
 msgid "8-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-8
 msgid "8-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-8
 msgid "8-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-8
 msgid "8-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-8
 msgid "8-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-8
 msgid "8-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-8
 msgid "8-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-8
 msgid "8-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-8
 msgid "8-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-8
 msgid "8-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-8
 msgid "8-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-8
 msgid "8-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-8
 msgid "8-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-8
 msgid "8-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-8
 msgid "8-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-8
 msgid "8-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-8
 msgid "8-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-8
 msgid "8-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-8
 msgid "8-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-8
 msgid "8-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-8
 msgid "8-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_16
-msgid "921 - for business purposes: base 16%"
-msgstr "921 - à des fins de l'entreprise: base 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_13
-msgid "923 - for business purposes: base 13%"
-msgstr "923 - à des fins de l'entreprise: base 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_7
-msgid "925 - for business purposes: base 7%"
-msgstr "925 - à des fins de l'entreprise: base 7%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_16
-msgid "931 - for non-business purposes: base 16%"
-msgstr "931 - à des fins étrangères à l'entreprise: base 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_13
-msgid "933 - for non-business purposes: base 13%"
-msgstr "933 - à des fins étrangères à l'entreprise: base 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_7
-msgid "935 - for non-business purposes: base 7%"
-msgstr "935 - à des fins étrangères à l'entreprise: base 7%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_16
-msgid "941 - not exempt within the territory: base 16%"
-msgstr "941 - non exonérées à l'intérieur du pays: base 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_13
-msgid "943 - not exempt within the territory: base 13%"
-msgstr "943 - non exonérées à l'intérieur du pays: base 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_7
-msgid "945 - not exempt within the territory: base 7%"
-msgstr "945 - non exonérées à l'intérieur du pays: base 7%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_16
-msgid "951 - not established or residing within the Community: base 16%"
-msgstr "951 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: base 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_13
-msgid "953 - not established or residing within the Community: base 13%"
-msgstr "953 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: base 13%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_7
-msgid "955 - not established or residing within the Community: base 7%"
-msgstr "955 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: base 7%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_16
-msgid "961 - suppliers established within the territory: base 16%"
-msgstr "961 - effectuées au déclarant par des assujettis établis "
-"à l'intérieur du pays: base 16%"
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_7
-msgid "963 - base 7%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_7
-msgid "964 - tax 7%"
-msgstr "964 - taxe 7%"
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_16
 msgid "901 - base 16%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_13
-msgid "903 - base 13%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_7
-msgid "905 - base 7%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1826,9 +2061,19 @@ msgid "902 - tax 16%"
 msgstr "902 - taxe 16%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_13
+msgid "903 - base 13%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_13
 msgid "904 - tax 13%"
 msgstr "904 - taxe 13%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_7
+msgid "905 - base 7%"
+msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_7
@@ -1841,19 +2086,14 @@ msgid "911 - base 16%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_13
-msgid "913 - base 13%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_7
-msgid "915 - base 7%"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_16
 msgid "912 - tax 16%"
 msgstr "912 - taxe 16%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_13
+msgid "913 - base 13%"
+msgstr ""
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_13
@@ -1861,9 +2101,19 @@ msgid "914 - tax 13%"
 msgstr "914 - taxe 13%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_7
+msgid "915 - base 7%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_7
 msgid "916 - tax 7%"
 msgstr "916 - taxe 7%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_16
+msgid "921 - for business purposes: base 16%"
+msgstr "921 - à des fins de l'entreprise: base 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_16
@@ -1871,9 +2121,19 @@ msgid "922 - for business purposes: tax 16%"
 msgstr "922 - à des fins de l'entreprise: taxe 16%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_13
+msgid "923 - for business purposes: base 13%"
+msgstr "923 - à des fins de l'entreprise: base 13%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_13
 msgid "924 - for business purposes: tax 13%"
 msgstr "924 - à des fins de l'entreprise: taxe 13%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_7
+msgid "925 - for business purposes: base 7%"
+msgstr "925 - à des fins de l'entreprise: base 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_7
@@ -1881,9 +2141,19 @@ msgid "926 - for business purposes: tax 7%"
 msgstr "926 - à des fins de l'entreprise: taxe 7%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_16
+msgid "931 - for non-business purposes: base 16%"
+msgstr "931 - à des fins étrangères à l'entreprise: base 16%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_16
 msgid "932 - for non-business purposes: tax 16%"
 msgstr "932 - à des fins étrangères à l'entreprise: taxe 16%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_13
+msgid "933 - for non-business purposes: base 13%"
+msgstr "933 - à des fins étrangères à l'entreprise: base 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_13
@@ -1891,9 +2161,19 @@ msgid "934 - for non-business purposes: tax 13%"
 msgstr "934 - à des fins étrangères à l'entreprise: taxe 13%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_7
+msgid "935 - for non-business purposes: base 7%"
+msgstr "935 - à des fins étrangères à l'entreprise: base 7%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_7
 msgid "936 - for non-business purposes: tax 7%"
 msgstr "936 - à des fins étrangères à l'entreprise: taxe 7%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_16
+msgid "941 - not exempt within the territory: base 16%"
+msgstr "941 - non exonérées à l'intérieur du pays: base 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_16
@@ -1901,9 +2181,19 @@ msgid "942 - not exempt within the territory: tax 16%"
 msgstr "942 - non exonérées à l'intérieur du pays: taxe 16%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_13
+msgid "943 - not exempt within the territory: base 13%"
+msgstr "943 - non exonérées à l'intérieur du pays: base 13%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_13
 msgid "944 - not exempt within the territory: tax 13%"
 msgstr "944 - non exonérées à l'intérieur du pays: taxe 13%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_7
+msgid "945 - not exempt within the territory: base 7%"
+msgstr "945 - non exonérées à l'intérieur du pays: base 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_7
@@ -1911,60 +2201,113 @@ msgid "946 - not exempt within the territory: tax 7%"
 msgstr "946 - non exonérées à l'intérieur du pays: taxe 7%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_16
+msgid "951 - not established or residing within the Community: base 16%"
+msgstr ""
+"951 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: base 16%"
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_16
 msgid "952 - not established or residing within the Community: tax 16%"
-msgstr "952 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: taxe 16%"
+msgstr ""
+"952 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: taxe 16%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_13
+msgid "953 - not established or residing within the Community: base 13%"
+msgstr ""
+"953 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: base 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_13
 msgid "954 - not established or residing within the Community: tax 13%"
-msgstr "954 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: taxe 13%"
+msgstr ""
+"954 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: taxe 13%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_7
+msgid "955 - not established or residing within the Community: base 7%"
+msgstr ""
+"955 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: base 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_7
 msgid "956 - not established or residing within the Community: tax 7%"
-msgstr "956 - effectuées au déclarant par des assujettis établis en dehors "
-"de la Communauté: taxe 7%"
+msgstr ""
+"956 - effectuées au déclarant par des assujettis établis en dehors de la "
+"Communauté: taxe 7%"
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_16
+msgid "961 - suppliers established within the territory: base 16%"
+msgstr ""
+"961 - effectuées au déclarant par des assujettis établis à l'intérieur du "
+"pays: base 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_16
 msgid "962 - suppliers established within the territory: tax 16%"
-msgstr "962 - effectuées au déclarant par des assujettis établis "
-"à l'intérieur du pays: taxe 16%"
+msgstr ""
+"962 - effectuées au déclarant par des assujettis établis à l'intérieur du "
+"pays: taxe 16%"
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_7
+msgid "963 - base 7%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_7
+msgid "964 - tax 7%"
+msgstr "964 - taxe 7%"
+
+#. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46128
+#: model:account.group,name:l10n_lu.2_account_group_46128
 #: model:account.group.template,name:l10n_lu.account_group_46128
 msgid "ACD - Other amounts payable"
 msgstr "ACD – Autres dettes"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42148
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42148
+#: model:account.group,name:l10n_lu.2_account_group_42148
 #: model:account.group.template,name:l10n_lu.account_group_42148
 msgid "ACD - Other amounts receivable"
 msgstr "ACD – Autres créances"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_46148
 #: model:account.account.template,name:l10n_lu.lu_2020_account_46148
+#: model:account.group,name:l10n_lu.2_account_group_46148
 #: model:account.group.template,name:l10n_lu.account_group_46148
 msgid "AED - Other debts"
 msgstr "AED - Autres dettes"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_635
 #: model:account.group.template,name:l10n_lu.account_group_635
 msgid "AVA and FVA on receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65112
+#: model:account.group,name:l10n_lu.2_account_group_65112
 #: model:account.group.template,name:l10n_lu.account_group_65112
 msgid "AVA on amounts owed by affiliated undertakings"
 msgstr "DCV sur créances sur des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6352
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6352
+#: model:account.group,name:l10n_lu.2_account_group_6352
 #: model:account.group.template,name:l10n_lu.account_group_6352
 msgid ""
 "AVA on amounts owed by affiliated undertakings and undertakings with which "
@@ -1974,7 +2317,9 @@ msgstr ""
 "lesquelles l'entreprise a un lien de participation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65114
+#: model:account.group,name:l10n_lu.2_account_group_65114
 #: model:account.group.template,name:l10n_lu.account_group_65114
 msgid ""
 "AVA on amounts owed by undertakings with which the undertaking is linked by "
@@ -1984,13 +2329,17 @@ msgstr ""
 "de participation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_63313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_63313
+#: model:account.group,name:l10n_lu.2_account_group_63313
 #: model:account.group.template,name:l10n_lu.account_group_63313
 msgid "AVA on buildings"
 msgstr "DCV sur constructions / bâtiments"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6322
+#: model:account.group,name:l10n_lu.2_account_group_6322
 #: model:account.group.template,name:l10n_lu.account_group_6322
 msgid ""
 "AVA on concessions, patents, licences, trademarks and similar rights and "
@@ -2000,31 +2349,41 @@ msgstr ""
 "similaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6321
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6321
+#: model:account.group,name:l10n_lu.2_account_group_6321
 #: model:account.group.template,name:l10n_lu.account_group_6321
 msgid "AVA on development costs"
 msgstr "DCV sur frais de développement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6324
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6324
+#: model:account.group,name:l10n_lu.2_account_group_6324
 #: model:account.group.template,name:l10n_lu.account_group_6324
 msgid "AVA on down payments and intangible fixed assets under development"
 msgstr "DCV sur acomptes versés et immobilisations incorporelles en cours"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6334
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6334
+#: model:account.group,name:l10n_lu.2_account_group_6334
 #: model:account.group.template,name:l10n_lu.account_group_6334
 msgid "AVA on down payments and tangible fixed assets under development"
 msgstr "DCV sur acomptes versés et immobilisations corporelles en cours"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6345
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6345
+#: model:account.group,name:l10n_lu.2_account_group_6345
 #: model:account.group.template,name:l10n_lu.account_group_6345
 msgid "AVA on down payments on inventories"
 msgstr "DCV sur acomptes versés sur stocks"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6313
+#: model:account.group,name:l10n_lu.2_account_group_6313
 #: model:account.group.template,name:l10n_lu.account_group_6313
 msgid ""
 "AVA on expenses for capital increases and various operations (mergers, "
@@ -2034,95 +2393,123 @@ msgstr ""
 "scissions, transformations)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6511
 #: model:account.group.template,name:l10n_lu.account_group_6511
 msgid "AVA on financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_63314
 #: model:account.account.template,name:l10n_lu.lu_2020_account_63314
+#: model:account.group,name:l10n_lu.2_account_group_63314
 #: model:account.group.template,name:l10n_lu.account_group_63314
 msgid "AVA on fixtures and fittings-out of buildings"
 msgstr "DCV sur agencements et aménagements de constructions / bâtiments"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_63312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_63312
+#: model:account.group,name:l10n_lu.2_account_group_63312
 #: model:account.group.template,name:l10n_lu.account_group_63312
 msgid "AVA on fixtures and fittings-out of land"
 msgstr "DCV sur agencements et aménagements de terrains"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_631
 #: model:account.group.template,name:l10n_lu.account_group_631
 msgid "AVA on formation expenses and similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6323
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6323
+#: model:account.group,name:l10n_lu.2_account_group_6323
 #: model:account.group.template,name:l10n_lu.account_group_6323
 msgid "AVA on goodwill acquired for consideration"
 msgstr ""
 "DCV sur fonds de commerce dans la mesure où il a été acquis à titre onéreux"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_632
 #: model:account.group.template,name:l10n_lu.account_group_632
 msgid "AVA on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_634
 #: model:account.group.template,name:l10n_lu.account_group_634
 msgid "AVA on inventories"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6343
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6343
+#: model:account.group,name:l10n_lu.2_account_group_6343
 #: model:account.group.template,name:l10n_lu.account_group_6343
 msgid "AVA on inventories of goods"
 msgstr "DCV sur stocks de produits"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6344
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6344
+#: model:account.group,name:l10n_lu.2_account_group_6344
 #: model:account.group.template,name:l10n_lu.account_group_6344
 msgid "AVA on inventories of merchandise and other goods for resale"
-msgstr "DCV sur stocks de marchandises et d'autres biens destinés à la revente"
+msgstr ""
+"DCV sur stocks de marchandises et d'autres biens destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6341
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6341
+#: model:account.group,name:l10n_lu.2_account_group_6341
 #: model:account.group.template,name:l10n_lu.account_group_6341
 msgid "AVA on inventories of raw materials and consumables"
 msgstr "DCV sur stocks de matières premières et consommables"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6342
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6342
+#: model:account.group,name:l10n_lu.2_account_group_6342
 #: model:account.group.template,name:l10n_lu.account_group_6342
 msgid "AVA on inventories of work and contracts in progress"
 msgstr ""
 "DCV sur stocks de produits en cours de fabrication et commandes en cours"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_63311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_63311
+#: model:account.group,name:l10n_lu.2_account_group_63311
 #: model:account.group.template,name:l10n_lu.account_group_63311
 msgid "AVA on land"
 msgstr "DCV sur terrains"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6331
 #: model:account.group.template,name:l10n_lu.account_group_6331
 msgid ""
 "AVA on land, fittings-out and buildings and FVA on investment properties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6314
+#: model:account.group,name:l10n_lu.2_account_group_6314
 #: model:account.group.template,name:l10n_lu.account_group_6314
 msgid "AVA on loan-issuance expenses"
 msgstr "DCV sur frais d'émission d'emprunts"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65116
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65116
+#: model:account.group,name:l10n_lu.2_account_group_65116
 #: model:account.group.template,name:l10n_lu.account_group_65116
 msgid "AVA on loans, deposits and claims held as fixed assets"
 msgstr "DCV sur prêts, dépôts et créances immobilisés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6333
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6333
+#: model:account.group,name:l10n_lu.2_account_group_6333
 #: model:account.group.template,name:l10n_lu.account_group_6333
 msgid ""
 "AVA on other fixtures and fittings, tools and equipment (including rolling "
@@ -2132,72 +2519,95 @@ msgstr ""
 "roulant)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6353
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6353
+#: model:account.group,name:l10n_lu.2_account_group_6353
 #: model:account.group.template,name:l10n_lu.account_group_6353
 msgid "AVA on other receivables"
 msgstr "DCV sur autres créances"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6318
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6318
+#: model:account.group,name:l10n_lu.2_account_group_6318
 #: model:account.group.template,name:l10n_lu.account_group_6318
 msgid "AVA on other similar expenses"
 msgstr "DCV sur autres frais assimilés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65318
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65318
+#: model:account.group,name:l10n_lu.2_account_group_65318
 #: model:account.group.template,name:l10n_lu.account_group_65318
 msgid "AVA on other transferable securities"
 msgstr "DCV sur autres valeurs mobilières"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65312
+#: model:account.group,name:l10n_lu.2_account_group_65312
 #: model:account.group.template,name:l10n_lu.account_group_65312
 msgid "AVA on own shares or own corporate units"
 msgstr "DCV sur actions propres ou parts propres"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65113
+#: model:account.group,name:l10n_lu.2_account_group_65113
 #: model:account.group.template,name:l10n_lu.account_group_65113
 msgid "AVA on participating interests"
 msgstr "DCV sur participations"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6332
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6332
+#: model:account.group,name:l10n_lu.2_account_group_6332
 #: model:account.group.template,name:l10n_lu.account_group_6332
 msgid "AVA on plant and machinery"
 msgstr "DCV sur installations techniques et machines"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65115
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65115
+#: model:account.group,name:l10n_lu.2_account_group_65115
 #: model:account.group.template,name:l10n_lu.account_group_65115
 msgid "AVA on securities held as fixed assets"
 msgstr "DCV sur titres ayant le caractère d'immobilisations"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6311
+#: model:account.group,name:l10n_lu.2_account_group_6311
 #: model:account.group.template,name:l10n_lu.account_group_6311
 msgid "AVA on set-up and start-up costs"
 msgstr "DCV sur frais de constitution et de premier établissement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65311
+#: model:account.group,name:l10n_lu.2_account_group_65111
+#: model:account.group,name:l10n_lu.2_account_group_65311
 #: model:account.group.template,name:l10n_lu.account_group_65111
 #: model:account.group.template,name:l10n_lu.account_group_65311
 msgid "AVA on shares in affiliated undertakings"
 msgstr "DCV sur parts dans des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65313
+#: model:account.group,name:l10n_lu.2_account_group_65313
 #: model:account.group.template,name:l10n_lu.account_group_65313
 msgid ""
-"AVA on shares in undertakings with which the undertaking is linked by virtue "
-"of participating interests"
+"AVA on shares in undertakings with which the undertaking is linked by virtue"
+" of participating interests"
 msgstr ""
-"DCV sur parts dans des entreprises avec lesquelles l'entreprise a un lien de "
-"participation"
+"DCV sur parts dans des entreprises avec lesquelles l'entreprise a un lien de"
+" participation"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_633
 #: model:account.group.template,name:l10n_lu.account_group_633
 msgid ""
 "AVA on tangible fixed assets and fair value adjustments (FVA) on investment "
@@ -2205,17 +2615,21 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6351
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6351
+#: model:account.group,name:l10n_lu.2_account_group_6351
 #: model:account.group.template,name:l10n_lu.account_group_6351
 msgid "AVA on trade receivables"
 msgstr "DCV sur créances résultant de ventes et prestations de services"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6531
 #: model:account.group.template,name:l10n_lu.account_group_6531
 msgid "AVA on transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106142
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106142
 msgid "Accident insurance"
 msgstr "Accident"
@@ -2223,129 +2637,166 @@ msgstr "Accident"
 #. module: l10n_lu
 #: model:ir.model,name:l10n_lu.model_account_chart_template
 msgid "Account Chart Template"
-msgstr ""
+msgstr "Modèle de plan comptable"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_106
 #: model:account.group.template,name:l10n_lu.account_group_106
 msgid "Account of the owner or the co-owners"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61342
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61342
+#: model:account.group,name:l10n_lu.2_account_group_61342
 #: model:account.group.template,name:l10n_lu.account_group_61342
 msgid "Accounting, tax consulting, auditing and similar fees"
 msgstr "Honoraires comptables, fiscaux, d'audit et assimilés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_16121
 #: model:account.account.template,name:l10n_lu.lu_2020_account_16121
 msgid "Acquired against payment (except Goodwill)"
 msgstr "Acquis à titre onéreux"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_771
 #: model:account.account.template,name:l10n_lu.lu_2011_account_771
+#: model:account.group,name:l10n_lu.2_account_group_771
 #: model:account.group.template,name:l10n_lu.account_group_771
 msgid "Adjustments of corporate income tax (CIT)"
 msgstr "Régularisations d'impôt sur le revenu des collectivités (IRC)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_773
 #: model:account.account.template,name:l10n_lu.lu_2011_account_773
+#: model:account.group,name:l10n_lu.2_account_group_773
 #: model:account.group.template,name:l10n_lu.account_group_773
 msgid "Adjustments of foreign income taxes"
 msgstr "Régularisations d'impôts étrangers sur le résultat"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_783
 #: model:account.account.template,name:l10n_lu.lu_2011_account_783
+#: model:account.group,name:l10n_lu.2_account_group_783
 #: model:account.group.template,name:l10n_lu.account_group_783
 msgid "Adjustments of foreign taxes"
 msgstr "Régularisations d'impôts étrangers"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_77
 #: model:account.group.template,name:l10n_lu.account_group_77
 msgid "Adjustments of income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_772
 #: model:account.account.template,name:l10n_lu.lu_2011_account_772
+#: model:account.group,name:l10n_lu.2_account_group_772
 #: model:account.group.template,name:l10n_lu.account_group_772
 msgid "Adjustments of municipal business tax (MBT)"
 msgstr "Régularisations d'impôt commercial communal (ICC)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_781
 #: model:account.account.template,name:l10n_lu.lu_2011_account_781
+#: model:account.group,name:l10n_lu.2_account_group_781
 #: model:account.group.template,name:l10n_lu.account_group_781
 msgid "Adjustments of net wealth tax (NWT)"
 msgstr "Régularisations d'impôt sur la fortune (IF)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_788
 #: model:account.account.template,name:l10n_lu.lu_2011_account_788
+#: model:account.group,name:l10n_lu.2_account_group_788
 #: model:account.group.template,name:l10n_lu.account_group_788
 msgid "Adjustments of other taxes"
 msgstr "Régularisations d'autres impôts"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_78
 #: model:account.group.template,name:l10n_lu.account_group_78
 msgid "Adjustments of other taxes not included in the previous caption"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_782
 #: model:account.account.template,name:l10n_lu.lu_2011_account_782
+#: model:account.group,name:l10n_lu.2_account_group_782
 #: model:account.group.template,name:l10n_lu.account_group_782
 msgid "Adjustments of subscription tax"
 msgstr "Régularisations de taxe d'abonnement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42111
+#: model:account.group,name:l10n_lu.2_account_group_42111
 #: model:account.group.template,name:l10n_lu.account_group_42111
 msgid "Advances and down payments"
 msgstr "Avances et acomptes"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_659
 #: model:account.group.template,name:l10n_lu.account_group_659
 msgid "Allocations to financial provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6591
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6591
+#: model:account.group,name:l10n_lu.2_account_group_6591
 #: model:account.group.template,name:l10n_lu.account_group_6591
 msgid "Allocations to financial provisions - affiliated undertakings"
 msgstr "Dotations aux provisions financières - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6592
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6592
+#: model:account.group,name:l10n_lu.2_account_group_6592
 #: model:account.group.template,name:l10n_lu.account_group_6592
 msgid "Allocations to financial provisions - other"
 msgstr "Dotations aux provisions financières - autres"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6492
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6492
+#: model:account.group,name:l10n_lu.2_account_group_6492
 #: model:account.group.template,name:l10n_lu.account_group_6492
 msgid "Allocations to operating provisions"
 msgstr "Dotations aux provisions d'exploitation"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_649
 #: model:account.group.template,name:l10n_lu.account_group_649
 msgid "Allocations to provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_679
 #: model:account.account.template,name:l10n_lu.lu_2020_account_679
+#: model:account.group,name:l10n_lu.2_account_group_679
 #: model:account.group.template,name:l10n_lu.account_group_679
 msgid "Allocations to provisions for deferred taxes"
 msgstr "Dotations aux provisions pour impôts différés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6491
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6491
+#: model:account.group,name:l10n_lu.2_account_group_6491
 #: model:account.group.template,name:l10n_lu.account_group_6491
 msgid "Allocations to tax provisions"
 msgstr "Dotations aux provisions pour impôts"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_647
 #: model:account.account.template,name:l10n_lu.lu_2011_account_647
+#: model:account.group,name:l10n_lu.2_account_group_647
 #: model:account.group.template,name:l10n_lu.account_group_647
 msgid "Allocations to tax-exempt capital gains"
 msgstr "Dotations aux plus-values immunisées"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_653
 #: model:account.group.template,name:l10n_lu.account_group_653
 msgid ""
 "Allocations to value adjustment (AVA) and fair-value adjustments (FVA) on "
@@ -2353,6 +2804,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_63
 #: model:account.group.template,name:l10n_lu.account_group_63
 msgid ""
 "Allocations to value adjustments (AVA) and fair value adjustments (FVA) on "
@@ -2361,6 +2813,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_651
 #: model:account.group.template,name:l10n_lu.account_group_651
 msgid ""
 "Allocations to value adjustments (AVA) and fair-value adjustments (FVA) of "
@@ -2368,11 +2821,22 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_232
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6452
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75112
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65212
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6452
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75112
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75212
+#: model:account.group,name:l10n_lu.2_account_group_232
+#: model:account.group,name:l10n_lu.2_account_group_411
+#: model:account.group,name:l10n_lu.2_account_group_6452
+#: model:account.group,name:l10n_lu.2_account_group_65212
+#: model:account.group,name:l10n_lu.2_account_group_75212
+#: model:account.group,name:l10n_lu.2_account_group_75222
 #: model:account.group.template,name:l10n_lu.account_group_232
 #: model:account.group.template,name:l10n_lu.account_group_411
 #: model:account.group.template,name:l10n_lu.account_group_6452
@@ -2383,6 +2847,7 @@ msgid "Amounts owed by affiliated undertakings"
 msgstr "Créances sur des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_41
 #: model:account.group.template,name:l10n_lu.account_group_41
 msgid ""
 "Amounts owed by affiliated undertakings and by undertakings with which the "
@@ -2390,19 +2855,25 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4112
 #: model:account.group.template,name:l10n_lu.account_group_4112
 msgid ""
 "Amounts owed by affiliated undertakings receivable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4111
 #: model:account.group.template,name:l10n_lu.account_group_4111
 msgid "Amounts owed by affiliated undertakings receivable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4212
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4222
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4222
+#: model:account.group,name:l10n_lu.2_account_group_4212
+#: model:account.group,name:l10n_lu.2_account_group_4222
 #: model:account.group.template,name:l10n_lu.account_group_4212
 #: model:account.group.template,name:l10n_lu.account_group_4222
 msgid ""
@@ -2411,11 +2882,13 @@ msgid ""
 msgstr "Créances sur associés ou actionnaires (autres qu'entreprises liées)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4217
 #: model:account.group.template,name:l10n_lu.account_group_4217
 msgid "Amounts owed by the Social Security and other social bodies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75114
 msgid ""
 "Amounts owed by undertakings with which the company is linked by virtue of "
@@ -2425,10 +2898,20 @@ msgstr ""
 "participation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_234
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6453
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65214
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75214
 #: model:account.account.template,name:l10n_lu.lu_2011_account_234
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6453
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65214
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75214
+#: model:account.group,name:l10n_lu.2_account_group_234
+#: model:account.group,name:l10n_lu.2_account_group_412
+#: model:account.group,name:l10n_lu.2_account_group_6453
+#: model:account.group,name:l10n_lu.2_account_group_65214
+#: model:account.group,name:l10n_lu.2_account_group_75214
+#: model:account.group,name:l10n_lu.2_account_group_75224
 #: model:account.group.template,name:l10n_lu.account_group_234
 #: model:account.group.template,name:l10n_lu.account_group_412
 #: model:account.group.template,name:l10n_lu.account_group_6453
@@ -2443,6 +2926,7 @@ msgstr ""
 "participation"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4121
 #: model:account.group.template,name:l10n_lu.account_group_4121
 msgid ""
 "Amounts owed by undertakings with which the undertaking is linked by virtue "
@@ -2450,21 +2934,25 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_194
 #: model:account.group.template,name:l10n_lu.account_group_194
 msgid "Amounts owed to credit institutions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_451
 #: model:account.group.template,name:l10n_lu.account_group_451
 msgid "Amounts payable to affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4512
 #: model:account.group.template,name:l10n_lu.account_group_4512
 msgid "Amounts payable to affiliated undertakings after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_45
 #: model:account.group.template,name:l10n_lu.account_group_45
 msgid ""
 "Amounts payable to affiliated undertakings and to undertakings with which "
@@ -2472,13 +2960,18 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4511
 #: model:account.group.template,name:l10n_lu.account_group_4511
 msgid "Amounts payable to affiliated undertakings within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4713
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4723
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4713
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4723
+#: model:account.group,name:l10n_lu.2_account_group_4713
+#: model:account.group,name:l10n_lu.2_account_group_4723
 #: model:account.group.template,name:l10n_lu.account_group_4713
 #: model:account.group.template,name:l10n_lu.account_group_4723
 msgid "Amounts payable to directors, managers, statutory auditors and similar"
@@ -2486,8 +2979,12 @@ msgstr ""
 "Dettes envers administrateurs, gérants, commissaires et organes assimilés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4712
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4722
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4712
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4722
+#: model:account.group,name:l10n_lu.2_account_group_4712
+#: model:account.group,name:l10n_lu.2_account_group_4722
 #: model:account.group.template,name:l10n_lu.account_group_4712
 #: model:account.group.template,name:l10n_lu.account_group_4722
 msgid ""
@@ -2496,14 +2993,19 @@ msgid ""
 msgstr "Dettes envers associés et actionnaires (autres qu'entreprises liées)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4714
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4724
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4714
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4724
+#: model:account.group,name:l10n_lu.2_account_group_4714
+#: model:account.group,name:l10n_lu.2_account_group_4724
 #: model:account.group.template,name:l10n_lu.account_group_4714
 #: model:account.group.template,name:l10n_lu.account_group_4724
 msgid "Amounts payable to staff"
 msgstr "Dettes envers le personnel"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_452
 #: model:account.group.template,name:l10n_lu.account_group_452
 msgid ""
 "Amounts payable to undertakings with which the undertaking is linked by "
@@ -2511,6 +3013,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4522
 #: model:account.group.template,name:l10n_lu.account_group_4522
 msgid ""
 "Amounts payable to undertakings with which the undertaking is linked by "
@@ -2518,6 +3021,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4521
 #: model:account.group.template,name:l10n_lu.account_group_4521
 msgid ""
 "Amounts payable to undertakings with which the undertaking is linked by "
@@ -2525,35 +3029,50 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4122
 #: model:account.group.template,name:l10n_lu.account_group_4122
 msgid "Amounts receivable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60813
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60813
+#: model:account.group,name:l10n_lu.2_account_group_60813
 #: model:account.group.template,name:l10n_lu.account_group_60813
 msgid "Architects' and engineers' fees"
 msgstr "Frais d'architectes et d'ingénieurs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6431
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6431
+#: model:account.group,name:l10n_lu.2_account_group_6431
 #: model:account.group.template,name:l10n_lu.account_group_6431
 msgid "Attendance fees"
 msgstr "Jetons de présence"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_643
 #: model:account.group.template,name:l10n_lu.account_group_643
 msgid "Attendance fees, director's fees and similar remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_743
 #: model:account.account.template,name:l10n_lu.lu_2011_account_743
+#: model:account.group,name:l10n_lu.2_account_group_743
 #: model:account.group.template,name:l10n_lu.account_group_743
 msgid "Attendance fees, director's fees and similar remunerations"
 msgstr "Jetons de présence, tantièmes et rémunérations assimilées"
 
 #. module: l10n_lu
+#: model:account.report.column,name:l10n_lu.tax_report_balance
+msgid "Balance"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61333
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61333
+#: model:account.group,name:l10n_lu.2_account_group_61333
 #: model:account.group.template,name:l10n_lu.account_group_61333
 msgid ""
 "Bank account charges and bank commissions (included custody fees on "
@@ -2563,82 +3082,107 @@ msgstr ""
 "titres) "
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7552
 #: model:account.group.template,name:l10n_lu.account_group_7552
 msgid "Bank and similar interest"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6552
 #: model:account.group.template,name:l10n_lu.account_group_6552
 msgid "Banking and similar interest"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6133
 #: model:account.group.template,name:l10n_lu.account_group_6133
 msgid "Banking and similar services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65521
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65521
+#: model:account.group,name:l10n_lu.2_account_group_65521
 #: model:account.group.template,name:l10n_lu.account_group_65521
 msgid "Banking interest on current accounts"
 msgstr "Intérêts sur comptes bancaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65522
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65522
+#: model:account.group,name:l10n_lu.2_account_group_65522
 #: model:account.group.template,name:l10n_lu.account_group_65522
 msgid "Banking interest on financing operations"
 msgstr "Intérêts bancaires sur opérations de financement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5131
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5131
+#: model:account.group,name:l10n_lu.2_account_group_5131
 #: model:account.group.template,name:l10n_lu.account_group_5131
 msgid "Banks and CCP : available balance"
 msgstr "Banques et CCP : avoirs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5132
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5132
+#: model:account.group,name:l10n_lu.2_account_group_5132
 #: model:account.group.template,name:l10n_lu.account_group_5132
 msgid "Banks and CCP : overdraft"
 msgstr "Banques et CCP : découverts"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_513
 #: model:account.group.template,name:l10n_lu.account_group_513
 msgid "Banks and postal cheques accounts (CCP)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6467
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6467
+#: model:account.group,name:l10n_lu.2_account_group_6467
 #: model:account.group.template,name:l10n_lu.account_group_6467
 msgid "Bar licence tax"
 msgstr "Taxe de cabaretage"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62111
+#: model:account.group,name:l10n_lu.2_account_group_62111
 #: model:account.group.template,name:l10n_lu.account_group_62111
 msgid "Base wages"
 msgstr "Salaires de base"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62115
+#: model:account.account,name:l10n_lu.2_lu_2011_account_746
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62115
 #: model:account.account.template,name:l10n_lu.lu_2011_account_746
+#: model:account.group,name:l10n_lu.2_account_group_62115
+#: model:account.group,name:l10n_lu.2_account_group_746
 #: model:account.group.template,name:l10n_lu.account_group_62115
 #: model:account.group.template,name:l10n_lu.account_group_746
 msgid "Benefits in kind"
 msgstr "Avantages en nature"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_442
 #: model:account.group.template,name:l10n_lu.account_group_442
 msgid "Bills of exchange payable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4422
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4422
+#: model:account.group,name:l10n_lu.2_account_group_4422
 #: model:account.group.template,name:l10n_lu.account_group_4422
 msgid "Bills of exchange payable after more than one year"
 msgstr "Effets à payer dont la durée résiduelle est supérieure à un an"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4421
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4421
+#: model:account.group,name:l10n_lu.2_account_group_4421
 #: model:account.group.template,name:l10n_lu.account_group_4421
 msgid "Bills of exchange payable within one year"
 msgstr ""
@@ -2646,13 +3190,60 @@ msgstr ""
 
 #. module: l10n_lu
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652221
-#: model:account.account.template,name:l10n_lu.lu_2020_account_752221
 #: model:account.group.template,name:l10n_lu.account_group_652221
+msgid "Book value of amounts owed by affiliated undertakings disposed of"
+msgstr "Valeur comptable de créances cédées sur des entreprises liées"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652241
+#: model:account.group.template,name:l10n_lu.account_group_652241
+msgid ""
+"Book value of amounts owed by undertakings with which the undertaking is "
+"linked by virtue of participating interests disposed of"
+msgstr "Valeur comptable de créances cédées sur participations"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_64411
+#: model:account.group.template,name:l10n_lu.account_group_64411
+msgid "Book value of intangible fixed assets disposed of"
+msgstr "Valeur comptable d'immobilisations incorporelles cédées"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652231
+#: model:account.group.template,name:l10n_lu.account_group_652231
+msgid "Book value of participating interests disposed of"
+msgstr "Valeur comptable de participations cédées"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652251
+#: model:account.group.template,name:l10n_lu.account_group_652251
+msgid "Book value of securities held as fixed assets disposed of"
+msgstr "Valeur comptable de titres cédés ayant le caractère d'immobilisations"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652211
+#: model:account.group.template,name:l10n_lu.account_group_652211
+msgid "Book value of shares in affiliated undertakings disposed of"
+msgstr "Valeur comptable de parts cédées dans des entreprises liées"
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_64421
+#: model:account.group.template,name:l10n_lu.account_group_64421
+msgid "Book value of tangible fixed assets disposed of"
+msgstr "Valeur comptable d'immobilisations corporelles cédées"
+
+#. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652221
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752221
+#: model:account.account.template,name:l10n_lu.lu_2020_account_752221
+#: model:account.group,name:l10n_lu.2_account_group_652221
+#: model:account.group,name:l10n_lu.2_account_group_752221
 #: model:account.group.template,name:l10n_lu.account_group_752221
 msgid "Book value of yielded amounts owed by affiliated undertakings"
 msgstr "Valeur comptable de créances cédées sur des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_752241
 #: model:account.group.template,name:l10n_lu.account_group_752241
 msgid ""
 "Book value of yielded amounts owed by undertakings with which the "
@@ -2660,66 +3251,88 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652241
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652241
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752241
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752241
-#: model:account.group.template,name:l10n_lu.account_group_652241
+#: model:account.group,name:l10n_lu.2_account_group_652241
 msgid ""
 "Book value of yielded amounts owed by undertakings with which the "
 "undertaking is linked by virtue of participating interests"
 msgstr "Valeur comptable de créances cédées sur participations"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_64411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74411
-#: model:account.group.template,name:l10n_lu.account_group_64411
+#: model:account.group,name:l10n_lu.2_account_group_64411
+#: model:account.group,name:l10n_lu.2_account_group_74411
 #: model:account.group.template,name:l10n_lu.account_group_74411
 msgid "Book value of yielded intangible fixed assets"
 msgstr "Valeur comptable d'immobilisations incorporelles cédées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652261
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752261
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652261
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752261
+#: model:account.group,name:l10n_lu.2_account_group_652261
+#: model:account.group,name:l10n_lu.2_account_group_752261
 #: model:account.group.template,name:l10n_lu.account_group_652261
 #: model:account.group.template,name:l10n_lu.account_group_752261
 msgid "Book value of yielded loans, deposits and claims held as fixed assets"
 msgstr "Valeur comptable de prêts, dépôts et créances immobilisés cédés"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652231
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652231
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752231
-#: model:account.group.template,name:l10n_lu.account_group_652231
+#: model:account.group,name:l10n_lu.2_account_group_652231
+#: model:account.group,name:l10n_lu.2_account_group_752231
 #: model:account.group.template,name:l10n_lu.account_group_752231
 msgid "Book value of yielded participating interests"
 msgstr "Valeur comptable de participations cédées"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652251
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652251
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752251
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752251
-#: model:account.group.template,name:l10n_lu.account_group_652251
+#: model:account.group,name:l10n_lu.2_account_group_652251
+#: model:account.group,name:l10n_lu.2_account_group_752251
 #: model:account.group.template,name:l10n_lu.account_group_752251
 msgid "Book value of yielded securities held as fixed assets"
 msgstr "Valeur comptable de titres cédés ayant le caractère d'immobilisations"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752211
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752211
-#: model:account.group.template,name:l10n_lu.account_group_652211
+#: model:account.group,name:l10n_lu.2_account_group_652211
+#: model:account.group,name:l10n_lu.2_account_group_752211
 #: model:account.group.template,name:l10n_lu.account_group_752211
 msgid "Book value of yielded shares in affiliated undertakings"
 msgstr "Valeur comptable de parts cédées dans des entreprises liées"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_64421
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64421
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74421
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74421
-#: model:account.group.template,name:l10n_lu.account_group_64421
+#: model:account.group,name:l10n_lu.2_account_group_64421
+#: model:account.group,name:l10n_lu.2_account_group_74421
 #: model:account.group.template,name:l10n_lu.account_group_74421
 msgid "Book value of yielded tangible fixed assets"
 msgstr "Valeur comptable d'immobilisations corporelles cédées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61112
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61221
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61411
+#: model:account.group,name:l10n_lu.2_account_group_2213
+#: model:account.group,name:l10n_lu.2_account_group_61112
+#: model:account.group,name:l10n_lu.2_account_group_61221
+#: model:account.group,name:l10n_lu.2_account_group_61411
 #: model:account.group.template,name:l10n_lu.account_group_2213
 #: model:account.group.template,name:l10n_lu.account_group_61112
 #: model:account.group.template,name:l10n_lu.account_group_61221
@@ -2728,83 +3341,109 @@ msgid "Buildings"
 msgstr "Constructions / Bâtiments"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60763
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60763
+#: model:account.group,name:l10n_lu.2_account_group_60763
 #: model:account.group.template,name:l10n_lu.account_group_60763
 msgid "Buildings for resale"
 msgstr "Immeubles destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_22131
 #: model:account.group.template,name:l10n_lu.account_group_22131
 msgid "Buildings in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22132
+#: model:account.group,name:l10n_lu.2_account_group_22132
 #: model:account.group.template,name:l10n_lu.account_group_22132
 msgid "Buildings in foreign countries"
 msgstr "Constructions / Bâtiments à l'étranger"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_314
+#: model:account.group,name:l10n_lu.2_account_group_314
 #: model:account.group.template,name:l10n_lu.account_group_314
 msgid "Buildings under construction"
 msgstr "Immeubles en construction"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61523
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61523
+#: model:account.group,name:l10n_lu.2_account_group_61523
 #: model:account.group.template,name:l10n_lu.account_group_61523
 msgid "Business assignments"
 msgstr "Missions"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6144
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6144
+#: model:account.group,name:l10n_lu.2_account_group_6144
 #: model:account.group.template,name:l10n_lu.account_group_6144
 msgid "Business risk insurance"
 msgstr "Assurance risque d'exploitation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10629
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10629
 msgid "Business share in private expenses"
 msgstr "Quote-part professionnelle de frais privés"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6
 #: model:account.group.template,name:l10n_lu.account_group_6
 msgid "CHARGES ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461212
+#: model:account.group,name:l10n_lu.2_account_group_461212
 #: model:account.group.template,name:l10n_lu.account_group_461212
 msgid "CIT - Tax payable"
 msgstr "IRC – dette fiscale à payer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6711
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6711
+#: model:account.group,name:l10n_lu.2_account_group_6711
 #: model:account.group.template,name:l10n_lu.account_group_6711
 msgid "CIT - current financial year"
 msgstr "IRC - exercice courant"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6712
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6712
+#: model:account.group,name:l10n_lu.2_account_group_6712
 #: model:account.group.template,name:l10n_lu.account_group_6712
 msgid "CIT - previous financial years"
 msgstr "IRC - exercices antérieurs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_115
 #: model:account.account.template,name:l10n_lu.lu_2011_account_115
+#: model:account.group,name:l10n_lu.2_account_group_115
 #: model:account.group.template,name:l10n_lu.account_group_115
 msgid "Capital contribution without issue of shares"
 msgstr "Apport en capitaux propres non rémunéré par des  titres "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7473
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7473
+#: model:account.group,name:l10n_lu.2_account_group_16
+#: model:account.group,name:l10n_lu.2_account_group_7473
 #: model:account.group.template,name:l10n_lu.account_group_16
 #: model:account.group.template,name:l10n_lu.account_group_7473
 msgid "Capital investment subsidies"
 msgstr "Subventions d'investissement en capital"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_104
 #: model:account.account.template,name:l10n_lu.lu_2020_account_104
+#: model:account.group,name:l10n_lu.2_account_group_104
 #: model:account.group.template,name:l10n_lu.account_group_104
 msgid "Capital of individual companies, corporate partnerships and similar"
 msgstr ""
@@ -2812,203 +3451,270 @@ msgstr ""
 "assimilées"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_72
 #: model:account.group.template,name:l10n_lu.account_group_72
 msgid "Capitalised production"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106166
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106166
 msgid "Car"
 msgstr "Voiture"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_51
 #: model:account.group.template,name:l10n_lu.account_group_51
 msgid "Cash at bank, in postal cheques accounts, cheques and in hand"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_516
 #: model:account.account.template,name:l10n_lu.lu_2020_account_516
+#: model:account.group,name:l10n_lu.2_account_group_516
 #: model:account.group.template,name:l10n_lu.account_group_516
 msgid "Cash in hand"
 msgstr "Caisse"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10611
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10611
 msgid "Cash withdrawals (daily life)"
 msgstr "Prélèvements en numéraire (train de vie)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6222
+#: model:account.group,name:l10n_lu.2_account_group_6222
 #: model:account.group.template,name:l10n_lu.account_group_6222
 msgid "Casual workers"
 msgstr "Salaires occasionnels"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61515
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61515
+#: model:account.group,name:l10n_lu.2_account_group_61515
 #: model:account.group.template,name:l10n_lu.account_group_61515
 msgid "Catalogues, printed materials and publications"
 msgstr "Catalogues et imprimés et publications"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7121
+#: model:account.group,name:l10n_lu.2_account_group_7121
 #: model:account.group.template,name:l10n_lu.account_group_7121
 msgid "Change in inventories of finished goods"
 msgstr "Variation des stocks de produits finis"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_712
 #: model:account.group.template,name:l10n_lu.account_group_712
 msgid "Change in inventories of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_71
 #: model:account.group.template,name:l10n_lu.account_group_71
 msgid "Change in inventories of goods and of work in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7123
+#: model:account.group,name:l10n_lu.2_account_group_7123
 #: model:account.group.template,name:l10n_lu.account_group_7123
 msgid "Change in inventories of residual goods"
 msgstr "Variation des stocks de produits résiduels"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7122
+#: model:account.group,name:l10n_lu.2_account_group_7122
 #: model:account.group.template,name:l10n_lu.account_group_7122
 msgid "Change in inventories of semi-finished goods"
 msgstr "Variation des stocks de produits intermédiaires"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_711
 #: model:account.group.template,name:l10n_lu.account_group_711
 msgid "Change in inventories of work and contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7111
+#: model:account.group,name:l10n_lu.2_account_group_7111
 #: model:account.group.template,name:l10n_lu.account_group_7111
 msgid "Change in inventories of work in progress"
 msgstr "Variation des stocks de produits en cours de fabrication"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7114
+#: model:account.group,name:l10n_lu.2_account_group_7114
 #: model:account.group.template,name:l10n_lu.account_group_7114
 msgid "Change in inventories: buildings under construction"
 msgstr "Variation des stocks : immeubles en construction"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7112
+#: model:account.group,name:l10n_lu.2_account_group_7112
 #: model:account.group.template,name:l10n_lu.account_group_7112
 msgid "Change in inventories: contracts in progress - goods"
 msgstr "Variation des stocks : commandes en cours – produits"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7113
+#: model:account.group,name:l10n_lu.2_account_group_7113
 #: model:account.group.template,name:l10n_lu.account_group_7113
 msgid "Change in inventories: contracts in progress - services"
 msgstr "Variation des stocks : commandes en cours – prestations de services"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_607
 #: model:account.group.template,name:l10n_lu.account_group_607
 msgid "Changes in inventory"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6073
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6073
+#: model:account.group,name:l10n_lu.2_account_group_6073
 #: model:account.group.template,name:l10n_lu.account_group_6073
 msgid "Changes in inventory of consumable materials and supplies"
 msgstr "Variation des stocks de matières et fournitures consommables"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6076
 #: model:account.group.template,name:l10n_lu.account_group_6076
 msgid "Changes in inventory of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6074
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6074
+#: model:account.group,name:l10n_lu.2_account_group_6074
 #: model:account.group.template,name:l10n_lu.account_group_6074
 msgid "Changes in inventory of packaging"
 msgstr "Variation des stocks d'emballages"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6071
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6071
+#: model:account.group,name:l10n_lu.2_account_group_6071
 #: model:account.group.template,name:l10n_lu.account_group_6071
 msgid "Changes in inventory of raw materials"
 msgstr "Variation des stocks de matières premières"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62412
+#: model:account.group,name:l10n_lu.2_account_group_62412
 #: model:account.group.template,name:l10n_lu.account_group_62412
 msgid "Changes to provisions for complementary pensions"
 msgstr "Variations sur provisions pour pensions complémentaires"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_652
 #: model:account.group.template,name:l10n_lu.account_group_652
 msgid "Charges and loss of disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_61334
 #: model:account.group.template,name:l10n_lu.account_group_61334
 msgid "Charges for electronic means of paiment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61334
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61334
 msgid "Charges for electronic means of payment"
 msgstr "Frais sur moyens de paiements électroniques"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6521
 #: model:account.group.template,name:l10n_lu.account_group_6521
 msgid "Charges of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106152
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106152
 msgid "Child benefit office"
 msgstr "Allocations familiales"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6165
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6165
+#: model:account.group,name:l10n_lu.2_account_group_6165
 #: model:account.group.template,name:l10n_lu.account_group_6165
 msgid "Collective staff transportation"
 msgstr "Transports collectifs du personnel"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6131
+#: model:account.account,name:l10n_lu.2_lu_2020_account_705
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6131
 #: model:account.account.template,name:l10n_lu.lu_2020_account_705
+#: model:account.group,name:l10n_lu.2_account_group_6131
+#: model:account.group,name:l10n_lu.2_account_group_705
 #: model:account.group.template,name:l10n_lu.account_group_6131
 #: model:account.group.template,name:l10n_lu.account_group_705
 msgid "Commissions and brokerage fees"
 msgstr "Commissions et courtages"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7453
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7453
+#: model:account.group,name:l10n_lu.2_account_group_7453
 #: model:account.group.template,name:l10n_lu.account_group_7453
 msgid "Compensatory allowances"
 msgstr "Indemnités compensatoires"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6241
 #: model:account.group.template,name:l10n_lu.account_group_6241
 msgid "Complementary pensions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62415
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62415
+#: model:account.group,name:l10n_lu.2_account_group_62415
 #: model:account.group.template,name:l10n_lu.account_group_62415
 msgid "Complementary pensions paid by the employer"
 msgstr "Pensions complémentaires versées par l'employeur"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2235
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2235
+#: model:account.group,name:l10n_lu.2_account_group_2235
 #: model:account.group.template,name:l10n_lu.account_group_2235
 msgid "Computer equipment"
 msgstr "Matériel informatique "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21221
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6411
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72121
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70311
+#: model:account.group,name:l10n_lu.2_account_group_21211
+#: model:account.group,name:l10n_lu.2_account_group_21221
+#: model:account.group,name:l10n_lu.2_account_group_6411
+#: model:account.group,name:l10n_lu.2_account_group_70311
+#: model:account.group,name:l10n_lu.2_account_group_72121
+#: model:account.group,name:l10n_lu.2_account_group_7411
 #: model:account.group.template,name:l10n_lu.account_group_21211
 #: model:account.group.template,name:l10n_lu.account_group_21221
 #: model:account.group.template,name:l10n_lu.account_group_6411
@@ -3019,6 +3725,9 @@ msgid "Concessions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1612
+#: model:account.group,name:l10n_lu.2_account_group_212
+#: model:account.group,name:l10n_lu.2_account_group_7212
 #: model:account.group.template,name:l10n_lu.account_group_1612
 #: model:account.group.template,name:l10n_lu.account_group_212
 #: model:account.group.template,name:l10n_lu.account_group_7212
@@ -3027,41 +3736,62 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_312
+#: model:account.group,name:l10n_lu.2_account_group_312
 #: model:account.group.template,name:l10n_lu.account_group_312
 msgid "Contracts in progress - goods"
 msgstr "Commandes en cours – produits"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_313
+#: model:account.group,name:l10n_lu.2_account_group_313
 #: model:account.group.template,name:l10n_lu.account_group_313
 msgid "Contracts in progress - services"
 msgstr "Commandes en cours – prestations de services"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_113
+#: model:account.group,name:l10n_lu.2_account_group_113
 #: model:account.group.template,name:l10n_lu.account_group_113
 msgid "Contribution premium"
 msgstr "Primes d'apport"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6187
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6187
+#: model:account.group,name:l10n_lu.2_account_group_6187
 #: model:account.group.template,name:l10n_lu.account_group_6187
 msgid "Contributions to professional associations"
 msgstr "Cotisations aux associations professionnelles"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_192
 #: model:account.group.template,name:l10n_lu.account_group_192
 msgid "Convertible debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212151
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212251
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64151
+#: model:account.account,name:l10n_lu.2_lu_2011_account_721251
+#: model:account.account,name:l10n_lu.2_lu_2011_account_74151
+#: model:account.account,name:l10n_lu.2_lu_2020_account_703151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212251
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_721251
 #: model:account.account.template,name:l10n_lu.lu_2011_account_74151
 #: model:account.account.template,name:l10n_lu.lu_2020_account_703151
+#: model:account.group,name:l10n_lu.2_account_group_212151
+#: model:account.group,name:l10n_lu.2_account_group_212251
+#: model:account.group,name:l10n_lu.2_account_group_64151
+#: model:account.group,name:l10n_lu.2_account_group_703151
+#: model:account.group,name:l10n_lu.2_account_group_721251
+#: model:account.group,name:l10n_lu.2_account_group_74151
 #: model:account.group.template,name:l10n_lu.account_group_212151
 #: model:account.group.template,name:l10n_lu.account_group_212251
 #: model:account.group.template,name:l10n_lu.account_group_64151
@@ -3072,108 +3802,143 @@ msgid "Copyrights and reproduction rights"
 msgstr "Droits d'auteur et de reproduction"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42141
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42141
+#: model:account.group,name:l10n_lu.2_account_group_42141
 #: model:account.group.template,name:l10n_lu.account_group_42141
 msgid "Corporate income tax"
 msgstr "Impôt sur le revenu des collectivités (IRC)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_46121
+#: model:account.group,name:l10n_lu.2_account_group_671
 #: model:account.group.template,name:l10n_lu.account_group_46121
 #: model:account.group.template,name:l10n_lu.account_group_671
 msgid "Corporate income tax (CIT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461211
+#: model:account.group,name:l10n_lu.2_account_group_461211
 #: model:account.group.template,name:l10n_lu.account_group_461211
 msgid "Corporate income tax - Tax accrual"
 msgstr "IRC – charge fiscale estimée"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6182
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6182
+#: model:account.group,name:l10n_lu.2_account_group_6182
 #: model:account.group.template,name:l10n_lu.account_group_6182
 msgid "Costs of training, symposiums, seminars, conferences"
 msgstr "Frais de formation, colloques, séminaires, conférences"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_16122
 #: model:account.account.template,name:l10n_lu.lu_2020_account_16122
 msgid "Created by the undertaking itself"
 msgstr "Créés par l'entreprise elle-même"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_67321
 #: model:account.account.template,name:l10n_lu.lu_2011_account_67321
+#: model:account.group,name:l10n_lu.2_account_group_67321
 #: model:account.group.template,name:l10n_lu.account_group_67321
 msgid "Current financial year"
 msgstr "Exercice courant"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4011
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4021
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4011
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4021
+#: model:account.group,name:l10n_lu.2_account_group_4011
+#: model:account.group,name:l10n_lu.2_account_group_4021
 #: model:account.group.template,name:l10n_lu.account_group_4011
 #: model:account.group.template,name:l10n_lu.account_group_4021
 msgid "Customers"
 msgstr "Clients"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_40111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_40111
 msgid "Customers (PoS)"
 msgstr "Clients (POS)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4012
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4012
+#: model:account.group,name:l10n_lu.2_account_group_4012
 #: model:account.group.template,name:l10n_lu.account_group_4012
 msgid "Customers - Receivable bills of exchange"
 msgstr "Clients – Effets à recevoir"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4014
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4014
+#: model:account.group,name:l10n_lu.2_account_group_4014
 #: model:account.group.template,name:l10n_lu.account_group_4014
 msgid "Customers - Unbilled sales"
 msgstr "Clients – Factures à établir"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6145
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6145
+#: model:account.group,name:l10n_lu.2_account_group_6145
 #: model:account.group.template,name:l10n_lu.account_group_6145
 msgid "Customers credit insurance"
 msgstr "Assurance insolvabilité clients"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4015
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4015
+#: model:account.group,name:l10n_lu.2_account_group_4015
 #: model:account.group.template,name:l10n_lu.account_group_4015
 msgid "Customers with a credit balance"
 msgstr "Clients créditeurs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4025
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4025
+#: model:account.group,name:l10n_lu.2_account_group_4025
 #: model:account.group.template,name:l10n_lu.account_group_4025
 msgid "Customers with creditor balance"
 msgstr "Clients créditeurs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4215
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4215
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4613
+#: model:account.group,name:l10n_lu.2_account_group_4215
+#: model:account.group,name:l10n_lu.2_account_group_4613
 #: model:account.group.template,name:l10n_lu.account_group_4215
 #: model:account.group.template,name:l10n_lu.account_group_4613
 msgid "Customs and Excise Authority (ADA)"
 msgstr "Administration des Douanes et Accises (ADA)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4
 #: model:account.group.template,name:l10n_lu.account_group_4
 msgid "DEBTORS AND CREDITORS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106154
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106154
 msgid "Death and other health insurance funds"
 msgstr "Caisse de décès, médico-chirurgicale, Prestaplus"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_19
 #: model:account.group.template,name:l10n_lu.account_group_19
 msgid "Debenture loans and amounts owed to credit institutions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5083
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5083
+#: model:account.group,name:l10n_lu.2_account_group_5083
 #: model:account.group.template,name:l10n_lu.account_group_5083
 msgid "Debenture loans and other notes issued and repurchased by the company"
 msgstr ""
@@ -3181,50 +3946,70 @@ msgstr ""
 "par elle"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_23521
 #: model:account.account.template,name:l10n_lu.lu_2011_account_23521
+#: model:account.group,name:l10n_lu.2_account_group_23521
 #: model:account.group.template,name:l10n_lu.account_group_23521
 msgid "Debentures"
 msgstr "Obligations"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_481
 #: model:account.account.template,name:l10n_lu.lu_2011_account_481
+#: model:account.group,name:l10n_lu.2_account_group_481
 #: model:account.group.template,name:l10n_lu.account_group_481
 msgid "Deferred charges (on one or more financial years)"
 msgstr "Charges à reporter (sur un ou plusieurs exercices) "
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_48
 #: model:account.group.template,name:l10n_lu.account_group_48
 msgid "Deferred charges and income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_482
 #: model:account.account.template,name:l10n_lu.lu_2011_account_482
+#: model:account.group,name:l10n_lu.2_account_group_482
 #: model:account.group.template,name:l10n_lu.account_group_482
 msgid "Deferred income (on one or more financial years)"
 msgstr "Produits à reporter (sur un ou plusieurs exercices)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_183
 #: model:account.account.template,name:l10n_lu.lu_2011_account_183
+#: model:account.group,name:l10n_lu.2_account_group_183
 #: model:account.group.template,name:l10n_lu.account_group_183
 msgid "Deferred tax provisions"
 msgstr "Provisions pour impôts différés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_2362
 #: model:account.account.template,name:l10n_lu.lu_2020_account_2362
+#: model:account.group,name:l10n_lu.2_account_group_2362
 #: model:account.group.template,name:l10n_lu.account_group_2362
 msgid "Deposits and guarantees paid"
 msgstr "Dépôts et cautionnements versés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106192
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106192
 msgid "Deposits on private financial accounts"
 msgstr "Placements sur comptes financiers privés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42187
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42287
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4717
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4727
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42187
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42287
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4717
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4727
+#: model:account.group,name:l10n_lu.2_account_group_42187
+#: model:account.group,name:l10n_lu.2_account_group_42287
+#: model:account.group,name:l10n_lu.2_account_group_4717
+#: model:account.group,name:l10n_lu.2_account_group_4727
 #: model:account.group.template,name:l10n_lu.account_group_42187
 #: model:account.group.template,name:l10n_lu.account_group_42287
 #: model:account.group.template,name:l10n_lu.account_group_4717
@@ -3233,15 +4018,23 @@ msgid "Derivative financial instruments"
 msgstr "Instruments financiers dérivés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221111
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221111
+#: model:account.group,name:l10n_lu.2_account_group_221111
 #: model:account.group.template,name:l10n_lu.account_group_221111
 msgid "Developed land"
 msgstr "Terrains bâtis"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1611
 #: model:account.account.template,name:l10n_lu.lu_2011_account_211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7211
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1611
+#: model:account.group,name:l10n_lu.2_account_group_1611
+#: model:account.group,name:l10n_lu.2_account_group_211
+#: model:account.group,name:l10n_lu.2_account_group_7211
 #: model:account.group.template,name:l10n_lu.account_group_1611
 #: model:account.group.template,name:l10n_lu.account_group_211
 #: model:account.group.template,name:l10n_lu.account_group_7211
@@ -3249,192 +4042,260 @@ msgid "Development costs"
 msgstr "Frais de développement"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4214
+#: model:account.group,name:l10n_lu.2_account_group_4612
 #: model:account.group.template,name:l10n_lu.account_group_4214
 #: model:account.group.template,name:l10n_lu.account_group_4612
 msgid "Direct Tax Authority (ACD)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6432
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6432
+#: model:account.group,name:l10n_lu.2_account_group_6432
 #: model:account.group.template,name:l10n_lu.account_group_6432
 msgid "Director's fees"
 msgstr "Tantièmes"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6555
 #: model:account.group.template,name:l10n_lu.account_group_6555
 msgid "Discounts and charges on bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65551
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65551
+#: model:account.group,name:l10n_lu.2_account_group_65551
 #: model:account.group.template,name:l10n_lu.account_group_65551
 msgid "Discounts and charges on bills of exchange - affiliated undertakings"
 msgstr "Escomptes et frais sur effets de commerce - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65552
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65552
+#: model:account.group,name:l10n_lu.2_account_group_65552
 #: model:account.group.template,name:l10n_lu.account_group_65552
 msgid "Discounts and charges on bills of exchange - other"
 msgstr "Escomptes et frais sur effets de commerce - autres"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7555
 #: model:account.group.template,name:l10n_lu.account_group_7555
 msgid "Discounts on bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75551
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75551
+#: model:account.group,name:l10n_lu.2_account_group_75551
 #: model:account.group.template,name:l10n_lu.account_group_75551
 msgid "Discounts on bills of exchange - affiliated undertakings"
 msgstr "Escomptes d'effets de commerce - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75552
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75552
+#: model:account.group,name:l10n_lu.2_account_group_75552
 #: model:account.group.template,name:l10n_lu.account_group_75552
 msgid "Discounts on bills of exchange - other"
 msgstr "Escomptes d'effets de commerce - autres "
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7556
 #: model:account.group.template,name:l10n_lu.account_group_7556
 msgid "Discounts received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75561
+#: model:account.group,name:l10n_lu.2_account_group_75561
 #: model:account.group.template,name:l10n_lu.account_group_75561
 msgid "Discounts received - affiliated undertakings"
 msgstr "Escomptes obtenus - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75562
+#: model:account.group,name:l10n_lu.2_account_group_75562
 #: model:account.group.template,name:l10n_lu.account_group_75562
 msgid "Discounts received - other"
 msgstr "Escomptes obtenus - autres "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752262
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752262
+#: model:account.group,name:l10n_lu.2_account_group_752262
 #: model:account.group.template,name:l10n_lu.account_group_752262
 msgid "Disposal proceed of loans, deposits and claims held as fixed assets"
 msgstr "Produits de cession de prêts, dépôts et créances immobilisés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652222
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752222
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652222
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752222
+#: model:account.group,name:l10n_lu.2_account_group_652222
+#: model:account.group,name:l10n_lu.2_account_group_752222
 #: model:account.group.template,name:l10n_lu.account_group_652222
 #: model:account.group.template,name:l10n_lu.account_group_752222
 msgid "Disposal proceeds of amounts owed by affiliated undertakings"
 msgstr "Produits de cession de créances sur des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652242
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752242
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652242
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752242
+#: model:account.group,name:l10n_lu.2_account_group_652242
+#: model:account.group,name:l10n_lu.2_account_group_752242
 #: model:account.group.template,name:l10n_lu.account_group_652242
 #: model:account.group.template,name:l10n_lu.account_group_752242
 msgid ""
-"Disposal proceeds of amounts owed by undertakings with which the undertaking "
-"is linked by virtue of participating interests"
+"Disposal proceeds of amounts owed by undertakings with which the undertaking"
+" is linked by virtue of participating interests"
 msgstr "Produits de cession de créances sur participations"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64412
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_64412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74412
+#: model:account.group,name:l10n_lu.2_account_group_64412
+#: model:account.group,name:l10n_lu.2_account_group_74412
 #: model:account.group.template,name:l10n_lu.account_group_64412
 #: model:account.group.template,name:l10n_lu.account_group_74412
 msgid "Disposal proceeds of intangible fixed assets"
 msgstr "Produits de cession d'immobilisations incorporelles"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652262
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652262
+#: model:account.group,name:l10n_lu.2_account_group_652262
 #: model:account.group.template,name:l10n_lu.account_group_652262
 msgid "Disposal proceeds of loans, deposits and claims held as fixed assets"
 msgstr "Produits de cession de prêts, dépôts et créances immobilisés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652232
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752232
+#: model:account.group,name:l10n_lu.2_account_group_652232
+#: model:account.group,name:l10n_lu.2_account_group_752232
 #: model:account.group.template,name:l10n_lu.account_group_652232
 #: model:account.group.template,name:l10n_lu.account_group_752232
 msgid "Disposal proceeds of participating interests"
 msgstr "Produits de cession de participations"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652252
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752252
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652252
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752252
+#: model:account.group,name:l10n_lu.2_account_group_652252
+#: model:account.group,name:l10n_lu.2_account_group_752252
 #: model:account.group.template,name:l10n_lu.account_group_652252
 #: model:account.group.template,name:l10n_lu.account_group_752252
 msgid "Disposal proceeds of securities held as fixed assets"
 msgstr "Produits de cession de titres ayant le caractère d'immobilisations"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652212
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752212
+#: model:account.group,name:l10n_lu.2_account_group_652212
+#: model:account.group,name:l10n_lu.2_account_group_752212
 #: model:account.group.template,name:l10n_lu.account_group_652212
 #: model:account.group.template,name:l10n_lu.account_group_752212
 msgid "Disposal proceeds of shares in affiliated undertakings"
 msgstr "Produits de cession de parts dans des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64422
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_64422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74422
+#: model:account.group,name:l10n_lu.2_account_group_64422
+#: model:account.group,name:l10n_lu.2_account_group_74422
 #: model:account.group.template,name:l10n_lu.account_group_64422
 #: model:account.group.template,name:l10n_lu.account_group_74422
 msgid "Disposal proceeds of tangible fixed assets"
 msgstr "Produits de cession d'immobilisations corporelles"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6181
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6181
+#: model:account.group,name:l10n_lu.2_account_group_6181
 #: model:account.group.template,name:l10n_lu.account_group_6181
 msgid "Documentation"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61516
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61516
+#: model:account.group,name:l10n_lu.2_account_group_61516
 #: model:account.group.template,name:l10n_lu.account_group_61516
 msgid "Donations"
 msgstr "Dons courants"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4013
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4013
+#: model:account.group,name:l10n_lu.2_account_group_4013
 #: model:account.group.template,name:l10n_lu.account_group_4013
 msgid "Doubtful or disputed customers"
 msgstr "Clients douteux ou litigieux"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_214
 #: model:account.account.template,name:l10n_lu.lu_2020_account_214
+#: model:account.group,name:l10n_lu.2_account_group_214
 #: model:account.group.template,name:l10n_lu.account_group_214
 msgid "Down payments and intangible fixed assets under development"
 msgstr "Acomptes versés et immobilisations incorporelles en cours"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_224
 #: model:account.group.template,name:l10n_lu.account_group_224
 msgid "Down payments and tangible fixed assets under development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_37
 #: model:account.account.template,name:l10n_lu.lu_2020_account_37
+#: model:account.group,name:l10n_lu.2_account_group_37
 #: model:account.group.template,name:l10n_lu.account_group_37
 msgid "Down payments on account on inventories"
 msgstr "Acomptes versés sur stocks"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_432
 #: model:account.account.template,name:l10n_lu.lu_2011_account_432
+#: model:account.group,name:l10n_lu.2_account_group_432
 #: model:account.group.template,name:l10n_lu.account_group_432
 msgid "Down payments received after more than one year"
 msgstr "Acomptes reçus dont la durée résiduelle est supérieure à un an"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_315
 #: model:account.group.template,name:l10n_lu.account_group_315
 msgid ""
 "Down payments received on inventories of work and on contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4311
+#: model:account.group,name:l10n_lu.2_account_group_4321
 #: model:account.group.template,name:l10n_lu.account_group_4311
 #: model:account.group.template,name:l10n_lu.account_group_4321
 msgid "Down payments received on orders"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_43
 #: model:account.group.template,name:l10n_lu.account_group_43
 msgid ""
 "Down payments received on orders as far as they are not deducted distinctly "
@@ -3442,13 +4303,18 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_431
 #: model:account.account.template,name:l10n_lu.lu_2011_account_431
+#: model:account.group,name:l10n_lu.2_account_group_431
 #: model:account.group.template,name:l10n_lu.account_group_431
 msgid "Down payments received within one year"
 msgstr ""
 "Acomptes reçus dont la durée résiduelle est inférieure ou égale à un an"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1922
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1932
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1942
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1922
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1932
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1942
@@ -3456,6 +4322,9 @@ msgid "Due and payable after more than one year"
 msgstr "Dont la durée résiduelle est supérieure à un an"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1921
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1931
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1941
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1921
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1931
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1941
@@ -3463,89 +4332,111 @@ msgid "Due and payable within one year"
 msgstr "Dont la durée résiduelle est inférieure ou égale à un an"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6463
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6463
+#: model:account.group,name:l10n_lu.2_account_group_6463
 #: model:account.group.template,name:l10n_lu.account_group_6463
 msgid "Duties on imported merchandise"
 msgstr "Droits sur les marchandises en provenance de l'étranger"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1
 #: model:account.group.template,name:l10n_lu.account_group_1
 msgid "EQUITY, PROVISIONS AND FINANCIAL LIABILITIES ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_private_LU_IC
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_private_LU_IC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_private_LU_IC
 msgid "EU private"
 msgstr "EU privé"
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-0
 msgid "EX-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-0
 msgid "EX-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-EC-0
 msgid "EX-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-EC-0
 msgid "EX-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-EC-0
 msgid "EX-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-IC-0
 msgid "EX-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-IC-0
 msgid "EX-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-IC-0
 msgid "EX-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-IC-0
 msgid "EX-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60315
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61845
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60315
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61845
+#: model:account.group,name:l10n_lu.2_account_group_60315
+#: model:account.group,name:l10n_lu.2_account_group_61845
 #: model:account.group.template,name:l10n_lu.account_group_60315
 #: model:account.group.template,name:l10n_lu.account_group_61845
 msgid "Electricity"
 msgstr "Electricité"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_105
 #: model:account.account.template,name:l10n_lu.lu_2011_account_105
+#: model:account.group,name:l10n_lu.2_account_group_105
 #: model:account.group.template,name:l10n_lu.account_group_105
 msgid "Endowment of branches"
 msgstr "Dotation des succursales"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6464
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6464
+#: model:account.group,name:l10n_lu.2_account_group_6464
 #: model:account.group.template,name:l10n_lu.account_group_6464
 msgid "Excise duties on production and tax on consumption"
 msgstr "Droits d'accises à la production et taxe de consommation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_203
 #: model:account.account.template,name:l10n_lu.lu_2011_account_203
+#: model:account.group,name:l10n_lu.2_account_group_203
 #: model:account.group.template,name:l10n_lu.account_group_203
 msgid ""
 "Expenses for increases in capital and for various operations (merger, "
@@ -3555,81 +4446,108 @@ msgstr ""
 "scissions, transformations)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_617
 #: model:account.group.template,name:l10n_lu.account_group_617
 msgid "External staff of the company"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6172
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6172
+#: model:account.group,name:l10n_lu.2_account_group_6172
 #: model:account.group.template,name:l10n_lu.account_group_6172
 msgid "External staff on secondment"
 msgstr "Personnel prêté à l'entreprise"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_EC
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_EC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_EC
 msgid "Extra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_5
 #: model:account.group.template,name:l10n_lu.account_group_5
 msgid "FINANCIAL ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2
 #: model:account.group.template,name:l10n_lu.account_group_2
 msgid "FORMATION EXPENSES AND FIXED ASSETS ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6512
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7512
+#: model:account.group,name:l10n_lu.2_account_group_6512
+#: model:account.group,name:l10n_lu.2_account_group_7512
 #: model:account.group.template,name:l10n_lu.account_group_6512
 #: model:account.group.template,name:l10n_lu.account_group_7512
 msgid "FVA on financial fixed assets"
 msgstr "AJV sur immobilisations financières"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_63315
+#: model:account.account,name:l10n_lu.2_lu_2020_account_73315
 #: model:account.account.template,name:l10n_lu.lu_2020_account_63315
 #: model:account.account.template,name:l10n_lu.lu_2020_account_73315
+#: model:account.group,name:l10n_lu.2_account_group_63315
+#: model:account.group,name:l10n_lu.2_account_group_73315
 #: model:account.group.template,name:l10n_lu.account_group_63315
 #: model:account.group.template,name:l10n_lu.account_group_73315
 msgid "FVA on investment properties"
 msgstr "AJV sur immeubles de placement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6354
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7354
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6354
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7354
+#: model:account.group,name:l10n_lu.2_account_group_6354
+#: model:account.group,name:l10n_lu.2_account_group_7354
 #: model:account.group.template,name:l10n_lu.account_group_6354
 #: model:account.group.template,name:l10n_lu.account_group_7354
 msgid "FVA on receivables from current assets"
 msgstr "AJV sur créances de l'actif circulant"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6532
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6532
+#: model:account.group,name:l10n_lu.2_account_group_6532
+#: model:account.group,name:l10n_lu.2_account_group_7532
 #: model:account.group.template,name:l10n_lu.account_group_6532
 #: model:account.group.template,name:l10n_lu.account_group_7532
 msgid "FVA on transferable securities"
 msgstr "AJV sur valeurs mobilières"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61336
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61336
+#: model:account.group,name:l10n_lu.2_account_group_61336
 #: model:account.group.template,name:l10n_lu.account_group_61336
 msgid "Factoring services"
 msgstr "Rémunérations d'affacturage"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7532
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7532
 msgid "Fair value adjustments on transferable securities"
 msgstr "AJV sur valeurs mobilières"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61513
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61513
+#: model:account.group,name:l10n_lu.2_account_group_61513
 #: model:account.group.template,name:l10n_lu.account_group_61513
 msgid "Fairs and exhibitions"
 msgstr "Foires et expositions"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_641
+#: model:account.group,name:l10n_lu.2_account_group_7031
 #: model:account.group.template,name:l10n_lu.account_group_641
 #: model:account.group.template,name:l10n_lu.account_group_7031
 msgid ""
@@ -3638,6 +4556,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_741
 #: model:account.group.template,name:l10n_lu.account_group_741
 msgid ""
 "Fees and royalties for concessions, patents, licences, trademarks and "
@@ -3645,177 +4564,230 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65
 #: model:account.group.template,name:l10n_lu.account_group_65
 msgid "Financial charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_23
 #: model:account.group.template,name:l10n_lu.account_group_23
 msgid "Financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75
 #: model:account.group.template,name:l10n_lu.account_group_75
 msgid "Financial income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6115
 #: model:account.group.template,name:l10n_lu.account_group_6115
 msgid "Financial leasing on movable property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6114
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6114
+#: model:account.group,name:l10n_lu.2_account_group_6114
 #: model:account.group.template,name:l10n_lu.account_group_6114
 msgid "Financial leasing on real property"
 msgstr "Leasing financier immobilier"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_1882
 #: model:account.account.template,name:l10n_lu.lu_2011_account_1882
+#: model:account.group,name:l10n_lu.2_account_group_1882
 #: model:account.group.template,name:l10n_lu.account_group_1882
 msgid "Financial provisions"
 msgstr "Provisions financières"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6481
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6481
+#: model:account.group,name:l10n_lu.2_account_group_6481
 #: model:account.group.template,name:l10n_lu.account_group_6481
 msgid "Fines, sanctions and penalties"
 msgstr "Amendes, sanctions et pénalités"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106143
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106143
 msgid "Fire insurance"
 msgstr "Incendie"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2214
 #: model:account.group.template,name:l10n_lu.account_group_2214
 msgid "Fixtures and fitting-outs of buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22141
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22141
+#: model:account.group,name:l10n_lu.2_account_group_22141
 #: model:account.group.template,name:l10n_lu.account_group_22141
 msgid "Fixtures and fitting-outs of buildings in Luxembourg"
-msgstr "Agencements et aménagements de constructions / bâtiments au Luxembourg"
+msgstr ""
+"Agencements et aménagements de constructions / bâtiments au Luxembourg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22142
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22142
+#: model:account.group,name:l10n_lu.2_account_group_22142
 #: model:account.group.template,name:l10n_lu.account_group_22142
 msgid "Fixtures and fitting-outs of buildings in foreign countries"
 msgstr "Agencements et aménagements de constructions / bâtiments à l'étranger"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22121
+#: model:account.group,name:l10n_lu.2_account_group_22121
 #: model:account.group.template,name:l10n_lu.account_group_22121
 msgid "Fixtures and fitting-outs of land in Luxembourg"
 msgstr "Agencements et aménagements de terrains au Luxembourg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22122
+#: model:account.group,name:l10n_lu.2_account_group_22122
 #: model:account.group.template,name:l10n_lu.account_group_22122
 msgid "Fixtures and fitting-outs of land in foreign countries"
 msgstr "Agencements et aménagements de terrains à l'étranger"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2212
 #: model:account.group.template,name:l10n_lu.account_group_2212
 msgid "Fixtures and fittings-out of land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4622
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4622
+#: model:account.group,name:l10n_lu.2_account_group_4622
 #: model:account.group.template,name:l10n_lu.account_group_4622
 msgid "Foreign Social Security offices"
 msgstr "Organismes étrangers de sécurité sociale"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421811
+#: model:account.account,name:l10n_lu.2_lu_2020_account_46151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421811
 #: model:account.account.template,name:l10n_lu.lu_2020_account_46151
+#: model:account.group,name:l10n_lu.2_account_group_421811
+#: model:account.group,name:l10n_lu.2_account_group_46151
 #: model:account.group.template,name:l10n_lu.account_group_421811
 #: model:account.group.template,name:l10n_lu.account_group_46151
 msgid "Foreign VAT"
 msgstr "TVA étrangères"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_756
 #: model:account.group.template,name:l10n_lu.account_group_756
 msgid "Foreign currency exchange gains"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7561
+#: model:account.group,name:l10n_lu.2_account_group_7561
 #: model:account.group.template,name:l10n_lu.account_group_7561
 msgid "Foreign currency exchange gains - affiliated undertakings"
 msgstr "Gains de change - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7562
+#: model:account.group,name:l10n_lu.2_account_group_7562
 #: model:account.group.template,name:l10n_lu.account_group_7562
 msgid "Foreign currency exchange gains - other"
 msgstr "Gains de change - autres "
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_656
 #: model:account.group.template,name:l10n_lu.account_group_656
 msgid "Foreign currency exchange losses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6561
+#: model:account.group,name:l10n_lu.2_account_group_6561
 #: model:account.group.template,name:l10n_lu.account_group_6561
 msgid "Foreign currency exchange losses - affiliated undertakings"
 msgstr "Pertes de change - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6562
+#: model:account.group,name:l10n_lu.2_account_group_6562
 #: model:account.group.template,name:l10n_lu.account_group_6562
 msgid "Foreign currency exchange losses - other"
 msgstr "Pertes de change - autres"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_673
 #: model:account.group.template,name:l10n_lu.account_group_673
 msgid "Foreign income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42172
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42172
+#: model:account.group,name:l10n_lu.2_account_group_42172
 #: model:account.group.template,name:l10n_lu.account_group_42172
 msgid "Foreign social security offices"
 msgstr "Organismes étrangers de sécurité sociale"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4615
 #: model:account.group.template,name:l10n_lu.account_group_4615
 msgid "Foreign tax authorities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_683
 #: model:account.account.template,name:l10n_lu.lu_2011_account_683
+#: model:account.group,name:l10n_lu.2_account_group_42181
+#: model:account.group,name:l10n_lu.2_account_group_683
 #: model:account.group.template,name:l10n_lu.account_group_42181
 #: model:account.group.template,name:l10n_lu.account_group_683
 msgid "Foreign taxes"
 msgstr "Impôts étrangers "
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_20
 #: model:account.group.template,name:l10n_lu.account_group_20
 msgid "Formation expenses and similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_755231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_755231
+#: model:account.group,name:l10n_lu.2_account_group_65411
 #: model:account.group.template,name:l10n_lu.account_group_65411
 msgid "From affiliated undertakings"
 msgstr "Sur des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_755232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_755232
 msgid "From other"
 msgstr "Intérêts sur leasings financiers - autres "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65413
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65413
 msgid "From other receivables from current assets"
 msgstr "Sur autres créances de l'actif circulant"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65412
+#: model:account.group,name:l10n_lu.2_account_group_65412
 #: model:account.group.template,name:l10n_lu.account_group_65412
 msgid ""
 "From undertakings with which the undertaking is linked by virtue of "
@@ -3824,11 +4796,13 @@ msgstr ""
 "Sur des entreprises avec lesquelles l'entreprise a un lien de participation"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6031
 #: model:account.group.template,name:l10n_lu.account_group_6031
 msgid "Fuels, gas, water and electricity"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6184
 #: model:account.group.template,name:l10n_lu.account_group_6184
 msgid ""
 "Fuels, gas, water and electricity (not included in the production of goods "
@@ -3836,17 +4810,21 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106145
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106145
 msgid "Full coverage insurance"
 msgstr "Multirisques"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2234
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2234
+#: model:account.group,name:l10n_lu.2_account_group_2234
 #: model:account.group.template,name:l10n_lu.account_group_2234
 msgid "Furniture"
 msgstr "Mobilier"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_754
 #: model:account.group.template,name:l10n_lu.account_group_754
 msgid ""
 "Gain on disposal and other income from current receivables and transferable "
@@ -3854,102 +4832,131 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7522
 #: model:account.group.template,name:l10n_lu.account_group_7522
 msgid "Gain on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_744
 #: model:account.group.template,name:l10n_lu.account_group_744
 msgid "Gain on disposal of intangible and tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7441
 #: model:account.group.template,name:l10n_lu.account_group_7441
 msgid "Gain on disposal of intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7541
 #: model:account.group.template,name:l10n_lu.account_group_7541
 msgid "Gain on disposal of receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7542
 #: model:account.group.template,name:l10n_lu.account_group_7542
 msgid "Gain on disposal of transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60313
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61843
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60313
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61843
+#: model:account.group,name:l10n_lu.2_account_group_60313
+#: model:account.group,name:l10n_lu.2_account_group_61843
 #: model:account.group.template,name:l10n_lu.account_group_60313
 #: model:account.group.template,name:l10n_lu.account_group_61843
 msgid "Gas"
 msgstr "Gaz"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6121
+#: model:account.group,name:l10n_lu.2_account_group_6121
 #: model:account.group.template,name:l10n_lu.account_group_6121
 msgid ""
-"General subcontracting (not included in the production of goods and services)"
+"General subcontracting (not included in the production of goods and "
+"services)"
 msgstr "Sous-traitance générale (non incorporée aux ouvrages et produits)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106194
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106194
 msgid "Gifts and allowance to children"
 msgstr "Dons et dotations aux enfants"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61514
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61514
+#: model:account.group,name:l10n_lu.2_account_group_61514
 #: model:account.group.template,name:l10n_lu.account_group_61514
 msgid "Gifts to customers"
 msgstr "Cadeaux à la clientèle"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_213
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_213
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1613
+#: model:account.group,name:l10n_lu.2_account_group_1613
+#: model:account.group,name:l10n_lu.2_account_group_213
 #: model:account.group.template,name:l10n_lu.account_group_1613
 #: model:account.group.template,name:l10n_lu.account_group_213
 msgid "Goodwill acquired for consideration"
 msgstr "Fonds de commerce, dans la mesure où il a été acquis à titre onéreux"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6556
 #: model:account.group.template,name:l10n_lu.account_group_6556
 msgid "Granted discounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65561
+#: model:account.group,name:l10n_lu.2_account_group_65561
 #: model:account.group.template,name:l10n_lu.account_group_65561
 msgid "Granted discounts - affiliated undertakings"
 msgstr "Escomptes accordés - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65562
+#: model:account.group,name:l10n_lu.2_account_group_65562
 #: model:account.group.template,name:l10n_lu.account_group_65562
 msgid "Granted discounts - other"
 msgstr "Escomptes accordés - autres"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_212152
 #: model:account.group.template,name:l10n_lu.account_group_212152
 msgid "Greenhous gas and similar emission quotas"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212152
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212152
 msgid "Greenhouse gas and similar emission quotas"
 msgstr "Quotas d'émission de gaz à effet de serre et assimilés"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6211
 #: model:account.group.template,name:l10n_lu.account_group_6211
 msgid "Gross wages"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106153
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106153
 msgid "Health insurance funds"
 msgstr "Cotisations pour mutuelles"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106163
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106163
 msgid "Heating, gas, electricity"
 msgstr "Chauffage, gaz, électricité"
@@ -3970,17 +4977,21 @@ msgid "III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)"
 msgstr "III. CALCUL DE LA TAXE DEDUCTIBLE (taxe en amont)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7
 #: model:account.group.template,name:l10n_lu.account_group_7
 msgid "INCOME ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_3
 #: model:account.group.template,name:l10n_lu.account_group_3
 msgid "INVENTORIES ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6132
+#: model:account.group,name:l10n_lu.2_account_group_6132
 #: model:account.group.template,name:l10n_lu.account_group_6132
 msgid "IT services"
 msgstr "Services informatiques"
@@ -3991,125 +5002,157 @@ msgid "IV. TAX TO BE PAID OR TO BE RECLAIMED"
 msgstr "IV. CALCUL DE L'EXCEDENT"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62114
+#: model:account.group,name:l10n_lu.2_account_group_62114
 #: model:account.group.template,name:l10n_lu.account_group_62114
 msgid "Incentives, bonuses and commissions"
 msgstr "Gratifications, primes et commissions"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_752
 #: model:account.group.template,name:l10n_lu.account_group_752
 msgid "Income and gain on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7521
 #: model:account.group.template,name:l10n_lu.account_group_7521
 msgid "Income from financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7442
 #: model:account.group.template,name:l10n_lu.account_group_7442
 msgid "Income of yielded tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106281
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106281
 msgid "Income tax"
 msgstr "Impôt sur le revenu (IRPP)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106181
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106181
 msgid "Income tax paid"
 msgstr "Impôt sur le revenu payé (IRPP)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_67
 #: model:account.group.template,name:l10n_lu.account_group_67
 msgid "Income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_642
 #: model:account.account.template,name:l10n_lu.lu_2011_account_642
+#: model:account.group,name:l10n_lu.2_account_group_642
 #: model:account.group.template,name:l10n_lu.account_group_642
 msgid "Indemnities, damages and interest"
 msgstr "Indemnités, dommages et intérêts"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4216
 #: model:account.group.template,name:l10n_lu.account_group_4216
 msgid "Indirect Tax Authority (AED)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4614
 #: model:account.group.template,name:l10n_lu.account_group_4614
 msgid "Indirect tax authorities (AED)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_42162
+#: model:account.group,name:l10n_lu.2_account_group_46142
 #: model:account.group.template,name:l10n_lu.account_group_42162
 #: model:account.group.template,name:l10n_lu.account_group_46142
 msgid "Indirect taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6183
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6183
+#: model:account.group,name:l10n_lu.2_account_group_6183
 #: model:account.group.template,name:l10n_lu.account_group_6183
 msgid "Industrial and non-industrial waste treatment"
 msgstr "Elimination des déchets industriels et non industriels"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10621
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10621
 msgid "Inheritance or donation"
 msgstr "Héritage ou donation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106195
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106195
 msgid "Inheritance taxes and mutation tax due to death"
 msgstr "Droits de succession et droits de mutation par décès"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62414
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62414
+#: model:account.group,name:l10n_lu.2_account_group_62414
 #: model:account.group.template,name:l10n_lu.account_group_62414
 msgid "Insolvency insurance premiums"
 msgstr "Prime d'assurance insolvabilité"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6141
 #: model:account.group.template,name:l10n_lu.account_group_6141
 msgid "Insurance for assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7481
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7481
+#: model:account.group,name:l10n_lu.2_account_group_7481
 #: model:account.group.template,name:l10n_lu.account_group_7481
 msgid "Insurance indemnities"
 msgstr "Indemnités d'assurance"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6142
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6142
+#: model:account.group,name:l10n_lu.2_account_group_6142
 #: model:account.group.template,name:l10n_lu.account_group_6142
 msgid "Insurance on rented assets"
 msgstr "Assurance sur biens pris en location"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_614
 #: model:account.group.template,name:l10n_lu.account_group_614
 msgid "Insurance premiums"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_21
+#: model:account.group,name:l10n_lu.2_account_group_721
 #: model:account.group.template,name:l10n_lu.account_group_21
 #: model:account.group.template,name:l10n_lu.account_group_721
 msgid "Intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_655
 #: model:account.group.template,name:l10n_lu.account_group_655
 msgid "Interest and discounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75541
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75541
+#: model:account.group,name:l10n_lu.2_account_group_75541
 #: model:account.group.template,name:l10n_lu.account_group_75541
 msgid "Interest on amounts owed by affiliated undertakings"
 msgstr "Intérêts sur des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7554
 #: model:account.group.template,name:l10n_lu.account_group_7554
 msgid ""
 "Interest on amounts owed by affiliated undertakings and undertakings with "
@@ -4117,7 +5160,9 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75542
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75542
+#: model:account.group,name:l10n_lu.2_account_group_75542
 #: model:account.group.template,name:l10n_lu.account_group_75542
 msgid ""
 "Interest on amounts owed by undertakings with which the undertaking is "
@@ -4127,99 +5172,129 @@ msgstr ""
 "participation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75521
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75521
+#: model:account.group,name:l10n_lu.2_account_group_75521
 #: model:account.group.template,name:l10n_lu.account_group_75521
 msgid "Interest on bank accounts"
 msgstr "Intérêts sur comptes bancaires"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6551
 #: model:account.group.template,name:l10n_lu.account_group_6551
 msgid "Interest on debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65511
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65511
+#: model:account.group,name:l10n_lu.2_account_group_65511
 #: model:account.group.template,name:l10n_lu.account_group_65511
 msgid "Interest on debenture loans - affiliated undertakings"
 msgstr "Intérêts sur emprunts obligataires - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65512
+#: model:account.group,name:l10n_lu.2_account_group_65512
 #: model:account.group.template,name:l10n_lu.account_group_65512
 msgid "Interest on debenture loans - other"
 msgstr "Intérêts sur emprunts obligataires - autres"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65523
+#: model:account.group,name:l10n_lu.2_account_group_75523
 #: model:account.group.template,name:l10n_lu.account_group_65523
 #: model:account.group.template,name:l10n_lu.account_group_75523
 msgid "Interest on financial leases"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_655231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_655231
+#: model:account.group,name:l10n_lu.2_account_group_655231
 #: model:account.group.template,name:l10n_lu.account_group_655231
 msgid "Interest on financial leases - affiliated undertakings"
 msgstr "Intérêts sur leasings financiers - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_655232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_655232
+#: model:account.group,name:l10n_lu.2_account_group_655232
 #: model:account.group.template,name:l10n_lu.account_group_655232
 msgid "Interest on financial leases - other"
 msgstr "Intérêts sur leasings financiers - autres"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7558
 #: model:account.group.template,name:l10n_lu.account_group_7558
 msgid "Interest on other amounts receivable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75581
+#: model:account.group,name:l10n_lu.2_account_group_75581
 #: model:account.group.template,name:l10n_lu.account_group_75581
 msgid "Interest on other amounts receivable - affiliated undertakings"
 msgstr "Intérêts sur autres créances - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75582
+#: model:account.group,name:l10n_lu.2_account_group_75582
 #: model:account.group.template,name:l10n_lu.account_group_75582
 msgid "Interest on other amounts receivable - other"
 msgstr "Intérêts sur autres créances - autres"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6553
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6553
+#: model:account.group,name:l10n_lu.2_account_group_6553
 #: model:account.group.template,name:l10n_lu.account_group_6553
 msgid "Interest on trade payables"
 msgstr "Intérêts sur dettes commerciales"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7553
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7553
+#: model:account.group,name:l10n_lu.2_account_group_7553
 #: model:account.group.template,name:l10n_lu.account_group_7553
 msgid "Interest on trade receivables"
 msgstr "Intérêts sur créances commerciales"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6558
 #: model:account.group.template,name:l10n_lu.account_group_6558
 msgid "Interest payable on other loans and debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65581
+#: model:account.group,name:l10n_lu.2_account_group_65581
 #: model:account.group.template,name:l10n_lu.account_group_65581
 msgid "Interest payable on other loans and debts - affiliated undertakings"
 msgstr "Intérêts sur autres emprunts et dettes - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65582
+#: model:account.group,name:l10n_lu.2_account_group_65582
 #: model:account.group.template,name:l10n_lu.account_group_65582
 msgid "Interest payable on other loans and debts - other"
 msgstr "Intérêts sur autres emprunts et dettes - autres"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65541
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65541
+#: model:account.group,name:l10n_lu.2_account_group_65541
 #: model:account.group.template,name:l10n_lu.account_group_65541
 msgid "Interest payable to affiliated undertakings"
 msgstr "Intérêts sur des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6554
 #: model:account.group.template,name:l10n_lu.account_group_6554
 msgid ""
 "Interest payable to affiliated undertakings and undertakings with which the "
@@ -4227,7 +5302,9 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65542
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65542
+#: model:account.group,name:l10n_lu.2_account_group_65542
 #: model:account.group.template,name:l10n_lu.account_group_65542
 msgid ""
 "Interest payable to undertakings with which the undertaking is linked by "
@@ -4237,121 +5314,155 @@ msgstr ""
 "participation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7452
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7452
+#: model:account.group,name:l10n_lu.2_account_group_7452
 #: model:account.group.template,name:l10n_lu.account_group_7452
 msgid "Interest subsidies"
 msgstr "Bonifications d'intérêt"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_15
 #: model:account.account.template,name:l10n_lu.lu_2011_account_15
+#: model:account.group,name:l10n_lu.2_account_group_15
 #: model:account.group.template,name:l10n_lu.account_group_15
 msgid "Interim dividends"
 msgstr "Acomptes sur dividendes"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_517
 #: model:account.group.template,name:l10n_lu.account_group_517
 msgid "Internal transfers"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5172
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5172
+#: model:account.group,name:l10n_lu.2_account_group_5172
 #: model:account.group.template,name:l10n_lu.account_group_5172
 msgid "Internal transfers : credit balance"
 msgstr "Virements internes : solde créditeur"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5171
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5171
+#: model:account.group,name:l10n_lu.2_account_group_5171
 #: model:account.group.template,name:l10n_lu.account_group_5171
 msgid "Internal transfers : debit balance"
 msgstr "Virements internes : solde débiteur"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_IC
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_IC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_IC
 msgid "Intra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_363
 #: model:account.group.template,name:l10n_lu.account_group_363
 msgid "Inventories of buildings for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3631
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3631
+#: model:account.group,name:l10n_lu.2_account_group_3631
 #: model:account.group.template,name:l10n_lu.account_group_3631
 msgid "Inventories of buildings for resale in Luxembourg"
 msgstr "Stocks d'immeubles au Luxembourg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3632
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3632
+#: model:account.group,name:l10n_lu.2_account_group_3632
 #: model:account.group.template,name:l10n_lu.account_group_3632
 msgid "Inventories of buildings for resale in foreign countries"
 msgstr "Stocks d'immeubles à l'étranger"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_303
 #: model:account.account.template,name:l10n_lu.lu_2020_account_303
+#: model:account.group,name:l10n_lu.2_account_group_303
 #: model:account.group.template,name:l10n_lu.account_group_303
 msgid "Inventories of consumable materials and supplies"
 msgstr "Stocks de matières et fournitures consommables"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_321
 #: model:account.account.template,name:l10n_lu.lu_2011_account_321
+#: model:account.group,name:l10n_lu.2_account_group_321
 #: model:account.group.template,name:l10n_lu.account_group_321
 msgid "Inventories of finished goods"
 msgstr "Stocks de produits finis"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_32
 #: model:account.group.template,name:l10n_lu.account_group_32
 msgid "Inventories of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_362
 #: model:account.group.template,name:l10n_lu.account_group_362
 msgid "Inventories of land for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3621
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3621
+#: model:account.group,name:l10n_lu.2_account_group_3621
 #: model:account.group.template,name:l10n_lu.account_group_3621
 msgid "Inventories of land for resale in Luxembourg"
 msgstr "Stocks de terrains au Luxembourg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3622
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3622
+#: model:account.group,name:l10n_lu.2_account_group_3622
 #: model:account.group.template,name:l10n_lu.account_group_3622
 msgid "Inventories of land for resale in foreign countries"
 msgstr "Stocks de terrains à l'étranger"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_361
 #: model:account.account.template,name:l10n_lu.lu_2020_account_361
+#: model:account.group,name:l10n_lu.2_account_group_361
 #: model:account.group.template,name:l10n_lu.account_group_361
 msgid "Inventories of merchandise"
 msgstr "Stocks de marchandises"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_36
 #: model:account.group.template,name:l10n_lu.account_group_36
 msgid "Inventories of merchandises and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_304
 #: model:account.account.template,name:l10n_lu.lu_2020_account_304
+#: model:account.group,name:l10n_lu.2_account_group_304
 #: model:account.group.template,name:l10n_lu.account_group_304
 msgid "Inventories of packaging"
 msgstr "Stocks d'emballages"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_301
 #: model:account.account.template,name:l10n_lu.lu_2011_account_301
+#: model:account.group,name:l10n_lu.2_account_group_301
 #: model:account.group.template,name:l10n_lu.account_group_301
 msgid "Inventories of raw materials"
 msgstr "Stocks de matières premières"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_30
 #: model:account.group.template,name:l10n_lu.account_group_30
 msgid "Inventories of raw materials and consumables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_323
 #: model:account.account.template,name:l10n_lu.lu_2020_account_323
+#: model:account.group,name:l10n_lu.2_account_group_323
 #: model:account.group.template,name:l10n_lu.account_group_323
 msgid ""
 "Inventories of residual goods (waste, rejected and recuperable material)"
@@ -4359,17 +5470,22 @@ msgstr ""
 "Stocks de produits résiduels (déchets, rebuts, matières de récupération)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_322
+#: model:account.group,name:l10n_lu.2_account_group_322
 #: model:account.group.template,name:l10n_lu.account_group_322
 msgid "Inventories of semi-finished goods"
 msgstr "Stocks de produits intermédiaires"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_31
 #: model:account.group.template,name:l10n_lu.account_group_31
 msgid "Inventories of work and contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4312
+#: model:account.group,name:l10n_lu.2_account_group_4322
 #: model:account.group.template,name:l10n_lu.account_group_4312
 #: model:account.group.template,name:l10n_lu.account_group_4322
 msgid ""
@@ -4377,187 +5493,255 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_311
+#: model:account.group,name:l10n_lu.2_account_group_311
 #: model:account.group.template,name:l10n_lu.account_group_311
 msgid "Inventories of work in progress"
 msgstr "Stocks de produits en cours de fabrication"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2215
 #: model:account.group.template,name:l10n_lu.account_group_2215
 msgid "Investment properties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22151
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22151
+#: model:account.group,name:l10n_lu.2_account_group_22151
 #: model:account.group.template,name:l10n_lu.account_group_22151
 msgid "Investment properties in Luxembourg"
 msgstr "Immeubles de placement au Luxembourg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22152
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22152
+#: model:account.group,name:l10n_lu.2_account_group_22152
 #: model:account.group.template,name:l10n_lu.account_group_22152
 msgid "Investment properties in foreign countries"
 msgstr "Immeubles de placement à l'étranger"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42131
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42131
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42231
+#: model:account.group,name:l10n_lu.2_account_group_42131
+#: model:account.group,name:l10n_lu.2_account_group_42231
 #: model:account.group.template,name:l10n_lu.account_group_42131
 #: model:account.group.template,name:l10n_lu.account_group_42231
 msgid "Investment subsidies"
 msgstr "Subventions d'investissement"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_42171
+#: model:account.group,name:l10n_lu.2_account_group_4621
 #: model:account.group.template,name:l10n_lu.account_group_42171
 #: model:account.group.template,name:l10n_lu.account_group_4621
 msgid "Joint Social Security Centre (CCSS)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61111
+#: model:account.group,name:l10n_lu.2_account_group_2211
+#: model:account.group,name:l10n_lu.2_account_group_61111
 #: model:account.group.template,name:l10n_lu.account_group_2211
 #: model:account.group.template,name:l10n_lu.account_group_61111
 msgid "Land"
 msgstr "Terrains"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60762
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60762
+#: model:account.group,name:l10n_lu.2_account_group_60762
 #: model:account.group.template,name:l10n_lu.account_group_60762
 msgid "Land for resale"
 msgstr "Terrains destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_22111
 #: model:account.group.template,name:l10n_lu.account_group_22111
 msgid "Land in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22112
+#: model:account.group,name:l10n_lu.2_account_group_22112
 #: model:account.group.template,name:l10n_lu.account_group_22112
 msgid "Land in foreign countries"
 msgstr "Terrains à l'étranger"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2241
 #: model:account.group.template,name:l10n_lu.account_group_2241
 msgid "Land, fitting-outs and buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22411
+#: model:account.group,name:l10n_lu.2_account_group_22411
 #: model:account.group.template,name:l10n_lu.account_group_22411
 msgid "Land, fitting-outs and buildings in Luxembourg"
 msgstr "Terrains, aménagements et constructions au Luxembourg"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22412
+#: model:account.group,name:l10n_lu.2_account_group_22412
 #: model:account.group.template,name:l10n_lu.account_group_22412
 msgid "Land, fitting-outs and buildings in foreign countries"
 msgstr "Terrains, aménagements et constructions à l'étranger"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7221
+#: model:account.group,name:l10n_lu.2_account_group_7221
 #: model:account.group.template,name:l10n_lu.account_group_7221
 msgid "Land, fittings and buildings"
 msgstr "Terrains, aménagements et constructions"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_221
 #: model:account.group.template,name:l10n_lu.account_group_221
 msgid "Land, fixtures and fitting-outs and buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47162
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47262
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47162
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47262
+#: model:account.group,name:l10n_lu.2_account_group_47162
+#: model:account.group,name:l10n_lu.2_account_group_47262
 #: model:account.group.template,name:l10n_lu.account_group_47162
 #: model:account.group.template,name:l10n_lu.account_group_47262
 msgid "Lease debts"
 msgstr "Dettes de leasing"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_131
 #: model:account.account.template,name:l10n_lu.lu_2011_account_131
+#: model:account.group,name:l10n_lu.2_account_group_131
 #: model:account.group.template,name:l10n_lu.account_group_131
 msgid "Legal reserve"
 msgstr "Réserve légale"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61341
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61341
+#: model:account.group,name:l10n_lu.2_account_group_61341
 #: model:account.group.template,name:l10n_lu.account_group_61341
 msgid "Legal, litigation and similar fees"
 msgstr "Honoraires juridiques, de contentieux et assimilés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47163
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47263
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47163
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47263
+#: model:account.group,name:l10n_lu.2_account_group_47163
+#: model:account.group,name:l10n_lu.2_account_group_47263
 #: model:account.group.template,name:l10n_lu.account_group_47163
 #: model:account.group.template,name:l10n_lu.account_group_47263
 msgid "Life annuities"
 msgstr "Rentes viagères"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106141
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106141
 msgid "Life insurance"
 msgstr "Vie"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_486
 #: model:account.account.template,name:l10n_lu.lu_2011_account_486
+#: model:account.group,name:l10n_lu.2_account_group_486
 #: model:account.group.template,name:l10n_lu.account_group_486
 msgid "Linking accounts (branches) - Assets"
 msgstr "Comptes de liaison (succursales) – Actif"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_487
 #: model:account.account.template,name:l10n_lu.lu_2011_account_487
+#: model:account.group,name:l10n_lu.2_account_group_487
 #: model:account.group.template,name:l10n_lu.account_group_487
 msgid "Linking accounts (branches) - Liabilities"
 msgstr "Comptes de liaison (succursales) – Passif"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60312
+#: model:account.group,name:l10n_lu.2_account_group_60312
 #: model:account.group.template,name:l10n_lu.account_group_60312
 msgid "Liquid fuels"
 msgstr "Combustibles liquides"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61842
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61842
+#: model:account.group,name:l10n_lu.2_account_group_61842
 #: model:account.group.template,name:l10n_lu.account_group_61842
 msgid "Liquid fuels (oil, motor fuel, etc.)"
 msgstr "Combustibles liquides (mazout, carburants, etc.)"
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2011_chart_1_liquidity_transfer
+#: model:account.account,name:l10n_lu.2_lu_2011_chart_1_liquidity_transfer
 msgid "Liquidity Transfer"
 msgstr "Transfert de liquidité"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5084
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5084
+#: model:account.group,name:l10n_lu.2_account_group_5084
 #: model:account.group.template,name:l10n_lu.account_group_5084
 msgid "Listed debenture loans"
 msgstr "Obligations – Titres cotés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_235111
 #: model:account.account.template,name:l10n_lu.lu_2020_account_235111
+#: model:account.group,name:l10n_lu.2_account_group_235111
 #: model:account.group.template,name:l10n_lu.account_group_235111
 msgid "Listed shares"
 msgstr "Actions cotées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2236
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2236
+#: model:account.group,name:l10n_lu.2_account_group_2236
 #: model:account.group.template,name:l10n_lu.account_group_2236
 msgid "Livestock"
 msgstr "Cheptel"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_204
 #: model:account.account.template,name:l10n_lu.lu_2011_account_204
+#: model:account.group,name:l10n_lu.2_account_group_204
 #: model:account.group.template,name:l10n_lu.account_group_204
 msgid "Loan issuances expenses"
 msgstr "Frais d'émission d'emprunts"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_2361
 #: model:account.account.template,name:l10n_lu.lu_2020_account_2361
+#: model:account.group,name:l10n_lu.2_account_group_2361
 #: model:account.group.template,name:l10n_lu.account_group_2361
 msgid "Loans"
 msgstr "Prêts"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41112
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41122
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41212
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41222
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45112
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45122
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45212
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41212
@@ -4566,6 +5750,14 @@ msgstr "Prêts"
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45222
+#: model:account.group,name:l10n_lu.2_account_group_41112
+#: model:account.group,name:l10n_lu.2_account_group_41122
+#: model:account.group,name:l10n_lu.2_account_group_41212
+#: model:account.group,name:l10n_lu.2_account_group_41222
+#: model:account.group,name:l10n_lu.2_account_group_45112
+#: model:account.group,name:l10n_lu.2_account_group_45122
+#: model:account.group,name:l10n_lu.2_account_group_45212
+#: model:account.group,name:l10n_lu.2_account_group_45222
 #: model:account.group.template,name:l10n_lu.account_group_41112
 #: model:account.group.template,name:l10n_lu.account_group_41122
 #: model:account.group.template,name:l10n_lu.account_group_41212
@@ -4578,21 +5770,32 @@ msgid "Loans and advances"
 msgstr "Prêts et avances"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4716
+#: model:account.group,name:l10n_lu.2_account_group_4726
 #: model:account.group.template,name:l10n_lu.account_group_4716
 #: model:account.group.template,name:l10n_lu.account_group_4726
 msgid "Loans and similar debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61332
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61332
+#: model:account.group,name:l10n_lu.2_account_group_61332
 #: model:account.group.template,name:l10n_lu.account_group_61332
 msgid "Loans' issuance expenses"
 msgstr "Frais sur émission d'emprunts"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75116
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65216
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75216
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75116
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65216
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75216
+#: model:account.group,name:l10n_lu.2_account_group_236
+#: model:account.group,name:l10n_lu.2_account_group_65216
+#: model:account.group,name:l10n_lu.2_account_group_75216
+#: model:account.group,name:l10n_lu.2_account_group_75226
 #: model:account.group.template,name:l10n_lu.account_group_236
 #: model:account.group.template,name:l10n_lu.account_group_65216
 #: model:account.group.template,name:l10n_lu.account_group_75216
@@ -4601,17 +5804,21 @@ msgid "Loans, deposits and claims held as fixed assets"
 msgstr "Prêts, dépôts et créances immobilisés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2363
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2363
+#: model:account.group,name:l10n_lu.2_account_group_2363
 #: model:account.group.template,name:l10n_lu.account_group_2363
 msgid "Long-term receivables"
 msgstr "Créances immobilisées"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65222
 #: model:account.group.template,name:l10n_lu.account_group_65222
 msgid "Loss on disposal of amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65224
 #: model:account.group.template,name:l10n_lu.account_group_65224
 msgid ""
 "Loss on disposal of amounts owed by undertakings with which the undertaking "
@@ -4619,31 +5826,37 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6522
 #: model:account.group.template,name:l10n_lu.account_group_6522
 msgid "Loss on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_644
 #: model:account.group.template,name:l10n_lu.account_group_644
 msgid "Loss on disposal of intangible and tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6441
 #: model:account.group.template,name:l10n_lu.account_group_6441
 msgid "Loss on disposal of intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65226
 #: model:account.group.template,name:l10n_lu.account_group_65226
 msgid "Loss on disposal of loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65223
 #: model:account.group.template,name:l10n_lu.account_group_65223
 msgid "Loss on disposal of participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_654
 #: model:account.group.template,name:l10n_lu.account_group_654
 msgid ""
 "Loss on disposal of receivables and transferable securities from current "
@@ -4651,37 +5864,45 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6541
 #: model:account.group.template,name:l10n_lu.account_group_6541
 msgid "Loss on disposal of receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65225
 #: model:account.group.template,name:l10n_lu.account_group_65225
 msgid "Loss on disposal of securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65221
 #: model:account.group.template,name:l10n_lu.account_group_65221
 msgid "Loss on disposal of shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6442
 #: model:account.group.template,name:l10n_lu.account_group_6442
 msgid "Loss on disposal of tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6542
 #: model:account.group.template,name:l10n_lu.account_group_6542
 msgid "Loss on disposal of transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_645
 #: model:account.group.template,name:l10n_lu.account_group_645
 msgid "Losses on bad debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6037
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6037
+#: model:account.group,name:l10n_lu.2_account_group_6037
 #: model:account.group.template,name:l10n_lu.account_group_6037
 msgid "Lubricants"
 msgstr "Lubrifiants"
@@ -4692,251 +5913,325 @@ msgid "Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_LU
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_LU
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_LU
 msgid "Luxembourgish Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461221
+#: model:account.group,name:l10n_lu.2_account_group_461221
 #: model:account.group.template,name:l10n_lu.account_group_461221
 msgid "MBT - Tax accrual"
 msgstr "ICC – charge fiscale estimée"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461222
+#: model:account.group,name:l10n_lu.2_account_group_461222
 #: model:account.group.template,name:l10n_lu.account_group_461222
 msgid "MBT - Tax payable"
 msgstr "ICC – dette fiscale à payer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6721
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6721
+#: model:account.group,name:l10n_lu.2_account_group_6721
 #: model:account.group.template,name:l10n_lu.account_group_6721
 msgid "MBT - current financial year"
 msgstr "ICC - exercice courant"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6722
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6722
+#: model:account.group,name:l10n_lu.2_account_group_6722
 #: model:account.group.template,name:l10n_lu.account_group_6722
 msgid "MBT - previous financial years"
 msgstr "ICC - exercices antérieurs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2222
+#: model:account.group,name:l10n_lu.2_account_group_2222
 #: model:account.group.template,name:l10n_lu.account_group_2222
 msgid "Machinery"
 msgstr "Machines"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6032
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61854
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6032
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61854
+#: model:account.group,name:l10n_lu.2_account_group_6032
+#: model:account.group,name:l10n_lu.2_account_group_61854
 #: model:account.group.template,name:l10n_lu.account_group_6032
 #: model:account.group.template,name:l10n_lu.account_group_61854
 msgid "Maintenance supplies"
 msgstr "Produits d'entretien"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_615211
 #: model:account.group.template,name:l10n_lu.account_group_615211
 msgid "Management (if appropriate owner and partner)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_615211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_615211
 msgid "Management (respectively owner and partner)"
 msgstr "Direction (respectivement exploitant et associés)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6151
 #: model:account.group.template,name:l10n_lu.account_group_6151
 msgid "Marketing and advertising costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_615
 #: model:account.group.template,name:l10n_lu.account_group_615
 msgid "Marketing and communication costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60761
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60761
+#: model:account.group,name:l10n_lu.2_account_group_60761
 #: model:account.group.template,name:l10n_lu.account_group_60761
 msgid "Merchandise"
 msgstr "Marchandises"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_112
+#: model:account.group,name:l10n_lu.2_account_group_112
 #: model:account.group.template,name:l10n_lu.account_group_112
 msgid "Merger premium"
 msgstr "Primes de fusion"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_618
 #: model:account.group.template,name:l10n_lu.account_group_618
 msgid "Miscellaneous external charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6488
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6488
+#: model:account.group,name:l10n_lu.2_account_group_6488
 #: model:account.group.template,name:l10n_lu.account_group_6488
 msgid "Miscellaneous operating charges"
 msgstr "Charges d'exploitation diverses"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7488
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7488
+#: model:account.group,name:l10n_lu.2_account_group_7488
 #: model:account.group.template,name:l10n_lu.account_group_7488
 msgid "Miscellaneous operating income"
 msgstr "Produits d'exploitation divers"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4218
+#: model:account.group,name:l10n_lu.2_account_group_4228
 #: model:account.group.template,name:l10n_lu.account_group_4218
 #: model:account.group.template,name:l10n_lu.account_group_4228
 msgid "Miscellaneous receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221313
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221313
+#: model:account.group,name:l10n_lu.2_account_group_221313
 #: model:account.group.template,name:l10n_lu.account_group_221313
 msgid "Mixed-use buildings"
 msgstr "Constructions / Bâtiments à usage mixte"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6036
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6036
+#: model:account.group,name:l10n_lu.2_account_group_6036
 #: model:account.group.template,name:l10n_lu.account_group_6036
 msgid "Motor fuels"
 msgstr "Carburants"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2232
+#: model:account.group,name:l10n_lu.2_account_group_2232
 #: model:account.group.template,name:l10n_lu.account_group_2232
 msgid "Motor vehicles"
 msgstr "Véhicules de transport"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6466
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6466
+#: model:account.group,name:l10n_lu.2_account_group_6466
 #: model:account.group.template,name:l10n_lu.account_group_6466
 msgid "Motor-vehicle taxes"
 msgstr "Taxes sur les véhicules"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4611
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4611
+#: model:account.group,name:l10n_lu.2_account_group_4611
 #: model:account.group.template,name:l10n_lu.account_group_4611
 msgid "Municipal authorities"
 msgstr "Administrations communales"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42142
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42142
+#: model:account.group,name:l10n_lu.2_account_group_42142
+#: model:account.group,name:l10n_lu.2_account_group_672
 #: model:account.group.template,name:l10n_lu.account_group_42142
 #: model:account.group.template,name:l10n_lu.account_group_672
 msgid "Municipal business tax"
 msgstr "Impôt commercial communal (ICC)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106284
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106284
+#: model:account.group,name:l10n_lu.2_account_group_46122
 #: model:account.group.template,name:l10n_lu.account_group_46122
 msgid "Municipal business tax (MBT)"
 msgstr "Impôt commercial communal (ICC)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106183
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106183
 msgid "Municipal business tax - payment in arrears"
 msgstr "Impôt commercial communal (ICC) - arriérés payés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461231
+#: model:account.group,name:l10n_lu.2_account_group_461231
 #: model:account.group.template,name:l10n_lu.account_group_461231
 msgid "NWT - Tax accrual"
 msgstr "IF – charge fiscale estimée"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461232
+#: model:account.group,name:l10n_lu.2_account_group_461232
 #: model:account.group.template,name:l10n_lu.account_group_461232
 msgid "NWT - Tax payable"
 msgstr "IF – dette fiscale à payer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6811
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6811
+#: model:account.group,name:l10n_lu.2_account_group_6811
 #: model:account.group.template,name:l10n_lu.account_group_6811
 msgid "NWT - current financial year"
 msgstr "IF - exercice courant"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6812
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6812
+#: model:account.group,name:l10n_lu.2_account_group_6812
 #: model:account.group.template,name:l10n_lu.account_group_6812
 msgid "NWT - previous financial years"
 msgstr "IF - exercices antérieurs"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_70
 #: model:account.group.template,name:l10n_lu.account_group_70
 msgid "Net turnover"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42143
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42143
+#: model:account.group,name:l10n_lu.2_account_group_42143
 #: model:account.group.template,name:l10n_lu.account_group_42143
 msgid "Net wealth tax"
 msgstr "Impôt sur la fortune (IF)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_46123
+#: model:account.group,name:l10n_lu.2_account_group_681
 #: model:account.group.template,name:l10n_lu.account_group_46123
 #: model:account.group.template,name:l10n_lu.account_group_681
 msgid "Net wealth tax (NWT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_193
 #: model:account.group.template,name:l10n_lu.account_group_193
 msgid "Non-convertible debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6462
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6462
+#: model:account.group,name:l10n_lu.2_account_group_6462
 #: model:account.group.template,name:l10n_lu.account_group_6462
 msgid "Non-refundable VAT"
 msgstr "TVA non récupérable"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221312
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221312
+#: model:account.group,name:l10n_lu.2_account_group_221312
 #: model:account.group.template,name:l10n_lu.account_group_221312
 msgid "Non-residential buildings"
 msgstr "Constructions / Bâtiments non résidentiels"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7099
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7099
+#: model:account.group,name:l10n_lu.2_account_group_7099
 #: model:account.group.template,name:l10n_lu.account_group_7099
 msgid "Not allocated rebates, discounts and refunds"
 msgstr "RRR non affectés"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_NO
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_NO
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_NO
 msgid "Not liable to VAT"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6135
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6135
+#: model:account.group,name:l10n_lu.2_account_group_6135
 #: model:account.group.template,name:l10n_lu.account_group_6135
 msgid "Notarial and similar fees"
 msgstr "Frais d'actes notariés et assimilés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6035
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6035
+#: model:account.group,name:l10n_lu.2_account_group_6035
 #: model:account.group.template,name:l10n_lu.account_group_6035
 msgid "Office and administrative supplies"
 msgstr "Fournitures administratives et de bureau"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61851
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61851
+#: model:account.group,name:l10n_lu.2_account_group_61851
 #: model:account.group.template,name:l10n_lu.account_group_61851
 msgid "Office supplies"
 msgstr "Fournitures administratives et de bureau"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75411
 msgid "On affiliated undertakings"
 msgstr "Sur des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75413
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75413
 msgid "On other current receivables"
 msgstr "Sur autres créances de l'actif circulant"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75412
 msgid ""
 "On undertakings with which the undertaking is linked by virtue of "
@@ -4945,26 +6240,44 @@ msgstr ""
 "Sur des entreprises avec lesquelles l'entreprise a un lien de participation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_1881
 #: model:account.account.template,name:l10n_lu.lu_2011_account_1881
+#: model:account.group,name:l10n_lu.2_account_group_1881
 #: model:account.group.template,name:l10n_lu.account_group_1881
 msgid "Operating provisions"
 msgstr "Provisions d'exploitation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42132
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42232
+#: model:account.group,name:l10n_lu.2_account_group_42132
+#: model:account.group,name:l10n_lu.2_account_group_42232
 #: model:account.group.template,name:l10n_lu.account_group_42132
 #: model:account.group.template,name:l10n_lu.account_group_42232
 msgid "Operating subsidies"
 msgstr "Subventions d'exploitation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61418
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6228
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61128
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61158
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61228
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61858
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61418
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6228
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61128
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61158
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61228
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61858
+#: model:account.group,name:l10n_lu.2_account_group_61128
+#: model:account.group,name:l10n_lu.2_account_group_61158
+#: model:account.group,name:l10n_lu.2_account_group_61228
+#: model:account.group,name:l10n_lu.2_account_group_61418
+#: model:account.group,name:l10n_lu.2_account_group_61858
+#: model:account.group,name:l10n_lu.2_account_group_6228
 #: model:account.group.template,name:l10n_lu.account_group_61128
 #: model:account.group.template,name:l10n_lu.account_group_61158
 #: model:account.group.template,name:l10n_lu.account_group_61228
@@ -4975,12 +6288,15 @@ msgid "Other"
 msgstr "Autres"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106178
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106178
 msgid "Other acquisitions"
 msgstr "Autres acquisitions"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61338
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61338
+#: model:account.group,name:l10n_lu.2_account_group_61338
 #: model:account.group.template,name:l10n_lu.account_group_61338
 msgid ""
 "Other banking and similar services (except interest and similar expenses)"
@@ -4988,120 +6304,156 @@ msgstr ""
 "Autres services bancaires et assimilés (hors intérêts et frais assimilés)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6218
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6218
+#: model:account.group,name:l10n_lu.2_account_group_6218
 #: model:account.group.template,name:l10n_lu.account_group_6218
 msgid "Other benefits"
 msgstr "Autres avantages"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221318
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221318
+#: model:account.group,name:l10n_lu.2_account_group_221318
 #: model:account.group.template,name:l10n_lu.account_group_221318
 msgid "Other buildings"
 msgstr "Autres constructions / bâtiments"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_168
 #: model:account.account.template,name:l10n_lu.lu_2011_account_168
+#: model:account.group,name:l10n_lu.2_account_group_168
 #: model:account.group.template,name:l10n_lu.account_group_168
 msgid "Other capital investment subsidies"
 msgstr "Autres subventions d'investissement en capital"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_518
 #: model:account.account.template,name:l10n_lu.lu_2011_account_518
+#: model:account.group,name:l10n_lu.2_account_group_518
 #: model:account.group.template,name:l10n_lu.account_group_518
 msgid "Other cash amounts"
 msgstr "Autres avoirs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_708
 #: model:account.account.template,name:l10n_lu.lu_2020_account_708
+#: model:account.group,name:l10n_lu.2_account_group_708
 #: model:account.group.template,name:l10n_lu.account_group_708
 msgid "Other components of turnover"
 msgstr "Autres éléments du chiffre d'affaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6038
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6038
+#: model:account.group,name:l10n_lu.2_account_group_6038
 #: model:account.group.template,name:l10n_lu.account_group_6038
 msgid "Other consumable supplies"
 msgstr "Autres fournitures consommables"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106158
 msgid "Other contributions"
 msgstr "Autres cotisations"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_47
 #: model:account.group.template,name:l10n_lu.account_group_47
 msgid "Other debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_472
 #: model:account.group.template,name:l10n_lu.account_group_472
 msgid "Other debts payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_471
 #: model:account.group.template,name:l10n_lu.account_group_471
 msgid "Other debts payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106248
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106248
 msgid "Other disposals"
 msgstr "Autres cessions"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6468
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6468
+#: model:account.group,name:l10n_lu.2_account_group_6468
 #: model:account.group.template,name:l10n_lu.account_group_6468
 msgid "Other duties and taxes"
 msgstr "Autres droits et taxes"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_61
 #: model:account.group.template,name:l10n_lu.account_group_61
 msgid "Other external charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_658
 #: model:account.group.template,name:l10n_lu.account_group_658
 msgid "Other financial charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6581
+#: model:account.group,name:l10n_lu.2_account_group_6581
 #: model:account.group.template,name:l10n_lu.account_group_6581
 msgid "Other financial charges - affiliated undertakings"
 msgstr "Autres charges financières - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6582
+#: model:account.group,name:l10n_lu.2_account_group_6582
 #: model:account.group.template,name:l10n_lu.account_group_6582
 msgid "Other financial charges - other"
 msgstr "Autres charges financières - autres"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_758
 #: model:account.group.template,name:l10n_lu.account_group_758
 msgid "Other financial income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7581
+#: model:account.group,name:l10n_lu.2_account_group_7581
 #: model:account.group.template,name:l10n_lu.account_group_7581
 msgid "Other financial income - affiliated undertakings"
 msgstr "Autres produits financiers - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7582
+#: model:account.group,name:l10n_lu.2_account_group_7582
 #: model:account.group.template,name:l10n_lu.account_group_7582
 msgid "Other financial income - other"
 msgstr "Autres produits financiers - autres "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2238
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2238
+#: model:account.group,name:l10n_lu.2_account_group_2238
 #: model:account.group.template,name:l10n_lu.account_group_2238
 msgid "Other fixtures"
 msgstr "Autres installations"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7223
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7333
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7223
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7333
+#: model:account.group,name:l10n_lu.2_account_group_7223
+#: model:account.group,name:l10n_lu.2_account_group_7333
 #: model:account.group.template,name:l10n_lu.account_group_7223
 #: model:account.group.template,name:l10n_lu.account_group_7333
 msgid ""
@@ -5110,7 +6462,10 @@ msgstr ""
 "Autres installations, outillage et mobilier (y compris matériel roulant)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2243
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2243
+#: model:account.group,name:l10n_lu.2_account_group_223
+#: model:account.group,name:l10n_lu.2_account_group_2243
 #: model:account.group.template,name:l10n_lu.account_group_223
 #: model:account.group.template,name:l10n_lu.account_group_2243
 msgid ""
@@ -5119,115 +6474,160 @@ msgstr ""
 "Autres installations, outillage et mobilier (y compris matériel roulant)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6738
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6738
+#: model:account.group,name:l10n_lu.2_account_group_6738
 #: model:account.group.template,name:l10n_lu.account_group_6738
 msgid "Other foreign income taxes"
 msgstr "Autres impôts étrangers sur le résultat"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421818
+#: model:account.account,name:l10n_lu.2_lu_2020_account_46158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421818
 #: model:account.account.template,name:l10n_lu.lu_2020_account_46158
+#: model:account.group,name:l10n_lu.2_account_group_421818
+#: model:account.group,name:l10n_lu.2_account_group_46158
 #: model:account.group.template,name:l10n_lu.account_group_421818
 #: model:account.group.template,name:l10n_lu.account_group_46158
 msgid "Other foreign taxes"
 msgstr "Autres impôts étrangers"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106168
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106168
 msgid "Other in kind withdrawals"
 msgstr "Autres prélèvements en nature"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7548
 #: model:account.group.template,name:l10n_lu.account_group_7548
 msgid "Other income from transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421628
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461428
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421628
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461428
+#: model:account.group,name:l10n_lu.2_account_group_421628
+#: model:account.group,name:l10n_lu.2_account_group_461428
 #: model:account.group.template,name:l10n_lu.account_group_421628
 #: model:account.group.template,name:l10n_lu.account_group_461428
 msgid "Other indirect taxes"
 msgstr "Autres impôts indirects"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6148
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6148
+#: model:account.group,name:l10n_lu.2_account_group_6148
 #: model:account.group.template,name:l10n_lu.account_group_6148
 msgid "Other insurances"
 msgstr "Autres assurances"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_755
 #: model:account.group.template,name:l10n_lu.account_group_755
 msgid "Other interest income from current assets and discounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221118
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221118
+#: model:account.group,name:l10n_lu.2_account_group_221118
 #: model:account.group.template,name:l10n_lu.account_group_221118
 msgid "Other land"
 msgstr "Autres terrains"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47161
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47261
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47161
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47261
+#: model:account.group,name:l10n_lu.2_account_group_47161
+#: model:account.group,name:l10n_lu.2_account_group_47261
 #: model:account.group.template,name:l10n_lu.account_group_47161
 #: model:account.group.template,name:l10n_lu.account_group_47261
 msgid "Other loans"
 msgstr "Autres emprunts"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4718
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4728
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4718
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4728
+#: model:account.group,name:l10n_lu.2_account_group_4718
+#: model:account.group,name:l10n_lu.2_account_group_4728
 #: model:account.group.template,name:l10n_lu.account_group_4718
 #: model:account.group.template,name:l10n_lu.account_group_4728
 msgid "Other miscellaneous debts"
 msgstr "Autres dettes diverses"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6188
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6188
+#: model:account.group,name:l10n_lu.2_account_group_6188
 #: model:account.group.template,name:l10n_lu.account_group_6188
 msgid "Other miscellaneous external charges"
 msgstr "Autres charges externes diverses"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_648
 #: model:account.group.template,name:l10n_lu.account_group_648
 msgid "Other miscellaneous operating charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_748
 #: model:account.group.template,name:l10n_lu.account_group_748
 msgid "Other miscellaneous operating income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42188
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42288
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42188
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42288
+#: model:account.group,name:l10n_lu.2_account_group_42188
+#: model:account.group,name:l10n_lu.2_account_group_42288
 #: model:account.group.template,name:l10n_lu.account_group_42188
 #: model:account.group.template,name:l10n_lu.account_group_42288
 msgid "Other miscellaneous receivables"
 msgstr "Autres créances diverses"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5088
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5088
+#: model:account.group,name:l10n_lu.2_account_group_5088
 #: model:account.group.template,name:l10n_lu.account_group_5088
 msgid "Other miscellaneous transferable securities"
 msgstr "Autres valeurs mobilières diverses"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_64
 #: model:account.group.template,name:l10n_lu.account_group_64
 msgid "Other operating charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_74
 #: model:account.group.template,name:l10n_lu.account_group_74
 msgid "Other operating income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45118
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45128
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45218
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45228
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45118
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45218
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45228
+#: model:account.group,name:l10n_lu.2_account_group_45118
+#: model:account.group,name:l10n_lu.2_account_group_45128
+#: model:account.group,name:l10n_lu.2_account_group_45218
+#: model:account.group,name:l10n_lu.2_account_group_45228
 #: model:account.group.template,name:l10n_lu.account_group_45118
 #: model:account.group.template,name:l10n_lu.account_group_45128
 #: model:account.group.template,name:l10n_lu.account_group_45218
@@ -5236,47 +6636,70 @@ msgid "Other payables"
 msgstr "Autres dettes"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106148
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106148
 msgid "Other private insurance premiums"
 msgstr "Autres primes d’assurances privées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61348
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61348
+#: model:account.group,name:l10n_lu.2_account_group_61348
 #: model:account.group.template,name:l10n_lu.account_group_61348
 msgid "Other professional fees"
 msgstr "Autres honoraires"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_188
 #: model:account.group.template,name:l10n_lu.account_group_188
 msgid "Other provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6088
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6088
+#: model:account.group,name:l10n_lu.2_account_group_6088
 #: model:account.group.template,name:l10n_lu.account_group_6088
 msgid "Other purchases included in the production of goods and services"
 msgstr "Autres achats incorporés aux ouvrages et produits"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61518
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61518
+#: model:account.group,name:l10n_lu.2_account_group_61518
 #: model:account.group.template,name:l10n_lu.account_group_61518
 msgid "Other purchases of advertising services"
 msgstr "Autres achats de services publicitaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6082
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6082
+#: model:account.group,name:l10n_lu.2_account_group_6082
 #: model:account.group.template,name:l10n_lu.account_group_6082
 msgid ""
 "Other purchases of material included in the production of goods and services"
 msgstr "Autres achats de matériel incorporés aux ouvrages et produits"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41118
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41128
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41218
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41228
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42168
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6454
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41118
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41218
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41228
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42168
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6454
+#: model:account.group,name:l10n_lu.2_account_group_41118
+#: model:account.group,name:l10n_lu.2_account_group_41128
+#: model:account.group,name:l10n_lu.2_account_group_41218
+#: model:account.group,name:l10n_lu.2_account_group_41228
+#: model:account.group,name:l10n_lu.2_account_group_42
+#: model:account.group,name:l10n_lu.2_account_group_42168
+#: model:account.group,name:l10n_lu.2_account_group_6454
 #: model:account.group.template,name:l10n_lu.account_group_41118
 #: model:account.group.template,name:l10n_lu.account_group_41128
 #: model:account.group.template,name:l10n_lu.account_group_41218
@@ -5288,92 +6711,126 @@ msgid "Other receivables"
 msgstr "Autres créances"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_422
 #: model:account.group.template,name:l10n_lu.account_group_422
 msgid "Other receivables after one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_421
 #: model:account.group.template,name:l10n_lu.account_group_421
 msgid "Other receivables within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64658
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64658
+#: model:account.group,name:l10n_lu.2_account_group_64658
 #: model:account.group.template,name:l10n_lu.account_group_64658
 msgid "Other registration fees, stamp duties and mortgage duties"
 msgstr "Autres droits d'enregistrement et de timbre, droits d'hypothèques"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6138
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6138
+#: model:account.group,name:l10n_lu.2_account_group_6138
 #: model:account.group.template,name:l10n_lu.account_group_6138
 msgid "Other remuneration of intermediaries and professional fees"
 msgstr "Autres rémunérations d'intermédiaires et honoraires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_1381
 #: model:account.account.template,name:l10n_lu.lu_2011_account_1381
+#: model:account.group,name:l10n_lu.2_account_group_1381
 #: model:account.group.template,name:l10n_lu.account_group_1381
 msgid "Other reserves available for distribution"
 msgstr "Autres réserves disponibles"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1382
 #: model:account.group.template,name:l10n_lu.account_group_1382
 msgid "Other reserves not available for distribution"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_138
 #: model:account.group.template,name:l10n_lu.account_group_138
 msgid "Other reserves, including fair-value reserve"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_128
+#: model:account.group,name:l10n_lu.2_account_group_128
 #: model:account.group.template,name:l10n_lu.account_group_128
 msgid "Other revaluation reserves"
 msgstr "Autres réserves de réévaluation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2358
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2358
+#: model:account.group,name:l10n_lu.2_account_group_2358
 #: model:account.group.template,name:l10n_lu.account_group_2358
 msgid "Other securities held as fixed assets"
 msgstr "Autres titres ayant le caractère d'immobilisations"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_23528
 #: model:account.account.template,name:l10n_lu.lu_2011_account_23528
+#: model:account.group,name:l10n_lu.2_account_group_23528
 #: model:account.group.template,name:l10n_lu.account_group_23528
 msgid "Other securities held as fixed assets (creditor's right)"
 msgstr "Autres titres immobilisés (droit de créance)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_23518
 #: model:account.account.template,name:l10n_lu.lu_2011_account_23518
+#: model:account.group,name:l10n_lu.2_account_group_23518
 #: model:account.group.template,name:l10n_lu.account_group_23518
 msgid "Other securities held as fixed assets (equity right)"
 msgstr "Autres titres immobilisés (droit de propriété)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47164
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47264
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47164
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47264
+#: model:account.group,name:l10n_lu.2_account_group_47168
+#: model:account.group,name:l10n_lu.2_account_group_47268
 #: model:account.group.template,name:l10n_lu.account_group_47168
 #: model:account.group.template,name:l10n_lu.account_group_47268
 msgid "Other similar debts"
 msgstr "Autres dettes assimilées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_208
 #: model:account.account.template,name:l10n_lu.lu_2011_account_208
+#: model:account.group,name:l10n_lu.2_account_group_208
 #: model:account.group.template,name:l10n_lu.account_group_208
 msgid "Other similar expenses"
 msgstr "Autres frais assimilés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6438
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6438
+#: model:account.group,name:l10n_lu.2_account_group_6438
 #: model:account.group.template,name:l10n_lu.account_group_6438
 msgid "Other similar remuneration"
 msgstr "Autres rémunérations assimilées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64158
+#: model:account.account,name:l10n_lu.2_lu_2011_account_721258
+#: model:account.account,name:l10n_lu.2_lu_2011_account_74158
+#: model:account.account,name:l10n_lu.2_lu_2020_account_703158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_721258
 #: model:account.account.template,name:l10n_lu.lu_2011_account_74158
 #: model:account.account.template,name:l10n_lu.lu_2020_account_703158
+#: model:account.group,name:l10n_lu.2_account_group_64158
+#: model:account.group,name:l10n_lu.2_account_group_703158
+#: model:account.group,name:l10n_lu.2_account_group_721258
+#: model:account.group,name:l10n_lu.2_account_group_74158
 #: model:account.group.template,name:l10n_lu.account_group_64158
 #: model:account.group.template,name:l10n_lu.account_group_703158
 #: model:account.group.template,name:l10n_lu.account_group_721258
@@ -5382,94 +6839,130 @@ msgid "Other similar rights and assets"
 msgstr "Autres droits et valeurs similaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212158
+#: model:account.group,name:l10n_lu.2_account_group_212158
 #: model:account.group.template,name:l10n_lu.account_group_212158
 msgid "Other similar rights and assets acquired for consideration"
 msgstr "Autres droits et valeurs similaires acquis à titre onéreux"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212258
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212258
+#: model:account.group,name:l10n_lu.2_account_group_212258
 #: model:account.group.template,name:l10n_lu.account_group_212258
 msgid "Other similar rights and assets created by the undertaking itself"
 msgstr "Autres droits et valeurs similaires créés par l'entreprise elle-même"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42178
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4628
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42178
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4628
+#: model:account.group,name:l10n_lu.2_account_group_42178
+#: model:account.group,name:l10n_lu.2_account_group_4628
 #: model:account.group.template,name:l10n_lu.account_group_42178
 #: model:account.group.template,name:l10n_lu.account_group_4628
 msgid "Other social bodies"
 msgstr "Autres organismes sociaux"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6232
+#: model:account.group,name:l10n_lu.2_account_group_6232
 #: model:account.group.template,name:l10n_lu.account_group_6232
 msgid "Other social security costs (including illness, accidents, a.s.o.)"
 msgstr "Autres charges sociales (y inclus maladie, accident, etc.)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106198
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106198
 msgid "Other special private withdrawals"
 msgstr "Autres prélèvements privés particuliers"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_624
 #: model:account.group.template,name:l10n_lu.account_group_624
 msgid "Other staff expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6248
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6248
+#: model:account.group,name:l10n_lu.2_account_group_6248
 #: model:account.group.template,name:l10n_lu.account_group_6248
 msgid "Other staff expenses not mentioned above"
 msgstr "Autres frais de personnel non visés ci-dessus"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_622
 #: model:account.group.template,name:l10n_lu.account_group_622
 msgid "Other staff remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42138
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42238
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42138
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42238
+#: model:account.group,name:l10n_lu.2_account_group_42138
+#: model:account.group,name:l10n_lu.2_account_group_42238
 #: model:account.group.template,name:l10n_lu.account_group_42138
 #: model:account.group.template,name:l10n_lu.account_group_42238
 msgid "Other subsidies"
 msgstr "Autres subventions"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7458
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7458
+#: model:account.group,name:l10n_lu.2_account_group_7458
 #: model:account.group.template,name:l10n_lu.account_group_7458
 msgid "Other subsidies for operating activities"
 msgstr "Autres subventions d'exploitation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621128
+#: model:account.group,name:l10n_lu.2_account_group_621128
 #: model:account.group.template,name:l10n_lu.account_group_621128
 msgid "Other supplements"
 msgstr "Autres suppléments"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106288
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106288
 msgid "Other tax refunds"
 msgstr "Autres remboursements d’impôts"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106188
+#: model:account.account,name:l10n_lu.2_lu_2011_account_688
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106188
 #: model:account.account.template,name:l10n_lu.lu_2011_account_688
+#: model:account.group,name:l10n_lu.2_account_group_688
 #: model:account.group.template,name:l10n_lu.account_group_688
 msgid "Other taxes"
 msgstr "Autres impôts"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_68
 #: model:account.group.template,name:l10n_lu.account_group_68
 msgid "Other taxes not included in the previous caption"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75488
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65428
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75318
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75428
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75488
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65428
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75318
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75428
+#: model:account.group,name:l10n_lu.2_account_group_508
+#: model:account.group,name:l10n_lu.2_account_group_65428
+#: model:account.group,name:l10n_lu.2_account_group_75428
+#: model:account.group,name:l10n_lu.2_account_group_75488
 #: model:account.group.template,name:l10n_lu.account_group_508
 #: model:account.group.template,name:l10n_lu.account_group_65428
 #: model:account.group.template,name:l10n_lu.account_group_75428
@@ -5478,28 +6971,41 @@ msgid "Other transferable securities"
 msgstr "Autres valeurs mobilières"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6168
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6168
+#: model:account.group,name:l10n_lu.2_account_group_6168
 #: model:account.group.template,name:l10n_lu.account_group_6168
 msgid "Other transportation"
 msgstr "Autres transports"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60814
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60814
+#: model:account.group,name:l10n_lu.2_account_group_60814
 #: model:account.group.template,name:l10n_lu.account_group_60814
 msgid "Outsourcing included in the production of goods and services"
 msgstr "Sous-traitance incorporée aux ouvrages et produits"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621123
+#: model:account.group,name:l10n_lu.2_account_group_621123
 #: model:account.group.template,name:l10n_lu.account_group_621123
 msgid "Overtime"
 msgstr "Heures supplémentaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75482
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65422
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75312
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75422
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75482
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75312
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75422
+#: model:account.group,name:l10n_lu.2_account_group_65422
+#: model:account.group,name:l10n_lu.2_account_group_75422
+#: model:account.group,name:l10n_lu.2_account_group_75482
 #: model:account.group.template,name:l10n_lu.account_group_65422
 #: model:account.group.template,name:l10n_lu.account_group_75422
 #: model:account.group.template,name:l10n_lu.account_group_75482
@@ -5507,7 +7013,9 @@ msgid "Own shares or corporate units"
 msgstr "Actions propres ou parts propres"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_502
 #: model:account.account.template,name:l10n_lu.lu_2011_account_502
+#: model:account.group,name:l10n_lu.2_account_group_502
 #: model:account.group.template,name:l10n_lu.account_group_502
 msgid "Own shares or own corporate units"
 msgstr "Actions propres ou parts propres"
@@ -5518,10 +7026,18 @@ msgid "PCMN Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_233
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75113
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65213
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75213
 #: model:account.account.template,name:l10n_lu.lu_2011_account_233
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75113
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65213
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75213
+#: model:account.group,name:l10n_lu.2_account_group_233
+#: model:account.group,name:l10n_lu.2_account_group_65213
+#: model:account.group,name:l10n_lu.2_account_group_75213
+#: model:account.group,name:l10n_lu.2_account_group_75223
 #: model:account.group.template,name:l10n_lu.account_group_233
 #: model:account.group.template,name:l10n_lu.account_group_65213
 #: model:account.group.template,name:l10n_lu.account_group_75213
@@ -5530,12 +7046,24 @@ msgid "Participating interests"
 msgstr "Participations"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21212
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21222
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6412
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72122
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7412
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70312
+#: model:account.group,name:l10n_lu.2_account_group_21212
+#: model:account.group,name:l10n_lu.2_account_group_21222
+#: model:account.group,name:l10n_lu.2_account_group_6412
+#: model:account.group,name:l10n_lu.2_account_group_70312
+#: model:account.group,name:l10n_lu.2_account_group_72122
+#: model:account.group,name:l10n_lu.2_account_group_7412
 #: model:account.group.template,name:l10n_lu.account_group_21212
 #: model:account.group.template,name:l10n_lu.account_group_21222
 #: model:account.group.template,name:l10n_lu.account_group_6412
@@ -5546,19 +7074,27 @@ msgid "Patents"
 msgstr "Brevets"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10622
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10622
 msgid "Personal holdings"
 msgstr "Avoirs privés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2221
+#: model:account.group,name:l10n_lu.2_account_group_2221
 #: model:account.group.template,name:l10n_lu.account_group_2221
 msgid "Plant"
 msgstr "Installations techniques"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2242
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2242
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7222
+#: model:account.group,name:l10n_lu.2_account_group_222
+#: model:account.group,name:l10n_lu.2_account_group_2242
+#: model:account.group,name:l10n_lu.2_account_group_7222
 #: model:account.group.template,name:l10n_lu.account_group_222
 #: model:account.group.template,name:l10n_lu.account_group_2242
 #: model:account.group.template,name:l10n_lu.account_group_7222
@@ -5566,133 +7102,176 @@ msgid "Plant and machinery"
 msgstr "Installations techniques et machines "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61531
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61531
+#: model:account.group,name:l10n_lu.2_account_group_61531
 #: model:account.group.template,name:l10n_lu.account_group_61531
 msgid "Postal charges"
 msgstr "Frais postaux"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6153
 #: model:account.group.template,name:l10n_lu.account_group_6153
 msgid "Postal charges and telecommunication costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62411
+#: model:account.group,name:l10n_lu.2_account_group_62411
 #: model:account.group.template,name:l10n_lu.account_group_62411
 msgid "Premiums for external pensions funds"
 msgstr "Primes à des fonds de pensions extérieurs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_114
+#: model:account.group,name:l10n_lu.2_account_group_114
 #: model:account.group.template,name:l10n_lu.account_group_114
 msgid "Premiums on conversion of bonds into shares"
 msgstr "Primes de conversion d'obligations en actions"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61511
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61511
+#: model:account.group,name:l10n_lu.2_account_group_61511
 #: model:account.group.template,name:l10n_lu.account_group_61511
 msgid "Press advertising"
 msgstr "Annonces et insertions"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_67322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_67322
+#: model:account.group,name:l10n_lu.2_account_group_67322
 #: model:account.group.template,name:l10n_lu.account_group_67322
 msgid "Previous financial years"
 msgstr "Exercices antérieurs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106174
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106244
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106174
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106244
 msgid "Private buildings"
 msgstr "Immeubles privés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106172
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106242
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106172
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106242
 msgid "Private car"
 msgstr "Voiture privée"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106171
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106241
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106171
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106241
 msgid "Private furniture"
 msgstr "Mobilier privé"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106173
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106173
 msgid "Private held securities"
 msgstr "Titres privés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10623
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10623
 msgid "Private loans"
 msgstr "Emprunts privés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10613
 msgid "Private share of medical services expenses"
 msgstr "Part personnelle des frais de maladie"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106243
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106243
 msgid "Private shares / bonds"
 msgstr "Titres privés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7451
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7451
+#: model:account.group,name:l10n_lu.2_account_group_7451
 #: model:account.group.template,name:l10n_lu.account_group_7451
 msgid "Product subsidies"
 msgstr "Subventions sur produits"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6134
 #: model:account.group.template,name:l10n_lu.account_group_6134
 msgid "Professional fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221112
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221112
+#: model:account.group,name:l10n_lu.2_account_group_221112
 #: model:account.group.template,name:l10n_lu.account_group_221112
 msgid "Property rights and similar"
 msgstr "Droits immobiliers et assimilés"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_18
 #: model:account.group.template,name:l10n_lu.account_group_18
 msgid "Provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_181
 #: model:account.account.template,name:l10n_lu.lu_2011_account_181
+#: model:account.group,name:l10n_lu.2_account_group_181
 #: model:account.group.template,name:l10n_lu.account_group_181
 msgid "Provisions for pensions and similar obligations"
 msgstr "Provisions pour pensions et obligations similaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_182
 #: model:account.account.template,name:l10n_lu.lu_2020_account_182
+#: model:account.group,name:l10n_lu.2_account_group_182
 #: model:account.group.template,name:l10n_lu.account_group_182
 msgid "Provisions for taxation"
 msgstr "Provisions pour impôts"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621122
+#: model:account.group,name:l10n_lu.2_account_group_621122
 #: model:account.group.template,name:l10n_lu.account_group_621122
 msgid "Public holidays"
 msgstr "Jours fériés légaux"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6083
 #: model:account.group.template,name:l10n_lu.account_group_6083
 msgid "Purchase of greenhous gas and similar emission quotas"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6083
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6083
 msgid "Purchase of greenhouse gas and similar emission quotas"
 msgstr "Achats de quotas d'émission de gaz à effet de serre et assimilés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45121
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45221
+#: model:account.group,name:l10n_lu.2_account_group_45111
+#: model:account.group,name:l10n_lu.2_account_group_45121
+#: model:account.group,name:l10n_lu.2_account_group_45211
+#: model:account.group,name:l10n_lu.2_account_group_45221
 #: model:account.group.template,name:l10n_lu.account_group_45111
 #: model:account.group.template,name:l10n_lu.account_group_45121
 #: model:account.group.template,name:l10n_lu.account_group_45211
@@ -5701,128 +7280,169 @@ msgid "Purchases and services"
 msgstr "Achats et prestations de services"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6063
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6063
+#: model:account.group,name:l10n_lu.2_account_group_6063
 #: model:account.group.template,name:l10n_lu.account_group_6063
 msgid "Purchases of buildings for resale"
 msgstr "Achats d'immeubles destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_603
 #: model:account.group.template,name:l10n_lu.account_group_603
 msgid "Purchases of consumable materials and supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_608
 #: model:account.group.template,name:l10n_lu.account_group_608
 msgid "Purchases of items included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6062
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6062
+#: model:account.group,name:l10n_lu.2_account_group_6062
 #: model:account.group.template,name:l10n_lu.account_group_6062
 msgid "Purchases of land for resale"
 msgstr "Achats de terrains destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6061
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6061
+#: model:account.group,name:l10n_lu.2_account_group_6061
 #: model:account.group.template,name:l10n_lu.account_group_6061
 msgid "Purchases of merchandise"
 msgstr "Achats de marchandises"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_606
 #: model:account.group.template,name:l10n_lu.account_group_606
 msgid "Purchases of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_604
 #: model:account.account.template,name:l10n_lu.lu_2020_account_604
+#: model:account.group,name:l10n_lu.2_account_group_604
 #: model:account.group.template,name:l10n_lu.account_group_604
 msgid "Purchases of packaging"
 msgstr "Achats d'emballages"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_601
 #: model:account.account.template,name:l10n_lu.lu_2020_account_601
+#: model:account.group,name:l10n_lu.2_account_group_601
 #: model:account.group.template,name:l10n_lu.account_group_601
 msgid "Purchases of raw materials"
 msgstr "Achats de matières premières"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7095
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7095
+#: model:account.group,name:l10n_lu.2_account_group_7095
 #: model:account.group.template,name:l10n_lu.account_group_7095
 msgid "RDR on commissions and brokerage fees"
 msgstr "RRR sur commissions et courtages"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7098
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7098
+#: model:account.group,name:l10n_lu.2_account_group_7098
 #: model:account.group.template,name:l10n_lu.account_group_7098
 msgid "RDR on other components of turnover"
 msgstr "RRR sur autres éléments du chiffre d'affaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6098
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6098
+#: model:account.group,name:l10n_lu.2_account_group_6098
 #: model:account.group.template,name:l10n_lu.account_group_6098
 msgid "RDR on purchases included in the production of goods and services"
 msgstr "RRR sur achats incorporés aux ouvrages et produits"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6093
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6093
+#: model:account.group,name:l10n_lu.2_account_group_6093
 #: model:account.group.template,name:l10n_lu.account_group_6093
 msgid "RDR on purchases of consumable materials and supplies"
 msgstr "RRR sur achats de matières et fournitures consommables"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6096
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6096
+#: model:account.group,name:l10n_lu.2_account_group_6096
 #: model:account.group.template,name:l10n_lu.account_group_6096
 msgid "RDR on purchases of merchandise and other goods for resale"
-msgstr "RRR sur achats de marchandises et d'autres biens destinés à la revente"
+msgstr ""
+"RRR sur achats de marchandises et d'autres biens destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6094
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6094
+#: model:account.group,name:l10n_lu.2_account_group_6094
 #: model:account.group.template,name:l10n_lu.account_group_6094
 msgid "RDR on purchases of packaging"
 msgstr "RRR sur achats d'emballages"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6091
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6091
+#: model:account.group,name:l10n_lu.2_account_group_6091
 #: model:account.group.template,name:l10n_lu.account_group_6091
 msgid "RDR on purchases of raw materials"
 msgstr "RRR sur achats de matières premières"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7092
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7092
+#: model:account.group,name:l10n_lu.2_account_group_7092
 #: model:account.group.template,name:l10n_lu.account_group_7092
 msgid "RDR on sales of goods"
 msgstr "RRR sur ventes de produits"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7096
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7096
+#: model:account.group,name:l10n_lu.2_account_group_7096
 #: model:account.group.template,name:l10n_lu.account_group_7096
 msgid "RDR on sales of merchandise and other goods for resale"
-msgstr "RRR sur ventes de marchandises et d'autres biens destinés à la revente"
+msgstr ""
+"RRR sur ventes de marchandises et d'autres biens destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7094
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7094
+#: model:account.group,name:l10n_lu.2_account_group_7094
 #: model:account.group.template,name:l10n_lu.account_group_7094
 msgid "RDR on sales of packages"
 msgstr "RRR sur ventes d'emballages"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7093
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7093
+#: model:account.group,name:l10n_lu.2_account_group_7093
 #: model:account.group.template,name:l10n_lu.account_group_7093
 msgid "RDR on sales of services"
 msgstr "RRR sur prestations de services"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_735
 #: model:account.group.template,name:l10n_lu.account_group_735
 msgid "RVA and FVA on receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75112
 #: model:account.group.template,name:l10n_lu.account_group_75112
 msgid "RVA on amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7352
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7352
+#: model:account.group,name:l10n_lu.2_account_group_7352
 #: model:account.group.template,name:l10n_lu.account_group_7352
 msgid ""
 "RVA on amounts owed by affiliated undertakings and undertakings with which "
@@ -5832,6 +7452,7 @@ msgstr ""
 "lesquelles l'entreprise a un lien de participation"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75114
 #: model:account.group.template,name:l10n_lu.account_group_75114
 msgid ""
 "RVA on amounts owed by undertakings with which the company is linked by "
@@ -5839,13 +7460,17 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73313
+#: model:account.group,name:l10n_lu.2_account_group_73313
 #: model:account.group.template,name:l10n_lu.account_group_73313
 msgid "RVA on buildings"
 msgstr "RCV sur constructions / bâtiments"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7322
+#: model:account.group,name:l10n_lu.2_account_group_7322
 #: model:account.group.template,name:l10n_lu.account_group_7322
 msgid ""
 "RVA on concessions, patents, licences, trademarks and similar rights and "
@@ -5855,88 +7480,114 @@ msgstr ""
 "similaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7321
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7321
+#: model:account.group,name:l10n_lu.2_account_group_7321
 #: model:account.group.template,name:l10n_lu.account_group_7321
 msgid "RVA on development costs"
 msgstr "RCV sur frais de développement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7324
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7324
+#: model:account.group,name:l10n_lu.2_account_group_7324
 #: model:account.group.template,name:l10n_lu.account_group_7324
 msgid "RVA on down payments and intangible fixed assets under development"
 msgstr "RCV sur acomptes versés et immobilisations incorporelles en cours"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7334
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7334
+#: model:account.group,name:l10n_lu.2_account_group_7334
 #: model:account.group.template,name:l10n_lu.account_group_7334
 msgid "RVA on down payments and tangible fixed assets under development"
 msgstr "RCV sur acomptes versés et immobilisations corporelles en cours"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7345
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7345
+#: model:account.group,name:l10n_lu.2_account_group_7345
 #: model:account.group.template,name:l10n_lu.account_group_7345
 msgid "RVA on down payments on inventories"
 msgstr "RCV sur acomptes versés sur stocks"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7511
 #: model:account.group.template,name:l10n_lu.account_group_7511
 msgid "RVA on financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73314
+#: model:account.group,name:l10n_lu.2_account_group_73314
 #: model:account.group.template,name:l10n_lu.account_group_73314
 msgid "RVA on fixtures and fittings-out of buildings"
 msgstr "RCV sur agencements et aménagements de constructions / bâtiments"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73312
+#: model:account.group,name:l10n_lu.2_account_group_73312
 #: model:account.group.template,name:l10n_lu.account_group_73312
 msgid "RVA on fixtures and fittings-out of land"
 msgstr "RCV sur agencements et aménagements de terrains"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_732
 #: model:account.group.template,name:l10n_lu.account_group_732
 msgid "RVA on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_734
 #: model:account.group.template,name:l10n_lu.account_group_734
 msgid "RVA on inventories"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7343
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7343
+#: model:account.group,name:l10n_lu.2_account_group_7343
 #: model:account.group.template,name:l10n_lu.account_group_7343
 msgid "RVA on inventories of goods"
 msgstr "RCV sur stocks de produits "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7344
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7344
+#: model:account.group,name:l10n_lu.2_account_group_7344
 #: model:account.group.template,name:l10n_lu.account_group_7344
 msgid "RVA on inventories of merchandise and other goods for resale"
 msgstr "RCV sur stocks de marchandises et autres biens destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7341
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7341
+#: model:account.group,name:l10n_lu.2_account_group_7341
 #: model:account.group.template,name:l10n_lu.account_group_7341
 msgid "RVA on inventories of raw materials and consumables"
 msgstr "RCV sur stocks de matières premières et consommables"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7342
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7342
+#: model:account.group,name:l10n_lu.2_account_group_7342
 #: model:account.group.template,name:l10n_lu.account_group_7342
 msgid "RVA on inventories of work and contracts in progress"
 msgstr ""
 "RCV sur stocks de produits en cours de fabrication et commandes en cours"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73311
+#: model:account.group,name:l10n_lu.2_account_group_73311
 #: model:account.group.template,name:l10n_lu.account_group_73311
 msgid "RVA on land"
 msgstr "RCV sur terrains"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7331
 #: model:account.group.template,name:l10n_lu.account_group_7331
 msgid ""
 "RVA on land, fixtures and fittings-out and buildings and FVA on investment "
@@ -5944,56 +7595,69 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75116
 #: model:account.group.template,name:l10n_lu.account_group_75116
 msgid "RVA on loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7353
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7353
+#: model:account.group,name:l10n_lu.2_account_group_7353
 #: model:account.group.template,name:l10n_lu.account_group_7353
 msgid "RVA on other receivables"
 msgstr "RCV sur autres créances"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75318
 #: model:account.group.template,name:l10n_lu.account_group_75318
 msgid "RVA on other transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75312
 #: model:account.group.template,name:l10n_lu.account_group_75312
 msgid "RVA on own shares or corporate units"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75113
 #: model:account.group.template,name:l10n_lu.account_group_75113
 msgid "RVA on participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7332
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7332
+#: model:account.group,name:l10n_lu.2_account_group_7332
 #: model:account.group.template,name:l10n_lu.account_group_7332
 msgid "RVA on plant and machinery"
 msgstr "RCV sur installations techniques et machines"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75115
 #: model:account.group.template,name:l10n_lu.account_group_75115
 msgid "RVA on securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75111
+#: model:account.group,name:l10n_lu.2_account_group_75311
 #: model:account.group.template,name:l10n_lu.account_group_75111
 #: model:account.group.template,name:l10n_lu.account_group_75311
 msgid "RVA on shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75313
 #: model:account.group.template,name:l10n_lu.account_group_75313
 msgid ""
-"RVA on shares in undertakings with which the undertaking is linked by virtue "
-"of participating interests"
+"RVA on shares in undertakings with which the undertaking is linked by virtue"
+" of participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_733
 #: model:account.group.template,name:l10n_lu.account_group_733
 msgid ""
 "RVA on tangible fixed assets and fair value adjustments (FVA) on investment "
@@ -6001,23 +7665,29 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7351
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7351
+#: model:account.group,name:l10n_lu.2_account_group_7351
 #: model:account.group.template,name:l10n_lu.account_group_7351
 msgid "RVA on trade receivables"
 msgstr "RCV sur créances résultant de ventes et prestations de services"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7531
 #: model:account.group.template,name:l10n_lu.account_group_7531
 msgid "RVA on transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6461
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6461
+#: model:account.group,name:l10n_lu.2_account_group_6461
 #: model:account.group.template,name:l10n_lu.account_group_6461
 msgid "Real property tax"
 msgstr "Impôt foncier"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_709
 #: model:account.group.template,name:l10n_lu.account_group_709
 msgid ""
 "Rebates, discounts and refunds (RDR) granted and not immediately deducted "
@@ -6025,14 +7695,17 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_609
 #: model:account.group.template,name:l10n_lu.account_group_609
 msgid ""
-"Rebates, discounts and refunds (RDR) received and not directly deducted from "
-"purchases"
+"Rebates, discounts and refunds (RDR) received and not directly deducted from"
+" purchases"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_619
 #: model:account.account.template,name:l10n_lu.lu_2011_account_619
+#: model:account.group,name:l10n_lu.2_account_group_619
 #: model:account.group.template,name:l10n_lu.account_group_619
 msgid "Rebates, discounts and refunds received on other external charges"
 msgstr ""
@@ -6040,267 +7713,345 @@ msgstr ""
 "autres charges externes"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10627
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10627
 msgid "Received child benefit"
 msgstr "Allocations familiales reçues"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4711
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4721
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4711
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4721
+#: model:account.group,name:l10n_lu.2_account_group_4711
+#: model:account.group,name:l10n_lu.2_account_group_4721
 #: model:account.group.template,name:l10n_lu.account_group_4711
 #: model:account.group.template,name:l10n_lu.account_group_4721
 msgid "Received deposits and guarantees"
 msgstr "Dépôts et cautionnements reçus"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10625
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10625
 msgid "Received rents"
 msgstr "Loyers encaissés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10626
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10626
 msgid "Received wages or pensions"
 msgstr "Salaires ou rentes touchés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61524
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61524
+#: model:account.group,name:l10n_lu.2_account_group_61524
 #: model:account.group.template,name:l10n_lu.account_group_61524
 msgid "Receptions and entertainment costs"
 msgstr "Réceptions et frais de représentation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106193
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106193
 msgid "Refund of private debts"
 msgstr "Remboursements de dettes privées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6219
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6219
+#: model:account.group,name:l10n_lu.2_account_group_6219
 #: model:account.group.template,name:l10n_lu.account_group_6219
 msgid "Refunds on wages paid"
 msgstr "Remboursements sur salaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421621
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461421
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421621
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461421
+#: model:account.group,name:l10n_lu.2_account_group_421621
+#: model:account.group,name:l10n_lu.2_account_group_461421
 #: model:account.group.template,name:l10n_lu.account_group_421621
 #: model:account.group.template,name:l10n_lu.account_group_461421
 msgid "Registration duties"
 msgstr "Droits d'enregistrement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64651
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64651
+#: model:account.group,name:l10n_lu.2_account_group_64651
 #: model:account.group.template,name:l10n_lu.account_group_64651
 msgid "Registration fees"
 msgstr "Droits d'enregistrement"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6465
 #: model:account.group.template,name:l10n_lu.account_group_6465
 msgid "Registration fees, stamp duties and mortgage duties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61522
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61522
+#: model:account.group,name:l10n_lu.2_account_group_61522
 #: model:account.group.template,name:l10n_lu.account_group_61522
 msgid "Relocation expenses"
 msgstr "Frais de déménagement de l'entreprise"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_613
 #: model:account.group.template,name:l10n_lu.account_group_613
 msgid "Remuneration of intermediaries and professional fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106162
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106162
 msgid "Rent"
 msgstr "Loyer"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7032
 #: model:account.group.template,name:l10n_lu.account_group_7032
 msgid "Rental income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_742
 #: model:account.group.template,name:l10n_lu.account_group_742
 msgid "Rental income from ancillary activities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70322
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70322
+#: model:account.group,name:l10n_lu.2_account_group_70322
 #: model:account.group.template,name:l10n_lu.account_group_70322
 msgid "Rental income from movable property"
 msgstr "Revenus de location mobilière"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70321
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70321
+#: model:account.group,name:l10n_lu.2_account_group_70321
 #: model:account.group.template,name:l10n_lu.account_group_70321
 msgid "Rental income from real property"
 msgstr "Revenus de location immobilière"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7422
+#: model:account.group,name:l10n_lu.2_account_group_7422
 #: model:account.group.template,name:l10n_lu.account_group_7422
 msgid "Rental income on movable property"
 msgstr "Revenus de location mobilière"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7421
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7421
+#: model:account.group,name:l10n_lu.2_account_group_7421
 #: model:account.group.template,name:l10n_lu.account_group_7421
 msgid "Rental income on real property"
 msgstr "Revenus de location immobilière"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6112
 #: model:account.group.template,name:l10n_lu.account_group_6112
 msgid "Rents and operational leasing on movable property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6111
 #: model:account.group.template,name:l10n_lu.account_group_6111
 msgid "Rents and operationnal leasing for real property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_611
 #: model:account.group.template,name:l10n_lu.account_group_611
 msgid "Rents and service charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106191
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106191
 msgid "Repairs to private buildings"
 msgstr "Réparations aux immeubles privés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60812
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60812
+#: model:account.group,name:l10n_lu.2_account_group_60812
 #: model:account.group.template,name:l10n_lu.account_group_60812
 msgid "Research and development"
 msgstr "Recherche et développement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_13821
 #: model:account.account.template,name:l10n_lu.lu_2020_account_13821
+#: model:account.group,name:l10n_lu.2_account_group_13821
 #: model:account.group.template,name:l10n_lu.account_group_13821
 msgid "Reserve for net wealth tax (NWT)"
 msgstr "Réserve pour l'impôt sur la fortune (IF)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_13
 #: model:account.group.template,name:l10n_lu.account_group_13
 msgid "Reserves"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_132
+#: model:account.group,name:l10n_lu.2_account_group_132
 #: model:account.group.template,name:l10n_lu.account_group_132
 msgid "Reserves for own shares or own corporate units"
 msgstr "Réserve pour actions propres ou parts propres"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_13822
 #: model:account.account.template,name:l10n_lu.lu_2020_account_13822
+#: model:account.group,name:l10n_lu.2_account_group_13822
 #: model:account.group.template,name:l10n_lu.account_group_13822
 msgid "Reserves in application of fair value"
 msgstr "Réserves en application de la juste valeur"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_122
+#: model:account.group,name:l10n_lu.2_account_group_122
 #: model:account.group.template,name:l10n_lu.account_group_122
 msgid "Reserves in application of the equity method"
 msgstr "Réserves de mise en équivalence"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_13828
 #: model:account.account.template,name:l10n_lu.lu_2020_account_13828
+#: model:account.group,name:l10n_lu.2_account_group_13828
 #: model:account.group.template,name:l10n_lu.account_group_13828
 msgid "Reserves not available for distribution not mentioned above"
 msgstr "Réserves non disponibles non visées ci-dessus"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_133
 #: model:account.account.template,name:l10n_lu.lu_2011_account_133
+#: model:account.group,name:l10n_lu.2_account_group_133
 #: model:account.group.template,name:l10n_lu.account_group_133
 msgid "Reserves provided for by the articles of association"
 msgstr "Réserves statutaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221311
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221311
+#: model:account.group,name:l10n_lu.2_account_group_221311
 #: model:account.group.template,name:l10n_lu.account_group_221311
 msgid "Residential buildings"
 msgstr "Constructions / Bâtiments résidentiels"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_142
 #: model:account.account.template,name:l10n_lu.lu_2011_account_142
+#: model:account.group,name:l10n_lu.2_account_group_142
 #: model:account.group.template,name:l10n_lu.account_group_142
 msgid "Result for the financial year"
 msgstr "Résultat de l'exercice"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_14
 #: model:account.group.template,name:l10n_lu.account_group_14
 msgid "Result for the financial year and results brought forward"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_141
 #: model:account.group.template,name:l10n_lu.account_group_141
 msgid "Results brought forward"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1412
+#: model:account.group,name:l10n_lu.2_account_group_1412
 #: model:account.group.template,name:l10n_lu.account_group_1412
 msgid "Results brought forward (assigned)"
 msgstr "Résultats reportés (affectés)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1411
+#: model:account.group,name:l10n_lu.2_account_group_1411
 #: model:account.group.template,name:l10n_lu.account_group_1411
 msgid "Results brought forward in the process of assignment"
 msgstr "Résultats reportés en instance d'affectation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2237
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2237
+#: model:account.group,name:l10n_lu.2_account_group_2237
 #: model:account.group.template,name:l10n_lu.account_group_2237
 msgid "Returnable packaging"
 msgstr "Emballages récupérables"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_12
 #: model:account.group.template,name:l10n_lu.account_group_12
 msgid "Revaluation reserves"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_759
 #: model:account.group.template,name:l10n_lu.account_group_759
 msgid "Reversals of financial provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7591
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7591
+#: model:account.group,name:l10n_lu.2_account_group_7591
 #: model:account.group.template,name:l10n_lu.account_group_7591
 msgid "Reversals of financial provisions - affiliated undertakings"
 msgstr "Reprises de provisions financières - entreprises liées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7592
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7592
+#: model:account.group,name:l10n_lu.2_account_group_7592
 #: model:account.group.template,name:l10n_lu.account_group_7592
 msgid "Reversals of financial provisions - other"
 msgstr "Reprises de provisions financières - autres "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7492
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7492
+#: model:account.group,name:l10n_lu.2_account_group_7492
 #: model:account.group.template,name:l10n_lu.account_group_7492
 msgid "Reversals of operating provisions"
 msgstr "Reprises de provisions d'exploitation"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_749
 #: model:account.group.template,name:l10n_lu.account_group_749
 msgid "Reversals of provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_779
 #: model:account.account.template,name:l10n_lu.lu_2020_account_779
+#: model:account.group,name:l10n_lu.2_account_group_779
 #: model:account.group.template,name:l10n_lu.account_group_779
 msgid "Reversals of provisions for deferred taxes"
 msgstr "Reprises de provisions pour impôts différés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7491
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7491
+#: model:account.group,name:l10n_lu.2_account_group_7491
 #: model:account.group.template,name:l10n_lu.account_group_7491
 msgid "Reversals of provisions for taxes"
 msgstr "Reprises de provisions pour impôts"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_747
 #: model:account.group.template,name:l10n_lu.account_group_747
 msgid ""
 "Reversals of temporarily not taxable capital gains and of investment "
@@ -6308,6 +8059,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_751
 #: model:account.group.template,name:l10n_lu.account_group_751
 msgid ""
 "Reversals of value adjustments (RVA) and fair-value adjustments (FVA) on "
@@ -6315,6 +8067,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_753
 #: model:account.group.template,name:l10n_lu.account_group_753
 msgid ""
 "Reversals of value adjustments (RVA) and fair-value adjustments (FVA) on "
@@ -6322,6 +8075,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_73
 #: model:account.group.template,name:l10n_lu.account_group_73
 msgid ""
 "Reversals of value adjustments (RVA) on intangible, tangible and current "
@@ -6329,10 +8083,18 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61123
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61153
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61223
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61153
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61223
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61412
+#: model:account.group,name:l10n_lu.2_account_group_61123
+#: model:account.group,name:l10n_lu.2_account_group_61153
+#: model:account.group,name:l10n_lu.2_account_group_61223
+#: model:account.group,name:l10n_lu.2_account_group_61412
 #: model:account.group.template,name:l10n_lu.account_group_61123
 #: model:account.group.template,name:l10n_lu.account_group_61153
 #: model:account.group.template,name:l10n_lu.account_group_61223
@@ -6341,95 +8103,128 @@ msgid "Rolling stock"
 msgstr "Matériel roulant"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_703001
 #: model:account.account.template,name:l10n_lu.lu_2020_account_703001
 msgid "Sale of Services"
 msgstr "Prestations de services"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7063
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7063
+#: model:account.group,name:l10n_lu.2_account_group_7063
 #: model:account.group.template,name:l10n_lu.account_group_7063
 msgid "Sales of buildings for resale"
 msgstr "Ventes d'immeubles destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7021
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7021
+#: model:account.group,name:l10n_lu.2_account_group_7021
 #: model:account.group.template,name:l10n_lu.account_group_7021
 msgid "Sales of finished goods"
 msgstr "Ventes de produits finis"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_702
 #: model:account.group.template,name:l10n_lu.account_group_702
 msgid "Sales of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7062
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7062
+#: model:account.group,name:l10n_lu.2_account_group_7062
 #: model:account.group.template,name:l10n_lu.account_group_7062
 msgid "Sales of land resale"
 msgstr "Ventes de terrains destinés à la revente"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7061
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7061
+#: model:account.group,name:l10n_lu.2_account_group_7061
 #: model:account.group.template,name:l10n_lu.account_group_7061
 msgid "Sales of merchandise"
 msgstr "Ventes de marchandises"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_706
 #: model:account.group.template,name:l10n_lu.account_group_706
 msgid "Sales of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_704
 #: model:account.account.template,name:l10n_lu.lu_2011_account_704
+#: model:account.group,name:l10n_lu.2_account_group_704
 #: model:account.group.template,name:l10n_lu.account_group_704
 msgid "Sales of packaging"
 msgstr "Ventes d'emballages"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7023
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7023
+#: model:account.group,name:l10n_lu.2_account_group_7023
 #: model:account.group.template,name:l10n_lu.account_group_7023
 msgid "Sales of residual products"
 msgstr "Ventes de produits résiduels"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7022
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7022
+#: model:account.group,name:l10n_lu.2_account_group_7022
 #: model:account.group.template,name:l10n_lu.account_group_7022
 msgid "Sales of semi-finished goods"
 msgstr "Ventes de produits intermédiaires"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_703
 #: model:account.group.template,name:l10n_lu.account_group_703
 msgid "Sales of services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7039
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7039
+#: model:account.group,name:l10n_lu.2_account_group_7039
 #: model:account.group.template,name:l10n_lu.account_group_7039
 msgid "Sales of services in the course of completion"
 msgstr "Prestations de services en cours de réalisation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7033
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7033
+#: model:account.group,name:l10n_lu.2_account_group_7033
 #: model:account.group.template,name:l10n_lu.account_group_7033
 msgid "Sales of services not mentioned above"
 msgstr "Prestations de services non visées ci-dessus"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7029
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7029
+#: model:account.group,name:l10n_lu.2_account_group_7029
 #: model:account.group.template,name:l10n_lu.account_group_7029
 msgid "Sales of work in progress"
 msgstr "Ventes de produits en cours de fabrication"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61512
+#: model:account.group,name:l10n_lu.2_account_group_61512
 #: model:account.group.template,name:l10n_lu.account_group_61512
 msgid "Samples"
 msgstr "Echantillons"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75115
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65215
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75215
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75115
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65215
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75215
+#: model:account.group,name:l10n_lu.2_account_group_235
+#: model:account.group,name:l10n_lu.2_account_group_65215
+#: model:account.group,name:l10n_lu.2_account_group_75215
+#: model:account.group,name:l10n_lu.2_account_group_75225
 #: model:account.group.template,name:l10n_lu.account_group_235
 #: model:account.group.template,name:l10n_lu.account_group_65215
 #: model:account.group.template,name:l10n_lu.account_group_75215
@@ -6438,80 +8233,111 @@ msgid "Securities held as fixed assets"
 msgstr "Titres ayant le caractère d'immobilisations"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2352
 #: model:account.group.template,name:l10n_lu.account_group_2352
 msgid "Securities held as fixed assets (creditor's right)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2351
 #: model:account.group.template,name:l10n_lu.account_group_2351
 msgid "Securities held as fixed assets (equity right)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6113
+#: model:account.group,name:l10n_lu.2_account_group_6113
 #: model:account.group.template,name:l10n_lu.account_group_6113
 msgid "Service charges and co-ownership expenses"
 msgstr "Charges locatives et de copropriété"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6081
 #: model:account.group.template,name:l10n_lu.account_group_6081
 msgid "Services included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6122
 #: model:account.group.template,name:l10n_lu.account_group_6122
 msgid "Servicing, repairs and maintenance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_201
 #: model:account.account.template,name:l10n_lu.lu_2011_account_201
+#: model:account.group,name:l10n_lu.2_account_group_201
 #: model:account.group.template,name:l10n_lu.account_group_201
 msgid "Set-up and start-up costs"
 msgstr "Frais de constitution et de premier établissement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62116
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62116
+#: model:account.group,name:l10n_lu.2_account_group_62116
 #: model:account.group.template,name:l10n_lu.account_group_62116
 msgid "Severance pay"
 msgstr "Indemnités de licenciement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_657
 #: model:account.account.template,name:l10n_lu.lu_2011_account_657
+#: model:account.group,name:l10n_lu.2_account_group_657
 #: model:account.group.template,name:l10n_lu.account_group_657
 msgid ""
 "Share in the losses of undertakings accounted for under the equity method"
 msgstr "Quote-part dans la perte des entreprises mises en équivalence"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_757
 #: model:account.account.template,name:l10n_lu.lu_2011_account_757
+#: model:account.group,name:l10n_lu.2_account_group_757
 #: model:account.group.template,name:l10n_lu.account_group_757
-msgid "Share of profit from undertakings accounted for under the equity method"
+msgid ""
+"Share of profit from undertakings accounted for under the equity method"
 msgstr "Quote-part de bénéfice dans les entreprises mises en équivalence"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_111
+#: model:account.group,name:l10n_lu.2_account_group_111
 #: model:account.group.template,name:l10n_lu.account_group_111
 msgid "Share premium"
 msgstr "Primes d'émission"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_11
 #: model:account.group.template,name:l10n_lu.account_group_11
 msgid "Share premium and similar premiums"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5081
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5081
+#: model:account.group,name:l10n_lu.2_account_group_5081
 #: model:account.group.template,name:l10n_lu.account_group_5081
 msgid "Shares - listed securities"
 msgstr "Actions – Titres cotés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5082
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5082
+#: model:account.group,name:l10n_lu.2_account_group_5082
 #: model:account.group.template,name:l10n_lu.account_group_5082
 msgid "Shares - unlisted securities"
 msgstr "Actions – Titres non cotés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_231
+#: model:account.account,name:l10n_lu.2_lu_2011_account_501
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75481
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65421
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75311
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75421
 #: model:account.account.template,name:l10n_lu.lu_2011_account_231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_501
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75111
@@ -6521,6 +8347,14 @@ msgstr "Actions – Titres non cotés"
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75211
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75311
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75421
+#: model:account.group,name:l10n_lu.2_account_group_231
+#: model:account.group,name:l10n_lu.2_account_group_501
+#: model:account.group,name:l10n_lu.2_account_group_65211
+#: model:account.group,name:l10n_lu.2_account_group_65421
+#: model:account.group,name:l10n_lu.2_account_group_75211
+#: model:account.group,name:l10n_lu.2_account_group_75221
+#: model:account.group,name:l10n_lu.2_account_group_75421
+#: model:account.group,name:l10n_lu.2_account_group_75481
 #: model:account.group.template,name:l10n_lu.account_group_231
 #: model:account.group.template,name:l10n_lu.account_group_501
 #: model:account.group.template,name:l10n_lu.account_group_65211
@@ -6533,6 +8367,7 @@ msgid "Shares in affiliated undertakings"
 msgstr "Parts dans des entreprises liées"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65423
 #: model:account.group.template,name:l10n_lu.account_group_65423
 msgid ""
 "Shares in in undertakings with which the undertaking is linked by virtue of "
@@ -6540,11 +8375,19 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_503
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75483
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65423
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75313
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75423
 #: model:account.account.template,name:l10n_lu.lu_2011_account_503
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75483
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65423
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75313
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75423
+#: model:account.group,name:l10n_lu.2_account_group_503
+#: model:account.group,name:l10n_lu.2_account_group_75423
+#: model:account.group,name:l10n_lu.2_account_group_75483
 #: model:account.group.template,name:l10n_lu.account_group_503
 #: model:account.group.template,name:l10n_lu.account_group_75423
 #: model:account.group.template,name:l10n_lu.account_group_75483
@@ -6556,17 +8399,26 @@ msgstr ""
 "participation"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_2353
 #: model:account.account.template,name:l10n_lu.lu_2020_account_2353
+#: model:account.group,name:l10n_lu.2_account_group_2353
 #: model:account.group.template,name:l10n_lu.account_group_2353
 msgid "Shares of collective investment funds"
 msgstr "Parts d'OPC"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_23511
 #: model:account.group.template,name:l10n_lu.account_group_23511
 msgid "Shares or corporate units"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_21215
+#: model:account.group,name:l10n_lu.2_account_group_21225
+#: model:account.group,name:l10n_lu.2_account_group_6415
+#: model:account.group,name:l10n_lu.2_account_group_70315
+#: model:account.group,name:l10n_lu.2_account_group_72125
+#: model:account.group,name:l10n_lu.2_account_group_7415
 #: model:account.group.template,name:l10n_lu.account_group_21215
 #: model:account.group.template,name:l10n_lu.account_group_21225
 #: model:account.group.template,name:l10n_lu.account_group_6415
@@ -6577,45 +8429,66 @@ msgid "Similar rights and assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61852
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61852
+#: model:account.group,name:l10n_lu.2_account_group_61852
 #: model:account.group.template,name:l10n_lu.account_group_61852
 msgid "Small equipment"
 msgstr "Petit équipement"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106151
 msgid "Social Security"
 msgstr "Assurances sociales (assurance dépendance) "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42171
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4621
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42171
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4621
 msgid "Social Security office (CCSS)"
 msgstr "Centre Commun de Sécurité Sociale (CCSS)"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_623
 #: model:account.group.template,name:l10n_lu.account_group_623
 msgid "Social security costs (employer's share)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_462
 #: model:account.group.template,name:l10n_lu.account_group_462
 msgid "Social security debts and other social securities offices"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6231
+#: model:account.group,name:l10n_lu.2_account_group_6231
 #: model:account.group.template,name:l10n_lu.account_group_6231
 msgid "Social security on pensions"
 msgstr "Charges sociales couvrant les pensions"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21213
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21223
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6413
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72123
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7413
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21213
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21223
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6413
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7413
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70313
+#: model:account.group,name:l10n_lu.2_account_group_21213
+#: model:account.group,name:l10n_lu.2_account_group_21223
+#: model:account.group,name:l10n_lu.2_account_group_6413
+#: model:account.group,name:l10n_lu.2_account_group_70313
+#: model:account.group,name:l10n_lu.2_account_group_72123
+#: model:account.group,name:l10n_lu.2_account_group_7413
 #: model:account.group.template,name:l10n_lu.account_group_21213
 #: model:account.group.template,name:l10n_lu.account_group_21223
 #: model:account.group.template,name:l10n_lu.account_group_6413
@@ -6626,109 +8499,144 @@ msgid "Software licences"
 msgstr "Licences informatiques "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60311
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61841
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60311
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61841
+#: model:account.group,name:l10n_lu.2_account_group_60311
+#: model:account.group,name:l10n_lu.2_account_group_61841
 #: model:account.group.template,name:l10n_lu.account_group_60311
 #: model:account.group.template,name:l10n_lu.account_group_61841
 msgid "Solid fuels"
 msgstr "Combustibles solides"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61517
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61517
+#: model:account.group,name:l10n_lu.2_account_group_61517
 #: model:account.group.template,name:l10n_lu.account_group_61517
 msgid "Sponsorship"
 msgstr "Sponsoring"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_615212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_615212
+#: model:account.group,name:l10n_lu.2_account_group_615212
 #: model:account.group.template,name:l10n_lu.account_group_615212
 msgid "Staff"
 msgstr "Personnel"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4211
 #: model:account.group.template,name:l10n_lu.account_group_4211
 msgid "Staff - Advances and down payments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4221
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4221
+#: model:account.group,name:l10n_lu.2_account_group_4221
 #: model:account.group.template,name:l10n_lu.account_group_4221
 msgid "Staff - advances and down payments"
 msgstr "Personnel – Avances et acomptes"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_62
 #: model:account.group.template,name:l10n_lu.account_group_62
 msgid "Staff expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_621
 #: model:account.group.template,name:l10n_lu.account_group_621
 msgid "Staff remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_483
 #: model:account.group.template,name:l10n_lu.account_group_483
 msgid "State - Greenhous gas and similar emission quotas received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4715
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4715
+#: model:account.group,name:l10n_lu.2_account_group_4715
 #: model:account.group.template,name:l10n_lu.account_group_4715
 msgid ""
 "State - Greenhous gas and similar emission quotas to be returned or acquired"
 msgstr ""
-"Etat – Quotas d'émission de gaz à effet de serre et assimilés à restituer ou "
-"à acquérir"
+"Etat – Quotas d'émission de gaz à effet de serre et assimilés à restituer ou"
+" à acquérir"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_483
 #: model:account.account.template,name:l10n_lu.lu_2011_account_483
 msgid "State - Greenhouse gas and similar emission quotas received"
 msgstr "Etat - Quotas d'émission de gaz à effet de serre et assimilés alloués"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4213
+#: model:account.group,name:l10n_lu.2_account_group_4223
 #: model:account.group.template,name:l10n_lu.account_group_4213
 #: model:account.group.template,name:l10n_lu.account_group_4223
 msgid "State - Subsidies to be received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6221
+#: model:account.group,name:l10n_lu.2_account_group_6221
 #: model:account.group.template,name:l10n_lu.account_group_6221
 msgid "Students"
 msgstr "Etudiants"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_612
 #: model:account.group.template,name:l10n_lu.account_group_612
 msgid "Subcontracting, servicing, repairs and maintenance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_101
 #: model:account.account.template,name:l10n_lu.lu_2011_account_101
+#: model:account.group,name:l10n_lu.2_account_group_101
 #: model:account.group.template,name:l10n_lu.account_group_101
 msgid "Subscribed capital"
 msgstr "Capital souscrit"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_103
 #: model:account.account.template,name:l10n_lu.lu_2011_account_103
+#: model:account.group,name:l10n_lu.2_account_group_103
 #: model:account.group.template,name:l10n_lu.account_group_103
 msgid "Subscribed capital called but unpaid"
 msgstr "Capital souscrit appelé et non versé "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_102
 #: model:account.account.template,name:l10n_lu.lu_2011_account_102
+#: model:account.group,name:l10n_lu.2_account_group_102
 #: model:account.group.template,name:l10n_lu.account_group_102
 msgid "Subscribed capital not called"
 msgstr "Capital souscrit non appelé"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_10
 #: model:account.group.template,name:l10n_lu.account_group_10
 msgid "Subscribed capital or branches' assigned capital and owner's account"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421622
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461422
+#: model:account.account,name:l10n_lu.2_lu_2011_account_682
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421622
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461422
 #: model:account.account.template,name:l10n_lu.lu_2011_account_682
+#: model:account.group,name:l10n_lu.2_account_group_421622
+#: model:account.group,name:l10n_lu.2_account_group_461422
+#: model:account.group,name:l10n_lu.2_account_group_682
 #: model:account.group.template,name:l10n_lu.account_group_421622
 #: model:account.group.template,name:l10n_lu.account_group_461422
 #: model:account.group.template,name:l10n_lu.account_group_682
@@ -6736,29 +8644,37 @@ msgid "Subscription tax"
 msgstr "Taxe d'abonnement"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_745
 #: model:account.group.template,name:l10n_lu.account_group_745
 msgid "Subsidies for operating activities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7454
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7454
+#: model:account.group,name:l10n_lu.2_account_group_7454
 #: model:account.group.template,name:l10n_lu.account_group_7454
 msgid "Subsidies in favour of employment development"
 msgstr "Subventions destinées à promouvoir l'emploi"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_161
 #: model:account.group.template,name:l10n_lu.account_group_161
 msgid "Subsidies on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1621
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1621
+#: model:account.group,name:l10n_lu.2_account_group_1621
 #: model:account.group.template,name:l10n_lu.account_group_1621
 msgid "Subsidies on land, fitting-outs and buildings"
 msgstr "Subventions sur terrains, aménagements et constructions"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1623
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1623
+#: model:account.group,name:l10n_lu.2_account_group_1623
 #: model:account.group.template,name:l10n_lu.account_group_1623
 msgid ""
 "Subsidies on other fixtures, fittings, tools and equipment (including "
@@ -6768,57 +8684,77 @@ msgstr ""
 "matériel roulant)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1622
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1622
+#: model:account.group,name:l10n_lu.2_account_group_1622
 #: model:account.group.template,name:l10n_lu.account_group_1622
 msgid "Subsidies on plant and machinery"
 msgstr "Subventions sur installations techniques et machines"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_162
 #: model:account.group.template,name:l10n_lu.account_group_162
 msgid "Subsidies on tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621121
+#: model:account.group,name:l10n_lu.2_account_group_621121
 #: model:account.group.template,name:l10n_lu.account_group_621121
 msgid "Sunday"
 msgstr "Dimanche"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_44111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_44121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_44111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_44121
+#: model:account.group,name:l10n_lu.2_account_group_44111
+#: model:account.group,name:l10n_lu.2_account_group_44121
 #: model:account.group.template,name:l10n_lu.account_group_44111
 #: model:account.group.template,name:l10n_lu.account_group_44121
 msgid "Suppliers"
 msgstr "Fournisseurs"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_44112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_44112
+#: model:account.group,name:l10n_lu.2_account_group_44112
 #: model:account.group.template,name:l10n_lu.account_group_44112
 msgid "Suppliers - invoices not yet received"
 msgstr "Fournisseurs – Factures non parvenues"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_44113
+#: model:account.account,name:l10n_lu.2_lu_2020_account_44123
 #: model:account.account.template,name:l10n_lu.lu_2020_account_44113
 #: model:account.account.template,name:l10n_lu.lu_2020_account_44123
+#: model:account.group,name:l10n_lu.2_account_group_44113
+#: model:account.group,name:l10n_lu.2_account_group_44123
 #: model:account.group.template,name:l10n_lu.account_group_44113
 #: model:account.group.template,name:l10n_lu.account_group_44123
 msgid "Suppliers with a debit balance"
 msgstr "Fournisseurs débiteurs"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6185
 #: model:account.group.template,name:l10n_lu.account_group_6185
 msgid "Supplies and small equipment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6186
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6186
+#: model:account.group,name:l10n_lu.2_account_group_6186
 #: model:account.group.template,name:l10n_lu.account_group_6186
 msgid "Surveillance and security charges"
 msgstr "Frais de surveillance et de gardiennage"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62117
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62117
+#: model:account.group,name:l10n_lu.2_account_group_62117
 #: model:account.group.template,name:l10n_lu.account_group_62117
 msgid "Survivor's pay"
 msgstr "Trimestre de faveur"
@@ -6839,6 +8775,11 @@ msgid "TVA 12%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_13
+msgid "TVA 13%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.tax.group,name:l10n_lu.tax_group_14
 msgid "TVA 14%"
 msgstr ""
@@ -6846,6 +8787,11 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.group,name:l10n_lu.tax_group_15
 msgid "TVA 15%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_16
+msgid "TVA 16%"
 msgstr ""
 
 #. module: l10n_lu
@@ -6864,135 +8810,190 @@ msgid "TVA 6%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_7
+msgid "TVA 7%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.tax.group,name:l10n_lu.tax_group_8
 msgid "TVA 8%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60811
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60811
+#: model:account.group,name:l10n_lu.2_account_group_60811
 #: model:account.group.template,name:l10n_lu.account_group_60811
 msgid "Tailoring"
 msgstr "Travail à façon"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_22
+#: model:account.group,name:l10n_lu.2_account_group_722
 #: model:account.group.template,name:l10n_lu.account_group_22
 #: model:account.group.template,name:l10n_lu.account_group_722
 msgid "Tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report,name:l10n_lu.tax_report
+msgid "Tax Report"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_46
 #: model:account.group.template,name:l10n_lu.account_group_46
 msgid "Tax and social security debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_461
 #: model:account.group.template,name:l10n_lu.account_group_461
 msgid "Tax debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6733
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6733
+#: model:account.group,name:l10n_lu.2_account_group_6733
 #: model:account.group.template,name:l10n_lu.account_group_6733
 msgid "Taxes levied on non-resident undertakings"
 msgstr "Impôts supportés par les entreprises non résidentes"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6732
 #: model:account.group.template,name:l10n_lu.account_group_6732
 msgid "Taxes levied on permanent establishments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_646
 #: model:account.group.template,name:l10n_lu.account_group_646
 msgid "Taxes, duties and similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61532
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61532
+#: model:account.group,name:l10n_lu.2_account_group_61532
 #: model:account.group.template,name:l10n_lu.account_group_61532
 msgid "Telecommunication costs"
 msgstr "Frais de télécommunication"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106165
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106165
 msgid "Telephone"
 msgstr "Téléphone"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_13823
 #: model:account.group.template,name:l10n_lu.account_group_13823
 msgid "Temporarily not taxable capital gains"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7471
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7471
+#: model:account.group,name:l10n_lu.2_account_group_7471
 #: model:account.group.template,name:l10n_lu.account_group_7471
 msgid "Temporarily not taxable capital gains not reinvested"
 msgstr "Plus-values immunisées non réinvesties"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7472
+#: model:account.account,name:l10n_lu.2_lu_2020_account_138232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7472
 #: model:account.account.template,name:l10n_lu.lu_2020_account_138232
+#: model:account.group,name:l10n_lu.2_account_group_138232
+#: model:account.group,name:l10n_lu.2_account_group_7472
 #: model:account.group.template,name:l10n_lu.account_group_138232
 #: model:account.group.template,name:l10n_lu.account_group_7472
 msgid "Temporarily not taxable capital gains reinvested"
 msgstr "Plus-values immunisées réinvesties"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_138231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_138231
+#: model:account.group,name:l10n_lu.2_account_group_138231
 #: model:account.group.template,name:l10n_lu.account_group_138231
 msgid "Temporarily not taxable capital gains to reinvest"
 msgstr "Plus-values immunisées à réinvestir"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_123
+#: model:account.group,name:l10n_lu.2_account_group_123
 #: model:account.group.template,name:l10n_lu.account_group_123
 msgid "Temporarily not taxable currency translation adjustments"
 msgstr "Plus-values sur écarts de conversion immunisées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6171
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6171
+#: model:account.group,name:l10n_lu.2_account_group_6171
 #: model:account.group.template,name:l10n_lu.account_group_6171
 msgid "Temporary staff"
 msgstr "Personnel intérimaire"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106144
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6146
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106144
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6146
+#: model:account.group,name:l10n_lu.2_account_group_6146
 #: model:account.group.template,name:l10n_lu.account_group_6146
 msgid "Third-party insurance"
 msgstr "Assurance responsabilité civile"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2233
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2233
+#: model:account.group,name:l10n_lu.2_account_group_2233
 #: model:account.group.template,name:l10n_lu.account_group_2233
 msgid "Tools"
 msgstr "Outillage"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_441
 #: model:account.group.template,name:l10n_lu.account_group_441
 msgid "Trade payables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4412
 #: model:account.group.template,name:l10n_lu.account_group_4412
 msgid "Trade payables after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_44
 #: model:account.group.template,name:l10n_lu.account_group_44
 msgid "Trade payables and bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4411
 #: model:account.group.template,name:l10n_lu.account_group_4411
 msgid "Trade payables within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41121
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41221
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6451
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6451
+#: model:account.group,name:l10n_lu.2_account_group_41111
+#: model:account.group,name:l10n_lu.2_account_group_41121
+#: model:account.group,name:l10n_lu.2_account_group_41211
+#: model:account.group,name:l10n_lu.2_account_group_41221
+#: model:account.group,name:l10n_lu.2_account_group_6451
 #: model:account.group.template,name:l10n_lu.account_group_41111
 #: model:account.group.template,name:l10n_lu.account_group_41121
 #: model:account.group.template,name:l10n_lu.account_group_41211
@@ -7002,32 +9003,47 @@ msgid "Trade receivables"
 msgstr "Ventes et prestations de services"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_40
 #: model:account.group.template,name:l10n_lu.account_group_40
 msgid "Trade receivables (Receivables from sales and rendering of services)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_402
 #: model:account.group.template,name:l10n_lu.account_group_402
 msgid "Trade receivables due and payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_401
 #: model:account.group.template,name:l10n_lu.account_group_401
 msgid "Trade receivables due and payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6414
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6414
+#: model:account.group,name:l10n_lu.2_account_group_6414
 #: model:account.group.template,name:l10n_lu.account_group_6414
 msgid "Trademarks and franchise"
 msgstr "Marques et franchises"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21214
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21224
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72124
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7414
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21214
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21224
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72124
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7414
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70314
+#: model:account.group,name:l10n_lu.2_account_group_21214
+#: model:account.group,name:l10n_lu.2_account_group_21224
+#: model:account.group,name:l10n_lu.2_account_group_70314
+#: model:account.group,name:l10n_lu.2_account_group_72124
+#: model:account.group,name:l10n_lu.2_account_group_7414
 #: model:account.group.template,name:l10n_lu.account_group_21214
 #: model:account.group.template,name:l10n_lu.account_group_21224
 #: model:account.group.template,name:l10n_lu.account_group_70314
@@ -7037,133 +9053,181 @@ msgid "Trademarks and franchises"
 msgstr "Marques et franchises"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_50
 #: model:account.group.template,name:l10n_lu.account_group_50
 msgid "Transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_484
 #: model:account.account.template,name:l10n_lu.lu_2011_account_484
+#: model:account.group,name:l10n_lu.2_account_group_484
 #: model:account.group.template,name:l10n_lu.account_group_484
 msgid "Transitory or suspense accounts - Assets"
 msgstr "Comptes transitoires ou d'attente – Actif"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_485
 #: model:account.account.template,name:l10n_lu.lu_2011_account_485
+#: model:account.group,name:l10n_lu.2_account_group_485
 #: model:account.group.template,name:l10n_lu.account_group_485
 msgid "Transitory or suspense accounts - Liabilities"
 msgstr "Comptes transitoires ou d'attente – Passif"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6143
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6143
+#: model:account.group,name:l10n_lu.2_account_group_6143
 #: model:account.group.template,name:l10n_lu.account_group_6143
 msgid "Transport insurance"
 msgstr "Assurance-transport"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2231
+#: model:account.group,name:l10n_lu.2_account_group_2231
 #: model:account.group.template,name:l10n_lu.account_group_2231
 msgid "Transportation and handling equipment"
 msgstr "Equipement de transport et de manutention"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_616
 #: model:account.group.template,name:l10n_lu.account_group_616
 msgid "Transportation of goods and collective staff transportation"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6161
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6161
+#: model:account.group,name:l10n_lu.2_account_group_6161
 #: model:account.group.template,name:l10n_lu.account_group_6161
 msgid "Transportation of purchased goods"
 msgstr "Transports sur achats"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6162
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6162
+#: model:account.group,name:l10n_lu.2_account_group_6162
 #: model:account.group.template,name:l10n_lu.account_group_6162
 msgid "Transportation of sold goods"
 msgstr "Transports sur ventes"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6152
 #: model:account.group.template,name:l10n_lu.account_group_6152
 msgid "Travel and entertainment expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_61521
 #: model:account.group.template,name:l10n_lu.account_group_61521
 msgid "Travel expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6099
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6099
+#: model:account.group,name:l10n_lu.2_account_group_6099
 #: model:account.group.template,name:l10n_lu.account_group_6099
 msgid "Unallocated RDR"
 msgstr "RRR non affectés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5085
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5085
+#: model:account.group,name:l10n_lu.2_account_group_5085
 #: model:account.group.template,name:l10n_lu.account_group_5085
 msgid "Unlisted debenture loans"
 msgstr "Obligations – Titres non cotés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_235112
 #: model:account.account.template,name:l10n_lu.lu_2020_account_235112
+#: model:account.group,name:l10n_lu.2_account_group_235112
 #: model:account.group.template,name:l10n_lu.account_group_235112
 msgid "Unlisted shares"
 msgstr "Actions non cotées"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_60
 #: model:account.group.template,name:l10n_lu.account_group_60
 msgid "Use of merchandise, raw and consumable materials"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461418
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461418
+#: model:account.group,name:l10n_lu.2_account_group_461418
 #: model:account.group.template,name:l10n_lu.account_group_461418
 msgid "VAT - Other payables"
 msgstr "TVA – Autres dettes"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421618
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421618
+#: model:account.group,name:l10n_lu.2_account_group_421618
 #: model:account.group.template,name:l10n_lu.account_group_421618
 msgid "VAT - Other receivables"
 msgstr "TVA – Autres créances"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421613
+#: model:account.group,name:l10n_lu.2_account_group_421613
 #: model:account.group.template,name:l10n_lu.account_group_421613
 msgid "VAT down payments made"
 msgstr "TVA acomptes versés"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461413
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461413
+#: model:account.group,name:l10n_lu.2_account_group_461413
 #: model:account.group.template,name:l10n_lu.account_group_461413
 msgid "VAT down payments received"
 msgstr "TVA acomptes reçus"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_421611
 #: model:account.account.template,name:l10n_lu.lu_2020_account_421611
+#: model:account.group,name:l10n_lu.2_account_group_421611
 #: model:account.group.template,name:l10n_lu.account_group_421611
 msgid "VAT paid and recoverable"
 msgstr "TVA en amont"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461412
+#: model:account.group,name:l10n_lu.2_account_group_461412
 #: model:account.group.template,name:l10n_lu.account_group_461412
 msgid "VAT payable"
 msgstr "TVA à payer"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421612
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421612
+#: model:account.group,name:l10n_lu.2_account_group_421612
 #: model:account.group.template,name:l10n_lu.account_group_421612
 msgid "VAT receivable"
 msgstr "TVA à recevoir"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_461411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_461411
+#: model:account.group,name:l10n_lu.2_account_group_461411
 #: model:account.group.template,name:l10n_lu.account_group_461411
 msgid "VAT received"
 msgstr "TVA en aval"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4019
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4029
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41119
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41129
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41219
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41229
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42119
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42189
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42289
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4019
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4029
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41119
@@ -7173,6 +9237,15 @@ msgstr "TVA en aval"
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42119
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42189
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42289
+#: model:account.group,name:l10n_lu.2_account_group_4019
+#: model:account.group,name:l10n_lu.2_account_group_4029
+#: model:account.group,name:l10n_lu.2_account_group_41119
+#: model:account.group,name:l10n_lu.2_account_group_41129
+#: model:account.group,name:l10n_lu.2_account_group_41219
+#: model:account.group,name:l10n_lu.2_account_group_41229
+#: model:account.group,name:l10n_lu.2_account_group_42119
+#: model:account.group,name:l10n_lu.2_account_group_42189
+#: model:account.group,name:l10n_lu.2_account_group_42289
 #: model:account.group.template,name:l10n_lu.account_group_4019
 #: model:account.group.template,name:l10n_lu.account_group_4029
 #: model:account.group.template,name:l10n_lu.account_group_41119
@@ -7186,39 +9259,49 @@ msgid "Value adjustments"
 msgstr "Corrections de valeur"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_42161
+#: model:account.group,name:l10n_lu.2_account_group_46141
 #: model:account.group.template,name:l10n_lu.account_group_42161
 #: model:account.group.template,name:l10n_lu.account_group_46141
 msgid "Value-added tax (VAT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_62112
 #: model:account.group.template,name:l10n_lu.account_group_62112
 msgid "Wage supplements"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106161
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106161
 msgid "Wages"
 msgstr "Salaires"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106164
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106164
 msgid "Water"
 msgstr "Eau"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60314
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60314
+#: model:account.group,name:l10n_lu.2_account_group_60314
 #: model:account.group.template,name:l10n_lu.account_group_60314
 msgid "Water and sewage"
 msgstr "Eau et eaux usées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61844
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61844
+#: model:account.group,name:l10n_lu.2_account_group_61844
 #: model:account.group.template,name:l10n_lu.account_group_61844
 msgid "Water and waste water"
 msgstr "Eau et eaux usées"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10612
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10612
 msgid "Withdrawals of merchandise, finished products and services (at cost)"
 msgstr ""
@@ -7226,72 +9309,101 @@ msgstr ""
 "prix de revient)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62413
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62413
+#: model:account.group,name:l10n_lu.2_account_group_62413
 #: model:account.group.template,name:l10n_lu.account_group_62413
 msgid "Withholding tax on complementary pensions"
 msgstr "Retenue d'impôt sur pension complémentaire"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46126
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42146
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46126
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42146
+#: model:account.group,name:l10n_lu.2_account_group_42146
+#: model:account.group,name:l10n_lu.2_account_group_46126
 #: model:account.group.template,name:l10n_lu.account_group_42146
 #: model:account.group.template,name:l10n_lu.account_group_46126
 msgid "Withholding tax on director's fees"
 msgstr "Retenue d'impôt sur les tantièmes"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46125
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42145
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46125
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42145
+#: model:account.group,name:l10n_lu.2_account_group_42145
+#: model:account.group,name:l10n_lu.2_account_group_46125
 #: model:account.group.template,name:l10n_lu.account_group_42145
 #: model:account.group.template,name:l10n_lu.account_group_46125
 msgid "Withholding tax on financial investment income"
 msgstr "Retenue d'impôt sur revenus de capitaux mobiliers"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46124
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42144
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46124
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42144
+#: model:account.group,name:l10n_lu.2_account_group_42144
+#: model:account.group,name:l10n_lu.2_account_group_46124
 #: model:account.group.template,name:l10n_lu.account_group_42144
 #: model:account.group.template,name:l10n_lu.account_group_46124
 msgid "Withholding tax on wages and salaries"
 msgstr "Retenue d'impôt sur traitements et salaires (RTS)"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6731
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6731
+#: model:account.group,name:l10n_lu.2_account_group_6731
 #: model:account.group.template,name:l10n_lu.account_group_6731
 msgid "Withholding taxes"
 msgstr "Retenues d'impôt à la source"
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6034
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61853
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6034
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61853
+#: model:account.group,name:l10n_lu.2_account_group_6034
+#: model:account.group,name:l10n_lu.2_account_group_61853
 #: model:account.group.template,name:l10n_lu.account_group_6034
 #: model:account.group.template,name:l10n_lu.account_group_61853
 msgid "Work clothes"
 msgstr "Vêtements professionnels "
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6033
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6033
+#: model:account.group,name:l10n_lu.2_account_group_6033
 #: model:account.group.template,name:l10n_lu.account_group_6033
 msgid "Workshop, factory and store supplies and small equipment"
 msgstr "Fournitures et petit équipement d'atelier, d'usine et de magasin"
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_16121
 #: model:account.group.template,name:l10n_lu.account_group_16121
 msgid "acquired against payment (except Goodwill)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2121
 #: model:account.group.template,name:l10n_lu.account_group_2121
 msgid "acquired for consideration (except Goodwill)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_16122
+#: model:account.group,name:l10n_lu.2_account_group_2122
 #: model:account.group.template,name:l10n_lu.account_group_16122
 #: model:account.group.template,name:l10n_lu.account_group_2122
 msgid "created by the undertaking itself"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1922
+#: model:account.group,name:l10n_lu.2_account_group_1932
+#: model:account.group,name:l10n_lu.2_account_group_1942
 #: model:account.group.template,name:l10n_lu.account_group_1922
 #: model:account.group.template,name:l10n_lu.account_group_1932
 #: model:account.group.template,name:l10n_lu.account_group_1942
@@ -7299,6 +9411,9 @@ msgid "due and payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1921
+#: model:account.group,name:l10n_lu.2_account_group_1931
+#: model:account.group,name:l10n_lu.2_account_group_1941
 #: model:account.group.template,name:l10n_lu.account_group_1921
 #: model:account.group.template,name:l10n_lu.account_group_1931
 #: model:account.group.template,name:l10n_lu.account_group_1941
@@ -7306,31 +9421,37 @@ msgid "due and payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_755231
 #: model:account.group.template,name:l10n_lu.account_group_755231
 msgid "from affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_755232
 #: model:account.group.template,name:l10n_lu.account_group_755232
 msgid "from other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65413
 #: model:account.group.template,name:l10n_lu.account_group_65413
 msgid "from other receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75411
 #: model:account.group.template,name:l10n_lu.account_group_75411
 msgid "on affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75413
 #: model:account.group.template,name:l10n_lu.account_group_75413
 msgid "on other current receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75412
 #: model:account.group.template,name:l10n_lu.account_group_75412
 msgid ""
 "on undertakings with which the undertaking is linked by virtue of "

--- a/addons/l10n_lu/i18n_extra/l10n_lu.pot
+++ b/addons/l10n_lu/i18n_extra/l10n_lu.pot
@@ -16,136 +16,163 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-IC-EX
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-IC-EX
 msgid " EX-IC-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_V-ART-43_60b
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_V-ART-43_60b
 msgid "0-E-Art.43&60b"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_V-ART-44_56q
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_V-ART-44_56q
 msgid "0-E-Art.44&56q"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-PA-0
 msgid "0-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-PA-0
 msgid "0-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-0
 msgid "0-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-EC-0
 msgid "0-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-EC-0
 msgid "0-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-EC-0
 msgid "0-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-EC-0
 msgid "0-EC-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-EC-0
 msgid "0-EC-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-EC-Tab
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-EC-Tab
 msgid "0-EC-ST-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-IC-0
 msgid "0-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-IC-0
 msgid "0-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-IC-0
 msgid "0-IC-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-IC-0
 msgid "0-IC-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-IC-Tab
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-IC-Tab
 msgid "0-IC-ST-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-TR-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-TR-0
 msgid "0-ICT-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-PA-0
 msgid "0-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-PA-0
 msgid "0-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-PA-0
 msgid "0-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-PA-0
 msgid "0-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_SANS
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_SANS
 msgid "0-P-Tax-Free"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-PA-0
 msgid "0-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-PA-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-PA-0
 msgid "0-S-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_SANS_sale
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_SANS_sale
 msgid "0-S-Tax-Free"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-PA-Tab
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-PA-Tab
 msgid "0-ST-G"
 msgstr ""
@@ -156,18 +183,8 @@ msgid "012 - Overall turnover"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
-msgid "014"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014 - Exports"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
-msgid "015"
 msgstr ""
 
 #. module: l10n_lu
@@ -176,18 +193,8 @@ msgid "015 - Other exemptions"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
-msgid "016"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016 - Other exemptions"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
-msgid "017"
 msgstr ""
 
 #. module: l10n_lu
@@ -198,11 +205,6 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
-msgid "018"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
 msgid ""
 "018 - Supply, subsequent to intra-Community acquisitions of goods, in the "
@@ -210,13 +212,9 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
-msgid "019"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
-msgid "019 - Supplies other than referred to in 018 and 423 or 424"
+msgid ""
+"019 - Other supplies carried out (for which the place of supply is) abroad"
 msgstr ""
 
 #. module: l10n_lu
@@ -230,18 +228,8 @@ msgid "022 - Taxable turnover"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
-msgid "031"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031 - base 3%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
-msgid "033"
 msgstr ""
 
 #. module: l10n_lu
@@ -255,11 +243,6 @@ msgid "037 - Breakdown of taxable turnover – base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
-msgid "040"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040 - tax 3%"
 msgstr ""
@@ -267,11 +250,6 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
 msgid "046 - Breakdown of taxable turnover – tax"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
-msgid "049"
 msgstr ""
 
 #. module: l10n_lu
@@ -285,11 +263,6 @@ msgid "051 - Intra-Community acquisitions of goods – base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
-msgid "054"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054 - tax 3%"
 msgstr ""
@@ -300,18 +273,8 @@ msgid "056 - Intra-Community acquisitions of goods – tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
-msgid "059"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059 - for business purposes: base 3%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
-msgid "063"
 msgstr ""
 
 #. module: l10n_lu
@@ -325,18 +288,8 @@ msgid "065 - Importation of goods – base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
-msgid "068"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068 - for business purposes: tax 3%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
-msgid "073"
 msgstr ""
 
 #. module: l10n_lu
@@ -350,18 +303,8 @@ msgid "076 - Total tax due"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
-msgid "090"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090 - Due in respect of the application of goods for business purposes"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
-msgid "092"
 msgstr ""
 
 #. module: l10n_lu
@@ -386,11 +329,6 @@ msgstr ""
 msgid ""
 "095 - where the deductible proportion determined in accordance to article 50"
 " is applied"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
-msgid "096"
 msgstr ""
 
 #. module: l10n_lu
@@ -426,6 +364,217 @@ msgid "105 - Exceeding amount"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-13
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-ECP-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-ECP-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-EC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-IC-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VB-PA-13
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VP-PA-13
+msgid "13%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-13
+msgid "13-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-13
+msgid "13-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-13
+msgid "13-EC(P)-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-13
+msgid "13-EC(P)-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-13
+msgid "13-EC(P)-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-13
+msgid "13-EC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-13
+msgid "13-EC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-13
+msgid "13-EC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-13
+msgid "13-EC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-13
+msgid "13-EC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-13
+msgid "13-EC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-13
+msgid "13-IC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-13
+msgid "13-IC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-13
+msgid "13-IC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-13
+msgid "13-IC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-13
+msgid "13-IC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-13
+msgid "13-IC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-13
+msgid "13-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-13
+msgid "13-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-13
+msgid "13-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-13
+msgid "13-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-13
+msgid "13-S-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-13
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-13
+msgid "13-S-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-14
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-14
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-14
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-14
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-14
@@ -453,123 +602,141 @@ msgid "14%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-14
 msgid "14-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-14
 msgid "14-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-14
 msgid "14-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-14
 msgid "14-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-14
 msgid "14-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-14
 msgid "14-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-14
 msgid "14-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-14
 msgid "14-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-14
 msgid "14-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-14
 msgid "14-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-14
 msgid "14-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-14
 msgid "14-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-14
 msgid "14-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-14
 msgid "14-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-14
 msgid "14-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-14
 msgid "14-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-14
 msgid "14-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-14
 msgid "14-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-14
 msgid "14-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-14
 msgid "14-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-14
 msgid "14-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-14
 msgid "14-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-14
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-14
 msgid "14-S-S"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
-msgid "152"
 msgstr ""
 
 #. module: l10n_lu
@@ -578,6 +745,226 @@ msgid "152 - Acquisitions, in the context of triangular transactions – base"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_ATN_sale_16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-16
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_ATN_sale_16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-ECP-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_FP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-ECP-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-EC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-IC-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_IP-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VB-PA-16
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_VP-PA-16
+msgid "16%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_ATN_sale_16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_ATN_sale_16
+msgid "16-ATN"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-16
+msgid "16-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-16
+msgid "16-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-16
+msgid "16-EC(P)-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-16
+msgid "16-EC(P)-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-16
+msgid "16-EC(P)-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-16
+msgid "16-EC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-16
+msgid "16-EC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-16
+msgid "16-EC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-16
+msgid "16-EC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-16
+msgid "16-EC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-16
+msgid "16-EC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-16
+msgid "16-IC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-16
+msgid "16-IC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-16
+msgid "16-IC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-16
+msgid "16-IC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-16
+msgid "16-IC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-16
+msgid "16-IC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-16
+msgid "16-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-16
+msgid "16-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-16
+msgid "16-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-16
+msgid "16-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-16
+msgid "16-S-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-16
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-16
+msgid "16-S-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-ECP-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_AP-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_ATN_sale
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-ECP-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_FP-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-ECP-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-EC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-IC-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_IP-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VB-PA-17
+#: model:account.tax,description:l10n_lu.2_lu_2015_tax_VP-PA-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-EC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-ECP-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AB-IC-17
@@ -585,6 +972,7 @@ msgstr ""
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-EC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-IC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_AP-PA-17
+#: model:account.tax.template,description:l10n_lu.lu_2015_tax_ATN_sale
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-EC-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-ECP-17
 #: model:account.tax.template,description:l10n_lu.lu_2015_tax_FB-IC-17
@@ -605,123 +993,147 @@ msgid "17%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_ATN_sale
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_ATN_sale
+msgid "17-ATN"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-17
 msgid "17-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-17
 msgid "17-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-17
 msgid "17-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-17
 msgid "17-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-17
 msgid "17-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-17
 msgid "17-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-17
 msgid "17-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-17
 msgid "17-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-17
 msgid "17-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-17
 msgid "17-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-17
 msgid "17-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-17
 msgid "17-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-17
 msgid "17-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-17
 msgid "17-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-17
 msgid "17-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-17
 msgid "17-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-17
 msgid "17-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-17
 msgid "17-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-17
 msgid "17-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-17
 msgid "17-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-17
 msgid "17-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-17
 msgid "17-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-17
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-17
 msgid "17-S-S"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_exempt
-msgid "194"
 msgstr ""
 
 #. module: l10n_lu
@@ -730,28 +1142,13 @@ msgid "194 - base exempt"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
-msgid "195"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195 - for business purposes: base exempt"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
-msgid "196"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196 - for non-business purposes: base exempt"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
-msgid "226"
 msgstr ""
 
 #. module: l10n_lu
@@ -762,18 +1159,8 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
-msgid "227"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227 - Special arrangement for tax suspension: adjustment"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
-msgid "228"
 msgstr ""
 
 #. module: l10n_lu
@@ -782,116 +1169,139 @@ msgid "228 - Adjusted tax - special arrangement for tax suspension"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-PA-3
 msgid "3-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-PA-3
 msgid "3-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-3
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-3
 msgid "3-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-3
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-3
 msgid "3-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-3
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-3
 msgid "3-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-EC-3
 msgid "3-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-EC-3
 msgid "3-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-EC-3
 msgid "3-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-EC-3
 msgid "3-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-EC-3
 msgid "3-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-EC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-EC-3
 msgid "3-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-IC-3
 msgid "3-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-IC-3
 msgid "3-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-IC-3
 msgid "3-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-IC-3
 msgid "3-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-IC-3
 msgid "3-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-IC-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-IC-3
 msgid "3-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IB-PA-3
 msgid "3-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_IP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_IP-PA-3
 msgid "3-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-PA-3
 msgid "3-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-PA-3
 msgid "3-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VB-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VB-PA-3
 msgid "3-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_VP-PA-3
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_VP-PA-3
 msgid "3-S-S"
 msgstr ""
@@ -916,20 +1326,10 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
-msgid "419"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
 msgid ""
 "419 - Inland supplies for which the customer is liable for the payment of "
 "VAT"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
-msgid "423"
 msgstr ""
 
 #. module: l10n_lu
@@ -939,18 +1339,8 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
-msgid "424"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424 - exempt in the MS where the customer is identified"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
-msgid "431"
 msgstr ""
 
 #. module: l10n_lu
@@ -959,18 +1349,8 @@ msgid "431 - not exempt within the territory: base 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
-msgid "432"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432 - not exempt within the territory: tax 3%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
-msgid "435"
 msgstr ""
 
 #. module: l10n_lu
@@ -984,28 +1364,13 @@ msgid "436 - base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
-msgid "441"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441 - not established or residing within the Community: base 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
-msgid "442"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442 - not established or residing within the Community: tax 3%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
-msgid "445"
 msgstr ""
 
 #. module: l10n_lu
@@ -1019,29 +1384,14 @@ msgid "454 - Total Sales / Receipts"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
-msgid "455"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
 msgid ""
 "455 - Application of goods for non-business use and for business purposes"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
-msgid "456"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456 - Non-business use of goods and supply of services free of charge"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
-msgid "457"
 msgstr ""
 
 #. module: l10n_lu
@@ -1052,18 +1402,8 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
-msgid "458"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458 - Invoiced by other taxable persons for goods or services supplied"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
-msgid "459"
 msgstr ""
 
 #. module: l10n_lu
@@ -1072,18 +1412,8 @@ msgid "459 - Due in respect of intra-Community acquisitions of goods"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
-msgid "460"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460 - Due or paid in respect of importation of goods"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
-msgid "461"
 msgstr ""
 
 #. module: l10n_lu
@@ -1107,11 +1437,6 @@ msgid "464 - tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
-msgid "471"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid ""
 "471 - Telecommunications services, radio and television broadcasting "
@@ -1124,8 +1449,155 @@ msgid "472 - Other sales / receipts"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
-msgid "701"
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_8_supplies_carried_out_domestic
+msgid ""
+"481 - Supplies carried out within the scope of the domestic SME scheme of "
+"article 57bis (7)"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_9_supplies_carried_out_cross_border
+msgid ""
+"482 - Supplies carried out within the scope of the cross-border SME scheme "
+"of article 57 quater"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-7
+msgid "7-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-7
+msgid "7-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-7
+msgid "7-EC(P)-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-7
+msgid "7-EC(P)-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-7
+msgid "7-EC(P)-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-7
+msgid "7-EC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-7
+msgid "7-EC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-7
+msgid "7-EC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-7
+msgid "7-EC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-7
+msgid "7-EC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-7
+msgid "7-EC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-7
+msgid "7-IC-E-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-7
+msgid "7-IC-E-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-7
+msgid "7-IC-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-7
+msgid "7-IC-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-7
+msgid "7-IC-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-7
+msgid "7-IC-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-7
+msgid "7-IG"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-7
+msgid "7-IS"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-7
+msgid "7-P-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-7
+msgid "7-P-S"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-7
+msgid "7-S-G"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-7
+#: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-7
+msgid "7-S-S"
 msgstr ""
 
 #. module: l10n_lu
@@ -1134,18 +1606,8 @@ msgid "701 - base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
-msgid "702"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702 - tax 17%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
-msgid "703"
 msgstr ""
 
 #. module: l10n_lu
@@ -1154,18 +1616,8 @@ msgid "703 - base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
-msgid "704"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704 - tax 14%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
-msgid "705"
 msgstr ""
 
 #. module: l10n_lu
@@ -1174,18 +1626,8 @@ msgid "705 - base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
-msgid "706"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706 - tax 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
-msgid "711"
 msgstr ""
 
 #. module: l10n_lu
@@ -1194,18 +1636,8 @@ msgid "711 - base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
-msgid "712"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712 - tax 17%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
-msgid "713"
 msgstr ""
 
 #. module: l10n_lu
@@ -1214,18 +1646,8 @@ msgid "713 - base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
-msgid "714"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714 - tax 14%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
-msgid "715"
 msgstr ""
 
 #. module: l10n_lu
@@ -1234,18 +1656,8 @@ msgid "715 - base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
-msgid "716"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716 - tax 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
-msgid "719"
 msgstr ""
 
 #. module: l10n_lu
@@ -1256,18 +1668,8 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
-msgid "721"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721 - for business purposes: base 17%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
-msgid "722"
 msgstr ""
 
 #. module: l10n_lu
@@ -1276,18 +1678,8 @@ msgid "722 - for business purposes: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
-msgid "723"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723 - for business purposes: base 14%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
-msgid "724"
 msgstr ""
 
 #. module: l10n_lu
@@ -1296,28 +1688,13 @@ msgid "724 - for business purposes: tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
-msgid "725"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725 - for business purposes: base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
-msgid "726"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
-msgid "729"
 msgstr ""
 
 #. module: l10n_lu
@@ -1328,18 +1705,8 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
-msgid "731"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731 - for non-business purposes: base 17%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
-msgid "732"
 msgstr ""
 
 #. module: l10n_lu
@@ -1348,18 +1715,8 @@ msgid "732 - for non-business purposes: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
-msgid "733"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733 - for non-business purposes: base 14%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
-msgid "734"
 msgstr ""
 
 #. module: l10n_lu
@@ -1368,18 +1725,8 @@ msgid "734 - for non-business purposes: tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
-msgid "735"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735 - for non-business purposes: base 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
-msgid "736"
 msgstr ""
 
 #. module: l10n_lu
@@ -1388,18 +1735,8 @@ msgid "736 - for non-business purposes: tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
-msgid "741"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741 - not exempt within the territory: base 17%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
-msgid "742"
 msgstr ""
 
 #. module: l10n_lu
@@ -1408,18 +1745,8 @@ msgid "742 - not exempt within the territory: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
-msgid "743"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743 - not exempt within the territory: base 14%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
-msgid "744"
 msgstr ""
 
 #. module: l10n_lu
@@ -1428,18 +1755,8 @@ msgid "744 - not exempt within the territory: tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
-msgid "745"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745 - not exempt within the territory: base 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
-msgid "746"
 msgstr ""
 
 #. module: l10n_lu
@@ -1448,18 +1765,8 @@ msgid "746 - not exempt within the territory: tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
-msgid "751"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751 - not established or residing within the Community: base 17%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
-msgid "752"
 msgstr ""
 
 #. module: l10n_lu
@@ -1468,18 +1775,8 @@ msgid "752 - not established or residing within the Community: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
-msgid "753"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753 - not established or residing within the Community: base 14%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
-msgid "754"
 msgstr ""
 
 #. module: l10n_lu
@@ -1488,18 +1785,8 @@ msgid "754 - not established or residing within the Community: tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
-msgid "755"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755 - not established or residing within the Community: base 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
-msgid "756"
 msgstr ""
 
 #. module: l10n_lu
@@ -1508,18 +1795,8 @@ msgid "756 - not established or residing within the Community: tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
-msgid "761"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761 - suppliers established within the territory: base 17%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
-msgid "762"
 msgstr ""
 
 #. module: l10n_lu
@@ -1528,18 +1805,8 @@ msgid "762 - suppliers established within the territory: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
-msgid "763"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763 - base 8%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
-msgid "764"
 msgstr ""
 
 #. module: l10n_lu
@@ -1572,193 +1839,151 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_17
+msgid "769 - base 17%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_17
+msgid "770 - tax 17%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-8
 msgid "8-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-PA-8
 msgid "8-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-8
 msgid "8-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-ECP-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-ECP-8
 msgid "8-EC(P)-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-8
 msgid "8-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-EC-8
 msgid "8-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-EC-8
 msgid "8-EC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-EC-8
 msgid "8-EC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-EC-8
 msgid "8-EC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-EC-8
 msgid "8-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-EC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-EC-8
 msgid "8-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-IC-8
 msgid "8-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FP-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FP-IC-8
 msgid "8-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-IC-8
 msgid "8-IC-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-IC-8
 msgid "8-IC-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-IC-8
 msgid "8-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-IC-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-IC-8
 msgid "8-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IB-PA-8
 msgid "8-IG"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_IP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_IP-PA-8
 msgid "8-IS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-PA-8
 msgid "8-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AP-PA-8
 msgid "8-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VB-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VB-PA-8
 msgid "8-S-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_VP-PA-8
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_VP-PA-8
 msgid "8-S-S"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_16
-msgid "921 - for business purposes: base 16%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_13
-msgid "923 - for business purposes: base 13%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_7
-msgid "925 - for business purposes: base 7%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_16
-msgid "931 - for non-business purposes: base 16%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_13
-msgid "933 - for non-business purposes: base 13%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_7
-msgid "935 - for non-business purposes: base 7%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_16
-msgid "941 - not exempt within the territory: base 16%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_13
-msgid "943 - not exempt within the territory: base 13%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_7
-msgid "945 - not exempt within the territory: base 7%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_16
-msgid "951 - not established or residing within the Community: base 16%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_13
-msgid "953 - not established or residing within the Community: base 13%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_7
-msgid "955 - not established or residing within the Community: base 7%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_16
-msgid "961 - suppliers established within the territory: base 16%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_7
-msgid "963 - base 7%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_7
-msgid "964 - tax 7%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1767,23 +1992,23 @@ msgid "901 - base 16%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_13
-msgid "903 - base 13%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_7
-msgid "905 - base 7%"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_16
 msgid "902 - tax 16%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_13
+msgid "903 - base 13%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_13
 msgid "904 - tax 13%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_7
+msgid "905 - base 7%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1797,18 +2022,13 @@ msgid "911 - base 16%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_13
-msgid "913 - base 13%"
-msgstr ""
-
-#. module: l10n_lu
-#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_7
-msgid "915 - base 7%"
-msgstr ""
-
-#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_16
 msgid "912 - tax 16%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_13
+msgid "913 - base 13%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1817,8 +2037,18 @@ msgid "914 - tax 13%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_7
+msgid "915 - base 7%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_7
 msgid "916 - tax 7%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_16
+msgid "921 - for business purposes: base 16%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1827,8 +2057,18 @@ msgid "922 - for business purposes: tax 16%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_13
+msgid "923 - for business purposes: base 13%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_13
 msgid "924 - for business purposes: tax 13%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_7
+msgid "925 - for business purposes: base 7%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1837,8 +2077,18 @@ msgid "926 - for business purposes: tax 7%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_16
+msgid "931 - for non-business purposes: base 16%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_16
 msgid "932 - for non-business purposes: tax 16%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_13
+msgid "933 - for non-business purposes: base 13%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1847,8 +2097,18 @@ msgid "934 - for non-business purposes: tax 13%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_7
+msgid "935 - for non-business purposes: base 7%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_7
 msgid "936 - for non-business purposes: tax 7%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_16
+msgid "941 - not exempt within the territory: base 16%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1857,8 +2117,18 @@ msgid "942 - not exempt within the territory: tax 16%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_13
+msgid "943 - not exempt within the territory: base 13%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_13
 msgid "944 - not exempt within the territory: tax 13%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_7
+msgid "945 - not exempt within the territory: base 7%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1867,8 +2137,18 @@ msgid "946 - not exempt within the territory: tax 7%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_16
+msgid "951 - not established or residing within the Community: base 16%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_16
 msgid "952 - not established or residing within the Community: tax 16%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_13
+msgid "953 - not established or residing within the Community: base 13%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1877,8 +2157,18 @@ msgid "954 - not established or residing within the Community: tax 13%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_7
+msgid "955 - not established or residing within the Community: base 7%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_7
 msgid "956 - not established or residing within the Community: tax 7%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_16
+msgid "961 - suppliers established within the territory: base 16%"
 msgstr ""
 
 #. module: l10n_lu
@@ -1887,36 +2177,57 @@ msgid "962 - suppliers established within the territory: tax 16%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_7
+msgid "963 - base 7%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_7
+msgid "964 - tax 7%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46128
+#: model:account.group,name:l10n_lu.2_account_group_46128
 #: model:account.group.template,name:l10n_lu.account_group_46128
 msgid "ACD - Other amounts payable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42148
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42148
+#: model:account.group,name:l10n_lu.2_account_group_42148
 #: model:account.group.template,name:l10n_lu.account_group_42148
 msgid "ACD - Other amounts receivable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_46148
 #: model:account.account.template,name:l10n_lu.lu_2020_account_46148
+#: model:account.group,name:l10n_lu.2_account_group_46148
 #: model:account.group.template,name:l10n_lu.account_group_46148
 msgid "AED - Other debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_635
 #: model:account.group.template,name:l10n_lu.account_group_635
 msgid "AVA and FVA on receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65112
+#: model:account.group,name:l10n_lu.2_account_group_65112
 #: model:account.group.template,name:l10n_lu.account_group_65112
 msgid "AVA on amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6352
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6352
+#: model:account.group,name:l10n_lu.2_account_group_6352
 #: model:account.group.template,name:l10n_lu.account_group_6352
 msgid ""
 "AVA on amounts owed by affiliated undertakings and undertakings with which "
@@ -1924,7 +2235,9 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65114
+#: model:account.group,name:l10n_lu.2_account_group_65114
 #: model:account.group.template,name:l10n_lu.account_group_65114
 msgid ""
 "AVA on amounts owed by undertakings with which the undertaking is linked by "
@@ -1932,13 +2245,17 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_63313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_63313
+#: model:account.group,name:l10n_lu.2_account_group_63313
 #: model:account.group.template,name:l10n_lu.account_group_63313
 msgid "AVA on buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6322
+#: model:account.group,name:l10n_lu.2_account_group_6322
 #: model:account.group.template,name:l10n_lu.account_group_6322
 msgid ""
 "AVA on concessions, patents, licences, trademarks and similar rights and "
@@ -1946,31 +2263,41 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6321
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6321
+#: model:account.group,name:l10n_lu.2_account_group_6321
 #: model:account.group.template,name:l10n_lu.account_group_6321
 msgid "AVA on development costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6324
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6324
+#: model:account.group,name:l10n_lu.2_account_group_6324
 #: model:account.group.template,name:l10n_lu.account_group_6324
 msgid "AVA on down payments and intangible fixed assets under development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6334
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6334
+#: model:account.group,name:l10n_lu.2_account_group_6334
 #: model:account.group.template,name:l10n_lu.account_group_6334
 msgid "AVA on down payments and tangible fixed assets under development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6345
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6345
+#: model:account.group,name:l10n_lu.2_account_group_6345
 #: model:account.group.template,name:l10n_lu.account_group_6345
 msgid "AVA on down payments on inventories"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6313
+#: model:account.group,name:l10n_lu.2_account_group_6313
 #: model:account.group.template,name:l10n_lu.account_group_6313
 msgid ""
 "AVA on expenses for capital increases and various operations (mergers, "
@@ -1978,93 +2305,120 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6511
 #: model:account.group.template,name:l10n_lu.account_group_6511
 msgid "AVA on financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_63314
 #: model:account.account.template,name:l10n_lu.lu_2020_account_63314
+#: model:account.group,name:l10n_lu.2_account_group_63314
 #: model:account.group.template,name:l10n_lu.account_group_63314
 msgid "AVA on fixtures and fittings-out of buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_63312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_63312
+#: model:account.group,name:l10n_lu.2_account_group_63312
 #: model:account.group.template,name:l10n_lu.account_group_63312
 msgid "AVA on fixtures and fittings-out of land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_631
 #: model:account.group.template,name:l10n_lu.account_group_631
 msgid "AVA on formation expenses and similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6323
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6323
+#: model:account.group,name:l10n_lu.2_account_group_6323
 #: model:account.group.template,name:l10n_lu.account_group_6323
 msgid "AVA on goodwill acquired for consideration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_632
 #: model:account.group.template,name:l10n_lu.account_group_632
 msgid "AVA on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_634
 #: model:account.group.template,name:l10n_lu.account_group_634
 msgid "AVA on inventories"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6343
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6343
+#: model:account.group,name:l10n_lu.2_account_group_6343
 #: model:account.group.template,name:l10n_lu.account_group_6343
 msgid "AVA on inventories of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6344
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6344
+#: model:account.group,name:l10n_lu.2_account_group_6344
 #: model:account.group.template,name:l10n_lu.account_group_6344
 msgid "AVA on inventories of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6341
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6341
+#: model:account.group,name:l10n_lu.2_account_group_6341
 #: model:account.group.template,name:l10n_lu.account_group_6341
 msgid "AVA on inventories of raw materials and consumables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6342
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6342
+#: model:account.group,name:l10n_lu.2_account_group_6342
 #: model:account.group.template,name:l10n_lu.account_group_6342
 msgid "AVA on inventories of work and contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_63311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_63311
+#: model:account.group,name:l10n_lu.2_account_group_63311
 #: model:account.group.template,name:l10n_lu.account_group_63311
 msgid "AVA on land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6331
 #: model:account.group.template,name:l10n_lu.account_group_6331
 msgid ""
 "AVA on land, fittings-out and buildings and FVA on investment properties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6314
+#: model:account.group,name:l10n_lu.2_account_group_6314
 #: model:account.group.template,name:l10n_lu.account_group_6314
 msgid "AVA on loan-issuance expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65116
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65116
+#: model:account.group,name:l10n_lu.2_account_group_65116
 #: model:account.group.template,name:l10n_lu.account_group_65116
 msgid "AVA on loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6333
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6333
+#: model:account.group,name:l10n_lu.2_account_group_6333
 #: model:account.group.template,name:l10n_lu.account_group_6333
 msgid ""
 "AVA on other fixtures and fittings, tools and equipment (including rolling "
@@ -2072,63 +2426,85 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6353
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6353
+#: model:account.group,name:l10n_lu.2_account_group_6353
 #: model:account.group.template,name:l10n_lu.account_group_6353
 msgid "AVA on other receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6318
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6318
+#: model:account.group,name:l10n_lu.2_account_group_6318
 #: model:account.group.template,name:l10n_lu.account_group_6318
 msgid "AVA on other similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65318
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65318
+#: model:account.group,name:l10n_lu.2_account_group_65318
 #: model:account.group.template,name:l10n_lu.account_group_65318
 msgid "AVA on other transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65312
+#: model:account.group,name:l10n_lu.2_account_group_65312
 #: model:account.group.template,name:l10n_lu.account_group_65312
 msgid "AVA on own shares or own corporate units"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65113
+#: model:account.group,name:l10n_lu.2_account_group_65113
 #: model:account.group.template,name:l10n_lu.account_group_65113
 msgid "AVA on participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6332
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6332
+#: model:account.group,name:l10n_lu.2_account_group_6332
 #: model:account.group.template,name:l10n_lu.account_group_6332
 msgid "AVA on plant and machinery"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65115
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65115
+#: model:account.group,name:l10n_lu.2_account_group_65115
 #: model:account.group.template,name:l10n_lu.account_group_65115
 msgid "AVA on securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6311
+#: model:account.group,name:l10n_lu.2_account_group_6311
 #: model:account.group.template,name:l10n_lu.account_group_6311
 msgid "AVA on set-up and start-up costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65311
+#: model:account.group,name:l10n_lu.2_account_group_65111
+#: model:account.group,name:l10n_lu.2_account_group_65311
 #: model:account.group.template,name:l10n_lu.account_group_65111
 #: model:account.group.template,name:l10n_lu.account_group_65311
 msgid "AVA on shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65313
+#: model:account.group,name:l10n_lu.2_account_group_65313
 #: model:account.group.template,name:l10n_lu.account_group_65313
 msgid ""
 "AVA on shares in undertakings with which the undertaking is linked by virtue"
@@ -2136,6 +2512,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_633
 #: model:account.group.template,name:l10n_lu.account_group_633
 msgid ""
 "AVA on tangible fixed assets and fair value adjustments (FVA) on investment "
@@ -2143,17 +2520,21 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6351
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6351
+#: model:account.group,name:l10n_lu.2_account_group_6351
 #: model:account.group.template,name:l10n_lu.account_group_6351
 msgid "AVA on trade receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6531
 #: model:account.group.template,name:l10n_lu.account_group_6531
 msgid "AVA on transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106142
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106142
 msgid "Accident insurance"
 msgstr ""
@@ -2164,126 +2545,163 @@ msgid "Account Chart Template"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_106
 #: model:account.group.template,name:l10n_lu.account_group_106
 msgid "Account of the owner or the co-owners"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61342
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61342
+#: model:account.group,name:l10n_lu.2_account_group_61342
 #: model:account.group.template,name:l10n_lu.account_group_61342
 msgid "Accounting, tax consulting, auditing and similar fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_16121
 #: model:account.account.template,name:l10n_lu.lu_2020_account_16121
 msgid "Acquired against payment (except Goodwill)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_771
 #: model:account.account.template,name:l10n_lu.lu_2011_account_771
+#: model:account.group,name:l10n_lu.2_account_group_771
 #: model:account.group.template,name:l10n_lu.account_group_771
 msgid "Adjustments of corporate income tax (CIT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_773
 #: model:account.account.template,name:l10n_lu.lu_2011_account_773
+#: model:account.group,name:l10n_lu.2_account_group_773
 #: model:account.group.template,name:l10n_lu.account_group_773
 msgid "Adjustments of foreign income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_783
 #: model:account.account.template,name:l10n_lu.lu_2011_account_783
+#: model:account.group,name:l10n_lu.2_account_group_783
 #: model:account.group.template,name:l10n_lu.account_group_783
 msgid "Adjustments of foreign taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_77
 #: model:account.group.template,name:l10n_lu.account_group_77
 msgid "Adjustments of income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_772
 #: model:account.account.template,name:l10n_lu.lu_2011_account_772
+#: model:account.group,name:l10n_lu.2_account_group_772
 #: model:account.group.template,name:l10n_lu.account_group_772
 msgid "Adjustments of municipal business tax (MBT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_781
 #: model:account.account.template,name:l10n_lu.lu_2011_account_781
+#: model:account.group,name:l10n_lu.2_account_group_781
 #: model:account.group.template,name:l10n_lu.account_group_781
 msgid "Adjustments of net wealth tax (NWT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_788
 #: model:account.account.template,name:l10n_lu.lu_2011_account_788
+#: model:account.group,name:l10n_lu.2_account_group_788
 #: model:account.group.template,name:l10n_lu.account_group_788
 msgid "Adjustments of other taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_78
 #: model:account.group.template,name:l10n_lu.account_group_78
 msgid "Adjustments of other taxes not included in the previous caption"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_782
 #: model:account.account.template,name:l10n_lu.lu_2011_account_782
+#: model:account.group,name:l10n_lu.2_account_group_782
 #: model:account.group.template,name:l10n_lu.account_group_782
 msgid "Adjustments of subscription tax"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42111
+#: model:account.group,name:l10n_lu.2_account_group_42111
 #: model:account.group.template,name:l10n_lu.account_group_42111
 msgid "Advances and down payments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_659
 #: model:account.group.template,name:l10n_lu.account_group_659
 msgid "Allocations to financial provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6591
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6591
+#: model:account.group,name:l10n_lu.2_account_group_6591
 #: model:account.group.template,name:l10n_lu.account_group_6591
 msgid "Allocations to financial provisions - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6592
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6592
+#: model:account.group,name:l10n_lu.2_account_group_6592
 #: model:account.group.template,name:l10n_lu.account_group_6592
 msgid "Allocations to financial provisions - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6492
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6492
+#: model:account.group,name:l10n_lu.2_account_group_6492
 #: model:account.group.template,name:l10n_lu.account_group_6492
 msgid "Allocations to operating provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_649
 #: model:account.group.template,name:l10n_lu.account_group_649
 msgid "Allocations to provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_679
 #: model:account.account.template,name:l10n_lu.lu_2020_account_679
+#: model:account.group,name:l10n_lu.2_account_group_679
 #: model:account.group.template,name:l10n_lu.account_group_679
 msgid "Allocations to provisions for deferred taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6491
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6491
+#: model:account.group,name:l10n_lu.2_account_group_6491
 #: model:account.group.template,name:l10n_lu.account_group_6491
 msgid "Allocations to tax provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_647
 #: model:account.account.template,name:l10n_lu.lu_2011_account_647
+#: model:account.group,name:l10n_lu.2_account_group_647
 #: model:account.group.template,name:l10n_lu.account_group_647
 msgid "Allocations to tax-exempt capital gains"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_653
 #: model:account.group.template,name:l10n_lu.account_group_653
 msgid ""
 "Allocations to value adjustment (AVA) and fair-value adjustments (FVA) on "
@@ -2291,6 +2709,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_63
 #: model:account.group.template,name:l10n_lu.account_group_63
 msgid ""
 "Allocations to value adjustments (AVA) and fair value adjustments (FVA) on "
@@ -2299,6 +2718,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_651
 #: model:account.group.template,name:l10n_lu.account_group_651
 msgid ""
 "Allocations to value adjustments (AVA) and fair-value adjustments (FVA) of "
@@ -2306,11 +2726,22 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_232
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6452
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75112
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65212
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6452
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75112
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75212
+#: model:account.group,name:l10n_lu.2_account_group_232
+#: model:account.group,name:l10n_lu.2_account_group_411
+#: model:account.group,name:l10n_lu.2_account_group_6452
+#: model:account.group,name:l10n_lu.2_account_group_65212
+#: model:account.group,name:l10n_lu.2_account_group_75212
+#: model:account.group,name:l10n_lu.2_account_group_75222
 #: model:account.group.template,name:l10n_lu.account_group_232
 #: model:account.group.template,name:l10n_lu.account_group_411
 #: model:account.group.template,name:l10n_lu.account_group_6452
@@ -2321,6 +2752,7 @@ msgid "Amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_41
 #: model:account.group.template,name:l10n_lu.account_group_41
 msgid ""
 "Amounts owed by affiliated undertakings and by undertakings with which the "
@@ -2328,19 +2760,25 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4112
 #: model:account.group.template,name:l10n_lu.account_group_4112
 msgid ""
 "Amounts owed by affiliated undertakings receivable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4111
 #: model:account.group.template,name:l10n_lu.account_group_4111
 msgid "Amounts owed by affiliated undertakings receivable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4212
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4222
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4222
+#: model:account.group,name:l10n_lu.2_account_group_4212
+#: model:account.group,name:l10n_lu.2_account_group_4222
 #: model:account.group.template,name:l10n_lu.account_group_4212
 #: model:account.group.template,name:l10n_lu.account_group_4222
 msgid ""
@@ -2349,11 +2787,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4217
 #: model:account.group.template,name:l10n_lu.account_group_4217
 msgid "Amounts owed by the Social Security and other social bodies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75114
 msgid ""
 "Amounts owed by undertakings with which the company is linked by virtue of "
@@ -2361,10 +2801,20 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_234
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6453
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65214
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75214
 #: model:account.account.template,name:l10n_lu.lu_2011_account_234
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6453
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65214
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75214
+#: model:account.group,name:l10n_lu.2_account_group_234
+#: model:account.group,name:l10n_lu.2_account_group_412
+#: model:account.group,name:l10n_lu.2_account_group_6453
+#: model:account.group,name:l10n_lu.2_account_group_65214
+#: model:account.group,name:l10n_lu.2_account_group_75214
+#: model:account.group,name:l10n_lu.2_account_group_75224
 #: model:account.group.template,name:l10n_lu.account_group_234
 #: model:account.group.template,name:l10n_lu.account_group_412
 #: model:account.group.template,name:l10n_lu.account_group_6453
@@ -2377,6 +2827,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4121
 #: model:account.group.template,name:l10n_lu.account_group_4121
 msgid ""
 "Amounts owed by undertakings with which the undertaking is linked by virtue "
@@ -2384,21 +2835,25 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_194
 #: model:account.group.template,name:l10n_lu.account_group_194
 msgid "Amounts owed to credit institutions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_451
 #: model:account.group.template,name:l10n_lu.account_group_451
 msgid "Amounts payable to affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4512
 #: model:account.group.template,name:l10n_lu.account_group_4512
 msgid "Amounts payable to affiliated undertakings after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_45
 #: model:account.group.template,name:l10n_lu.account_group_45
 msgid ""
 "Amounts payable to affiliated undertakings and to undertakings with which "
@@ -2406,21 +2861,30 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4511
 #: model:account.group.template,name:l10n_lu.account_group_4511
 msgid "Amounts payable to affiliated undertakings within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4713
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4723
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4713
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4723
+#: model:account.group,name:l10n_lu.2_account_group_4713
+#: model:account.group,name:l10n_lu.2_account_group_4723
 #: model:account.group.template,name:l10n_lu.account_group_4713
 #: model:account.group.template,name:l10n_lu.account_group_4723
 msgid "Amounts payable to directors, managers, statutory auditors and similar"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4712
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4722
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4712
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4722
+#: model:account.group,name:l10n_lu.2_account_group_4712
+#: model:account.group,name:l10n_lu.2_account_group_4722
 #: model:account.group.template,name:l10n_lu.account_group_4712
 #: model:account.group.template,name:l10n_lu.account_group_4722
 msgid ""
@@ -2429,14 +2893,19 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4714
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4724
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4714
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4724
+#: model:account.group,name:l10n_lu.2_account_group_4714
+#: model:account.group,name:l10n_lu.2_account_group_4724
 #: model:account.group.template,name:l10n_lu.account_group_4714
 #: model:account.group.template,name:l10n_lu.account_group_4724
 msgid "Amounts payable to staff"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_452
 #: model:account.group.template,name:l10n_lu.account_group_452
 msgid ""
 "Amounts payable to undertakings with which the undertaking is linked by "
@@ -2444,6 +2913,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4522
 #: model:account.group.template,name:l10n_lu.account_group_4522
 msgid ""
 "Amounts payable to undertakings with which the undertaking is linked by "
@@ -2451,6 +2921,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4521
 #: model:account.group.template,name:l10n_lu.account_group_4521
 msgid ""
 "Amounts payable to undertakings with which the undertaking is linked by "
@@ -2458,35 +2929,50 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4122
 #: model:account.group.template,name:l10n_lu.account_group_4122
 msgid "Amounts receivable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60813
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60813
+#: model:account.group,name:l10n_lu.2_account_group_60813
 #: model:account.group.template,name:l10n_lu.account_group_60813
 msgid "Architects' and engineers' fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6431
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6431
+#: model:account.group,name:l10n_lu.2_account_group_6431
 #: model:account.group.template,name:l10n_lu.account_group_6431
 msgid "Attendance fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_643
 #: model:account.group.template,name:l10n_lu.account_group_643
 msgid "Attendance fees, director's fees and similar remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_743
 #: model:account.account.template,name:l10n_lu.lu_2011_account_743
+#: model:account.group,name:l10n_lu.2_account_group_743
 #: model:account.group.template,name:l10n_lu.account_group_743
 msgid "Attendance fees, director's fees and similar remunerations"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report.column,name:l10n_lu.tax_report_balance
+msgid "Balance"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61333
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61333
+#: model:account.group,name:l10n_lu.2_account_group_61333
 #: model:account.group.template,name:l10n_lu.account_group_61333
 msgid ""
 "Bank account charges and bank commissions (included custody fees on "
@@ -2494,95 +2980,167 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7552
 #: model:account.group.template,name:l10n_lu.account_group_7552
 msgid "Bank and similar interest"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6552
 #: model:account.group.template,name:l10n_lu.account_group_6552
 msgid "Banking and similar interest"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6133
 #: model:account.group.template,name:l10n_lu.account_group_6133
 msgid "Banking and similar services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65521
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65521
+#: model:account.group,name:l10n_lu.2_account_group_65521
 #: model:account.group.template,name:l10n_lu.account_group_65521
 msgid "Banking interest on current accounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65522
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65522
+#: model:account.group,name:l10n_lu.2_account_group_65522
 #: model:account.group.template,name:l10n_lu.account_group_65522
 msgid "Banking interest on financing operations"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5131
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5131
+#: model:account.group,name:l10n_lu.2_account_group_5131
 #: model:account.group.template,name:l10n_lu.account_group_5131
 msgid "Banks and CCP : available balance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5132
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5132
+#: model:account.group,name:l10n_lu.2_account_group_5132
 #: model:account.group.template,name:l10n_lu.account_group_5132
 msgid "Banks and CCP : overdraft"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_513
 #: model:account.group.template,name:l10n_lu.account_group_513
 msgid "Banks and postal cheques accounts (CCP)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6467
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6467
+#: model:account.group,name:l10n_lu.2_account_group_6467
 #: model:account.group.template,name:l10n_lu.account_group_6467
 msgid "Bar licence tax"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62111
+#: model:account.group,name:l10n_lu.2_account_group_62111
 #: model:account.group.template,name:l10n_lu.account_group_62111
 msgid "Base wages"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62115
+#: model:account.account,name:l10n_lu.2_lu_2011_account_746
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62115
 #: model:account.account.template,name:l10n_lu.lu_2011_account_746
+#: model:account.group,name:l10n_lu.2_account_group_62115
+#: model:account.group,name:l10n_lu.2_account_group_746
 #: model:account.group.template,name:l10n_lu.account_group_62115
 #: model:account.group.template,name:l10n_lu.account_group_746
 msgid "Benefits in kind"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_442
 #: model:account.group.template,name:l10n_lu.account_group_442
 msgid "Bills of exchange payable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4422
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4422
+#: model:account.group,name:l10n_lu.2_account_group_4422
 #: model:account.group.template,name:l10n_lu.account_group_4422
 msgid "Bills of exchange payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4421
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4421
+#: model:account.group,name:l10n_lu.2_account_group_4421
 #: model:account.group.template,name:l10n_lu.account_group_4421
 msgid "Bills of exchange payable within one year"
 msgstr ""
 
 #. module: l10n_lu
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652221
-#: model:account.account.template,name:l10n_lu.lu_2020_account_752221
 #: model:account.group.template,name:l10n_lu.account_group_652221
+msgid "Book value of amounts owed by affiliated undertakings disposed of"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652241
+#: model:account.group.template,name:l10n_lu.account_group_652241
+msgid ""
+"Book value of amounts owed by undertakings with which the undertaking is "
+"linked by virtue of participating interests disposed of"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_64411
+#: model:account.group.template,name:l10n_lu.account_group_64411
+msgid "Book value of intangible fixed assets disposed of"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652231
+#: model:account.group.template,name:l10n_lu.account_group_652231
+msgid "Book value of participating interests disposed of"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652251
+#: model:account.group.template,name:l10n_lu.account_group_652251
+msgid "Book value of securities held as fixed assets disposed of"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_652211
+#: model:account.group.template,name:l10n_lu.account_group_652211
+msgid "Book value of shares in affiliated undertakings disposed of"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account.template,name:l10n_lu.lu_2020_account_64421
+#: model:account.group.template,name:l10n_lu.account_group_64421
+msgid "Book value of tangible fixed assets disposed of"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652221
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752221
+#: model:account.account.template,name:l10n_lu.lu_2020_account_752221
+#: model:account.group,name:l10n_lu.2_account_group_652221
+#: model:account.group,name:l10n_lu.2_account_group_752221
 #: model:account.group.template,name:l10n_lu.account_group_752221
 msgid "Book value of yielded amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_752241
 #: model:account.group.template,name:l10n_lu.account_group_752241
 msgid ""
 "Book value of yielded amounts owed by undertakings with which the "
@@ -2590,66 +3148,88 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652241
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652241
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752241
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752241
-#: model:account.group.template,name:l10n_lu.account_group_652241
+#: model:account.group,name:l10n_lu.2_account_group_652241
 msgid ""
 "Book value of yielded amounts owed by undertakings with which the "
 "undertaking is linked by virtue of participating interests"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_64411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74411
-#: model:account.group.template,name:l10n_lu.account_group_64411
+#: model:account.group,name:l10n_lu.2_account_group_64411
+#: model:account.group,name:l10n_lu.2_account_group_74411
 #: model:account.group.template,name:l10n_lu.account_group_74411
 msgid "Book value of yielded intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652261
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752261
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652261
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752261
+#: model:account.group,name:l10n_lu.2_account_group_652261
+#: model:account.group,name:l10n_lu.2_account_group_752261
 #: model:account.group.template,name:l10n_lu.account_group_652261
 #: model:account.group.template,name:l10n_lu.account_group_752261
 msgid "Book value of yielded loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652231
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652231
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752231
-#: model:account.group.template,name:l10n_lu.account_group_652231
+#: model:account.group,name:l10n_lu.2_account_group_652231
+#: model:account.group,name:l10n_lu.2_account_group_752231
 #: model:account.group.template,name:l10n_lu.account_group_752231
 msgid "Book value of yielded participating interests"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652251
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652251
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752251
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752251
-#: model:account.group.template,name:l10n_lu.account_group_652251
+#: model:account.group,name:l10n_lu.2_account_group_652251
+#: model:account.group,name:l10n_lu.2_account_group_752251
 #: model:account.group.template,name:l10n_lu.account_group_752251
 msgid "Book value of yielded securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_652211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752211
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752211
-#: model:account.group.template,name:l10n_lu.account_group_652211
+#: model:account.group,name:l10n_lu.2_account_group_652211
+#: model:account.group,name:l10n_lu.2_account_group_752211
 #: model:account.group.template,name:l10n_lu.account_group_752211
 msgid "Book value of yielded shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2020_account_64421
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64421
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74421
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74421
-#: model:account.group.template,name:l10n_lu.account_group_64421
+#: model:account.group,name:l10n_lu.2_account_group_64421
+#: model:account.group,name:l10n_lu.2_account_group_74421
 #: model:account.group.template,name:l10n_lu.account_group_74421
 msgid "Book value of yielded tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61112
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61221
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61411
+#: model:account.group,name:l10n_lu.2_account_group_2213
+#: model:account.group,name:l10n_lu.2_account_group_61112
+#: model:account.group,name:l10n_lu.2_account_group_61221
+#: model:account.group,name:l10n_lu.2_account_group_61411
 #: model:account.group.template,name:l10n_lu.account_group_2213
 #: model:account.group.template,name:l10n_lu.account_group_61112
 #: model:account.group.template,name:l10n_lu.account_group_61221
@@ -2658,285 +3238,378 @@ msgid "Buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60763
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60763
+#: model:account.group,name:l10n_lu.2_account_group_60763
 #: model:account.group.template,name:l10n_lu.account_group_60763
 msgid "Buildings for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_22131
 #: model:account.group.template,name:l10n_lu.account_group_22131
 msgid "Buildings in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22132
+#: model:account.group,name:l10n_lu.2_account_group_22132
 #: model:account.group.template,name:l10n_lu.account_group_22132
 msgid "Buildings in foreign countries"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_314
+#: model:account.group,name:l10n_lu.2_account_group_314
 #: model:account.group.template,name:l10n_lu.account_group_314
 msgid "Buildings under construction"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61523
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61523
+#: model:account.group,name:l10n_lu.2_account_group_61523
 #: model:account.group.template,name:l10n_lu.account_group_61523
 msgid "Business assignments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6144
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6144
+#: model:account.group,name:l10n_lu.2_account_group_6144
 #: model:account.group.template,name:l10n_lu.account_group_6144
 msgid "Business risk insurance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10629
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10629
 msgid "Business share in private expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6
 #: model:account.group.template,name:l10n_lu.account_group_6
 msgid "CHARGES ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461212
+#: model:account.group,name:l10n_lu.2_account_group_461212
 #: model:account.group.template,name:l10n_lu.account_group_461212
 msgid "CIT - Tax payable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6711
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6711
+#: model:account.group,name:l10n_lu.2_account_group_6711
 #: model:account.group.template,name:l10n_lu.account_group_6711
 msgid "CIT - current financial year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6712
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6712
+#: model:account.group,name:l10n_lu.2_account_group_6712
 #: model:account.group.template,name:l10n_lu.account_group_6712
 msgid "CIT - previous financial years"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_115
 #: model:account.account.template,name:l10n_lu.lu_2011_account_115
+#: model:account.group,name:l10n_lu.2_account_group_115
 #: model:account.group.template,name:l10n_lu.account_group_115
 msgid "Capital contribution without issue of shares"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7473
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7473
+#: model:account.group,name:l10n_lu.2_account_group_16
+#: model:account.group,name:l10n_lu.2_account_group_7473
 #: model:account.group.template,name:l10n_lu.account_group_16
 #: model:account.group.template,name:l10n_lu.account_group_7473
 msgid "Capital investment subsidies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_104
 #: model:account.account.template,name:l10n_lu.lu_2020_account_104
+#: model:account.group,name:l10n_lu.2_account_group_104
 #: model:account.group.template,name:l10n_lu.account_group_104
 msgid "Capital of individual companies, corporate partnerships and similar"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_72
 #: model:account.group.template,name:l10n_lu.account_group_72
 msgid "Capitalised production"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106166
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106166
 msgid "Car"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_51
 #: model:account.group.template,name:l10n_lu.account_group_51
 msgid "Cash at bank, in postal cheques accounts, cheques and in hand"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_516
 #: model:account.account.template,name:l10n_lu.lu_2020_account_516
+#: model:account.group,name:l10n_lu.2_account_group_516
 #: model:account.group.template,name:l10n_lu.account_group_516
 msgid "Cash in hand"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10611
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10611
 msgid "Cash withdrawals (daily life)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6222
+#: model:account.group,name:l10n_lu.2_account_group_6222
 #: model:account.group.template,name:l10n_lu.account_group_6222
 msgid "Casual workers"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61515
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61515
+#: model:account.group,name:l10n_lu.2_account_group_61515
 #: model:account.group.template,name:l10n_lu.account_group_61515
 msgid "Catalogues, printed materials and publications"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7121
+#: model:account.group,name:l10n_lu.2_account_group_7121
 #: model:account.group.template,name:l10n_lu.account_group_7121
 msgid "Change in inventories of finished goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_712
 #: model:account.group.template,name:l10n_lu.account_group_712
 msgid "Change in inventories of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_71
 #: model:account.group.template,name:l10n_lu.account_group_71
 msgid "Change in inventories of goods and of work in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7123
+#: model:account.group,name:l10n_lu.2_account_group_7123
 #: model:account.group.template,name:l10n_lu.account_group_7123
 msgid "Change in inventories of residual goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7122
+#: model:account.group,name:l10n_lu.2_account_group_7122
 #: model:account.group.template,name:l10n_lu.account_group_7122
 msgid "Change in inventories of semi-finished goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_711
 #: model:account.group.template,name:l10n_lu.account_group_711
 msgid "Change in inventories of work and contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7111
+#: model:account.group,name:l10n_lu.2_account_group_7111
 #: model:account.group.template,name:l10n_lu.account_group_7111
 msgid "Change in inventories of work in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7114
+#: model:account.group,name:l10n_lu.2_account_group_7114
 #: model:account.group.template,name:l10n_lu.account_group_7114
 msgid "Change in inventories: buildings under construction"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7112
+#: model:account.group,name:l10n_lu.2_account_group_7112
 #: model:account.group.template,name:l10n_lu.account_group_7112
 msgid "Change in inventories: contracts in progress - goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7113
+#: model:account.group,name:l10n_lu.2_account_group_7113
 #: model:account.group.template,name:l10n_lu.account_group_7113
 msgid "Change in inventories: contracts in progress - services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_607
 #: model:account.group.template,name:l10n_lu.account_group_607
 msgid "Changes in inventory"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6073
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6073
+#: model:account.group,name:l10n_lu.2_account_group_6073
 #: model:account.group.template,name:l10n_lu.account_group_6073
 msgid "Changes in inventory of consumable materials and supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6076
 #: model:account.group.template,name:l10n_lu.account_group_6076
 msgid "Changes in inventory of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6074
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6074
+#: model:account.group,name:l10n_lu.2_account_group_6074
 #: model:account.group.template,name:l10n_lu.account_group_6074
 msgid "Changes in inventory of packaging"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6071
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6071
+#: model:account.group,name:l10n_lu.2_account_group_6071
 #: model:account.group.template,name:l10n_lu.account_group_6071
 msgid "Changes in inventory of raw materials"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62412
+#: model:account.group,name:l10n_lu.2_account_group_62412
 #: model:account.group.template,name:l10n_lu.account_group_62412
 msgid "Changes to provisions for complementary pensions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_652
 #: model:account.group.template,name:l10n_lu.account_group_652
 msgid "Charges and loss of disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_61334
 #: model:account.group.template,name:l10n_lu.account_group_61334
 msgid "Charges for electronic means of paiment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61334
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61334
 msgid "Charges for electronic means of payment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6521
 #: model:account.group.template,name:l10n_lu.account_group_6521
 msgid "Charges of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106152
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106152
 msgid "Child benefit office"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6165
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6165
+#: model:account.group,name:l10n_lu.2_account_group_6165
 #: model:account.group.template,name:l10n_lu.account_group_6165
 msgid "Collective staff transportation"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6131
+#: model:account.account,name:l10n_lu.2_lu_2020_account_705
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6131
 #: model:account.account.template,name:l10n_lu.lu_2020_account_705
+#: model:account.group,name:l10n_lu.2_account_group_6131
+#: model:account.group,name:l10n_lu.2_account_group_705
 #: model:account.group.template,name:l10n_lu.account_group_6131
 #: model:account.group.template,name:l10n_lu.account_group_705
 msgid "Commissions and brokerage fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7453
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7453
+#: model:account.group,name:l10n_lu.2_account_group_7453
 #: model:account.group.template,name:l10n_lu.account_group_7453
 msgid "Compensatory allowances"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6241
 #: model:account.group.template,name:l10n_lu.account_group_6241
 msgid "Complementary pensions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62415
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62415
+#: model:account.group,name:l10n_lu.2_account_group_62415
 #: model:account.group.template,name:l10n_lu.account_group_62415
 msgid "Complementary pensions paid by the employer"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2235
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2235
+#: model:account.group,name:l10n_lu.2_account_group_2235
 #: model:account.group.template,name:l10n_lu.account_group_2235
 msgid "Computer equipment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21221
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6411
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72121
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70311
+#: model:account.group,name:l10n_lu.2_account_group_21211
+#: model:account.group,name:l10n_lu.2_account_group_21221
+#: model:account.group,name:l10n_lu.2_account_group_6411
+#: model:account.group,name:l10n_lu.2_account_group_70311
+#: model:account.group,name:l10n_lu.2_account_group_72121
+#: model:account.group,name:l10n_lu.2_account_group_7411
 #: model:account.group.template,name:l10n_lu.account_group_21211
 #: model:account.group.template,name:l10n_lu.account_group_21221
 #: model:account.group.template,name:l10n_lu.account_group_6411
@@ -2947,6 +3620,9 @@ msgid "Concessions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1612
+#: model:account.group,name:l10n_lu.2_account_group_212
+#: model:account.group,name:l10n_lu.2_account_group_7212
 #: model:account.group.template,name:l10n_lu.account_group_1612
 #: model:account.group.template,name:l10n_lu.account_group_212
 #: model:account.group.template,name:l10n_lu.account_group_7212
@@ -2955,41 +3631,62 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_312
+#: model:account.group,name:l10n_lu.2_account_group_312
 #: model:account.group.template,name:l10n_lu.account_group_312
 msgid "Contracts in progress - goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_313
+#: model:account.group,name:l10n_lu.2_account_group_313
 #: model:account.group.template,name:l10n_lu.account_group_313
 msgid "Contracts in progress - services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_113
+#: model:account.group,name:l10n_lu.2_account_group_113
 #: model:account.group.template,name:l10n_lu.account_group_113
 msgid "Contribution premium"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6187
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6187
+#: model:account.group,name:l10n_lu.2_account_group_6187
 #: model:account.group.template,name:l10n_lu.account_group_6187
 msgid "Contributions to professional associations"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_192
 #: model:account.group.template,name:l10n_lu.account_group_192
 msgid "Convertible debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212151
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212251
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64151
+#: model:account.account,name:l10n_lu.2_lu_2011_account_721251
+#: model:account.account,name:l10n_lu.2_lu_2011_account_74151
+#: model:account.account,name:l10n_lu.2_lu_2020_account_703151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212251
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_721251
 #: model:account.account.template,name:l10n_lu.lu_2011_account_74151
 #: model:account.account.template,name:l10n_lu.lu_2020_account_703151
+#: model:account.group,name:l10n_lu.2_account_group_212151
+#: model:account.group,name:l10n_lu.2_account_group_212251
+#: model:account.group,name:l10n_lu.2_account_group_64151
+#: model:account.group,name:l10n_lu.2_account_group_703151
+#: model:account.group,name:l10n_lu.2_account_group_721251
+#: model:account.group,name:l10n_lu.2_account_group_74151
 #: model:account.group.template,name:l10n_lu.account_group_212151
 #: model:account.group.template,name:l10n_lu.account_group_212251
 #: model:account.group.template,name:l10n_lu.account_group_64151
@@ -3000,157 +3697,212 @@ msgid "Copyrights and reproduction rights"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42141
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42141
+#: model:account.group,name:l10n_lu.2_account_group_42141
 #: model:account.group.template,name:l10n_lu.account_group_42141
 msgid "Corporate income tax"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_46121
+#: model:account.group,name:l10n_lu.2_account_group_671
 #: model:account.group.template,name:l10n_lu.account_group_46121
 #: model:account.group.template,name:l10n_lu.account_group_671
 msgid "Corporate income tax (CIT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461211
+#: model:account.group,name:l10n_lu.2_account_group_461211
 #: model:account.group.template,name:l10n_lu.account_group_461211
 msgid "Corporate income tax - Tax accrual"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6182
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6182
+#: model:account.group,name:l10n_lu.2_account_group_6182
 #: model:account.group.template,name:l10n_lu.account_group_6182
 msgid "Costs of training, symposiums, seminars, conferences"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_16122
 #: model:account.account.template,name:l10n_lu.lu_2020_account_16122
 msgid "Created by the undertaking itself"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_67321
 #: model:account.account.template,name:l10n_lu.lu_2011_account_67321
+#: model:account.group,name:l10n_lu.2_account_group_67321
 #: model:account.group.template,name:l10n_lu.account_group_67321
 msgid "Current financial year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4011
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4021
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4011
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4021
+#: model:account.group,name:l10n_lu.2_account_group_4011
+#: model:account.group,name:l10n_lu.2_account_group_4021
 #: model:account.group.template,name:l10n_lu.account_group_4011
 #: model:account.group.template,name:l10n_lu.account_group_4021
 msgid "Customers"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_40111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_40111
 msgid "Customers (PoS)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4012
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4012
+#: model:account.group,name:l10n_lu.2_account_group_4012
 #: model:account.group.template,name:l10n_lu.account_group_4012
 msgid "Customers - Receivable bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4014
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4014
+#: model:account.group,name:l10n_lu.2_account_group_4014
 #: model:account.group.template,name:l10n_lu.account_group_4014
 msgid "Customers - Unbilled sales"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6145
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6145
+#: model:account.group,name:l10n_lu.2_account_group_6145
 #: model:account.group.template,name:l10n_lu.account_group_6145
 msgid "Customers credit insurance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4015
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4015
+#: model:account.group,name:l10n_lu.2_account_group_4015
 #: model:account.group.template,name:l10n_lu.account_group_4015
 msgid "Customers with a credit balance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4025
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4025
+#: model:account.group,name:l10n_lu.2_account_group_4025
 #: model:account.group.template,name:l10n_lu.account_group_4025
 msgid "Customers with creditor balance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4215
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4215
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4613
+#: model:account.group,name:l10n_lu.2_account_group_4215
+#: model:account.group,name:l10n_lu.2_account_group_4613
 #: model:account.group.template,name:l10n_lu.account_group_4215
 #: model:account.group.template,name:l10n_lu.account_group_4613
 msgid "Customs and Excise Authority (ADA)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4
 #: model:account.group.template,name:l10n_lu.account_group_4
 msgid "DEBTORS AND CREDITORS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106154
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106154
 msgid "Death and other health insurance funds"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_19
 #: model:account.group.template,name:l10n_lu.account_group_19
 msgid "Debenture loans and amounts owed to credit institutions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5083
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5083
+#: model:account.group,name:l10n_lu.2_account_group_5083
 #: model:account.group.template,name:l10n_lu.account_group_5083
 msgid "Debenture loans and other notes issued and repurchased by the company"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_23521
 #: model:account.account.template,name:l10n_lu.lu_2011_account_23521
+#: model:account.group,name:l10n_lu.2_account_group_23521
 #: model:account.group.template,name:l10n_lu.account_group_23521
 msgid "Debentures"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_481
 #: model:account.account.template,name:l10n_lu.lu_2011_account_481
+#: model:account.group,name:l10n_lu.2_account_group_481
 #: model:account.group.template,name:l10n_lu.account_group_481
 msgid "Deferred charges (on one or more financial years)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_48
 #: model:account.group.template,name:l10n_lu.account_group_48
 msgid "Deferred charges and income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_482
 #: model:account.account.template,name:l10n_lu.lu_2011_account_482
+#: model:account.group,name:l10n_lu.2_account_group_482
 #: model:account.group.template,name:l10n_lu.account_group_482
 msgid "Deferred income (on one or more financial years)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_183
 #: model:account.account.template,name:l10n_lu.lu_2011_account_183
+#: model:account.group,name:l10n_lu.2_account_group_183
 #: model:account.group.template,name:l10n_lu.account_group_183
 msgid "Deferred tax provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_2362
 #: model:account.account.template,name:l10n_lu.lu_2020_account_2362
+#: model:account.group,name:l10n_lu.2_account_group_2362
 #: model:account.group.template,name:l10n_lu.account_group_2362
 msgid "Deposits and guarantees paid"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106192
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106192
 msgid "Deposits on private financial accounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42187
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42287
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4717
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4727
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42187
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42287
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4717
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4727
+#: model:account.group,name:l10n_lu.2_account_group_42187
+#: model:account.group,name:l10n_lu.2_account_group_42287
+#: model:account.group,name:l10n_lu.2_account_group_4717
+#: model:account.group,name:l10n_lu.2_account_group_4727
 #: model:account.group.template,name:l10n_lu.account_group_42187
 #: model:account.group.template,name:l10n_lu.account_group_42287
 #: model:account.group.template,name:l10n_lu.account_group_4717
@@ -3159,15 +3911,23 @@ msgid "Derivative financial instruments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221111
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221111
+#: model:account.group,name:l10n_lu.2_account_group_221111
 #: model:account.group.template,name:l10n_lu.account_group_221111
 msgid "Developed land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1611
 #: model:account.account.template,name:l10n_lu.lu_2011_account_211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7211
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1611
+#: model:account.group,name:l10n_lu.2_account_group_1611
+#: model:account.group,name:l10n_lu.2_account_group_211
+#: model:account.group,name:l10n_lu.2_account_group_7211
 #: model:account.group.template,name:l10n_lu.account_group_1611
 #: model:account.group.template,name:l10n_lu.account_group_211
 #: model:account.group.template,name:l10n_lu.account_group_7211
@@ -3175,85 +3935,114 @@ msgid "Development costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4214
+#: model:account.group,name:l10n_lu.2_account_group_4612
 #: model:account.group.template,name:l10n_lu.account_group_4214
 #: model:account.group.template,name:l10n_lu.account_group_4612
 msgid "Direct Tax Authority (ACD)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6432
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6432
+#: model:account.group,name:l10n_lu.2_account_group_6432
 #: model:account.group.template,name:l10n_lu.account_group_6432
 msgid "Director's fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6555
 #: model:account.group.template,name:l10n_lu.account_group_6555
 msgid "Discounts and charges on bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65551
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65551
+#: model:account.group,name:l10n_lu.2_account_group_65551
 #: model:account.group.template,name:l10n_lu.account_group_65551
 msgid "Discounts and charges on bills of exchange - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65552
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65552
+#: model:account.group,name:l10n_lu.2_account_group_65552
 #: model:account.group.template,name:l10n_lu.account_group_65552
 msgid "Discounts and charges on bills of exchange - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7555
 #: model:account.group.template,name:l10n_lu.account_group_7555
 msgid "Discounts on bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75551
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75551
+#: model:account.group,name:l10n_lu.2_account_group_75551
 #: model:account.group.template,name:l10n_lu.account_group_75551
 msgid "Discounts on bills of exchange - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75552
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75552
+#: model:account.group,name:l10n_lu.2_account_group_75552
 #: model:account.group.template,name:l10n_lu.account_group_75552
 msgid "Discounts on bills of exchange - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7556
 #: model:account.group.template,name:l10n_lu.account_group_7556
 msgid "Discounts received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75561
+#: model:account.group,name:l10n_lu.2_account_group_75561
 #: model:account.group.template,name:l10n_lu.account_group_75561
 msgid "Discounts received - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75562
+#: model:account.group,name:l10n_lu.2_account_group_75562
 #: model:account.group.template,name:l10n_lu.account_group_75562
 msgid "Discounts received - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752262
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752262
+#: model:account.group,name:l10n_lu.2_account_group_752262
 #: model:account.group.template,name:l10n_lu.account_group_752262
 msgid "Disposal proceed of loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652222
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752222
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652222
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752222
+#: model:account.group,name:l10n_lu.2_account_group_652222
+#: model:account.group,name:l10n_lu.2_account_group_752222
 #: model:account.group.template,name:l10n_lu.account_group_652222
 #: model:account.group.template,name:l10n_lu.account_group_752222
 msgid "Disposal proceeds of amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652242
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752242
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652242
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752242
+#: model:account.group,name:l10n_lu.2_account_group_652242
+#: model:account.group,name:l10n_lu.2_account_group_752242
 #: model:account.group.template,name:l10n_lu.account_group_652242
 #: model:account.group.template,name:l10n_lu.account_group_752242
 msgid ""
@@ -3262,105 +4051,144 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64412
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_64412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74412
+#: model:account.group,name:l10n_lu.2_account_group_64412
+#: model:account.group,name:l10n_lu.2_account_group_74412
 #: model:account.group.template,name:l10n_lu.account_group_64412
 #: model:account.group.template,name:l10n_lu.account_group_74412
 msgid "Disposal proceeds of intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652262
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652262
+#: model:account.group,name:l10n_lu.2_account_group_652262
 #: model:account.group.template,name:l10n_lu.account_group_652262
 msgid "Disposal proceeds of loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652232
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752232
+#: model:account.group,name:l10n_lu.2_account_group_652232
+#: model:account.group,name:l10n_lu.2_account_group_752232
 #: model:account.group.template,name:l10n_lu.account_group_652232
 #: model:account.group.template,name:l10n_lu.account_group_752232
 msgid "Disposal proceeds of participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652252
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752252
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652252
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752252
+#: model:account.group,name:l10n_lu.2_account_group_652252
+#: model:account.group,name:l10n_lu.2_account_group_752252
 #: model:account.group.template,name:l10n_lu.account_group_652252
 #: model:account.group.template,name:l10n_lu.account_group_752252
 msgid "Disposal proceeds of securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_652212
+#: model:account.account,name:l10n_lu.2_lu_2020_account_752212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_652212
 #: model:account.account.template,name:l10n_lu.lu_2020_account_752212
+#: model:account.group,name:l10n_lu.2_account_group_652212
+#: model:account.group,name:l10n_lu.2_account_group_752212
 #: model:account.group.template,name:l10n_lu.account_group_652212
 #: model:account.group.template,name:l10n_lu.account_group_752212
 msgid "Disposal proceeds of shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_64422
+#: model:account.account,name:l10n_lu.2_lu_2020_account_74422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_64422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_74422
+#: model:account.group,name:l10n_lu.2_account_group_64422
+#: model:account.group,name:l10n_lu.2_account_group_74422
 #: model:account.group.template,name:l10n_lu.account_group_64422
 #: model:account.group.template,name:l10n_lu.account_group_74422
 msgid "Disposal proceeds of tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6181
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6181
+#: model:account.group,name:l10n_lu.2_account_group_6181
 #: model:account.group.template,name:l10n_lu.account_group_6181
 msgid "Documentation"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61516
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61516
+#: model:account.group,name:l10n_lu.2_account_group_61516
 #: model:account.group.template,name:l10n_lu.account_group_61516
 msgid "Donations"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4013
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4013
+#: model:account.group,name:l10n_lu.2_account_group_4013
 #: model:account.group.template,name:l10n_lu.account_group_4013
 msgid "Doubtful or disputed customers"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_214
 #: model:account.account.template,name:l10n_lu.lu_2020_account_214
+#: model:account.group,name:l10n_lu.2_account_group_214
 #: model:account.group.template,name:l10n_lu.account_group_214
 msgid "Down payments and intangible fixed assets under development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_224
 #: model:account.group.template,name:l10n_lu.account_group_224
 msgid "Down payments and tangible fixed assets under development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_37
 #: model:account.account.template,name:l10n_lu.lu_2020_account_37
+#: model:account.group,name:l10n_lu.2_account_group_37
 #: model:account.group.template,name:l10n_lu.account_group_37
 msgid "Down payments on account on inventories"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_432
 #: model:account.account.template,name:l10n_lu.lu_2011_account_432
+#: model:account.group,name:l10n_lu.2_account_group_432
 #: model:account.group.template,name:l10n_lu.account_group_432
 msgid "Down payments received after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_315
 #: model:account.group.template,name:l10n_lu.account_group_315
 msgid ""
 "Down payments received on inventories of work and on contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4311
+#: model:account.group,name:l10n_lu.2_account_group_4321
 #: model:account.group.template,name:l10n_lu.account_group_4311
 #: model:account.group.template,name:l10n_lu.account_group_4321
 msgid "Down payments received on orders"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_43
 #: model:account.group.template,name:l10n_lu.account_group_43
 msgid ""
 "Down payments received on orders as far as they are not deducted distinctly "
@@ -3368,12 +4196,17 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_431
 #: model:account.account.template,name:l10n_lu.lu_2011_account_431
+#: model:account.group,name:l10n_lu.2_account_group_431
 #: model:account.group.template,name:l10n_lu.account_group_431
 msgid "Down payments received within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1922
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1932
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1942
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1922
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1932
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1942
@@ -3381,6 +4214,9 @@ msgid "Due and payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1921
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1931
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1941
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1921
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1931
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1941
@@ -3388,89 +4224,111 @@ msgid "Due and payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6463
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6463
+#: model:account.group,name:l10n_lu.2_account_group_6463
 #: model:account.group.template,name:l10n_lu.account_group_6463
 msgid "Duties on imported merchandise"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1
 #: model:account.group.template,name:l10n_lu.account_group_1
 msgid "EQUITY, PROVISIONS AND FINANCIAL LIABILITIES ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_private_LU_IC
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_private_LU_IC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_private_LU_IC
 msgid "EU private"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_FB-ECP-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-ECP-0
 msgid "EX-EC(P)-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2015_tax_AB-ECP-0
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_AB-ECP-0
 msgid "EX-EC(P)-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-EC-0
 msgid "EX-EC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-EC-0
 msgid "EX-EC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-EC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-EC-0
 msgid "EX-EC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FB-IC-0
 msgid "EX-IC-E-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_FP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_FP-IC-0
 msgid "EX-IC-E-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AB-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AB-IC-0
 msgid "EX-IC-P-G"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax,name:l10n_lu.2_lu_2011_tax_AP-IC-0
 #: model:account.tax.template,name:l10n_lu.lu_2011_tax_AP-IC-0
 msgid "EX-IC-P-S"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60315
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61845
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60315
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61845
+#: model:account.group,name:l10n_lu.2_account_group_60315
+#: model:account.group,name:l10n_lu.2_account_group_61845
 #: model:account.group.template,name:l10n_lu.account_group_60315
 #: model:account.group.template,name:l10n_lu.account_group_61845
 msgid "Electricity"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_105
 #: model:account.account.template,name:l10n_lu.lu_2011_account_105
+#: model:account.group,name:l10n_lu.2_account_group_105
 #: model:account.group.template,name:l10n_lu.account_group_105
 msgid "Endowment of branches"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6464
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6464
+#: model:account.group,name:l10n_lu.2_account_group_6464
 #: model:account.group.template,name:l10n_lu.account_group_6464
 msgid "Excise duties on production and tax on consumption"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_203
 #: model:account.account.template,name:l10n_lu.lu_2011_account_203
+#: model:account.group,name:l10n_lu.2_account_group_203
 #: model:account.group.template,name:l10n_lu.account_group_203
 msgid ""
 "Expenses for increases in capital and for various operations (merger, "
@@ -3478,81 +4336,108 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_617
 #: model:account.group.template,name:l10n_lu.account_group_617
 msgid "External staff of the company"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6172
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6172
+#: model:account.group,name:l10n_lu.2_account_group_6172
 #: model:account.group.template,name:l10n_lu.account_group_6172
 msgid "External staff on secondment"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_EC
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_EC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_EC
 msgid "Extra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_5
 #: model:account.group.template,name:l10n_lu.account_group_5
 msgid "FINANCIAL ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2
 #: model:account.group.template,name:l10n_lu.account_group_2
 msgid "FORMATION EXPENSES AND FIXED ASSETS ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6512
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7512
+#: model:account.group,name:l10n_lu.2_account_group_6512
+#: model:account.group,name:l10n_lu.2_account_group_7512
 #: model:account.group.template,name:l10n_lu.account_group_6512
 #: model:account.group.template,name:l10n_lu.account_group_7512
 msgid "FVA on financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_63315
+#: model:account.account,name:l10n_lu.2_lu_2020_account_73315
 #: model:account.account.template,name:l10n_lu.lu_2020_account_63315
 #: model:account.account.template,name:l10n_lu.lu_2020_account_73315
+#: model:account.group,name:l10n_lu.2_account_group_63315
+#: model:account.group,name:l10n_lu.2_account_group_73315
 #: model:account.group.template,name:l10n_lu.account_group_63315
 #: model:account.group.template,name:l10n_lu.account_group_73315
 msgid "FVA on investment properties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6354
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7354
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6354
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7354
+#: model:account.group,name:l10n_lu.2_account_group_6354
+#: model:account.group,name:l10n_lu.2_account_group_7354
 #: model:account.group.template,name:l10n_lu.account_group_6354
 #: model:account.group.template,name:l10n_lu.account_group_7354
 msgid "FVA on receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6532
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6532
+#: model:account.group,name:l10n_lu.2_account_group_6532
+#: model:account.group,name:l10n_lu.2_account_group_7532
 #: model:account.group.template,name:l10n_lu.account_group_6532
 #: model:account.group.template,name:l10n_lu.account_group_7532
 msgid "FVA on transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61336
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61336
+#: model:account.group,name:l10n_lu.2_account_group_61336
 #: model:account.group.template,name:l10n_lu.account_group_61336
 msgid "Factoring services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7532
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7532
 msgid "Fair value adjustments on transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61513
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61513
+#: model:account.group,name:l10n_lu.2_account_group_61513
 #: model:account.group.template,name:l10n_lu.account_group_61513
 msgid "Fairs and exhibitions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_641
+#: model:account.group,name:l10n_lu.2_account_group_7031
 #: model:account.group.template,name:l10n_lu.account_group_641
 #: model:account.group.template,name:l10n_lu.account_group_7031
 msgid ""
@@ -3561,6 +4446,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_741
 #: model:account.group.template,name:l10n_lu.account_group_741
 msgid ""
 "Fees and royalties for concessions, patents, licences, trademarks and "
@@ -3568,177 +4454,229 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65
 #: model:account.group.template,name:l10n_lu.account_group_65
 msgid "Financial charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_23
 #: model:account.group.template,name:l10n_lu.account_group_23
 msgid "Financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75
 #: model:account.group.template,name:l10n_lu.account_group_75
 msgid "Financial income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6115
 #: model:account.group.template,name:l10n_lu.account_group_6115
 msgid "Financial leasing on movable property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6114
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6114
+#: model:account.group,name:l10n_lu.2_account_group_6114
 #: model:account.group.template,name:l10n_lu.account_group_6114
 msgid "Financial leasing on real property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_1882
 #: model:account.account.template,name:l10n_lu.lu_2011_account_1882
+#: model:account.group,name:l10n_lu.2_account_group_1882
 #: model:account.group.template,name:l10n_lu.account_group_1882
 msgid "Financial provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6481
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6481
+#: model:account.group,name:l10n_lu.2_account_group_6481
 #: model:account.group.template,name:l10n_lu.account_group_6481
 msgid "Fines, sanctions and penalties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106143
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106143
 msgid "Fire insurance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2214
 #: model:account.group.template,name:l10n_lu.account_group_2214
 msgid "Fixtures and fitting-outs of buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22141
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22141
+#: model:account.group,name:l10n_lu.2_account_group_22141
 #: model:account.group.template,name:l10n_lu.account_group_22141
 msgid "Fixtures and fitting-outs of buildings in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22142
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22142
+#: model:account.group,name:l10n_lu.2_account_group_22142
 #: model:account.group.template,name:l10n_lu.account_group_22142
 msgid "Fixtures and fitting-outs of buildings in foreign countries"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22121
+#: model:account.group,name:l10n_lu.2_account_group_22121
 #: model:account.group.template,name:l10n_lu.account_group_22121
 msgid "Fixtures and fitting-outs of land in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22122
+#: model:account.group,name:l10n_lu.2_account_group_22122
 #: model:account.group.template,name:l10n_lu.account_group_22122
 msgid "Fixtures and fitting-outs of land in foreign countries"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2212
 #: model:account.group.template,name:l10n_lu.account_group_2212
 msgid "Fixtures and fittings-out of land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4622
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4622
+#: model:account.group,name:l10n_lu.2_account_group_4622
 #: model:account.group.template,name:l10n_lu.account_group_4622
 msgid "Foreign Social Security offices"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421811
+#: model:account.account,name:l10n_lu.2_lu_2020_account_46151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421811
 #: model:account.account.template,name:l10n_lu.lu_2020_account_46151
+#: model:account.group,name:l10n_lu.2_account_group_421811
+#: model:account.group,name:l10n_lu.2_account_group_46151
 #: model:account.group.template,name:l10n_lu.account_group_421811
 #: model:account.group.template,name:l10n_lu.account_group_46151
 msgid "Foreign VAT"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_756
 #: model:account.group.template,name:l10n_lu.account_group_756
 msgid "Foreign currency exchange gains"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7561
+#: model:account.group,name:l10n_lu.2_account_group_7561
 #: model:account.group.template,name:l10n_lu.account_group_7561
 msgid "Foreign currency exchange gains - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7562
+#: model:account.group,name:l10n_lu.2_account_group_7562
 #: model:account.group.template,name:l10n_lu.account_group_7562
 msgid "Foreign currency exchange gains - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_656
 #: model:account.group.template,name:l10n_lu.account_group_656
 msgid "Foreign currency exchange losses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6561
+#: model:account.group,name:l10n_lu.2_account_group_6561
 #: model:account.group.template,name:l10n_lu.account_group_6561
 msgid "Foreign currency exchange losses - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6562
+#: model:account.group,name:l10n_lu.2_account_group_6562
 #: model:account.group.template,name:l10n_lu.account_group_6562
 msgid "Foreign currency exchange losses - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_673
 #: model:account.group.template,name:l10n_lu.account_group_673
 msgid "Foreign income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42172
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42172
+#: model:account.group,name:l10n_lu.2_account_group_42172
 #: model:account.group.template,name:l10n_lu.account_group_42172
 msgid "Foreign social security offices"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4615
 #: model:account.group.template,name:l10n_lu.account_group_4615
 msgid "Foreign tax authorities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_683
 #: model:account.account.template,name:l10n_lu.lu_2011_account_683
+#: model:account.group,name:l10n_lu.2_account_group_42181
+#: model:account.group,name:l10n_lu.2_account_group_683
 #: model:account.group.template,name:l10n_lu.account_group_42181
 #: model:account.group.template,name:l10n_lu.account_group_683
 msgid "Foreign taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_20
 #: model:account.group.template,name:l10n_lu.account_group_20
 msgid "Formation expenses and similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65411
+#: model:account.account,name:l10n_lu.2_lu_2020_account_755231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_755231
+#: model:account.group,name:l10n_lu.2_account_group_65411
 #: model:account.group.template,name:l10n_lu.account_group_65411
 msgid "From affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_755232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_755232
 msgid "From other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65413
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65413
 msgid "From other receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65412
+#: model:account.group,name:l10n_lu.2_account_group_65412
 #: model:account.group.template,name:l10n_lu.account_group_65412
 msgid ""
 "From undertakings with which the undertaking is linked by virtue of "
@@ -3746,11 +4684,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6031
 #: model:account.group.template,name:l10n_lu.account_group_6031
 msgid "Fuels, gas, water and electricity"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6184
 #: model:account.group.template,name:l10n_lu.account_group_6184
 msgid ""
 "Fuels, gas, water and electricity (not included in the production of goods "
@@ -3758,17 +4698,21 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106145
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106145
 msgid "Full coverage insurance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2234
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2234
+#: model:account.group,name:l10n_lu.2_account_group_2234
 #: model:account.group.template,name:l10n_lu.account_group_2234
 msgid "Furniture"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_754
 #: model:account.group.template,name:l10n_lu.account_group_754
 msgid ""
 "Gain on disposal and other income from current receivables and transferable "
@@ -3776,40 +4720,51 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7522
 #: model:account.group.template,name:l10n_lu.account_group_7522
 msgid "Gain on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_744
 #: model:account.group.template,name:l10n_lu.account_group_744
 msgid "Gain on disposal of intangible and tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7441
 #: model:account.group.template,name:l10n_lu.account_group_7441
 msgid "Gain on disposal of intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7541
 #: model:account.group.template,name:l10n_lu.account_group_7541
 msgid "Gain on disposal of receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7542
 #: model:account.group.template,name:l10n_lu.account_group_7542
 msgid "Gain on disposal of transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60313
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61843
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60313
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61843
+#: model:account.group,name:l10n_lu.2_account_group_60313
+#: model:account.group,name:l10n_lu.2_account_group_61843
 #: model:account.group.template,name:l10n_lu.account_group_60313
 #: model:account.group.template,name:l10n_lu.account_group_61843
 msgid "Gas"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6121
+#: model:account.group,name:l10n_lu.2_account_group_6121
 #: model:account.group.template,name:l10n_lu.account_group_6121
 msgid ""
 "General subcontracting (not included in the production of goods and "
@@ -3817,62 +4772,79 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106194
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106194
 msgid "Gifts and allowance to children"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61514
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61514
+#: model:account.group,name:l10n_lu.2_account_group_61514
 #: model:account.group.template,name:l10n_lu.account_group_61514
 msgid "Gifts to customers"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_213
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_213
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1613
+#: model:account.group,name:l10n_lu.2_account_group_1613
+#: model:account.group,name:l10n_lu.2_account_group_213
 #: model:account.group.template,name:l10n_lu.account_group_1613
 #: model:account.group.template,name:l10n_lu.account_group_213
 msgid "Goodwill acquired for consideration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6556
 #: model:account.group.template,name:l10n_lu.account_group_6556
 msgid "Granted discounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65561
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65561
+#: model:account.group,name:l10n_lu.2_account_group_65561
 #: model:account.group.template,name:l10n_lu.account_group_65561
 msgid "Granted discounts - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65562
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65562
+#: model:account.group,name:l10n_lu.2_account_group_65562
 #: model:account.group.template,name:l10n_lu.account_group_65562
 msgid "Granted discounts - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_212152
 #: model:account.group.template,name:l10n_lu.account_group_212152
 msgid "Greenhous gas and similar emission quotas"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212152
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212152
 msgid "Greenhouse gas and similar emission quotas"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6211
 #: model:account.group.template,name:l10n_lu.account_group_6211
 msgid "Gross wages"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106153
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106153
 msgid "Health insurance funds"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106163
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106163
 msgid "Heating, gas, electricity"
 msgstr ""
@@ -3893,17 +4865,21 @@ msgid "III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7
 #: model:account.group.template,name:l10n_lu.account_group_7
 msgid "INCOME ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_3
 #: model:account.group.template,name:l10n_lu.account_group_3
 msgid "INVENTORIES ACCOUNTS"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6132
+#: model:account.group,name:l10n_lu.2_account_group_6132
 #: model:account.group.template,name:l10n_lu.account_group_6132
 msgid "IT services"
 msgstr ""
@@ -3914,125 +4890,157 @@ msgid "IV. TAX TO BE PAID OR TO BE RECLAIMED"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62114
+#: model:account.group,name:l10n_lu.2_account_group_62114
 #: model:account.group.template,name:l10n_lu.account_group_62114
 msgid "Incentives, bonuses and commissions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_752
 #: model:account.group.template,name:l10n_lu.account_group_752
 msgid "Income and gain on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7521
 #: model:account.group.template,name:l10n_lu.account_group_7521
 msgid "Income from financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7442
 #: model:account.group.template,name:l10n_lu.account_group_7442
 msgid "Income of yielded tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106281
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106281
 msgid "Income tax"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106181
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106181
 msgid "Income tax paid"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_67
 #: model:account.group.template,name:l10n_lu.account_group_67
 msgid "Income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_642
 #: model:account.account.template,name:l10n_lu.lu_2011_account_642
+#: model:account.group,name:l10n_lu.2_account_group_642
 #: model:account.group.template,name:l10n_lu.account_group_642
 msgid "Indemnities, damages and interest"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4216
 #: model:account.group.template,name:l10n_lu.account_group_4216
 msgid "Indirect Tax Authority (AED)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4614
 #: model:account.group.template,name:l10n_lu.account_group_4614
 msgid "Indirect tax authorities (AED)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_42162
+#: model:account.group,name:l10n_lu.2_account_group_46142
 #: model:account.group.template,name:l10n_lu.account_group_42162
 #: model:account.group.template,name:l10n_lu.account_group_46142
 msgid "Indirect taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6183
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6183
+#: model:account.group,name:l10n_lu.2_account_group_6183
 #: model:account.group.template,name:l10n_lu.account_group_6183
 msgid "Industrial and non-industrial waste treatment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10621
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10621
 msgid "Inheritance or donation"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106195
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106195
 msgid "Inheritance taxes and mutation tax due to death"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62414
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62414
+#: model:account.group,name:l10n_lu.2_account_group_62414
 #: model:account.group.template,name:l10n_lu.account_group_62414
 msgid "Insolvency insurance premiums"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6141
 #: model:account.group.template,name:l10n_lu.account_group_6141
 msgid "Insurance for assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7481
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7481
+#: model:account.group,name:l10n_lu.2_account_group_7481
 #: model:account.group.template,name:l10n_lu.account_group_7481
 msgid "Insurance indemnities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6142
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6142
+#: model:account.group,name:l10n_lu.2_account_group_6142
 #: model:account.group.template,name:l10n_lu.account_group_6142
 msgid "Insurance on rented assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_614
 #: model:account.group.template,name:l10n_lu.account_group_614
 msgid "Insurance premiums"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_21
+#: model:account.group,name:l10n_lu.2_account_group_721
 #: model:account.group.template,name:l10n_lu.account_group_21
 #: model:account.group.template,name:l10n_lu.account_group_721
 msgid "Intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_655
 #: model:account.group.template,name:l10n_lu.account_group_655
 msgid "Interest and discounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75541
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75541
+#: model:account.group,name:l10n_lu.2_account_group_75541
 #: model:account.group.template,name:l10n_lu.account_group_75541
 msgid "Interest on amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7554
 #: model:account.group.template,name:l10n_lu.account_group_7554
 msgid ""
 "Interest on amounts owed by affiliated undertakings and undertakings with "
@@ -4040,7 +5048,9 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75542
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75542
+#: model:account.group,name:l10n_lu.2_account_group_75542
 #: model:account.group.template,name:l10n_lu.account_group_75542
 msgid ""
 "Interest on amounts owed by undertakings with which the undertaking is "
@@ -4048,99 +5058,129 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75521
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75521
+#: model:account.group,name:l10n_lu.2_account_group_75521
 #: model:account.group.template,name:l10n_lu.account_group_75521
 msgid "Interest on bank accounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6551
 #: model:account.group.template,name:l10n_lu.account_group_6551
 msgid "Interest on debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65511
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65511
+#: model:account.group,name:l10n_lu.2_account_group_65511
 #: model:account.group.template,name:l10n_lu.account_group_65511
 msgid "Interest on debenture loans - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_65512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_65512
+#: model:account.group,name:l10n_lu.2_account_group_65512
 #: model:account.group.template,name:l10n_lu.account_group_65512
 msgid "Interest on debenture loans - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65523
+#: model:account.group,name:l10n_lu.2_account_group_75523
 #: model:account.group.template,name:l10n_lu.account_group_65523
 #: model:account.group.template,name:l10n_lu.account_group_75523
 msgid "Interest on financial leases"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_655231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_655231
+#: model:account.group,name:l10n_lu.2_account_group_655231
 #: model:account.group.template,name:l10n_lu.account_group_655231
 msgid "Interest on financial leases - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_655232
 #: model:account.account.template,name:l10n_lu.lu_2020_account_655232
+#: model:account.group,name:l10n_lu.2_account_group_655232
 #: model:account.group.template,name:l10n_lu.account_group_655232
 msgid "Interest on financial leases - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7558
 #: model:account.group.template,name:l10n_lu.account_group_7558
 msgid "Interest on other amounts receivable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75581
+#: model:account.group,name:l10n_lu.2_account_group_75581
 #: model:account.group.template,name:l10n_lu.account_group_75581
 msgid "Interest on other amounts receivable - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75582
+#: model:account.group,name:l10n_lu.2_account_group_75582
 #: model:account.group.template,name:l10n_lu.account_group_75582
 msgid "Interest on other amounts receivable - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6553
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6553
+#: model:account.group,name:l10n_lu.2_account_group_6553
 #: model:account.group.template,name:l10n_lu.account_group_6553
 msgid "Interest on trade payables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7553
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7553
+#: model:account.group,name:l10n_lu.2_account_group_7553
 #: model:account.group.template,name:l10n_lu.account_group_7553
 msgid "Interest on trade receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6558
 #: model:account.group.template,name:l10n_lu.account_group_6558
 msgid "Interest payable on other loans and debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65581
+#: model:account.group,name:l10n_lu.2_account_group_65581
 #: model:account.group.template,name:l10n_lu.account_group_65581
 msgid "Interest payable on other loans and debts - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65582
+#: model:account.group,name:l10n_lu.2_account_group_65582
 #: model:account.group.template,name:l10n_lu.account_group_65582
 msgid "Interest payable on other loans and debts - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65541
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65541
+#: model:account.group,name:l10n_lu.2_account_group_65541
 #: model:account.group.template,name:l10n_lu.account_group_65541
 msgid "Interest payable to affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6554
 #: model:account.group.template,name:l10n_lu.account_group_6554
 msgid ""
 "Interest payable to affiliated undertakings and undertakings with which the "
@@ -4148,7 +5188,9 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65542
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65542
+#: model:account.group,name:l10n_lu.2_account_group_65542
 #: model:account.group.template,name:l10n_lu.account_group_65542
 msgid ""
 "Interest payable to undertakings with which the undertaking is linked by "
@@ -4156,138 +5198,177 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7452
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7452
+#: model:account.group,name:l10n_lu.2_account_group_7452
 #: model:account.group.template,name:l10n_lu.account_group_7452
 msgid "Interest subsidies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_15
 #: model:account.account.template,name:l10n_lu.lu_2011_account_15
+#: model:account.group,name:l10n_lu.2_account_group_15
 #: model:account.group.template,name:l10n_lu.account_group_15
 msgid "Interim dividends"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_517
 #: model:account.group.template,name:l10n_lu.account_group_517
 msgid "Internal transfers"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5172
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5172
+#: model:account.group,name:l10n_lu.2_account_group_5172
 #: model:account.group.template,name:l10n_lu.account_group_5172
 msgid "Internal transfers : credit balance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_5171
 #: model:account.account.template,name:l10n_lu.lu_2020_account_5171
+#: model:account.group,name:l10n_lu.2_account_group_5171
 #: model:account.group.template,name:l10n_lu.account_group_5171
 msgid "Internal transfers : debit balance"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_IC
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_IC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_IC
 msgid "Intra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_363
 #: model:account.group.template,name:l10n_lu.account_group_363
 msgid "Inventories of buildings for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3631
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3631
+#: model:account.group,name:l10n_lu.2_account_group_3631
 #: model:account.group.template,name:l10n_lu.account_group_3631
 msgid "Inventories of buildings for resale in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3632
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3632
+#: model:account.group,name:l10n_lu.2_account_group_3632
 #: model:account.group.template,name:l10n_lu.account_group_3632
 msgid "Inventories of buildings for resale in foreign countries"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_303
 #: model:account.account.template,name:l10n_lu.lu_2020_account_303
+#: model:account.group,name:l10n_lu.2_account_group_303
 #: model:account.group.template,name:l10n_lu.account_group_303
 msgid "Inventories of consumable materials and supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_321
 #: model:account.account.template,name:l10n_lu.lu_2011_account_321
+#: model:account.group,name:l10n_lu.2_account_group_321
 #: model:account.group.template,name:l10n_lu.account_group_321
 msgid "Inventories of finished goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_32
 #: model:account.group.template,name:l10n_lu.account_group_32
 msgid "Inventories of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_362
 #: model:account.group.template,name:l10n_lu.account_group_362
 msgid "Inventories of land for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3621
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3621
+#: model:account.group,name:l10n_lu.2_account_group_3621
 #: model:account.group.template,name:l10n_lu.account_group_3621
 msgid "Inventories of land for resale in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_3622
 #: model:account.account.template,name:l10n_lu.lu_2020_account_3622
+#: model:account.group,name:l10n_lu.2_account_group_3622
 #: model:account.group.template,name:l10n_lu.account_group_3622
 msgid "Inventories of land for resale in foreign countries"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_361
 #: model:account.account.template,name:l10n_lu.lu_2020_account_361
+#: model:account.group,name:l10n_lu.2_account_group_361
 #: model:account.group.template,name:l10n_lu.account_group_361
 msgid "Inventories of merchandise"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_36
 #: model:account.group.template,name:l10n_lu.account_group_36
 msgid "Inventories of merchandises and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_304
 #: model:account.account.template,name:l10n_lu.lu_2020_account_304
+#: model:account.group,name:l10n_lu.2_account_group_304
 #: model:account.group.template,name:l10n_lu.account_group_304
 msgid "Inventories of packaging"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_301
 #: model:account.account.template,name:l10n_lu.lu_2011_account_301
+#: model:account.group,name:l10n_lu.2_account_group_301
 #: model:account.group.template,name:l10n_lu.account_group_301
 msgid "Inventories of raw materials"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_30
 #: model:account.group.template,name:l10n_lu.account_group_30
 msgid "Inventories of raw materials and consumables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_323
 #: model:account.account.template,name:l10n_lu.lu_2020_account_323
+#: model:account.group,name:l10n_lu.2_account_group_323
 #: model:account.group.template,name:l10n_lu.account_group_323
 msgid ""
 "Inventories of residual goods (waste, rejected and recuperable material)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_322
+#: model:account.group,name:l10n_lu.2_account_group_322
 #: model:account.group.template,name:l10n_lu.account_group_322
 msgid "Inventories of semi-finished goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_31
 #: model:account.group.template,name:l10n_lu.account_group_31
 msgid "Inventories of work and contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4312
+#: model:account.group,name:l10n_lu.2_account_group_4322
 #: model:account.group.template,name:l10n_lu.account_group_4312
 #: model:account.group.template,name:l10n_lu.account_group_4322
 msgid ""
@@ -4295,187 +5376,255 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_311
+#: model:account.group,name:l10n_lu.2_account_group_311
 #: model:account.group.template,name:l10n_lu.account_group_311
 msgid "Inventories of work in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2215
 #: model:account.group.template,name:l10n_lu.account_group_2215
 msgid "Investment properties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22151
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22151
+#: model:account.group,name:l10n_lu.2_account_group_22151
 #: model:account.group.template,name:l10n_lu.account_group_22151
 msgid "Investment properties in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_22152
 #: model:account.account.template,name:l10n_lu.lu_2020_account_22152
+#: model:account.group,name:l10n_lu.2_account_group_22152
 #: model:account.group.template,name:l10n_lu.account_group_22152
 msgid "Investment properties in foreign countries"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42131
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42131
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42231
+#: model:account.group,name:l10n_lu.2_account_group_42131
+#: model:account.group,name:l10n_lu.2_account_group_42231
 #: model:account.group.template,name:l10n_lu.account_group_42131
 #: model:account.group.template,name:l10n_lu.account_group_42231
 msgid "Investment subsidies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_42171
+#: model:account.group,name:l10n_lu.2_account_group_4621
 #: model:account.group.template,name:l10n_lu.account_group_42171
 #: model:account.group.template,name:l10n_lu.account_group_4621
 msgid "Joint Social Security Centre (CCSS)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61111
+#: model:account.group,name:l10n_lu.2_account_group_2211
+#: model:account.group,name:l10n_lu.2_account_group_61111
 #: model:account.group.template,name:l10n_lu.account_group_2211
 #: model:account.group.template,name:l10n_lu.account_group_61111
 msgid "Land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60762
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60762
+#: model:account.group,name:l10n_lu.2_account_group_60762
 #: model:account.group.template,name:l10n_lu.account_group_60762
 msgid "Land for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_22111
 #: model:account.group.template,name:l10n_lu.account_group_22111
 msgid "Land in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22112
+#: model:account.group,name:l10n_lu.2_account_group_22112
 #: model:account.group.template,name:l10n_lu.account_group_22112
 msgid "Land in foreign countries"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2241
 #: model:account.group.template,name:l10n_lu.account_group_2241
 msgid "Land, fitting-outs and buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22411
+#: model:account.group,name:l10n_lu.2_account_group_22411
 #: model:account.group.template,name:l10n_lu.account_group_22411
 msgid "Land, fitting-outs and buildings in Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_22412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_22412
+#: model:account.group,name:l10n_lu.2_account_group_22412
 #: model:account.group.template,name:l10n_lu.account_group_22412
 msgid "Land, fitting-outs and buildings in foreign countries"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7221
+#: model:account.group,name:l10n_lu.2_account_group_7221
 #: model:account.group.template,name:l10n_lu.account_group_7221
 msgid "Land, fittings and buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_221
 #: model:account.group.template,name:l10n_lu.account_group_221
 msgid "Land, fixtures and fitting-outs and buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47162
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47262
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47162
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47262
+#: model:account.group,name:l10n_lu.2_account_group_47162
+#: model:account.group,name:l10n_lu.2_account_group_47262
 #: model:account.group.template,name:l10n_lu.account_group_47162
 #: model:account.group.template,name:l10n_lu.account_group_47262
 msgid "Lease debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_131
 #: model:account.account.template,name:l10n_lu.lu_2011_account_131
+#: model:account.group,name:l10n_lu.2_account_group_131
 #: model:account.group.template,name:l10n_lu.account_group_131
 msgid "Legal reserve"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61341
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61341
+#: model:account.group,name:l10n_lu.2_account_group_61341
 #: model:account.group.template,name:l10n_lu.account_group_61341
 msgid "Legal, litigation and similar fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47163
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47263
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47163
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47263
+#: model:account.group,name:l10n_lu.2_account_group_47163
+#: model:account.group,name:l10n_lu.2_account_group_47263
 #: model:account.group.template,name:l10n_lu.account_group_47163
 #: model:account.group.template,name:l10n_lu.account_group_47263
 msgid "Life annuities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106141
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106141
 msgid "Life insurance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_486
 #: model:account.account.template,name:l10n_lu.lu_2011_account_486
+#: model:account.group,name:l10n_lu.2_account_group_486
 #: model:account.group.template,name:l10n_lu.account_group_486
 msgid "Linking accounts (branches) - Assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_487
 #: model:account.account.template,name:l10n_lu.lu_2011_account_487
+#: model:account.group,name:l10n_lu.2_account_group_487
 #: model:account.group.template,name:l10n_lu.account_group_487
 msgid "Linking accounts (branches) - Liabilities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60312
+#: model:account.group,name:l10n_lu.2_account_group_60312
 #: model:account.group.template,name:l10n_lu.account_group_60312
 msgid "Liquid fuels"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61842
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61842
+#: model:account.group,name:l10n_lu.2_account_group_61842
 #: model:account.group.template,name:l10n_lu.account_group_61842
 msgid "Liquid fuels (oil, motor fuel, etc.)"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.account.template,name:l10n_lu.lu_2011_chart_1_liquidity_transfer
+#: model:account.account,name:l10n_lu.2_lu_2011_chart_1_liquidity_transfer
 msgid "Liquidity Transfer"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5084
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5084
+#: model:account.group,name:l10n_lu.2_account_group_5084
 #: model:account.group.template,name:l10n_lu.account_group_5084
 msgid "Listed debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_235111
 #: model:account.account.template,name:l10n_lu.lu_2020_account_235111
+#: model:account.group,name:l10n_lu.2_account_group_235111
 #: model:account.group.template,name:l10n_lu.account_group_235111
 msgid "Listed shares"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2236
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2236
+#: model:account.group,name:l10n_lu.2_account_group_2236
 #: model:account.group.template,name:l10n_lu.account_group_2236
 msgid "Livestock"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_204
 #: model:account.account.template,name:l10n_lu.lu_2011_account_204
+#: model:account.group,name:l10n_lu.2_account_group_204
 #: model:account.group.template,name:l10n_lu.account_group_204
 msgid "Loan issuances expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_2361
 #: model:account.account.template,name:l10n_lu.lu_2020_account_2361
+#: model:account.group,name:l10n_lu.2_account_group_2361
 #: model:account.group.template,name:l10n_lu.account_group_2361
 msgid "Loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41112
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41122
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41212
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41222
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45112
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45122
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45212
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41212
@@ -4484,6 +5633,14 @@ msgstr ""
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45222
+#: model:account.group,name:l10n_lu.2_account_group_41112
+#: model:account.group,name:l10n_lu.2_account_group_41122
+#: model:account.group,name:l10n_lu.2_account_group_41212
+#: model:account.group,name:l10n_lu.2_account_group_41222
+#: model:account.group,name:l10n_lu.2_account_group_45112
+#: model:account.group,name:l10n_lu.2_account_group_45122
+#: model:account.group,name:l10n_lu.2_account_group_45212
+#: model:account.group,name:l10n_lu.2_account_group_45222
 #: model:account.group.template,name:l10n_lu.account_group_41112
 #: model:account.group.template,name:l10n_lu.account_group_41122
 #: model:account.group.template,name:l10n_lu.account_group_41212
@@ -4496,21 +5653,32 @@ msgid "Loans and advances"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4716
+#: model:account.group,name:l10n_lu.2_account_group_4726
 #: model:account.group.template,name:l10n_lu.account_group_4716
 #: model:account.group.template,name:l10n_lu.account_group_4726
 msgid "Loans and similar debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61332
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61332
+#: model:account.group,name:l10n_lu.2_account_group_61332
 #: model:account.group.template,name:l10n_lu.account_group_61332
 msgid "Loans' issuance expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75116
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65216
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75216
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75116
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65216
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75216
+#: model:account.group,name:l10n_lu.2_account_group_236
+#: model:account.group,name:l10n_lu.2_account_group_65216
+#: model:account.group,name:l10n_lu.2_account_group_75216
+#: model:account.group,name:l10n_lu.2_account_group_75226
 #: model:account.group.template,name:l10n_lu.account_group_236
 #: model:account.group.template,name:l10n_lu.account_group_65216
 #: model:account.group.template,name:l10n_lu.account_group_75216
@@ -4519,17 +5687,21 @@ msgid "Loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2363
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2363
+#: model:account.group,name:l10n_lu.2_account_group_2363
 #: model:account.group.template,name:l10n_lu.account_group_2363
 msgid "Long-term receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65222
 #: model:account.group.template,name:l10n_lu.account_group_65222
 msgid "Loss on disposal of amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65224
 #: model:account.group.template,name:l10n_lu.account_group_65224
 msgid ""
 "Loss on disposal of amounts owed by undertakings with which the undertaking "
@@ -4537,31 +5709,37 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6522
 #: model:account.group.template,name:l10n_lu.account_group_6522
 msgid "Loss on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_644
 #: model:account.group.template,name:l10n_lu.account_group_644
 msgid "Loss on disposal of intangible and tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6441
 #: model:account.group.template,name:l10n_lu.account_group_6441
 msgid "Loss on disposal of intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65226
 #: model:account.group.template,name:l10n_lu.account_group_65226
 msgid "Loss on disposal of loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65223
 #: model:account.group.template,name:l10n_lu.account_group_65223
 msgid "Loss on disposal of participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_654
 #: model:account.group.template,name:l10n_lu.account_group_654
 msgid ""
 "Loss on disposal of receivables and transferable securities from current "
@@ -4569,37 +5747,45 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6541
 #: model:account.group.template,name:l10n_lu.account_group_6541
 msgid "Loss on disposal of receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65225
 #: model:account.group.template,name:l10n_lu.account_group_65225
 msgid "Loss on disposal of securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65221
 #: model:account.group.template,name:l10n_lu.account_group_65221
 msgid "Loss on disposal of shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6442
 #: model:account.group.template,name:l10n_lu.account_group_6442
 msgid "Loss on disposal of tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6542
 #: model:account.group.template,name:l10n_lu.account_group_6542
 msgid "Loss on disposal of transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_645
 #: model:account.group.template,name:l10n_lu.account_group_645
 msgid "Losses on bad debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6037
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6037
+#: model:account.group,name:l10n_lu.2_account_group_6037
 #: model:account.group.template,name:l10n_lu.account_group_6037
 msgid "Lubricants"
 msgstr ""
@@ -4610,251 +5796,325 @@ msgid "Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_LU
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_LU
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_LU
 msgid "Luxembourgish Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461221
+#: model:account.group,name:l10n_lu.2_account_group_461221
 #: model:account.group.template,name:l10n_lu.account_group_461221
 msgid "MBT - Tax accrual"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461222
+#: model:account.group,name:l10n_lu.2_account_group_461222
 #: model:account.group.template,name:l10n_lu.account_group_461222
 msgid "MBT - Tax payable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6721
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6721
+#: model:account.group,name:l10n_lu.2_account_group_6721
 #: model:account.group.template,name:l10n_lu.account_group_6721
 msgid "MBT - current financial year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6722
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6722
+#: model:account.group,name:l10n_lu.2_account_group_6722
 #: model:account.group.template,name:l10n_lu.account_group_6722
 msgid "MBT - previous financial years"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2222
+#: model:account.group,name:l10n_lu.2_account_group_2222
 #: model:account.group.template,name:l10n_lu.account_group_2222
 msgid "Machinery"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6032
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61854
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6032
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61854
+#: model:account.group,name:l10n_lu.2_account_group_6032
+#: model:account.group,name:l10n_lu.2_account_group_61854
 #: model:account.group.template,name:l10n_lu.account_group_6032
 #: model:account.group.template,name:l10n_lu.account_group_61854
 msgid "Maintenance supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_615211
 #: model:account.group.template,name:l10n_lu.account_group_615211
 msgid "Management (if appropriate owner and partner)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_615211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_615211
 msgid "Management (respectively owner and partner)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6151
 #: model:account.group.template,name:l10n_lu.account_group_6151
 msgid "Marketing and advertising costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_615
 #: model:account.group.template,name:l10n_lu.account_group_615
 msgid "Marketing and communication costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60761
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60761
+#: model:account.group,name:l10n_lu.2_account_group_60761
 #: model:account.group.template,name:l10n_lu.account_group_60761
 msgid "Merchandise"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_112
+#: model:account.group,name:l10n_lu.2_account_group_112
 #: model:account.group.template,name:l10n_lu.account_group_112
 msgid "Merger premium"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_618
 #: model:account.group.template,name:l10n_lu.account_group_618
 msgid "Miscellaneous external charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6488
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6488
+#: model:account.group,name:l10n_lu.2_account_group_6488
 #: model:account.group.template,name:l10n_lu.account_group_6488
 msgid "Miscellaneous operating charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7488
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7488
+#: model:account.group,name:l10n_lu.2_account_group_7488
 #: model:account.group.template,name:l10n_lu.account_group_7488
 msgid "Miscellaneous operating income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4218
+#: model:account.group,name:l10n_lu.2_account_group_4228
 #: model:account.group.template,name:l10n_lu.account_group_4218
 #: model:account.group.template,name:l10n_lu.account_group_4228
 msgid "Miscellaneous receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221313
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221313
+#: model:account.group,name:l10n_lu.2_account_group_221313
 #: model:account.group.template,name:l10n_lu.account_group_221313
 msgid "Mixed-use buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6036
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6036
+#: model:account.group,name:l10n_lu.2_account_group_6036
 #: model:account.group.template,name:l10n_lu.account_group_6036
 msgid "Motor fuels"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2232
+#: model:account.group,name:l10n_lu.2_account_group_2232
 #: model:account.group.template,name:l10n_lu.account_group_2232
 msgid "Motor vehicles"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6466
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6466
+#: model:account.group,name:l10n_lu.2_account_group_6466
 #: model:account.group.template,name:l10n_lu.account_group_6466
 msgid "Motor-vehicle taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4611
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4611
+#: model:account.group,name:l10n_lu.2_account_group_4611
 #: model:account.group.template,name:l10n_lu.account_group_4611
 msgid "Municipal authorities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42142
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42142
+#: model:account.group,name:l10n_lu.2_account_group_42142
+#: model:account.group,name:l10n_lu.2_account_group_672
 #: model:account.group.template,name:l10n_lu.account_group_42142
 #: model:account.group.template,name:l10n_lu.account_group_672
 msgid "Municipal business tax"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106284
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106284
+#: model:account.group,name:l10n_lu.2_account_group_46122
 #: model:account.group.template,name:l10n_lu.account_group_46122
 msgid "Municipal business tax (MBT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106183
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106183
 msgid "Municipal business tax - payment in arrears"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461231
+#: model:account.group,name:l10n_lu.2_account_group_461231
 #: model:account.group.template,name:l10n_lu.account_group_461231
 msgid "NWT - Tax accrual"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461232
+#: model:account.group,name:l10n_lu.2_account_group_461232
 #: model:account.group.template,name:l10n_lu.account_group_461232
 msgid "NWT - Tax payable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6811
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6811
+#: model:account.group,name:l10n_lu.2_account_group_6811
 #: model:account.group.template,name:l10n_lu.account_group_6811
 msgid "NWT - current financial year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6812
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6812
+#: model:account.group,name:l10n_lu.2_account_group_6812
 #: model:account.group.template,name:l10n_lu.account_group_6812
 msgid "NWT - previous financial years"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_70
 #: model:account.group.template,name:l10n_lu.account_group_70
 msgid "Net turnover"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42143
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42143
+#: model:account.group,name:l10n_lu.2_account_group_42143
 #: model:account.group.template,name:l10n_lu.account_group_42143
 msgid "Net wealth tax"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_46123
+#: model:account.group,name:l10n_lu.2_account_group_681
 #: model:account.group.template,name:l10n_lu.account_group_46123
 #: model:account.group.template,name:l10n_lu.account_group_681
 msgid "Net wealth tax (NWT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_193
 #: model:account.group.template,name:l10n_lu.account_group_193
 msgid "Non-convertible debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6462
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6462
+#: model:account.group,name:l10n_lu.2_account_group_6462
 #: model:account.group.template,name:l10n_lu.account_group_6462
 msgid "Non-refundable VAT"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221312
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221312
+#: model:account.group,name:l10n_lu.2_account_group_221312
 #: model:account.group.template,name:l10n_lu.account_group_221312
 msgid "Non-residential buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7099
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7099
+#: model:account.group,name:l10n_lu.2_account_group_7099
 #: model:account.group.template,name:l10n_lu.account_group_7099
 msgid "Not allocated rebates, discounts and refunds"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_NO
+#: model:account.fiscal.position,name:l10n_lu.2_account_fiscal_position_template_LU_NO
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_NO
 msgid "Not liable to VAT"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6135
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6135
+#: model:account.group,name:l10n_lu.2_account_group_6135
 #: model:account.group.template,name:l10n_lu.account_group_6135
 msgid "Notarial and similar fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6035
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6035
+#: model:account.group,name:l10n_lu.2_account_group_6035
 #: model:account.group.template,name:l10n_lu.account_group_6035
 msgid "Office and administrative supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61851
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61851
+#: model:account.group,name:l10n_lu.2_account_group_61851
 #: model:account.group.template,name:l10n_lu.account_group_61851
 msgid "Office supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75411
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75411
 msgid "On affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75413
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75413
 msgid "On other current receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75412
 msgid ""
 "On undertakings with which the undertaking is linked by virtue of "
@@ -4862,26 +6122,44 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_1881
 #: model:account.account.template,name:l10n_lu.lu_2011_account_1881
+#: model:account.group,name:l10n_lu.2_account_group_1881
 #: model:account.group.template,name:l10n_lu.account_group_1881
 msgid "Operating provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42132
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42232
+#: model:account.group,name:l10n_lu.2_account_group_42132
+#: model:account.group,name:l10n_lu.2_account_group_42232
 #: model:account.group.template,name:l10n_lu.account_group_42132
 #: model:account.group.template,name:l10n_lu.account_group_42232
 msgid "Operating subsidies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61418
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6228
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61128
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61158
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61228
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61858
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61418
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6228
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61128
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61158
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61228
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61858
+#: model:account.group,name:l10n_lu.2_account_group_61128
+#: model:account.group,name:l10n_lu.2_account_group_61158
+#: model:account.group,name:l10n_lu.2_account_group_61228
+#: model:account.group,name:l10n_lu.2_account_group_61418
+#: model:account.group,name:l10n_lu.2_account_group_61858
+#: model:account.group,name:l10n_lu.2_account_group_6228
 #: model:account.group.template,name:l10n_lu.account_group_61128
 #: model:account.group.template,name:l10n_lu.account_group_61158
 #: model:account.group.template,name:l10n_lu.account_group_61228
@@ -4892,132 +6170,171 @@ msgid "Other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106178
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106178
 msgid "Other acquisitions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61338
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61338
+#: model:account.group,name:l10n_lu.2_account_group_61338
 #: model:account.group.template,name:l10n_lu.account_group_61338
 msgid ""
 "Other banking and similar services (except interest and similar expenses)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6218
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6218
+#: model:account.group,name:l10n_lu.2_account_group_6218
 #: model:account.group.template,name:l10n_lu.account_group_6218
 msgid "Other benefits"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221318
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221318
+#: model:account.group,name:l10n_lu.2_account_group_221318
 #: model:account.group.template,name:l10n_lu.account_group_221318
 msgid "Other buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_168
 #: model:account.account.template,name:l10n_lu.lu_2011_account_168
+#: model:account.group,name:l10n_lu.2_account_group_168
 #: model:account.group.template,name:l10n_lu.account_group_168
 msgid "Other capital investment subsidies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_518
 #: model:account.account.template,name:l10n_lu.lu_2011_account_518
+#: model:account.group,name:l10n_lu.2_account_group_518
 #: model:account.group.template,name:l10n_lu.account_group_518
 msgid "Other cash amounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_708
 #: model:account.account.template,name:l10n_lu.lu_2020_account_708
+#: model:account.group,name:l10n_lu.2_account_group_708
 #: model:account.group.template,name:l10n_lu.account_group_708
 msgid "Other components of turnover"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6038
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6038
+#: model:account.group,name:l10n_lu.2_account_group_6038
 #: model:account.group.template,name:l10n_lu.account_group_6038
 msgid "Other consumable supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106158
 msgid "Other contributions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_47
 #: model:account.group.template,name:l10n_lu.account_group_47
 msgid "Other debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_472
 #: model:account.group.template,name:l10n_lu.account_group_472
 msgid "Other debts payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_471
 #: model:account.group.template,name:l10n_lu.account_group_471
 msgid "Other debts payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106248
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106248
 msgid "Other disposals"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6468
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6468
+#: model:account.group,name:l10n_lu.2_account_group_6468
 #: model:account.group.template,name:l10n_lu.account_group_6468
 msgid "Other duties and taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_61
 #: model:account.group.template,name:l10n_lu.account_group_61
 msgid "Other external charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_658
 #: model:account.group.template,name:l10n_lu.account_group_658
 msgid "Other financial charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6581
+#: model:account.group,name:l10n_lu.2_account_group_6581
 #: model:account.group.template,name:l10n_lu.account_group_6581
 msgid "Other financial charges - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6582
+#: model:account.group,name:l10n_lu.2_account_group_6582
 #: model:account.group.template,name:l10n_lu.account_group_6582
 msgid "Other financial charges - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_758
 #: model:account.group.template,name:l10n_lu.account_group_758
 msgid "Other financial income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7581
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7581
+#: model:account.group,name:l10n_lu.2_account_group_7581
 #: model:account.group.template,name:l10n_lu.account_group_7581
 msgid "Other financial income - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7582
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7582
+#: model:account.group,name:l10n_lu.2_account_group_7582
 #: model:account.group.template,name:l10n_lu.account_group_7582
 msgid "Other financial income - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2238
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2238
+#: model:account.group,name:l10n_lu.2_account_group_2238
 #: model:account.group.template,name:l10n_lu.account_group_2238
 msgid "Other fixtures"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7223
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7333
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7223
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7333
+#: model:account.group,name:l10n_lu.2_account_group_7223
+#: model:account.group,name:l10n_lu.2_account_group_7333
 #: model:account.group.template,name:l10n_lu.account_group_7223
 #: model:account.group.template,name:l10n_lu.account_group_7333
 msgid ""
@@ -5025,7 +6342,10 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2243
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2243
+#: model:account.group,name:l10n_lu.2_account_group_223
+#: model:account.group,name:l10n_lu.2_account_group_2243
 #: model:account.group.template,name:l10n_lu.account_group_223
 #: model:account.group.template,name:l10n_lu.account_group_2243
 msgid ""
@@ -5033,115 +6353,160 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6738
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6738
+#: model:account.group,name:l10n_lu.2_account_group_6738
 #: model:account.group.template,name:l10n_lu.account_group_6738
 msgid "Other foreign income taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421818
+#: model:account.account,name:l10n_lu.2_lu_2020_account_46158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421818
 #: model:account.account.template,name:l10n_lu.lu_2020_account_46158
+#: model:account.group,name:l10n_lu.2_account_group_421818
+#: model:account.group,name:l10n_lu.2_account_group_46158
 #: model:account.group.template,name:l10n_lu.account_group_421818
 #: model:account.group.template,name:l10n_lu.account_group_46158
 msgid "Other foreign taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106168
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106168
 msgid "Other in kind withdrawals"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7548
 #: model:account.group.template,name:l10n_lu.account_group_7548
 msgid "Other income from transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421628
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461428
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421628
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461428
+#: model:account.group,name:l10n_lu.2_account_group_421628
+#: model:account.group,name:l10n_lu.2_account_group_461428
 #: model:account.group.template,name:l10n_lu.account_group_421628
 #: model:account.group.template,name:l10n_lu.account_group_461428
 msgid "Other indirect taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6148
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6148
+#: model:account.group,name:l10n_lu.2_account_group_6148
 #: model:account.group.template,name:l10n_lu.account_group_6148
 msgid "Other insurances"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_755
 #: model:account.group.template,name:l10n_lu.account_group_755
 msgid "Other interest income from current assets and discounts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221118
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221118
+#: model:account.group,name:l10n_lu.2_account_group_221118
 #: model:account.group.template,name:l10n_lu.account_group_221118
 msgid "Other land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47161
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47261
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47161
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47261
+#: model:account.group,name:l10n_lu.2_account_group_47161
+#: model:account.group,name:l10n_lu.2_account_group_47261
 #: model:account.group.template,name:l10n_lu.account_group_47161
 #: model:account.group.template,name:l10n_lu.account_group_47261
 msgid "Other loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4718
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4728
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4718
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4728
+#: model:account.group,name:l10n_lu.2_account_group_4718
+#: model:account.group,name:l10n_lu.2_account_group_4728
 #: model:account.group.template,name:l10n_lu.account_group_4718
 #: model:account.group.template,name:l10n_lu.account_group_4728
 msgid "Other miscellaneous debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6188
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6188
+#: model:account.group,name:l10n_lu.2_account_group_6188
 #: model:account.group.template,name:l10n_lu.account_group_6188
 msgid "Other miscellaneous external charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_648
 #: model:account.group.template,name:l10n_lu.account_group_648
 msgid "Other miscellaneous operating charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_748
 #: model:account.group.template,name:l10n_lu.account_group_748
 msgid "Other miscellaneous operating income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42188
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42288
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42188
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42288
+#: model:account.group,name:l10n_lu.2_account_group_42188
+#: model:account.group,name:l10n_lu.2_account_group_42288
 #: model:account.group.template,name:l10n_lu.account_group_42188
 #: model:account.group.template,name:l10n_lu.account_group_42288
 msgid "Other miscellaneous receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5088
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5088
+#: model:account.group,name:l10n_lu.2_account_group_5088
 #: model:account.group.template,name:l10n_lu.account_group_5088
 msgid "Other miscellaneous transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_64
 #: model:account.group.template,name:l10n_lu.account_group_64
 msgid "Other operating charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_74
 #: model:account.group.template,name:l10n_lu.account_group_74
 msgid "Other operating income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45118
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45128
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45218
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45228
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45118
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45218
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45228
+#: model:account.group,name:l10n_lu.2_account_group_45118
+#: model:account.group,name:l10n_lu.2_account_group_45128
+#: model:account.group,name:l10n_lu.2_account_group_45218
+#: model:account.group,name:l10n_lu.2_account_group_45228
 #: model:account.group.template,name:l10n_lu.account_group_45118
 #: model:account.group.template,name:l10n_lu.account_group_45128
 #: model:account.group.template,name:l10n_lu.account_group_45218
@@ -5150,47 +6515,70 @@ msgid "Other payables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106148
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106148
 msgid "Other private insurance premiums"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61348
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61348
+#: model:account.group,name:l10n_lu.2_account_group_61348
 #: model:account.group.template,name:l10n_lu.account_group_61348
 msgid "Other professional fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_188
 #: model:account.group.template,name:l10n_lu.account_group_188
 msgid "Other provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6088
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6088
+#: model:account.group,name:l10n_lu.2_account_group_6088
 #: model:account.group.template,name:l10n_lu.account_group_6088
 msgid "Other purchases included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61518
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61518
+#: model:account.group,name:l10n_lu.2_account_group_61518
 #: model:account.group.template,name:l10n_lu.account_group_61518
 msgid "Other purchases of advertising services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6082
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6082
+#: model:account.group,name:l10n_lu.2_account_group_6082
 #: model:account.group.template,name:l10n_lu.account_group_6082
 msgid ""
 "Other purchases of material included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41118
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41128
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41218
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41228
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42168
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6454
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41118
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41218
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41228
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42168
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6454
+#: model:account.group,name:l10n_lu.2_account_group_41118
+#: model:account.group,name:l10n_lu.2_account_group_41128
+#: model:account.group,name:l10n_lu.2_account_group_41218
+#: model:account.group,name:l10n_lu.2_account_group_41228
+#: model:account.group,name:l10n_lu.2_account_group_42
+#: model:account.group,name:l10n_lu.2_account_group_42168
+#: model:account.group,name:l10n_lu.2_account_group_6454
 #: model:account.group.template,name:l10n_lu.account_group_41118
 #: model:account.group.template,name:l10n_lu.account_group_41128
 #: model:account.group.template,name:l10n_lu.account_group_41218
@@ -5202,92 +6590,126 @@ msgid "Other receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_422
 #: model:account.group.template,name:l10n_lu.account_group_422
 msgid "Other receivables after one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_421
 #: model:account.group.template,name:l10n_lu.account_group_421
 msgid "Other receivables within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64658
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64658
+#: model:account.group,name:l10n_lu.2_account_group_64658
 #: model:account.group.template,name:l10n_lu.account_group_64658
 msgid "Other registration fees, stamp duties and mortgage duties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6138
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6138
+#: model:account.group,name:l10n_lu.2_account_group_6138
 #: model:account.group.template,name:l10n_lu.account_group_6138
 msgid "Other remuneration of intermediaries and professional fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_1381
 #: model:account.account.template,name:l10n_lu.lu_2011_account_1381
+#: model:account.group,name:l10n_lu.2_account_group_1381
 #: model:account.group.template,name:l10n_lu.account_group_1381
 msgid "Other reserves available for distribution"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1382
 #: model:account.group.template,name:l10n_lu.account_group_1382
 msgid "Other reserves not available for distribution"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_138
 #: model:account.group.template,name:l10n_lu.account_group_138
 msgid "Other reserves, including fair-value reserve"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_128
+#: model:account.group,name:l10n_lu.2_account_group_128
 #: model:account.group.template,name:l10n_lu.account_group_128
 msgid "Other revaluation reserves"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2358
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2358
+#: model:account.group,name:l10n_lu.2_account_group_2358
 #: model:account.group.template,name:l10n_lu.account_group_2358
 msgid "Other securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_23528
 #: model:account.account.template,name:l10n_lu.lu_2011_account_23528
+#: model:account.group,name:l10n_lu.2_account_group_23528
 #: model:account.group.template,name:l10n_lu.account_group_23528
 msgid "Other securities held as fixed assets (creditor's right)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_23518
 #: model:account.account.template,name:l10n_lu.lu_2011_account_23518
+#: model:account.group,name:l10n_lu.2_account_group_23518
 #: model:account.group.template,name:l10n_lu.account_group_23518
 msgid "Other securities held as fixed assets (equity right)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47164
+#: model:account.account,name:l10n_lu.2_lu_2020_account_47264
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47164
 #: model:account.account.template,name:l10n_lu.lu_2020_account_47264
+#: model:account.group,name:l10n_lu.2_account_group_47168
+#: model:account.group,name:l10n_lu.2_account_group_47268
 #: model:account.group.template,name:l10n_lu.account_group_47168
 #: model:account.group.template,name:l10n_lu.account_group_47268
 msgid "Other similar debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_208
 #: model:account.account.template,name:l10n_lu.lu_2011_account_208
+#: model:account.group,name:l10n_lu.2_account_group_208
 #: model:account.group.template,name:l10n_lu.account_group_208
 msgid "Other similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6438
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6438
+#: model:account.group,name:l10n_lu.2_account_group_6438
 #: model:account.group.template,name:l10n_lu.account_group_6438
 msgid "Other similar remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64158
+#: model:account.account,name:l10n_lu.2_lu_2011_account_721258
+#: model:account.account,name:l10n_lu.2_lu_2011_account_74158
+#: model:account.account,name:l10n_lu.2_lu_2020_account_703158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_721258
 #: model:account.account.template,name:l10n_lu.lu_2011_account_74158
 #: model:account.account.template,name:l10n_lu.lu_2020_account_703158
+#: model:account.group,name:l10n_lu.2_account_group_64158
+#: model:account.group,name:l10n_lu.2_account_group_703158
+#: model:account.group,name:l10n_lu.2_account_group_721258
+#: model:account.group,name:l10n_lu.2_account_group_74158
 #: model:account.group.template,name:l10n_lu.account_group_64158
 #: model:account.group.template,name:l10n_lu.account_group_703158
 #: model:account.group.template,name:l10n_lu.account_group_721258
@@ -5296,94 +6718,130 @@ msgid "Other similar rights and assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212158
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212158
+#: model:account.group,name:l10n_lu.2_account_group_212158
 #: model:account.group.template,name:l10n_lu.account_group_212158
 msgid "Other similar rights and assets acquired for consideration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_212258
 #: model:account.account.template,name:l10n_lu.lu_2011_account_212258
+#: model:account.group,name:l10n_lu.2_account_group_212258
 #: model:account.group.template,name:l10n_lu.account_group_212258
 msgid "Other similar rights and assets created by the undertaking itself"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42178
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4628
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42178
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4628
+#: model:account.group,name:l10n_lu.2_account_group_42178
+#: model:account.group,name:l10n_lu.2_account_group_4628
 #: model:account.group.template,name:l10n_lu.account_group_42178
 #: model:account.group.template,name:l10n_lu.account_group_4628
 msgid "Other social bodies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6232
+#: model:account.group,name:l10n_lu.2_account_group_6232
 #: model:account.group.template,name:l10n_lu.account_group_6232
 msgid "Other social security costs (including illness, accidents, a.s.o.)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106198
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106198
 msgid "Other special private withdrawals"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_624
 #: model:account.group.template,name:l10n_lu.account_group_624
 msgid "Other staff expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6248
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6248
+#: model:account.group,name:l10n_lu.2_account_group_6248
 #: model:account.group.template,name:l10n_lu.account_group_6248
 msgid "Other staff expenses not mentioned above"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_622
 #: model:account.group.template,name:l10n_lu.account_group_622
 msgid "Other staff remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42138
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42238
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42138
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42238
+#: model:account.group,name:l10n_lu.2_account_group_42138
+#: model:account.group,name:l10n_lu.2_account_group_42238
 #: model:account.group.template,name:l10n_lu.account_group_42138
 #: model:account.group.template,name:l10n_lu.account_group_42238
 msgid "Other subsidies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7458
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7458
+#: model:account.group,name:l10n_lu.2_account_group_7458
 #: model:account.group.template,name:l10n_lu.account_group_7458
 msgid "Other subsidies for operating activities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621128
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621128
+#: model:account.group,name:l10n_lu.2_account_group_621128
 #: model:account.group.template,name:l10n_lu.account_group_621128
 msgid "Other supplements"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106288
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106288
 msgid "Other tax refunds"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106188
+#: model:account.account,name:l10n_lu.2_lu_2011_account_688
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106188
 #: model:account.account.template,name:l10n_lu.lu_2011_account_688
+#: model:account.group,name:l10n_lu.2_account_group_688
 #: model:account.group.template,name:l10n_lu.account_group_688
 msgid "Other taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_68
 #: model:account.group.template,name:l10n_lu.account_group_68
 msgid "Other taxes not included in the previous caption"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75488
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65428
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75318
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75428
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75488
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65428
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75318
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75428
+#: model:account.group,name:l10n_lu.2_account_group_508
+#: model:account.group,name:l10n_lu.2_account_group_65428
+#: model:account.group,name:l10n_lu.2_account_group_75428
+#: model:account.group,name:l10n_lu.2_account_group_75488
 #: model:account.group.template,name:l10n_lu.account_group_508
 #: model:account.group.template,name:l10n_lu.account_group_65428
 #: model:account.group.template,name:l10n_lu.account_group_75428
@@ -5392,28 +6850,41 @@ msgid "Other transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6168
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6168
+#: model:account.group,name:l10n_lu.2_account_group_6168
 #: model:account.group.template,name:l10n_lu.account_group_6168
 msgid "Other transportation"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60814
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60814
+#: model:account.group,name:l10n_lu.2_account_group_60814
 #: model:account.group.template,name:l10n_lu.account_group_60814
 msgid "Outsourcing included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621123
+#: model:account.group,name:l10n_lu.2_account_group_621123
 #: model:account.group.template,name:l10n_lu.account_group_621123
 msgid "Overtime"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75482
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65422
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75312
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75422
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75482
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75312
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75422
+#: model:account.group,name:l10n_lu.2_account_group_65422
+#: model:account.group,name:l10n_lu.2_account_group_75422
+#: model:account.group,name:l10n_lu.2_account_group_75482
 #: model:account.group.template,name:l10n_lu.account_group_65422
 #: model:account.group.template,name:l10n_lu.account_group_75422
 #: model:account.group.template,name:l10n_lu.account_group_75482
@@ -5421,7 +6892,9 @@ msgid "Own shares or corporate units"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_502
 #: model:account.account.template,name:l10n_lu.lu_2011_account_502
+#: model:account.group,name:l10n_lu.2_account_group_502
 #: model:account.group.template,name:l10n_lu.account_group_502
 msgid "Own shares or own corporate units"
 msgstr ""
@@ -5432,10 +6905,18 @@ msgid "PCMN Luxembourg"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_233
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75113
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65213
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75213
 #: model:account.account.template,name:l10n_lu.lu_2011_account_233
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75113
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65213
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75213
+#: model:account.group,name:l10n_lu.2_account_group_233
+#: model:account.group,name:l10n_lu.2_account_group_65213
+#: model:account.group,name:l10n_lu.2_account_group_75213
+#: model:account.group,name:l10n_lu.2_account_group_75223
 #: model:account.group.template,name:l10n_lu.account_group_233
 #: model:account.group.template,name:l10n_lu.account_group_65213
 #: model:account.group.template,name:l10n_lu.account_group_75213
@@ -5444,12 +6925,24 @@ msgid "Participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21212
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21222
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6412
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72122
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7412
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70312
+#: model:account.group,name:l10n_lu.2_account_group_21212
+#: model:account.group,name:l10n_lu.2_account_group_21222
+#: model:account.group,name:l10n_lu.2_account_group_6412
+#: model:account.group,name:l10n_lu.2_account_group_70312
+#: model:account.group,name:l10n_lu.2_account_group_72122
+#: model:account.group,name:l10n_lu.2_account_group_7412
 #: model:account.group.template,name:l10n_lu.account_group_21212
 #: model:account.group.template,name:l10n_lu.account_group_21222
 #: model:account.group.template,name:l10n_lu.account_group_6412
@@ -5460,19 +6953,27 @@ msgid "Patents"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10622
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10622
 msgid "Personal holdings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2221
+#: model:account.group,name:l10n_lu.2_account_group_2221
 #: model:account.group.template,name:l10n_lu.account_group_2221
 msgid "Plant"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2242
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7222
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2242
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7222
+#: model:account.group,name:l10n_lu.2_account_group_222
+#: model:account.group,name:l10n_lu.2_account_group_2242
+#: model:account.group,name:l10n_lu.2_account_group_7222
 #: model:account.group.template,name:l10n_lu.account_group_222
 #: model:account.group.template,name:l10n_lu.account_group_2242
 #: model:account.group.template,name:l10n_lu.account_group_7222
@@ -5480,133 +6981,176 @@ msgid "Plant and machinery"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61531
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61531
+#: model:account.group,name:l10n_lu.2_account_group_61531
 #: model:account.group.template,name:l10n_lu.account_group_61531
 msgid "Postal charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6153
 #: model:account.group.template,name:l10n_lu.account_group_6153
 msgid "Postal charges and telecommunication costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62411
+#: model:account.group,name:l10n_lu.2_account_group_62411
 #: model:account.group.template,name:l10n_lu.account_group_62411
 msgid "Premiums for external pensions funds"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_114
 #: model:account.account.template,name:l10n_lu.lu_2011_account_114
+#: model:account.group,name:l10n_lu.2_account_group_114
 #: model:account.group.template,name:l10n_lu.account_group_114
 msgid "Premiums on conversion of bonds into shares"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61511
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61511
+#: model:account.group,name:l10n_lu.2_account_group_61511
 #: model:account.group.template,name:l10n_lu.account_group_61511
 msgid "Press advertising"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_67322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_67322
+#: model:account.group,name:l10n_lu.2_account_group_67322
 #: model:account.group.template,name:l10n_lu.account_group_67322
 msgid "Previous financial years"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106174
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106244
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106174
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106244
 msgid "Private buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106172
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106242
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106172
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106242
 msgid "Private car"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106171
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106241
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106171
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106241
 msgid "Private furniture"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106173
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106173
 msgid "Private held securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10623
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10623
 msgid "Private loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10613
 msgid "Private share of medical services expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106243
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106243
 msgid "Private shares / bonds"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7451
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7451
+#: model:account.group,name:l10n_lu.2_account_group_7451
 #: model:account.group.template,name:l10n_lu.account_group_7451
 msgid "Product subsidies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6134
 #: model:account.group.template,name:l10n_lu.account_group_6134
 msgid "Professional fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221112
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221112
+#: model:account.group,name:l10n_lu.2_account_group_221112
 #: model:account.group.template,name:l10n_lu.account_group_221112
 msgid "Property rights and similar"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_18
 #: model:account.group.template,name:l10n_lu.account_group_18
 msgid "Provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_181
 #: model:account.account.template,name:l10n_lu.lu_2011_account_181
+#: model:account.group,name:l10n_lu.2_account_group_181
 #: model:account.group.template,name:l10n_lu.account_group_181
 msgid "Provisions for pensions and similar obligations"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_182
 #: model:account.account.template,name:l10n_lu.lu_2020_account_182
+#: model:account.group,name:l10n_lu.2_account_group_182
 #: model:account.group.template,name:l10n_lu.account_group_182
 msgid "Provisions for taxation"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621122
+#: model:account.group,name:l10n_lu.2_account_group_621122
 #: model:account.group.template,name:l10n_lu.account_group_621122
 msgid "Public holidays"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6083
 #: model:account.group.template,name:l10n_lu.account_group_6083
 msgid "Purchase of greenhous gas and similar emission quotas"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6083
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6083
 msgid "Purchase of greenhouse gas and similar emission quotas"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45121
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_45221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_45221
+#: model:account.group,name:l10n_lu.2_account_group_45111
+#: model:account.group,name:l10n_lu.2_account_group_45121
+#: model:account.group,name:l10n_lu.2_account_group_45211
+#: model:account.group,name:l10n_lu.2_account_group_45221
 #: model:account.group.template,name:l10n_lu.account_group_45111
 #: model:account.group.template,name:l10n_lu.account_group_45121
 #: model:account.group.template,name:l10n_lu.account_group_45211
@@ -5615,128 +7159,167 @@ msgid "Purchases and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6063
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6063
+#: model:account.group,name:l10n_lu.2_account_group_6063
 #: model:account.group.template,name:l10n_lu.account_group_6063
 msgid "Purchases of buildings for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_603
 #: model:account.group.template,name:l10n_lu.account_group_603
 msgid "Purchases of consumable materials and supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_608
 #: model:account.group.template,name:l10n_lu.account_group_608
 msgid "Purchases of items included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6062
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6062
+#: model:account.group,name:l10n_lu.2_account_group_6062
 #: model:account.group.template,name:l10n_lu.account_group_6062
 msgid "Purchases of land for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6061
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6061
+#: model:account.group,name:l10n_lu.2_account_group_6061
 #: model:account.group.template,name:l10n_lu.account_group_6061
 msgid "Purchases of merchandise"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_606
 #: model:account.group.template,name:l10n_lu.account_group_606
 msgid "Purchases of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_604
 #: model:account.account.template,name:l10n_lu.lu_2020_account_604
+#: model:account.group,name:l10n_lu.2_account_group_604
 #: model:account.group.template,name:l10n_lu.account_group_604
 msgid "Purchases of packaging"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_601
 #: model:account.account.template,name:l10n_lu.lu_2020_account_601
+#: model:account.group,name:l10n_lu.2_account_group_601
 #: model:account.group.template,name:l10n_lu.account_group_601
 msgid "Purchases of raw materials"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7095
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7095
+#: model:account.group,name:l10n_lu.2_account_group_7095
 #: model:account.group.template,name:l10n_lu.account_group_7095
 msgid "RDR on commissions and brokerage fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7098
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7098
+#: model:account.group,name:l10n_lu.2_account_group_7098
 #: model:account.group.template,name:l10n_lu.account_group_7098
 msgid "RDR on other components of turnover"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6098
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6098
+#: model:account.group,name:l10n_lu.2_account_group_6098
 #: model:account.group.template,name:l10n_lu.account_group_6098
 msgid "RDR on purchases included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6093
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6093
+#: model:account.group,name:l10n_lu.2_account_group_6093
 #: model:account.group.template,name:l10n_lu.account_group_6093
 msgid "RDR on purchases of consumable materials and supplies"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6096
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6096
+#: model:account.group,name:l10n_lu.2_account_group_6096
 #: model:account.group.template,name:l10n_lu.account_group_6096
 msgid "RDR on purchases of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6094
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6094
+#: model:account.group,name:l10n_lu.2_account_group_6094
 #: model:account.group.template,name:l10n_lu.account_group_6094
 msgid "RDR on purchases of packaging"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6091
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6091
+#: model:account.group,name:l10n_lu.2_account_group_6091
 #: model:account.group.template,name:l10n_lu.account_group_6091
 msgid "RDR on purchases of raw materials"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7092
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7092
+#: model:account.group,name:l10n_lu.2_account_group_7092
 #: model:account.group.template,name:l10n_lu.account_group_7092
 msgid "RDR on sales of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7096
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7096
+#: model:account.group,name:l10n_lu.2_account_group_7096
 #: model:account.group.template,name:l10n_lu.account_group_7096
 msgid "RDR on sales of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7094
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7094
+#: model:account.group,name:l10n_lu.2_account_group_7094
 #: model:account.group.template,name:l10n_lu.account_group_7094
 msgid "RDR on sales of packages"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7093
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7093
+#: model:account.group,name:l10n_lu.2_account_group_7093
 #: model:account.group.template,name:l10n_lu.account_group_7093
 msgid "RDR on sales of services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_735
 #: model:account.group.template,name:l10n_lu.account_group_735
 msgid "RVA and FVA on receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75112
 #: model:account.group.template,name:l10n_lu.account_group_75112
 msgid "RVA on amounts owed by affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7352
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7352
+#: model:account.group,name:l10n_lu.2_account_group_7352
 #: model:account.group.template,name:l10n_lu.account_group_7352
 msgid ""
 "RVA on amounts owed by affiliated undertakings and undertakings with which "
@@ -5744,6 +7327,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75114
 #: model:account.group.template,name:l10n_lu.account_group_75114
 msgid ""
 "RVA on amounts owed by undertakings with which the company is linked by "
@@ -5751,13 +7335,17 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73313
+#: model:account.group,name:l10n_lu.2_account_group_73313
 #: model:account.group.template,name:l10n_lu.account_group_73313
 msgid "RVA on buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7322
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7322
+#: model:account.group,name:l10n_lu.2_account_group_7322
 #: model:account.group.template,name:l10n_lu.account_group_7322
 msgid ""
 "RVA on concessions, patents, licences, trademarks and similar rights and "
@@ -5765,87 +7353,113 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7321
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7321
+#: model:account.group,name:l10n_lu.2_account_group_7321
 #: model:account.group.template,name:l10n_lu.account_group_7321
 msgid "RVA on development costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7324
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7324
+#: model:account.group,name:l10n_lu.2_account_group_7324
 #: model:account.group.template,name:l10n_lu.account_group_7324
 msgid "RVA on down payments and intangible fixed assets under development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7334
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7334
+#: model:account.group,name:l10n_lu.2_account_group_7334
 #: model:account.group.template,name:l10n_lu.account_group_7334
 msgid "RVA on down payments and tangible fixed assets under development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7345
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7345
+#: model:account.group,name:l10n_lu.2_account_group_7345
 #: model:account.group.template,name:l10n_lu.account_group_7345
 msgid "RVA on down payments on inventories"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7511
 #: model:account.group.template,name:l10n_lu.account_group_7511
 msgid "RVA on financial fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73314
+#: model:account.group,name:l10n_lu.2_account_group_73314
 #: model:account.group.template,name:l10n_lu.account_group_73314
 msgid "RVA on fixtures and fittings-out of buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73312
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73312
+#: model:account.group,name:l10n_lu.2_account_group_73312
 #: model:account.group.template,name:l10n_lu.account_group_73312
 msgid "RVA on fixtures and fittings-out of land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_732
 #: model:account.group.template,name:l10n_lu.account_group_732
 msgid "RVA on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_734
 #: model:account.group.template,name:l10n_lu.account_group_734
 msgid "RVA on inventories"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7343
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7343
+#: model:account.group,name:l10n_lu.2_account_group_7343
 #: model:account.group.template,name:l10n_lu.account_group_7343
 msgid "RVA on inventories of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7344
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7344
+#: model:account.group,name:l10n_lu.2_account_group_7344
 #: model:account.group.template,name:l10n_lu.account_group_7344
 msgid "RVA on inventories of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7341
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7341
+#: model:account.group,name:l10n_lu.2_account_group_7341
 #: model:account.group.template,name:l10n_lu.account_group_7341
 msgid "RVA on inventories of raw materials and consumables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7342
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7342
+#: model:account.group,name:l10n_lu.2_account_group_7342
 #: model:account.group.template,name:l10n_lu.account_group_7342
 msgid "RVA on inventories of work and contracts in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_73311
 #: model:account.account.template,name:l10n_lu.lu_2011_account_73311
+#: model:account.group,name:l10n_lu.2_account_group_73311
 #: model:account.group.template,name:l10n_lu.account_group_73311
 msgid "RVA on land"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7331
 #: model:account.group.template,name:l10n_lu.account_group_7331
 msgid ""
 "RVA on land, fixtures and fittings-out and buildings and FVA on investment "
@@ -5853,49 +7467,61 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75116
 #: model:account.group.template,name:l10n_lu.account_group_75116
 msgid "RVA on loans, deposits and claims held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7353
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7353
+#: model:account.group,name:l10n_lu.2_account_group_7353
 #: model:account.group.template,name:l10n_lu.account_group_7353
 msgid "RVA on other receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75318
 #: model:account.group.template,name:l10n_lu.account_group_75318
 msgid "RVA on other transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75312
 #: model:account.group.template,name:l10n_lu.account_group_75312
 msgid "RVA on own shares or corporate units"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75113
 #: model:account.group.template,name:l10n_lu.account_group_75113
 msgid "RVA on participating interests"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7332
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7332
+#: model:account.group,name:l10n_lu.2_account_group_7332
 #: model:account.group.template,name:l10n_lu.account_group_7332
 msgid "RVA on plant and machinery"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75115
 #: model:account.group.template,name:l10n_lu.account_group_75115
 msgid "RVA on securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75111
+#: model:account.group,name:l10n_lu.2_account_group_75311
 #: model:account.group.template,name:l10n_lu.account_group_75111
 #: model:account.group.template,name:l10n_lu.account_group_75311
 msgid "RVA on shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75313
 #: model:account.group.template,name:l10n_lu.account_group_75313
 msgid ""
 "RVA on shares in undertakings with which the undertaking is linked by virtue"
@@ -5903,6 +7529,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_733
 #: model:account.group.template,name:l10n_lu.account_group_733
 msgid ""
 "RVA on tangible fixed assets and fair value adjustments (FVA) on investment "
@@ -5910,23 +7537,29 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7351
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7351
+#: model:account.group,name:l10n_lu.2_account_group_7351
 #: model:account.group.template,name:l10n_lu.account_group_7351
 msgid "RVA on trade receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7531
 #: model:account.group.template,name:l10n_lu.account_group_7531
 msgid "RVA on transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6461
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6461
+#: model:account.group,name:l10n_lu.2_account_group_6461
 #: model:account.group.template,name:l10n_lu.account_group_6461
 msgid "Real property tax"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_709
 #: model:account.group.template,name:l10n_lu.account_group_709
 msgid ""
 "Rebates, discounts and refunds (RDR) granted and not immediately deducted "
@@ -5934,6 +7567,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_609
 #: model:account.group.template,name:l10n_lu.account_group_609
 msgid ""
 "Rebates, discounts and refunds (RDR) received and not directly deducted from"
@@ -5941,273 +7575,353 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_619
 #: model:account.account.template,name:l10n_lu.lu_2011_account_619
+#: model:account.group,name:l10n_lu.2_account_group_619
 #: model:account.group.template,name:l10n_lu.account_group_619
 msgid "Rebates, discounts and refunds received on other external charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10627
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10627
 msgid "Received child benefit"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4711
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4721
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4711
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4721
+#: model:account.group,name:l10n_lu.2_account_group_4711
+#: model:account.group,name:l10n_lu.2_account_group_4721
 #: model:account.group.template,name:l10n_lu.account_group_4711
 #: model:account.group.template,name:l10n_lu.account_group_4721
 msgid "Received deposits and guarantees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10625
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10625
 msgid "Received rents"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10626
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10626
 msgid "Received wages or pensions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61524
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61524
+#: model:account.group,name:l10n_lu.2_account_group_61524
 #: model:account.group.template,name:l10n_lu.account_group_61524
 msgid "Receptions and entertainment costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106193
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106193
 msgid "Refund of private debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6219
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6219
+#: model:account.group,name:l10n_lu.2_account_group_6219
 #: model:account.group.template,name:l10n_lu.account_group_6219
 msgid "Refunds on wages paid"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421621
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461421
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421621
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461421
+#: model:account.group,name:l10n_lu.2_account_group_421621
+#: model:account.group,name:l10n_lu.2_account_group_461421
 #: model:account.group.template,name:l10n_lu.account_group_421621
 #: model:account.group.template,name:l10n_lu.account_group_461421
 msgid "Registration duties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_64651
 #: model:account.account.template,name:l10n_lu.lu_2011_account_64651
+#: model:account.group,name:l10n_lu.2_account_group_64651
 #: model:account.group.template,name:l10n_lu.account_group_64651
 msgid "Registration fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6465
 #: model:account.group.template,name:l10n_lu.account_group_6465
 msgid "Registration fees, stamp duties and mortgage duties"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61522
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61522
+#: model:account.group,name:l10n_lu.2_account_group_61522
 #: model:account.group.template,name:l10n_lu.account_group_61522
 msgid "Relocation expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_613
 #: model:account.group.template,name:l10n_lu.account_group_613
 msgid "Remuneration of intermediaries and professional fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106162
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106162
 msgid "Rent"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_7032
 #: model:account.group.template,name:l10n_lu.account_group_7032
 msgid "Rental income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_742
 #: model:account.group.template,name:l10n_lu.account_group_742
 msgid "Rental income from ancillary activities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70322
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70322
+#: model:account.group,name:l10n_lu.2_account_group_70322
 #: model:account.group.template,name:l10n_lu.account_group_70322
 msgid "Rental income from movable property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70321
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70321
+#: model:account.group,name:l10n_lu.2_account_group_70321
 #: model:account.group.template,name:l10n_lu.account_group_70321
 msgid "Rental income from real property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7422
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7422
+#: model:account.group,name:l10n_lu.2_account_group_7422
 #: model:account.group.template,name:l10n_lu.account_group_7422
 msgid "Rental income on movable property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7421
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7421
+#: model:account.group,name:l10n_lu.2_account_group_7421
 #: model:account.group.template,name:l10n_lu.account_group_7421
 msgid "Rental income on real property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6112
 #: model:account.group.template,name:l10n_lu.account_group_6112
 msgid "Rents and operational leasing on movable property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6111
 #: model:account.group.template,name:l10n_lu.account_group_6111
 msgid "Rents and operationnal leasing for real property"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_611
 #: model:account.group.template,name:l10n_lu.account_group_611
 msgid "Rents and service charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106191
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106191
 msgid "Repairs to private buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60812
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60812
+#: model:account.group,name:l10n_lu.2_account_group_60812
 #: model:account.group.template,name:l10n_lu.account_group_60812
 msgid "Research and development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_13821
 #: model:account.account.template,name:l10n_lu.lu_2020_account_13821
+#: model:account.group,name:l10n_lu.2_account_group_13821
 #: model:account.group.template,name:l10n_lu.account_group_13821
 msgid "Reserve for net wealth tax (NWT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_13
 #: model:account.group.template,name:l10n_lu.account_group_13
 msgid "Reserves"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_132
 #: model:account.account.template,name:l10n_lu.lu_2011_account_132
+#: model:account.group,name:l10n_lu.2_account_group_132
 #: model:account.group.template,name:l10n_lu.account_group_132
 msgid "Reserves for own shares or own corporate units"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_13822
 #: model:account.account.template,name:l10n_lu.lu_2020_account_13822
+#: model:account.group,name:l10n_lu.2_account_group_13822
 #: model:account.group.template,name:l10n_lu.account_group_13822
 msgid "Reserves in application of fair value"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_122
 #: model:account.account.template,name:l10n_lu.lu_2011_account_122
+#: model:account.group,name:l10n_lu.2_account_group_122
 #: model:account.group.template,name:l10n_lu.account_group_122
 msgid "Reserves in application of the equity method"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_13828
 #: model:account.account.template,name:l10n_lu.lu_2020_account_13828
+#: model:account.group,name:l10n_lu.2_account_group_13828
 #: model:account.group.template,name:l10n_lu.account_group_13828
 msgid "Reserves not available for distribution not mentioned above"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_133
 #: model:account.account.template,name:l10n_lu.lu_2011_account_133
+#: model:account.group,name:l10n_lu.2_account_group_133
 #: model:account.group.template,name:l10n_lu.account_group_133
 msgid "Reserves provided for by the articles of association"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_221311
 #: model:account.account.template,name:l10n_lu.lu_2020_account_221311
+#: model:account.group,name:l10n_lu.2_account_group_221311
 #: model:account.group.template,name:l10n_lu.account_group_221311
 msgid "Residential buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_142
 #: model:account.account.template,name:l10n_lu.lu_2011_account_142
+#: model:account.group,name:l10n_lu.2_account_group_142
 #: model:account.group.template,name:l10n_lu.account_group_142
 msgid "Result for the financial year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_14
 #: model:account.group.template,name:l10n_lu.account_group_14
 msgid "Result for the financial year and results brought forward"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_141
 #: model:account.group.template,name:l10n_lu.account_group_141
 msgid "Results brought forward"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1412
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1412
+#: model:account.group,name:l10n_lu.2_account_group_1412
 #: model:account.group.template,name:l10n_lu.account_group_1412
 msgid "Results brought forward (assigned)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1411
+#: model:account.group,name:l10n_lu.2_account_group_1411
 #: model:account.group.template,name:l10n_lu.account_group_1411
 msgid "Results brought forward in the process of assignment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2237
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2237
+#: model:account.group,name:l10n_lu.2_account_group_2237
 #: model:account.group.template,name:l10n_lu.account_group_2237
 msgid "Returnable packaging"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_12
 #: model:account.group.template,name:l10n_lu.account_group_12
 msgid "Revaluation reserves"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_759
 #: model:account.group.template,name:l10n_lu.account_group_759
 msgid "Reversals of financial provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7591
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7591
+#: model:account.group,name:l10n_lu.2_account_group_7591
 #: model:account.group.template,name:l10n_lu.account_group_7591
 msgid "Reversals of financial provisions - affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7592
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7592
+#: model:account.group,name:l10n_lu.2_account_group_7592
 #: model:account.group.template,name:l10n_lu.account_group_7592
 msgid "Reversals of financial provisions - other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7492
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7492
+#: model:account.group,name:l10n_lu.2_account_group_7492
 #: model:account.group.template,name:l10n_lu.account_group_7492
 msgid "Reversals of operating provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_749
 #: model:account.group.template,name:l10n_lu.account_group_749
 msgid "Reversals of provisions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_779
 #: model:account.account.template,name:l10n_lu.lu_2020_account_779
+#: model:account.group,name:l10n_lu.2_account_group_779
 #: model:account.group.template,name:l10n_lu.account_group_779
 msgid "Reversals of provisions for deferred taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7491
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7491
+#: model:account.group,name:l10n_lu.2_account_group_7491
 #: model:account.group.template,name:l10n_lu.account_group_7491
 msgid "Reversals of provisions for taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_747
 #: model:account.group.template,name:l10n_lu.account_group_747
 msgid ""
 "Reversals of temporarily not taxable capital gains and of investment "
@@ -6215,6 +7929,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_751
 #: model:account.group.template,name:l10n_lu.account_group_751
 msgid ""
 "Reversals of value adjustments (RVA) and fair-value adjustments (FVA) on "
@@ -6222,6 +7937,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_753
 #: model:account.group.template,name:l10n_lu.account_group_753
 msgid ""
 "Reversals of value adjustments (RVA) and fair-value adjustments (FVA) on "
@@ -6229,6 +7945,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_73
 #: model:account.group.template,name:l10n_lu.account_group_73
 msgid ""
 "Reversals of value adjustments (RVA) on intangible, tangible and current "
@@ -6236,10 +7953,18 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61123
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61153
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61223
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61153
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61223
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61412
+#: model:account.group,name:l10n_lu.2_account_group_61123
+#: model:account.group,name:l10n_lu.2_account_group_61153
+#: model:account.group,name:l10n_lu.2_account_group_61223
+#: model:account.group,name:l10n_lu.2_account_group_61412
 #: model:account.group.template,name:l10n_lu.account_group_61123
 #: model:account.group.template,name:l10n_lu.account_group_61153
 #: model:account.group.template,name:l10n_lu.account_group_61223
@@ -6248,95 +7973,128 @@ msgid "Rolling stock"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_703001
 #: model:account.account.template,name:l10n_lu.lu_2020_account_703001
 msgid "Sale of Services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7063
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7063
+#: model:account.group,name:l10n_lu.2_account_group_7063
 #: model:account.group.template,name:l10n_lu.account_group_7063
 msgid "Sales of buildings for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7021
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7021
+#: model:account.group,name:l10n_lu.2_account_group_7021
 #: model:account.group.template,name:l10n_lu.account_group_7021
 msgid "Sales of finished goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_702
 #: model:account.group.template,name:l10n_lu.account_group_702
 msgid "Sales of goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7062
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7062
+#: model:account.group,name:l10n_lu.2_account_group_7062
 #: model:account.group.template,name:l10n_lu.account_group_7062
 msgid "Sales of land resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7061
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7061
+#: model:account.group,name:l10n_lu.2_account_group_7061
 #: model:account.group.template,name:l10n_lu.account_group_7061
 msgid "Sales of merchandise"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_706
 #: model:account.group.template,name:l10n_lu.account_group_706
 msgid "Sales of merchandise and other goods for resale"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_704
 #: model:account.account.template,name:l10n_lu.lu_2011_account_704
+#: model:account.group,name:l10n_lu.2_account_group_704
 #: model:account.group.template,name:l10n_lu.account_group_704
 msgid "Sales of packaging"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7023
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7023
+#: model:account.group,name:l10n_lu.2_account_group_7023
 #: model:account.group.template,name:l10n_lu.account_group_7023
 msgid "Sales of residual products"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7022
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7022
+#: model:account.group,name:l10n_lu.2_account_group_7022
 #: model:account.group.template,name:l10n_lu.account_group_7022
 msgid "Sales of semi-finished goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_703
 #: model:account.group.template,name:l10n_lu.account_group_703
 msgid "Sales of services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7039
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7039
+#: model:account.group,name:l10n_lu.2_account_group_7039
 #: model:account.group.template,name:l10n_lu.account_group_7039
 msgid "Sales of services in the course of completion"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7033
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7033
+#: model:account.group,name:l10n_lu.2_account_group_7033
 #: model:account.group.template,name:l10n_lu.account_group_7033
 msgid "Sales of services not mentioned above"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7029
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7029
+#: model:account.group,name:l10n_lu.2_account_group_7029
 #: model:account.group.template,name:l10n_lu.account_group_7029
 msgid "Sales of work in progress"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61512
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61512
+#: model:account.group,name:l10n_lu.2_account_group_61512
 #: model:account.group.template,name:l10n_lu.account_group_61512
 msgid "Samples"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75115
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65215
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75215
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75115
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65215
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75215
+#: model:account.group,name:l10n_lu.2_account_group_235
+#: model:account.group,name:l10n_lu.2_account_group_65215
+#: model:account.group,name:l10n_lu.2_account_group_75215
+#: model:account.group,name:l10n_lu.2_account_group_75225
 #: model:account.group.template,name:l10n_lu.account_group_235
 #: model:account.group.template,name:l10n_lu.account_group_65215
 #: model:account.group.template,name:l10n_lu.account_group_75215
@@ -6345,81 +8103,111 @@ msgid "Securities held as fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2352
 #: model:account.group.template,name:l10n_lu.account_group_2352
 msgid "Securities held as fixed assets (creditor's right)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2351
 #: model:account.group.template,name:l10n_lu.account_group_2351
 msgid "Securities held as fixed assets (equity right)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6113
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6113
+#: model:account.group,name:l10n_lu.2_account_group_6113
 #: model:account.group.template,name:l10n_lu.account_group_6113
 msgid "Service charges and co-ownership expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6081
 #: model:account.group.template,name:l10n_lu.account_group_6081
 msgid "Services included in the production of goods and services"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6122
 #: model:account.group.template,name:l10n_lu.account_group_6122
 msgid "Servicing, repairs and maintenance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_201
 #: model:account.account.template,name:l10n_lu.lu_2011_account_201
+#: model:account.group,name:l10n_lu.2_account_group_201
 #: model:account.group.template,name:l10n_lu.account_group_201
 msgid "Set-up and start-up costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62116
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62116
+#: model:account.group,name:l10n_lu.2_account_group_62116
 #: model:account.group.template,name:l10n_lu.account_group_62116
 msgid "Severance pay"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_657
 #: model:account.account.template,name:l10n_lu.lu_2011_account_657
+#: model:account.group,name:l10n_lu.2_account_group_657
 #: model:account.group.template,name:l10n_lu.account_group_657
 msgid ""
 "Share in the losses of undertakings accounted for under the equity method"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_757
 #: model:account.account.template,name:l10n_lu.lu_2011_account_757
+#: model:account.group,name:l10n_lu.2_account_group_757
 #: model:account.group.template,name:l10n_lu.account_group_757
 msgid ""
 "Share of profit from undertakings accounted for under the equity method"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_111
+#: model:account.group,name:l10n_lu.2_account_group_111
 #: model:account.group.template,name:l10n_lu.account_group_111
 msgid "Share premium"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_11
 #: model:account.group.template,name:l10n_lu.account_group_11
 msgid "Share premium and similar premiums"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5081
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5081
+#: model:account.group,name:l10n_lu.2_account_group_5081
 #: model:account.group.template,name:l10n_lu.account_group_5081
 msgid "Shares - listed securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5082
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5082
+#: model:account.group,name:l10n_lu.2_account_group_5082
 #: model:account.group.template,name:l10n_lu.account_group_5082
 msgid "Shares - unlisted securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_231
+#: model:account.account,name:l10n_lu.2_lu_2011_account_501
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75481
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65421
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75211
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75311
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75421
 #: model:account.account.template,name:l10n_lu.lu_2011_account_231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_501
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75111
@@ -6429,6 +8217,14 @@ msgstr ""
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75211
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75311
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75421
+#: model:account.group,name:l10n_lu.2_account_group_231
+#: model:account.group,name:l10n_lu.2_account_group_501
+#: model:account.group,name:l10n_lu.2_account_group_65211
+#: model:account.group,name:l10n_lu.2_account_group_65421
+#: model:account.group,name:l10n_lu.2_account_group_75211
+#: model:account.group,name:l10n_lu.2_account_group_75221
+#: model:account.group,name:l10n_lu.2_account_group_75421
+#: model:account.group,name:l10n_lu.2_account_group_75481
 #: model:account.group.template,name:l10n_lu.account_group_231
 #: model:account.group.template,name:l10n_lu.account_group_501
 #: model:account.group.template,name:l10n_lu.account_group_65211
@@ -6441,6 +8237,7 @@ msgid "Shares in affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65423
 #: model:account.group.template,name:l10n_lu.account_group_65423
 msgid ""
 "Shares in in undertakings with which the undertaking is linked by virtue of "
@@ -6448,11 +8245,19 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_503
+#: model:account.account,name:l10n_lu.2_lu_2011_account_75483
+#: model:account.account,name:l10n_lu.2_lu_2020_account_65423
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75313
+#: model:account.account,name:l10n_lu.2_lu_2020_account_75423
 #: model:account.account.template,name:l10n_lu.lu_2011_account_503
 #: model:account.account.template,name:l10n_lu.lu_2011_account_75483
 #: model:account.account.template,name:l10n_lu.lu_2020_account_65423
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75313
 #: model:account.account.template,name:l10n_lu.lu_2020_account_75423
+#: model:account.group,name:l10n_lu.2_account_group_503
+#: model:account.group,name:l10n_lu.2_account_group_75423
+#: model:account.group,name:l10n_lu.2_account_group_75483
 #: model:account.group.template,name:l10n_lu.account_group_503
 #: model:account.group.template,name:l10n_lu.account_group_75423
 #: model:account.group.template,name:l10n_lu.account_group_75483
@@ -6462,17 +8267,26 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_2353
 #: model:account.account.template,name:l10n_lu.lu_2020_account_2353
+#: model:account.group,name:l10n_lu.2_account_group_2353
 #: model:account.group.template,name:l10n_lu.account_group_2353
 msgid "Shares of collective investment funds"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_23511
 #: model:account.group.template,name:l10n_lu.account_group_23511
 msgid "Shares or corporate units"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_21215
+#: model:account.group,name:l10n_lu.2_account_group_21225
+#: model:account.group,name:l10n_lu.2_account_group_6415
+#: model:account.group,name:l10n_lu.2_account_group_70315
+#: model:account.group,name:l10n_lu.2_account_group_72125
+#: model:account.group,name:l10n_lu.2_account_group_7415
 #: model:account.group.template,name:l10n_lu.account_group_21215
 #: model:account.group.template,name:l10n_lu.account_group_21225
 #: model:account.group.template,name:l10n_lu.account_group_6415
@@ -6483,45 +8297,66 @@ msgid "Similar rights and assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61852
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61852
+#: model:account.group,name:l10n_lu.2_account_group_61852
 #: model:account.group.template,name:l10n_lu.account_group_61852
 msgid "Small equipment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106151
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106151
 msgid "Social Security"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42171
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4621
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42171
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4621
 msgid "Social Security office (CCSS)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_623
 #: model:account.group.template,name:l10n_lu.account_group_623
 msgid "Social security costs (employer's share)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_462
 #: model:account.group.template,name:l10n_lu.account_group_462
 msgid "Social security debts and other social securities offices"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6231
+#: model:account.group,name:l10n_lu.2_account_group_6231
 #: model:account.group.template,name:l10n_lu.account_group_6231
 msgid "Social security on pensions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21213
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21223
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6413
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72123
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7413
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70313
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21213
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21223
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6413
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7413
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70313
+#: model:account.group,name:l10n_lu.2_account_group_21213
+#: model:account.group,name:l10n_lu.2_account_group_21223
+#: model:account.group,name:l10n_lu.2_account_group_6413
+#: model:account.group,name:l10n_lu.2_account_group_70313
+#: model:account.group,name:l10n_lu.2_account_group_72123
+#: model:account.group,name:l10n_lu.2_account_group_7413
 #: model:account.group.template,name:l10n_lu.account_group_21213
 #: model:account.group.template,name:l10n_lu.account_group_21223
 #: model:account.group.template,name:l10n_lu.account_group_6413
@@ -6532,107 +8367,142 @@ msgid "Software licences"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_60311
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61841
 #: model:account.account.template,name:l10n_lu.lu_2011_account_60311
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61841
+#: model:account.group,name:l10n_lu.2_account_group_60311
+#: model:account.group,name:l10n_lu.2_account_group_61841
 #: model:account.group.template,name:l10n_lu.account_group_60311
 #: model:account.group.template,name:l10n_lu.account_group_61841
 msgid "Solid fuels"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61517
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61517
+#: model:account.group,name:l10n_lu.2_account_group_61517
 #: model:account.group.template,name:l10n_lu.account_group_61517
 msgid "Sponsorship"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_615212
 #: model:account.account.template,name:l10n_lu.lu_2011_account_615212
+#: model:account.group,name:l10n_lu.2_account_group_615212
 #: model:account.group.template,name:l10n_lu.account_group_615212
 msgid "Staff"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4211
 #: model:account.group.template,name:l10n_lu.account_group_4211
 msgid "Staff - Advances and down payments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_4221
 #: model:account.account.template,name:l10n_lu.lu_2020_account_4221
+#: model:account.group,name:l10n_lu.2_account_group_4221
 #: model:account.group.template,name:l10n_lu.account_group_4221
 msgid "Staff - advances and down payments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_62
 #: model:account.group.template,name:l10n_lu.account_group_62
 msgid "Staff expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_621
 #: model:account.group.template,name:l10n_lu.account_group_621
 msgid "Staff remuneration"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_483
 #: model:account.group.template,name:l10n_lu.account_group_483
 msgid "State - Greenhous gas and similar emission quotas received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4715
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4715
+#: model:account.group,name:l10n_lu.2_account_group_4715
 #: model:account.group.template,name:l10n_lu.account_group_4715
 msgid ""
 "State - Greenhous gas and similar emission quotas to be returned or acquired"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_483
 #: model:account.account.template,name:l10n_lu.lu_2011_account_483
 msgid "State - Greenhouse gas and similar emission quotas received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4213
+#: model:account.group,name:l10n_lu.2_account_group_4223
 #: model:account.group.template,name:l10n_lu.account_group_4213
 #: model:account.group.template,name:l10n_lu.account_group_4223
 msgid "State - Subsidies to be received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6221
+#: model:account.group,name:l10n_lu.2_account_group_6221
 #: model:account.group.template,name:l10n_lu.account_group_6221
 msgid "Students"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_612
 #: model:account.group.template,name:l10n_lu.account_group_612
 msgid "Subcontracting, servicing, repairs and maintenance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_101
 #: model:account.account.template,name:l10n_lu.lu_2011_account_101
+#: model:account.group,name:l10n_lu.2_account_group_101
 #: model:account.group.template,name:l10n_lu.account_group_101
 msgid "Subscribed capital"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_103
 #: model:account.account.template,name:l10n_lu.lu_2011_account_103
+#: model:account.group,name:l10n_lu.2_account_group_103
 #: model:account.group.template,name:l10n_lu.account_group_103
 msgid "Subscribed capital called but unpaid"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_102
 #: model:account.account.template,name:l10n_lu.lu_2011_account_102
+#: model:account.group,name:l10n_lu.2_account_group_102
 #: model:account.group.template,name:l10n_lu.account_group_102
 msgid "Subscribed capital not called"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_10
 #: model:account.group.template,name:l10n_lu.account_group_10
 msgid "Subscribed capital or branches' assigned capital and owner's account"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421622
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461422
+#: model:account.account,name:l10n_lu.2_lu_2011_account_682
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421622
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461422
 #: model:account.account.template,name:l10n_lu.lu_2011_account_682
+#: model:account.group,name:l10n_lu.2_account_group_421622
+#: model:account.group,name:l10n_lu.2_account_group_461422
+#: model:account.group,name:l10n_lu.2_account_group_682
 #: model:account.group.template,name:l10n_lu.account_group_421622
 #: model:account.group.template,name:l10n_lu.account_group_461422
 #: model:account.group.template,name:l10n_lu.account_group_682
@@ -6640,29 +8510,37 @@ msgid "Subscription tax"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_745
 #: model:account.group.template,name:l10n_lu.account_group_745
 msgid "Subsidies for operating activities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_7454
 #: model:account.account.template,name:l10n_lu.lu_2020_account_7454
+#: model:account.group,name:l10n_lu.2_account_group_7454
 #: model:account.group.template,name:l10n_lu.account_group_7454
 msgid "Subsidies in favour of employment development"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_161
 #: model:account.group.template,name:l10n_lu.account_group_161
 msgid "Subsidies on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1621
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1621
+#: model:account.group,name:l10n_lu.2_account_group_1621
 #: model:account.group.template,name:l10n_lu.account_group_1621
 msgid "Subsidies on land, fitting-outs and buildings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1623
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1623
+#: model:account.group,name:l10n_lu.2_account_group_1623
 #: model:account.group.template,name:l10n_lu.account_group_1623
 msgid ""
 "Subsidies on other fixtures, fittings, tools and equipment (including "
@@ -6670,57 +8548,77 @@ msgid ""
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_1622
 #: model:account.account.template,name:l10n_lu.lu_2020_account_1622
+#: model:account.group,name:l10n_lu.2_account_group_1622
 #: model:account.group.template,name:l10n_lu.account_group_1622
 msgid "Subsidies on plant and machinery"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_162
 #: model:account.group.template,name:l10n_lu.account_group_162
 msgid "Subsidies on tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_621121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_621121
+#: model:account.group,name:l10n_lu.2_account_group_621121
 #: model:account.group.template,name:l10n_lu.account_group_621121
 msgid "Sunday"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_44111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_44121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_44111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_44121
+#: model:account.group,name:l10n_lu.2_account_group_44111
+#: model:account.group,name:l10n_lu.2_account_group_44121
 #: model:account.group.template,name:l10n_lu.account_group_44111
 #: model:account.group.template,name:l10n_lu.account_group_44121
 msgid "Suppliers"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_44112
 #: model:account.account.template,name:l10n_lu.lu_2011_account_44112
+#: model:account.group,name:l10n_lu.2_account_group_44112
 #: model:account.group.template,name:l10n_lu.account_group_44112
 msgid "Suppliers - invoices not yet received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_44113
+#: model:account.account,name:l10n_lu.2_lu_2020_account_44123
 #: model:account.account.template,name:l10n_lu.lu_2020_account_44113
 #: model:account.account.template,name:l10n_lu.lu_2020_account_44123
+#: model:account.group,name:l10n_lu.2_account_group_44113
+#: model:account.group,name:l10n_lu.2_account_group_44123
 #: model:account.group.template,name:l10n_lu.account_group_44113
 #: model:account.group.template,name:l10n_lu.account_group_44123
 msgid "Suppliers with a debit balance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6185
 #: model:account.group.template,name:l10n_lu.account_group_6185
 msgid "Supplies and small equipment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6186
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6186
+#: model:account.group,name:l10n_lu.2_account_group_6186
 #: model:account.group.template,name:l10n_lu.account_group_6186
 msgid "Surveillance and security charges"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_62117
 #: model:account.account.template,name:l10n_lu.lu_2011_account_62117
+#: model:account.group,name:l10n_lu.2_account_group_62117
 #: model:account.group.template,name:l10n_lu.account_group_62117
 msgid "Survivor's pay"
 msgstr ""
@@ -6741,6 +8639,11 @@ msgid "TVA 12%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_13
+msgid "TVA 13%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.tax.group,name:l10n_lu.tax_group_14
 msgid "TVA 14%"
 msgstr ""
@@ -6748,6 +8651,11 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.tax.group,name:l10n_lu.tax_group_15
 msgid "TVA 15%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_16
+msgid "TVA 16%"
 msgstr ""
 
 #. module: l10n_lu
@@ -6766,135 +8674,190 @@ msgid "TVA 6%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_7
+msgid "TVA 7%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.tax.group,name:l10n_lu.tax_group_8
 msgid "TVA 8%"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60811
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60811
+#: model:account.group,name:l10n_lu.2_account_group_60811
 #: model:account.group.template,name:l10n_lu.account_group_60811
 msgid "Tailoring"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_22
+#: model:account.group,name:l10n_lu.2_account_group_722
 #: model:account.group.template,name:l10n_lu.account_group_22
 #: model:account.group.template,name:l10n_lu.account_group_722
 msgid "Tangible fixed assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.report,name:l10n_lu.tax_report
+msgid "Tax Report"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_46
 #: model:account.group.template,name:l10n_lu.account_group_46
 msgid "Tax and social security debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_461
 #: model:account.group.template,name:l10n_lu.account_group_461
 msgid "Tax debts"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6733
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6733
+#: model:account.group,name:l10n_lu.2_account_group_6733
 #: model:account.group.template,name:l10n_lu.account_group_6733
 msgid "Taxes levied on non-resident undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6732
 #: model:account.group.template,name:l10n_lu.account_group_6732
 msgid "Taxes levied on permanent establishments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_646
 #: model:account.group.template,name:l10n_lu.account_group_646
 msgid "Taxes, duties and similar expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_61532
 #: model:account.account.template,name:l10n_lu.lu_2011_account_61532
+#: model:account.group,name:l10n_lu.2_account_group_61532
 #: model:account.group.template,name:l10n_lu.account_group_61532
 msgid "Telecommunication costs"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106165
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106165
 msgid "Telephone"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_13823
 #: model:account.group.template,name:l10n_lu.account_group_13823
 msgid "Temporarily not taxable capital gains"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7471
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7471
+#: model:account.group,name:l10n_lu.2_account_group_7471
 #: model:account.group.template,name:l10n_lu.account_group_7471
 msgid "Temporarily not taxable capital gains not reinvested"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7472
+#: model:account.account,name:l10n_lu.2_lu_2020_account_138232
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7472
 #: model:account.account.template,name:l10n_lu.lu_2020_account_138232
+#: model:account.group,name:l10n_lu.2_account_group_138232
+#: model:account.group,name:l10n_lu.2_account_group_7472
 #: model:account.group.template,name:l10n_lu.account_group_138232
 #: model:account.group.template,name:l10n_lu.account_group_7472
 msgid "Temporarily not taxable capital gains reinvested"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_138231
 #: model:account.account.template,name:l10n_lu.lu_2020_account_138231
+#: model:account.group,name:l10n_lu.2_account_group_138231
 #: model:account.group.template,name:l10n_lu.account_group_138231
 msgid "Temporarily not taxable capital gains to reinvest"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_123
 #: model:account.account.template,name:l10n_lu.lu_2011_account_123
+#: model:account.group,name:l10n_lu.2_account_group_123
 #: model:account.group.template,name:l10n_lu.account_group_123
 msgid "Temporarily not taxable currency translation adjustments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6171
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6171
+#: model:account.group,name:l10n_lu.2_account_group_6171
 #: model:account.group.template,name:l10n_lu.account_group_6171
 msgid "Temporary staff"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106144
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6146
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106144
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6146
+#: model:account.group,name:l10n_lu.2_account_group_6146
 #: model:account.group.template,name:l10n_lu.account_group_6146
 msgid "Third-party insurance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2233
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2233
+#: model:account.group,name:l10n_lu.2_account_group_2233
 #: model:account.group.template,name:l10n_lu.account_group_2233
 msgid "Tools"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_441
 #: model:account.group.template,name:l10n_lu.account_group_441
 msgid "Trade payables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4412
 #: model:account.group.template,name:l10n_lu.account_group_4412
 msgid "Trade payables after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_44
 #: model:account.group.template,name:l10n_lu.account_group_44
 msgid "Trade payables and bills of exchange"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_4411
 #: model:account.group.template,name:l10n_lu.account_group_4411
 msgid "Trade payables within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41111
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41121
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41211
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41221
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6451
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41111
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41121
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41211
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41221
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6451
+#: model:account.group,name:l10n_lu.2_account_group_41111
+#: model:account.group,name:l10n_lu.2_account_group_41121
+#: model:account.group,name:l10n_lu.2_account_group_41211
+#: model:account.group,name:l10n_lu.2_account_group_41221
+#: model:account.group,name:l10n_lu.2_account_group_6451
 #: model:account.group.template,name:l10n_lu.account_group_41111
 #: model:account.group.template,name:l10n_lu.account_group_41121
 #: model:account.group.template,name:l10n_lu.account_group_41211
@@ -6904,32 +8867,47 @@ msgid "Trade receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_40
 #: model:account.group.template,name:l10n_lu.account_group_40
 msgid "Trade receivables (Receivables from sales and rendering of services)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_402
 #: model:account.group.template,name:l10n_lu.account_group_402
 msgid "Trade receivables due and payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_401
 #: model:account.group.template,name:l10n_lu.account_group_401
 msgid "Trade receivables due and payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6414
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6414
+#: model:account.group,name:l10n_lu.2_account_group_6414
 #: model:account.group.template,name:l10n_lu.account_group_6414
 msgid "Trademarks and franchise"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21214
+#: model:account.account,name:l10n_lu.2_lu_2011_account_21224
+#: model:account.account,name:l10n_lu.2_lu_2011_account_72124
+#: model:account.account,name:l10n_lu.2_lu_2011_account_7414
+#: model:account.account,name:l10n_lu.2_lu_2020_account_70314
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21214
 #: model:account.account.template,name:l10n_lu.lu_2011_account_21224
 #: model:account.account.template,name:l10n_lu.lu_2011_account_72124
 #: model:account.account.template,name:l10n_lu.lu_2011_account_7414
 #: model:account.account.template,name:l10n_lu.lu_2020_account_70314
+#: model:account.group,name:l10n_lu.2_account_group_21214
+#: model:account.group,name:l10n_lu.2_account_group_21224
+#: model:account.group,name:l10n_lu.2_account_group_70314
+#: model:account.group,name:l10n_lu.2_account_group_72124
+#: model:account.group,name:l10n_lu.2_account_group_7414
 #: model:account.group.template,name:l10n_lu.account_group_21214
 #: model:account.group.template,name:l10n_lu.account_group_21224
 #: model:account.group.template,name:l10n_lu.account_group_70314
@@ -6939,133 +8917,181 @@ msgid "Trademarks and franchises"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_50
 #: model:account.group.template,name:l10n_lu.account_group_50
 msgid "Transferable securities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_484
 #: model:account.account.template,name:l10n_lu.lu_2011_account_484
+#: model:account.group,name:l10n_lu.2_account_group_484
 #: model:account.group.template,name:l10n_lu.account_group_484
 msgid "Transitory or suspense accounts - Assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_485
 #: model:account.account.template,name:l10n_lu.lu_2011_account_485
+#: model:account.group,name:l10n_lu.2_account_group_485
 #: model:account.group.template,name:l10n_lu.account_group_485
 msgid "Transitory or suspense accounts - Liabilities"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_6143
 #: model:account.account.template,name:l10n_lu.lu_2020_account_6143
+#: model:account.group,name:l10n_lu.2_account_group_6143
 #: model:account.group.template,name:l10n_lu.account_group_6143
 msgid "Transport insurance"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_2231
 #: model:account.account.template,name:l10n_lu.lu_2011_account_2231
+#: model:account.group,name:l10n_lu.2_account_group_2231
 #: model:account.group.template,name:l10n_lu.account_group_2231
 msgid "Transportation and handling equipment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_616
 #: model:account.group.template,name:l10n_lu.account_group_616
 msgid "Transportation of goods and collective staff transportation"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6161
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6161
+#: model:account.group,name:l10n_lu.2_account_group_6161
 #: model:account.group.template,name:l10n_lu.account_group_6161
 msgid "Transportation of purchased goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6162
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6162
+#: model:account.group,name:l10n_lu.2_account_group_6162
 #: model:account.group.template,name:l10n_lu.account_group_6162
 msgid "Transportation of sold goods"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_6152
 #: model:account.group.template,name:l10n_lu.account_group_6152
 msgid "Travel and entertainment expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_61521
 #: model:account.group.template,name:l10n_lu.account_group_61521
 msgid "Travel expenses"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6099
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6099
+#: model:account.group,name:l10n_lu.2_account_group_6099
 #: model:account.group.template,name:l10n_lu.account_group_6099
 msgid "Unallocated RDR"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_5085
 #: model:account.account.template,name:l10n_lu.lu_2011_account_5085
+#: model:account.group,name:l10n_lu.2_account_group_5085
 #: model:account.group.template,name:l10n_lu.account_group_5085
 msgid "Unlisted debenture loans"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_235112
 #: model:account.account.template,name:l10n_lu.lu_2020_account_235112
+#: model:account.group,name:l10n_lu.2_account_group_235112
 #: model:account.group.template,name:l10n_lu.account_group_235112
 msgid "Unlisted shares"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_60
 #: model:account.group.template,name:l10n_lu.account_group_60
 msgid "Use of merchandise, raw and consumable materials"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461418
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461418
+#: model:account.group,name:l10n_lu.2_account_group_461418
 #: model:account.group.template,name:l10n_lu.account_group_461418
 msgid "VAT - Other payables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421618
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421618
+#: model:account.group,name:l10n_lu.2_account_group_421618
 #: model:account.group.template,name:l10n_lu.account_group_421618
 msgid "VAT - Other receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421613
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421613
+#: model:account.group,name:l10n_lu.2_account_group_421613
 #: model:account.group.template,name:l10n_lu.account_group_421613
 msgid "VAT down payments made"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461413
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461413
+#: model:account.group,name:l10n_lu.2_account_group_461413
 #: model:account.group.template,name:l10n_lu.account_group_461413
 msgid "VAT down payments received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_421611
 #: model:account.account.template,name:l10n_lu.lu_2020_account_421611
+#: model:account.group,name:l10n_lu.2_account_group_421611
 #: model:account.group.template,name:l10n_lu.account_group_421611
 msgid "VAT paid and recoverable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_461412
 #: model:account.account.template,name:l10n_lu.lu_2011_account_461412
+#: model:account.group,name:l10n_lu.2_account_group_461412
 #: model:account.group.template,name:l10n_lu.account_group_461412
 msgid "VAT payable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_421612
 #: model:account.account.template,name:l10n_lu.lu_2011_account_421612
+#: model:account.group,name:l10n_lu.2_account_group_421612
 #: model:account.group.template,name:l10n_lu.account_group_421612
 msgid "VAT receivable"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_461411
 #: model:account.account.template,name:l10n_lu.lu_2020_account_461411
+#: model:account.group,name:l10n_lu.2_account_group_461411
 #: model:account.group.template,name:l10n_lu.account_group_461411
 msgid "VAT received"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4019
+#: model:account.account,name:l10n_lu.2_lu_2011_account_4029
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41119
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41129
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41219
+#: model:account.account,name:l10n_lu.2_lu_2011_account_41229
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42119
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42189
+#: model:account.account,name:l10n_lu.2_lu_2011_account_42289
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4019
 #: model:account.account.template,name:l10n_lu.lu_2011_account_4029
 #: model:account.account.template,name:l10n_lu.lu_2011_account_41119
@@ -7075,6 +9101,15 @@ msgstr ""
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42119
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42189
 #: model:account.account.template,name:l10n_lu.lu_2011_account_42289
+#: model:account.group,name:l10n_lu.2_account_group_4019
+#: model:account.group,name:l10n_lu.2_account_group_4029
+#: model:account.group,name:l10n_lu.2_account_group_41119
+#: model:account.group,name:l10n_lu.2_account_group_41129
+#: model:account.group,name:l10n_lu.2_account_group_41219
+#: model:account.group,name:l10n_lu.2_account_group_41229
+#: model:account.group,name:l10n_lu.2_account_group_42119
+#: model:account.group,name:l10n_lu.2_account_group_42189
+#: model:account.group,name:l10n_lu.2_account_group_42289
 #: model:account.group.template,name:l10n_lu.account_group_4019
 #: model:account.group.template,name:l10n_lu.account_group_4029
 #: model:account.group.template,name:l10n_lu.account_group_41119
@@ -7088,110 +9123,149 @@ msgid "Value adjustments"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_42161
+#: model:account.group,name:l10n_lu.2_account_group_46141
 #: model:account.group.template,name:l10n_lu.account_group_42161
 #: model:account.group.template,name:l10n_lu.account_group_46141
 msgid "Value-added tax (VAT)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_62112
 #: model:account.group.template,name:l10n_lu.account_group_62112
 msgid "Wage supplements"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106161
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106161
 msgid "Wages"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_106164
 #: model:account.account.template,name:l10n_lu.lu_2011_account_106164
 msgid "Water"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_60314
 #: model:account.account.template,name:l10n_lu.lu_2020_account_60314
+#: model:account.group,name:l10n_lu.2_account_group_60314
 #: model:account.group.template,name:l10n_lu.account_group_60314
 msgid "Water and sewage"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61844
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61844
+#: model:account.group,name:l10n_lu.2_account_group_61844
 #: model:account.group.template,name:l10n_lu.account_group_61844
 msgid "Water and waste water"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_10612
 #: model:account.account.template,name:l10n_lu.lu_2011_account_10612
 msgid "Withdrawals of merchandise, finished products and services (at cost)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2020_account_62413
 #: model:account.account.template,name:l10n_lu.lu_2020_account_62413
+#: model:account.group,name:l10n_lu.2_account_group_62413
 #: model:account.group.template,name:l10n_lu.account_group_62413
 msgid "Withholding tax on complementary pensions"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46126
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42146
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46126
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42146
+#: model:account.group,name:l10n_lu.2_account_group_42146
+#: model:account.group,name:l10n_lu.2_account_group_46126
 #: model:account.group.template,name:l10n_lu.account_group_42146
 #: model:account.group.template,name:l10n_lu.account_group_46126
 msgid "Withholding tax on director's fees"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46125
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42145
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46125
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42145
+#: model:account.group,name:l10n_lu.2_account_group_42145
+#: model:account.group,name:l10n_lu.2_account_group_46125
 #: model:account.group.template,name:l10n_lu.account_group_42145
 #: model:account.group.template,name:l10n_lu.account_group_46125
 msgid "Withholding tax on financial investment income"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_46124
+#: model:account.account,name:l10n_lu.2_lu_2020_account_42144
 #: model:account.account.template,name:l10n_lu.lu_2011_account_46124
 #: model:account.account.template,name:l10n_lu.lu_2020_account_42144
+#: model:account.group,name:l10n_lu.2_account_group_42144
+#: model:account.group,name:l10n_lu.2_account_group_46124
 #: model:account.group.template,name:l10n_lu.account_group_42144
 #: model:account.group.template,name:l10n_lu.account_group_46124
 msgid "Withholding tax on wages and salaries"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6731
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6731
+#: model:account.group,name:l10n_lu.2_account_group_6731
 #: model:account.group.template,name:l10n_lu.account_group_6731
 msgid "Withholding taxes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6034
+#: model:account.account,name:l10n_lu.2_lu_2020_account_61853
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6034
 #: model:account.account.template,name:l10n_lu.lu_2020_account_61853
+#: model:account.group,name:l10n_lu.2_account_group_6034
+#: model:account.group,name:l10n_lu.2_account_group_61853
 #: model:account.group.template,name:l10n_lu.account_group_6034
 #: model:account.group.template,name:l10n_lu.account_group_61853
 msgid "Work clothes"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.account,name:l10n_lu.2_lu_2011_account_6033
 #: model:account.account.template,name:l10n_lu.lu_2011_account_6033
+#: model:account.group,name:l10n_lu.2_account_group_6033
 #: model:account.group.template,name:l10n_lu.account_group_6033
 msgid "Workshop, factory and store supplies and small equipment"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_16121
 #: model:account.group.template,name:l10n_lu.account_group_16121
 msgid "acquired against payment (except Goodwill)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_2121
 #: model:account.group.template,name:l10n_lu.account_group_2121
 msgid "acquired for consideration (except Goodwill)"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_16122
+#: model:account.group,name:l10n_lu.2_account_group_2122
 #: model:account.group.template,name:l10n_lu.account_group_16122
 #: model:account.group.template,name:l10n_lu.account_group_2122
 msgid "created by the undertaking itself"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1922
+#: model:account.group,name:l10n_lu.2_account_group_1932
+#: model:account.group,name:l10n_lu.2_account_group_1942
 #: model:account.group.template,name:l10n_lu.account_group_1922
 #: model:account.group.template,name:l10n_lu.account_group_1932
 #: model:account.group.template,name:l10n_lu.account_group_1942
@@ -7199,6 +9273,9 @@ msgid "due and payable after more than one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_1921
+#: model:account.group,name:l10n_lu.2_account_group_1931
+#: model:account.group,name:l10n_lu.2_account_group_1941
 #: model:account.group.template,name:l10n_lu.account_group_1921
 #: model:account.group.template,name:l10n_lu.account_group_1931
 #: model:account.group.template,name:l10n_lu.account_group_1941
@@ -7206,31 +9283,37 @@ msgid "due and payable within one year"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_755231
 #: model:account.group.template,name:l10n_lu.account_group_755231
 msgid "from affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_755232
 #: model:account.group.template,name:l10n_lu.account_group_755232
 msgid "from other"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_65413
 #: model:account.group.template,name:l10n_lu.account_group_65413
 msgid "from other receivables from current assets"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75411
 #: model:account.group.template,name:l10n_lu.account_group_75411
 msgid "on affiliated undertakings"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75413
 #: model:account.group.template,name:l10n_lu.account_group_75413
 msgid "on other current receivables"
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.group,name:l10n_lu.2_account_group_75412
 #: model:account.group.template,name:l10n_lu.account_group_75412
 msgid ""
 "on undertakings with which the undertaking is linked by virtue of "


### PR DESCRIPTION
Description of the issue this commit addresses:

In january 2025, updates were made to some sections of the LU tax report and chart of accounts. Therefore, the version we use is out of date.

---

Desired behavior after this commit is merged:

The COA and VAT reports use the new values updated in 2025.

---

Enterprise PR: https://github.com/odoo/enterprise/pull/81644
task-4587067

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
