### PR TITLE
[FIX] spreadsheet: share button css

### DIFF
--- a/addons/spreadsheet/static/src/components/share_button/share_button.scss
+++ b/addons/spreadsheet/static/src/components/share_button/share_button.scss
@@ -2,3 +2,9 @@
   width: 320px;
   height: 100px;
 }
+
+.o-spreadsheet {
+  .o-dropdown.o_topbar_share_icon {
+    display: block;
+  }
+}


### PR DESCRIPTION
The `.o-dropdown` class changed scope in o-spreadsheet. It was now applied to the share button, and breaking its style with a `display: flex`.

Task: [4655800](https://www.odoo.com/web#id=4655800&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
