### PR TITLE
[DOC] fields: read_group example update

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -212,11 +212,11 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
         .. code-block:: python
 
             @api.model
-            def _read_group_selection_field(self, values, domain, order):
+            def _read_group_selection_field(self, values, domain):
                 return ['choice1', 'choice2', ...] # available selection choices.
 
             @api.model
-            def _read_group_many2one_field(self, records, domain, order):
+            def _read_group_many2one_field(self, records, domain):
                 return records + self.search([custom_domain])
 
     .. rubric:: Computed Fields


### PR DESCRIPTION
The function does not take an `order` parameter.

closes odoo/documentation#12557


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
