### PR TITLE
[IMP] account_peppol: Misc imps

### DIFF
--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -46,7 +46,7 @@ class ResPartner(models.Model):
             ('9914', "Austria UID"),
             ('9915', "Austria VOKZ"),
             ('0208', "Belgian Company Registry"),
-            ('9925', "Belgian VAT number"),
+            ('9925', "Belgian VAT"),
             ('9924', "Bosnia and Herzegovina VAT"),
             ('9926', "Bulgaria VAT"),
             ('9934', "Croatia VAT"),

--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -18,19 +18,25 @@ msgstr ""
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
-msgid " (Consumer)"
-msgstr ""
-
-#. module: account_peppol
-#. odoo-python
-#: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
 msgid " (Customer not on Peppol)"
 msgstr ""
 
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
-msgid " (Demo/Test mode)"
+msgid " (Demo)"
+msgstr ""
+
+#. module: account_peppol
+#. odoo-python
+#: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
+msgid " (Test)"
+msgstr ""
+
+#. module: account_peppol
+#. odoo-python
+#: code:addons/account_peppol/wizard/account_move_send_wizard.py:0
+msgid " (no VAT)"
 msgstr ""
 
 #. module: account_peppol
@@ -785,20 +791,8 @@ msgstr ""
 
 #. module: account_peppol
 #. odoo-python
-#: code:addons/account_peppol/wizard/peppol_registration.py:0
-msgid "Registered as a receiver."
-msgstr ""
-
-#. module: account_peppol
-#. odoo-python
 #: code:addons/account_peppol/tools/demo_utils.py:0
 msgid "Registered as a sender (demo)."
-msgstr ""
-
-#. module: account_peppol
-#. odoo-python
-#: code:addons/account_peppol/wizard/peppol_registration.py:0
-msgid "Registered as a sender."
 msgstr ""
 
 #. module: account_peppol
@@ -810,7 +804,6 @@ msgstr ""
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/models/res_config_settings.py:0
-#: code:addons/account_peppol/wizard/peppol_registration.py:0
 msgid "Registered to receive documents via Peppol."
 msgstr ""
 
@@ -937,8 +930,6 @@ msgid ""
 msgstr ""
 
 #. module: account_peppol
-#. odoo-python
-#: code:addons/account_peppol/wizard/peppol_registration.py:0
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_partner_form_account_peppol
 msgid ""
 "The recommended identification method for Belgium is your Company Registry "
@@ -1123,8 +1114,16 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_peppol/wizard/peppol_registration.py:0
 msgid ""
+"Your Peppol registration will be activated soon. You can already send "
+"invoices."
+msgstr ""
+
+#. module: account_peppol
+#. odoo-python
+#: code:addons/account_peppol/wizard/peppol_registration.py:0
+msgid ""
 "Your company is already registered on another Access Point for receiving "
-"invoices.We will register you on Odoo as a sender only."
+"invoices.We will register you as a sender only."
 msgstr ""
 
 #. module: account_peppol
@@ -1140,7 +1139,6 @@ msgstr ""
 #. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/models/res_config_settings.py:0
-#: code:addons/account_peppol/wizard/peppol_registration.py:0
 msgid ""
 "Your registration on Peppol network should be activated within a day. The "
 "updated status will be visible in Settings."

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -17,17 +17,17 @@ class AccountMoveSend(models.AbstractModel):
         def peppol_partner(moves):
             return moves.partner_id.commercial_partner_id
 
-        def filter_peppol_state(moves, state):
+        def filter_peppol_state(moves, states):
             return peppol_partner(moves.filtered(
                 lambda m: self.env['res.partner']._get_peppol_verification_state(
                     peppol_partner(m).peppol_endpoint,
                     peppol_partner(m).peppol_eas,
-                    moves_data[m]['invoice_edi_format']) == state))
+                    moves_data[m]['invoice_edi_format']) in states))
 
         alerts = super()._get_alerts(moves, moves_data)
         # Check for invalid peppol partners.
         peppol_moves = moves.filtered(lambda m: 'peppol' in moves_data[m]['sending_methods'])
-        invalid_partners = filter_peppol_state(peppol_moves, 'not_valid_format')
+        invalid_partners = filter_peppol_state(peppol_moves, ['not_valid_format'])
         if invalid_partners and not 'account_edi_ubl_cii_configure_partner' in alerts:
             alerts['account_peppol_warning_partner'] = {
                 'message': _("Customer is on Peppol but did not enable receiving documents."),
@@ -56,13 +56,13 @@ class AccountMoveSend(models.AbstractModel):
         always_on_companies = moves.company_id.filtered(
             lambda c: c.country_code in info_always_on_countries and c.account_peppol_proxy_state not in can_send
         )
-        if always_on_companies and any_moves_not_sent_peppol and not filter_peppol_state(moves, 'not_valid'):
+        if always_on_companies and any_moves_not_sent_peppol and not filter_peppol_state(moves, ['not_valid', 'not_verified']):
             alerts.pop('account_edi_ubl_cii_configure_company', False)
-            alerts['account_peppol_partner_want_peppol'] = {
+            alerts['account_peppol_what_is_peppol'] = {
                 'message': _("You can send this invoice electronically via Peppol."),
                 **what_is_peppol_alert,
             }
-        elif (peppol_not_selected_partners := filter_peppol_state(not_peppol_moves, 'valid')) and any_moves_not_sent_peppol:
+        elif (peppol_not_selected_partners := filter_peppol_state(not_peppol_moves, ['valid'])) and any_moves_not_sent_peppol:
             # Check for not peppol partners that are on the network.
             if len(peppol_not_selected_partners) == 1:
                 alerts['account_peppol_partner_want_peppol'] = {

--- a/addons/account_peppol/wizard/account_move_send_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_wizard.py
@@ -24,11 +24,15 @@ class AccountMoveSendWizard(models.TransientModel):
                 if peppol_partner.peppol_verification_state == 'not_valid':
                     addendum_disable_reason = _(' (Customer not on Peppol)')
                 elif peppol_partner.peppol_verification_state == 'not_verified':
-                    addendum_disable_reason = _(' (Consumer)')
+                    addendum_disable_reason = _(' (no VAT)')
                 else:
                     addendum_disable_reason = ''
                 vals_not_valid = {'readonly': True, 'checked': False} if addendum_disable_reason else {}
-                addendum_mode = _(' (Demo/Test mode)') if peppol_proxy_mode != 'prod' else ''
+                addendum_mode = ''
+                if peppol_proxy_mode == 'test':
+                    addendum_mode = _(' (Test)')
+                elif peppol_proxy_mode == 'demo':
+                    addendum_mode = _(' (Demo)')
                 if addendum_disable_reason or addendum_mode:
                     wizard.sending_method_checkboxes = {
                         **wizard.sending_method_checkboxes,

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -108,14 +108,10 @@ class PeppolRegistration(models.TransientModel):
                     'message': _("The endpoint number might not be correct. "
                                 "Please check if you entered the right identification number."),
                 }
-            if wizard.company_id.country_code == 'BE' and wizard.peppol_eas not in (False, '0208'):
-                peppol_warnings['company_peppol_eas_warning'] = {
-                    'message': _("The recommended identification method for Belgium is your Company Registry Number."),
-                }
             if not wizard.smp_registration:
                 peppol_warnings['company_on_another_smp'] = {
                     'message': _("Your company is already registered on another Access Point for receiving invoices."
-                                 "We will register you on Odoo as a sender only.")
+                                 "We will register you as a sender only.")
                 }
             wizard.peppol_warnings = peppol_warnings or False
 
@@ -293,21 +289,18 @@ class PeppolRegistration(models.TransientModel):
         # success
         notifications = {
             'sender': {
-                'title': _('Registered as a sender.'),
                 'message': _('You can now send electronic invoices via Peppol.'),
             },
             'smp_registration': {  # TODO remove in master
-                'title': _('Registered to receive documents via Peppol.'),
-                'message': _('Your registration on Peppol network should be activated within a day. The updated status will be visible in Settings.'),
+                'message': _('Your Peppol registration will be activated soon. You can already send invoices.'),
             },
             'receiver': {
-                'title': _('Registered as a receiver.'),
                 'message': _('You can now send and receive electronic invoices via Peppol'),
             },
         }
         state = self.company_id.account_peppol_proxy_state
         return self._action_send_notification(
-            title=notifications[state]['title'],
+            title=None,
             message=notifications[state]['message'],
         )
 


### PR DESCRIPTION
Small UX/message improvements to Peppol:
- Shorten some messages/information.
- Rename the "(Consumer)" information to "(no VAT)".
- Don't display the activation banner in case of "no VAT".

task-no (last review comment of FP)
