### PR TITLE
[FIX] im_livechat: thread rename is not working

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -52,7 +52,7 @@ patch(Thread.prototype, {
     },
 
     get displayName() {
-        if (this.channel_type !== "livechat" || !this.correspondent) {
+        if (this.channel_type !== "livechat" || !this.correspondent || this.custom_channel_name) {
             return super.displayName;
         }
         if (!this.correspondent.persona.is_public && this.correspondent.persona.country) {


### PR DESCRIPTION
The rename in the chat window as well as in discuss is not working for livechat, this commit is fixing the issue. The name should now be visible by all operators but not to visitors

task-4431259

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
