### PR TITLE
[FIX] web: prevent overlapping of questions when dragging

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -524,6 +524,10 @@
         }
     }
 
+    .o_data_row.o_dragged {
+        display: flex;
+    }
+
     .o_optional_columns_dropdown .dropdown-item .o-checkbox .text-truncate {
         max-width: 30em;
     }


### PR DESCRIPTION
**Before this commit:**
Long question and answers overlap the wizard while dragging with the handler.

**After this commit:**
Long question and answers do not overlap the wizard while dragging with handler.

task-4452311

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
