### PR TITLE
[IMP] mail: Record.toData() returns flat data

### DIFF
--- a/addons/mail/static/src/core/common/activity_model.js
+++ b/addons/mail/static/src/core/common/activity_model.js
@@ -80,7 +80,7 @@ export class Activity extends Record {
     write_uid;
 
     serialize() {
-        return JSON.parse(JSON.stringify(this.toData()));
+        return JSON.parse(JSON.stringify(this.toData(["persona"])));
     }
 }
 

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -145,6 +145,14 @@ export class Persona extends Record {
         }
         this.im_status = newStatus;
     }
+
+    _getActualModelName() {
+        return this.type === "partner"
+            ? "res.partner"
+            : this.type === "visitor"
+            ? "website.visitor"
+            : "mail.guest";
+    }
 }
 
 Persona.register();

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -890,6 +890,10 @@ export class Thread extends Record {
         }
         this.leave();
     }
+
+    _getActualModelName() {
+        return this.model === "discuss.channel" ? "discuss.channel" : "mail.thread";
+    }
 }
 
 Thread.register();

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -104,7 +104,7 @@ const StorePatch = {
     _onActivityBroadcastChannelMessage({ data }) {
         switch (data.type) {
             case "INSERT":
-                this["mail.activity"].insert(data.payload, { broadcast: false });
+                this.insert(data.payload, { broadcast: false });
                 break;
             case "DELETE": {
                 const activity = this["mail.activity"].insert(data.payload, { broadcast: false });


### PR DESCRIPTION
Before this commit, `Record.toData()` was returning shallow data of record at hand, and relations had only data id of the related record.

This had the following drawbacks:

- a `toData()` of a record makes only sense with `insert()` on the targeted record
- it's hard to return deep data of record, e.g. we'd want to return message data but also the author data.

This commit improves `Record.toData()` to return data in a flat format. For example:

`Message.toData()`
```
{
   "mail.message": [{ id: 1, body: "hello-world!", author: { id: 10, type: "partner" } }],
}
```

This returns the shallow data of the record, and the data can be directly feed in `store.insert()` rather than the dedicated model.

If we want to retrieve some deep data in record, we can either give the relations to retrieve their shallow data:

`Message.toData(['author'])`
```
{
   "mail.message": [{ id: 1, body: "hello-world!", author: { id: 10, type: "partner" } }],
   "res.partner": [{ id: 10, type: "partner", name: "John" }],
}
```

Note:

The `store.insert()` feature was a discuss feature because there's concerns about "python" models. As the flat data is meant to be used with `store.insert()`, this feature has been moved to base store. The logic around python models are overrides in discuss store.

One could also retrieve all data in all relations, with `{ depth: true }`. Please be cautious about it: it can retrieve a lot of data! More data to retrive means more data to feed, which can lead to performance concerns.

https://github.com/odoo/enterprise/pull/81719

Originally from https://github.com/odoo/odoo/pull/199055