### PR TITLE
[FIX] web: prevent browser crash when setting a very long default value

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -282,6 +282,9 @@ class SetDefaultDialog extends Component {
                 return option[0] === value;
             })[1];
         }
+        if (displayed.length > 60) {
+            displayed = displayed.slice(0, 57) + "...";
+        }
         return [value, displayed];
     }
 

--- a/addons/web/static/tests/core/debug/debug_manager_tests.js
+++ b/addons/web/static/tests/core/debug/debug_manager_tests.js
@@ -813,4 +813,59 @@ QUnit.module("DebugMenu", (hooks) => {
             ["partner", "m2o", 1, true, true, false],
         ]);
     });
+
+    QUnit.test("set defaults: settings default value for a very long value", async (assert) => {
+        prepareRegistriesWithCleanup();
+        patchWithCleanup(odoo, {
+            debug: true,
+        });
+        registry.category("services").add("user", makeFakeUserService());
+        registry.category("debug").category("form").add("setDefaults", setDefaults);
+
+        const serverData = getActionManagerServerData();
+        serverData.actions[1234] = {
+            id: 1234,
+            xml_id: "action_1234",
+            name: "Partners",
+            res_model: "partner",
+            res_id: 1,
+            type: "ir.actions.act_window",
+            views: [[18, "form"]],
+        };
+        const fooValue = "12".repeat(250);
+        serverData.models.partner.records[0].foo = fooValue;
+        const mockRPC = async (route, args) => {
+            if (args.method === "check_access_rights") {
+                return Promise.resolve(true);
+            }
+            if (args.method === "set" && args.model === "ir.default") {
+                assert.step("setting default");
+                assert.deepEqual(args.args, ["partner", "foo", fooValue, true, true, false]);
+                return true;
+            }
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        await doAction(webClient, 1234);
+        await click(target.querySelector(".o_debug_manager button"));
+        await click(target.querySelector(".o_debug_manager .dropdown-item"));
+        const select = target.querySelector(".modal #formview_default_fields");
+
+        const options = Object.fromEntries(
+            Array.from(select.querySelectorAll("option")).map((option) => [
+                option.value,
+                option.textContent,
+            ])
+        );
+        assert.deepEqual(options, {
+            "": "",
+            display_name: "Display Name = First record",
+            foo: "Foo = 121212121212121212121212121212121212121212121212121212121...",
+        });
+
+        select.value = "foo";
+        select.dispatchEvent(new Event("change"));
+        await nextTick();
+        await click(target.querySelectorAll(".modal .modal-footer button")[1]);
+        assert.verifySteps(["setting default"]);
+    });
 });


### PR DESCRIPTION
Steps to reproduce
==================

- Install account_accountant
- Enable the debug mode
- Copy a very long text in the "Terms and Conditions" section
- Click on debug > Set Defaults
- Click on the Default selection

=> Chrome crashes

Depending on the window manager/OS, a weird Chrome window can appear spanning across multiple displays. Or Chrome can simply crash.

Cause of the issue
==================

The text value inside the select option is too long for Chrome to handle.

Solution
========

We can truncate the displayed text.

opw-4572496