### PR TITLE
[PERF] base: ir_attachment index on content

### DIFF
--- a/addons/hr_recruitment/models/__init__.py
+++ b/addons/hr_recruitment/models/__init__.py
@@ -17,6 +17,7 @@ from . import utm_campaign
 from . import utm_source
 from . import res_company
 from . import res_users
+from . import ir_attachment
 from . import ir_ui_menu
 from . import mail_activity_plan
 from . import hr_job_platform

--- a/addons/hr_recruitment/models/ir_attachment.py
+++ b/addons/hr_recruitment/models/ir_attachment.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.tools import SQL
+
+
+class IrAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    def init(self):
+        if self.env.registry.has_trigram:
+            indexed_field = SQL('UNACCENT(index_content)') if self.env.registry.has_unaccent else SQL('index_content')
+
+            self.env.cr.execute(SQL('''
+                CREATE INDEX IF NOT EXISTS ir_attachment_index_content_applicant_trgm_idx
+                    ON ir_attachment USING gin (%(indexed_field)s gin_trgm_ops)
+                 WHERE res_model = 'hr.applicant'
+            ''', indexed_field=indexed_field))


### PR DESCRIPTION
This commit adds a new index on the content of
the ir_attachment to permit users to search
attachments by a substring of their content
in a relatively efficient way given the
allowed indexes.

task-4610412

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
