### PR TITLE
[FIX] website_sale: resizeObserver undefined in destroy

### DIFF
--- a/addons/website_sale/static/src/js/cart.js
+++ b/addons/website_sale/static/src/js/cart.js
@@ -140,7 +140,7 @@ publicWidget.registry.websiteSaleCartNavigation = publicWidget.Widget.extend({
      * @override
      */
     destroy() {
-        this.resizeObserver.disconnect();
+        this.resizeObserver?.disconnect();
         super.destroy();
     },
 });


### PR DESCRIPTION
A resizeObserver was added in this commit ae1ca40d196715734a31d450a339bb6368ef6e01 
However it was only defined on mobile screens therefore it needs to be checked before the `disconnect()` is called



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
