### PR TITLE
[FIX] account: display correct placeholder name on invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -913,7 +913,7 @@ class AccountMove(models.Model):
     def _compute_name_placeholder(self):
         for move in self:
             if (not move.name or move.name == '/') and not move._get_last_sequence():
-                sequence_format_string, sequence_format_values = move._get_sequence_format_param(move._get_starting_sequence())
+                sequence_format_string, sequence_format_values = move._get_next_sequence_format()
                 sequence_format_values['seq'] = sequence_format_values['seq'] + 1
                 move.name_placeholder = sequence_format_string.format(**sequence_format_values)
             else:

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -234,6 +234,15 @@ class TestSequenceMixin(TestSequenceMixinCommon):
             self.assertMoveName(new_multiple_move_1, 'AJ/15-16/01/0001')
             move_form.date = fields.Date.to_date('2016-01-10')
 
+    def test_sequence_draft_change_date_with_new_sequence(self):
+        invoice_1 = self.test_move.copy({'date': '2016-02-01', 'journal_id': self.company_data['default_journal_sale'].id})
+        invoice_2 = invoice_1.copy({'date': '2016-02-02'})
+
+        self.assertMoveName(invoice_2, 'INV/15-16/0001')
+        invoice_1.name = 'INV/15-16/02/001'
+        invoice_2.date = '2016-03-01'
+        self.assertMoveName(invoice_2, 'INV/15-16/03/001')
+
     def test_sequence_draft_first_of_period(self):
         """
         | Step | Move | Action      | Date       | Name           |


### PR DESCRIPTION
### Steps to reproduce:
- Accounting > Customers > Invoices
- Select all
- Actions > Resequence
- Add a month in the sequence: INV/2025/03/001
- Create a new invoice and select a date in a future month
- The name in the placeholder does not respect the new sequencing format

### Cause:
`_compute_name_placeholder` uses `_get_starting_sequence` which always return the same format for invoices.

### Solution:
Change `_compute_name_placeholder`, mimicking the way the sequence number is computed in `_set_next_sequence`.

opw-4612328