### PR TITLE
[FIX] microsoft_account, microsoft_calendar: use microsoft_account for calendar

### DIFF
--- a/addons/microsoft_account/models/microsoft_service.py
+++ b/addons/microsoft_account/models/microsoft_service.py
@@ -85,6 +85,31 @@ class MicrosoftService(models.AbstractModel):
         return content.get('refresh_token')
 
     @api.model
+    def _refresh_microsoft_token(self, service, rtoken):
+        """ Call Microsoft API to refresh the token, with the given authorization code
+            :param service : the name of the microsoft service to actualize
+            :param rtoken : the code to exchange against the new refresh token
+            :returns the new refresh token
+        """
+        ICP_sudo = self.env['ir.config_parameter'].sudo()
+
+        headers = {"Content-type": "application/x-www-form-urlencoded"}
+        data = {
+            'client_id': self._get_microsoft_client_id(service),
+            'client_secret': _get_microsoft_client_secret(ICP_sudo, service),
+            'grant_type': 'refresh_token',
+            'refresh_token': rtoken,
+        }
+        dummy, response, dummy = self._do_request(
+            DEFAULT_MICROSOFT_TOKEN_ENDPOINT,
+            params=data,
+            headers=headers,
+            method='POST',
+            preuri=''
+        )
+        return response.get('access_token'), response.get('expires_in')
+
+    @api.model
     def _get_authorize_uri(self, from_url, service, scope, redirect_uri):
         """ This method return the url needed to allow this instance of Odoo to access to the scope
             of gmail specified as parameters

--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -40,28 +40,10 @@ class User(models.Model):
 
     def _refresh_microsoft_calendar_token(self, service='calendar'):
         self.ensure_one()
-        ICP_sudo = self.env['ir.config_parameter'].sudo()
-        client_id = self.env['microsoft.service']._get_microsoft_client_id('calendar')
-        client_secret = microsoft_service._get_microsoft_client_secret(ICP_sudo, 'calendar')
-
-        if not client_id or not client_secret:
-            raise UserError(_("The account for the Outlook Calendar service is not configured."))
-
-        headers = {"content-type": "application/x-www-form-urlencoded"}
-        data = {
-            'refresh_token': self.sudo().microsoft_calendar_rtoken,
-            'client_id': client_id,
-            'client_secret': client_secret,
-            'grant_type': 'refresh_token',
-        }
-
         try:
-            dummy, response, dummy = self.env['microsoft.service']._do_request(
-                microsoft_service.DEFAULT_MICROSOFT_TOKEN_ENDPOINT, params=data, headers=headers, method='POST', preuri=''
-            )
-            ttl = response.get('expires_in')
+            access_token, ttl = self.env['microsoft.service']._refresh_microsoft_token('calendar', self.sudo().microsoft_calendar_rtoken)
             self.sudo().write({
-                'microsoft_calendar_token': response.get('access_token'),
+                'microsoft_calendar_token': access_token,
                 'microsoft_calendar_token_validity': fields.Datetime.now() + timedelta(seconds=ttl),
             })
         except requests.HTTPError as error:


### PR DESCRIPTION
Before this commit, the refresh_token handling was done in the calendar module, even though it relates to token management and should therefore be handled by microsoft_account, which manages tokens and requests to Microsoft.

task-4653852
