### PR TITLE
[FIX] l10n_be_pos_sale : allow loading pos from child company

### DIFF
--- a/addons/l10n_be_pos_sale/models/pos_session.py
+++ b/addons/l10n_be_pos_sale/models/pos_session.py
@@ -7,7 +7,7 @@ class PosSession(models.Model):
     def _load_pos_data(self, data):
         data = super()._load_pos_data(data)
         if self.env.company.country_code == 'BE':
-            intracom_fpos = self.env["account.chart.template"].with_company(self.company_id).ref("fiscal_position_template_3", False)
+            intracom_fpos = self.env["account.chart.template"].with_company(self.company_id.root_id).ref("fiscal_position_template_3", False)
             if intracom_fpos:
                 data['data'][0]['_intracom_tax_ids'] = intracom_fpos.tax_ids.tax_dest_id.ids
         return data

--- a/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
+++ b/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
@@ -46,3 +46,16 @@ registry.category("web_tour.tours").add("PosSettleOrderTryInvoice", {
             PaymentScreen.isInvoiceButtonChecked(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_pos_branch_company_access", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -70,6 +70,34 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_pos_tour('PosSettleOrderIsInvoice', login="accountman")
 
+    def test_pos_branch_company_access(self):
+        self.product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'type': 'consu',
+            'available_in_pos': True,
+        })
+
+        branch = self.env['res.company'].create({
+            'name': 'Branch 1',
+            'parent_id': self.env.company.id,
+        })
+
+        self.env.cr.precommit.run()
+        self.pos_user.company_ids = [Command.link(branch.id)]
+
+        bank_payment_method = self.bank_payment_method.copy()
+        bank_payment_method.company_id = branch.id
+
+        b_pos_config = self.env['pos.config'].with_company(branch).create({
+            'name': 'Main',
+            'journal_id': self.company_data['default_journal_sale'].id,
+            'invoice_journal_id': self.company_data['default_journal_sale'].id,
+            'payment_method_ids': [(4, bank_payment_method.id)],
+        })
+
+        b_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % b_pos_config.id, 'test_pos_branch_company_access', login="pos_user")
+
 
 @odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
 class TestPoSSaleL10NBeNormalCompany(TestPointOfSaleHttpCommon):


### PR DESCRIPTION
Some users are encountering access error when opening the pos from a child company

Steps to reproduce:
-------------------
* Create a child company for "My Belgian Company"
* Register this company for the user Marc Demo
* Create a shop in the brach
* Now connect as Marc Demo
* Try to open the PoS
> Observation: Access error

Why the fix:
------------
Account chart template are only defined in the parent company.

opw-4644042