### PR TITLE
[IMP] certificate: Add certificate docstring and some robustness

### DIFF
--- a/addons/certificate/i18n/certificate.pot
+++ b/addons/certificate/i18n/certificate.pot
@@ -344,7 +344,19 @@ msgstr ""
 #. module: certificate
 #. odoo-python
 #: code:addons/certificate/models/key.py:0
+msgid "The key size should be at least 512 bytes."
+msgstr ""
+
+#. module: certificate
+#. odoo-python
+#: code:addons/certificate/models/key.py:0
 msgid "The private key could not be loaded."
+msgstr ""
+
+#. module: certificate
+#. odoo-python
+#: code:addons/certificate/models/key.py:0
+msgid "The public exponent should be 65537 (or 3 for legacy purposes)."
 msgstr ""
 
 #. module: certificate

--- a/addons/certificate/models/certificate.py
+++ b/addons/certificate/models/certificate.py
@@ -269,11 +269,30 @@ class Certificate(models.Model):
     # -------------------------------------------------------
 
     def _get_der_certificate_bytes(self, formatting='encodebytes'):
+        ''' Get the DER bytes of the certificate.
+
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: The formatted DER bytes of the certificate
+        :rtype: bytes
+        '''
         self.ensure_one()
         cert = x509.load_pem_x509_certificate(base64.b64decode(self.with_context(bin_size=False).pem_certificate))
         return _get_formatted_value(cert.public_bytes(serialization.Encoding.DER), formatting=formatting)
 
     def _get_fingerprint_bytes(self, hashing_algorithm='sha256', formatting='encodebytes'):
+        ''' Get the fingerprint bytes of the certificate.
+
+        :param optional,default='sha256' hashing_algorithm: The digest algorithm to use. Currently, only 'sha1' and 'sha256' are available.
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: The formatted fingerprint bytes of the certificate
+        :rtype: bytes
+        '''
         self.ensure_one()
         cert = x509.load_pem_x509_certificate(base64.b64decode(self.with_context(bin_size=False).pem_certificate))
         if hashing_algorithm not in STR_TO_HASH:
@@ -281,11 +300,30 @@ class Certificate(models.Model):
         return _get_formatted_value(cert.fingerprint(STR_TO_HASH[hashing_algorithm]), formatting=formatting)
 
     def _get_signature_bytes(self, formatting='encodebytes'):
+        ''' Get the signature bytes of the certificate.
+
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: The formatted signature bytes of the certificate
+        :rtype: bytes
+        '''
         self.ensure_one()
         cert = x509.load_pem_x509_certificate(base64.b64decode(self.with_context(bin_size=False).pem_certificate))
         return _get_formatted_value(cert.signature, formatting=formatting)
 
     def _get_public_key_numbers_bytes(self, formatting='encodebytes'):
+        ''' Get the certificate public key's public numbers bytes.
+
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: A tuple containing the formatted public number bytes of the certificate's public key
+
+        :rtype: tuple(bytes,bytes)
+        '''
         self.ensure_one()
         if self.public_key_id or self.private_key_id:
             return (self.public_key_id or self.private_key_id)._get_public_key_numbers_bytes(formatting=formatting)
@@ -297,6 +335,18 @@ class Certificate(models.Model):
         )
 
     def _get_public_key_bytes(self, encoding='der', formatting='encodebytes'):
+        ''' Get the certificate's public key bytes.
+
+        :param optional,default='der' encoding: The formatting of the returned bytes
+            - 'der' returns DER public key bytes
+            - other returns PEM public key bytes
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: The formatted certificate public key bytes in the corresponding format
+        :rtype: bytes
+        '''
         self.ensure_one()
         if self.public_key_id or self.private_key_id:
             return (self.public_key_id or self.private_key_id)._get_public_key_bytes(encoding=encoding, formatting=formatting)
@@ -318,7 +368,17 @@ class Certificate(models.Model):
         )
 
     def _sign(self, message, hashing_algorithm='sha256', formatting='encodebytes'):
-        """ Return the base64 encoded signature of message. """
+        ''' Compute and return the message's signature.
+
+        :param str|bytes message: The message to sign
+        :param optional,default='sha256' hashing_algorithm: The digest algorithm to use. Currently, only 'sha1' and 'sha256' are available.
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: The formatted signature bytes of the message
+        :rtype: bytes
+        '''
         self.ensure_one()
 
         if not self.is_valid:

--- a/addons/certificate/models/key.py
+++ b/addons/certificate/models/key.py
@@ -129,7 +129,17 @@ class Key(models.Model):
     # -------------------------------------------------------
 
     def _sign(self, message, hashing_algorithm='sha256', formatting='encodebytes'):
-        """ Return the base64 encoded signature of message. """
+        ''' Compute and return the message's signature.
+
+        :param str|bytes message: The message to sign
+        :param optional,default='sha256' hashing_algorithm: The digest algorithm to use. Currently, only 'sha1' and 'sha256' are available.
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: The formatted signature bytes of the message
+        :rtype: bytes
+        '''
         self.ensure_one()
 
         if self.public:
@@ -148,6 +158,15 @@ class Key(models.Model):
         )
 
     def _get_public_key_numbers_bytes(self, formatting='encodebytes'):
+        ''' Get the public key's public numbers bytes.
+
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: A tuple containing formatted public number bytes of the public key
+        :rtype: tuple(bytes,bytes)
+        '''
         self.ensure_one()
 
         return self._numbers_public_key_bytes_with_key(
@@ -156,6 +175,18 @@ class Key(models.Model):
         )
 
     def _get_public_key_bytes(self, encoding='der', formatting='encodebytes'):
+        ''' Get the public key bytes.
+
+        :param optional,default='der' encoding: The formatting of the returned bytes
+            - 'der' returns DER public key bytes
+            - other returns PEM public key bytes
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: The formatted public key bytes in the corresponding format
+        :rtype: bytes
+        '''
         self.ensure_one()
 
         if self.public:
@@ -173,6 +204,13 @@ class Key(models.Model):
         )
 
     def _decrypt(self, message, hashing_algorithm='sha256'):
+        ''' Decrypt the given message using the provided digest.
+
+        :param str|bytes message: The message to encode
+        :param optional,default='sha256' hashing_algorithm: The digest algorithm to use. Currently, only 'sha1' and 'sha256' are available.
+        :return: The decrypted text
+        :rtype: str
+        '''
         self.ensure_one()
 
         if not isinstance(message, bytes):
@@ -194,14 +232,30 @@ class Key(models.Model):
                 algorithm=STR_TO_HASH[hashing_algorithm],
                 label=None
             )
-        )
+        ).decode()
 
     @api.model
     def _sign_with_key(self, message, pem_key, pwd=None, hashing_algorithm='sha256', formatting='encodebytes'):
-        """ Return the base64 encoded signature of message. """
+        ''' Compute and return the message's signature for a given private key.
+
+        :param str|bytes message: The message to sign
+        :param str|bytes pem_key: A base64 encoded private key in the PEM format
+        :param str|bytes pwd: A password to decrypt the PEM key
+        :param optional,default='sha1' hashing_algorithm: The digest algorithm to use. Currently, only 'sha1' and 'sha256' are available.
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: The formatted signature bytes of the message
+        :rtype: bytes
+        '''
 
         if not isinstance(message, bytes):
             message = message.encode('utf-8')
+        if not isinstance(pem_key, bytes):
+            pem_key = pem_key.encode('utf-8')
+        if pwd and not isinstance(pwd, bytes):
+            pwd = pwd.encode('utf-8')
 
         if hashing_algorithm not in STR_TO_HASH:
             raise UserError(f"Unsupported hashing algorithm '{hashing_algorithm}'. Currently supported: sha1 and sha256.")
@@ -229,6 +283,19 @@ class Key(models.Model):
 
     @api.model
     def _numbers_public_key_bytes_with_key(self, pem_key, formatting='encodebytes'):
+        ''' Get the given public key's public numbers bytes.
+
+        :param str|bytes pem_key: A base64 encoded public key in the PEM format
+        :param optional,default='encodebytes' formatting: The formatting of the returned bytes
+            - 'encodebytes' returns a base64-encoded block of 76 characters lines
+            - 'base64' returns the raw base64-encoded data
+            - other returns non-encoded data
+        :return: A tuple containing the formatted public number bytes of the public key
+        :rtype: tuple(bytes,bytes)
+        '''
+        if not isinstance(pem_key, bytes):
+            pem_key = pem_key.encode('utf-8')
+
         try:
             public_key = serialization.load_pem_public_key(base64.b64decode(pem_key))
         except ValueError:
@@ -250,7 +317,14 @@ class Key(models.Model):
 
     @api.model
     def _generate_ec_private_key(self, company, name='id_ec', curve='SECP256R1'):
+        ''' Generate an elliptic curve private key.
 
+        :param res.company company: A company record
+        :param str,optional,default='id_ec' name: The name of the newly created key.
+        :param optional,default='SECP256R1' curve: The type of elliptic curve algorithm. Currently, only SECP256R1 is supported.
+        :return: A certificate.key record
+        :rtype: certificate.key
+        '''
         if curve not in STR_TO_CURVE:
             raise UserError(f"Unsupported curve algorithm '{curve}'. Currently supported: SECP256R1.")
 
@@ -267,6 +341,19 @@ class Key(models.Model):
 
     @api.model
     def _generate_rsa_private_key(self, company, name='id_rsa', public_exponent=65537, key_size=2048):
+        ''' Generate an RSA private key.
+
+        :param res.company company: A company record
+        :param str,optional,default='id_rsa' name: The name of the newly created key.
+        :param int,optional,default=65537 public_exponent: The public exponent of the new key: either 65537 or 3 (for legacy purposes)
+        :param int,optional,default=2048 key_size: The length of the modulus in bits; it is strongly recommended to be at least 2048 and must not be less than 512
+        :return: A certificate.key record
+        :rtype: certificate.key
+        '''
+        if (public_exponent not in [65537, 3]):
+            raise UserError(_("The public exponent should be 65537 (or 3 for legacy purposes)."))
+        if key_size < 512:
+            raise UserError(_("The key size should be at least 512 bytes."))
 
         private_key = rsa.generate_private_key(
             public_exponent=public_exponent,


### PR DESCRIPTION
The certificate and keys models were added in 18.0. A few docstrings could help devs using those methods.

Furthermore, a few more checks and robustness were added.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
