### PR TITLE
[IMP] hr_holidays: generate public holiday

### DIFF
--- a/addons/hr_holidays/__init__.py
+++ b/addons/hr_holidays/__init__.py
@@ -4,3 +4,14 @@ from . import controllers
 from . import models
 from . import report
 from . import wizard
+
+
+def _hr_holiday_post_init(env):
+    french_companies = env['res.company'].search_count([('partner_id.country_id.code', '=', 'FR')])
+    if french_companies:
+        env['ir.module.module'].search([
+            ('name', '=', 'l10n_fr_hr_work_entry_holidays'),
+            ('state', '=', 'uninstalled')
+        ]).sudo().button_install()
+
+    env['resource.calendar.leaves'].load_public_holidays(companies=env.companies, convert_datetime=False)

--- a/addons/hr_holidays/data/ir_cron_data.xml
+++ b/addons/hr_holidays/data/ir_cron_data.xml
@@ -18,4 +18,13 @@
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
     </record>
+
+    <record id="ir_cron_load_current_year_public_holidays" model="ir.cron">
+        <field name="name">Time off: Load Current Year Public Holidays</field>
+        <field name="model_id" ref="model_resource_calendar_leaves"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_load_current_year_public_holidays()</field>
+        <field name="interval_number">12</field>
+        <field name="interval_type">months</field>
+    </record>
 </odoo>

--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -1,10 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api, _
-from odoo.exceptions import ValidationError
-from odoo.fields import Domain
 import pytz
-from datetime import datetime
+import warnings
+from datetime import datetime, time
+
+from odoo import api, fields, models, _
+from odoo.fields import Domain
+from odoo.exceptions import ValidationError
+from odoo.tools.date_utils import convert_timezone
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+import holidays  # noqa: E402
 
 
 class ResourceCalendarLeaves(models.Model):
@@ -127,7 +133,7 @@ class ResourceCalendarLeaves(models.Model):
                 continue
             user_tz = pytz.timezone(self.env.user.tz) if self.env.user.tz else pytz.utc
             calendar_tz = pytz.timezone(self.env['resource.calendar'].browse(vals['calendar_id']).tz)
-            if user_tz != calendar_tz:
+            if user_tz != calendar_tz and self.env.context.get('convert_datetime', True):
                 datetime_from = self._ensure_datetime(vals['date_from'], '%Y-%m-%d %H:%M:%S')
                 datetime_to = self._ensure_datetime(vals['date_to'], '%Y-%m-%d %H:%M:%S')
                 if datetime_from and datetime_to:
@@ -157,6 +163,121 @@ class ResourceCalendarLeaves(models.Model):
         self._reevaluate_leaves(time_domain_dict)
 
         return res
+
+    def _generate_public_holidays(self, companies, year_range, convert_datetime=True):
+        response = []
+        subdivision_per_country_dict = holidays.list_supported_countries(include_aliases=True)
+        lang_per_country = holidays.list_localized_countries(include_aliases=True)
+        existing_holidays_dict = dict(self.env["resource.calendar.leaves"]._read_group(
+            domain=[
+                ('company_id', 'in', companies.ids),
+                ('date_from', '>=', datetime(year_range[0] - 1, 12, 31, 0, 0, 0)),
+                ('date_to', '<=', datetime(year_range[-1] + 1, 1, 2, 0, 0, 0)),
+                ('resource_id', '=', False),
+            ],
+            groupby=['company_id'],
+            aggregates=['id:recordset'],
+        ))
+
+        for company in companies:
+            if not company.country_code:
+                response.append({
+                    'title': self.env._('No Country Code'),
+                    'type': 'danger',
+                    'message': self.env._('Please select a country in %(company)s to load public holidays.', company=company.name),
+                })
+                continue
+            if company.country_code not in subdivision_per_country_dict:
+                response.append({
+                    'title': self.env._('No Public Holidays'),
+                    'type': 'danger',
+                    'message': self.env._('Public holidays are not available for %(country)s country.', country=company.country_id.name),
+                })
+                continue
+
+            company_subdiv = company.state_id.code[-2:] if company.state_id else None  # Code is in the format 'XX-YY', where XX is the country code and YY is the subdivision code
+            holidays_subdivs = subdivision_per_country_dict.get(company.country_code, None)
+            user_lang_iso_code = self.env["res.lang"]._lang_get(self.env.user.lang).iso_code[:2]
+            if not user_lang_iso_code or user_lang_iso_code not in lang_per_country.get(company.country_code, []):
+                user_lang_iso_code = 'en_US'
+
+            public_holiday_dict = holidays.country_holidays(
+                company.country_code,
+                subdiv=company_subdiv if company_subdiv and company_subdiv in holidays_subdivs else None,
+                years=year_range,
+                language=user_lang_iso_code,
+                observed=False,
+            )
+
+            overlapped_holidays = False
+            company_tz = pytz.timezone(company.resource_calendar_id.tz)
+            public_holidays_values_dict = {}
+
+            for holiday_date, holiday_name in public_holiday_dict.items():
+                holiday_start_utc = convert_timezone(datetime.combine(holiday_date, time.min), pytz.utc, company_tz)
+                holiday_end_utc = convert_timezone(datetime.combine(holiday_date, time.max), pytz.utc, company_tz)
+                overlapping = any(
+                    holiday.date_from <= holiday_end_utc and
+                    holiday.date_to >= holiday_start_utc
+                    for holiday in existing_holidays_dict.get(company, [])
+                )
+                if overlapping:
+                    overlapped_holidays = True
+                    continue
+                if holiday_date in public_holidays_values_dict:
+                    public_holidays_values_dict[holiday_date]['name'] += f" / {holiday_name}"
+                else:
+                    public_holidays_values_dict[holiday_date] = {
+                        'name': holiday_name,
+                        'date_from': holiday_start_utc,
+                        'date_to': holiday_end_utc,
+                        'company_id': company.id,
+                    }
+
+            new_public_holidays = self.env['resource.calendar.leaves'].with_context(convert_datetime=convert_datetime).create(
+                list(public_holidays_values_dict.values()),
+            )
+            notification = {
+                'title': self.env._('Public Holidays Import Notification'),
+                'type': 'success',
+                'message': self.env._('No new public time off were added as they already exist.'),
+            }
+            if not new_public_holidays:
+                response.append(notification)
+            else:
+                notification['message'] = self.env._(
+                    "Public holidays have been successfully created for %(company)s for the next %(years)s years.",
+                    company=company.name, years=len(year_range))
+                if overlapped_holidays:
+                    notification['message'] += " " + self.env._("Some were overlapping existing ones, not all records have been created.")
+                response.append(notification)
+
+        return response
+
+    def load_public_holidays(self, companies=False, convert_datetime=True):
+        notifications = []
+        if not companies:
+            companies = self.env.companies
+        current_year = datetime.now().year
+        notifications.extend(self._generate_public_holidays(
+            year_range=range(current_year, current_year + 5),
+            companies=companies or self.env.companies,
+            convert_datetime=convert_datetime,
+        ))
+        for notification in notifications:
+            self.env['bus.bus']._sendone(
+                self.env.user.partner_id,
+                'simple_notification',
+                notification,
+            )
+
+    def _cron_load_current_year_public_holidays(self):
+        current_year = datetime.now().year
+        self._generate_public_holidays(
+            year_range=[current_year, current_year + 1],
+            companies=self.env.companies,
+            convert_datetime=False,
+        )
 
 
 class ResourceCalendar(models.Model):

--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -94,22 +94,6 @@ class ResourceCalendarLeaves(models.Model):
                 leave._notify_change(message)
         leaves_to_recreate.sudo()._create_resource_leave()
 
-    def _convert_timezone(self, utc_naive_datetime, tz_from, tz_to):
-        """
-            Convert a naive date to another timezone that initial timezone
-            used to generate the date.
-            :param utc_naive_datetime: utc date without tzinfo
-            :type utc_naive_datetime: datetime
-            :param tz_from: timezone used to obtained `utc_naive_datetime`
-            :param tz_to: timezone in which we want the date
-            :return: datetime converted into tz_to without tzinfo
-            :rtype: datetime
-        """
-        naive_datetime_from = utc_naive_datetime.astimezone(tz_from).replace(tzinfo=None)
-        aware_datetime_to = tz_to.localize(naive_datetime_from)
-        utc_naive_datetime_to = aware_datetime_to.astimezone(pytz.utc).replace(tzinfo=None)
-        return utc_naive_datetime_to
-
     def _ensure_datetime(self, datetime_representation, date_format=None):
         """
             Be sure to get a datetime object if we have the necessary information.
@@ -137,8 +121,8 @@ class ResourceCalendarLeaves(models.Model):
                 datetime_from = self._ensure_datetime(vals['date_from'], '%Y-%m-%d %H:%M:%S')
                 datetime_to = self._ensure_datetime(vals['date_to'], '%Y-%m-%d %H:%M:%S')
                 if datetime_from and datetime_to:
-                    vals['date_from'] = self._convert_timezone(datetime_from, user_tz, calendar_tz)
-                    vals['date_to'] = self._convert_timezone(datetime_to, user_tz, calendar_tz)
+                    vals['date_from'] = convert_timezone(datetime_from, user_tz, calendar_tz)
+                    vals['date_to'] = convert_timezone(datetime_to, user_tz, calendar_tz)
         return vals_list
 
     @api.model_create_multi

--- a/addons/hr_holidays/views/resource_views.xml
+++ b/addons/hr_holidays/views/resource_views.xml
@@ -29,6 +29,17 @@
         <field name="mode">primary</field>
         <field name="priority">10</field>
         <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <header>
+                    <button
+                        name="load_public_holidays"
+                        string="Load Public Holidays"
+                        type="object"
+                        class="btn btn-secondary"
+                        display="always"
+                    />
+                </header>
+            </xpath>
             <xpath expr="//list" position="attributes">
                 <attribute name="editable">bottom</attribute>
             </xpath>

--- a/addons/resource/models/resource_calendar_leaves.py
+++ b/addons/resource/models/resource_calendar_leaves.py
@@ -34,8 +34,7 @@ class ResourceCalendarLeaves(models.Model):
 
     name = fields.Char('Reason')
     company_id = fields.Many2one(
-        'res.company', string="Company", readonly=True, store=True,
-        default=lambda self: self.env.company, compute='_compute_company_id')
+        'res.company', string="Company", default=lambda self: self.env.company)
     calendar_id = fields.Many2one(
         'resource.calendar', "Working Hours",
         compute='_compute_calendar_id', store=True, readonly=False,
@@ -54,11 +53,6 @@ class ResourceCalendarLeaves(models.Model):
     def _compute_calendar_id(self):
         for leave in self.filtered('resource_id'):
             leave.calendar_id = leave.resource_id.calendar_id
-
-    @api.depends('calendar_id')
-    def _compute_company_id(self):
-        for leave in self:
-            leave.company_id = leave.calendar_id.company_id or self.env.company
 
     @api.depends('date_from')
     def _compute_date_to(self):

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -460,3 +460,18 @@ def weeknumber(locale: babel.Locale, date: date) -> tuple[int, int]:
     doy = (date - fdow).days
 
     return date.year, (doy // 7 + 1)
+
+
+def convert_timezone(utc_naive_datetime: datetime, tz_from: tzinfo, tz_to: tzinfo) -> datetime:
+    """
+    Convert a naive UTC datetime to another timezone, considering the initial timezone.
+
+    :param utc_naive_datetime: UTC datetime without tzinfo.
+    :param tz_from: Timezone used to obtain `utc_naive_datetime`.
+    :param tz_to: Target timezone for the conversion.
+    :return: Datetime converted into `tz_to` without tzinfo.
+    :rtype: datetime
+    """
+    naive_datetime_from = utc_naive_datetime.astimezone(tz_from).replace(tzinfo=None)
+    aware_datetime_to = tz_to.localize(naive_datetime_from)
+    return aware_datetime_to.astimezone(pytz.utc).replace(tzinfo=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ gevent==24.2.1 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble)
 greenlet==1.1.2 ; sys_platform != 'win32' and python_version == '3.10'  # (Jammy)
 greenlet==2.0.2 ; sys_platform != 'win32' and python_version > '3.10' and python_version < '3.12'
 greenlet==3.0.3 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble)
+holidays==0.68 ;
 idna==2.10 ; python_version < '3.12'  # requests 2.25.1 depends on idna<3 and >=2.5
 idna==3.6 ; python_version >= '3.12'
 Jinja2==3.0.3 ; python_version <= '3.10'


### PR DESCRIPTION
In this PR,

- Public holidays will be generated after the time-off app is installed.
- Through the app installation, public holidays will be created for every company in the database.
- Each public holiday will cover the entire day, and the resource calendar will be the same as the company’s calendar.
- There is a cog menu action that allows users to create a public holiday for multiple companies.

Task-4596057