### PR TITLE
[FIX] account_payment: Avoid missing key errors for 'installment_state' in invoice template

### DIFF
--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -82,17 +82,17 @@
         <xpath expr="//t[@t-foreach='invoices']/tr/td[last()]" position="after">
             <td class="d-none d-lg-table-cell text-center">
                 <span
-                    t-if="invoice_data['installment_state'] in ('next', 'overdue')"
-                    t-attf-class="{{'text-danger' if invoice_data['installment_state'] == 'overdue' else ''}}"
+                    t-if="invoice_data.get('installment_state',False)  in ('next', 'overdue')"
+                    t-attf-class="{{'text-danger' if invoice_data.get('installment_state',False)  == 'overdue' else ''}}"
                     t-out="invoice_data['next_amount_to_pay']"
                     t-options="{'widget': 'monetary', 'display_currency': invoice.currency_id}"
                 />
                 <small
-                    t-if="invoice_data['installment_state'] == 'next'"
+                    t-if="invoice_data.get('installment_state',False)  == 'next'"
                     class="o_portal_invoice_due_date"
                     t-att-datetime="invoice_data['next_due_date']"
                 />
-                <small t-if="invoice_data['installment_state'] == 'overdue'" class="text-danger">
+                <small t-if="invoice_data.get('installment_state',False)  == 'overdue'" class="text-danger">
                     overdue
                 </small>
             </td>


### PR DESCRIPTION
Previously, when installment_state was None,
the template raised an error because None in ('next', 'overdue') is not a valid operation.
This change ensures safe access to installment_state using .get(), preventing potential errors when
the key is missing or its value is None.

**Description of the issue/feature this PR addresses:**
The invoice template was raising an error when installment_state was None, as the condition None in ('next', 'overdue') is invalid.

**Current behavior before PR:**
If installment_state is None, the template crashes due to an invalid comparison.

**Desired behavior after PR is merged:**
The template now safely retrieves installment_state using .get(), preventing errors when the key is missing or its value is None.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
