### PR TITLE
[FIX] discuss: prevent logging crash on quick call disconnect

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -343,7 +343,7 @@ export class Rtc extends Record {
             connectionType: undefined,
             hasPendingRequest: false,
             channel: undefined,
-            logs: new Map(), // deprecated
+            logs: {},
             sendCamera: false,
             sendScreen: false,
             updateAndBroadcastDebounce: undefined,
@@ -1306,7 +1306,7 @@ export class Rtc extends Record {
                 state: session.connectionState,
                 audioError: session.audioError,
                 videoError: session.videoError,
-                sfuConsumers: this.network.getSfuConsumerStats(session.id),
+                sfuConsumers: this.network?.getSfuConsumerStats(session.id),
             };
             if (session.eq(this.selfSession)) {
                 sessionInfo.isSelf = true;


### PR DESCRIPTION
Before this commit, leaving a call fast after joining it could lead to a race condition where the network wasn't even build by the time we are leaving the call. This would lead to a traceback when dumping the state of the call in the logs, which assumed that the network was defined.

This commit fixes this issue by only getting information from the network if it is exists.

The commit also removes the map initialization of `state.logs`, which was useless as it was replaced by an object.

