### PR TITLE
[FIX] stock: deliveryslip report design consistency

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -63,10 +63,10 @@
                     </div>
                     <div class="oe_structure"></div>
                     <t t-set="format_number" t-value="lambda x: int(x) if x == int(x) else x"/>
-                    <table class="table table-sm" t-if="o.state!='done'" name="stock_move_table" style="table-layout: fixed; width: 100%">
+                    <table class="table table-sm table-borderless" t-if="o.state!='done'" name="stock_move_table">
                         <thead>
                             <tr>
-                                <th name="th_sm_product" class="text-center"><strong>Product</strong></th>
+                                <th name="th_sm_product"><strong>Product</strong></th>
                                 <th name="th_sm_ordered" class="text-end"><strong>Ordered</strong></th>
                                 <th name="th_sm_quantity" class="text-end"><strong>Delivered</strong></th>
                             </tr>
@@ -91,12 +91,12 @@
                             </tr>
                         </tbody>
                     </table>
-                    <table class="table table-sm mt48" t-elif="o.move_line_ids and o.state=='done'" name="stock_move_line_table">
+                    <table class="table table-sm table-borderless" t-elif="o.move_line_ids and o.state=='done'" name="stock_move_line_table">
                         <t t-set="has_serial_number" t-value="False"/>
                         <t t-set="has_serial_number" t-value="o.move_line_ids.mapped('lot_id')" groups="stock.group_lot_on_delivery_slip"/>
                         <thead>
                             <tr>
-                                <th name="th_sml_product" class="text-center"><strong>Product</strong></th>
+                                <th name="th_sml_product"><strong>Product</strong></th>
                                 <th name="th_sml_qty_ordered" class="text-end" t-if="not has_serial_number">
                                     <strong>Ordered</strong>
                                 </th>
@@ -167,12 +167,12 @@
                         <p class="mt-5">
                             <span>Remaining quantities not yet delivered:</span>
                         </p>
-                        <table class="table table-sm" name="stock_backorder_table" style="table-layout: fixed; width: 100%">
+                        <table class="table table-sm table-borderless" name="stock_backorder_table">
                             <thead>
                                 <tr>
-                                    <th name="th_sb_product" class="text-center"><strong>Product</strong></th>
+                                    <th name="th_sb_product"><strong>Product</strong></th>
                                     <th/>
-                                    <th name="th_sb_quantity" class="text-center"><strong>Quantity</strong></th>
+                                    <th name="th_sb_quantity" class="text-end"><strong>Quantity</strong></th>
                                 </tr>
                             </thead>
                             <tbody>


### PR DESCRIPTION
From 18.2 the `stock.report_deliveryslip` is displaying a bordered table regardless of the external layout styling. This is due to the removal of the `table-borderless` class in commit [1]

Additionnaly some title in the table are not aligned to the content in their `<td>`.

For consistency with the other report the inner style which set the table-layout to fixed is removed to let the column fit the size of their content.

task-4658505
[1]: odoo/odoo@0058d1cf76559d13238e57bd26ece3f2c067246f

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4fd95647-b3ea-4829-b842-055de8cccbac) | ![image](https://github.com/user-attachments/assets/7251f971-03c4-46a7-8a7c-fcf29206e653) | 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
