### PR TITLE
[FIX] account: editable delivery_date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -309,8 +309,7 @@ class AccountMove(models.Model):
     delivery_date = fields.Date(
         string='Delivery Date',
         copy=False,
-        store=True,
-        compute='_compute_delivery_date',
+        compute='_compute_delivery_date', store=True, readonly=False,
     )
     show_delivery_date = fields.Boolean(compute='_compute_show_delivery_date')
     invoice_payment_term_id = fields.Many2one(


### PR DESCRIPTION
With `l10n_cz` and `sale_stock` installed:
* create a SO with a deliverable line
* confirm
* validate the delivery for the SO
* create the invoice for the SO
* set the payment term for Immediate Payment
* update the delivery date and the taxable supply date to different values

Issue: the delivery date is recomputed even though we just set it.

opw-4462810
