### PR TITLE
[IMP] web_tour: allow changing tooltip position on custom tours

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -40,7 +40,7 @@
                                     t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_loading"
                                     role="option"
                                     href="#"
-                                    class="dropdown-item ui-menu-item-wrapper"
+                                    class="o_loading dropdown-item ui-menu-item-wrapper"
                                     aria-selected="true"
                                 >
                                     <i class="fa fa-spin fa-circle-o-notch" /> <t t-esc="source.placeholder" />

--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -455,7 +455,10 @@ export class TourInteractive {
                 this.setActionListeners();
             } else if (!tempAnchors.length && this.anchorEls.length) {
                 this.pointer.hide();
-                if (!hoot.queryFirst(".o_home_menu", { visible: true })) {
+                if (
+                    !hoot.queryFirst(".o_home_menu", { visible: true }) &&
+                    !hoot.queryFirst(".dropdown-item.o_loading", { visible: true })
+                ) {
                     this.backward();
                 }
                 return;

--- a/addons/web_tour/static/src/tour_service/tour_step.js
+++ b/addons/web_tour/static/src/tour_service/tour_step.js
@@ -9,7 +9,7 @@ import { pick } from "@web/core/utils/objects";
  * @property {string} [id]
  * @property {HootSelector} trigger The node on which the action will be executed.
  * @property {string} [content] Description of the step.
- * @property {"top" | "botton" | "left" | "right"} [position] The position where the UI helper is shown.
+ * @property {"top" | "bottom" | "left" | "right"} [position] The position where the UI helper is shown.
  * @property {RunCommand} [run] The action to perform when trigger conditions are verified.
  * @property {number} [timeout] By default, when the trigger node isn't found after 10000 milliseconds, it throws an error.
  * You can change this value to lengthen or shorten the time before the error occurs [ms].

--- a/addons/web_tour/views/tour_views.xml
+++ b/addons/web_tour/views/tour_views.xml
@@ -29,6 +29,7 @@
                                         <field name="sequence" widget="handle"/>
                                         <field name="trigger"/>
                                         <field name="run"/>
+                                        <field name="tooltip_position"/>
                                         <field name="content"/>
                                     </list>
                                 </field>


### PR DESCRIPTION
Before this commit, changing the tooltip position of a custom tour was impossible. So, if the tooltip was missplaced, like when pointing at the button to return to the home.

Now, the tooltip position of the step can be changed in the custom tour view and the default value is "bottom".

TASK-ID: 4623449



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
