### PR TITLE
[FIX] sale_loyalty: prevent error while creating multiple rewards

### DIFF
--- a/addons/sale_loyalty/tests/common.py
+++ b/addons/sale_loyalty/tests/common.py
@@ -212,6 +212,8 @@ class TestSaleCouponCommon(SaleCommon):
             status = order._apply_program_reward(rewards, coupons)
             if 'error' in status:
                 raise ValidationError(status['error'])
+        elif len(coupons) == 1 and len(rewards) > 1:
+            return rewards
 
     def _claim_reward(self, order, program, coupon=False):
         if len(program.reward_ids) != 1:
@@ -231,6 +233,12 @@ class TestSaleCouponCommon(SaleCommon):
             if len(program.reward_ids) > 1 or len(coupons_per_program[program]) != 1 or not program.active:
                 continue
             self._claim_reward(order, program, coupons_per_program[program])
+
+    def _generate_coupons(self, loyality_program, coupon_qty=1):
+        self.env['loyalty.generate.wizard'].with_context(active_id=loyality_program.id).create({
+            'coupon_qty': coupon_qty,
+        }).generate_coupons()
+        return loyality_program.coupon_ids
 
 class TestSaleCouponNumbersCommon(TestSaleCouponCommon):
     @classmethod


### PR DESCRIPTION
This error occurs when a user creates multiple rewards of the same program using below steps :

Steps to Reproduce :

- Install module `sale_management` and `sale_loyalty.
- In Products, go to Discount & Loyalty.
- Create two new `Discount & Loyalty` with the program type `Coupons` and
 `Generate coupons. `
- Add multiple rewards to one coupon program.
- Create a sale order and apply a coupon code from the first Discount & Loyalty
  program. Repeat the process with the coupon code from the second program.

ValueError : Expected singleton: loyalty.reward(3, 4, 5)

This error occurs when the system tries to fetch global_rewards but receives multiple values instead of a single record.

This commit resolves the error by ensuring that only the global reward with the highest discount is selected.

Sentry - 6417784661

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
