### PR TITLE
[FIX] im_livechat: duplicated chat hub on website

### DIFF
--- a/addons/im_livechat/static/src/embed/frontend/boot_service.js
+++ b/addons/im_livechat/static/src/embed/frontend/boot_service.js
@@ -7,8 +7,6 @@ import { getTemplate } from "@web/core/templates";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 
-registry.category("main_components").remove("mail.ChatHub");
-
 export const livechatBootService = {
     dependencies: ["mail.store"],
 

--- a/addons/im_livechat/static/src/embed/frontend/chat_hub_service_patch.js
+++ b/addons/im_livechat/static/src/embed/frontend/chat_hub_service_patch.js
@@ -1,0 +1,8 @@
+import { chatHubService } from "@mail/core/common/chat_hub";
+import { patch } from "@web/core/utils/patch";
+
+patch(chatHubService, {
+    // When LiveChat is active, chat hub is added to the live chat root
+    // component, see: livechat_root.js, boot_service.js.
+    start() {},
+});


### PR DESCRIPTION
The live chat module the chat hub inside its shadow root. Do avoid duplicate, it used to remove the chat hub from the main components inside `boot_service.js` file. However, since [1], chat hub is added by a service. As a result, the code that used to removed the chat hub is executed too early resulting in two chat hubs being displayed.

This PR fixes the issue by patching the service responsible for adding the chat hub to the main components registry.

[1]: https://github.com/odoo/odoo/pull/201771