### PR TITLE
[FIX] web: save a dirty record without changes

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -590,11 +590,11 @@ export class Composer extends Component {
             context: context,
         };
         const options = {
-            onClose: (...args) => {
-                // args === [] : click on 'X' or press escape
+            onClose: (args) => {
+                // args === { dismiss: true } : click on 'X' or press escape
                 // args === { special: true } : click on 'discard'
-                const accidentalDiscard = args.length === 0;
-                const isDiscard = accidentalDiscard || args[0]?.special;
+                const accidentalDiscard = args?.dismiss;
+                const isDiscard = accidentalDiscard || args?.special;
                 // otherwise message is posted (args === [undefined])
                 if (!isDiscard && this.props.composer.thread.model === "mail.box") {
                     this.notifySendFromMailbox();

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -140,6 +140,6 @@ export class Dialog extends Component {
         if (this.data.dismiss) {
             await this.data.dismiss();
         }
-        return this.data.close();
+        return this.data.close({ dismiss: true });
     }
 }

--- a/addons/web/static/src/core/dialog/dialog_service.js
+++ b/addons/web/static/src/core/dialog/dialog_service.js
@@ -66,7 +66,10 @@ export const dialogService = {
                 },
                 {
                     onRemove: (closeParams) => {
-                        stack.pop();
+                        stack.splice(
+                            stack.findIndex((d) => d.id === id),
+                            1
+                        );
                         deactivate();
                         if (stack.length) {
                             stack.at(-1).isActive = true;

--- a/addons/web/static/src/core/dialog/dialog_service.js
+++ b/addons/web/static/src/core/dialog/dialog_service.js
@@ -39,7 +39,7 @@ export const dialogService = {
 
         const add = (dialogClass, props, options = {}) => {
             const id = nextId++;
-            const close = () => remove();
+            const close = (params) => remove(params);
             const subEnv = reactive({
                 id,
                 close,
@@ -65,7 +65,7 @@ export const dialogService = {
                     subEnv,
                 },
                 {
-                    onRemove: () => {
+                    onRemove: (closeParams) => {
                         stack.pop();
                         deactivate();
                         if (stack.length) {
@@ -73,7 +73,7 @@ export const dialogService = {
                         } else {
                             document.body.classList.remove("modal-open");
                         }
-                        options.onClose?.();
+                        options.onClose?.(closeParams);
                     },
                     rootId: options.context?.root?.el.getRootNode()?.host?.id,
                 }
@@ -82,9 +82,9 @@ export const dialogService = {
             return remove;
         };
 
-        function closeAll() {
+        function closeAll(params) {
             for (const dialog of [...stack].reverse()) {
-                dialog.close();
+                dialog.close(params);
             }
         }
 

--- a/addons/web/static/src/core/overlay/overlay_service.js
+++ b/addons/web/static/src/core/overlay/overlay_service.js
@@ -24,9 +24,9 @@ export const overlayService = {
             props: { overlays },
         });
 
-        const remove = (id, onRemove = () => {}) => {
+        const remove = (id, onRemove = () => {}, removeParams) => {
             if (id in overlays) {
-                onRemove();
+                onRemove(removeParams);
                 delete overlays[id];
             }
         };
@@ -39,7 +39,8 @@ export const overlayService = {
          */
         const add = (component, props, options = {}) => {
             const id = ++nextId;
-            const removeCurrentOverlay = () => remove(id, options.onRemove);
+            const removeCurrentOverlay = (removeParams) =>
+                remove(id, options.onRemove, removeParams);
             overlays[id] = {
                 id,
                 component,

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -998,6 +998,12 @@ export class Record extends DataPoint {
         const changes = this._getChanges();
         delete changes.id; // id never changes, and should not be written
         if (!creation && !Object.keys(changes).length) {
+            if (nextId) {
+                return this.model.load({ resId: nextId });
+            }
+            this._changes = markRaw({});
+            this.data = { ...this._values };
+            this.dirty = false;
             return true;
         }
         if (

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -657,7 +657,9 @@ export class FormController extends Component {
         if (this.props.onDiscard) {
             this.props.onDiscard(this.model.root);
         }
-        if (this.model.root.isNew || this.env.inDialog) {
+        if (this.env.inDialog) {
+            this.env.dialogData.close();
+        } else if (this.model.root.isNew) {
             this.env.config.historyBack();
         }
     }

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -24,6 +24,7 @@ import {
     Component,
     onMounted,
     onPatched,
+    status,
     onWillPatch,
     onWillRender,
     useExternalListener,
@@ -212,7 +213,9 @@ export class ListRenderer extends Component {
             // HACK: we need to wait for the next tick to be sure that the Field components are patched.
             // OWL don't wait the patch for the children components if the children trigger a patch by himself.
             await Promise.resolve();
-
+            if (status(this) === "destroyed") {
+                return;
+            }
             if (this.activeElement !== this.uiService.activeElement) {
                 return;
             }

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -140,7 +140,6 @@ export function makeActionManager(env, router = _router) {
     const keepLast = new KeepLast();
     let id = 0;
     let controllerStack = [];
-    let dialogCloseProm;
     let actionCache = {};
     let dialog = null;
     let nextDialog = null;
@@ -309,14 +308,14 @@ export function makeActionManager(env, router = _router) {
      *
      * @return {Function|undefined} When there was a dialog, returns its onClose callback for propagation to next dialog.
      */
-    function _removeDialog() {
+    async function _removeDialog(closeParams) {
         if (dialog) {
             const { onClose, remove } = dialog;
+            await onClose?.(closeParams);
             dialog = null;
             // Remove the dialog from the dialog_service.
             // The code is well enough designed to avoid falling in a function call loop.
             remove();
-            return onClose;
         }
     }
 
@@ -871,15 +870,11 @@ export function makeActionManager(env, router = _router) {
             controller.embeddedActions = embeddedActions;
         };
         controller.config.historyBack = () => {
-            if (dialog) {
-                _executeCloseAction();
+            const previousController = controllerStack[controllerStack.length - 2];
+            if (previousController) {
+                restore(previousController.jsId);
             } else {
-                const previousController = controllerStack[controllerStack.length - 2];
-                if (previousController) {
-                    restore(previousController.jsId);
-                } else {
-                    env.bus.trigger("WEBCLIENT:LOAD_DEFAULT_APP");
-                }
+                env.bus.trigger("WEBCLIENT:LOAD_DEFAULT_APP");
             }
         };
 
@@ -977,11 +972,7 @@ export function makeActionManager(env, router = _router) {
             }
             onMounted() {
                 if (action.target === "new") {
-                    dialogCloseProm = new Promise((_r) => {
-                        dialogCloseResolve = _r;
-                    }).then(() => {
-                        dialogCloseProm = undefined;
-                    });
+                    dialog?.remove();
                     dialog = nextDialog;
                 } else {
                     controller.getGlobalState = () => {
@@ -1042,14 +1033,10 @@ export function makeActionManager(env, router = _router) {
                 actionDialogProps.size = size;
             }
             actionDialogProps.footer = action.context.footer ?? actionDialogProps.footer;
-            const onClose = _removeDialog();
+            const onClose = dialog?.onClose;
+            delete dialog?.onClose;
             removeDialogFn = env.services.dialog.add(ActionDialog, actionDialogProps, {
-                onClose: () => {
-                    const onClose = _removeDialog();
-                    if (onClose) {
-                        onClose();
-                    }
-                },
+                onClose: (closeParams) => _removeDialog(closeParams),
             });
             if (nextDialog) {
                 nextDialog.remove();
@@ -1098,8 +1085,6 @@ export function makeActionManager(env, router = _router) {
             controller.props.globalState = controller.action.globalState;
         }
 
-        const closingProm = _executeCloseAction({ onCloseInfo: { noReload: true } });
-
         if (options.clearBreadcrumbs && !options.noEmptyTransition) {
             const def = new Deferred();
             env.bus.trigger("ACTION_MANAGER:UPDATE", {
@@ -1120,9 +1105,9 @@ export function makeActionManager(env, router = _router) {
             Component: ControllerComponent,
             componentProps: controller.props,
         };
-        env.services.dialog.closeAll();
+        env.services.dialog.closeAll({ noReload: true });
         env.bus.trigger("ACTION_MANAGER:UPDATE", controller.__info__);
-        return Promise.all([currentActionProm, closingProm]).then((r) => r[0]);
+        await currentActionProm;
     }
 
     // ---------------------------------------------------------------------------
@@ -1397,18 +1382,11 @@ export function makeActionManager(env, router = _router) {
         return doAction(nextAction, options);
     }
 
-    async function _executeCloseAction(params = {}) {
-        let onClose;
+    function _executeCloseAction(params = {}) {
         if (dialog) {
-            onClose = _removeDialog();
-        } else {
-            onClose = params.onClose;
+            return _removeDialog(params.onCloseInfo);
         }
-        if (onClose) {
-            await onClose(params.onCloseInfo);
-        }
-
-        return dialogCloseProm;
+        return params.onClose?.(params.onCloseInfo);
     }
 
     // ---------------------------------------------------------------------------

--- a/addons/web/static/tests/core/dialog.test.js
+++ b/addons/web/static/tests/core/dialog.test.js
@@ -104,14 +104,14 @@ test("click on the button x triggers the service close", async () => {
     }
     await makeDialogMockEnv({
         dialogData: {
-            close: () => expect.step("close"),
+            close: (params) => expect.step(`close ${JSON.stringify(params)}`),
             dismiss: () => expect.step("dismiss"),
         },
     });
     await mountWithCleanup(Parent);
     expect(".o_dialog").toHaveCount(1);
     await contains(".o_dialog header button[aria-label='Close']").click();
-    expect.verifySteps(["dismiss", "close"]);
+    expect.verifySteps(["dismiss", 'close {"dismiss":true}']);
 });
 
 test("click on the button x triggers the close and dismiss defined by a Child component", async () => {

--- a/addons/web/static/tests/core/dialog_service.test.js
+++ b/addons/web/static/tests/core/dialog_service.test.js
@@ -205,3 +205,30 @@ test("dialog component crashes", async () => {
     expect(".modal .o_error_dialog").toHaveCount(1);
     expect.verifyErrors(["Error: Some Error"]);
 });
+
+test("two dialogs, close the first one, closeAll", async () => {
+    class CustomDialog extends Component {
+        static components = { Dialog };
+        static template = xml`<Dialog title="props.title">content</Dialog>`;
+        static props = ["*"];
+    }
+    expect(".o_dialog").toHaveCount(0);
+    const close = getService("dialog").add(CustomDialog, { title: "Hello" });
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(1);
+    expect("header .modal-title").toHaveText("Hello");
+
+    getService("dialog").add(CustomDialog, { title: "Sauron" });
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(2);
+    expect(queryAllTexts("header .modal-title")).toEqual(["Hello", "Sauron"]);
+
+    close();
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(1);
+    expect("header .modal-title").toHaveText("Sauron");
+
+    getService("dialog").closeAll();
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(0);
+});

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -5370,6 +5370,82 @@ test(`switching to another record from a dirty one on desktop`, async () => {
     expect(getPagerValue()).toEqual([1]);
 });
 
+test.tags("desktop")("Save record, no changes but dirty (add and remove tag)", async () => {
+    onRpc("web_save", () => expect.step("ERROR: web_save should not be called"));
+    onRpc("web_read", () => expect.step("web_read"));
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `<form>
+                <field name="type_ids" widget="many2many_tags"/>
+              </form>`,
+        resId: 1,
+    });
+
+    expect(`.o_field_widget[name=type_ids] .o_tag`).toHaveCount(0);
+
+    // add a tag
+    await contains(`.o_input_dropdown input`).click();
+    await contains(`.dropdown-item:contains(gold)`).click();
+
+    expect(`.o_field_widget[name=type_ids] .o_tag`).toHaveCount(1);
+
+    // remove tag
+    await contains(`.o_field_widget[name=type_ids] .o_tag .o_delete`).click();
+    expect(`.o_field_widget[name=type_ids] .o_tag`).toHaveCount(0);
+    expect.verifySteps(["web_read", "web_read"]);
+
+    // click on save
+    await contains(`.o_form_button_save`).click();
+    // The `web_save` RPC should not be called as there are no changes.
+    // The record must be marked as not dirty.
+    expect(`.o_form_status_indicator_buttons.invisible`).toHaveCount(1);
+    expect.verifySteps([]); // avoid doint an extra web_read
+});
+
+test.tags("desktop")(
+    "switching to another record from a dirty record but wo changes (add and remove tag)",
+    async () => {
+        onRpc("web_save", () => expect.step("ERROR: web_save should not be called"));
+        onRpc("web_read", () => expect.step("web_read"));
+        await mountView({
+            type: "form",
+            resModel: "partner",
+            arch: `<form>
+                  <field name="type_ids" widget="many2many_tags"/>
+              </form>`,
+            resIds: [1, 2],
+            resId: 1,
+        });
+
+        expect(getPagerValue()).toEqual([1]);
+        expect(getPagerLimit()).toBe(2);
+
+        expect(`.o_field_widget[name=type_ids] .o_tag`).toHaveCount(0);
+        expect(`.o_breadcrumb`).toHaveText("first record");
+
+        // add a tag
+        await contains(`.o_input_dropdown input`).click();
+        await contains(`.dropdown-item:contains(gold)`).click();
+
+        expect(`.o_field_widget[name=type_ids] .o_tag`).toHaveCount(1);
+
+        // remove tag
+        await contains(`.o_field_widget[name=type_ids] .o_tag .o_delete`).click();
+        expect(`.o_field_widget[name=type_ids] .o_tag`).toHaveCount(0);
+        expect.verifySteps(["web_read", "web_read"]);
+
+        // click on the pager to switch to the next record
+        // The `web_save` RPC should not be called as there are no changes.
+        // The next record should be load correctly.
+        await contains(`.o_pager_next`).click();
+        expect(`.modal`).toHaveCount(0);
+        expect(getPagerValue()).toEqual([2]);
+        expect(`.o_breadcrumb`).toHaveText("second record");
+        expect.verifySteps(["web_read"]);
+    }
+);
+
 test(`do not reload after save when using pager`, async () => {
     onRpc(({ method }) => expect.step(method));
     await mountView({

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -819,6 +819,47 @@ test(`list view with adjacent buttons and optional field`, async () => {
     expect(`.o_data_row:eq(0) td.o_list_button`).toHaveCount(2);
 });
 
+test(`wait the view reload before closing the dialog`, async () => {
+    let searchReadDef;
+    onRpc("web_search_read", () => searchReadDef);
+    Foo._views = {
+        form: `<form><field name="foo"/></form>`,
+    };
+    onRpc("/web/dataset/call_button/foo/a", () => ({
+        type: "ir.actions.act_window",
+        name: "Archive Action",
+        res_model: "foo",
+        res_id: 1,
+        view_mode: "form",
+        target: "new",
+        views: [[false, "form"]],
+    }));
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list editable="bottom">
+                <field name="foo"/>
+                <button name="a" type="object" icon="fa-car"/>
+            </list>
+        `,
+    });
+    searchReadDef = new Deferred();
+    await contains(`tbody .o_list_button button:eq(0)`).click();
+    expect(`.o_dialog`).toHaveCount(1);
+    await contains(`.o_form_renderer .o_field_widget[name='foo'] input`).edit("plop");
+    await contains(`.o_dialog .o_form_button_save`).click();
+
+    await animationFrame(); // not needed but to be sure that the dialog is not closed.
+    expect(`.o_dialog`).toHaveCount(1);
+    searchReadDef.resolve();
+
+    await animationFrame();
+    expect(`.o_dialog`).toHaveCount(0);
+    expect(`tbody .o_list_char:eq(0)`).toHaveText("plop");
+});
+
 test(`list view with adjacent buttons with invisible modifier`, async () => {
     await mountView({
         resModel: "foo",

--- a/addons/web/static/tests/webclient/actions/close_action.test.js
+++ b/addons/web/static/tests/webclient/actions/close_action.test.js
@@ -4,7 +4,6 @@ import {
     contains,
     defineActions,
     defineModels,
-    findComponent,
     getService,
     models,
     mountWithCleanup,
@@ -13,7 +12,6 @@ import {
     webModels,
 } from "@web/../tests/web_test_helpers";
 
-import { formView } from "@web/views/form/form_view";
 import { listView } from "@web/views/list/list_view";
 import { WebClient } from "@web/webclient/webclient";
 
@@ -86,6 +84,7 @@ test("close the currently opened dialog", async () => {
     await getService("action").doAction({
         type: "ir.actions.act_window_close",
     });
+    await animationFrame();
     expect(".o_technical_modal .o_form_view").toHaveCount(0);
 });
 
@@ -145,21 +144,6 @@ test("close action with provided infos", async () => {
     );
 });
 
-test("history back calls on_close handler of dialog action", async () => {
-    const webClient = await mountWithCleanup(WebClient);
-    function onClose() {
-        expect.step("on_close");
-    }
-    // open a new dialog form
-    await getService("action").doAction(5, { onClose });
-    expect(".modal").toHaveCount(1);
-    const form = findComponent(webClient, (c) => c instanceof formView.Controller);
-    form.env.config.historyBack();
-    expect.verifySteps(["on_close"]);
-    await animationFrame();
-    expect(".modal").toHaveCount(0);
-});
-
 test.tags("desktop");
 test("history back called within on_close", async () => {
     let list;
@@ -189,33 +173,6 @@ test("history back called within on_close", async () => {
     expect(".o_list_view").toHaveCount(0);
     expect(".o_kanban_view").toHaveCount(1);
     expect.verifySteps(["on_close"]);
-});
-
-test.tags("desktop");
-test("history back calls onclose handler of dialog action with 2 breadcrumbs", async () => {
-    let list;
-    patchWithCleanup(listView.Controller.prototype, {
-        setup() {
-            super.setup(...arguments);
-            list = this;
-        },
-    });
-    await mountWithCleanup(WebClient);
-    await getService("action").doAction(1); // kanban
-    await getService("action").doAction(3); // list
-    expect(".o_list_view").toHaveCount(1);
-    function onClose() {
-        expect.step("on_close");
-    }
-    // open a new dialog form
-    await getService("action").doAction(5, { onClose });
-    expect(".modal").toHaveCount(1);
-    expect(".o_list_view").toHaveCount(1);
-    list.env.config.historyBack();
-    expect.verifySteps(["on_close"]);
-    await animationFrame();
-    expect(".o_list_view").toHaveCount(1);
-    expect(".modal").toHaveCount(0);
 });
 
 test.tags("desktop");

--- a/addons/web/static/tests/webclient/actions/report_action.test.js
+++ b/addons/web/static/tests/webclient/actions/report_action.test.js
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "@odoo/hoot";
-import { runAllTimers } from "@odoo/hoot-mock";
+import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import {
     contains,
     defineActions,
@@ -143,6 +143,7 @@ test("report actions can close modals and reload views", async () => {
     });
 
     await getService("action").doAction(11);
+    await animationFrame();
     expect(".o_technical_modal .o_form_view").toHaveCount(0, {
         message: "the modal should have been closed after the action report",
     });

--- a/addons/web/static/tests/webclient/actions/server_action.test.js
+++ b/addons/web/static/tests/webclient/actions/server_action.test.js
@@ -1,4 +1,5 @@
 import { expect, test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
 import {
     defineActions,
     defineModels,
@@ -57,9 +58,10 @@ test("can execute server actions from db ID", async () => {
             views: [[1, "kanban"]],
         },
     ]);
-    onRpc("/web/action/run", async () => {
-        return 1; // execute action 1
-    });
+    onRpc(
+        "/web/action/run",
+        async () => 1 // execute action 1
+    );
     stepAllNetworkCalls();
 
     await mountWithCleanup(WebClient);
@@ -92,9 +94,7 @@ test("handle server actions returning false", async function (assert) {
             views: [[false, "form"]],
         },
     ]);
-    onRpc("/web/action/run", async () => {
-        return false;
-    });
+    onRpc("/web/action/run", async () => false);
     stepAllNetworkCalls();
     await mountWithCleanup(WebClient);
     // execute an action in target="new"
@@ -108,6 +108,7 @@ test("handle server actions returning false", async function (assert) {
 
     // execute a server action that returns false
     await getService("action").doAction(2);
+    await animationFrame();
     expect(".o_technical_modal").toHaveCount(0, { message: "should have closed the modal" });
     expect.verifySteps([
         "/web/webclient/translations",
@@ -128,15 +129,13 @@ test("action with html help returned by a server action", async () => {
             type: "ir.actions.server",
         },
     ]);
-    onRpc("/web/action/run", async () => {
-        return {
-            res_model: "partner",
-            type: "ir.actions.act_window",
-            views: [[false, "kanban"]],
-            help: "<p>I am not a helper</p>",
-            domain: [[0, "=", 1]],
-        };
-    });
+    onRpc("/web/action/run", async () => ({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "kanban"]],
+        help: "<p>I am not a helper</p>",
+        domain: [[0, "=", 1]],
+    }));
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(2);

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -2185,6 +2185,7 @@ test("onClose should be called only once with right parameters", async () => {
         infos: { cantaloupe: "island" },
     });
     expect.verifySteps(["onClose"]);
+    await animationFrame();
     expect(".modal").toHaveCount(0);
 });
 


### PR DESCRIPTION
[FIX] web: save a dirty record without changes

- Open a record (e.g., a project task);
- Add a tag to a `many2many_tags` field;
- Remove the previously added tag;
- The record should be dirty (the save icon should be visible);
- Click on the save icon/or click to pager next.

Before this commit, the UI does nothing. It doesn't save, or it doesn't go to
the next record if you click on the pager next. This is because even if the
record is considered dirty, because some changes have been made (adding and
removing tags), there are no changes. And a condition prevents to call the
`web_save` RPC from being called if there are no changes. If the `web_save`
RPC is not called, we do nothing.

In this commit, we change this condition so that if the `web_save` RPC is not
called, we mark the record as not dirty. When we move to another record (pager
next), we do not need to mark the current record as not dirty, but the next
record is loaded.

X-original-commit: https://github.com/odoo/odoo/commit/43fb8a45ac629c1883ca9521a8879cf19ca7538b

-----------------

[FIX] web: wait the main view reload before closing the dialog

- On a slow connection;
- In a list view (or a form view), click on a button (a view button);
- Make some changes and save;
- Make some changes in the main view;

Because the connection is slow, the main view reloads after the user has made
some changes. This causes some issues, for example : the changes may be lost,
editable list views may become uneditable, forcing the user to click again.

This happens because on the action service, the callback function (`onClose`)
is called after the dialog is closed. In the case of a view button, the
callback function will reload the main view.

This commit changes that order, we will wait for the execution of the callback
to complete before closing the dialog.

-----------------

[FIX] web: close non-last dialog


- Open multiple dialogs;
- Close a non-last dialog;
- Close all remaining dialogs with `closeAll`.

Before this commit, a dialog wasn't closed. This is because when we close a
dialog we always remove the last one from the dialog stack. Which in our case
is not the right dialog. Conversely, the offset service removes the correct
dialog (it uses the id to do this). So we have a dialog on the offset service
that is not on the dialog service stack, and a dialog on the dialog service
stack that is no longer on the offset service.

This commit removes the correct dialog from the dialog stack using the id (as
it's done in the offset service).