### PR TITLE
[FIX] website: prevent error on creating a new page

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -693,10 +693,12 @@ class Website(Home):
                     html_tree = html.fromstring(View.with_context(inherit_branding=False)._render_template(
                         page.key,
                     ))
-                    wrap_el = html_tree.xpath('//div[@id="wrap"]')[0]
+                    wrap_el = html_tree.xpath('//div[@id="wrap"]')
+                    if not wrap_el:
+                        continue
                     group['templates'].append({
                         'key': page.key,
-                        'template': html.tostring(wrap_el),
+                        'template': html.tostring(wrap_el[0]),
                         'name': page.name,
                     })
                 group['is_custom'] = True


### PR DESCRIPTION
This error occurs when trying to create a new page after previously creating a custom page that contains missing or incomplete code, leading to unexpected behavior.

Steps to reproduce:
---
- Install the `Website` module.
- Navigate to Website > Site > Pages and create a new Blank Page (Test).
- Site > Properties > Enable `Is a Template` > Save & Close
- Open Page (Test) Settings, remove `id="wrap"` or `Add custom code` in Architecture, and save.
- Return to `Pages` and click `New`.

Traceback:
---
IndexError: list index out of range

At [1], this error occurs because the html_tree fails to find `id="wrap"` in the `<div>` element of the custom code added by the user in the architecture while creating a new page.

https://github.com/odoo/odoo/blob/aed6c283951929a8ba504fe3166838db566ed735/addons/website/controllers/main.py#L696

sentry-6390821119

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
