### PR TITLE
[FIX] point_of_sale: prevent error when placing a self-order without preset

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
+++ b/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
@@ -174,6 +174,8 @@ const deepSerialization = (
             }
             if (typeof recordId === "number" && recordId >= 0) {
                 result[fieldName] = record[fieldName].id;
+            } else if (record[fieldName] === undefined) {
+                result[fieldName] = false;
             }
             continue;
         }


### PR DESCRIPTION
Currently, an error is produced when a user deletes the default preset and then attempts to make a self-order.

**Steps to reproduce:**
- Install the `pos_self_order` module.
- Enable **Self Ordering** and set the default **Preset** (e.g., Eat In) under **Take out / Delivery / Members** in the shop settings .
- Delete that default **Preset**.
- Open the kiosk/mobile menu and try to place an order.
- Observe the backend error.

**Error:**
`KeyError: 'preset_id'`

The error occurs because the system attempts to access `preset_id` at [1], but the **serialize** function at [2] does not return `many2one` fields if they are `undefined`. As a result, `preset_id` is not passed to the controller, leading to a key error.

[1] - https://github.com/odoo/odoo/blob/987f97d6cc508b10c8c6a12823ca11597f22d861/addons/pos_self_order/controllers/orders.py#L13
[2] - https://github.com/odoo/odoo/blob/987f97d6cc508b10c8c6a12823ca11597f22d861/addons/pos_self_order/static/src/app/services/self_order_service.js#L681-L683

In previous version, `undefined` fields were passed with a `false` value - [3]. However, due to [this](https://github.com/odoo/odoo/commit/08bd51f2cb786a05cd5501e9238a5d5fde67367e#diff-bc77729691d9607e7c954274a0461c0eb5da593729381fcd0e16909d3a8b174cL201) commit serialization function is changed, without handling the case for `undefined` fields.

[3] - https://github.com/odoo/odoo/blob/d4e40e4be4233d91db80717891cef73c4fdec06c/addons/point_of_sale/static/src/app/models/related_models.js#L285

This commit ensures that any `undefined` fields are explicitly set to `false` during serialization, preventing the error.

Sentry - 6389908940