### PR TITLE
[FIX] mail: discuss sidebar IM status no cut on Firefox

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -56,6 +56,11 @@ $o-discuss-talkingColor: lighten($success, 10%);
     gap: map-get($spacers, 1) / 2;
 }
 
+.o-my-0_5 {
+    margin-top: map-get($spacers, 1) / 2;
+    margin-bottom: map-get($spacers, 1) / 2;
+}
+
 .o-py-0_5 {
     padding-top: map-get($spacers, 1) / 2;
     padding-bottom: map-get($spacers, 1) / 2;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -155,7 +155,7 @@
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
-                <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:32px;height:32px;margin-top:1px;margin-bottom:1px" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
+                <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5" style="width:32px;height:32px;" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/201984

PR above made a few style improvements in discuss sidebar, such as increasing the size of avatars and IM status to match the channel member list.

Since the avatars are bigger and therefore are close to border, there's a 1px vertical margin to prevent cutting IM status. However this works in chromium-based browsers but not Firefox: the position of IM status is slightly off by 1 pixel vertically for some reasons, which makes the IM status cut slightly on the bottom.

This commit fixes the issue by increasing vertical margin from 1px to 2px. This increases a bit the size of each item as a result, but thankfully it's minor drawback compared to cut IM status on Firefox.

Before / After
![Screenshot 2025-03-18 at 14 43 54](https://github.com/user-attachments/assets/997d7858-fa53-45d8-8e40-5c14b9e43788) ![Screenshot 2025-03-18 at 14 43 37](https://github.com/user-attachments/assets/3cf6df08-ab7f-4a75-b46e-7ad6b9b9e2d9)
