### PR TITLE
[REF] html_editor, *: rename disableXYZ options

### DIFF
--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -119,6 +119,7 @@ export class Editor {
 
     preparePlugins() {
         const Plugins = sortPlugins(this.config.Plugins || MAIN_PLUGINS);
+        this.config = Object.assign({}, ...Plugins.map((P) => P.defaultConfig), this.config);
         const plugins = new Map();
         for (const P of Plugins) {
             if (P.id === "") {

--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -263,10 +263,10 @@ export class HtmlField extends Component {
 
         const { sanitize_tags, sanitize } = this.props.record.fields[this.props.name];
         if (
-            !("disableVideo" in config) &&
+            !("allowMediaDialogVideo" in config) &&
             (sanitize_tags || (sanitize_tags === undefined && sanitize))
         ) {
-            config.disableVideo = true; // Tag-sanitized fields remove videos.
+            config.allowMediaDialogVideo = false; // Tag-sanitized fields remove videos.
         }
         if (this.props.codeview) {
             config.resources = {
@@ -325,14 +325,18 @@ export const htmlField = {
         if (options.height) {
             editorConfig.height = `${options.height}px`;
         }
-        if ("disableImage" in options) {
-            editorConfig.disableImage = Boolean(options.disableImage);
+        if ("allowImage" in options) {
+            editorConfig.allowImage = Boolean(options.allowImage);
         }
-        if ("disableVideo" in options) {
-            editorConfig.disableVideo = Boolean(options.disableVideo);
+        if ("allowMediaDialogVideo" in options) {
+            editorConfig.allowMediaDialogVideo = Boolean(options.allowMediaDialogVideo);
         }
-        if ("disableFile" in options) {
-            editorConfig.disableFile = Boolean(options.disableFile);
+        if ("allowFile" in options) {
+            editorConfig.allowFile = Boolean(options.allowFile);
+        }
+        if ("allowAttachmentCreation" in options) {
+            editorConfig.allowImage = Boolean(options.allowAttachmentCreation);
+            editorConfig.allowFile = Boolean(options.allowAttachmentCreation);
         }
         if ("baseContainer" in options) {
             editorConfig.baseContainer = options.baseContainer;

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -471,7 +471,7 @@ export class LinkPlugin extends Plugin {
             recordInfo: this.config.getRecordInfo?.() || {},
             canEdit:
                 !this.linkInDocument || !this.linkInDocument.classList.contains("o_link_readonly"),
-            canUpload: !this.config.disableFile,
+            canUpload: this.config.allowFile,
             onUpload: this.config.onAttachmentChange,
             type: this.type || "",
         };

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -9,6 +9,9 @@ import { _t } from "@web/core/l10n/translation";
 export class FilePlugin extends Plugin {
     static id = "file";
     static dependencies = ["dom", "history"];
+    static defaultConfig = {
+        allowFile: true,
+    };
     resources = {
         user_commands: {
             id: "uploadFile",
@@ -28,7 +31,7 @@ export class FilePlugin extends Plugin {
             description: _t("Upload a file"),
         }),
         unsplittable_node_predicates: (node) => node.classList?.contains("o_file_box"),
-        ...(!this.config.disableFile && {
+        ...(this.config.allowFile && {
             media_dialog_extra_tabs: {
                 id: "DOCUMENTS",
                 title: _t("Documents"),
@@ -44,7 +47,7 @@ export class FilePlugin extends Plugin {
     }
 
     isUploadCommandAvailable() {
-        return !this.config.disableFile;
+        return this.config.allowFile;
     }
 
     get componentForMediaDialog() {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -23,6 +23,10 @@ export class MediaPlugin extends Plugin {
     static id = "media";
     static dependencies = ["selection", "history", "dom", "dialog"];
     static shared = ["savePendingImages"];
+    static defaultConfig = {
+        allowImage: true,
+        allowMediaDialogVideo: true,
+    };
     resources = {
         user_commands: [
             {
@@ -50,9 +54,7 @@ export class MediaPlugin extends Plugin {
         ],
         powerbox_categories: withSequence(40, { id: "media", name: _t("Media") }),
         powerbox_items: [
-            ...(this.config.disableImage
-                ? []
-                : [{ categoryId: "media", commandId: "insertMedia" }]),
+            ...(this.config.allowImage ? [{ categoryId: "media", commandId: "insertMedia" }] : []),
         ],
         power_buttons: withSequence(1, { commandId: "insertMedia" }),
 
@@ -155,8 +157,8 @@ export class MediaPlugin extends Plugin {
                 this.onSaveMediaDialog(element, { node: params.node });
             },
             onAttachmentChange: this.config.onAttachmentChange || (() => {}),
-            noVideos: !!this.config.disableVideo,
-            noImages: !!this.config.disableImage,
+            noVideos: !this.config.allowMediaDialogVideo,
+            noImages: !this.config.allowImage,
             extraTabs: this.getResource("media_dialog_extra_tabs"),
             ...this.config.mediaModalParams,
             ...params,

--- a/addons/html_editor/static/src/main/youtube_plugin.js
+++ b/addons/html_editor/static/src/main/youtube_plugin.js
@@ -19,7 +19,7 @@ export class YoutubePlugin extends Plugin {
     handlePasteUrl(text, url) {
         // to know if this logic should be executed or not. Do we still want an
         // option of do we want to add a plugin whenever we want the feature?
-        const youtubeUrl = !this.config.disableVideo && YOUTUBE_URL_GET_VIDEO_ID.exec(url);
+        const youtubeUrl = this.config.allowMediaDialogVideo && YOUTUBE_URL_GET_VIDEO_ID.exec(url);
         if (youtubeUrl) {
             const restoreSavepoint = this.dependencies.history.makeSavePoint();
             // Open powerbox with commands to embed media or paste as link.

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -9,6 +9,7 @@ export class Plugin {
     static id = "";
     static dependencies = [];
     static shared = [];
+    static defaultConfig = {};
 
     /**
      * @param {Editor['document']} document

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1021,14 +1021,14 @@ test("MediaDialog contains 'Videos' tab by default in html field", async () => {
     ]);
 });
 
-test("MediaDialog does not contain 'Videos' tab in html field when 'disableVideo' = true", async () => {
+test("MediaDialog does not contain 'Videos' tab in html field when 'allowMediaDialogVideo' = false", async () => {
     await mountView({
         type: "form",
         resId: 1,
         resModel: "partner",
         arch: `
             <form>
-            <field name="txt" widget="html" options="{'disableVideo': True}"/>
+            <field name="txt" widget="html" options="{'allowMediaDialogVideo': False}"/>
             </form>`,
     });
 
@@ -1078,7 +1078,7 @@ test("MediaDialog does not contain 'Videos' tab when sanitize = true", async () 
     ]);
 });
 
-test("MediaDialog contains 'Videos' tab when sanitize_tags = true and 'disableVideo' = false", async () => {
+test("MediaDialog contains 'Videos' tab when sanitize_tags = true and 'allowMediaDialogVideo' = true", async () => {
     class SanitizePartner extends models.Model {
         _name = "sanitize.partner";
 
@@ -1093,7 +1093,7 @@ test("MediaDialog contains 'Videos' tab when sanitize_tags = true and 'disableVi
         resModel: "sanitize.partner",
         arch: `
             <form>
-                <field name="txt" widget="html" options="{'disableVideo': False}"/>
+                <field name="txt" widget="html" options="{'allowMediaDialogVideo': True}"/>
             </form>`,
     });
     setSelectionInHtmlField();
@@ -1127,20 +1127,36 @@ test("'Media' command is available by default", async () => {
     expect(queryAllTexts(".o-we-command-name")[0]).toBe("Media");
 });
 
-test("'Media' command is not available when 'disableImage' = true", async () => {
+test("'Media' command is not available when 'allowImage' = false", async () => {
     await mountView({
         type: "form",
         resId: 1,
         resModel: "partner",
         arch: `
             <form>
-                <field name="txt" widget="html" options="{'disableImage': True}"/>
+                <field name="txt" widget="html" options="{'allowImage': False}"/>
             </form>`,
     });
     setSelectionInHtmlField();
     await insertText(htmlEditor, "/media");
     await animationFrame();
     expect(queryAllTexts(".o-we-command-name")).not.toInclude("Media");
+});
+
+test("'Upload a file' command is not available when 'allowFile' = false", async () => {
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html" options="{'allowFile': False}"/>
+            </form>`,
+    });
+    setSelectionInHtmlField();
+    await insertText(htmlEditor, "/file");
+    await animationFrame();
+    expect(queryAllTexts(".o-we-command-name")).not.toInclude("Upload a file");
 });
 
 test("codeview is not available by default", async () => {

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -196,7 +196,7 @@
                     <notebook>
                         <page name="description_page" string="Description">
                             <field name="description" type="html" placeholder="Add details about this task..."
-                                options="{'collaborative': true, 'disableImage': true, 'disableVideo': true, 'disableFile': true}"/>
+                                options="{'collaborative': true, 'allowAttachmentCreation': false, 'allowMediaDialogVideo': false}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks">
                             <field name="child_ids" context="{

--- a/addons/website_event_exhibitor/views/event_sponsor_views.xml
+++ b/addons/website_event_exhibitor/views/event_sponsor_views.xml
@@ -120,7 +120,7 @@
                         <page string="Description"
                             name="page_description"
                             invisible="exhibitor_type == 'sponsor'">
-                            <field name="website_description" nolabel="1" options="{'disableVideo': False}"
+                            <field name="website_description" nolabel="1" options="{'allowMediaDialogVideo': True}"
                                 placeholder='e.g. "Openwood specializes in home decoration..."'/>
                         </page>
                     </notebook>


### PR DESCRIPTION
*: project, website_event_exhibitor

Purpose of this PR:

This PR refactors the configuration options related to media and attachments by:
- Renaming disableImage, disableVideo and disableFile to allowImage, allowMediaDialogVideo, and allowFile respectively.
- Adding a new configuration option allowAttachmentCreation, which leads to allowImage and allowFile.
- Introduce a new mechanism for setting default config through the defaultConfig resource.

enterprise: https://github.com/odoo/enterprise/pull/81646

task-4264480

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
