### PR TITLE
[FIX] account_payment: prevent crash test community

### DIFF
--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -288,7 +288,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 90.0,
                 'payment_amount_total': 100.0,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_eligible._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 90.0,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 90.0, 'account_type': 'asset_current'},
@@ -317,7 +317,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 100.0,
                 'payment_amount_total': 100.0,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_ineligible._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 100.0,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 100.0, 'account_type': 'asset_current'},
@@ -354,7 +354,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 103.5,
                 'payment_amount_total': 115.0,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_eligible_with_tax._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 103.5,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 103.5, 'account_type': 'asset_current'},
@@ -398,7 +398,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 113.5,
                 'payment_amount_total': 113.5,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_ineligible_with_mixed_and_tax._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 113.5,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 113.5, 'account_type': 'asset_current'},
@@ -441,7 +441,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 105.0,
                 'payment_amount_total': 115.0,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_eligible_with_excluded_and_tax._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 105.0,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 105.0, 'account_type': 'asset_current'},
@@ -478,7 +478,7 @@ class TestAccountPayment(AccountPaymentCommon):
             expected_values={
                 'payment_amount': 90,
                 'payment_amount_total': 100,
-                'invoice_payment_state': 'in_payment',
+                'invoice_payment_state': invoice_eligible_with_foreign_currency._get_invoice_in_payment_state(),
                 'invoice_amount_paid': 90,
                 'payment_line_ids': [
                     {'credit': 0.0, 'debit': 45.0, 'account_type': 'asset_current'},


### PR DESCRIPTION
Steps to reproduce:
- install account_payment
- run tests, e.g., `test_eligible_invoice_foreign_currency`

Issue:
It crashes

Cause:
If you don't have account_accountant the state of your payment will not be the same (see comments in the definition methods below) https://github.com/odoo/odoo/blob/18eb9cab4577fc9443a80eb78f485bcb81187d82/addons/account/models/account_move.py#L5023-L5027 https://github.com/odoo/enterprise/blob/a71c38fa6325cd18c686352d8f68d350461d37d0/account_accountant/models/account_move.py#L61-L63

runbot- 145227