### PR TITLE
[FIX] mail: correct position of chat bubble counter and IM status

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -65,7 +65,7 @@
 .o-mail-ChatBubble-counter {
     z-index: 7;
     top: -3px;
-    right: 8px;
+    right: -2px;
     display: inline-flex;
 }
 
@@ -92,7 +92,7 @@
 .o-mail-ChatBubble-status {
     z-index: 6;
     bottom: -2px;
-    right: 2px;
+    right: -3px;
     background-color: transparent;
 }
 


### PR DESCRIPTION
Follow-up of #201984

PR above made many style improvements, one of which was the chat bubble message preview that is closer to chat bubble. The solution of PR required reducing horizontal size of chat bubbles, therefore floating elements like counter and im_status need to be compensated.

This was done correctly for close, but IM status and counter were wrong. They should be offset by 5px, which was missing on IM status. On counter, the compensated value was done in the wrong direction... Hence the double correction.

Before / After
![Screenshot 2025-03-18 at 15 09 34](https://github.com/user-attachments/assets/c501d8a4-6683-4f8b-8932-369282bdd3b4) ![Screenshot 2025-03-18 at 15 09 15](https://github.com/user-attachments/assets/b4839728-6864-4b10-847c-e55c86dbb370)
