### PR TITLE
[IMP] base, web, *: Share ir.filters with specific users

### DIFF
--- a/addons/account/report/account_invoice_report_view.xml
+++ b/addons/account/report/account_invoice_report_view.xml
@@ -59,35 +59,35 @@
         <field name="name">By Salespersons</field>
         <field name="model_id">account.invoice.report</field>
         <field name="domain">[]</field>
-        <field name="user_id" eval="False"/>
+        <field name="user_ids" eval="False"/>
         <field name="context">{'group_by': ['invoice_date:month', 'invoice_user_id']}</field>
     </record>
     <record id="filter_invoice_product" model="ir.filters">
         <field name="name">By Product</field>
         <field name="model_id">account.invoice.report</field>
         <field name="domain">[]</field>
-        <field name="user_id" eval="False"/>
+        <field name="user_ids" eval="False"/>
         <field name="context">{'group_by': ['invoice_date:month', 'product_id'], 'set_visible':True, 'residual_invisible':True}</field>
     </record>
     <record id="filter_invoice_product_category" model="ir.filters">
         <field name="name">By Product Category</field>
         <field name="model_id">account.invoice.report</field>
         <field name="domain">[]</field>
-        <field name="user_id" eval="False"/>
+        <field name="user_ids" eval="False"/>
         <field name="context">{'group_by': ['invoice_date:month', 'product_categ_id'], 'residual_invisible':True}</field>
     </record>
     <record id="filter_invoice_refund" model="ir.filters">
         <field name="name">By Credit Note</field>
         <field name="model_id">account.invoice.report</field>
         <field name="domain">[('move_type', '=', 'out_refund')]</field>
-        <field name="user_id" eval="False"/>
+        <field name="user_ids" eval="False"/>
         <field name="context">{'group_by': ['invoice_date:month', 'invoice_user_id']}</field>
     </record>
     <record id="filter_invoice_country" model="ir.filters">
         <field name="name">By Country</field>
         <field name="model_id">account.invoice.report</field>
         <field name="domain">[]</field>
-        <field name="user_id" eval="False"/>
+        <field name="user_ids" eval="False"/>
         <field name="context">{'group_by': ['invoice_date:month', 'country_id']}</field>
     </record>
 

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -690,21 +690,21 @@ if records:
     <record id="hr_applicant_filter_recruiter" model="ir.filters">
         <field name="name">By Recruiter</field>
         <field name="model_id">hr.applicant</field>
-        <field name="user_id" eval="False"/>
+        <field name="user_ids" eval="False"/>
         <field name="action_id" ref="hr_applicant_action_analysis"/>
         <field name="context">{'group_by': ['create_date:month', 'user_id']}</field>
     </record>
     <record id="hr_applicant_filter_job" model="ir.filters">
         <field name="name">By Job</field>
         <field name="model_id">hr.applicant</field>
-        <field name="user_id" eval="False"/>
+        <field name="user_ids" eval="False"/>
         <field name="action_id" ref="hr_applicant_action_analysis"/>
         <field name="context">{'group_by': ['create_date:month', 'job_id']}</field>
     </record>
     <record id="hr_applicant_filter_department" model="ir.filters">
         <field name="name">By Department</field>
         <field name="model_id">hr.applicant</field>
-        <field name="user_id" eval="False"/>
+        <field name="user_ids" eval="False"/>
         <field name="action_id" ref="hr_applicant_action_analysis"/>
         <field name="context">{'group_by': ['create_date:month', 'department_id']}</field>
     </record>

--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -76,7 +76,7 @@
         <record id="filter_orders_per_session" model="ir.filters">
             <field name="name">Per session</field>
             <field name="model_id">report.pos.order</field>
-            <field name="user_id" eval="False"/>
+            <field name="user_ids" eval="False"/>
             <field name="context">{'group_by': ['date', 'session_id']}</field>
         </record>
 

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -212,7 +212,6 @@
 
             ('include', 'portal.assets_chatter_helpers'),
             'portal/static/src/chatter/core/**/*',
-            'project/static/src/project_sharing/search/favorite_menu/custom_favorite_item.xml',
             'project/static/src/project_sharing/**/*',
             'web/static/src/start.js',
         ],

--- a/addons/project/static/src/project_sharing/search/favorite_menu/custom_favorite_item.xml
+++ b/addons/project/static/src/project_sharing/search/favorite_menu/custom_favorite_item.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<templates xml:space="preserve">
-
-    <t t-inherit="web.CustomFavoriteItem" t-inherit-mode="extension">
-        <xpath expr="//CheckBox[@value='state.isShared']" position="replace"/>
-    </t>
-
-</templates>

--- a/addons/stock_account/report/account_invoice_report_view.xml
+++ b/addons/stock_account/report/account_invoice_report_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Inventory Valuation</field>
         <field name="model_id">account.invoice.report</field>
         <field name="domain">[('product_id.is_storable', '=', True)]</field>
-        <field name="user_id" eval="False"/>
+        <field name="user_ids" eval="False"/>
         <field name="context">{'group_by': ['product_id'], 'pivot_column_groupby': ['invoice_date:month'], 'pivot_measures': ['inventory_value'], 'graph_measure': 'inventory_value'}</field>
     </record>
 </odoo>

--- a/addons/web/static/src/search/custom_favorite_item/custom_favorite_item.xml
+++ b/addons/web/static/src/search/custom_favorite_item/custom_favorite_item.xml
@@ -3,23 +3,23 @@
 
     <t t-name="web.CustomFavoriteItem">
         <AccordionItem class="'o_add_favorite text-truncate'" description.translate="Save current search">
-            <div class="px-3 py-2">
+            <div class="px-3 py-1">
                 <input type="text"
-                    class="o_input"
+                    class="o_input my-1"
                     t-ref="description"
                     t-model.trim="state.description"
                     t-on-keydown="onInputKeydown"
                     />
-                <CheckBox value="state.isDefault" onChange.bind="onDefaultCheckboxChange">
+                <CheckBox value="state.isDefault" onChange.bind="(checked) => this.state.isDefault = checked">
                     <span data-tooltip="Use this filter by default when opening this view">Default filter</span>
                 </CheckBox>
-                <CheckBox value="state.isShared" onChange.bind="onShareCheckboxChange">
-                    <span data-tooltip="Make this filter available to other users">Shared</span>
-                </CheckBox>
             </div>
-            <div class="px-3 py-2">
+            <div class="px-3 pb-2 d-flex gap-2">
                 <button class="o_save_favorite btn btn-primary w-100" t-on-click="saveFavorite">
                     Save
+                </button>
+                <button class="o_edit_favorite btn btn-secondary w-100" t-on-click="editFavorite">
+                    Edit
                 </button>
             </div>
         </AccordionItem>

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
@@ -126,13 +126,13 @@ export class SearchBarMenu extends Component {
 
     get favorites() {
         return this.env.searchModel.getSearchItems(
-            (searchItem) => searchItem.type === "favorite" && searchItem.userId !== false
+            (searchItem) => searchItem.type === "favorite" && searchItem.userIds.length === 1
         );
     }
 
     get sharedFavorites() {
         const sharedFavorites = this.env.searchModel.getSearchItems(
-            (searchItem) => searchItem.type === "favorite" && searchItem.userId === false
+            (searchItem) => searchItem.type === "favorite" && searchItem.userIds.length !== 1
         );
         if (sharedFavorites.length <= 4 || this.state.sharedFavoritesExpanded) {
             this.state.sharedFavoritesExpanded = true;

--- a/addons/web/static/tests/_framework/search_test_helpers.js
+++ b/addons/web/static/tests/_framework/search_test_helpers.js
@@ -239,7 +239,12 @@ export async function editFavoriteName(name) {
 
 export async function saveFavorite() {
     await ensureSearchBarMenu();
-    await contains(`.o_favorite_menu .o_add_favorite + .o_accordion_values button`).click();
+    await contains(`.o_favorite_menu .o_save_favorite`).click();
+}
+
+export async function saveAndEditFavorite() {
+    await ensureSearchBarMenu();
+    await contains(`.o_favorite_menu .o_edit_favorite`).click();
 }
 
 //-----------------------------------------------------------------------------

--- a/addons/web/static/tests/search/custom_favorite_item.test.js
+++ b/addons/web/static/tests/search/custom_favorite_item.test.js
@@ -1,8 +1,6 @@
 import { after, expect, test } from "@odoo/hoot";
-import { press, queryAllTexts } from "@odoo/hoot-dom";
 import { Component, xml } from "@odoo/owl";
 import {
-    contains,
     defineModels,
     editFavoriteName,
     editSearch,
@@ -13,14 +11,15 @@ import {
     mountWithSearch,
     onRpc,
     saveFavorite,
+    saveAndEditFavorite,
     toggleSaveFavorite,
     toggleSearchBarMenu,
     validateSearch,
 } from "@web/../tests/web_test_helpers";
 
+import { useSetupAction } from "@web/search/action_hook";
 import { SearchBar } from "@web/search/search_bar/search_bar";
 import { SearchBarMenu } from "@web/search/search_bar_menu/search_bar_menu";
-import { useSetupAction } from "@web/search/action_hook";
 
 class Foo extends models.Model {
     bar = fields.Many2one({ relation: "partner" });
@@ -54,40 +53,8 @@ test("simple rendering", async () => {
     await toggleSearchBarMenu();
     await toggleSaveFavorite();
     expect(`.o_add_favorite + .o_accordion_values input[type="text"]`).toHaveValue("Action Name");
-    expect(`.o_add_favorite + .o_accordion_values input[type="checkbox"]`).toHaveCount(2);
-    expect(queryAllTexts(`.o_add_favorite + .o_accordion_values .form-check label`)).toEqual([
-        "Default filter",
-        "Shared",
-    ]);
-});
-
-test("favorites use by default and share are exclusive", async () => {
-    await mountWithSearch(SearchBar, {
-        resModel: "foo",
-        searchMenuTypes: ["favorite"],
-        searchViewId: false,
-    });
-
-    await toggleSearchBarMenu();
-    await toggleSaveFavorite();
-    expect(`input[type="checkbox"]`).toHaveCount(2);
-    expect(`input[type="checkbox"]:checked`).toHaveCount(0);
-
-    await contains(`input[type="checkbox"]:eq(0)`).check();
-    expect(`input[type="checkbox"]:eq(0)`).toBeChecked();
-    expect(`input[type="checkbox"]:eq(1)`).not.toBeChecked();
-
-    await contains(`input[type="checkbox"]:eq(1)`).check();
-    expect(`input[type="checkbox"]:eq(0)`).not.toBeChecked();
-    expect(`input[type="checkbox"]:eq(1)`).toBeChecked();
-
-    await contains(`input[type="checkbox"]:eq(0)`).check();
-    expect(`input[type="checkbox"]:eq(0)`).toBeChecked();
-    expect(`input[type="checkbox"]:eq(1)`).not.toBeChecked();
-
-    await contains(`input[type="checkbox"]:eq(0)`).uncheck();
-    expect(`input[type="checkbox"]:eq(0)`).not.toBeChecked();
-    expect(`input[type="checkbox"]:eq(1)`).not.toBeChecked();
+    expect(`.o_add_favorite + .o_accordion_values input[type="checkbox"]`).toHaveCount(1);
+    expect(`.o_add_favorite + .o_accordion_values .form-check label`).toHaveText("Default filter");
 });
 
 test("save filter", async () => {
@@ -97,13 +64,11 @@ test("save filter", async () => {
         static props = ["*"];
         setup() {
             useSetupAction({
-                getContext: () => {
-                    return { someKey: "foo" };
-                },
+                getContext: () => ({ someKey: "foo" }),
             });
         }
     }
-    onRpc("create_or_replace", ({ args, route }) => {
+    onRpc("create_filter", ({ args, route }) => {
         expect.step(route);
         const irFilter = args[0];
         expect(irFilter.context).toEqual({ group_by: [], someKey: "foo" });
@@ -124,11 +89,64 @@ test("save filter", async () => {
     await toggleSaveFavorite();
     await editFavoriteName("aaa");
     await saveFavorite();
-    expect.verifySteps(["/web/dataset/call_kw/ir.filters/create_or_replace", "CLEAR-CACHES"]);
+    expect.verifySteps(["/web/dataset/call_kw/ir.filters/create_filter", "CLEAR-CACHES"]);
+});
+
+test("save and edit filter", async () => {
+    class TestComponent extends Component {
+        static components = { SearchBarMenu };
+        static template = xml`<div><SearchBarMenu/></div>`;
+        static props = ["*"];
+        setup() {
+            useSetupAction({
+                getContext: () => ({ someKey: "foo" }),
+            });
+        }
+    }
+    onRpc("create_filter", ({ args, route }) => {
+        expect.step(route);
+        const irFilter = args[0];
+        expect(irFilter.context).toEqual({ group_by: [], someKey: "foo" });
+        return [7]; // fake serverSideId
+    });
+    mockService("action", {
+        doAction(action) {
+            expect(action).toEqual({
+                context: {
+                    form_view_ref: "base.ir_filters_view_edit_form",
+                },
+                res_id: 7,
+                res_model: "ir.filters",
+                type: "ir.actions.act_window",
+                views: [[false, "form"]],
+            });
+            expect.step("Edit favorite");
+        },
+    });
+
+    const component = await mountWithSearch(TestComponent, {
+        resModel: "foo",
+        context: { someOtherKey: "bar" }, // should not end up in filter's context
+        searchViewId: false,
+    });
+    const clearCacheListener = () => expect.step("CLEAR-CACHES");
+    component.env.bus.addEventListener("CLEAR-CACHES", clearCacheListener);
+    after(() => component.env.bus.removeEventListener("CLEAR-CACHES", clearCacheListener));
+    expect.verifySteps([]);
+
+    await toggleSearchBarMenu();
+    await toggleSaveFavorite();
+    await editFavoriteName("aaa");
+    await saveAndEditFavorite();
+    expect.verifySteps([
+        "/web/dataset/call_kw/ir.filters/create_filter",
+        "CLEAR-CACHES",
+        "Edit favorite",
+    ]);
 });
 
 test("dynamic filters are saved dynamic", async () => {
-    onRpc("create_or_replace", ({ args, route }) => {
+    onRpc("create_filter", ({ args, route }) => {
         expect.step(route);
         const irFilter = args[0];
         expect(irFilter.domain).toBe(
@@ -155,11 +173,11 @@ test("dynamic filters are saved dynamic", async () => {
     await editFavoriteName("My favorite");
     await saveFavorite();
     expect(getFacetTexts()).toEqual(["My favorite"]);
-    expect.verifySteps(["/web/dataset/call_kw/ir.filters/create_or_replace"]);
+    expect.verifySteps(["/web/dataset/call_kw/ir.filters/create_filter"]);
 });
 
 test("save filters created via autocompletion works", async () => {
-    onRpc("create_or_replace", ({ args, route }) => {
+    onRpc("create_filter", ({ args, route }) => {
         expect.step(route);
         const irFilter = args[0];
         expect(irFilter.domain).toBe(`[("foo", "ilike", "a")]`);
@@ -183,69 +201,7 @@ test("save filters created via autocompletion works", async () => {
     await editFavoriteName("My favorite");
     await saveFavorite();
     expect(getFacetTexts()).toEqual(["My favorite"]);
-    expect.verifySteps(["/web/dataset/call_kw/ir.filters/create_or_replace"]);
-});
-
-test("favorites have unique descriptions (the submenus of the favorite menu are correctly updated)", async () => {
-    mockService("notification", {
-        add(message, options) {
-            expect.step("notification");
-            expect(message).toBe("A filter with same name already exists.");
-            expect(options).toEqual({ type: "danger" });
-        },
-    });
-
-    onRpc("create_or_replace", ({ args, route }) => {
-        expect.step(route);
-        expect(args[0]).toEqual({
-            action_id: false,
-            context: { group_by: [] },
-            domain: `[]`,
-            is_default: false,
-            model_id: "foo",
-            name: "My favorite 2",
-            sort: `[]`,
-            embedded_action_id: false,
-            embedded_parent_res_id: false,
-            user_id: 7,
-        });
-        return [2]; // fake serverSideId
-    });
-
-    await mountWithSearch(SearchBar, {
-        resModel: "foo",
-        searchMenuTypes: ["favorite"],
-        searchViewId: false,
-        irFilters: [
-            {
-                context: "{}",
-                domain: "[]",
-                id: 1,
-                is_default: false,
-                name: "My favorite",
-                sort: "[]",
-                user_id: [2, "Mitchell Admin"],
-            },
-        ],
-    });
-
-    await toggleSearchBarMenu();
-    await toggleSaveFavorite();
-
-    // first try: should fail
-    await editFavoriteName("My favorite");
-    await saveFavorite();
-    expect.verifySteps(["notification"]);
-
-    // second try: should succeed
-    await editFavoriteName("My favorite 2");
-    await saveFavorite();
-    expect.verifySteps(["/web/dataset/call_kw/ir.filters/create_or_replace"]);
-
-    // third try: should fail
-    await editFavoriteName("My favorite 2");
-    await saveFavorite();
-    expect.verifySteps(["notification"]);
+    expect.verifySteps(["/web/dataset/call_kw/ir.filters/create_filter"]);
 });
 
 test("undefined name for filter shows notification and not error", async () => {
@@ -257,7 +213,7 @@ test("undefined name for filter shows notification and not error", async () => {
         },
     });
 
-    onRpc("create_or_replace", () => [7]); // fake serverSideId
+    onRpc("create_filter", () => [7]); // fake serverSideId
 
     await mountWithSearch(SearchBarMenu, {
         resModel: "foo",
@@ -267,37 +223,5 @@ test("undefined name for filter shows notification and not error", async () => {
     await toggleSearchBarMenu();
     await toggleSaveFavorite();
     await saveFavorite();
-    expect.verifySteps(["notification"]);
-});
-
-test("add favorite with enter which already exists", async () => {
-    mockService("notification", {
-        add(message, options) {
-            expect.step("notification");
-            expect(message).toBe("A name for your favorite filter is required.");
-            expect(options).toEqual({ type: "danger" });
-        },
-    });
-    await mountWithSearch(SearchBarMenu, {
-        resModel: "foo",
-        searchViewId: false,
-        irFilters: [
-            {
-                context: "{}",
-                domain: "[]",
-                id: 1,
-                is_default: false,
-                name: "My favorite",
-                sort: "[]",
-                user_id: [2, "Mitchell Admin"],
-            },
-        ],
-    });
-
-    await toggleSearchBarMenu();
-    await toggleSaveFavorite();
-    await editFavoriteName("My favorite");
-    await press("Enter");
-
     expect.verifySteps(["notification"]);
 });

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1317,7 +1317,7 @@ test("edit a favorite", async () => {
             is_default: true,
             name: "My favorite",
             sort: "[]",
-            user_id: [2, "Mitchell Admin"],
+            user_ids: [2],
         },
     ];
 

--- a/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
@@ -79,7 +79,7 @@ test("edit an active favorite", async () => {
             is_default: true,
             name: "My favorite",
             sort: "[]",
-            user_id: [2, "Mitchell Admin"],
+            user_ids: [2],
         },
     ];
     mockService("action", {
@@ -130,7 +130,7 @@ test("default favorite is not activated if activateFavorite is set to false", as
                 is_default: true,
                 name: "My favorite",
                 sort: "[]",
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
             },
         ],
         activateFavorite: false,
@@ -156,7 +156,7 @@ test(`toggle favorite correctly clears filter, groupbys and field "options"`, as
                 is_default: false,
                 name: "My favorite",
                 sort: "[]",
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
             },
         ],
         searchViewArch: `
@@ -209,7 +209,7 @@ test("edit a favorite with a groupby", async () => {
             is_default: true,
             name: "My favorite",
             sort: "[]",
-            user_id: [2, "Mitchell Admin"],
+            user_ids: [2],
         },
     ];
 
@@ -248,6 +248,7 @@ test("shared favorites are partially shown if there is more than 4", async () =>
             is_default: false,
             name: "My favorite" + i,
             sort: "[]",
+            user_ids: [],
         });
     }
     await mountWithSearch(SearchBarMenu, {

--- a/addons/web/static/tests/search/search_model.test.js
+++ b/addons/web/static/tests/search/search_model.test.js
@@ -233,7 +233,7 @@ test("parsing date filter with start_month, end_month, start_year, end_year attr
     const model = await createSearchModel({
         searchViewArch: `
             <search>
-                <filter 
+                <filter
                     name="date_filter"
                     string="Date"
                     date="date_field"
@@ -702,7 +702,7 @@ test("process favorite filters", async () => {
     const model = await createSearchModel({
         irFilters: [
             {
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
                 name: "Sorted filter",
                 id: 5,
                 context: `{"group_by":["foo","bar"]}`,
@@ -733,7 +733,7 @@ test("process favorite filters", async () => {
             removable: true,
             serverSideId: 5,
             type: "favorite",
-            userId: 2,
+            userIds: [2],
         },
     ]);
 });

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -1317,7 +1317,7 @@ test("save params succeeds", async () => {
     ];
 
     let serverId = 1;
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].context).toEqual(expectedContexts.shift());
         return [serverId++];
     });
@@ -2548,7 +2548,7 @@ test("graph_groupbys should be also used after first load", async () => {
         groupBy: ["date:quarter"],
         irFilters: [
             {
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
                 name: "Favorite",
                 id: 1,
                 context: JSON.stringify({
@@ -2714,7 +2714,7 @@ test("missing property field definition is fetched", async function () {
         arch: `<graph/>`,
         irFilters: [
             {
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
                 name: "My Filter",
                 id: 5,
                 context: `{"group_by": ['properties.my_char']}`,
@@ -2775,7 +2775,7 @@ test("missing deleted property field definition is created", async function () {
         arch: `<graph/>`,
         irFilters: [
             {
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
                 name: "My Filter",
                 id: 5,
                 context: `{"group_by": ['properties.my_char']}`,

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2867,7 +2867,7 @@ test(`change a record field in readonly should change same record in other group
 });
 
 test(`ordered target, sort attribute in context`, async () => {
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         const favorite = args[0];
         expect.step(favorite.sort);
         return [7];
@@ -2901,7 +2901,7 @@ test(`Loading a filter with a sort attribute`, async () => {
             is_default: true,
             name: "My favorite",
             sort: '["date asc", "foo desc"]',
-            user_id: [2, "Mitchell Admin"],
+            user_ids: [2],
         },
         {
             context: "{}",
@@ -2910,7 +2910,7 @@ test(`Loading a filter with a sort attribute`, async () => {
             is_default: false,
             name: "My second favorite",
             sort: '["date desc", "foo asc"]',
-            user_id: [2, "Mitchell Admin"],
+            user_ids: [2],
         },
     ];
 
@@ -12338,7 +12338,7 @@ test(`grouped list with groups_limit attribute, then ungroup`, async () => {
                 is_default: true,
                 name: "GroupBy IntField",
                 sort: "[]",
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
             },
         ],
     });
@@ -16916,7 +16916,7 @@ test(`reload properties definitions when domain change`, async () => {
                 id: 7,
                 name: "only one",
                 sort: "[]",
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
             },
         ],
     });

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -1357,7 +1357,7 @@ test("correctly save measures and groupbys to favorite", async () => {
     expect.assertions(3);
 
     let expectedContext;
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].context).toEqual(expectedContext);
         return true;
     });
@@ -1423,7 +1423,7 @@ test("correctly remove pivot_ keys from the context", async () => {
 
     let expectedContext;
 
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].context).toEqual(expectedContext);
         return true;
     });
@@ -1569,7 +1569,7 @@ test("Add a group by on the CP when a favorite already exists", async () => {
             is_default: true,
             name: "My favorite",
             sort: "[]",
-            user_id: [2, "Mitchell Admin"],
+            user_ids: [2],
         },
     ];
 
@@ -1605,7 +1605,7 @@ test("Adding a Favorite at anytime should modify the row/column groupby", async 
     Partner._views["search,false"] = `<search/>`;
     Partner._filters = [
         {
-            user_id: [2, "Mitchell Admin"],
+            user_ids: [2],
             name: "My favorite",
             id: 5,
             context: `{"pivot_row_groupby":["product_id"], "pivot_column_groupby": ["bar"]}`,
@@ -1741,7 +1741,7 @@ test("Reload, group by columns, reload", async () => {
 
     let expectedContext;
 
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].context).toEqual(expectedContext);
         return true;
     });
@@ -1871,7 +1871,7 @@ test("Empty results keep groupbys", async () => {
         pivot_row_groupby: [],
     };
 
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].context).toEqual(expectedContext);
         return true;
     });
@@ -2252,7 +2252,7 @@ test("Row and column groupbys plus a domain", async () => {
         pivot_row_groupby: ["product_id"],
     };
 
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].context).toEqual(expectedContext);
         return true;
     });
@@ -3264,7 +3264,7 @@ test("pivot_row_groupby should be also used after first load", async () => {
         },
     ];
 
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].context).toEqual(expectedContexts.shift());
         return [ids.shift()];
     });
@@ -3326,7 +3326,7 @@ test("pivot_row_groupby should be also used after first load (2)", async () => {
         arch: `<pivot/>`,
         irFilters: [
             {
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
                 name: "Favorite",
                 id: 1,
                 context: `
@@ -3365,7 +3365,7 @@ test("specific pivot keys in action context must have less importance than in fa
         },
         irFilters: [
             {
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
                 name: "My favorite",
                 id: 1,
                 context: `{
@@ -3380,7 +3380,7 @@ test("specific pivot keys in action context must have less importance than in fa
                 action_id: false,
             },
             {
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
                 name: "My favorite 2",
                 id: 2,
                 context: `{
@@ -3429,7 +3429,7 @@ test("favorite pivot_measures should be used even if found also in global contex
         groupable: false,
     });
 
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].context).toEqual({
             group_by: [],
             pivot_column_groupby: [],
@@ -3692,7 +3692,7 @@ test("missing property field definition is fetched", async function () {
         arch: `<pivot/>`,
         irFilters: [
             {
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
                 name: "My Filter",
                 id: 5,
                 context: `{"group_by": ['properties.my_char']}`,
@@ -3734,7 +3734,7 @@ test("missing deleted property field definition is created", async function (ass
         arch: `<pivot/>`,
         irFilters: [
             {
-                user_id: [2, "Mitchell Admin"],
+                user_ids: [2],
                 name: "My Filter",
                 id: 5,
                 context: `{"group_by": ['properties.my_char']}`,

--- a/addons/web/static/tests/views/view.test.js
+++ b/addons/web/static/tests/views/view.test.js
@@ -84,7 +84,7 @@ class Animal extends models.Model {
             is_default: true,
             name: "My favorite",
             sort: "[]",
-            user_id: [2, "Mitchell Admin"],
+            user_ids: [2],
         },
     ];
 }
@@ -533,7 +533,7 @@ test("rendering with given arch, fields, searchViewId, searchViewArch, searchVie
                     is_default: true,
                     name: "My favorite",
                     sort: "[]",
-                    user_id: [2, "Mitchell Admin"],
+                    user_ids: [2],
                 },
             ]);
         },
@@ -575,7 +575,7 @@ test("rendering with given arch, fields, searchViewId, searchViewArch, searchVie
             is_default: false,
             name: "My favorite",
             sort: "[]",
-            user_id: [2, "Mitchell Admin"],
+            user_ids: [2],
         },
     ];
     patchWithCleanup(ToyController.prototype, {

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -551,7 +551,7 @@ test("SelectCreateDialog: save current search on desktop", async () => {
     onRpc("get_views", ({ kwargs }) => {
         expect(kwargs.options.load_filters).toBe(true, { message: "Missing load_filters option" });
     });
-    onRpc("create_or_replace", ({ model, args }) => {
+    onRpc("create_filter", ({ model, args }) => {
         if (model === "ir.filters") {
             const irFilter = args[0];
             expect(irFilter.domain).toBe(`[("bar", "=", True)]`, {
@@ -612,7 +612,7 @@ test("SelectCreateDialog: save current search on mobile", async () => {
     onRpc("get_views", ({ kwargs }) => {
         expect(kwargs.options.load_filters).toBe(true, { message: "Missing load_filters option" });
     });
-    onRpc("create_or_replace", ({ model, args }) => {
+    onRpc("create_filter", ({ model, args }) => {
         if (model === "ir.filters") {
             const irFilter = args[0];
             expect(irFilter.domain).toBe(`[("bar", "=", True)]`, {

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -40,12 +40,7 @@ export {
     getDropdownMenu,
     mountWithCleanup,
 } from "./_framework/component_test_helpers";
-export {
-    contains,
-    defineStyle,
-    editAce,
-    sortableDrag,
-} from "./_framework/dom_test_helpers";
+export { contains, defineStyle, editAce, sortableDrag } from "./_framework/dom_test_helpers";
 export {
     clearRegistry,
     getMockEnv,
@@ -120,6 +115,7 @@ export {
     pagerPrevious,
     removeFacet,
     saveFavorite,
+    saveAndEditFavorite,
     selectGroup,
     switchView,
     toggleActionMenu,

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -233,15 +233,13 @@ test("can click on a embedded action and execute the corresponding action (with 
 
 test("can click on a embedded action and execute the corresponding action (with python_method)", async () => {
     await mountWithCleanup(WebClient);
-    onRpc("do_python_method", () => {
-        return {
-            id: 4,
-            name: "Favorite Ponies from python action",
-            res_model: "pony",
-            type: "ir.actions.act_window",
-            views: [[false, "kanban"]],
-        };
-    });
+    onRpc("do_python_method", () => ({
+        id: 4,
+        name: "Favorite Ponies from python action",
+        res_model: "pony",
+        type: "ir.actions.act_window",
+        views: [[false, "kanban"]],
+    }));
     await getService("action").doAction(1);
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
@@ -262,15 +260,13 @@ test("can click on a embedded action and execute the corresponding action (with 
 
 test("breadcrumbs are updated when clicking on embeddeds", async () => {
     await mountWithCleanup(WebClient);
-    onRpc("do_python_method", () => {
-        return {
-            id: 4,
-            name: "Favorite Ponies from python action",
-            res_model: "pony",
-            type: "ir.actions.act_window",
-            views: [[false, "kanban"]],
-        };
-    });
+    onRpc("do_python_method", () => ({
+        id: 4,
+        name: "Favorite Ponies from python action",
+        res_model: "pony",
+        type: "ir.actions.act_window",
+        views: [[false, "kanban"]],
+    }));
     await getService("action").doAction(1);
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
@@ -310,10 +306,10 @@ test("a view coming from a embedded can be saved in the embedded actions", async
         expect(values).not.toInclude("python_method");
         return [4, values.name]; // Fake new embedded action id
     });
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].domain).toBe(`[["name", "=", "Applejack"]]`);
         expect(args[0].embedded_action_id).toBe(4);
-        expect(args[0].user_id).toBe(false);
+        expect(args[0].user_ids).toEqual([]);
         return [5]; // Fake new filter id
     });
     await mountWithCleanup(WebClient);
@@ -355,11 +351,11 @@ test("a view coming from a embedded with python_method can be saved in the embed
             expect(values.python_method).toBe("do_python_method");
             expect(values).not.toInclude("action_id");
             return [4, values.name]; // Fake new embedded action id
-        } else if (method === "create_or_replace") {
+        } else if (method === "create_filter") {
             values = args[0][0];
             expect(args[0].domain).toBe(`[["name", "=", "Applejack"]]`);
             expect(args[0].embedded_action_id).toBe(4);
-            expect(args[0].user_id).toBe(false);
+            expect(args[0].user_ids).toEqual([]);
             return 5; // Fake new filter id
         } else if (method === "do_python_method") {
             return {

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -415,6 +415,7 @@ test("orderedBy in context is not propagated when executing another action", asy
             sort: "[]",
             is_default: true,
             name: "My filter",
+            user_ids: [],
         },
     ];
 
@@ -1679,7 +1680,7 @@ test("save current search", async () => {
         },
     });
 
-    onRpc("create_or_replace", ({ args }) => {
+    onRpc("create_filter", ({ args }) => {
         expect(args[0].domain).toBe(`[("m2o", "=", 1)]`);
         expect(args[0].context).toEqual({
             group_by: [],
@@ -1725,6 +1726,7 @@ test("list with default_order and favorite filter with no orderedBy", async () =
             sort: "[]",
             domain: '[("m2o", "=", 1)]',
             is_default: false,
+            user_ids: [],
         },
     ];
     await mountWithCleanup(WebClient);
@@ -1779,6 +1781,7 @@ test("action with default favorite and context.active_id", async () => {
             sort: "[]",
             domain: '[("bar", "=", 1)]',
             is_default: true,
+            user_ids: [],
         },
     ];
     onRpc("web_search_read", ({ kwargs }) => {

--- a/addons/website_blog/data/blog_snippet_template_data.xml
+++ b/addons/website_blog/data/blog_snippet_template_data.xml
@@ -5,7 +5,7 @@
         <record id="dynamic_snippet_latest_blog_post_filter" model="ir.filters">
             <field name="name">Latest Blog Posts</field>
             <field name="model_id">blog.post</field>
-            <field name="user_id" eval="False" />
+            <field name="user_ids" eval="False" />
             <field name="domain">[('post_date', '&lt;=', context_today())]</field>
             <field name="sort">["post_date desc"]</field>
             <field name="action_id" ref="website.action_website"/>
@@ -13,7 +13,7 @@
         <record id="dynamic_snippet_most_viewed_blog_post_filter" model="ir.filters">
             <field name="name">Most Viewed Blog Posts</field>
             <field name="model_id">blog.post</field>
-            <field name="user_id" eval="False" />
+            <field name="user_ids" eval="False" />
             <field name="domain">[('post_date', '&lt;=', context_today()), ('visits', '!=', False)]</field>
             <field name="sort">["visits desc"]</field>
             <field name="action_id" ref="website.action_website"/>

--- a/addons/website_event/data/website_snippet_data.xml
+++ b/addons/website_event/data/website_snippet_data.xml
@@ -5,7 +5,7 @@
     <record id="ir_filters_event_list_snippet" model="ir.filters">
         <field name="name">Upcoming Events</field>
         <field name="model_id">event.event</field>
-        <field name="user_id" eval="False" />
+        <field name="user_ids" eval="False" />
         <field name="domain">[
             ('date_begin', '&gt;=', context_today()),
             ('is_visible_on_website', '=', True)
@@ -23,7 +23,7 @@
     <record id="ir_filters_event_list_snippet_unfinished" model="ir.filters">
         <field name="name">Upcoming and Ongoing Events</field>
         <field name="model_id">event.event</field>
-        <field name="user_id" eval="False" />
+        <field name="user_ids" eval="False" />
         <field name="domain">[('is_finished', '=', False), ('is_visible_on_website', '=', True)]</field>
         <field name="sort">["date_begin asc"]</field>
     </record>

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -70,7 +70,7 @@
         <record id="dynamic_snippet_newest_products_filter" model="ir.filters">
             <field name="name">Newest Products</field>
             <field name="model_id">product.product</field>
-            <field name="user_id" eval="False" />
+            <field name="user_ids" eval="False" />
             <field name="domain">[('website_published', '=', True)]</field>
             <field name="context">{'display_default_code': False, 'add2cart_rerender': False}</field>
             <field name="sort">["create_date desc"]</field>

--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-from odoo.exceptions import UserError
 from odoo.tools.safe_eval import safe_eval, datetime
 
 
@@ -12,7 +11,7 @@ class IrFilters(models.Model):
     _order = 'model_id, name, id desc'
 
     name = fields.Char(string='Filter Name', required=True)
-    user_id = fields.Many2one('res.users', string='User', ondelete='cascade')
+    user_ids = fields.Many2many('res.users', string='Users', ondelete='cascade', help="The users the filter is shared with. If empty, the filter is shared with all users.")
     domain = fields.Text(default='[]', required=True)
     context = fields.Text(default='{}', required=True)
     sort = fields.Char(default='[]', required=True)
@@ -26,12 +25,8 @@ class IrFilters(models.Model):
     embedded_parent_res_id = fields.Integer(help="id of the record the filter should be applied to. Only used in combination with embedded actions")
     active = fields.Boolean(default=True)
 
-    # Partial constraint, complemented by unique index (see below). Still
-    # useful to keep because it provides a proper error message when a
-    # violation occurs, as it shares the same prefix as the unique index.
-    _name_model_uid_unique = models.Constraint(
-        'UNIQUE (model_id, user_id, action_id, embedded_action_id, embedded_parent_res_id, name)',
-        "Filter names must be unique",
+    _get_filters_index = models.Index(
+        '(model_id, action_id, embedded_action_id, embedded_parent_res_id)',
     )
     # The embedded_parent_res_id can only be defined when the embedded_action_id field is set.
     # As the embedded model is linked to only one res_model, It ensure the unicity of the filter regarding the
@@ -43,11 +38,6 @@ class IrFilters(models.Model):
     _check_sort_json = models.Constraint(
         "CHECK(sort IS NULL OR jsonb_typeof(sort::jsonb) = 'array')",
         "Invalid sort definition",
-    )
-    # Use unique index to implement unique constraint on the lowercase name (not possible using a constraint)
-    _name_model_uid_unique_action_index = models.UniqueIndex(
-        '(model_id, COALESCE(user_id, -1), COALESCE(action_id, -1), '
-        'lower(name), embedded_parent_res_id, COALESCE(embedded_action_id,-1))',
     )
 
     @api.model
@@ -100,83 +90,22 @@ class IrFilters(models.Model):
             The action does not have to correspond to the model, it may only be
             a contextual action.
         :return: list of :meth:`~osv.read`-like dicts containing the
-            ``name``, ``is_default``, ``domain``, ``user_id`` (m2o tuple),
+            ``name``, ``is_default``, ``domain``, ``user_ids`` (m2m),
             ``action_id`` (m2o tuple), ``embedded_action_id`` (m2o tuple), ``embedded_parent_res_id``
             and ``context`` of the matching ``ir.filters``.
         """
-        # available filters: private filters (user_id=uid) and public filters (uid=NULL),
+        # available filters: private filters (user_ids=uids) and public filters (uids=NULL),
         # and filters for the action (action_id=action_id) or global (action_id=NULL)
         user_context = self.env['res.users'].context_get()
         action_domain = self._get_action_domain(action_id, embedded_action_id, embedded_parent_res_id)
         return self.with_context(user_context).search_read(
-            action_domain + [('model_id', '=', model), ('user_id', 'in', [self._uid, False])],
-            ['name', 'is_default', 'domain', 'context', 'user_id', 'sort', 'embedded_action_id', 'embedded_parent_res_id'],
+            action_domain + [('model_id', '=', model), ('user_ids', 'in', [self._uid, False])],
+            ['name', 'is_default', 'domain', 'context', 'user_ids', 'sort', 'embedded_action_id', 'embedded_parent_res_id'],
         )
 
     @api.model
-    def _check_global_default(self, vals: dict, matching_filters: list[dict]) -> None:
-        """Checks if there is a global default for the model_id requested.
-
-        If there is, and the default is different than the record being written
-        (-> we're not updating the current global default), raise an error
-        to avoid users unknowingly overwriting existing global defaults (they
-        have to explicitly remove the current default before setting a new one)
-
-        This method should only be called if ``vals`` is trying to set
-        ``is_default``
-
-        :raises odoo.exceptions.UserError: if there is an existing default and
-                                            we're not updating it
-        """
-        domain = self._get_action_domain(vals.get('action_id'), vals.get('embedded_action_id'), vals.get('embedded_parent_res_id'))
-        defaults = self.search(domain + [
-            ('model_id', '=', vals['model_id']),
-            ('user_id', '=', False),
-            ('is_default', '=', True),
-        ])
-
-        if not defaults:
-            return
-        if matching_filters and (matching_filters[0]['id'] == defaults.id):
-            return
-
-        raise UserError(self.env._("There is already a shared filter set as default for %(model)s, delete or change it before setting a new default", model=vals.get('model_id')))
-
-    @api.model
-    def create_or_replace(self, vals):
-        action_id = vals.get('action_id')
+    def create_filter(self, vals):
         embedded_action_id = vals.get('embedded_action_id')
         if not embedded_action_id and 'embedded_parent_res_id' in vals:
             del vals['embedded_parent_res_id']
-        embedded_parent_res_id = vals.get('embedded_parent_res_id')
-        current_filters = self.get_filters(vals['model_id'], action_id, embedded_action_id, embedded_parent_res_id)
-        matching_filters = [f for f in current_filters
-                            if f['name'].lower() == vals['name'].lower()
-                            # next line looks for matching user_ids (specific or global), i.e.
-                            # f.user_id is False and vals.user_id is False or missing,
-                            # or f.user_id.id == vals.user_id
-                            if (f['user_id'] and f['user_id'][0]) == vals.get('user_id')]
-
-        if vals.get('is_default'):
-            if vals.get('user_id'):
-                # Setting new default: any other default that belongs to the user
-                # should be turned off
-                domain = self._get_action_domain(action_id, embedded_action_id, embedded_parent_res_id)
-                defaults = self.search(domain + [
-                    ('model_id', '=', vals['model_id']),
-                    ('user_id', '=', vals['user_id']),
-                    ('is_default', '=', True),
-                ])
-                if defaults:
-                    defaults.write({'is_default': False})
-            else:
-                self._check_global_default(vals, matching_filters)
-
-        # When a filter exists for the same (name, model, user) triple, we simply
-        # replace its definition (considering action_id irrelevant here)
-        if matching_filters:
-            matching_filter = self.browse(matching_filters[0]['id'])
-            matching_filter.write(vals)
-            return matching_filter
-
         return self.create(vals)

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -84,27 +84,20 @@
         </record>
 
         <record id="ir_filters_employee_rule" model="ir.rule">
-            <field name="name">ir.filters.owner</field>
+            <field name="name">ir.filter: owner or global</field>
             <field name="model_id" ref="model_ir_filters"/>
-            <field name="domain_force">[('user_id','in',[False,user.id])]</field>
+            <field name="domain_force">[('user_ids','in',[False,user.id])]</field>
             <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
-            <field name="perm_unlink" eval="False"/>
-        </record>
-
-        <record id="ir_filters_delete_own_rule" model="ir.rule">
-            <field name="name">ir.filters.own.rule.delete</field>
-            <field name="model_id" ref="model_ir_filters"/>
-            <field name="domain_force">[('user_id', '=', user.id)]</field>
-            <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
-            <field name="perm_read" eval="False"/>
-            <field name="perm_write" eval="False"/>
-            <field name="perm_create" eval="False"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
         </record>
 
         <record id="ir_filters_portal_public_rule" model="ir.rule">
             <field name="name">ir.filter: portal/public</field>
             <field name="model_id" ref="model_ir_filters"/>
-            <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="domain_force">[('user_ids', 'in', user.ids)]</field>
             <field name="groups" eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_public'))]"/>
         </record>
 

--- a/odoo/addons/base/tests/test_ir_filters.py
+++ b/odoo/addons/base/tests/test_ir_filters.py
@@ -35,245 +35,51 @@ class TestGetFilters(FiltersCase):
     def test_own_filters(self):
         self.build(
             'ir.filters',
-            dict(name='a', user_id=self.USER_ID, model_id='ir.filters'),
-            dict(name='b', user_id=self.USER_ID, model_id='ir.filters'),
-            dict(name='c', user_id=self.USER_ID, model_id='ir.filters'),
-            dict(name='d', user_id=self.USER_ID, model_id='ir.filters'))
+            dict(name='a', user_ids=[self.USER_ID], model_id='ir.filters'),
+            dict(name='b', user_ids=[self.USER_ID], model_id='ir.filters'),
+            dict(name='c', user_ids=[self.USER_ID], model_id='ir.filters'),
+            dict(name='d', user_ids=[self.USER_ID], model_id='ir.filters'))
 
         filters = self.env['ir.filters'].with_user(self.USER_ID).get_filters('ir.filters')
 
         self.assertItemsEqual(noid(filters), [
-            dict(name='a', is_default=False, user_id=self.USER_NG, domain='[]', context='{}', sort='[]'),
-            dict(name='b', is_default=False, user_id=self.USER_NG, domain='[]', context='{}', sort='[]'),
-            dict(name='c', is_default=False, user_id=self.USER_NG, domain='[]', context='{}', sort='[]'),
-            dict(name='d', is_default=False, user_id=self.USER_NG, domain='[]', context='{}', sort='[]'),
+            dict(name='a', is_default=False, user_ids=[self.USER_NG[0]], domain='[]', context='{}', sort='[]'),
+            dict(name='b', is_default=False, user_ids=[self.USER_NG[0]], domain='[]', context='{}', sort='[]'),
+            dict(name='c', is_default=False, user_ids=[self.USER_NG[0]], domain='[]', context='{}', sort='[]'),
+            dict(name='d', is_default=False, user_ids=[self.USER_NG[0]], domain='[]', context='{}', sort='[]'),
         ])
 
     def test_global_filters(self):
         self.build(
             'ir.filters',
-            dict(name='a', user_id=False, model_id='ir.filters'),
-            dict(name='b', user_id=False, model_id='ir.filters'),
-            dict(name='c', user_id=False, model_id='ir.filters'),
-            dict(name='d', user_id=False, model_id='ir.filters'),
+            dict(name='a', user_ids=[], model_id='ir.filters'),
+            dict(name='b', user_ids=[], model_id='ir.filters'),
+            dict(name='c', user_ids=[], model_id='ir.filters'),
+            dict(name='d', user_ids=[], model_id='ir.filters'),
         )
 
         filters = self.env['ir.filters'].with_user(self.USER_ID).get_filters('ir.filters')
 
         self.assertItemsEqual(noid(filters), [
-            dict(name='a', is_default=False, user_id=False, domain='[]', context='{}', sort='[]'),
-            dict(name='b', is_default=False, user_id=False, domain='[]', context='{}', sort='[]'),
-            dict(name='c', is_default=False, user_id=False, domain='[]', context='{}', sort='[]'),
-            dict(name='d', is_default=False, user_id=False, domain='[]', context='{}', sort='[]'),
+            dict(name='a', is_default=False, user_ids=[], domain='[]', context='{}', sort='[]'),
+            dict(name='b', is_default=False, user_ids=[], domain='[]', context='{}', sort='[]'),
+            dict(name='c', is_default=False, user_ids=[], domain='[]', context='{}', sort='[]'),
+            dict(name='d', is_default=False, user_ids=[], domain='[]', context='{}', sort='[]'),
         ])
 
     def test_no_third_party_filters(self):
         self.build(
             'ir.filters',
-            dict(name='a', user_id=False, model_id='ir.filters'),
-            dict(name='b', user_id=ADMIN_USER_ID, model_id='ir.filters'),
-            dict(name='c', user_id=self.USER_ID, model_id='ir.filters'),
-            dict(name='d', user_id=ADMIN_USER_ID, model_id='ir.filters')  )
+            dict(name='a', user_ids=[], model_id='ir.filters'),
+            dict(name='b', user_ids=[ADMIN_USER_ID], model_id='ir.filters'),
+            dict(name='c', user_ids=[self.USER_ID], model_id='ir.filters'),
+            dict(name='d', user_ids=[ADMIN_USER_ID], model_id='ir.filters'))
 
         filters = self.env['ir.filters'].with_user(self.USER_ID).get_filters('ir.filters')
 
         self.assertItemsEqual(noid(filters), [
-            dict(name='a', is_default=False, user_id=False, domain='[]', context='{}', sort='[]'),
-            dict(name='c', is_default=False, user_id=self.USER_NG, domain='[]', context='{}', sort='[]'),
-        ])
-
-
-class TestOwnDefaults(FiltersCase):
-
-    def test_new_no_filter(self):
-        """
-        When creating a @is_default filter with no existing filter, that new
-        filter gets the default flag
-        """
-        Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        Filters.create_or_replace({
-            'name': 'a',
-            'model_id': 'ir.filters',
-            'user_id': self.USER_ID,
-            'is_default': True,
-        })
-        filters = Filters.get_filters('ir.filters')
-
-        self.assertItemsEqual(noid(filters), [
-            dict(name='a', user_id=self.USER_NG, is_default=True,
-                 domain='[]', context='{}', sort='[]'),
-        ])
-
-    def test_new_filter_not_default(self):
-        """
-        When creating a @is_default filter with existing non-default filters,
-        the new filter gets the flag
-        """
-        self.build(
-            'ir.filters',
-            dict(name='a', user_id=self.USER_ID, model_id='ir.filters'),
-            dict(name='b', user_id=self.USER_ID, model_id='ir.filters'),
-        )
-
-        Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        Filters.create_or_replace({
-            'name': 'c',
-            'model_id': 'ir.filters',
-            'user_id': self.USER_ID,
-            'is_default': True,
-        })
-        filters = Filters.get_filters('ir.filters')
-
-        self.assertItemsEqual(noid(filters), [
-            dict(name='a', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
-            dict(name='b', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
-            dict(name='c', user_id=self.USER_NG, is_default=True, domain='[]', context='{}', sort='[]'),
-        ])
-
-    def test_new_filter_existing_default(self):
-        """
-        When creating a @is_default filter where an existing filter is already
-        @is_default, the flag should be *moved* from the old to the new filter
-        """
-        self.build(
-            'ir.filters',
-            dict(name='a', user_id=self.USER_ID, model_id='ir.filters'),
-            dict(name='b', is_default=True, user_id=self.USER_ID, model_id='ir.filters'),
-        )
-
-        Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        Filters.create_or_replace({
-            'name': 'c',
-            'model_id': 'ir.filters',
-            'user_id': self.USER_ID,
-            'is_default': True,
-        })
-        filters = Filters.get_filters('ir.filters')
-
-        self.assertItemsEqual(noid(filters), [
-            dict(name='a', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
-            dict(name='b', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
-            dict(name='c', user_id=self.USER_NG, is_default=True, domain='[]', context='{}', sort='[]'),
-        ])
-
-    def test_update_filter_set_default(self):
-        """
-        When updating an existing filter to @is_default, if an other filter
-        already has the flag the flag should be moved
-        """
-        self.build(
-            'ir.filters',
-            dict(name='a', user_id=self.USER_ID, model_id='ir.filters'),
-            dict(name='b', is_default=True, user_id=self.USER_ID, model_id='ir.filters'),
-        )
-
-        Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        Filters.create_or_replace({
-            'name': 'a',
-            'model_id': 'ir.filters',
-            'user_id': self.USER_ID,
-            'is_default': True,
-        })
-        filters = Filters.get_filters('ir.filters')
-
-        self.assertItemsEqual(noid(filters), [
-            dict(name='a', user_id=self.USER_NG, is_default=True, domain='[]', context='{}', sort='[]'),
-            dict(name='b', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
-        ])
-
-
-class TestGlobalDefaults(FiltersCase):
-
-    def test_new_filter_not_default(self):
-        """
-        When creating a @is_default filter with existing non-default filters,
-        the new filter gets the flag
-        """
-        self.build(
-            'ir.filters',
-            dict(name='a', user_id=False, model_id='ir.filters'),
-            dict(name='b', user_id=False, model_id='ir.filters'),
-        )
-
-        Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        Filters.create_or_replace({
-            'name': 'c',
-            'model_id': 'ir.filters',
-            'user_id': False,
-            'is_default': True,
-        })
-        filters = Filters.get_filters('ir.filters')
-
-        self.assertItemsEqual(noid(filters), [
-            dict(name='a', user_id=False, is_default=False, domain='[]', context='{}', sort='[]'),
-            dict(name='b', user_id=False, is_default=False, domain='[]', context='{}', sort='[]'),
-            dict(name='c', user_id=False, is_default=True, domain='[]', context='{}', sort='[]'),
-        ])
-
-    def test_new_filter_existing_default(self):
-        """
-        When creating a @is_default filter where an existing filter is already
-        @is_default, an error should be generated
-        """
-        self.build(
-            'ir.filters',
-            dict(name='a', user_id=False, model_id='ir.filters'),
-            dict(name='b', is_default=True, user_id=False, model_id='ir.filters'),
-        )
-
-        Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        with self.assertRaises(exceptions.UserError):
-            Filters.create_or_replace({
-                'name': 'c',
-                'model_id': 'ir.filters',
-                'user_id': False,
-                'is_default': True,
-            })
-
-    def test_update_filter_set_default(self):
-        """
-        When updating an existing filter to @is_default, if an other filter
-        already has the flag an error should be generated
-        """
-        self.build(
-            'ir.filters',
-            dict(name='a', user_id=False, model_id='ir.filters'),
-            dict(name='b', is_default=True, user_id=False, model_id='ir.filters'),
-        )
-
-        Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        with self.assertRaises(exceptions.UserError):
-            Filters.create_or_replace({
-                'name': 'a',
-                'model_id': 'ir.filters',
-                'user_id': False,
-                'is_default': True,
-            })
-
-    def test_update_default_filter(self):
-        """
-        Replacing the current default global filter should not generate any error
-        """
-        self.build(
-            'ir.filters',
-            dict(name='a', user_id=False, model_id='ir.filters'),
-            dict(name='b', is_default=True, user_id=False, model_id='ir.filters'),
-        )
-
-        Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        context_value = "{'some_key': True}"
-        Filters.create_or_replace({
-            'name': 'b',
-            'model_id': 'ir.filters',
-            'user_id': False,
-            'context': context_value,
-            'is_default': True,
-        })
-        filters = Filters.get_filters('ir.filters')
-
-        self.assertItemsEqual(noid(filters), [
-            dict(name='a', user_id=False, is_default=False, domain='[]', context='{}', sort='[]'),
-            dict(name='b', user_id=False, is_default=True, domain='[]', context=context_value, sort='[]'),
+            dict(name='a', is_default=False, user_ids=[], domain='[]', context='{}', sort='[]'),
+            dict(name='c', is_default=False, user_ids=[self.USER_NG[0]], domain='[]', context='{}', sort='[]'),
         ])
 
 
@@ -350,18 +156,18 @@ class TestEmbeddedFilters(FiltersCase):
 
     def test_global_filters_with_embedded_action(self):
         Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        Filters.create_or_replace({
+        Filters.create_filter({
             'name': 'a',
             'model_id': 'ir.filters',
-            'user_id': False,
+            'user_ids': [],
             'is_default': True,
             'embedded_action_id': self.embedded_action_1.id,
             'embedded_parent_res_id': 1
         })
-        Filters.create_or_replace({
+        Filters.create_filter({
             'name': 'b',
             'model_id': 'ir.filters',
-            'user_id': self.USER_ID,
+            'user_ids': [self.USER_ID],
             'is_default': False,
             'embedded_action_id': self.embedded_action_2.id,
             'embedded_parent_res_id': 1
@@ -369,7 +175,7 @@ class TestEmbeddedFilters(FiltersCase):
 
         # If embedded_action_id and embedded_parent_res_id are set, should return the corresponding filter
         filters = self.env['ir.filters'].with_user(self.USER_ID).get_filters('ir.filters', embedded_action_id=self.embedded_action_1.id, embedded_parent_res_id=1)
-        self.assertItemsEqual(noid(filters), [dict(name='a', is_default=True, user_id=False, domain='[]', context='{}', sort='[]')])
+        self.assertItemsEqual(noid(filters), [dict(name='a', is_default=True, user_ids=[], domain='[]', context='{}', sort='[]')])
 
         # Check that the filter is correctly linked to one embedded_parent_res_id and is not returned if another one is set
         filters = self.env['ir.filters'].with_user(self.USER_ID).get_filters('ir.filters', embedded_action_id=self.embedded_action_1.id, embedded_parent_res_id=2)
@@ -377,7 +183,7 @@ class TestEmbeddedFilters(FiltersCase):
 
         # Check that a shared filter can be fetched with another user
         filters = self.env['ir.filters'].with_user(ADMIN_USER_ID).get_filters('ir.filters', embedded_action_id=self.embedded_action_1.id, embedded_parent_res_id=1)
-        self.assertItemsEqual(noid(filters), [dict(name='a', is_default=True, user_id=False, domain='[]', context='{}', sort='[]')])
+        self.assertItemsEqual(noid(filters), [dict(name='a', is_default=True, user_ids=[], domain='[]', context='{}', sort='[]')])
 
         # If embedded_action_id and embedded_parent_res_id are not set, should return no filters
         filters = self.env['ir.filters'].with_user(self.USER_ID).get_filters('ir.filters')
@@ -385,18 +191,18 @@ class TestEmbeddedFilters(FiltersCase):
 
     def test_global_filters_with_no_embedded_action(self):
         Filters = self.env['ir.filters'].with_user(self.USER_ID)
-        filter_a = Filters.create_or_replace({
+        filter_a = Filters.create_filter({
             'name': 'a',
             'model_id': 'ir.filters',
-            'user_id': False,
+            'user_ids': [],
             'is_default': True,
             'embedded_action_id': False,
             'embedded_parent_res_id': 0,
         })
-        filter_b = Filters.create_or_replace({
+        filter_b = Filters.create_filter({
             'name': 'b',
             'model_id': 'ir.filters',
-            'user_id': self.USER_ID,
+            'user_ids': [self.USER_ID],
             'is_default': True,
             'embedded_action_id': False,
             'embedded_parent_res_id': 1,

--- a/odoo/addons/base/views/ir_filters_views.xml
+++ b/odoo/addons/base/views/ir_filters_views.xml
@@ -13,7 +13,7 @@
                         <group>
                             <group>
                                 <field name="name"/>
-                                <field name="user_id" string="Owner" placeholder="All users"/>
+                                <field name="user_ids" string="Shared with" widget="many2many_avatar_user" placeholder="All users"/>
                                 <field name="is_default" widget="boolean_toggle"/>
                                 <field name="model_id" groups="base.group_no_one"/>
                                 <field name="action_id" groups="base.group_no_one"/>
@@ -46,7 +46,7 @@
                 <list string="Filters">
                     <field name="name"/>
                     <field name="model_id"/>
-                    <field name="user_id"/>
+                    <field name="user_ids" widget="many2many_avatar_user"/>
                     <field name="is_default"/>
                     <field name="action_id"/>
                     <field name="domain" groups="base.group_no_one"/>
@@ -60,17 +60,16 @@
             <field name="arch" type="xml">
                 <search string="Filters">
                     <field name="name" string="Filter Name"/>
-                    <filter string="User" domain="[('user_id','!=',False)]" name="user" help="Filters visible only for one user"/>
-                    <filter string="Shared" domain="[('user_id','=',False)]" name="shared" help="Filters shared with all users"/>
-                    <filter string="My filters" domain="[('user_id','=',uid)]" name="my_filters" help="Filters created by myself"/>
+                    <filter string="Global" domain="[('user_ids','=',False)]" name="shared" help="Filters shared with all users"/>
+                    <filter string="My filters" domain="[('user_ids','in',[uid])]" name="my_filters" help="Filters shared with myself"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group expand="0" string="Group By">
-                        <filter string="User" name="user" domain="[]" context="{'group_by':'user_id'}"/>
+                        <filter string="User" name="user" domain="[]" context="{'group_by':'user_ids'}"/>
                         <filter string="Model" name="model" domain="[]" context="{'group_by':'model_id'}"/>
                     </group>
                     <field name="model_id"/>
-                    <field name="user_id"/>
+                    <field name="user_ids"/>
                 </search>
             </field>
         </record>


### PR DESCRIPTION
This commit enhances how ir.filters can be shared with other users by making the process more flexible and intuitive:

- Removes the "Shared" checkbox at filter creation, as sharing favorites with all users by default was often unnecessary.
- Adds an "Edit" button next to "Save," allowing users to directly access the form view of the favorite after creation.
- Replaces the user_id many2one field with a many2many field, enabling selective sharing of favorites with specific users.
- Defaults to the current user at creation, while keeping the option to share the favorite with all users if no specific users are selected.

task-4610809