### PR TITLE
[FIX] web: new kanban: footer should wrap elements

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -200,8 +200,9 @@
 
         > footer, > main > footer {
             display: flex;
+            flex-wrap: wrap;
             align-items: center;
-            column-gap: var(--Card-Footer-gap, #{map-get($spacers, 2)});
+            gap: var(--Card-Footer-gap, #{map-get($spacers, 2)});
             margin-top: auto;
             padding-top: var(--KanbanRecord-padding-v);
             font-size: var(--Card-Footer-font-size, .875rem);


### PR DESCRIPTION
Before this commit, when the footer had many items, those were not wrapped so, the overflew under the next card.

After this commit, elements inside the footer are wrapped, and they overflow on a next line.

task-4609581

Description of the issue/feature this PR addresses:

Current behavior before PR:
![Screenshot from 2025-03-19 14-37-53](https://github.com/user-attachments/assets/87174007-54d6-4f8f-b886-a8a77f1fd753)



Desired behavior after PR is merged:
![Screenshot from 2025-03-19 14-37-30](https://github.com/user-attachments/assets/db984c3a-b309-4e80-bf51-41883193b66f)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
