### PR TITLE
[FIX] website: hide create-link button when translating


### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -39,6 +39,10 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
 
         this.__onSelectionChange = ev => {
             this._toggleAnimatedTextButton();
+            if (this.options.enableTranslation) {
+                this._$toolbarContainer[0].querySelector('#create-link').classList.add("d-none");
+            }
+
         };
         this.$body[0].ownerDocument.addEventListener('selectionchange', this.__onSelectionChange);
 


### PR DESCRIPTION

Scenario:
- translate website page
- set a link in the content of translation
- save

Result: nothing is saved

Issue: content is split in translatable node (which is an element node +
that can contain some inline tags such as B, I, ...) but we don't
support adding a link in a translatable node (which would change the
number of nodes).

Fix: hide the create link button when we are translating.

opw-4645879
