### PR TITLE
[FIX] spreadsheet: Ensure spreadsheet_data are json files

### DIFF
--- a/addons/spreadsheet/models/spreadsheet_mixin.py
+++ b/addons/spreadsheet/models/spreadsheet_mixin.py
@@ -28,13 +28,13 @@ class SpreadsheetMixin(models.AbstractModel):
 
     @api.constrains("spreadsheet_binary_data")
     def _check_spreadsheet_data(self):
-        if not(tools.config['test_enable'] or tools.config['test_file']):
-            return None
         for spreadsheet in self.filtered("spreadsheet_binary_data"):
             try:
                 data = json.loads(base64.b64decode(spreadsheet.spreadsheet_binary_data).decode())
             except (json.JSONDecodeError, UnicodeDecodeError):
                 raise ValidationError(_("Uh-oh! Looks like the spreadsheet file contains invalid data."))
+            if not (tools.config['test_enable'] or tools.config['test_file']):
+                continue
             if data.get("[Content_Types].xml"):
                 # this is a xlsx file
                 continue


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/188792 we mistakenly removed the check that ensured the spreadsheet_data attachment was a valid JSON file.

Task-4657990

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
