### PR TITLE
[IMP] web: rework many2x menu

### DIFF
--- a/addons/analytic/static/tests/analytic_distribution_tests.js
+++ b/addons/analytic/static/tests/analytic_distribution_tests.js
@@ -159,7 +159,7 @@ QUnit.module("Analytic", (hooks) => {
         let field = target.querySelector('.o_field_analytic_distribution');
         await click(field, ".o_input_dropdown");
         assert.containsN(target, ".analytic_distribution_popup", 1, "popup should be visible");
-        
+
         let popup = target.querySelector('.analytic_distribution_popup');
         let planTable = popup.querySelectorAll('table')[0];
 
@@ -176,7 +176,7 @@ QUnit.module("Analytic", (hooks) => {
         await click(planTable, "tr:first-of-type .o_field_percentage input");
         let input = document.activeElement;
         await editInput(input, null, "19.7001");
-        
+
         // mandatory plan is red
         assert.containsOnce(planTable, 'th:contains("Departments") .text-danger:contains("50%")', "Mandatory plan has invalid status");
 
@@ -260,9 +260,9 @@ QUnit.module("Analytic", (hooks) => {
         // add a line
         let planTable = popup.querySelectorAll('table')[0];
         await addRow(planTable)
-        await selectDropdownItem(planTable.querySelector("tr[name='line_2']"), "x_plan5_id", "Search More...");
+        await selectDropdownItem(planTable.querySelector("tr[name='line_2']"), "x_plan5_id", "Search more...");
         assert.containsN(target, ".modal-dialog .o_list_renderer", 1, "select create list dialog is visible");
-        
+
         await click(target, ".modal-dialog .modal-title");
         await click(target, ".modal-dialog .o_data_row:nth-of-type(4) .o_data_cell:first-of-type");
         assert.containsNone(target, ".modal-dialog .o_list_renderer", "select create list dialog is closed");

--- a/addons/base_import/static/tests/import_records_tests.js
+++ b/addons/base_import/static/tests/import_records_tests.js
@@ -254,7 +254,7 @@ QUnit.module("Base Import Tests", (hooks) => {
                 },
             });
 
-            await selectDropdownItem(target, "m2o", "Search More...");
+            await selectDropdownItem(target, "m2o", "Search more...");
             const dialog = target.querySelector(".modal");
             assert.containsNone(dialog, ".o_cp_action_menus");
             assert.containsNone(dialog, ".o_import_menu");

--- a/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
@@ -65,7 +65,7 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
             run: `edit ${leaveType2}`,
         },
         {
-            trigger: `.ui-autocomplete .ui-menu-item a:contains('${noRecords}')`,
+            trigger: `.ui-autocomplete .ui-menu-item span:contains('${noRecords}')`,
         },
         // Check if a time-off could be requested using leave_type_3
         {

--- a/addons/sale_expense/static/tests/sale_order_many2one_tests.js
+++ b/addons/sale_expense/static/tests/sale_order_many2one_tests.js
@@ -67,7 +67,7 @@ QUnit.module('sale_expense', {
 
         await clickDropdown(this.target, "sale_order_id");
 
-        assert.containsN(this.target, 'li.o-autocomplete--dropdown-item', 9);
-        assert.containsNone(this.target, '.o_m2o_dropdown_option_search_more', "Should not display the 'Search More... option'");
+        assert.containsN(this.target, 'li.o-autocomplete--dropdown-item', 8);
+        assert.containsNone(this.target, '.o_m2o_dropdown_option_search_more', "Should not display the 'Search more... option'");
     });
 });

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -576,7 +576,7 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
             trigger:
                 ".o_field_widget[name='trg_field_ref'] .o-autocomplete--dropdown-menu:not(:has(a .fa-spin)",
             run() {
-                assertEqual(this.anchor.innerText, "test stage\nSearch More...");
+                assertEqual(this.anchor.innerText, "test stage\nSearch more...");
             },
         },
         {
@@ -595,7 +595,7 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
             trigger:
                 ".o_field_widget[name='trg_field_ref'] .o-autocomplete--dropdown-menu:not(:has(a .fa-spin)",
             run() {
-                assertEqual(this.anchor.innerText, "test tag\nSearch More...");
+                assertEqual(this.anchor.innerText, "test tag\nSearch more...");
             },
         },
         {

--- a/addons/web/static/src/core/autocomplete/autocomplete.scss
+++ b/addons/web/static/src/core/autocomplete/autocomplete.scss
@@ -10,6 +10,11 @@
     }
 
     .ui-menu-item {
+        > span {
+            --dropdown-link-hover-color: var(--dropdown-color);
+            --dropdown-link-hover-bg: var(--dropdown-bg);
+        }
+
         > a.ui-state-active {
             margin: 0;
             border: none;

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -55,13 +55,13 @@
                                     t-on-mouseenter="() => this.onOptionMouseEnter([source_index, option_index])"
                                     t-on-mouseleave="() => this.onOptionMouseLeave([source_index, option_index])"
                                     t-on-click="() => this.onOptionClick(option)"
-                                    t-on-pointerdown="() => this.ignoreBlur = true"
+                                    t-on-pointerdown="(ev) => this.onOptionPointerDown(option, ev)"
                                 >
-                                    <a
-                                        t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_{{option_index}}"
-                                        role="option"
-                                        href="#"
+                                    <t t-tag="option.unselectable ? 'span' : 'a'"
                                         class="dropdown-item ui-menu-item-wrapper text-truncate"
+                                        t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_{{option_index}}"
+                                        t-att-role="!option.unselectable and 'option'"
+                                        t-att-href="!option.unselectable and '#'"
                                         t-att-class="{ 'ui-state-active': isActiveSourceOption([source_index, option_index]) }"
                                         t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
                                     >
@@ -73,7 +73,7 @@
                                                 <t t-esc="option.label"/>
                                             </t>
                                         </t>
-                                    </a>
+                                    </t>
                                 </li>
                             </t>
                         </t>

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -256,7 +256,7 @@ export class PropertyValue extends Component {
                     : false;
 
             if (newValue && newValue[0] && newValue[1] === undefined) {
-                // The "Search More" option in the Many2XAutocomplete component
+                // The "Search more" option in the Many2XAutocomplete component
                 // only return the record ID, and not the name. But we need to name
                 // in the component props to be able to display it.
                 // Make a RPC call to resolve the display name of the record.

--- a/addons/web/static/tests/core/model_selector.test.js
+++ b/addons/web/static/tests/core/model_selector.test.js
@@ -147,25 +147,6 @@ test("model_selector: select a model", async () => {
     expect.verifySteps(["model selected"]);
 });
 
-test("model_selector: click on start typing", async () => {
-    await mountModelSelector([
-        "model_1",
-        "model_2",
-        "model_3",
-        "model_4",
-        "model_5",
-        "model_6",
-        "model_7",
-        "model_8",
-        "model_9",
-        "model_10",
-    ]);
-    await contains(".o-autocomplete--input").click();
-    await contains("li.o-autocomplete--dropdown-item:eq(8)").click();
-    expect(".o-autocomplete--input").toHaveValue("");
-    expect(".o-autocomplete.dropdown ul").toHaveCount(0);
-});
-
 test("model_selector: with an initial value", async () => {
     await mountModelSelector(["model_1", "model_2", "model_3"], "Model 1");
     expect(".o-autocomplete--input").toHaveValue("Model 1");

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -147,9 +147,9 @@ test("Many2ManyTagsField with and without color on desktop", async () => {
     // Add a tag to second field
     expect("[name=timmy] .o_tag").toHaveCount(0);
     await clickFieldDropdown("timmy");
-    expect("[name='timmy'] .o-autocomplete.dropdown li").toHaveCount(4, {
+    expect("[name='timmy'] .o-autocomplete.dropdown li").toHaveCount(3, {
         message:
-            "autocomplete dropdown should have 4 entries (2 values + 'Search More...' + 'Search and Edit...')",
+            "autocomplete dropdown should have 3 entries (2 values + 'Search more...')",
     });
     await clickFieldDropdownItem("timmy", "gold");
     expect("[name=timmy] .o_tag").toHaveCount(1);
@@ -259,7 +259,7 @@ test("Many2ManyTagsField with color: rendering and edition on desktop", async ()
     await contains("div[name='timmy'] .o-autocomplete.dropdown input").click();
     expect(`.dropdown-item-selected`).toHaveCount(2);
     expect(queryAllTexts`.dropdown-item-selected`).toEqual(["gold", "silver"]);
-    expect(".o-autocomplete--dropdown-menu li").toHaveCount(5);
+    expect(".o-autocomplete--dropdown-menu li").toHaveCount(4);
     expect(".o-autocomplete--dropdown-menu li a:eq(2)").toHaveText("red");
 
     await contains(".o-autocomplete--dropdown-menu li a:eq(2)").click();
@@ -401,7 +401,7 @@ test("Many2ManyTagsField view a domain on desktop", async () => {
 
     await clickFieldDropdown("timmy");
 
-    expect(".o-autocomplete--dropdown-menu li").toHaveCount(4);
+    expect(".o-autocomplete--dropdown-menu li").toHaveCount(3);
 
     expect(".o-autocomplete--dropdown-menu li a:eq(0)").toHaveText("gold");
 
@@ -476,12 +476,11 @@ test("use binary field as the domain on desktop", async () => {
 
     await clickFieldDropdown("timmy");
 
-    expect(".o-autocomplete--dropdown-menu li").toHaveCount(4);
+    expect(".o-autocomplete--dropdown-menu li").toHaveCount(3);
     expect(queryAllTexts(".o-autocomplete--dropdown-menu li")).toEqual([
         "gold",
         "silver",
-        "Search More...",
-        "Start typing...",
+        "Search more...",
     ]);
     expect(".o-autocomplete--dropdown-menu li a:eq(0)").toHaveText("gold");
 
@@ -544,13 +543,13 @@ test("Domain: allow python code domain in fieldInfo on desktop", async () => {
 
     // foo set => only silver (id=5) selectable
     await clickFieldDropdown("timmy");
-    expect(".o-autocomplete--dropdown-menu li").toHaveCount(3);
+    expect(".o-autocomplete--dropdown-menu li").toHaveCount(2);
     expect(".o-autocomplete--dropdown-menu li a:eq(0)").toHaveText("silver");
-    await clickFieldDropdownItem("timmy", "Start typing...");
+
     // set foo = "" => only gold (id=2) selectable
     await contains("[name=foo] input").clear();
     await clickFieldDropdown("timmy");
-    expect(".o-autocomplete--dropdown-menu li").toHaveCount(3);
+    expect(".o-autocomplete--dropdown-menu li").toHaveCount(2);
     expect(".o-autocomplete--dropdown-menu li a:eq(0)").toHaveText("gold");
 });
 
@@ -572,7 +571,7 @@ test("Many2ManyTagsField in a new record on desktop", async () => {
     expect(".o_form_view .o_form_editable").toHaveCount(1);
 
     await clickFieldDropdown("timmy");
-    expect("[name='timmy'] .o-autocomplete.dropdown li").toHaveCount(4);
+    expect("[name='timmy'] .o-autocomplete.dropdown li").toHaveCount(3);
     await clickFieldDropdownItem("timmy", "gold");
 
     expect(".o_field_many2many_tags .badge").toHaveCount(1);
@@ -1050,7 +1049,7 @@ test("Many2ManyTagsField: select multiple records on desktop", async () => {
             </form>`,
     });
 
-    await selectFieldDropdownItem("timmy", "Search More...");
+    await selectFieldDropdownItem("timmy", "Search more...");
 
     expect(".o_dialog").toHaveCount(1);
     // + 1 for the select all
@@ -1093,7 +1092,7 @@ test("Many2ManyTagsField: select multiple records doesn't show already added tag
                 </form>`,
     });
 
-    await selectFieldDropdownItem("timmy", "Search More...");
+    await selectFieldDropdownItem("timmy", "Search more...");
 
     expect(".o_dialog .o_list_renderer .o_list_record_selector input").toHaveCount(
         PartnerType._records.length + 1
@@ -1266,11 +1265,8 @@ test("Many2ManyTagsField: conditional create/delete actions on desktop", async (
 
     await clickFieldDropdown("partner_ids");
     await runAllTimers();
-    expect(
-        ".o-autocomplete.dropdown li.o_m2o_start_typing a:contains(Start typing...)"
-    ).toHaveCount(1);
 
-    await clickFieldDropdownItem("partner_ids", "Search More...");
+    await clickFieldDropdownItem("partner_ids", "Search more...");
 
     expect(".modal .modal-footer button").toHaveCount(3);
 
@@ -1284,7 +1280,6 @@ test("Many2ManyTagsField: conditional create/delete actions on desktop", async (
 
     expect(queryAllTexts(`.o-autocomplete.dropdown li.o_m2o_dropdown_option`)).toEqual([
         'Create "Something that does not exist"',
-        "Search More...",
         "Create and edit...",
     ]);
 
@@ -1298,13 +1293,13 @@ test("Many2ManyTagsField: conditional create/delete actions on desktop", async (
     await clickFieldDropdown("partner_ids");
     await runAllTimers();
 
-    // only Search More option should be available
+    // only Search more option should be available
     expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(1);
     expect(
-        ".o-autocomplete.dropdown li.o_m2o_dropdown_option a:contains(Search More...)"
+        ".o-autocomplete.dropdown li.o_m2o_dropdown_option a:contains(Search more...)"
     ).toHaveCount(1);
 
-    await clickFieldDropdownItem("partner_ids", "Search More...");
+    await clickFieldDropdownItem("partner_ids", "Search more...");
 
     expect(".modal .modal-footer button").toHaveCount(2);
 
@@ -1314,9 +1309,9 @@ test("Many2ManyTagsField: conditional create/delete actions on desktop", async (
     await contains(".o_field_many2many_tags input").edit("Pa", { confirm: false });
     await runAllTimers();
 
-    // only Search More option should be available
+    // only Search more option should be available
     expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(1);
-    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option a:contains(Search More)").toHaveCount(
+    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option a:contains(Search more)").toHaveCount(
         1
     );
 });
@@ -1467,7 +1462,7 @@ test("Many2ManyTagsField supports 'create' props to be a Boolean on desktop", as
 
     await contains(".o_field_many2many_tags input").click();
     expect(".o_field_many2many_tags .o-autocomplete--dropdown-menu").toHaveText(
-        "gold\nsilver\nSearch More..."
+        "gold\nsilver\nSearch more..."
     );
 });
 
@@ -1555,11 +1550,8 @@ test("Many2ManyTagsField with option 'no_quick_create' set to true on desktop", 
         confirm: false,
     });
     await runAllTimers();
-    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(2);
-    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option:eq(0)").toHaveClass(
-        "o_m2o_dropdown_option_search_more"
-    );
-    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option:eq(1)").toHaveClass(
+    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(1);
+    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveClass(
         "o_m2o_dropdown_option_create_edit"
     );
     await clickFieldDropdownItem("timmy", "Create and edit...");
@@ -1613,7 +1605,6 @@ test("Many2ManyTagsField with option 'no_create' set to true on desktop", async 
         confirm: false,
     });
     await runAllTimers();
-    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(1);
     expect(".o-autocomplete.dropdown li.o_m2o_no_result").toHaveCount(1);
 });
 
@@ -1629,7 +1620,8 @@ test("Many2ManyTagsField with attribute 'can_create' set to false on desktop", a
         confirm: false,
     });
     await runAllTimers();
-    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(1);
+    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(0);
+    expect(".o-autocomplete.dropdown li.o_m2o_no_result").toHaveCount(1);
 });
 
 test.tags("desktop");
@@ -2019,28 +2011,28 @@ test("search typeahead", async () => {
     await runAllTimers();
     expect.verifySteps([]);
     expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
-        "Search More...",
         "Start typing 3 characters",
+        "Search more...",
     ]);
 
     await contains(".o_field_widget[name=timmy] input").edit("g", { confirm: false });
     await runAllTimers();
     expect.verifySteps([]);
     expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
-        'Create "g"',
-        "Search More...",
-        "Create and edit...",
         "Start typing 3 characters",
+        'Create "g"',
+        "Create and edit...",
+        "Search more...",
     ]);
 
     await contains(".o_field_widget[name=timmy] input").edit("go", { confirm: false });
     await runAllTimers();
     expect.verifySteps([]);
     expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
-        'Create "go"',
-        "Search More...",
-        "Create and edit...",
         "Start typing 3 characters",
+        'Create "go"',
+        "Create and edit...",
+        "Search more...",
     ]);
 
     await contains(".o_field_widget[name=timmy] input").edit("gol", { confirm: false });
@@ -2049,8 +2041,8 @@ test("search typeahead", async () => {
     expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
         "gold",
         'Create "gol"',
-        "Search More...",
         "Create and edit...",
+        "Search more...",
     ]);
 });
 

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -551,7 +551,7 @@ test("many2ones in form views with search more", async () => {
             </form>`,
     });
 
-    await selectFieldDropdownItem("trululu", "Search More...");
+    await selectFieldDropdownItem("trululu", "Search more...");
 
     expect("tr.o_data_row").toHaveCount(9);
     expect(".o_field_widget[name=trululu] input").toHaveValue("aaa");
@@ -562,7 +562,7 @@ test("many2ones in form views with search more", async () => {
     expect("tr.o_data_row").toHaveCount(0);
 });
 
-test("many2ones: Open the selection dialog several times using the 'Search More...' button with a context containing 'search_default_...'", async () => {
+test("many2ones: Open the selection dialog several times using the 'Search more...' button with a context containing 'search_default_...'", async () => {
     for (let i = 5; i < 11; i++) {
         Partner._records.push({ id: i, name: `Partner ${i}` });
     }
@@ -592,7 +592,7 @@ test("many2ones: Open the selection dialog several times using the 'Search More.
             </form>`,
     });
 
-    await selectFieldDropdownItem("trululu", "Search More...");
+    await selectFieldDropdownItem("trululu", "Search more...");
 
     expect(".modal .o_data_row").toHaveCount(1);
     expect(getFacetTexts(".modal")).toEqual(["Displayed name\nPartner 10"]);
@@ -600,7 +600,7 @@ test("many2ones: Open the selection dialog several times using the 'Search More.
     await contains(".modal .btn-close").click();
     expect(".modal").toHaveCount(0);
 
-    await selectFieldDropdownItem("trululu", "Search More...");
+    await selectFieldDropdownItem("trululu", "Search more...");
     expect(".modal .o_data_row").toHaveCount(1);
     expect(getFacetTexts(".modal")).toEqual(["Displayed name\nPartner 10"]);
 });
@@ -922,13 +922,14 @@ test("empty many2one field", async () => {
 
     await contains(".o_field_many2one input").click();
     expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(1);
-    expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(1);
+    expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(0);
 
     await contains(".o_field_many2one[name='trululu'] input").edit("abc", { confirm: false });
     await runAllTimers();
 
-    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(3);
+    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(2);
     expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(0);
+    expect(".dropdown-menu li.o_m2o_no_result").toHaveCount(1);
 });
 
 test("empty readonly many2one field", async () => {
@@ -960,7 +961,7 @@ test("empty many2one field with node options", async () => {
     });
 
     await contains(".o_field_many2one[name='trululu'] input").click();
-    expect(".o_field_many2one[name='trululu'] .dropdown-menu li.o_m2o_start_typing").toHaveCount(1);
+    expect(".o_field_many2one[name='trululu'] .dropdown-menu li.o_m2o_start_typing").toHaveCount(0);
 
     await contains(".o_field_many2one[name='product_id'] input").click();
     expect(".o_field_many2one[name='product_id'] .dropdown-menu li.o_m2o_start_typing").toHaveCount(
@@ -994,7 +995,7 @@ test("many2one with no_create_edit and no_quick_create options should show no re
 test("many2one in edit mode", async () => {
     expect.assertions(17);
 
-    // create 10 partners to have the 'Search More' option in the autocomplete dropdown
+    // create 10 partners to have the 'Search more' option in the autocomplete dropdown
     for (let i = 0; i < 10; i++) {
         const id = 20 + i;
         Partner._records.push({ id, name: `Partner ${id}` });
@@ -1047,9 +1048,9 @@ test("many2one in edit mode", async () => {
     expect(".o_field_many2one[name='trululu'] .dropdown-menu").not.toBeVisible();
     expect(".o_field_many2one input").toHaveValue("first record");
 
-    // change the value of the m2o with a record in the 'Search More' modal
+    // change the value of the m2o with a record in the 'Search more' modal
     await clickFieldDropdown("trululu");
-    // click on 'Search More' (mouseenter required by ui-autocomplete)
+    // click on 'Search more' (mouseenter required by ui-autocomplete)
     await contains(
         ".o_field_many2one[name='trululu'] .dropdown-menu .o_m2o_dropdown_option_search_more"
     ).click();
@@ -1278,7 +1279,7 @@ test("many2one search with trailing and leading spaces", async () => {
     expect(".o_field_many2one[name='trululu'] .dropdown-menu").toBeVisible();
     expect(
         ".o_field_many2one[name='trululu'] .dropdown-menu li:not(.o_m2o_dropdown_option)"
-    ).toHaveCount(4);
+    ).toHaveCount(3);
 
     // search with leading spaces
     await contains(input).edit("   first", { confirm: false });
@@ -1384,7 +1385,7 @@ test("standalone many2one field", async () => {
 
     await contains(".o_field_widget input").edit("xyzzrot", { confirm: false });
     await runAllTimers();
-    await contains(".o_field_widget .ui-menu-item").click();
+    await contains(".o_field_widget .o_m2o_dropdown_option_create").click();
     expect(".o_field_widget .o_external_button").toHaveCount(0);
     expect.verifySteps(["web_name_search", "name_create"]);
 });
@@ -1411,7 +1412,7 @@ test("form: quick create then save directly", async () => {
 
     await contains(".o_field_widget[name=trululu] input").edit("b", { confirm: false });
     await runAllTimers();
-    await contains(".ui-menu-item").click();
+    await contains(".o_m2o_dropdown_option_create").click();
     await contains(".o_form_button_save").click();
 
     // should wait for the name_create before creating the record
@@ -1438,7 +1439,7 @@ test("form: quick create for field that returns false after name_create call", a
 
     await contains(".o_field_widget[name=trululu] input").edit("beam", { confirm: false });
     await runAllTimers();
-    await contains(".ui-menu-item").click();
+    await contains(".o_m2o_dropdown_option_create").click();
     expect.verifySteps(["name_create"]);
     expect(".o_input_dropdown input").toHaveValue("");
 });
@@ -1475,7 +1476,7 @@ test("list: quick create then save directly", async () => {
 
     await contains(".o_field_widget[name=trululu] input").edit("b", { confirm: false });
     await runAllTimers();
-    await contains(".ui-menu-item").click();
+    await contains(".o_m2o_dropdown_option_create").click();
 
     await contains(".o_list_button_save").click();
 
@@ -1524,7 +1525,7 @@ test("list in form: quick create then save directly", async () => {
 
     await contains(".o_field_widget[name=trululu] input").edit("b", { confirm: false });
     await runAllTimers();
-    await contains(".ui-menu-item").click();
+    await contains(".o_m2o_dropdown_option_create").click();
 
     await contains(".o_form_button_save").click();
 
@@ -1566,7 +1567,7 @@ test("name_create in form dialog", async () => {
         confirm: false,
     });
     await runAllTimers();
-    await contains(".modal .o_field_widget[name=product_id] .ui-menu-item").click();
+    await contains(".modal .o_field_widget[name=product_id] .o_m2o_dropdown_option_create").click();
 
     expect.verifySteps(["name_create"]);
 });
@@ -1619,7 +1620,7 @@ test("many2one inside one2many form view, with domain", async () => {
     await contains(".o_data_row .o_data_cell").click();
     await contains(".o_field_widget[name=trululu] input").click();
     await runAllTimers();
-    await clickFieldDropdownItem("trululu", "Search More...");
+    await clickFieldDropdownItem("trululu", "Search more...");
 
     expect(".modal .o_list_view").toHaveCount(1);
     expect(".modal .o_data_row").toHaveCount(8);
@@ -1664,7 +1665,7 @@ test("list in form: quick create then add a new line directly", async () => {
 
     await contains(".o_field_widget[name=trululu] input").edit("b", { confirm: false });
     await runAllTimers();
-    await contains(".ui-menu-item").click();
+    await contains(".o_m2o_dropdown_option_create").click();
 
     await contains(".o_field_x2many_list_row_add a").click();
 
@@ -2480,7 +2481,7 @@ test("failing quick create on a many2one because ValidationError", async () => {
 
     await contains(".o_field_widget[name='product_id'] input").edit("abcd", { confirm: false });
     await runAllTimers();
-    await contains(".o_field_widget[name='product_id'] .dropdown-item").click();
+    await contains(".o_field_widget[name='product_id'] .o_m2o_dropdown_option_create").click();
     await animationFrame(); // wait for the error service to ensure that there's no error dialog
     expect(".o_error_dialog").toHaveCount(0);
     expect(".modal .o_form_view").toHaveCount(1);
@@ -2509,7 +2510,7 @@ test("failing quick create on a many2one", async () => {
     await contains(".o_field_widget[name='product_id'] input").edit("abcd", { confirm: false });
     await runAllTimers();
     expect.errors(1);
-    await contains(".o_field_widget[name='product_id'] .dropdown-item").click();
+    await contains(".o_field_widget[name='product_id'] .o_m2o_dropdown_option_create").click();
     await animationFrame(); // wait for the error service
     expect.verifyErrors(["RPC_ERROR"]);
     expect(".o_error_dialog").toHaveCount(1);
@@ -2545,7 +2546,7 @@ test("failing quick create on a many2one inside a one2many because ValidationErr
     await contains(".o_field_x2many_list_row_add a").click();
     await contains(".o_field_widget[name='product_id'] input").edit("abcd", { confirm: false });
     await runAllTimers();
-    await contains(".o_field_widget[name='product_id'] .dropdown-item").click();
+    await contains(".o_field_widget[name='product_id'] .o_m2o_dropdown_option_create").click();
 
     expect(".modal .o_form_view").toHaveCount(1);
     expect(".modal .o_field_widget[name='name'] input").toHaveValue("abcd");
@@ -2572,10 +2573,8 @@ test("slow create on a many2one", async () => {
     });
     await contains(".o_field_many2one input").edit("new product", { confirm: false });
     await runAllTimers();
-    await press("arrowdown");
     await press("tab");
     await animationFrame();
-
 
     expect(".modal").toHaveCount(1);
     // cancel the many2one creation with Discard button
@@ -2586,7 +2585,6 @@ test("slow create on a many2one", async () => {
     // cancel the many2one creation with Close button
     await contains(".o_field_many2one input").edit("new product", { confirm: false });
     await runAllTimers();
-    await press("arrowdown");
     await press("tab");
     await animationFrame();
 
@@ -2602,7 +2600,6 @@ test("slow create on a many2one", async () => {
 
     await contains(".o_field_many2one input").edit("new product", { confirm: false });
     await runAllTimers();
-    await press("arrowdown");
     await press("tab");
     await animationFrame();
     expect(".modal").toHaveCount(1);
@@ -2613,7 +2610,6 @@ test("slow create on a many2one", async () => {
     // confirm the many2one creation
     await contains(".o_field_many2one input").edit("new product", { confirm: false });
     await runAllTimers();
-    await press("arrowdown");
     await press("tab");
     await animationFrame();
 
@@ -2653,11 +2649,9 @@ test("no_create option on a many2one", async () => {
 
     await contains(".o_field_many2one input").edit("new partner", { confirm: false });
     await runAllTimers();
-    await press("arrowdown");
-    await press("tab");
-
-    expect(".modal").toHaveCount(0);
-    expect(".o_field_many2one input").toHaveValue("");
+    expect(".o_m2o_dropdown_option_create").toHaveCount(0);
+    expect(".o_m2o_dropdown_option_create_edit").toHaveCount(0);
+    await press("escape");
 });
 
 test("no_create option on a many2one when can_create is absent", async () => {
@@ -2674,11 +2668,9 @@ test("no_create option on a many2one when can_create is absent", async () => {
     });
     await contains(".o_field_many2one input").edit("new partner", { confirm: false });
     await runAllTimers();
-    await press("arrowdown");
-    await press("tab");
-
-    expect(".modal").toHaveCount(0);
-    expect(".o_field_many2one input").toHaveValue("");
+    expect(".o_m2o_dropdown_option_create").toHaveCount(0);
+    expect(".o_m2o_dropdown_option_create_edit").toHaveCount(0);
+    await press("escape");
 });
 
 test("no_quick_create option on a many2one when can_create is absent", async () => {
@@ -2695,13 +2687,9 @@ test("no_quick_create option on a many2one when can_create is absent", async () 
     });
     await contains(".o_field_many2one input").edit("new partner", { confirm: false });
     await runAllTimers();
-    expect(".ui-autocomplete .o_m2o_dropdown_option").toHaveCount(2);
-    expect(".ui-autocomplete .o_m2o_dropdown_option:eq(0)").toHaveClass(
-        "o_m2o_dropdown_option_search_more"
-    );
-    expect(".ui-autocomplete .o_m2o_dropdown_option:eq(1)").toHaveClass(
-        "o_m2o_dropdown_option_create_edit"
-    );
+    expect(queryAllTexts(".ui-autocomplete .o_m2o_dropdown_option")).toEqual([
+        "Create and edit...",
+    ]);
 });
 
 test("can_create and can_write option on a many2one", async () => {
@@ -2826,7 +2814,7 @@ test("propagate can_create onto the search popup", async () => {
 
     await contains(".o_field_many2one[name=product_id] input").edit("", { confirm: false });
     await runAllTimers();
-    await clickFieldDropdownItem("product_id", "Search More...");
+    await clickFieldDropdownItem("product_id", "Search more...");
 
     expect(".modal-dialog.modal-lg").toHaveCount(1);
 
@@ -2925,7 +2913,6 @@ test("pressing ENTER on a 'no_quick_create' many2one should open a M2ODialog", a
         confirm: false,
     });
     await runAllTimers();
-    await press("arrowdown");
     await press("Enter");
     await animationFrame();
     expect(".modal").toHaveCount(1);
@@ -3226,7 +3213,7 @@ test("many2one: domain updated by an onchange", async () => {
 });
 
 test("search more in many2one: no text in input", async () => {
-    // when the user clicks on 'Search More...' in a many2one dropdown, and there is no text
+    // when the user clicks on 'Search more...' in a many2one dropdown, and there is no text
     // in the input (i.e. no value to search on), we bypass the web_name_search that is meant to
     // return a list of preselected ids to filter on in the list view (opened in a dialog)
     expect.assertions(2);
@@ -3271,7 +3258,7 @@ test("search more in many2one: no text in input", async () => {
 });
 
 test("search more in many2one: text in input", async () => {
-    // when the user clicks on 'Search More...' in a many2one dropdown, and there is some
+    // when the user clicks on 'Search more...' in a many2one dropdown, and there is some
     // text in the input, we perform a web_name_search to get a (limited) list of preselected
     // ids and we add a dynamic filter (with those ids) to the search view in the dialog, so
     // that the user can remove this filter to bypass the limit
@@ -3407,7 +3394,7 @@ test("updating a many2one from a many2many", async () => {
 });
 
 test("search more in many2one: cannot resequence inside dialog", async () => {
-    // when the user clicks on 'Search More...' in a many2one dropdown, resequencing inside
+    // when the user clicks on 'Search more...' in a many2one dropdown, resequencing inside
     // the dialog works
     Partner._fields.sequence = fields.Integer();
     for (let i = 0; i < 8; i++) {
@@ -3528,7 +3515,7 @@ test("search more in many2one: group and use the pager", async () => {
         arch: '<form><field name="trululu" /></form>',
     });
 
-    await selectFieldDropdownItem("trululu", "Search More...");
+    await selectFieldDropdownItem("trululu", "Search more...");
     await toggleSearchBarMenu(".modal");
     await toggleMenuItem("Bar");
 
@@ -3618,7 +3605,7 @@ test("search more pager is reset when doing a new search", async () => {
             </form>`,
     });
 
-    await selectFieldDropdownItem("trululu", "Search More...");
+    await selectFieldDropdownItem("trululu", "Search more...");
 
     await contains(".modal .o_pager_next").click();
 
@@ -3918,28 +3905,28 @@ test("search typeahead", async () => {
     await runAllTimers();
     expect.verifySteps([]);
     expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
-        "Search More...",
         "Start typing 3 characters",
+        "Search more...",
     ]);
 
     await contains(".o_field_widget[name=trululu] input").edit("r", { confirm: false });
     await runAllTimers();
     expect.verifySteps([]);
     expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
-        "Create \"r\"",
-        "Search More...",
-        "Create and edit...",
         "Start typing 3 characters",
+        "Create \"r\"",
+        "Create and edit...",
+        "Search more...",
     ]);
 
     await contains(".o_field_widget[name=trululu] input").edit("re", { confirm: false });
     await runAllTimers();
     expect.verifySteps([]);
     expect(queryAllTexts(`.o-autocomplete.dropdown li`)).toEqual([
-        "Create \"re\"",
-        "Search More...",
-        "Create and edit...",
         "Start typing 3 characters",
+        "Create \"re\"",
+        "Create and edit...",
+        "Search more...",
     ]);
 
     await contains(".o_field_widget[name=trululu] input").edit("rec", { confirm: false });
@@ -3949,7 +3936,7 @@ test("search typeahead", async () => {
         "first record",
         "second record",
         "Create \"rec\"",
-        "Search More...",
         "Create and edit...",
+        "Search more...",
     ]);
 });

--- a/addons/web/static/tests/views/fields/many2one_reference_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_reference_field.test.js
@@ -169,7 +169,7 @@ test("Many2OneReferenceField set value with search more", async () => {
     });
 
     expect(".o_field_widget input").toHaveValue("type 1");
-    await selectFieldDropdownItem("res_id", "Search More...");
+    await selectFieldDropdownItem("res_id", "Search more...");
     expect(".o_dialog .o_list_view").toHaveCount(1);
     await contains(".o_data_row .o_data_cell:eq(6)").click();
     expect(".o_dialog .o_list_view").toHaveCount(0);
@@ -178,7 +178,7 @@ test("Many2OneReferenceField set value with search more", async () => {
         "get_views", // form view
         "web_read", // partner id 1
         "web_name_search", // many2one
-        "get_views", // Search More...
+        "get_views", // Search more...
         "web_search_read", // SelectCreateDialog
         "has_group",
         "web_read", // read selected value

--- a/addons/web/static/tests/views/fields/reference_field.test.js
+++ b/addons/web/static/tests/views/fields/reference_field.test.js
@@ -169,13 +169,10 @@ test("ReferenceField respects no_quick_create", async () => {
     await click(".o_field_widget[name='reference'] input");
     await edit("new partner");
     await runAllTimers();
-    expect(".ui-autocomplete .o_m2o_dropdown_option").toHaveCount(2, {
-        message: "Dropdown should be opened and have two items",
+    expect(".ui-autocomplete .o_m2o_dropdown_option").toHaveCount(1, {
+        message: "Dropdown should be opened and have one item",
     });
     expect(".ui-autocomplete .o_m2o_dropdown_option:eq(0)").toHaveClass(
-        "o_m2o_dropdown_option_search_more"
-    );
-    expect(".ui-autocomplete .o_m2o_dropdown_option:eq(1)").toHaveClass(
         "o_m2o_dropdown_option_create_edit"
     );
 });
@@ -406,7 +403,7 @@ test("Many2One 'Search more...' updates on resModel change", async () => {
     await select("product");
     await animationFrame();
 
-    // Opening the Search More... option
+    // Opening the Search more... option
     await click("div.o_field_reference input.o_input");
     await animationFrame();
     await click("div.o_field_reference .o_m2o_dropdown_option_search_more");

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -9654,7 +9654,7 @@ test(`grouped list with another grouped list parent, click unfold`, async () => 
 
     await contains(`.o_data_cell`).click();
     await contains(`.o_field_widget[name=m2o] input`).click();
-    await contains(`.o-autocomplete--dropdown-item:contains(Search More...)`).click();
+    await contains(`.o-autocomplete--dropdown-item:contains(Search more...)`).click();
     expect(`.modal-content`).toHaveCount(1);
     expect(`.modal-content .o_group_name`).toHaveCount(0, { message: "list in modal not grouped" });
 
@@ -10909,7 +10909,7 @@ test(`multi edition: many2many_tags in many2many field`, async () => {
     await contains(`.o_data_row:eq(1) .o_list_record_selector input`).click();
     await contains(`.o_data_row:eq(0) .o_data_cell:eq(0)`).click();
     await contains(`.o_field_widget[name=m2m] input`).click();
-    await contains(`.o-autocomplete--dropdown-item:contains(Search More...)`).click();
+    await contains(`.o-autocomplete--dropdown-item:contains(Search more...)`).click();
     expect(`.modal`).toHaveCount(1, { message: "should have open the modal" });
 
     await contains(`.modal .o_data_row:eq(2) .o_field_cell`).click();
@@ -15978,7 +15978,7 @@ test(`Search more in a many2one`, async () => {
     ]);
 
     await contains(`.o_data_row:eq(0) td.o_list_many2one`).click();
-    await selectFieldDropdownItem("m2o", "Search More...");
+    await selectFieldDropdownItem("m2o", "Search more...");
     expect.verifySteps([]);
 
     await contains(`.modal .o_data_row:eq(2) td[name=display_name]`).click();
@@ -17175,7 +17175,7 @@ test(`context keys not passed down the stack and not to fields`, async () => {
     ]);
 
     await contains(
-        `.o_selected_row .o_field_many2many_tags .dropdown-item:contains(Search More...)`
+        `.o_selected_row .o_field_many2many_tags .dropdown-item:contains(Search more...)`
     ).click();
     expect.verifySteps([
         {


### PR DESCRIPTION
This commit reworks the many2x dropdown menu. The "start typing" and "no records" menu item are now displayed on top of the menu and the "search more" button is displayed as the last item. The conditions to display some items has changed too. The "start typing" item does not show anymore when record items are displayed and the "no records" item is now always displayed if there are no records. Before the item was displayed if we didn't have the creation permission.

task-4652321