### PR TITLE
[IMP] web: m2o: change value to object and support relatedFields

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -2,7 +2,7 @@
 
 import { Domain } from "@web/core/domain";
 import { DynamicList } from "./dynamic_list";
-import { getGroupServerValue } from "./utils";
+import { createMany2OneValue, getGroupServerValue } from "./utils";
 
 export class DynamicGroupList extends DynamicList {
     static type = "DynamicGroupList";
@@ -123,7 +123,7 @@ export class DynamicGroupList extends DynamicList {
         // step 2: update record value
         const value =
             targetGroup.groupByField.type === "many2one"
-                ? [targetGroup.value, targetGroup.displayName]
+                ? createMany2OneValue([targetGroup.value, targetGroup.displayName])
                 : targetGroup.value;
         const revert = () => {
             targetGroup._removeRecords([record.id]);

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -492,9 +492,17 @@ export class Record extends DataPoint {
             return pair && createMany2OneValue(pair);
         }
         if (resId && displayName === undefined) {
+            const fieldSpec = { display_name: {} };
+            if (this.activeFields[fieldName].related) {
+                Object.assign(fieldSpec, getFieldsSpec(
+                    this.activeFields[fieldName].related.activeFields,
+                    this.activeFields[fieldName].related.fields,
+                    getBasicEvalContext(this.config),
+                ));
+            }
             const kwargs = {
                 context,
-                specification: { display_name: {} },
+                specification: fieldSpec,
             };
             const records = await this.model.orm.webRead(resModel, [resId], kwargs);
             return createMany2OneValue(records[0]);

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -265,7 +265,7 @@ export function extractFieldsFromArchInfo({ fieldNodes, widgetNodes }, fields) {
                 activeField.required = "False";
             }
         }
-        if (fields[fieldName].type === "many2one_reference" && fieldNode.views) {
+        if (["many2one", "many2one_reference"].includes(fields[fieldName].type) && fieldNode.views) {
             const viewDescr = fieldNode.views.default;
             activeField.related = extractFieldsFromArchInfo(viewDescr, viewDescr.fields);
         }
@@ -393,6 +393,13 @@ export function getFieldsSpec(activeFields, fields, evalContext, { orderBys, wit
             case "reference": {
                 fieldsSpec[fieldName].fields = {};
                 if (!isAlwaysInvisible) {
+                    if (related) {
+                        fieldsSpec[fieldName].fields = getFieldsSpec(
+                            related.activeFields,
+                            related.fields,
+                            evalContext
+                        );
+                    }
                     fieldsSpec[fieldName].fields.display_name = {};
                     fieldsSpec[fieldName].context = getFieldContextForSpec(
                         activeFields,

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -501,11 +501,7 @@ export function parseServerValue(field, value) {
             };
         }
         case "many2one": {
-            if (Array.isArray(value)) {
-                // Used for web_read_group, where the value is an array of [id, display_name]
-                return value;
-            }
-            return value ? [value.id, value.display_name] : false;
+            return createMany2OneValue(value);
         }
         case "properties": {
             return value
@@ -632,7 +628,10 @@ function getValueFromGroupData(field, rawValue) {
         return parseServerValue(field, rawValue[0]);
     }
     const value = parseServerValue(field, rawValue);
-    if (["many2one", "many2many"].includes(field.type)) {
+    if (field.type === "many2one") {
+        return value && value.id;
+    }
+    if (field.type === "many2many") {
         return value ? value[0] : false;
     }
     return value;
@@ -859,4 +858,21 @@ export async function resequence({
         records.splice(0, records.length, ...originalOrder);
         throw error;
     }
+}
+
+/**
+ * @param {object | [number, string] | false} value
+ * @returns {object}
+ */
+export function createMany2OneValue(value) {
+    if (!value) {
+        return false;
+    }
+
+    if (Array.isArray(value)) {
+        value = Object.assign(value, { id: value[0], display_name: value[1] });
+    } else {
+        value = Object.assign([value.id, value.display_name], value);
+    }
+    return value;
 }

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -334,7 +334,7 @@ export class Field extends Component {
                 fieldInfo.views = views;
             }
         }
-        if (fields[name].type === "many2one_reference") {
+        if (["many2one", "many2one_reference"].includes(fields[name].type)) {
             let relatedFields = fieldInfo.field.relatedFields;
             if (relatedFields) {
                 relatedFields = Object.fromEntries(relatedFields.map((f) => [f.name, f]));

--- a/addons/web/static/src/views/fields/many2one/many2one.js
+++ b/addons/web/static/src/views/fields/many2one/many2one.js
@@ -7,7 +7,7 @@ import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { useService } from "@web/core/utils/hooks";
-import { getFieldDomain } from "@web/model/relational_model/utils";
+import { createMany2OneValue, getFieldDomain } from "@web/model/relational_model/utils";
 import { Many2XAutocomplete, useOpenMany2XRecord } from "../relational_utils";
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -101,7 +101,7 @@ export class Many2One extends Component {
         specification: { type: Object, optional: true },
         string: { type: String, optional: true },
         update: { type: Function },
-        value: { type: [Array, { value: false }] },
+        value: { type: [Array, Object, { value: false }] },
     };
     static defaultProps = {
         canCreate: true,
@@ -240,7 +240,7 @@ export class Many2One extends Component {
 
     get value() {
         const value = this.props.value;
-        return value ? { id: value[0], display_name: value[1] } : null;
+        return value ? createMany2OneValue(value) : null;
     }
 
     async openBarcodeScanner() {
@@ -319,7 +319,7 @@ export class Many2One extends Component {
 
     update(idNamePair) {
         this.state.isFloating = false;
-        return this.props.update(idNamePair);
+        return this.props.update(createMany2OneValue(idNamePair));
     }
 }
 

--- a/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
@@ -6,7 +6,7 @@
         <KanbanMany2One t-props="m2oProps">
             <t t-set-slot="avatar">
                 <span class="o_avatar o_m2o_avatar">
-                    <img t-attf-src="/web/image/{{relation}}/{{props.record.data[props.name][0]}}/avatar_128" class="rounded"/>
+                    <img t-attf-src="/web/image/{{relation}}/{{props.record.data[props.name].id}}/avatar_128" class="rounded"/>
                 </span>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -7,7 +7,7 @@
         <div class="d-flex align-items-center gap-1">
             <span class="o_avatar o_m2o_avatar">
                 <t t-if="value !== false">
-                    <img class="rounded" t-attf-src="/web/image/{{relation}}/{{value[0]}}/avatar_128"/>
+                    <img class="rounded" t-attf-src="/web/image/{{relation}}/{{value.id}}/avatar_128"/>
                 </t>
                 <t t-elif="!props.readonly">
                     <span class="o_avatar_empty o_m2o_avatar_empty"/>

--- a/addons/web/static/src/views/fields/many2one_reference/many2one_reference_field.js
+++ b/addons/web/static/src/views/fields/many2one_reference/many2one_reference_field.js
@@ -18,7 +18,7 @@ export class Many2OneReferenceField extends Component {
         return {
             ...props,
             relation,
-            value: value ? [value.resId, value.displayName] : false,
+            value: value ? { id: value.resId, display_name: value.displayName } : false,
             readonly: this.props.readonly || !relation,
             update: (changes) => this.update(changes),
         };
@@ -32,8 +32,8 @@ export class Many2OneReferenceField extends Component {
         return this.props.record.data[modelField];
     }
 
-    update([resId, displayName]) {
-        const nextVal = { resId, displayName };
+    update(record) {
+        const nextVal = record && { resId: record.id, displayName: record.display_name };
         return this.props.record.update({ [this.props.name]: nextVal });
     }
 }

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -10634,7 +10634,7 @@ test(`fieldDependencies support for fields: dependence on a relational field`, a
     registry.category("fields").add("custom_field", {
         component: class CustomField extends Component {
             static props = ["*"];
-            static template = xml`<span t-esc="props.record.data.product_id[1]"/>`;
+            static template = xml`<span t-esc="props.record.data.product_id.display_name"/>`;
         },
         fieldDependencies: [{ name: "product_id", type: "many2one", relation: "product" }],
     });

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -11963,6 +11963,70 @@ test(`custom x2many with relatedFields and list view not inline`, async () => {
     expect.verifySteps(["web_read", "web_save"]);
 });
 
+test(`custom many2one with relatedFields`, async () => {
+    class CustomMany2One extends Component {
+        static template = xml`
+            <t t-set="value" t-value="props.record.data[props.name]"/>
+            <div class="content">
+                <div t-esc="value.id"/>
+                <div t-esc="value.display_name"/>
+                <div t-esc="value.foo"/>
+                <div t-esc="value.int_field"/>
+            </div>
+            <button id="update-m2o" t-on-click="() => this.update()">Update</button>
+        `;
+        static props = ["*"];
+
+        update() {
+            return this.props.record.update({ [this.props.name]: { id: 2 } });
+        }
+    }
+    fieldsRegistry.add("my_widget", {
+        component: CustomMany2One,
+        relatedFields: [
+            { name: "foo", type: "char" },
+            { name: "int_field", type: "integer" },
+        ],
+    });
+
+    onRpc("web_read", ({ kwargs }) => {
+        expect.step("web_read");
+        expect.step(kwargs.specification);
+    });
+
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="parent_id" widget="my_widget"/></form>`,
+        resId: 1,
+    });
+    expect.verifySteps([
+        "web_read",
+        {
+            display_name: {},
+            parent_id: {
+                fields: {
+                    display_name: {},
+                    foo: {},
+                    int_field: {},
+                },
+            },
+        },
+    ]);
+    expect(`.o_field_widget[name="parent_id"] .content`).toHaveText("4\naaa\nMy little Foo Value\n0");
+
+    await contains(`#update-m2o`).click();
+    expect.verifySteps([
+        "web_read",
+        {
+            display_name: {},
+            foo: {},
+            int_field: {},
+        }
+    ]);
+    expect(`.o_field_widget[name="parent_id"] .content`).toHaveText("2\nsecond record\nblip\n9");
+});
+
 test(`existing record with falsy display_name`, async () => {
     Partner._records[0].name = "";
     await mountView({

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -12055,7 +12055,7 @@ test("fieldDependencies support for fields", async () => {
 test("fieldDependencies support for fields: dependence on a relational field", async () => {
     const customField = {
         component: class CustomField extends Component {
-            static template = xml`<span t-esc="props.record.data.product_id[1]"/>`;
+            static template = xml`<span t-esc="props.record.data.product_id.display_name"/>`;
             static props = ["*"];
         },
         fieldDependencies: [{ name: "product_id", type: "many2one", relation: "product" }],

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -15488,7 +15488,7 @@ test(`fieldDependencies support for fields`, async () => {
 test(`fieldDependencies support for fields: dependence on a relational field`, async () => {
     registry.category("fields").add("custom_field", {
         component: class CustomField extends Component {
-            static template = xml`<span t-esc="props.record.data.m2o[0]"/>`;
+            static template = xml`<span t-esc="props.record.data.m2o.id"/>`;
             static props = ["*"];
         },
         fieldDependencies: [{ name: "m2o", type: "many2one", relation: "bar" }],


### PR DESCRIPTION
[[IMP] web: change m2o value to object](https://github.com/odoo/odoo/pull/202534/commits/f06b553e7ddaf92fb74e6917c95a6ae1cdd4373d)
Currently, in the RelationalModel, the value of a many2one is
represented by an Array [id, display_name]. This prevents relatedFields
from being easily added.
In this commit, we add a hack that assigns data on the array. That makes
possible to use it as a simple object.

[[IMP] web: support relatedFields on many2one](https://github.com/odoo/odoo/pull/202534/commits/86ec3fcc4d0b205b31350b789423059fbe408263)
This commit adds the support of relatedFields on many2one fields.
It allows to load additionnal fields of the relation along with the
display_name of the many2one.

task-3547961
task-4658839
