### PR TITLE
[IMP] stock: restrict product selection to respective templates

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { Component } from "@odoo/owl";
+import { Component, markup } from "@odoo/owl";
 
 export class ForecastedButtons extends Component {
     static template = "stock.ForecastedButtons";
@@ -51,6 +51,9 @@ export class ForecastedButtons extends Component {
         const action = await this.orm.call(this.resModel, "action_open_quants", [[this.productId]]);
         if (action.res_model === "stock.quant") { // Quant view in inventory mode.
             action.views = [[false, "list"]];
+        }
+        if (action.help) {
+            action.help = markup(action.help);
         }
         return this.actionService.doAction(action, { onClose: this._onClose.bind(this) });
     }

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.js
@@ -14,22 +14,11 @@ export class ForecastedHeader extends Component {
     }
 
     async _onClickInventory(){
-        const context = this._getActionContext();
-        const action = await this.orm.call('stock.quant', 'action_view_quants', [], { context });
+        const productIds = this.props.docs.product_variants_ids;
+        const action = await this.orm.call('product.product', 'action_open_quants', [productIds]);
         if (action.help) {
             action.help = markup(action.help);
         }
         return this.action.doAction(action);
-    }
-
-    _getActionContext(){
-        const context = { ...this.context };
-        const templates = this.props.docs.product_templates_ids;
-        if (templates) {
-            context.search_default_product_tmpl_id = templates;
-        } else {
-            context.search_default_product_id = this.props.docs.product_variants_ids;
-        }
-        return context;
     }
 }

--- a/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.js
+++ b/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.js
@@ -19,6 +19,17 @@ patch(Parent.prototype, {
             target: 'current',
             context: context,
         });
+    },
+
+    _getActionContext() {
+        const context = { ...this.context };
+        const templates = this.props.docs.product_templates_ids;
+        if (templates) {
+            context.search_default_product_tmpl_id = templates;
+        } else {
+            context.search_default_product_id = this.props.docs.product_variants_ids;
+        }
+        return context;
     }
 });
 


### PR DESCRIPTION
Before commit:
--------------------------------------
- In the stock.quant view (opened by clicking the 'On Hand' value in the
  forecast report), able to update the quant of any product, even if it didn’t
  belong to the respective product/template.
- When there was no quants for product and the 'Update Quantity' button was
  clicked from the forecast report, the stock.quant no-content page appeared
  with raw HTML content.

With this commit:
--------------------------------------
- When updating a quant, only products belonging to the respective
  product/template can be selected.
- Pre-fill the product if only one variant exists.
- The stock.quant no-content page is now correctly displayed.

Task ID: [4599942](https://www.odoo.com/odoo/project/966/tasks/4599942)