### PR TITLE
[FIX] l10n_ee: fix po file tags

### DIFF
--- a/addons/l10n_ee/i18n/et.po
+++ b/addons/l10n_ee/i18n/et.po
@@ -8,10 +8,12 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-11 10:39+0000\n"
 "PO-Revision-Date: 2024-12-11 10:39+0000\n"
-"POT-Creation-Date: 2024-11-08 14:25+0000\n"
-"PO-Revision-Date: 2024-11-08 14:25+0000\n"
-"POT-Creation-Date: 2025-02-19 11:15+0000\n"
-"PO-Revision-Date: 2025-02-19 11:15+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: l10n_ee
 #: model:account.report.line,name:l10n_ee.tax_report_line_1


### PR DESCRIPTION
Fix erroneous .po tag modification from commit https://github.com/odoo/odoo/commit/d1f664131ee4c72bfff1b82baef81b30afdb8ece due to faulty conflict resolution.
