### PR TITLE
[FIX] l10n_in: Prevent traceback when changing company country

### DIFF
--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -99,8 +99,8 @@ class ResCompany(models.Model):
                 ]
                 self._activate_l10n_in_taxes(gst_group_refs, company)
                 # Set sale and purchase tax accounts when user registered under GST.
-                company.account_sale_tax_id = self.env['account.chart.template'].with_company(company).ref('sgst_sale_5').id
-                company.account_purchase_tax_id = self.env['account.chart.template'].with_company(company).ref('sgst_purchase_5').id
+                company.account_sale_tax_id = self.env['account.chart.template'].with_company(company).ref('sgst_sale_5', raise_if_not_found=False)
+                company.account_purchase_tax_id = self.env['account.chart.template'].with_company(company).ref('sgst_purchase_5', raise_if_not_found=False)
 
     @api.depends('parent_id.l10n_in_tds_feature', 'parent_id.l10n_in_tcs_feature', 'parent_id.l10n_in_is_gst_registered')
     def _compute_l10n_in_parent_based_features(self):
@@ -112,9 +112,11 @@ class ResCompany(models.Model):
 
     def _activate_l10n_in_taxes(self, group_refs, company):
         for group_ref in group_refs:
-            tax_group_id = self.env['account.chart.template'].with_company(company).ref(group_ref).id
+            tax_group = self.env['account.chart.template'].with_company(company).ref(group_ref, raise_if_not_found=False)
+            if not tax_group:
+                continue
             taxes = self.env['account.tax'].with_company(company).with_context(active_test=False).search([
-                ('tax_group_id', '=', tax_group_id),
+                ('tax_group_id', '=', tax_group.id),
             ])
             taxes.write({'active': True})
 


### PR DESCRIPTION
This commit ensures that taxes are updated based on the company's fiscal country instead of the company address country, preventing errors when modifying the company’s address.

Steps to reproduce the issue:
1. Install Indian localization (`l10n_in`).
2. Create a new company, set any country, and load its localization (except India).
3. Change the country in the company address.
4. Add a GSTIN (VAT) number.

Before this fix, changing the company’s country caused a traceback due to incorrect tax modifications.

Task ID: 4680276
