### PR TITLE
[FIX] account: incorrect display of the payment date field

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -24,7 +24,7 @@
                                t-on-click.prevent="() => this.assignOutstandingCredit(line.id)">Add</a>
                         </td>
                         <td style="max-width: 11em;">
-                            <a t-att-title="line.date"
+                            <a t-att-title="line.formattedDate"
                                role="button"
                                class="oe_form_field btn btn-link open_account_move"
                                t-on-click="() => this.openMove(line.move_id)"
@@ -39,7 +39,7 @@
                            <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line_index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-bs-toggle="tooltip" t-on-click.stop="(ev) => this.onInfoClick(ev, line_index)"></a>
                         </td>
                         <td t-if="!line.is_exchange">
-                            <i class="o_field_widget text-start o_payment_label">Paid on <t t-esc="line.date"></t></i>
+                            <i class="o_field_widget text-start o_payment_label">Paid on <t t-out="line.formattedDate"></t></i>
                         </td>
                         <td t-if="line.is_exchange" colspan="2">
                             <i class="o_field_widget text-start text-muted text-start">

--- a/addons/account/static/src/components/account_payment_field/account_payment_field.js
+++ b/addons/account/static/src/components/account_payment_field/account_payment_field.js
@@ -4,7 +4,7 @@ import { registry } from "@web/core/registry";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
 import { localization } from "@web/core/l10n/localization";
-import { parseDate, formatDate } from "@web/core/l10n/dates";
+import { formatDate, deserializeDate } from "@web/core/l10n/dates";
 
 import { formatMonetary } from "@web/views/fields/formatters";
 
@@ -35,7 +35,7 @@ export class AccountPaymentField extends Component {
             value.amount_formatted = formatMonetary(value.amount, { currencyId: value.currency_id });
             if (value.date) {
                 // value.date is a string, parse to date and format to the users date format
-                value.date = formatDate(parseDate(value.date));
+                value.formattedDate = formatDate(deserializeDate(value.date))
             }
         }
         this.lines = info.content;


### PR DESCRIPTION
An incorrect date being represented (14/11/2007 is displayed as 20/07/1114) on the payment field.
The date was parsed two times with the format of the user's language, while the first parse should be based on the current format of the database.

To reproduce:
- Change user language to Spanish or French.
- Register a payment for an invoice with a payment date between October 1st and December 31st, from 2001 to 2012.
- "Paid on 20/07/1114" appears.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4486653)
opw-4486653