### PR TITLE
[FIX] website_forum: use url_for for microdata

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -92,7 +92,11 @@ class Http(models.AbstractModel):
             :param lang_code: Must be the lang `code`. It could also be something
                               else, such as `'[lang]'` (used for url_return).
         '''
-        path, _, qs = (url_from or '').partition('?')
+        path, sep, qs = (url_from or '').partition('?')
+
+        if not qs:
+            path, sep, qs = (url_from or '').partition('#')
+
         if (
             path
             # don't try to match route if we know that no rewrite has been loaded.
@@ -105,7 +109,7 @@ class Http(models.AbstractModel):
             )
         ):
             url_from, _ = request.env['ir.http'].url_rewrite(path)
-            url_from = url_from if not qs else url_from + '?%s' % qs
+            url_from = url_from if not qs else f"{url_from}{sep}{qs}"
 
         return super()._url_for(url_from, lang_code)
 

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -831,7 +831,7 @@ class Post(models.Model):
         res = {
             "upvoteCount": self.vote_count,
             "datePublished": self.create_date.isoformat() + 'Z',
-            "url": self.website_url,
+            "url": self.env['ir.http']._url_for(self.website_url),
             "author": {
                 "@type": "Person",
                 "name": self.create_uid.sudo().name,
@@ -846,7 +846,7 @@ class Post(models.Model):
             res["text"] = self.plain_content or self.name
             res["answerCount"] = self.child_count
         if self.create_uid.sudo().website_published:
-            res["author"]["url"] = f"/forum/user/{ self.create_uid.sudo().id }"
+            res["author"]["url"] = self.env['ir.http']._url_for(f"/forum/user/{ self.create_uid.sudo().id }")
         return res
 
     def go_to_website(self):


### PR DESCRIPTION
Previously, the `lang` parameter was missing from the URL, and URLs were not correctly updated when a 308 redirect was present.

This commit ensures that the `lang` parameter is added and that URLs are properly converted after a 308 redirect.
