### PR TITLE
[FIX] website_sale: resizeObserver undefined in destroy

### DIFF
--- a/addons/website_sale/static/src/js/cart.js
+++ b/addons/website_sale/static/src/js/cart.js
@@ -135,7 +135,7 @@ publicWidget.registry.websiteSaleCartNavigation = publicWidget.Widget.extend({
      * @override
      */
     destroy() {
-        this.resizeObserver.disconnect();
+        this.resizeObserver?.disconnect();
         super.destroy();
     },
 });


### PR DESCRIPTION
A resizeObserver was added in this commit ea75cfde10cdcd8f20660f2c7ffca68bc93168cf 
However it was only defined on mobile screens therefore it needs to be checked before the disconnect() is called

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
