### PR TITLE
[FIX] {purchase_,}mrp: cancel MO linked to PO

### DIFF
--- a/addons/mrp/data/mail_templates.xml
+++ b/addons/mrp/data/mail_templates.xml
@@ -14,13 +14,14 @@
                         <t t-set="order" t-value="exception[0]"/>
                         <t t-set="new_qty" t-value="exception[1][0]"/>
                         <t t-set="old_qty" t-value="exception[1][1]"/>
+                            <t t-set="uom" t-value="move_raw_id.product_uom_id if 'product_uom_id' in move_raw_id else move_raw_id.product_uom"/>
                             <a href="#" data-oe-model="mrp.production" t-att-data-oe-id="production_order.id"><t t-esc="production_order.name"/></a>:
-                            <t t-esc="new_qty"/> <t t-esc="move_raw_id.product_uom.name"/> of <t t-esc="move_raw_id.product_id.name"/>
+                            <t t-esc="new_qty"/> <t t-esc="uom.name"/> of <t t-esc="move_raw_id.product_id.name"/>
                             <t t-if="cancel">
                                 cancelled
                             </t>
                             <t t-if="not cancel">
-                                ordered instead of <t t-esc="old_qty"/> <t t-esc="move_raw_id.product_uom.name"/>
+                                ordered instead of <t t-esc="old_qty"/> <t t-esc="uom.name"/>
                             </t>
                       </li>
                 </ul>


### PR DESCRIPTION
Currently, a traceback occurs when the user  tries to cancel the Manufacturing Order which is linked with a Purchase Order

### Steps to reproduce:

1) Install purchase and MRP
2) Enable UOm and multi-step routes from settings
3) Unarchive the MTO route
4) Create 2 products:
	- FP: route Manufacturing, MTO
	- COMP: Route buy, MTO and a set vendor
5) Create a BOM with FP as Final Product and COMP as component.
6) Create and confirm an MO for 1 unit of FP
7) Cancel the MO
#### > Qweb Error: 'purchase.order.line' object has no attribute 'product_uom' > The MO was not cancelled

### Cause of the issue:

In order_exceptions we do get objects like `sale.order.line`, `purchase.order.line`, `stock.move`etc.... 
depending on the MRP order.

Which is used in the `mrp.exception_on_mo` template to display the The UOM, product name, etc., 
in the activity can be found in the line below. 

https://github.com/odoo/odoo/blob/51c6a0dd06a362d5f8327741287beb422f250b7d/addons/mrp/data/mail_templates.xml#L18

But when we get `purchase.order.line` in `order_exception`,we get the 
above traceback because product_uom is changed to `product_uom_id` from the below commit.

https://github.com/odoo/odoo/pull/186250/files#diff-5684edced9bdfc98021a85de4c6cdf691ea7add74e56ab50334a1d7db9ef4224L32-R33

We can resolve this issue by checking whether the product_uom_id available in the move_raw_id or not.

sentry-6240577568

