### PR TITLE
[IMP] l10n_be_codabox: remove limitation for accountant

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 11:26+0000\n"
-"PO-Revision-Date: 2025-02-10 11:26+0000\n"
+"POT-Creation-Date: 2025-03-03 11:38+0000\n"
+"PO-Revision-Date: 2025-03-03 11:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -31267,6 +31267,13 @@ msgid ""
 "This module allows Accounting Firms to connect to CodaBox\n"
 "and automatically import CODA and SODA statements for their clients in Odoo.\n"
 "The connection must be done by the Accounting Firm.\n"
+msgstr ""
+
+#. module: base
+#: model:ir.module.module,description:base.module_account_online_payment
+msgid ""
+"This module allows customers to pay their invoices online using various "
+"payment methods."
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fr.po
+++ b/odoo/addons/base/i18n/fr.po
@@ -15,8 +15,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 11:26+0000\n"
-"PO-Revision-Date: 2023-10-26 23:09+0000\n"
+"POT-Creation-Date: 2025-03-03 11:38+0000\n"
+"PO-Revision-Date: 2025-03-03 11:38+0000\n"
 "Last-Translator: Manon Rondou, 2025\n"
 "Language-Team: French (https://app.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -22561,13 +22561,6 @@ msgid "Footer text displayed at the bottom of all reports."
 msgstr "Pied de page de tous les rapports."
 
 #. module: base
-#: model:ir.module.module,summary:base.module_l10n_be_codabox
-#: model:ir.module.module,summary:base.module_l10n_be_codabox_bridge
-#: model:ir.module.module,summary:base.module_l10n_be_codabox_bridge_wizard
-msgid "For Accounting Firms"
-msgstr "Pour les cabinets comptables"
-
-#. module: base
 #: model:ir.model.fields,help:base.field_ir_actions_server__value
 #: model:ir.model.fields,help:base.field_ir_cron__value
 msgid ""
@@ -38350,13 +38343,11 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_be_codabox_bridge
 #: model:ir.module.module,description:base.module_l10n_be_codabox_bridge_wizard
 msgid ""
-"This module allows Accounting Firms to connect to CodaBox\n"
-"and automatically import CODA and SODA statements for their clients in Odoo.\n"
-"The connection must be done by the Accounting Firm.\n"
+"This module allows connection to CodaBox and automatically imports CODA and "
+"SODA statements in Odoo."
 msgstr ""
-"Ce module permet aux cabinets comptables de se connecter à la CodaBox\n"
-"et d'importer automatiquement les relevés CODA et SODA de leurs clients dans Odoo.\n"
-"La connexion doit être effectuée par le cabinet comptable.\n"
+"Ce module permet de se connecter à CodaBox et d'importer automatiquement "
+"les déclarations CODA et SODA dans Odoo."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_sale_fedex

--- a/odoo/addons/base/i18n/nl.po
+++ b/odoo/addons/base/i18n/nl.po
@@ -16,9 +16,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 11:26+0000\n"
-"PO-Revision-Date: 2023-10-26 23:09+0000\n"
-"Last-Translator: Manon Rondou, 2025\n"
+"POT-Creation-Date: 2025-02-10 16:32+0000\n"
+"PO-Revision-Date: 2024-09-25 09:41+0000\n"
+"Last-Translator: Tiffany Chang, 2025\n"
 "Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22496,8 +22496,6 @@ msgstr "Voettekst, weergegeven aan de onderzijde van alle rapportages."
 
 #. module: base
 #: model:ir.module.module,summary:base.module_l10n_be_codabox
-#: model:ir.module.module,summary:base.module_l10n_be_codabox_bridge
-#: model:ir.module.module,summary:base.module_l10n_be_codabox_bridge_wizard
 msgid "For Accounting Firms"
 msgstr "Voor Accountantskantoren"
 
@@ -38201,13 +38199,21 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_be_codabox_bridge
 #: model:ir.module.module,description:base.module_l10n_be_codabox_bridge_wizard
 msgid ""
-"This module allows Accounting Firms to connect to CodaBox\n"
-"and automatically import CODA and SODA statements for their clients in Odoo.\n"
-"The connection must be done by the Accounting Firm.\n"
+"This module allows connection to CodaBox and automatically imports CODA and "
+"SODA statements in Odoo."
 msgstr ""
 "Dit module stelt Accountantskantoren in staat om verbinding te maken met CodaBox\n"
 "en automatisch CODA- en SODA-afschriften te importeren voor hun klanten in Odoo.\n"
 "De verbinding moet worden gemaakt door het Accountantskantoor.\n"
+
+#. module: base
+#: model:ir.module.module,description:base.module_account_online_payment
+msgid ""
+"This module allows customers to pay their invoices online using various "
+"payment methods."
+msgstr ""
+"Met deze module kunnen klanten hun facturen online betalen met verschillende"
+" betaalmethoden."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_sale_fedex


### PR DESCRIPTION
### Before

Codabox used to require a fiduciary VAT and the VAT of a company (managed by the fiduciary) in order to connect to their services. 
- Access to Codabox was limited to companies with an accounting firm with a VAT number assigned


### Now

Codabox gives the opportunity for companies to directly connect (without being a fiduciary/ being managed by one). This is through the same port as before, just receiving two identical  VAT numbers.  

- Module summary, descriptions and other texts are updated to generalize 

- Companies without an accounting firm can access the Codabox configuration settings

odoo/enterprise/pull/81655
odoo/documentation/pull/12540

task - 4460499