### PR TITLE
[FIX] hr_holidays: fallback for hours/day for empty employee for allocations

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -346,4 +346,4 @@ class HrEmployee(models.Model):
         return (allocations_leaves_consumed, to_recheck_leaves_per_leave_type)
 
     def _get_hours_per_day(self, date_from):
-        return self._get_calendars(date_from)[self.id].hours_per_day
+        return self._get_calendars(date_from)[self.id].hours_per_day if self else 0

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -385,3 +385,16 @@ class TestAllocations(TestHrHolidaysCommon):
         })
 
         self.assertEqual(allocation.allocation_type, 'regular')
+
+    def test_create_allocation_from_company_with_no_employee_for_current_user(self):
+        """
+            This test makes sure that the allocation can be created if the current company doesn't have an employee
+            linked to the loggedIn user.
+        """
+        self.user_hrmanager.employee_id = False
+        allocation_form = Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager))
+        self.assertFalse(allocation_form.employee_id)
+        allocation_form.employee_id = self.employee
+        allocation_form.holiday_status_id = self.leave_type
+        allocation = allocation_form.save()
+        self.assertTrue(allocation)


### PR DESCRIPTION
Steps to reproduce the bug:
- Install Timeoff app
- Switch to a company that has no employee linked to loggedInUser
- Open Timeoff, Management then Allocation and create a New allocation

Issue:
_compute_number_of_hours_display is called due to onChange of number_of_days when opening the form view. The compute hours function displays as the initial value the number of hours/day of the employee of the allocation.

The allocation defaults to the employee linked to loggedInUser, but since the company has none, the allocation form employee is set to empty, causing the compute hours function to fail and throw a traceback.

opw-4648319
opw-4652752
opw-4649177

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
