### PR TITLE
[FIX] mail: dark bg in dark theme for avatar card

### DIFF
--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.dark.scss
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.dark.scss
@@ -1,0 +1,3 @@
+.o_avatar_card {
+    --card-bg: #{$gray-100};
+}

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.AvatarCardPopover">
-        <div class="o_avatar_card card border-0 rounded bg-inherit">
-            <div class="card-body bg-inherit">
+        <div class="o_avatar_card card border-0 rounded">
+            <div class="card-body bg-inherit rounded">
                 <div class="d-flex align-items-start gap-2 bg-inherit">
                     <span class="o_avatar pt-1 position-relative o_card_avatar bg-inherit">
                         <img t-if="props.id"


### PR DESCRIPTION
Avatar card popover is hard to read in dark theme, because the bg is gray. This was fixed by https://github.com/odoo/odoo/pull/193872

However another fix has been merged afterward and reverted this change by mistake: https://github.com/odoo/odoo/pull/188068

This commit re-adds the dark bg color of avatar card popover in dark theme.

The `.bg-inherit` at top-level is preventing the `--card-bg`. This is likely a mistake as there's no purpose to bg-inherit at card-level: the `.bg-inherit` is for IM status inside the card, which should use the card bg color. This `.bg-inherit` has been removed.

Before / After
![Screenshot 2025-03-19 at 13 48 29](https://github.com/user-attachments/assets/a5fde765-1e60-4432-85ff-1fe3e2a13374) ![Screenshot 2025-03-19 at 13 47 56](https://github.com/user-attachments/assets/c9fd17f9-7936-4d99-b9e1-6ed9e7f9456a)

