### PR TITLE
[IMP] point_of_sale: invoice company by default

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -31,7 +31,8 @@ class ResPartner(models.Model):
     def _load_pos_data_fields(self, config_id):
         return [
             'id', 'name', 'street', 'city', 'state_id', 'country_id', 'vat', 'lang', 'phone', 'zip', 'mobile', 'email',
-            'barcode', 'write_date', 'property_account_position_id', 'property_product_pricelist', 'parent_name', 'contact_address'
+            'barcode', 'write_date', 'property_account_position_id', 'property_product_pricelist', 'parent_name', 'contact_address',
+            'company_type',
         ]
 
     def _compute_pos_order(self):

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -132,14 +132,14 @@ export class PosOrder extends Base {
                 ? 1
                 : -1;
 
-        const baseLines = orderLines.map((line) => {
-            return accountTaxHelpers.prepare_base_line_for_taxes_computation(
+        const baseLines = orderLines.map((line) =>
+            accountTaxHelpers.prepare_base_line_for_taxes_computation(
                 line,
                 line.prepareBaseLineForTaxesComputationExtraValues({
                     quantity: documentSign * line.qty,
                 })
-            );
-        });
+            )
+        );
         accountTaxHelpers.add_tax_details_in_base_lines(baseLines, company);
         accountTaxHelpers.round_base_lines_tax_details(baseLines, company);
 
@@ -939,6 +939,9 @@ export class PosOrder extends Base {
         this.assert_editable();
         this.update({ partner_id: partner });
         this.updatePricelistAndFiscalPosition(partner);
+        if (partner.company_type == "company") {
+            this.set_to_invoice(true);
+        }
     }
 
     get_partner() {


### PR DESCRIPTION
After this commit, when a company is selected, the order is set to "to_invoice = true" by default. The user is still able to put it back to false if he wants.

task-id: 4658640

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
