### PR TITLE
[FIX] website: prevent traceback when no `.s_tabs_nav .nav` exists

### DIFF
--- a/addons/website/static/src/snippets/s_tabs/options.js
+++ b/addons/website/static/src/snippets/s_tabs/options.js
@@ -191,7 +191,7 @@ options.registry.NavTabsStyle = options.Class.extend({
 
         switch (methodName) {
             case 'setStyle':
-                const matchingValue = params.possibleValues.find(value => navEl.classList.contains(value));
+                const matchingValue = params.possibleValues.find(value => !navEl || navEl.classList.contains(value));
                 return matchingValue;
             case 'setDirection':
                 return this.$target.find('.s_tabs_nav:first .nav').hasClass('flex-sm-column') ? 'vertical' : 'horizontal';


### PR DESCRIPTION
**Problem**:
After commit [https://github.com/odoo-dev/odoo/commit/80fde992370e4474c27a383a61814ce1159f550c](https://github.com/odoo/odoo/commit/80fde992370e4474c27a383a61814ce1159f550c),
if all tabs in a "Tabs" block are removed and saved, the next time the
editor is opened, there is a traceback because `navEl` is `null`.

**Solution**:
Use the first value from `possibleValues` in case `navEl` is `null`
this will prevent traceback in that case but does not prevent reaching
the no tab situation (Still able to remove all tabs).

**Steps to Reproduce**:
1. Add a **"Tabs"** block.
2. Click inside the first tab to edit its content.
3. Press **Backspace** repeatedly until the tab is completely removed.
4. Repeat for all remaining tabs until none are left.
5. Save and exit the editor.
6. Open the editor again.
   - **Issue**: A traceback occurs due to `navEl` being `null`.

**opw-4608389**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
