### PR TITLE
[FIX] hr_holidays: fix time off dashboard calendar side panel

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
@@ -6,7 +6,7 @@ import { Dropdown, DropdownItem } from "@web/core/dropdown/dropdown";
 
 import { serializeDate } from "@web/core/l10n/dates";
 
-import { TimeOffCalendarFilterPanel } from "./filter_panel/calendar_filter_panel";
+import { TimeOffCalendarSidePanel } from "./calendar_side_panel";
 import { TimeOffFormViewDialog } from "../view_dialog/form_view_dialog";
 import { useLeaveCancelWizard } from "../hooks";
 import { EventBus, useSubEnv } from "@odoo/owl";
@@ -16,7 +16,7 @@ export class TimeOffCalendarController extends CalendarController {
         ...TimeOffCalendarController.components,
         Dropdown,
         DropdownItem,
-        FilterPanel: TimeOffCalendarFilterPanel,
+        CalendarSidePanel: TimeOffCalendarSidePanel,
     };
     static template = "hr_holidays.CalendarController";
     setup() {
@@ -29,13 +29,6 @@ export class TimeOffCalendarController extends CalendarController {
 
     get employeeId() {
         return this.model.employeeId;
-    }
-
-    get filterPanelProps() {
-        return {
-            ...super.filterPanelProps,
-            employee_id: this.employeeId,
-        };
     }
 
     newTimeOffRequest() {

--- a/addons/hr_holidays/static/src/views/calendar/calendar_side_panel.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_side_panel.js
@@ -1,0 +1,16 @@
+import { CalendarSidePanel } from "@web/views/calendar/calendar_side_panel/calendar_side_panel";
+import { TimeOffCalendarFilterPanel } from "@hr_holidays/views/calendar/filter_panel/calendar_filter_panel";
+
+export class TimeOffCalendarSidePanel extends CalendarSidePanel {
+    static components = {
+        ...TimeOffCalendarSidePanel.components,
+        FilterPanel: TimeOffCalendarFilterPanel,
+    };
+
+    get filterPanelProps() {
+        return {
+            ...super.filterPanelProps,
+            employee_id: this.props.model.employeeId,
+        };
+    }
+}


### PR DESCRIPTION
Steps to Reproduce:
- Install the Time Off App.
- Public holidays and mandatory days are not visible on the calendar side panel.

Cause:
- The calendar filter panel has been moved inside the Calendar side panel.

Fix:
- Adjusted components to align with the updated structure.

task-4657446

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
