### PR TITLE
[IMP] project: allow subscription to sub-tasks

### DIFF
--- a/addons/project/data/mail_message_subtype_data.xml
+++ b/addons/project/data/mail_message_subtype_data.xml
@@ -8,6 +8,21 @@
         <field name="hidden" eval="True"/>
         <field name="description">Task Created</field>
     </record>
+    <record id="mt_subtask_new" model="mail.message.subtype">
+        <field name="name">Subtask Created</field>
+        <field name="res_model">project.task</field>
+        <field name="internal" eval="True"/>
+        <field name="hidden" eval="True"/>
+        <field name="default" eval="True"/>
+        <field name="description">Sub-task has been created</field>
+    </record>
+    <record id="mt_task_subtasks" model="mail.message.subtype">
+        <field name="name">Sub-tasks</field>
+        <field name="res_model">project.task</field>
+        <field name="internal" eval="True"/>
+        <field name="parent_id" ref="mt_subtask_new"/>
+        <field name="relation_field">parent_id</field>
+    </record>
     <record id="mt_task_stage" model="mail.message.subtype">
         <field name="name">Stage Changed</field>
         <field name="res_model">project.task</field>

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1563,7 +1563,10 @@ class ProjectTask(models.Model):
         return res
 
     def _creation_subtype(self):
-        return self.env.ref('project.mt_task_new')
+        if self.parent_id:
+            return self.env.ref('project.mt_subtask_new')
+        else:
+            return self.env.ref('project.mt_task_new')
 
     def _creation_message(self):
         self.ensure_one()


### PR DESCRIPTION
When we are dealing with quite big projects, people don't necessarily need to follow the entire project, but need to follow the subtasks of the tasks they are followers.

So we now allow to be automatically follower of the subtasks of a task.

TASK-ID: 4334954

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
