### PR TITLE
[FIX] web_editor: prevent unwrapping buttons in link tool

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -11,6 +11,7 @@ import {
     useState,
 } from "@odoo/owl";
 import { normalizeCSSColor } from '@web/core/utils/colors';
+import { isButton } from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
 
 /**
  * Allows to customize link content and style.
@@ -530,5 +531,5 @@ export class LinkTools extends Link {
 }
 
 export function shouldUnlink(link, colorCombinationClass) {
-    return (!link.getAttribute("href") && !link.matches(".oe_unremovable")) && !colorCombinationClass;
+    return (!link.getAttribute("href") && !link.matches(".oe_unremovable")) && !colorCombinationClass && !isButton(link);
 }


### PR DESCRIPTION
**Problem**:
When destroying the link tool, if an `<a>` tag with `btn` classes has no `href`, it gets unwrapped. This visually removes the button, leaving only its text content. While this has no effect on normal links, it makes buttons appear to disappear when closing the tool.

**Solution**:
Prevent unwrapping buttons (`<a>` with `btn` classes) when the link tool is destroyed.

**Steps to Reproduce**:
1. Open the website editor.
2. Add "Blocks" > "Features" > "Items".
3. Click inside a button to show the link tool.
4. Click outside the editable area.
5. Click inside the button again.
   - **Issue**: The button disappears, leaving only text.

**opw-4574401**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
