### PR TITLE
[FIX] point_of_sale,pos_restaurant,product: fix error if category is missing

### DIFF
--- a/addons/point_of_sale/data/scenarios/bakery_data.xml
+++ b/addons/point_of_sale/data/scenarios/bakery_data.xml
@@ -24,7 +24,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_wholemeal_loaf.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_tiger_white_loaf">
@@ -37,7 +37,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_tiger_white_loaf.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_butter_croissant">
@@ -50,7 +50,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_butter_croissant.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_apple_pie">
@@ -63,7 +63,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_apple_pie.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_cherry_pie">
@@ -76,7 +76,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_cherry_pie.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_sourdough_loaf">
@@ -89,7 +89,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_sourdough_loaf.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_multigrain_bread">
@@ -102,7 +102,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_multigrain_bread.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_rye_bread">
@@ -115,7 +115,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_rye_bread.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_cinnamon_roll">
@@ -128,7 +128,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_cinnamon_roll.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_pain_au_chocolat">
@@ -141,7 +141,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_pain_au_chocolat.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_blueberry_muffin">
@@ -154,7 +154,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_blueberry_muffin.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_bagel">
@@ -167,7 +167,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_pain_au_chocolat.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_cheese_croissant">
@@ -180,7 +180,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_cheese_croissant.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 		<record model="product.product" id="product_pecan_pie">
@@ -193,7 +193,7 @@
 			<field name="uom_id" ref="uom.product_uom_unit"/>
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_pecan_pie.png"/>
 			<field name="available_in_pos" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_pastries')])]" />
 		</record>
 	</data>

--- a/addons/point_of_sale/data/scenarios/furniture_data.xml
+++ b/addons/point_of_sale/data/scenarios/furniture_data.xml
@@ -32,7 +32,7 @@
             <field name="weight">0.01</field>
             <field name="barcode">2100002000003</field>
             <field name="taxes_id" eval="[(5,)]" />
-            <field name="categ_id" ref="product.product_category_goods"/>
+            <field name="categ_id" eval="ref('product.product_category_goods', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_miscellaneous')])]" />
             <field name="uom_id" ref="uom.product_uom_unit" />
             <field name="image_1920" type="base64" file="point_of_sale/static/img/wall_shelf_unit.png" />
@@ -45,7 +45,7 @@
             <field name="is_storable" eval="True"/>
             <field name="weight">0.01</field>
             <field name="taxes_id" eval="[(5,)]" />
-            <field name="categ_id" ref="product.product_category_goods"/>
+            <field name="categ_id" eval="ref('product.product_category_goods', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_miscellaneous')])]" />
             <field name="uom_id" ref="uom.product_uom_unit" />
             <field name="image_1920" type="base64" file="point_of_sale/static/img/small_shelf.png" />
@@ -58,7 +58,7 @@
             <field name="default_code">FURN_0004</field>
             <field name="is_storable" eval="True"/>
             <field name="weight">0.01</field>
-            <field name="categ_id" ref="product.product_category_goods"/>
+            <field name="categ_id" eval="ref('product.product_category_goods', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_miscellaneous')])]" />
             <field name="uom_id" ref="uom.product_uom_unit" />
             <field name="image_1920" type="base64" file="point_of_sale/static/img/letter_tray.png" />
@@ -72,7 +72,7 @@
             <field name="is_storable" eval="True"/>
             <field name="weight">0.01</field>
             <field name="barcode">2301000000006</field>
-            <field name="categ_id" ref="product.product_category_goods"/>
+            <field name="categ_id" eval="ref('product.product_category_goods', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_miscellaneous')])]" />
             <field name="uom_id" ref="uom.product_uom_unit" />
             <field name="image_1920" type="base64" file="point_of_sale/static/img/magnetic_board.png" />
@@ -84,7 +84,7 @@
             <field name="name">Whiteboard</field>
             <field name="is_storable" eval="True"/>
             <field name="weight">0.01</field>
-            <field name="categ_id" ref="product.product_category_goods"/>
+            <field name="categ_id" eval="ref('product.product_category_goods', raise_if_not_found=False)"/>
             <field name="uom_id" ref="uom.product_uom_unit" />
             <field name="image_1920" type="base64" file="point_of_sale/static/img/whiteboard.png" />
         </record>
@@ -96,7 +96,7 @@
             <field name="default_code">FURN_0003</field>
             <field name="is_storable" eval="True"/>
             <field name="weight">0.01</field>
-            <field name="categ_id" ref="product.product_category_goods"/>
+            <field name="categ_id" eval="ref('product.product_category_goods', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_miscellaneous')])]" />
             <field name="uom_id" ref="uom.product_uom_unit" />
             <field name="image_1920" type="base64" file="point_of_sale/static/img/led_lamp.png" />
@@ -110,7 +110,7 @@
             <field name="is_storable" eval="True"/>
             <field name="weight">0.01</field>
             <field name="barcode">2100001000004</field>
-            <field name="categ_id" ref="product.product_category_goods"/>
+            <field name="categ_id" eval="ref('product.product_category_goods', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_miscellaneous')])]" />
             <field name="uom_id" ref="uom.product_uom_unit" />
             <field name="image_1920" type="base64" file="point_of_sale/static/img/newspaper_stand.png" />
@@ -122,7 +122,7 @@
             <field name="name">Whiteboard Pen</field>
             <field name="weight">0.01</field>
             <field name="default_code">CONS_0001</field>
-            <field name="categ_id" ref="product.product_category_goods"/>
+            <field name="categ_id" eval="ref('product.product_category_goods', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_miscellaneous')])]" />
             <field name="uom_id" ref="uom.product_uom_unit" />
             <field name="image_1920" type="base64" file="point_of_sale/static/img/whiteboard_pen.png" />

--- a/addons/pos_restaurant/data/scenarios/restaurant_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_data.xml
@@ -29,7 +29,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-burger.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -88,7 +88,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-cheeseburger.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -116,7 +116,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pizza-ma.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -221,7 +221,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pizza-ve.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -295,7 +295,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pasta-4f.png"/>
             <field name="available_in_pos" eval="True"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
         </record>
 
@@ -357,7 +357,7 @@
             <field name="name">Funghi</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pizza-fu.png"/>
         </record>
         <record id="pos_food_bolo" model="product.product">
@@ -366,7 +366,7 @@
             <field name="name">Pasta Bolognese</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-pasta.png"/>
         </record>
         <record id="pos_food_chicken" model="product.product">
@@ -375,7 +375,7 @@
             <field name="name">Chicken Curry Sandwich</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-sandwich.png"/>
         </record>
         <record id="pos_food_tuna" model="product.product">
@@ -384,7 +384,7 @@
             <field name="name">Spicy Tuna Sandwich</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-tuna.png"/>
         </record>
         <record id="pos_food_mozza" model="product.product">
@@ -393,7 +393,7 @@
             <field name="name">Mozzarella Sandwich</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-mozza.png"/>
         </record>
         <record id="pos_food_club" model="product.product">
@@ -402,7 +402,7 @@
             <field name="name">Club Sandwich</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-club.png"/>
         </record>
         <record id="pos_food_maki" model="product.product">
@@ -411,7 +411,7 @@
             <field name="name">Lunch Maki 18pc</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-maki.png"/>
         </record>
         <record id="pos_food_salmon" model="product.product">
@@ -420,7 +420,7 @@
             <field name="name">Lunch Salmon 20pc</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-salmon.png"/>
         </record>
         <record id="pos_food_temaki" model="product.product">
@@ -429,7 +429,7 @@
             <field name="name">Lunch Temaki mix 3pc</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-temaki.png"/>
         </record>
         <record id="pos_food_chirashi" model="product.product">
@@ -438,7 +438,7 @@
             <field name="name">Salmon and Avocado</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-salmon-avocado.png"/>
         </record>
 
@@ -449,7 +449,7 @@
             <field name="name">Coca-Cola</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-coke.png"/>
         </record>
 
@@ -459,7 +459,7 @@
             <field name="name">Water</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-water.png"/>
         </record>
 
@@ -469,7 +469,7 @@
             <field name="name">Minute Maid</field>
             <field name="weight">0.01</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-minute_maid.png"/>
         </record>
 
@@ -478,7 +478,7 @@
             <field name="list_price">4.70</field>
             <field name="name">Espresso</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-espresso.png"/>
         </record>
 
@@ -487,7 +487,7 @@
             <field name="list_price">4.70</field>
             <field name="name">Green Tea</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-green_tea.png"/>
         </record>
 
@@ -496,7 +496,7 @@
             <field name="list_price">3.60</field>
             <field name="name">Milkshake Banana</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-milkshake_banana.png"/>
         </record>
 
@@ -505,7 +505,7 @@
             <field name="list_price">2.20</field>
             <field name="name">Ice Tea</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-ice_tea.png"/>
         </record>
 
@@ -514,7 +514,7 @@
             <field name="list_price">2.20</field>
             <field name="name">Schweppes</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-schweppes.png"/>
         </record>
 
@@ -523,7 +523,7 @@
             <field name="list_price">2.20</field>
             <field name="name">Fanta</field>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-fanta.png"/>
         </record>
 
@@ -581,7 +581,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/combo-hamb.png"/>
             <field name="combo_ids" eval="[(6, 0, [ref('drink_combo'), ref('burger_combo')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
             <field name="taxes_id" eval="[(5,)]"/>  <!-- no taxes -->
             <field name="supplier_taxes_id" eval="[(5,)]"/>

--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -12,7 +12,7 @@
             <field name="list_price">14.0</field>
             <field name="standard_price">8.0</field>
             <field name="type">service</field>
-            <field name="categ_id" ref="product.product_category_expenses"/>
+            <field name="categ_id" eval="ref('product.product_category_expenses', raise_if_not_found=False)"/>
         </record>
 
         <record id="expense_hotel" model="product.product">
@@ -21,13 +21,13 @@
             <field name="standard_price">400.0</field>
             <field name="type">service</field>
             <field name="uom_id" ref="uom.product_uom_day"/>
-            <field name="categ_id" ref="product_category_expenses"/>
+            <field name="categ_id" eval="ref('product_category_expenses', raise_if_not_found=False)"/>
         </record>
 
         <!-- Service products -->
         <record id="product_product_1" model="product.product">
             <field name="name">Virtual Interior Design</field>
-            <field name="categ_id" ref="product_category_services"/>
+            <field name="categ_id" eval="ref('product_category_services', raise_if_not_found=False)"/>
             <field name="standard_price">20.5</field>
             <field name="list_price">30.75</field>
             <field name="type">service</field>
@@ -36,7 +36,7 @@
 
         <record id="product_product_2" model="product.product">
             <field name="name">Virtual Home Staging</field>
-            <field name="categ_id" ref="product_category_services"/>
+            <field name="categ_id" eval="ref('product_category_services', raise_if_not_found=False)"/>
             <field name="standard_price">25.5</field>
             <field name="list_price">38.25</field>
             <field name="type">service</field>
@@ -492,7 +492,7 @@
             <field name="name">Local Delivery</field>
             <field name="default_code">Delivery_010</field>
             <field name="type">service</field>
-            <field name="categ_id" ref="product_category_services"/>
+            <field name="categ_id" eval="ref('product_category_services', raise_if_not_found=False)"/>
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
             <field name="list_price">10.0</field>


### PR DESCRIPTION
Currently, an exception is generated when the system tries to find the product category after all product categories have been deleted.

Steps to reproduce:

1. Install the `point_of_sale` module without demo data.
2. Navigate to Inventory -> Configuration -> Categories.
3. Delete all categories.
4. Navigate to Point of Sale -> load sample of furniture, bakery or restaurant shop
5. An error occurs.

Error:
```
ParseError
while parsing /home/odoo/src/odoo/saas-18.2/addons/product/data/product_demo.xml:10, somewhere inside
```
This issue[1] occurs because when the system tries to reference the missing product category, it results in a ParseError due to a missing required record.

[1] - https://github.com/odoo/odoo/blob/6c01e3994fab23ff1b23da807ecb0bf551066816/addons/product/data/product_demo.xml#L10-L16

This fix resolves the issue by returning False when the reference product category is missing.

sentry-6251128895

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
