### PR TITLE
[FIX] web: fix quick calendar without filters

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -220,6 +220,13 @@ export class CalendarModel extends Model {
         const [section] = this.filterSections;
         for (const date of dates) {
             const rawRecord = this.buildRawRecord({ start: date });
+            if (!section) {
+                records.push({
+                    ...rawRecord,
+                    ...values,
+                });
+                continue;
+            }
             for (const filter of section.filters) {
                 if (filter.active && filter.type === "record") {
                     records.push({


### PR DESCRIPTION
Fix the traceback appearing when using the calendar multi create without filters.
If there is no filter section, simply create the records.

related: https://github.com/odoo/odoo/pull/196568

Task-4660298

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
