### PR TITLE
[FIX] point_of_sale: allow coins/bills to have greater accuracy

### DIFF
--- a/addons/point_of_sale/models/pos_bill.py
+++ b/addons/point_of_sale/models/pos_bill.py
@@ -10,7 +10,7 @@ class PosBill(models.Model):
     _inherit = ["pos.load.mixin"]
 
     name = fields.Char("Name")
-    value = fields.Float("Value", required=True, digits=(16, 2))
+    value = fields.Float("Value", required=True, digits=(16, 4))
     pos_config_ids = fields.Many2many("pos.config", string="Point of Sales")
 
     @api.model

--- a/addons/point_of_sale/tests/test_point_of_sale.py
+++ b/addons/point_of_sale/tests/test_point_of_sale.py
@@ -87,3 +87,10 @@ class TestPointOfSale(TransactionCase):
         })
         # Check that original product should not be in combo anymore (replace by variants)
         self.assertTrue(original_product_id not in product_combo.combo_item_ids.mapped('product_id').ids, "Original product should not be in combo")
+
+    def test_pos_bill_digits(self):
+        coin = self.env["pos.bill"].create({
+            "name": "0.005 not rounded",
+            "value": 0.005
+        })
+        self.assertEqual(coin.value, 0.005)


### PR DESCRIPTION
Same issue as in https://github.com/odoo/odoo/commit/77c921586efbaaf93ea6d9bba399716c9d861c8c

It's not possible to create coins/bills with an accuracy greater than 2 but some countries need more than 2 decimals.

The decimal precision was reduced with this commit for cleaning purposes: https://github.com/odoo/odoo/commit/96a2478d0dd8342b5278d123b59b1baed1f52d46

opw-4640800