### PR TITLE
[FIX] survey: adapt test query counters for single app install

### DIFF
--- a/addons/survey/tests/test_survey_performance.py
+++ b/addons/survey/tests/test_survey_performance.py
@@ -16,7 +16,9 @@ class SurveyPerformance(common.TestSurveyResultsCommon, HttpCase):
         """
         url = f'/survey/results/{self.survey.id}?filters=A,0,{self.gras_id}|L,0,{self.answer_pauline.id}'
         self.authenticate('survey_manager', 'survey_manager')
-        with self.assertQueryCount(default=23):
+        # cold orm/fields cache (only survey: 26, all module: 23)
+        #  the extra requests are `_get_default_lang` which is not called when website is installed
+        with self.assertQueryCount(default=26):
             self.url_open(url)
 
     @warmup
@@ -27,12 +29,16 @@ class SurveyPerformance(common.TestSurveyResultsCommon, HttpCase):
         """
         url = f'/survey/results/{self.survey.id}?filters=A,0,{self.gras_id}|A,0,{self.cat_id}'
         self.authenticate('survey_manager', 'survey_manager')
-        with self.assertQueryCount(default=21):
+        # cold orm/fields cache (only survey: 24, all module: 21)
+        #  the extra requests are `_get_default_lang` which is not called when website is installed
+        with self.assertQueryCount(default=24):
             self.url_open(url)
 
     @warmup
     def test_survey_results_with_one_filter(self):
         url = f'/survey/results/{self.survey.id}?filters=A,0,{self.cat_id}'
         self.authenticate('survey_manager', 'survey_manager')
-        with self.assertQueryCount(default=21):
+        # cold orm/fields cache (only survey: 24, all module: 21)
+        #  the extra requests are `_get_default_lang` which is not called when website is installed
+        with self.assertQueryCount(default=24):
             self.url_open(url)


### PR DESCRIPTION
Query counter values are higher if only survey app is installed.
Based on the SQL query, it looks like with only survey there is extra query to load the default language

rb-111093
rb-111094
rb-111095