### PR TITLE
[FIX] mail: add thread on ir.cron (fix traceback)

### DIFF
--- a/addons/mail/models/ir_cron.py
+++ b/addons/mail/models/ir_cron.py
@@ -1,10 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, SUPERUSER_ID
+from odoo import fields, models, SUPERUSER_ID
 
 
 class IrCron(models.AbstractModel):
-    _inherit = 'ir.cron'
+    _name = 'ir.cron'
+    _inherit = ['ir.cron', 'mail.thread', 'mail.activity.mixin']
+
+    user_id = fields.Many2one(tracking=True)
+    interval_number = fields.Integer(tracking=True)
+    interval_type = fields.Selection(tracking=True)
+    priority = fields.Integer(tracking=True)
 
     def _notify_admin(self, message):
         """ Send a notification to the admin users. """


### PR DESCRIPTION
Since [1], server actions now have a chatter thread. The scheduled actions (ir.cron) uses delegation inheritance from the server action model. The ir.cron form view is also an extension of the server action form view, leading it to have the <chatter/> element but no mail.thread methods on the model itself.

This commit fixes that by making the ir.cron model to also inherit:
- mail.thread
- mail.activity.mixin

Furthermore, it adds tracking to some fields.

[1]: https://github.com/odoo/odoo/commit/f96e5919c28c970653b99ff317a39bbdc5af0ec7


opw-4657911