### PR TITLE
[FIX] point_of_sale: add missing depends to compute function

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -10,6 +10,7 @@ class AccountMove(models.Model):
     pos_order_ids = fields.One2many('pos.order', 'account_move')
     pos_payment_ids = fields.One2many('pos.payment', 'account_move_id')
 
+    @api.depends('tax_cash_basis_created_move_ids')
     def _compute_always_tax_exigible(self):
         super()._compute_always_tax_exigible()
         # The pos closing move does not create caba entries (anymore); we set the tax values directly on the closing move.


### PR DESCRIPTION
It was forgotten in commit 8f388beefca9964f26d13ea0327159e5632e09d9