### PR TITLE
[IMP] stock_account: Hide EDI cancel when there is a stock valuation

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -16,6 +16,12 @@ class AccountMove(models.Model):
             if move.sudo().line_ids.stock_valuation_layer_ids:
                 move.show_reset_to_draft_button = False
 
+    def _compute_edi_show_cancel_button(self):
+        super()._compute_edi_show_cancel_button()
+        for move in self:
+            if move.sudo().line_ids.stock_valuation_layer_ids:
+                move.edi_show_cancel_button = False
+
     # -------------------------------------------------------------------------
     # OVERRIDE METHODS
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Steps
---------
1. Install accounting, Inventory and Purchase
2. Set up the product
    a. Create a product Category TEST_CATEGORY
    b. Set the Costing Method to 'AVCO'
    c. Create a product TEST_PRODUCT having TEST_CATEGORY as product category
3. create a server action named TEST_CANCEL on 'journal entry' that execute
```
records.button_draft()
records.button_cancel()
```
(It simulates an EDI cancel like the one in Spanish SII)
4. Create a PO with 10 product TEST_PRODUCT of cost 70
5. Validate the Reception order
```
   -> TEST_PRODUCT cost is 70
```
6. Create the Bill from the PO but update the cost of TEST_PRODUCT to 80 and post the bill
```   
   -> TEST_PRODUCT cost is now 80
```
7. Go to the Accounting Bills list view
8. Tick the bill created in step 6 and, in action, click TEST_CANCEL
9. From the PO created in step 4, create a new bill but update the cost of TEST_PRODUCT to 85 and post the bill
```
   -> TEST_PRODUCT cost is now 95 ???
```

Problem
---------
The problem with valuation layer adjustments runs very deep and goes back years. Fixing it is a difficult task that requires a good grasp of the valuation layers. The solution issued in the meantime consited in removing the 'Draft' and 'Cancel' buttons from the UI when a move created a stock valuation. This issue is fully explained in task-4332146.

However, this practice has not been applied to EDI cancellation.

Objective
---------
Hide the EDI cancel button when there is a stock valuation.

Solution
---------
Extend the compute method to do just that, as it has been done for the classic 'Cancel' button.

opw-4504909

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
