### PR TITLE
[FIX] hr_org_chart: udpate org chart after save for new employees

### DIFF
--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.js
@@ -47,6 +47,7 @@ export class HrOrgChart extends Component {
 
         this.state = useState({'employee_id': null});
         this.lastParent = null;
+        this.lastEmployeeId = null;
         this._onEmployeeSubRedirect = onEmployeeSubRedirect();
 
         onWillStart(async () => {
@@ -54,13 +55,13 @@ export class HrOrgChart extends Component {
             // the widget is either dispayed in the context of a hr.employee form or a res.users form
             this.state.employee_id = this.employee.employee_ids !== undefined ? this.employee.employee_ids.resIds[0] : this.props.record.resId;
             this.state.parent_id = this.employee.parent_id?.[0] || this.employee.employee_parent_id?.[0];
-            this.original_employee_id = this.state.employee_id;
         });
 
         useRecordObserver(async (record) => {
-            this.state.employee_id = this.original_employee_id;
             const newParentId = record.data.parent_id?.[0] || false;
-            if (this.lastParent !== newParentId) {
+            const newEmployeeId = record.data.id || false;
+            this.state.employee_id = newEmployeeId;
+            if (this.lastParent !== newParentId || this.lastEmployeeId !== newEmployeeId) {
                 await this.fetchEmployeeData(this.state.employee_id, newParentId, true);
             }
             this.lastParent = newParentId;

--- a/addons/hr_org_chart/static/tests/hr_org_chart.test.js
+++ b/addons/hr_org_chart/static/tests/hr_org_chart.test.js
@@ -24,12 +24,15 @@ defineModels([Employee]);
 defineMailModels();
 
 test("hr org chart: empty render", async () => {
-    expect.assertions(2);
+    expect.assertions(3);
 
     onRpc("/hr/get_org_chart", async (request) => {
         const { params: args } = await request.json();
         expect("employee_id" in args).toBe(true, {
             message: "it should have 'employee_id' as argument",
+        });
+        expect("new_parent_id" in args).toBe(true, {
+            message: "it should have 'new_parent_id' as argument",
         });
         return {
             children: [],
@@ -43,7 +46,11 @@ test("hr org chart: empty render", async () => {
     await mountView({
         type: "form",
         resModel: "hr.employee",
-        arch: `<form><field name="child_ids" widget="hr_org_chart"/></form>`,
+        arch: `
+            <form>
+                <field name="child_ids" widget="hr_org_chart"/>
+                <field name="id" invisible="1"/>
+            </form>`,
         resId: 1,
     });
     expect(queryOne('[name="child_ids"]').children).toHaveLength(1, {
@@ -51,19 +58,26 @@ test("hr org chart: empty render", async () => {
     });
 });
 test("hr org chart: render without data", async () => {
-    expect.assertions(2);
+    expect.assertions(3);
 
     onRpc("/hr/get_org_chart", async (request) => {
         const { params: args } = await request.json();
         expect("employee_id" in args).toBe(true, {
             message: "it should have 'employee_id' as argument",
         });
+        expect("new_parent_id" in args).toBe(true, {
+            message: "it should have 'new_parent_id' as argument",
+        });
         return {}; // return no data
     });
     await mountView({
         type: "form",
         resModel: "hr.employee",
-        arch: `<form><field name="child_ids" widget="hr_org_chart"/></form>`,
+        arch: `
+            <form>
+                <field name="child_ids" widget="hr_org_chart"/>
+                <field name="id" invisible="1"/>
+            </form>`,
         resId: 1,
     });
     expect(queryOne('[name="child_ids"]').children).toHaveLength(1, {
@@ -71,12 +85,15 @@ test("hr org chart: render without data", async () => {
     });
 });
 test("hr org chart: basic render", async () => {
-    expect.assertions(3);
+    expect.assertions(4);
 
     onRpc("/hr/get_org_chart", async (request) => {
         const { params: args } = await request.json();
         expect("employee_id" in args).toBe(true, {
             message: "it should have 'employee_id' as argument",
+        });
+        expect("new_parent_id" in args).toBe(true, {
+            message: "it should have 'new_parent_id' as argument",
         });
         return {
             children: [
@@ -115,6 +132,7 @@ test("hr org chart: basic render", async () => {
                         <div id="o_employee_main">
                             <div id="o_employee_right">
                                 <field name="child_ids" widget="hr_org_chart"/>
+                                <field name="id" invisible="1"/>
                             </div>
                         </div>
                     </div>
@@ -130,12 +148,15 @@ test("hr org chart: basic render", async () => {
     });
 });
 test("hr org chart: basic manager render", async () => {
-    expect.assertions(4);
+    expect.assertions(5);
 
     onRpc("/hr/get_org_chart", async (request) => {
         const { params: args } = await request.json();
         expect("employee_id" in args).toBe(true, {
             message: "it should have 'employee_id' as argument",
+        });
+        expect("new_parent_id" in args).toBe(true, {
+            message: "it should have 'new_parent_id' as argument",
         });
         return {
             children: [
@@ -184,6 +205,7 @@ test("hr org chart: basic manager render", async () => {
                         <div id="o_employee_main">
                             <div id="o_employee_right">
                                 <field name="child_ids" widget="hr_org_chart"/>
+                                <field name="id" invisible="1"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Behavior before the fix:
- Changing the employee manager on a new employee which is not saved yet was causing the org chart to be wrong

This commit fixes the issue by updating the org chart of a new employee only when the record is saved.

task-4652193