### PR TITLE
[FIX] {website_,}sale_loyalty{,_delivery}: don't discount shipping

### DIFF
--- a/addons/website_sale_loyalty/static/tests/tours/test_update_shipping_after_discount.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_update_shipping_after_discount.js
@@ -47,5 +47,13 @@ registry.category('web_tour.tours').add('update_shipping_after_discount', {
             total: '0.00', // $50 total is covered by eWallet
             delivery: '5.00', // $50 is below $75 `free_over` amount, so no free shipping
         }),
+        {
+            content: "check discount code discount",
+            trigger: '[data-reward-type=discount] .oe_currency_value:not(:visible):contains(/^- 50.00$/)',
+        },
+        {
+            content: "check eWallet discount",
+            trigger: '[data-reward-type=discount] .oe_currency_value:not(:visible):contains(/^- 55.00$/)',
+        },
     ],
 });


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a promo code that applies a 50% discount;
2. have a fixed price delivery method;
3. apply code on an order with said delivery method.

Issue
-----
The 50% discount is applied to the shipping costs.

Cause
-----
When calculating the discountable amount in `_discountable_amount`, it uses the `_get_no_effect_on_threshold_lines` method to filter out sale order lines that shouldn't impact the amount discounted. This value gets stored in the `lines` recordset.

Commit d0e7be7832672 overlooked the existence of this variable when modifying the `_discountable_amount` method, and instead used `self.order_line`, using all lines to calculate the discountable amount.

Solution
--------
Use the filtered recordset to calculate the discountable amount.

opw-4658702