### PR TITLE
[FIX] portal: add tour information to frontend session

### DIFF
--- a/addons/portal/models/ir_http.py
+++ b/addons/portal/models/ir_http.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import models, api
+from odoo.http import request
 
 
 class IrHttp(models.AbstractModel):
@@ -10,3 +11,12 @@ class IrHttp(models.AbstractModel):
     def _get_translation_frontend_modules_name(cls):
         mods = super(IrHttp, cls)._get_translation_frontend_modules_name()
         return mods + ['portal']
+
+    @api.model
+    def get_frontend_session_info(self):
+        result = super().get_frontend_session_info()
+        if request.session.uid:
+            result["tour_enabled"] = self.env.user.tour_enabled
+            if self.env.user.tour_enabled:
+                result["current_tour"] = self.env["web_tour.tour"].get_current_tour()
+        return result


### PR DESCRIPTION
 **Steps to reproduce:**

   1. Go to Field Service app.
   2. Check the worksheet template in settings and start the onboarding tour
        of Field Service.
  
  **Issue:**
          The backend tour is not resuming on the frontend side.
  
  **Fix:**
    This commit ensures the tour is enabled and the current tour is added to the frontend session. When the tour resumes, it will fetch the tour enabled and current tour details from the session.
  
  **Technical:**
    In the tour service, the tour resumes only if the mode is set to "auto" or toursEnabled is present in the session. To handle this,  we added the tour details to the session.
  
tour_service.js
``` js
      if (tourState.getCurrentConfig().mode === "auto" || toursEnabled) {
          resumeTour();
      }
````

task-4489657
