### PR TITLE
[FIX] sale_loyalty: filter loyalty history data by related model

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -54,6 +54,7 @@ class SaleOrder(models.Model):
         loyalty_history_data = self.env['loyalty.history'].sudo()._read_group(
             domain=[
                 ('order_id', 'in', confirmed_so.ids),
+                ('order_model', '=', self._name),
             ],
             groupby=['order_id'],
             aggregates=['issued:sum', 'used:sum'],


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Setup an eWallet for POS and website
- Place an order of eWallet top up from POS
- Place an order of eWallet top up from ecommerce
- Make sure both has the same ID, or any POS order that has the same ID with sale.order ID
- You will see the loyalty issued becomes the sum of the unrelated model

Current behavior before PR:
- The loyalty showed in Portal / Odoo will be wrong if it clashes with other model ID

Desired behavior after PR is merged:
- Only consider the order that comes from the sale order model



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
