### PR TITLE
[FIX] sale_stock: No new Sale Order Line when transit not final destination

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -112,7 +112,11 @@ class StockPicking(models.Model):
             sale_order = move.picking_id.sale_id
             # Creates new SO line only when pickings linked to a sale order and
             # for moves with qty. done and not already linked to a SO line.
-            if not sale_order or move.location_dest_id.usage not in ['customer', 'transit'] or move.sale_line_id or not move.picked:
+            if not sale_order \
+                or move.location_dest_id.usage not in ['customer', 'transit'] \
+                or move.move_dest_ids \
+                or move.sale_line_id \
+                or not move.picked:
                 continue
             product = move.product_id
             so_line_vals = {

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2131,3 +2131,67 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         self.assertEqual(so.picking_ids[0].state, 'done')
         self.assertEqual(so.picking_ids[1].move_ids.move_line_ids[0].location_dest_id, child_location_1)
         self.assertEqual(so.picking_ids[1].move_ids.move_line_ids[1].location_dest_id, child_location_2)
+
+    def test_custom_delivery_route_new_sale_line(self):
+        """
+        Create a custom delivery route Stock -> Transit -> Customer that uses pull rules.
+        Ensure that the validating the move from Stock to Transit does NOT create a new SaleOrderLine.
+        """
+        warehouse = self.company_data['default_warehouse']
+        stock_location = warehouse.lot_stock_id
+        customer_location = self.env.ref('stock.stock_location_customers')
+        transit_location = self.env['stock.location'].create({
+            'name': 'Transit',
+            'usage': 'transit',
+            'location_id': warehouse.view_location_id.id,
+        })
+        warehouse.pick_type_id.default_location_dest_id = transit_location
+
+        warehouse.delivery_route_id = self.env['stock.route'].create({
+            'name': '2 Steps Pull Delivery Route',
+            'warehouse_selectable': True,
+            'warehouse_ids': [(4, warehouse.id)],
+            'rule_ids': [
+                Command.create({
+                    'name': 'Stock to Output',
+                    'action': 'pull',
+                    'location_src_id': stock_location.id,
+                    'location_dest_id': transit_location.id,
+                    'picking_type_id': warehouse.pick_type_id.id,
+                    'procure_method': 'make_to_stock',
+                }),
+                Command.create({
+                    'name': 'Output to Customer',
+                    'action': 'pull',
+                    'location_src_id': transit_location.id,
+                    'location_dest_id': customer_location.id,
+                    'picking_type_id': warehouse.out_type_id.id,
+                    'procure_method': 'make_to_order',
+                })
+            ]
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'name': 'Test Product',
+                'product_id': self.product_a.id,
+                'product_uom_qty': 1.0,
+                'price_unit': 1.0,
+            })],
+        })
+        sale_order.action_confirm()
+
+        # Ensure the created pickings follow the expected route
+        pickings = sale_order.picking_ids
+        self.assertEqual(len(pickings), 2, "Expected two pickings: Stock->Output and Output->Customer")
+        self.assertEqual(pickings[0].location_id, stock_location)
+        self.assertEqual(pickings[0].location_dest_id, transit_location)
+        self.assertEqual(pickings[1].location_id, transit_location)
+        self.assertEqual(pickings[1].location_dest_id, customer_location)
+
+        pickings[0].move_ids.picked = True
+        pickings[0].button_validate()
+
+        self.assertEqual(pickings[0].state, 'done')
+        self.assertEqual(len(sale_order.order_line), 1)


### PR DESCRIPTION

Commit 0bdfda2af4d70a6c33773ecd4aaa717ef6a17d62 introduced a new behavior where delivery transfer to transit locations (inter companies transfer) could create a new Sale Order Line if necessary. However, we do not want this behavior if the transit location is just a step in the delivery to the Customer location.

Hence, if there are any destination moves, we do not create a new sale order line.

OPW-4643937

---

Test result without fix:
```
2025-03-19 16:08:42,057 57047 ERROR oes_test_17.4 odoo.addons.sale_stock.tests.test_sale_stock: FAIL: TestSaleStock.test_custom_delivery_route_new_sale_line
Traceback (most recent call last):
  File "/home/odoo/projects/odoo-src/multiverse/src/saas-17.4/odoo/addons/sale_stock/tests/test_sale_stock.py", line 2197, in test_custom_delivery_route_new_sale_line
    self.assertEqual(len(sale_order.order_line), 1)
AssertionError: 2 != 1
 ``` 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
