### PR TITLE
[IMP] web: log exports

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -168,6 +168,7 @@ class GroupsTreeNode:
             node.count += count
 
         node.data = records.export_data(self._export_field_names).get('datas', [])
+        return records
 
 
 class ExportXlsxWriter:
@@ -492,8 +493,9 @@ class ExportFormat(object):
             # read_group(lazy=False) returns a dict only for final groups (with actual data),
             # not for intermediary groups. The full group tree must be re-constructed.
             tree = GroupsTreeNode(Model, field_names, groupby, groupby_type)
+            records = Model.browse()
             for leaf in groups_data:
-                tree.insert_leaf(leaf)
+                records |= tree.insert_leaf(leaf)
 
             response_data = self.from_group_data(fields, tree)
         else:
@@ -501,6 +503,14 @@ class ExportFormat(object):
 
             export_data = records.export_data(field_names).get('datas', [])
             response_data = self.from_data(columns_headers, export_data)
+
+        _logger.info(
+            "User %d exported %d %r records from %s. Fields: %s. %s: %s",
+            request.env.user.id, len(records.ids), records._name, request.httprequest.environ['REMOTE_ADDR'],
+            ','.join(field_names),
+            'IDs sample' if ids else 'Domain',
+            records.ids[:10] if ids else domain,
+        )
 
         # TODO: call `clean_filename` directly in `content_disposition`?
         return request.make_response(response_data,


### PR DESCRIPTION
For forensics purposes, having a log when users are doing an export is useful.

In this revision, the logger is put in the controller. It would be better to put it in a lower level method, such the `export_data` public method on the models.

However:
- The domain is only available in the controller. `export_data` does not receive the domain in its params. Putting the logger in `export_data` would therefore lead to the inability to log the domain. Or we would need to do one logger in the controller just for the domain, and a second logger in `export_data`.
- During an export using a group by (and without import compatibility) `export_data` is called recursively, in `insert_leaf`. Hence, if the logger would be put in `export_data`, there would be one log per group, therefore bloating the logs.

Hence, for stable versions, the decision taken is to put the log in the controller rather than in a lower level method. It's better than nothing.

A rework of the API of `export_data` is planned in master to solve the above concerns.