### PR TITLE
[FIX] l10n_in_edi: broken E invoice QR

### DIFF
--- a/addons/l10n_in_edi/views/edi_pdf_report.xml
+++ b/addons/l10n_in_edi/views/edi_pdf_report.xml
@@ -11,7 +11,7 @@
         </xpath>
         <xpath expr="//div[@id='right-elements']" position="after">
             <t t-set="l10n_in_einvoice_json" t-value="o._get_l10n_in_edi_response_json()"/>
-            <div t-attf-class="#{'col-5' if report_type != 'html' else 'ms-auto'} row" t-if="l10n_in_einvoice_json">
+            <div t-attf-class="#{'col-5' if report_type != 'html' else 'ms-auto'} row avoid-page-break-inside" t-if="l10n_in_einvoice_json">
                 <div class="col-7 me-2" t-attf-style="#{'' if report_type != 'html' else 'padding: 0 !important;'}">
                     <strong>IRN:</strong>
                     <span t-esc="l10n_in_einvoice_json['Irn']"/>


### PR DESCRIPTION
before this PR:
- The QR code on the E-Invoice broke when multiple invoice lines reduced the available space.

after this PR:
- Adjusted the layout to ensure the QR code moves to a new page if there isn't enough space on the current page.

task - 4658271
