### PR TITLE
[FIX] mail, website_{sale,slides}: copy link for public/portal chatter

### DIFF
--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -51,7 +51,8 @@ class PublicPageController(http.Controller):
 
     @http.route("/discuss/channel/<int:channel_id>", methods=["GET"], type="http", auth="public")
     @add_guest_to_context
-    def discuss_channel(self, channel_id):
+    def discuss_channel(self, channel_id, *, highlight_message_id=None):
+        # highlight_message_id is used JS side by parsing the query string
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel:
             raise NotFound()

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -764,6 +764,22 @@ class Channel(models.Model):
         considered. """
         raise UserError(_('Adding followers on channels is not possible. Consider adding members instead.'))
 
+    def _get_access_action(self, access_uid=None, force_website=False):
+        """ Redirect to Discuss instead of form view. """
+        self.ensure_one()
+        if not self.env.user._is_internal() or force_website:
+            return {
+                "type": "ir.actions.act_url",
+                "url": f"/discuss/channel/{self.id}",
+                "target": "self",
+                "target_type": "public",
+            }
+        return {
+            "type": "ir.actions.act_url",
+            "url": f"/odoo/action-mail.action_discuss?active_id={self.id}",
+            "target": "self",
+        }
+
     # ------------------------------------------------------------
     # BROADCAST
     # ------------------------------------------------------------

--- a/addons/mail/static/src/core/public_web/discuss_client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_client_action.js
@@ -4,6 +4,7 @@ import { Component, onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { router } from "@web/core/browser/router";
 
 /**
  * @typedef {Object} Props
@@ -63,9 +64,12 @@ export class DiscussClientAction extends Component {
         const [model, id] = this.parseActiveId(rawActiveId);
         const activeThread = await this.store.Thread.getOrFetch({ model, id });
         if (activeThread && activeThread.notEq(this.store.discuss.thread)) {
-            if (props.action?.params?.highlight_message_id) {
-                activeThread.highlightMessage = props.action.params.highlight_message_id;
-                delete props.action.params.highlight_message_id;
+            const highlight_message_id =
+                props.action?.params?.highlight_message_id || router.current.highlight_message_id;
+            if (highlight_message_id) {
+                activeThread.highlightMessage = highlight_message_id;
+                delete props.action?.params?.highlight_message_id;
+                delete router.current?.highlight_message_id;
             }
             activeThread.setAsDiscussThread(false);
         }

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -9,6 +9,7 @@ import {
 } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
+import { _t } from "@web/core/l10n/translation";
 import { Deferred } from "@web/core/utils/concurrency";
 import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 import { useService } from "@web/core/utils/hooks";
@@ -256,6 +257,7 @@ export function useVisible(refName, cb, { ready = true } = {}) {
 
 export function useMessageHighlight(duration = 2000) {
     let timeout;
+    const notification = useState(useService("notification"));
     const state = useState({
         clearHighlight() {
             if (this.highlightedMessageId) {
@@ -273,6 +275,10 @@ export function useMessageHighlight(duration = 2000) {
                 return;
             }
             await thread.loadAround(message.id);
+            if (message.isEmpty) {
+                notification.add(_t("The message has been deleted."));
+                return;
+            }
             const lastHighlightedMessageId = state.highlightedMessageId;
             this.clearHighlight();
             if (lastHighlightedMessageId === message.id) {

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -519,7 +519,7 @@ class TestMessageLinks(MailCommon, HttpCase):
             self.assertEqual(res.url, expected_url)
         with self.subTest(private_message_id=private_message_id):
             res = self.url_open(f'/mail/message/{private_message_id}')
-            self.assertEqual(res.status_code, 401)
+            self.assertEqual(res.status_code, 404)
 
     @users('employee')
     def test_message_link_by_public(self):

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -928,3 +928,15 @@ class ProductTemplate(models.Model):
     @api.model
     def _allow_publish_rating_stats(self):
         return True
+
+    def _get_access_action(self, access_uid=None, force_website=False):
+        """ Instead of the classic form view, redirect to website if it is published. """
+        self.ensure_one()
+        if force_website or self.website_published:
+            return {
+                "type": "ir.actions.act_url",
+                "url": self.website_url,
+                "target": "self",
+                "target_type": "public",
+            }
+        return super()._get_access_action(access_uid=access_uid, force_website=force_website)

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -1141,6 +1141,18 @@ class Channel(models.Model):
                 )
         return activities
 
+    def _get_access_action(self, access_uid=None, force_website=False):
+        """ Instead of the classic form view, redirect to website if it is published. """
+        self.ensure_one()
+        if force_website or self.website_published:
+            return {
+                "type": "ir.actions.act_url",
+                "url": self.website_url,
+                "target": "self",
+                "target_type": "public",
+            }
+        return super()._get_access_action(access_uid=access_uid, force_website=force_website)
+
     # ---------------------------------------------------------
     # Data / Misc
     # ---------------------------------------------------------


### PR DESCRIPTION
Before this commit, links produced by the "Copy Link" action on portal or public chatters would redirect to an unathorized page.

This happens because the route used in the link would check access rights to the message, which public and portal users usually don't have.

This commit fixes the issue by overriding the link route in modules with public chatter such that it would redirect to the page containing the chatter.

This commit also removes the possibility to copy links of messages inside portal documents for which a user has no read access to avoid leaking the access token.

task-4551910
