### PR TITLE
[IMP] [18.0] sale_stock: Display reservation issues on Qty at Date widget

### DIFF
--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -59,6 +59,7 @@ export class QtyAtDateWidget extends Component {
             if (['draft', 'sent'].includes(data.state)) {
                 // Moves aren't created yet, then the forecasted is only based on virtual_available of quant
                 this.calcData.forecasted_issue = !this.calcData.will_be_fulfilled && !data.is_mto;
+                this.calcData.reservation_issue = data.free_qty_today < data.qty_to_deliver;
             } else {
                 // Moves are created, using the forecasted data of related moves
                 this.calcData.forecasted_issue = !this.calcData.will_be_fulfilled || this.calcData.will_be_late;

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml
@@ -5,7 +5,7 @@
         <a t-att-tabindex="props.record.data.display_qty_widget ? '0' : '-1'"
             t-on-click="showPopup"
             t-att-class="!props.record.data.display_qty_widget ? 'invisible' : ''"
-            t-attf-class="fa fa-area-chart cursor-pointer {{ calcData.forecasted_issue ? 'text-danger' : '' }}"
+            t-attf-class="fa fa-area-chart cursor-pointer {{ calcData.forecasted_issue ? 'text-danger' : calcData.reservation_issue ? 'text-warning' : '' }}"
         />
     </t>
 
@@ -21,7 +21,7 @@
                     </tr>
                     <tr>
                         <td><strong>Available</strong><br /><small>All planned operations included</small></td>
-                        <td class="text-end"><b t-out='props.record.data.free_qty_today' t-att-class="!props.calcData.will_be_fulfilled ? 'text-danger': ''"/> <t t-out='props.record.data.product_uom[1]'/></td>
+                        <td class="text-end"><b t-out='props.record.data.free_qty_today' t-att-class="!props.calcData.will_be_fulfilled ? 'text-danger': props.calcData.reservation_issue ? 'text-warning': ''"/> <t t-out='props.record.data.product_uom[1]'/></td>
                     </tr>
                 </t>
                 <t t-elif="props.record.data.is_mto and ['draft', 'sent'].includes(props.record.data.state)">


### PR DESCRIPTION
When a user wants to sell products that has been reserved for another picking, a warning color appears on the Qty at Date widget.

## Description of the issue/feature this PR addresses:
An user wants to sell more quantities than Free Qty Today and nothing tells them that it's going to sell something that has been reserved for another picking.

## Current behavior before PR:
A green icon on Qty at Date widget is shown. 
The user doesn't click on the button because it's green and it indicates "all it's ok".
When the user confirms the sale, the picking is Partially Available and cannot deliver promised quantities.

## Desired behavior after PR is merged:
Warn the user that if are going to confirm the sale, an issue will happen.
To fullfill the picking completely, other picking must be unreserved.

![reservation_issue_color](https://github.com/user-attachments/assets/62f21cb4-819f-4e53-8476-2c2a4a0db6cd)

It's the same functionality as this OCA PR: https://github.com/OCA/sale-workflow/pull/3625

MT-9403 @moduon @rafaelbn

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
