### PR TITLE
[FIX] website_sale_stock: prevent combo out of stock

### DIFF
--- a/addons/website_sale_stock/models/sale_order_line.py
+++ b/addons/website_sale_stock/models/sale_order_line.py
@@ -15,4 +15,6 @@ class SaleOrderLine(models.Model):
         return self.shop_warning
 
     def _get_max_available_qty(self):
+        if self.product_type == "combo":
+            return min(p.free_qty - p._get_cart_qty() for p in self.linked_line_ids.product_id if p.is_storable and not p.allow_out_of_stock_order)
         return self.product_id.free_qty - self.product_id._get_cart_qty()

--- a/addons/website_sale_stock/views/website_sale_stock_templates.xml
+++ b/addons/website_sale_stock/views/website_sale_stock_templates.xml
@@ -3,7 +3,10 @@
 
     <template id="website_sale_stock_cart_lines" inherit_id="website_sale.cart_lines" name="Shopping Cart Lines">
         <xpath expr="//input[@type='text'][hasclass('quantity')]" position="attributes">
-            <attribute name="t-att-data-max">(line.product_uom_qty + line._get_max_available_qty()) if line.product_id.is_storable and not line.product_id.allow_out_of_stock_order else None</attribute>
+            <attribute name="t-att-data-max">(line.product_uom_qty + line._get_max_available_qty()) if (
+                line.product_id.is_storable and not line.product_id.allow_out_of_stock_order) or (
+                line.product_type == "combo" and any(p.is_storable and not p.allow_out_of_stock_order for p in line.linked_line_ids.product_id))
+                else None</attribute>
         </xpath>
         <xpath expr="//div[@name='website_sale_cart_line_quantity']" position="after">
             <div class="availability_messages"/>


### PR DESCRIPTION
Usecase:
Create a combo item with products that are not allowed to be out of stock on ecommerce.
In the classic process, it's okay. You are not allow to add more than available quantity.
However on the checkout page, you can increase as you want. If the user do it, it will order more stock than available.

Fix the flow to ensure that data-max is always equals to the min quantity of the products in combo.

opw-4614309

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
