### PR TITLE
[IMP] account, *sale: sale_order/move line unit price computation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5388,6 +5388,7 @@ class AccountMove(models.Model):
     def action_update_fpos_values(self):
         self.invoice_line_ids._compute_tax_ids()
         self.line_ids._compute_account_id()
+        self.line_ids._compute_price_unit()
 
     def open_created_caba_entries(self):
         self.ensure_one()

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1277,6 +1277,7 @@ class SaleOrder(models.Model):
         self.ensure_one()
 
         self._recompute_taxes()
+        self._recompute_prices()
 
         if self.partner_id:
             self.message_post(body=_("Product taxes have been recomputed according to fiscal position %s.",


### PR DESCRIPTION
### Before
Different behavior when:
1. Adding a fiscal position -> adding a product: unit price (price_unit) changes and keeps the same un-taxed price which is based on the original sales price minus the tax set on the product. 
2. Adding a product to an invoice/sale order -> adding a fiscal position and refreshing taxes: unit price (price_unit) stays the same while tax and price_subtotal adjust depending on other settings.

### Now
Scenario 2 behaves the same as 1, therefore recomputing the unit price when a fiscal position is set and taxes are refreshed.

task-4430319