### PR TITLE
[FIX] point_of_sale: prevent error while creating order offline

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
+++ b/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
@@ -184,9 +184,11 @@ const deepSerialization = (
             continue;
         }
         if (fieldName === "id") {
-            if (typeof record[fieldName] === "number") {
-                result[fieldName] = record[fieldName];
+            let value = record[fieldName];
+            if (typeof value === "string") {
+                value = parseInt(value.split("_")[1]);
             }
+            result[fieldName] = value !== undefined ? value : false;
             continue;
         }
         result[fieldName] = record[fieldName] !== undefined ? record[fieldName] : false;


### PR DESCRIPTION
This error occurs when creating an `order` and `validating payment` in offline mode
then reloading the same order.

Steps to reproduce:
- Install module `pos_restaurant`.
- Open `POS Restaurant`.
- Add some products to the order go to Payments, and select card(Pick any table)
- Open Inspect, go to the Network tab and enable Offline Mode.
- Click Validate, go to `Orders`, and click `Load Order`.
- Add Products to the `Orders` and click on Order.
- In the Network tab, enable No Throttling and click on Orders again.
- Do the above step one more time on the same table.

ValueError
Expected singleton: pos.order()

This error occurs due to the `missing handling ID` as a string like in saas18.1 at
[1], so when the fieldName is a string the type system is unable to fetch the ID

This commit resolves the error by ensuring that the ID is correctly 
processed. If it is a number, it remains unchanged. If it is a string containing
an underscore (_), the numeric part after _ is extracted.


Link [1] :https://github.com/odoo/odoo/blob/d4e40e4be4233d91db80717891cef73c4fdec06c/addons/point_of_sale/static/src/app/models/related_models.js#L281-L285

Sentry - 6365371665

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
