### PR TITLE
[FIX] mail: call invitation sound is too low

### DIFF
--- a/addons/mail/static/src/core/common/sound_effects_service.js
+++ b/addons/mail/static/src/core/common/sound_effects_service.js
@@ -17,7 +17,7 @@ export class SoundEffects {
             "ptt-press": { defaultVolume: 0.1, path: "/mail/static/src/audio/ptt-press" },
             "ptt-release": { defaultVolume: 0.1, path: "/mail/static/src/audio/ptt-release" },
             "call-invitation": {
-                defaultVolume: 0.15,
+                defaultVolume: 0.5,
                 path: "/mail/static/src/audio/call-invitation",
             },
             "new-message": { defaultVolume: 1, path: "/mail/static/src/audio/new-message" },


### PR DESCRIPTION
The sound effect was too low, to the point that new message notification was more audible than the call invitation, which doesn't make sense as call invitation is a more important alert than new message.

This commit increases significantly the call invitation volume to be about the same (or slightly more) than the new message alert.