### PR TITLE
[REV] *: issues date revert

### DIFF
--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -242,7 +242,6 @@ class AccountMoveSend(models.TransientModel):
                 xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
                 xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
                 <cbc:ID>{escape(filename)}</cbc:ID>
-                <cbc:IssueDate>{invoice.invoice_date}</cbc:IssueDate>
                 {doc_type_node}
                 <cac:Attachment>
                     <cbc:EmbeddedDocumentBinaryObject

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_refund.xml
@@ -13,7 +13,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case1.xml
@@ -17,7 +17,6 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
         </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case2.xml
@@ -17,7 +17,6 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
         </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case3.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case3.xml
@@ -17,7 +17,6 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
         </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case4.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case4.xml
@@ -17,7 +17,6 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
         </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_export_with_changed_taxes.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_export_with_changed_taxes.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_negative_unit_price.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_negative_unit_price.xml
@@ -17,7 +17,6 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_1.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_2.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_quantity_and_or_unit_price_zero.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_quantity_and_or_unit_price_zero.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_rounding.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_rounding.xml
@@ -17,7 +17,6 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_tax_exempt.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_tax_exempt.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
@@ -13,7 +13,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
@@ -17,7 +17,6 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_discount.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_discount.xml
@@ -14,7 +14,6 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cac:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_ecotax.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_ecotax.xml
@@ -17,7 +17,6 @@
     </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:IssueDate>___ignore___</cbc:IssueDate>
         <cbc:Attachment>
             <cbc:EmbeddedDocumentBinaryObject mimeCode="___ignore___" filename="___ignore___">
                 ___ignore___

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
    </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
@@ -18,7 +18,6 @@
   </cac:BillingReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
    </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice_without_vat.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice_without_vat.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
    </cbc:Attachment>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
@@ -13,7 +13,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:Attachment>
       <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
    </cbc:Attachment>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
@@ -15,7 +15,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">380</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
@@ -15,7 +15,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">380</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
@@ -15,7 +15,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">380</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
     <cbc:ID>RINV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">381</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="RINV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
     <cbc:ID>RINV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">381</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="RINV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
@@ -15,7 +15,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
@@ -15,7 +15,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
@@ -15,7 +15,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>INV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
     </cac:Attachment>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
@@ -14,7 +14,6 @@
   </cac:OrderReference>
   <cac:AdditionalDocumentReference xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
     <cbc:ID>RINV_2017_00001.pdf</cbc:ID>
-    <cbc:IssueDate>___ignore___</cbc:IssueDate>
     <cbc:DocumentTypeCode>50</cbc:DocumentTypeCode>
     <cac:Attachment>
       <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="RINV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>


### PR DESCRIPTION
In this commit: https://github.com/odoo/odoo/pull/192733/commits/ca9c9b319a7b653f7e17a7de1789081694bbd9d7 We introduced the issues data in the additional document reference. That broke that rule https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/UBL-CR-112/

no task id




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
