### PR TITLE
[FIX] website: fix edit mode interaction listener patch

### DIFF
--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -198,7 +198,24 @@ export class Interaction {
      * Mechanism to handle context-specific protection of a specific
      * chunk of synchronous code after returning from an asynchronous one.
      * This should typically be used around code that follows an
-     * await waitFor(...).
+     * await this.waitFor(...).
+     *
+     * Example use-case: website builder's edit-mode disables the history
+     * observer to ignore the changes done by interactions.
+     *
+     * A listener involving async code would then look like this:
+     * async onClick() {
+     *     // Code before await is protected
+     *     const result = await this.waitFor(...);
+     *     // Code here is not protected anymore
+     *     // Render variables can be updated because updateContent will run
+     *     // after the handler in a protected state
+     *     this.stuffUsedByTAtt = result.stuffUsedByTAtt;
+     *     this.protectSyncAfterAsync(() => {
+     *         // Code here is protected again, DOM can be updated
+     *         doStuff(this.el);
+     *     });
+     * }
      */
     protectSyncAfterAsync(fn) {
         return this.__colibri__.protectSyncAfterAsync(this, "protectSyncAfterAsync", fn);

--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -256,14 +256,18 @@ export class Interaction {
     /**
      * Debounces a function and makes sure it is cancelled upon destroy.
      */
-    debounced(fn, delay) {
+    debounced(fn, delay, options) {
         fn = this.__colibri__.protectSyncAfterAsync(this, "debounced", fn);
-        const debouncedFn = debounce(async (...args) => {
-            await fn.apply(this, args);
-            if (this.isReady && !this.isDestroyed) {
-                this.updateContent();
-            }
-        }, delay);
+        const debouncedFn = debounce(
+            async (...args) => {
+                await fn.apply(this, args);
+                if (this.isReady && !this.isDestroyed) {
+                    this.updateContent();
+                }
+            },
+            delay,
+            options
+        );
         this.registerCleanup(() => {
             debouncedFn.cancel();
         });

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -121,9 +121,9 @@ patch(Colibri.prototype, {
         let stealthFn = fn;
         if (wysiwyg?.odooEditor && !fn.isHandler && stealth) {
             const name = `${this.interaction.constructor.name}/${event}`;
-            stealthFn = async (...args) => {
+            stealthFn = (...args) => {
                 wysiwyg.odooEditor.observerUnactive(name);
-                const result = await fn(...args);
+                const result = fn(...args);
                 wysiwyg.odooEditor.observerActive(name);
                 return result;
             };


### PR DESCRIPTION
    Since [1] when the interaction listeners were patched for website's
    edit mode, the listeners async code was being awaited while the editor
    history was asked to ignore incoming DOM mutations. Because of this, any
    mutation happening in the meantime is missed by the editor.

    This commit fixes this by only wrapping the sync code in the unobserved
    editor history context, then awaiting a possibly pending Promise.

    The documentation of `protectSyncAfterAsync` is also improved.

    [1]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f#diff-0d0f8c01991b6a57c039e033bdfc079b80e144139f49d09f209b177ef7c64bb1R10

    task-4367641
