### PR TITLE
[FIX] pos*: skip preview screen not doing everything

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -391,6 +391,11 @@ export class PaymentScreen extends Component {
         let nextPage = this.nextPage;
         let switchScreen = true;
 
+        this.currentOrder.uiState.locked = true;
+        if (!this.pos.config.module_pos_restaurant) {
+            this.pos.sendOrderInPreparation(this.currentOrder, { orderDone: true });
+        }
+
         if (
             nextPage.page === "ReceiptScreen" &&
             this.currentOrder.nb_print === 0 &&
@@ -401,11 +406,10 @@ export class PaymentScreen extends Component {
                 : true;
 
             if (invoiced_finalized) {
-                this.pos.printReceipt({ order: this.currentOrder });
+                await this.pos.printReceipt({ order: this.currentOrder });
 
                 if (this.pos.config.iface_print_skip_screen) {
-                    this.currentOrder.setScreenData({ name: "" });
-                    this.currentOrder.uiState.locked = true;
+                    this.pos.orderDone(this.currentOrder);
                     switchScreen = this.currentOrder.uuid === this.pos.selectedOrderUuid;
                     nextPage = this.pos.defaultPage;
                     if (switchScreen) {

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -2,7 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useErrorHandlers, useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
 import { registry } from "@web/core/registry";
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
-import { useState, Component, onMounted } from "@odoo/owl";
+import { useState, Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -34,14 +34,6 @@ export class ReceiptScreen extends Component {
         this.sendReceipt = useTrackedAsync(this._sendReceiptToCustomer.bind(this));
         this.doFullPrint = useTrackedAsync(() => this.pos.printReceipt());
         this.doBasicPrint = useTrackedAsync(() => this.pos.printReceipt({ basic: true }));
-        onMounted(() => {
-            const order = this.pos.getOrder();
-            this.currentOrder.uiState.locked = true;
-
-            if (!this.pos.config.module_pos_restaurant) {
-                this.pos.sendOrderInPreparation(order, { orderDone: true });
-            }
-        });
     }
     actionSendReceiptOnEmail() {
         this.sendReceipt.call({
@@ -80,9 +72,8 @@ export class ReceiptScreen extends Component {
     showPhoneInput() {
         return false;
     }
-    async orderDone() {
-        this.currentOrder.uiState.screen_data.value = "";
-        this.currentOrder.uiState.locked = true;
+    orderDone() {
+        this.pos.orderDone(this.currentOrder);
         if (!this.pos.config.module_pos_restaurant) {
             this.pos.addNewOrder();
         }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2443,6 +2443,14 @@ export class PosStore extends WithLazyGetterTrap {
     getTime(date) {
         return date.toFormat("hh:mm");
     }
+
+    orderDone(order) {
+        order.setScreenData({ name: "" });
+        order.uiState.locked = true;
+        if (this.getOrder() === order) {
+            this.searchProductWord = "";
+        }
+    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};

--- a/addons/pos_sms/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/pos_sms/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -2,9 +2,6 @@ import { patch } from "@web/core/utils/patch";
 import { ReceiptScreen } from "@point_of_sale/app/screens/receipt_screen/receipt_screen";
 
 patch(ReceiptScreen.prototype, {
-    setup() {
-        super.setup(...arguments);
-    },
     showPhoneInput() {
         return super.showPhoneInput() || this.pos.config.module_pos_sms;
     },


### PR DESCRIPTION
pos*: point_of_sale, pos_sms

When setting the options automatic receipt printing with skip preview screen in a pos restaurant, after the payment, the user is redirected to the default screen instead of the floor screen. Currently, some actions are not done during the skipping of the receipt screen.

This commit make sure the actions are done when the skip preview screen is enabled.

task-id: 4170340

Enterprise PR: https://github.com/odoo/enterprise/pull/81768

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
