### PR TITLE
[FIX] survey: prevent division by zero on leaderboard template

### DIFF
--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -982,7 +982,7 @@ class Survey(models.Model):
 
             score_position = 0
             for leaderboard_item in leaderboard:
-                question_score = question_scores.get(leaderboard_item['id'], 0)
+                question_score = abs(round(question_scores.get(leaderboard_item['id'], 0), 2))
                 leaderboard_item.update({
                     'updated_score': leaderboard_item['scoring_total'],
                     'scoring_total': leaderboard_item['scoring_total'] - question_score,


### PR DESCRIPTION
Reproduce:
1. Make a scored live session survey with speed reward
2. Add a single choice question with a 1-point answer
3. Create a live session
4. Join with one participant
5. Play the survey, have the participant answer correctly
6. Proceed to leaderboard and expect a crash.

With the change of `survey.user.input`'s `scoring_total` digits of 8d436c5c, the total score of a user and the answer score for the first question were not exactly the same anymore.
Therefore, in `Survey._prepare_leaderboard_values` `scoring_total` was not exactly 0 but a small number (<0.01), and `max_score`'s computation in `user_input_session_leaderboard` template was therefore not replacing `scoring_total` with `1`, and dividing by `max_score` rounded to 0 in `t-set="width_ratio"` caused the crash.

We are choosing this fix because it does not rely on updating templates in dbs.

Task-4655784
