### PR TITLE
[FIX] pos,pos_restaurant: refund button not visible on ticket screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -2,12 +2,12 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.ActionpadWidget">
-        <div class="actionpad d-flex flex-column gap-2" t-if="currentOrder">
+        <div class="actionpad d-flex flex-column gap-2">
             <div t-if="ui.isSmall" class="d-flex gap-2">
                 <BackButton t-if="!props.showActionButton and pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>
                 <t t-if="props.onClickMore">
                     <SelectPartnerButton partner="props.partner"/>
-                    <button t-if="pos.config.use_presets"
+                    <button t-if="pos.config.use_presets and currentOrder"
                         class="btn btn-secondary btn-lg flex-shrink-0 border-0"
                         t-attf-class="{{`o_colorlist_item_color_${currentOrder.preset_id?.color}`}}"
                         t-on-click="() => this.pos.selectPreset()">

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -18,7 +18,7 @@
         </xpath>
         <!-- Replace the payment button by the order button -->
         <xpath expr="//div[hasclass('validation')]" position="inside">
-            <div t-if="this.swapButton" class="d-flex gap-2 flex-fill">
+            <div t-if="this.swapButton and currentOrder" class="d-flex gap-2 flex-fill">
                 <button
                     class="submit-order h-100 button btn btn-lg d-flex align-items-center w-50 flex-fill position-relative px-3 highlight btn-primary justify-content-between"
                     t-on-click="() => this.submitOrder()"


### PR DESCRIPTION
Steps:
- In the restaurant, navigate to the ticket screen from the floor screen.
- Select any paid order.
- The Refund button should be visible below the numpad but isn't.

Issue:
- The `ActionpadWidget` is only displayed if a current order is set. However, on the floor screen, no current order exists.

Fix:
- Removed the dependency of `ActionpadWidget` on the current order.

Task: 4658232
