### PR TITLE
[FIX] base: Properly apply `base.group_no_one` in List Views.

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1074,6 +1074,7 @@ actual arch.
             debug = node.attrib.pop('__debug__') == 'True'
             if debug != is_debug:
                 node.attrib['invisible'] = '1'
+                node.attrib['column_invisible'] = '1'
         return tree
 
     def _postprocess_view(self, node, model_name, editable=True, node_info=None, **options):


### PR DESCRIPTION
With a18d471652653e1dbfab5f30d2622641dd990192, the way debug mode (a.k.a `base.group_no_one`) is processed has changed.
It now  makes the field invisible when `group_no_one` is in the node, but this would still make the column itself visible in ListViews.

So we need to set the `column_invisible` attribute to true in addition to `invisible` to cover this case.
