### PR TITLE
[FIX] point_of_sale: prevent deletion of rounding methods used

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:26+0000\n"
-"PO-Revision-Date: 2025-02-10 08:26+0000\n"
+"POT-Creation-Date: 2025-03-19 11:06+0000\n"
+"PO-Revision-Date: 2025-03-19 11:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -7329,6 +7329,15 @@ msgstr ""
 msgid ""
 "You cannot delete a product saleable in point of sale while a session is "
 "still opened."
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/account_cash_rounding.py:0
+#, python-format
+msgid ""
+"You cannot delete a rounding method that is used in a Point of Sale "
+"configuration."
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/models/__init__.py
+++ b/addons/point_of_sale/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_bank_statement
+from . import account_cash_rounding
 from . import account_payment
 from . import account_journal
 from . import account_tax

--- a/addons/point_of_sale/models/account_cash_rounding.py
+++ b/addons/point_of_sale/models/account_cash_rounding.py
@@ -1,0 +1,11 @@
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class AccountCashRounding(models.Model):
+    _inherit = 'account.cash.rounding'
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_pos_config(self):
+        if self.env['pos.config'].search_count([('rounding_method', 'in', self.ids)], limit=1):
+            raise UserError(_('You cannot delete a rounding method that is used in a Point of Sale configuration.'))


### PR DESCRIPTION
A problem occurs when deleting a cash rounding method linked to a Point Of Sale configuration.

After deleting the cash rounding, the following error message appears: “The cash rounding strategy of the point of sale Shop must be: 'Add a rounding line'.” because the rounding method is empty.

The main issue arises when the cash rounding method is deleted while the POS session is open: it prevents the session from closing or modifying the cash rounding, locking the user out.

Steps to reproduce:
- Add a cash rounding for a POS
- Open the POS session
- Delete the cash rounding
- Try to enter the POS
- Error occurs

This fix ensures that the deleted cash rounding is no longer linked to any POS configuration.

opw-4651976
