### PR TITLE
[FIX] point_of_sale: Pre-fetch session states to prevent MemoryError

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -212,6 +212,7 @@ class PosConfig(models.Model):
     def _compute_current_session(self):
         """If there is an open session, store it to current_session_id / current_session_State.
         """
+        self.session_ids.fetch(["state"])
         for pos_config in self:
             opened_sessions = pos_config.session_ids.filtered(lambda s: s.state != 'closed')
             rescue_sessions = opened_sessions.filtered('rescue')


### PR DESCRIPTION
_compute_current_session tried to filter `session_ids` to retrieve session
 states,  but in databases with a large number of sessions, this caused
 excessive memory usage and a potential `MemoryError`.

```
select count(*) from pos_session
+---------+
| count   |
|---------|
| 3582911 |
+---------+x`
```

opw-4544050
upg-2459515


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
