### PR TITLE
[FIX] {crm_livechat,utm}: set no update

### DIFF
--- a/addons/crm_livechat/data/utm_data.xml
+++ b/addons/crm_livechat/data/utm_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
     <record model="utm.source" id="utm_source_livechat">
         <field name="name">Livechat</field>
     </record>

--- a/addons/utm/data/utm_medium_data.xml
+++ b/addons/utm/data/utm_medium_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
     <record model="utm.medium" id="utm_medium_website">
         <field name="name">Website</field>
     </record>

--- a/addons/utm/data/utm_source_data.xml
+++ b/addons/utm/data/utm_source_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
     <record model="utm.source" id="utm_source_search_engine">
         <field name="name">Search engine</field>
     </record>


### PR DESCRIPTION
Steps to reproduce:
1) Install utm module.
2) In link tracker edit utm named LinkedIn or any and add another with same name.
3) update the module.

We get an error that utm_medium or utm_source should be unique.

create goes through `_get_unique_names` method so its only a problem when updating the record.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
