### PR TITLE
[FIX] website: uneditable accordion snippets headers

### DIFF
--- a/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
@@ -22,6 +22,8 @@ class accordionOptionPlugin extends Plugin {
             DefineCustomIconAction,
             CustomAccordionIconAction,
         },
+        force_not_editable_selector: [".accordion-button"],
+        force_editable_selector: [".accordion-button span"],
     };
 }
 


### PR DESCRIPTION
Steps to Reproduce:
1. Open firefox and drop a accordion snippet onto the page.
2. Open the 2nd accordion item.
3. Click inside the item's content.
3. Click back on the item's header.
4. It won't select the text nor place the cursor to allow editing.

Issue:
Since the snippet redesign in Odoo 18.0, headers have been changed from anchor tags to buttons. However, Firefox does not allow buttons to be editable. When a button is inside a `contenteditable="true"` ancestor, it doesn't function correctly. To work around this issue, we either need to set the ancestor’s `contenteditable` attribute to `false` or make a nested `<span>` editable while keeping the button itself non-editable.

Issue ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1349292

Fix:
We need to set the buttons to contenteditable="false" while keeping the nested <span> as contenteditable="true". To achieve this, we added the relevant selectors in `force_not_editable_selector` and `force_editable_selector` within accordionOptionPlugin.

task-4613266