### PR TITLE
[REF] mail: be more defensive in default or suggested recipients

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -167,10 +167,10 @@ class AccountMoveSend(models.AbstractModel):
             else:
                 email_to = ''
 
-        for mail_data in tools.email_split(email_cc):
-            partners |= partners.find_or_create(mail_data)
-        for mail_data in tools.email_split(email_to):
-            partners |= partners.find_or_create(mail_data)
+        partners |= move._partner_find_from_emails_single(
+            tools.email_split(email_cc or '') + tools.email_split(email_to or ''),
+            no_create=False,
+        )
 
         if not mail_template.use_default_to and mail_template.partner_to:
             partner_to = self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'partner_to')

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -226,19 +226,21 @@ class HrApplicant(models.Model):
 
     def _inverse_partner_email(self):
         for applicant in self:
-            if not applicant.email_from:
+            email_normalized = tools.email_normalize(applicant.email_from or '')
+            if not email_normalized:
                 continue
             if not applicant.partner_id:
                 if not applicant.partner_name:
                     raise UserError(_("You must define a Contact Name for this applicant."))
-                applicant.partner_id = (
-                    self.env["res.partner"]
-                    .with_context(default_lang=self.env.lang)
-                    .find_or_create(applicant.email_from)
+                applicant.partner_id = applicant._partner_find_from_emails_single(
+                    [applicant.email_from], no_create=False,
+                    additional_values={
+                        email_normalized: {'lang': self.env.lang}
+                    },
                 )
             if applicant.partner_name and not applicant.partner_id.name:
                 applicant.partner_id.name = applicant.partner_name
-            if tools.email_normalize(applicant.email_from) != tools.email_normalize(applicant.partner_id.email):
+            if email_normalized != tools.email_normalize(applicant.partner_id.email):
                 # change email on a partner will trigger other heavy code, so avoid to change the email when
                 # it is the same. E.g. "email@example.com" vs "My Email" <email@example.com>""
                 applicant.partner_id.email = applicant.email_from

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -240,11 +240,9 @@ class HrApplicant(models.Model):
                 )
             if applicant.partner_name and not applicant.partner_id.name:
                 applicant.partner_id.name = applicant.partner_name
-            if email_normalized != tools.email_normalize(applicant.partner_id.email):
-                # change email on a partner will trigger other heavy code, so avoid to change the email when
-                # it is the same. E.g. "email@example.com" vs "My Email" <email@example.com>""
+            if email_normalized and not applicant.partner_id.email:
                 applicant.partner_id.email = applicant.email_from
-            if applicant.partner_phone:
+            if applicant.partner_phone and not applicant.partner_id.phone:
                 applicant.partner_id.phone = applicant.partner_phone
 
     @api.depends("email_normalized", "partner_phone_sanitized", "linkedin_profile")

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2035,10 +2035,8 @@ class MailThread(models.AbstractModel):
         # fetch information used to find existing partners, beware portal/public who
         # cannot read followers
         followers = self.sudo().message_partner_ids if 'message_partner_ids' in self else self.env['res.partner']
-        aliases = self.env['mail.alias'].sudo().search(
-            [('alias_full_name', 'in', emails_key_all)]
-        ) if avoid_alias else self.env['mail.alias'].sudo()
-        ban_emails = (ban_emails or []) + aliases.mapped('alias_full_name')
+        alias_emails = self.env['mail.alias.domain'].sudo()._find_aliases(emails_key_all) if avoid_alias else []
+        ban_emails = (ban_emails or []) + alias_emails
 
         # inspired notably from odoo/odoo@80a0b45df806ffecfb068b5ef05ae1931d655810; final
         # ordering is search order defined in '_find_or_create_from_emails', which is id ASC

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -398,9 +398,11 @@ class CalendarEvent(models.Model):
         elif self.env.user.partner_id.email not in emails:
             commands_attendee += [(0, 0, {'state': 'accepted', 'partner_id': self.env.user.partner_id.id})]
             commands_partner += [(4, self.env.user.partner_id.id)]
-        partners = self.env['mail.thread']._mail_find_partner_from_emails(emails, records=self, force_create=True)
+        partners = self.env['mail.thread']._partner_find_from_emails_single(emails, no_create=False)
         attendees_by_emails = {a.email: a for a in existing_attendees}
-        for email, partner, attendee_info in zip(emails, partners, microsoft_attendees):
+        partners_by_emails = {p.email_normalized: p for p in partners}
+        for email, attendee_info in zip(emails, microsoft_attendees):
+            partner = partners_by_emails.get(email_normalize(email) or email, self.env['res.partner'])
             # Responses from external invitations are stored in the 'responseStatus' field.
             # This field only carries the current user's event status because Microsoft hides other user's status.
             if self.env.user.email == email and microsoft_event.responseStatus:

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -4,7 +4,7 @@ from unittest.mock import DEFAULT
 import base64
 
 from odoo import exceptions, tools
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.addons.mail.tools.discuss import Store
@@ -19,11 +19,60 @@ class TestAPI(MailCommon, TestRecipients):
     def setUpClass(cls):
         super().setUpClass()
         cls.user_portal = cls._create_portal_user()
-        cls.test_partner = cls.env['res.partner'].create({
-            'email': '"Test External" <test.external@example.com>',
-            'phone': '+32455001122',
-            'name': 'Test External',
+        cls.test_partner, cls.test_partner_archived = cls.env['res.partner'].create([
+            {
+                'email': '"Test External" <test.external@example.com>',
+                'phone': '+32455001122',
+                'name': 'Name External',
+            }, {
+                'active': False,
+                'email': '"Test Archived" <test.archived@example.com>',
+                'phone': '+32455221100',
+                'name': 'Name Archived',
+            },
+        ])
+        cls.user_employee_2 = mail_new_test_user(
+            cls.env,
+            email='eglantine@example.com',
+            groups='base.group_user',
+            login='employee2',
+            name='Eglantine Employee',
+            notification_type='email',
+            signature='--\nEglantine',
+        )
+        cls.partner_employee_2 = cls.user_employee_2.partner_id
+        cls.user_employee_archived = mail_new_test_user(
+            cls.env,
+            email='albert@example.com',
+            groups='base.group_user',
+            login='albert',
+            name='Albert Alemployee',
+            notification_type='email',
+            signature='--\nAlbert',
+        )
+        cls.user_employee_archived.active = False
+        cls.partner_employee_archived = cls.user_employee_archived.partner_id
+
+        cls.test_aliases = cls.env['mail.alias'].create([
+            {
+                'alias_domain_id': cls.mail_alias_domain.id,
+                'alias_model_id': cls.env['ir.model']._get_id('mail.test.ticket.mc'),
+                'alias_name': 'test.alias.free',
+            }, {
+                'alias_domain_id': cls.mail_alias_domain.id,
+                'alias_model_id': cls.env['ir.model']._get_id('mail.test.ticket.mc'),
+                'alias_name': 'test.alias.partner',
+            }
+        ])
+        cls.test_partner_alias = cls.env['res.partner'].create({
+            'email': f'"Do not do this" <{cls.test_aliases[1].alias_full_name}>',
+            'name': 'Someone created a partner with email=alias',
         })
+        cls.test_partner_catchall = cls.env['res.partner'].create({
+            'email': f'"Do not do this neither" <{cls.mail_alias_domain.catchall_email}>',
+            'name': 'Someone created a partner with email=catchall',
+        })
+
         cls.ticket_record = cls.env['mail.test.ticket.mc'].create({
             'company_id': cls.user_employee.company_id.id,
             'email_from': '"Paulette Vachette" <paulette@test.example.com>',
@@ -56,6 +105,11 @@ class TestAPI(MailCommon, TestRecipients):
                 'name': 'Publicly Created',
             },
         ])
+
+    def test_assert_initial_values(self):
+        """ Just be sure of what we test """
+        self.assertFalse(self.user_employee_archived.active)
+        self.assertTrue(self.partner_employee_archived.active)
 
     @users('employee')
     def test_body_escape(self):
@@ -390,6 +444,74 @@ class TestAPI(MailCommon, TestRecipients):
                 'Mail: prioritize email should not return partner if email is found'
             )
 
+    @users('employee')
+    def test_message_get_default_recipients_banned(self):
+        """ Test defensive behavior to avoid contacting critical emails like
+        aliases, public users, ... """
+        tickets = self.env['mail.test.ticket.mc'].create([
+            # do not propose public partners
+            {
+                'customer_id': self.user_public.partner_id.id,
+                'name': 'Public',
+            },
+            # do not propose root
+            {
+                'customer_id': self.user_root.partner_id.id,
+                'name': 'Root',
+            },
+            # do not propose alias domain emails
+            {
+                'email_from': self.mail_alias_domain.catchall_email,
+            },
+            # do not propose when partner = alias
+            {
+                'customer_id': self.test_partner_alias.id,
+                'name': 'Partner = Alias',
+            },
+            # do not propose alias email
+            {
+                'email_from': self.test_aliases[0].alias_full_name,
+                'name': 'Alias email',
+            },
+            # do not propose alias email (even if linked to a partner)
+            {
+                'email_from': self.test_aliases[1].alias_full_name,
+                'name': 'Alias email, existing partner',
+            },
+            # propose archived
+            {
+                'customer_id': self.test_partner_archived.id,
+                'name': 'Archived partner',
+            },
+            # propose active based on archived user
+            {
+                'customer_id': self.partner_employee_archived.id,
+                'name': 'Archived partner',
+            },
+        ])
+        expected_all = [
+            # nobody to suggest (no public !)
+            {'email_cc': '', 'email_to': '', 'partner_ids': []},
+            # FIXME should be nobody to suggest (no root !)
+            {'email_cc': '', 'email_to': '', 'partner_ids': [self.partner_root.id]},
+            # FIXME alias domain email is not ok
+            {'email_cc': '', 'email_to': 'catchall.test@test.mycompany.com', 'partner_ids': []},
+            # FIXME partner with alias email is not ok
+            {'email_cc': '', 'email_to': '', 'partner_ids': [self.test_partner_alias.id]},
+            # FIXME alias email is not ok
+            {'email_cc': '', 'email_to': 'test.alias.free@test.mycompany.com', 'partner_ids': []},
+            # FIXME alias email is not ok even if linked to partner
+            {'email_cc': '', 'email_to': 'test.alias.partner@test.mycompany.com', 'partner_ids': []},
+            # archived is ok, customer
+            {'email_cc': '', 'email_to': '', 'partner_ids': [self.test_partner_archived.id]},
+            # active based on archived user is ok, customer
+            {'email_cc': '', 'email_to': '', 'partner_ids': [self.partner_employee_archived.id]},
+        ]
+        defaults = tickets._message_get_default_recipients(all_tos=False)
+        for ticket, expected in zip(tickets, expected_all, strict=True):
+            with self.subTest(ticket_name=ticket.name):
+                self.assertDictEqual(defaults[ticket.id], expected)
+
     @users("employee")
     def test_message_get_suggested_recipients(self):
         """ Test default creation values returned for suggested recipient. """
@@ -439,9 +561,123 @@ class TestAPI(MailCommon, TestRecipients):
                     }
                 )
 
-        # do not propose public partners
-        ticket_public = self.env['mail.test.ticket.mc'].create({'customer_id': self.user_public.partner_id.id})
-        self.assertFalse(ticket_public._message_get_suggested_recipients(no_create=True))
+    @users("employee")
+    def test_message_get_suggested_recipients_banned(self):
+        """ Ban list: public partners, aliases, alias domains """
+        domains = self.env['mail.alias.domain'].sudo().search([])
+        domains_cc_list = []
+        for domain in domains:
+            domains_cc_list += [
+                f'"Bounce {domain.name}" <{domain.bounce_email}>',
+                f'"Catchall {domain.name}" <{domain.catchall_email}>',
+                f'"Default {domain.name}" <{domain.default_from_email}>',
+            ]
+        tickets = self.env['mail.test.ticket.mc'].create([
+            # do not propose public partners
+            {
+                'customer_id': self.user_public.partner_id.id,
+                'name': 'Public',
+            },
+            # do not propose root
+            {
+                'customer_id': self.user_root.partner_id.id,
+                'name': 'Root',
+            },
+            # valid, but with message containing alias domain emails
+            {
+                'customer_id': self.test_partner.id,
+                'name': 'Valid partner + invalid domain emails in discussion',
+            },
+            # valid, but with message containing alias emails or partners
+            {
+                'customer_id': self.test_partner_archived.id,
+                'name': 'Valid partner archived + invalid in discussion',
+            },
+        ])
+        tickets[2].message_post(
+            author_id=self.user_root.partner_id.id,
+            body='Message with lots of invalid emails',
+            incoming_email_cc=', '.join(domains_cc_list),
+            message_type='email',
+            subtype_id=self.env.ref('mail.mt_comment').id,
+        )
+        tickets[3].message_post(
+            author_id=False,
+            email_from=self.mail_alias_domain.bounce_email,
+            body='Message with alias emails and partners',
+            message_type='email',
+            incoming_email_to=f'"Alias" <{self.test_aliases[0].alias_full_name}>',
+            partner_ids=(self.test_partner_alias + self.test_partner_catchall).ids,
+            subtype_id=self.env.ref('mail.mt_comment').id,
+        )
+        expected_all = [
+            # nobody to suggest (no public !)
+            [],
+            # FIXME should be nobody to suggest (no root !)
+            [
+                {
+                    'create_values': {},
+                    'email': self.user_root.email_normalized,
+                    'name': self.user_root.name,
+                    'partner_id': self.user_root.partner_id.id,
+                },
+            ],
+            # only valid is the customer FIXME and not alias domain bits !
+            [
+                {
+                    'create_values': {},
+                    'email': self.test_partner.email_normalized,
+                    'name': self.test_partner.name,
+                    'partner_id': self.test_partner.id,
+                },
+            ] + [
+                {
+                    'create_values': {},
+                    'email': 'catchall.test@test.mycompany.com',
+                    'name': self.test_partner_catchall.name,
+                    'partner_id': self.test_partner_catchall.id,
+                },
+            ] + [
+                {
+                    'create_values': {},
+                    'email': tools.mail.email_normalize(domain),
+                    'name': tools.mail.email_split_tuples(domain)[0][0],
+                    'partner_id': False,
+                } for domain in domains_cc_list if tools.mail.email_normalize(domain) != 'catchall.test@test.mycompany.com'
+            ],
+            # only valid is the customer FIXME and not aliases !
+            [
+                {
+                    'create_values': {},
+                    'email': self.test_partner_archived.email_normalized,
+                    'name': self.test_partner_archived.name,
+                    'partner_id': self.test_partner_archived.id,
+                },
+            ] + [
+                {
+                    'create_values': {},
+                    'email': self.test_partner_alias.email_normalized,
+                    'name': self.test_partner_alias.name,
+                    'partner_id': self.test_partner_alias.id,
+                }, {
+                    'create_values': {},
+                    'email': self.test_partner_catchall.email_normalized,
+                    'name': self.test_partner_catchall.name,
+                    'partner_id': self.test_partner_catchall.id,
+                }, {
+                    'create_values': {},
+                    'email': 'bounce.test@test.mycompany.com',
+                    'name': '',
+                    'partner_id': False,
+                },
+            ],
+        ]
+        suggested_all = tickets._message_get_suggested_recipients_batch(no_create=True, reply_discussion=True)
+        for ticket, expected in zip(tickets, expected_all, strict=True):
+            with self.subTest(ticket_name=ticket.name):
+                suggested = suggested_all[ticket.id]
+                for suggestion, expected_sugg in zip(suggested, expected, strict=True):
+                    self.assertDictEqual(suggestion, expected_sugg)
 
     @users("employee")
     def test_message_get_suggested_recipients_conversation(self):
@@ -472,17 +708,20 @@ class TestAPI(MailCommon, TestRecipients):
                 'incoming_email_cc': tools.mail.formataddr(test_cc_tuples[1]),
                 'incoming_email_to': tools.mail.formataddr(test_to_tuples[0]),
                 'message_type': 'email',
+                'subtype_id': self.env.ref('mail.mt_comment').id,
             }),
             (self.user_root, {
                 'body': 'Some automated email',
                 'message_type': 'email_outgoing',
                 'partner_ids': self.user_portal.partner_id.ids,
+                'subtype_id': self.env.ref('mail.mt_comment').id,
             }),
             (self.user_employee, {
                 'body': 'Salesman reply by email',
                 'incoming_email_cc': tools.mail.formataddr(test_cc_tuples[2]),
                 'incoming_email_to': tools.mail.formataddr(test_to_tuples[1]),
                 'message_type': 'email',
+                'subtype_id': self.env.ref('mail.mt_comment').id,
             }),
         ]:
             messages += test_record.with_user(user).message_post(**post_values)

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -613,16 +613,9 @@ class TestAPI(MailCommon, TestRecipients):
         expected_all = [
             # nobody to suggest (no public !)
             [],
-            # FIXME should be nobody to suggest (no root !)
-            [
-                {
-                    'create_values': {},
-                    'email': self.user_root.email_normalized,
-                    'name': self.user_root.name,
-                    'partner_id': self.user_root.partner_id.id,
-                },
-            ],
-            # only valid is the customer FIXME and not alias domain bits !
+            #nobody to suggest (no root !)
+            [],
+            # only valid is the customer
             [
                 {
                     'create_values': {},
@@ -630,45 +623,14 @@ class TestAPI(MailCommon, TestRecipients):
                     'name': self.test_partner.name,
                     'partner_id': self.test_partner.id,
                 },
-            ] + [
-                {
-                    'create_values': {},
-                    'email': 'catchall.test@test.mycompany.com',
-                    'name': self.test_partner_catchall.name,
-                    'partner_id': self.test_partner_catchall.id,
-                },
-            ] + [
-                {
-                    'create_values': {},
-                    'email': tools.mail.email_normalize(domain),
-                    'name': tools.mail.email_split_tuples(domain)[0][0],
-                    'partner_id': False,
-                } for domain in domains_cc_list if tools.mail.email_normalize(domain) != 'catchall.test@test.mycompany.com'
             ],
-            # only valid is the customer FIXME and not aliases !
+            # only valid is the customer (and not aliases nor partner with alias email)
             [
                 {
                     'create_values': {},
                     'email': self.test_partner_archived.email_normalized,
                     'name': self.test_partner_archived.name,
                     'partner_id': self.test_partner_archived.id,
-                },
-            ] + [
-                {
-                    'create_values': {},
-                    'email': self.test_partner_alias.email_normalized,
-                    'name': self.test_partner_alias.name,
-                    'partner_id': self.test_partner_alias.id,
-                }, {
-                    'create_values': {},
-                    'email': self.test_partner_catchall.email_normalized,
-                    'name': self.test_partner_catchall.name,
-                    'partner_id': self.test_partner_catchall.id,
-                }, {
-                    'create_values': {},
-                    'email': 'bounce.test@test.mycompany.com',
-                    'name': '',
-                    'partner_id': False,
                 },
             ],
         ]

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -487,7 +487,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        with self.assertQueryCount(admin=29, employee=29):  # tm: 20/20
+        with self.assertQueryCount(admin=32, employee=32):  # tm: 23/23
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -514,7 +514,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        with self.assertQueryCount(admin=30, employee=30):  # tm: 21/21
+        with self.assertQueryCount(admin=33, employee=33):  # tm: 24/24
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -543,7 +543,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_template.write({'attachment_ids': [(5, 0)]})
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=44, employee=44):  # tm 34/34
+        with self.assertQueryCount(admin=47, employee=47):  # tm 37/37
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -573,7 +573,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=44, employee=44):  # tm 36/36
+        with self.assertQueryCount(admin=47, employee=47):  # tm 37/37
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -948,7 +948,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients(self):
         record = self.test_records_recipients[0].with_env(self.env)
-        with self.assertQueryCount(employee=21):  # tm: 14
+        with self.assertQueryCount(employee=22):  # tm: 15
             recipients = record._message_get_suggested_recipients(no_create=False)
         new_partner = self.env['res.partner'].search([('email_normalized', '=', 'only.email.1@test.example.com')])
         self.assertEqual(len(new_partner), 1)
@@ -963,7 +963,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=26):  # tm: 19
+        with self.assertQueryCount(employee=29):  # tm: 22
             _recipients = records._message_get_suggested_recipients_batch(no_create=False)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
@@ -992,7 +992,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=67, employee=67):
+        with self.assertQueryCount(admin=68, employee=68):
             record.message_post_with_source(
                 template,
                 message_type='comment',
@@ -1074,7 +1074,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_partner_find_from_emails(self):
         """ Test '_partner_find_from_emails', notably to check batch optimization """
         records = self.test_records_recipients.with_user(self.env.user)
-        with self.assertQueryCount(employee=26):  # tm: 18
+        with self.assertQueryCount(employee=27):  # tm: 19
             partners = records._partner_find_from_emails(
                 {record: [record.email_from, record.partner_id.email, record.user_id.email] for record in records},
                 avoid_alias=True,

--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -138,13 +138,16 @@ class WebsiteEventBoothController(WebsiteEventController):
     def _prepare_booth_registration_partner_values(self, event, kwargs):
         if request.env.user._is_public():
             contact_email_normalized = tools.email_normalize(kwargs['contact_email'])
-            partner = request.env['res.partner'].sudo()._find_or_create_from_emails(
-                [contact_email_normalized],
-                additional_values={contact_email_normalized: {
-                    'phone': kwargs.get('contact_phone'),
-                    'name': kwargs.get('contact_name'),
-                }}
-            )[0]
+            if contact_email_normalized:
+                partner = event._partner_find_from_emails_single(
+                    [contact_email_normalized],
+                    additional_values={contact_email_normalized: {
+                        'phone': kwargs.get('contact_phone'),
+                        'name': kwargs.get('contact_name'),
+                    }},
+                )
+            else:
+                partner = request.env['res.partner']
         else:
             partner = request.env.user.partner_id
         return {


### PR DESCRIPTION
Rationale

Now that more emails and partners are suggested in chatter flow since
https://github.com/odoo/odoo/pull/185240 it highlights issue notably with aliases or alias
domains specific emails. We should ensure those are never proposed,
either as email or as partners.

Specifications: defensive email / partner fetch

Consider all emails coming from alias domains (catchall, bounce, default
from) are like aliases and should not be suggested.

Filter suggested partners whose emails match aliases or alias domain
emails.

Specifications: filter discussion message when replying to all

Filter before sorting, in order to keep only relevant messages. Also
add missing filter on subtype, which should be 'comment' or creation
subtype for incoming emails.

Indeed logged notes, even with pings, should not be considered as a
reply-all as purpose is to include customers and external people
involved in emails and discussions.

Then sort only based on date, considering most recent message is the
most important. No need to sort based on email or discussion as
date is the only relevant criterion.

Specifications: be sure addons use dedicated mail tools

Avoid aliases and alias domains emails added as follower or recipients
by using the correct tools.

Links

Followup of odoo/odoo#185240
Followup of odoo/odoo#198173
Followup of odoo/odoo#198095

Task-4656218
