### PR TITLE
[PERF] stock: optimize _compute_rules

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -121,23 +121,16 @@ class StockWarehouseOrderpoint(models.Model):
     @api.depends('route_id', 'product_id', 'location_id', 'company_id', 'warehouse_id', 'product_id.route_ids')
     def _compute_rules(self):
         orderpoints_to_compute = self.filtered(lambda orderpoint: orderpoint.product_id and orderpoint.location_id)
-        # Products without routes have no impact on _get_rules_from_location.
-        product_ids_with_routes = set(orderpoints_to_compute.product_id.filter_has_routes().ids)
-        # Small cache mapping (location_id, route_id) -> stock.rule.
-        # This reduces calls to _get_rules_from_location for products without routes.
+        # Small cache mapping (location_id, route_id, product_id.route_ids | product_id.categ_id.total_route_ids) -> stock.rule.
+        # This reduces calls to _get_rules_from_location for products without routes and products with the same routes.
         rules_cache = {}
         for orderpoint in orderpoints_to_compute:
-            if orderpoint.product_id.id not in product_ids_with_routes:
-                cache_key = (orderpoint.location_id, orderpoint.route_id)
-                rule_ids = rules_cache.get(cache_key) or orderpoint.product_id._get_rules_from_location(
-                    orderpoint.location_id, route_ids=orderpoint.route_id
-                )
-                orderpoint.rule_ids = rule_ids
-                rules_cache[cache_key] = rule_ids
-            else:
-                orderpoint.rule_ids = orderpoint.product_id._get_rules_from_location(
-                    orderpoint.location_id, route_ids=orderpoint.route_id
-                )
+            cache_key = (orderpoint.location_id, orderpoint.route_id, orderpoint.product_id.route_ids | orderpoint.product_id.categ_id.total_route_ids)
+            rule_ids = rules_cache.get(cache_key) or orderpoint.product_id._get_rules_from_location(
+                orderpoint.location_id, route_ids=orderpoint.route_id
+            )
+            orderpoint.rule_ids = rule_ids
+            rules_cache[cache_key] = rule_ids
         (self - orderpoints_to_compute).rule_ids = False
 
     @api.depends('route_id', 'product_id')


### PR DESCRIPTION
Originally, we compute rules for stock orderpoints based on product_id through `product_id._get_rules_from_location`, however, this function only relies on `product_id.route_ids` or
`product_id.categ_id.total_route_ids` which usually don't change a lot per product.

This PR leverages this idea that we can simply extend the caching key to include the routes_ids and categ_id.total_route_ids of products so we don't have to calculate the same value twice. For products without route_ids, it simply falls back to the original cache key.

Benchmarks

|Num. orderpoints| Before PR | After PR |
|---------------------|---------------|--------------|
|5636| 56.2  s| 39.5 s|

opw-4649249


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
