### PR TITLE
[IMP] mail: replace useMessageEdition hook by JS model

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -131,7 +131,7 @@
                     </div>
                 </div>
                 <SearchMessageResult t-if="messageSearch.searching or messageSearch.searched" thread="state.thread"  messageSearch="messageSearch" onClickJump.bind="closeSearch"/>
-                <Thread t-else="" messageEdition="messageEdition" thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>
+                <Thread t-else="" thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>
             </t>
         </div>
     </div>

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -1,6 +1,5 @@
 import { Composer } from "@mail/core/common/composer";
 import { Thread } from "@mail/core/common/thread";
-import { useMessageEdition } from "@mail/utils/common/hooks";
 
 import {
     Component,
@@ -35,7 +34,6 @@ export class Chatter extends Component {
         });
         this.rootRef = useRef("root");
         this.onScrollDebounced = useThrottleForAnimation(this.onScroll);
-        this.messageEdition = useMessageEdition();
         useChildSubEnv(this.childSubEnv);
 
         onMounted(this._onMounted);

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -5,7 +5,7 @@ import { AutoresizeInput } from "@mail/core/common/autoresize_input";
 import { CountryFlag } from "@mail/core/common/country_flag";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
-import { useHover, useMessageEdition, useMessageHighlight } from "@mail/utils/common/hooks";
+import { useHover, useMessageHighlight } from "@mail/utils/common/hooks";
 import { isEventHandled } from "@web/core/utils/misc";
 
 import { Component, toRaw, useChildSubEnv, useRef, useState } from "@odoo/owl";
@@ -42,7 +42,6 @@ export class ChatWindow extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.messageEdition = useMessageEdition();
         this.messageHighlight = useMessageHighlight();
         this.state = useState({
             actionsMenuOpened: false,

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -102,13 +102,13 @@
                     <t t-component="threadActions.activeAction.component" t-props="{ ...threadActions.activeAction.componentProps, thread }"/>
                 </div>
                 <t t-elif="thread">
-                    <Thread isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage" messageEdition="messageEdition"/>
+                    <Thread isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage"/>
                     <div t-if="thread.hasOtherMembersTyping" class="d-flex bg-inherit position-relative">
                         <div class="o-mail-ChatWindow-typing d-flex px-2 position-absolute bottom-0 start-0 w-100 bg-inherit align-items-center">
                             <Typing channel="thread" size="'medium'"/>
                         </div>
                     </div>
-                    <Composer composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
+                    <Composer composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
                 </t>
             </t>
         </div>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -46,7 +46,6 @@ const EDIT_CLICK_TYPE = {
 /**
  * @typedef {Object} Props
  * @property {import("models").Composer} composer
- * @property {import("@mail/utils/common/hooks").MessageEdition} [messageEdition]
  * @property {'compact'|'normal'|'extended'} [mode] default: 'normal'
  * @property {'message'|'note'|false} [type] default: false
  * @property {string} [placeholder]
@@ -81,7 +80,6 @@ export class Composer extends Component {
         "mode?",
         "placeholder?",
         "dropzoneRef?",
-        "messageEdition?",
         "className?",
         "sidebar?",
         "type?",
@@ -165,9 +163,6 @@ export class Composer extends Component {
                 },
                 () => this.allowUpload
             );
-        }
-        if (this.props.messageEdition) {
-            this.props.messageEdition.composerOfThread = this;
         }
         useChildSubEnv({ inComposer: true });
         useEffect(
@@ -472,10 +467,10 @@ export class Composer extends Component {
         const composer = toRaw(this.props.composer);
         switch (ev.key) {
             case "ArrowUp":
-                if (this.props.messageEdition && composer.text === "") {
+                if (!this.env.inChatter && composer.text === "") {
                     const messageToEdit = composer.thread.lastEditableMessageOfSelf;
                     if (messageToEdit) {
-                        this.props.messageEdition.enterEditMode(messageToEdit);
+                        messageToEdit.enterEditMode(this.props.composer.thread);
                     }
                 }
                 break;

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -85,7 +85,6 @@ export class Message extends Component {
         "isInChatWindow?",
         "onParentMessageClick?",
         "message",
-        "messageEdition?",
         "previousMessage?",
         "squashed?",
         "thread?",
@@ -100,7 +99,6 @@ export class Message extends Component {
         super.setup();
         this.popover = usePopover(this.constructor.components.Popover, { position: "top" });
         this.state = useState({
-            isEditing: false,
             isHovered: false,
             isClicked: false,
             expandOptions: false,
@@ -130,12 +128,6 @@ export class Message extends Component {
             message: this.props.message,
             alignedRight: this.isAlignedRight,
         });
-        useEffect(
-            (editingMessage) => {
-                this.state.isEditing = this.props.message.eq(editingMessage);
-            },
-            () => [this.props.messageEdition?.editingMessage]
-        );
         onMounted(() => {
             if (this.shadowBody.el) {
                 this.shadowRoot = this.shadowBody.el.attachShadow({ mode: "open" });
@@ -187,11 +179,11 @@ export class Message extends Component {
         );
         useEffect(
             () => {
-                if (!this.state.isEditing) {
+                if (!this.message.composer) {
                     this.prepareMessageBody(this.messageBody.el);
                 }
             },
-            () => [this.state.isEditing, this.message.richBody]
+            () => [this.message.composer, this.message.richBody]
         );
     }
 
@@ -211,7 +203,7 @@ export class Message extends Component {
             "px-1": this.props.isInChatWindow,
             "opacity-50": this.props.thread?.composer.replyToMessage?.notEq(this.props.message),
             "o-actionMenuMobileOpen": this.state.actionMenuMobileOpen,
-            "o-editing": this.state.isEditing,
+            "o-editing": this.props.message.composer,
         };
     }
 
@@ -395,7 +387,7 @@ export class Message extends Component {
     }
 
     exitEditMode() {
-        this.props.messageEdition.exitEditMode();
+        this.message.exitEditMode(this.props.thread);
     }
 
     onClickNotification(ev) {
@@ -430,7 +422,6 @@ export class Message extends Component {
                 message: this.props.message,
                 thread: this.props.thread,
                 isFirstMessage: this.props.isFirstMessage,
-                messageEdition: this.props.messageEdition,
                 openReactionMenu: () => this.openReactionMenu(),
                 state: this.state,
             },

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -57,13 +57,13 @@
                                    'flex-row-reverse': isAlignedRight,
                                    }"
                         >
-                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
-                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
+                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': props.message.composer, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
+                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': props.message.composer }">
                                     <t t-if="message.message_type === 'notification' and message.richBody" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
-                                    <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited))">
-                                        <MessageLinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" messageLinkPreviews="message.message_link_preview_ids"/>
+                                    <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or props.message.composer or message.edited))">
+                                        <MessageLinkPreviewList t-if="!props.message.composer and message.linkPreviewSquash" messageLinkPreviews="message.message_link_preview_ids"/>
                                         <t t-else="">
-                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
+                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': props.message.composer }">
                                                 <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',
@@ -72,16 +72,16 @@
                                                 <MessageInReply t-if="message.parentMessage" message="message" onClick="props.onParentMessageClick"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.is_note,
-                                                            'fs-1': !state.isEditing and !env.inChatter and message.onlyEmojis,
+                                                            'fs-1': !props.message.composer and !env.inChatter and message.onlyEmojis,
                                                             'mb-0': !message.is_note,
-                                                            'py-2': !message.is_note and !state.isEditing,
-                                                            'pt-2 pb-1': !message.is_note and state.isEditing,
+                                                            'py-2': !message.is_note and !props.message.composer,
+                                                            'pt-2 pb-1': !message.is_note and props.message.composer,
                                                             'o-note': message.is_note,
-                                                            'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note,
-                                                            'flex-grow-1': state.isEditing,
+                                                            'align-self-start rounded-end-3 rounded-bottom-3': !props.message.composer and !message.is_note,
+                                                            'flex-grow-1': props.message.composer,
                                                             }" t-ref="body">
                                                     <i t-if="message.isEmpty" class="text-muted opacity-75" t-esc="message.inlineBody"/>
-                                                    <Composer t-elif="props.message.eq(props.messageEdition?.editingMessage)" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
+                                                    <Composer t-elif="props.message.composer" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
                                                     <t t-else="">
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
@@ -123,7 +123,7 @@
     </t>
 
 <t t-name="mail.Message.actions">
-    <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions d-print-none"
+    <div t-if="props.hasActions and message.hasActions and !props.message.composer" class="o-mail-Message-actions d-print-none"
         t-att-class="{
             'start-0': isAlignedRight,
             'mx-1': !isMobileOS,

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.js
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.js
@@ -10,7 +10,6 @@ export class MessageActionMenuMobile extends Component {
         "close?",
         "thread?",
         "isFirstMessage?",
-        "messageEdition?",
         "openReactionMenu?",
         "state",
     ];

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -100,7 +100,7 @@ messageActionsRegistry
         icon: "fa fa-pencil",
         title: _t("Edit"),
         onClick: (component) => {
-            component.props.messageEdition.enterEditMode(component.props.message);
+            component.props.message.enterEditMode(component.props.thread);
             component.optionsDropdown?.close();
         },
         sequence: (component) => (component.props.message.isSelfAuthored ? 20 : 55),

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -503,6 +503,32 @@ export class Message extends Record {
         }
     }
 
+    /** @param {import("models").Thread} thread the thread where the message is being viewed when starting edition */
+    enterEditMode(thread) {
+        const text = convertBrToLineBreak(this.body);
+        if (thread?.messageInEdition) {
+            thread.messageInEdition.composer = undefined;
+        }
+        this.composer = {
+            mentionedPartners: this.recipients,
+            text,
+            selection: {
+                start: text.length,
+                end: text.length,
+                direction: "none",
+            },
+        };
+    }
+
+    /** @param {import("models").Thread} thread the thread where the message is being viewed when stopping edition */
+    exitEditMode(thread) {
+        const threadAsInEdition = this.threadAsInEdition;
+        this.composer = undefined;
+        if (threadAsInEdition && threadAsInEdition.eq(thread)) {
+            threadAsInEdition.composer.autofocus++;
+        }
+    }
+
     async react(content) {
         this.store.insert(
             await rpc(

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -2,7 +2,7 @@ import { DateSection } from "@mail/core/common/date_section";
 import { Message } from "@mail/core/common/message";
 import { NotificationMessage } from "./notification_message";
 import { Record } from "@mail/core/common/record";
-import { useMessageEdition, useVisible } from "@mail/utils/common/hooks";
+import { useVisible } from "@mail/utils/common/hooks";
 
 import {
     Component,
@@ -33,7 +33,6 @@ const PRESENT_MESSAGE_THRESHOLD = 10;
  * @property {boolean} [isInChatWindow=false]
  * @property {number} [jumpPresent=0]
  * @property {number} [jumpToNewMessage=0]
- * @property {import("@mail/utils/common/hooks").MessageEdition} [messageEdition]
  * @property {"asc"|"desc"} [order="asc"]
  * @property {import("models").Thread} thread
  * @property {string} [searchTerm]
@@ -48,7 +47,6 @@ export class Thread extends Component {
         "jumpPresent?",
         "jumpToNewMessage?",
         "thread",
-        "messageEdition?",
         "order?",
         "scrollRef?",
         "showEmptyMessage?",
@@ -80,7 +78,6 @@ export class Thread extends Component {
             scrollTop: null,
         });
         this.lastJumpPresent = this.props.jumpPresent;
-        this.messageEdition = this.props.messageEdition ?? useMessageEdition();
         this.orm = useService("orm");
         /** @type {ReturnType<import('@mail/utils/common/hooks').useMessageHighlight>|null} */
         this.messageHighlight = this.env.messageHighlight

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -34,7 +34,6 @@
                         squashed="isSquashed(msg, prevMsg)"
                         onParentMessageClick.bind="() => msg.parentMessage and env.messageHighlight?.highlightMessage(msg.parentMessage, props.thread)"
                         thread="props.thread"
-                        messageEdition="messageEdition"
                         isFirstMessage="msg_first"
                         hasActions="props.messageActions and !msg.eq(props.thread.from_message_id)"
                         showDates="props.showDates"

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -6,7 +6,7 @@ import { Thread } from "@mail/core/common/thread";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { DiscussSidebar } from "@mail/core/public_web/discuss_sidebar";
-import { useMessageEdition, useMessageHighlight } from "@mail/utils/common/hooks";
+import { useMessageHighlight } from "@mail/utils/common/hooks";
 
 import { Component, useRef, useState, useExternalListener, useEffect, useSubEnv } from "@odoo/owl";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
@@ -39,7 +39,6 @@ export class Discuss extends Component {
         super.setup();
         this.store = useService("mail.store");
         this.messageHighlight = useMessageHighlight();
-        this.messageEdition = useMessageEdition();
         this.contentRef = useRef("content");
         this.root = useRef("root");
         this.state = useState({ jumpThreadPresent: 0 });

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -93,8 +93,8 @@
                     <t name="core-content">
                         <t t-if="thread">
                             <div class="o-mail-Discuss-threadContainer d-flex flex-column flex-grow-1">
-                                <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition"/></t>
-                                <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.is_note ? 'note' : 'message') : undefined"/>
+                                <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent"/></t>
+                                <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.is_note ? 'note' : 'message') : undefined"/>
                             </div>
                             <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-Discuss-panelContainer h-100 border-start border-secondary flex-shrink-0">
                                 <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -2,7 +2,6 @@ import {
     onMounted,
     onPatched,
     onWillUnmount,
-    toRaw,
     useComponent,
     useEffect,
     useRef,
@@ -14,7 +13,6 @@ import { Deferred } from "@web/core/utils/concurrency";
 import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 import { useService } from "@web/core/utils/hooks";
 import { monitorAudio } from "@mail/utils/common/media_monitoring";
-import { convertBrToLineBreak } from "./format";
 
 export function useLazyExternalListener(target, eventName, handler, eventParams) {
     const boundHandler = handler.bind(useComponent());
@@ -427,39 +425,6 @@ export function useSelection({ refName, model, preserveOnClickAwayPredicate = ()
             }
         },
     };
-}
-
-export function useMessageEdition() {
-    const state = useState({
-        /** @type {import('@mail/core/common/composer').Composer} */
-        composerOfThread: null,
-        /** @type {import('@mail/core/common/message_model').Message} */
-        editingMessage: null,
-        enterEditMode(message) {
-            const rawMsg = toRaw(message);
-            const text = convertBrToLineBreak(rawMsg.body);
-            rawMsg.composer = {
-                mentionedPartners: rawMsg.recipients,
-                text,
-                selection: {
-                    start: text.length,
-                    end: text.length,
-                    direction: "none",
-                },
-            };
-            state.editingMessage = message;
-        },
-        exitEditMode() {
-            if (state.editingMessage) {
-                state.editingMessage.composer = undefined;
-            }
-            state.editingMessage = null;
-            if (state.composerOfThread) {
-                state.composerOfThread.props.composer.autofocus++;
-            }
-        },
-    });
-    return state;
 }
 
 export function useSequential() {


### PR DESCRIPTION
Before this commit, message edition feature was made with a component hook.

This feature is strongly linked to discuss modeling of threads and messages. Since this affects message in thread and composers of thread, this had the drawback of making component code more complex than they should.

When code relies on JS models, simpler code is in JS models. Component hooks have the advantage of context specific to a view, but this wasn't much taken advantage with this hook. There's a small part of autofocusing the thread being viewed again, but this is actually simpler with putting this logic also in JS models.

This commit replaces `useMessageEdition()` hook by equivalent JS models logic, which makes the code short and simpler.