### PR TITLE
[FIX] point_of_sale: use correct pricelist rule

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -203,27 +203,7 @@ export class ProductTemplate extends Base {
                     (!rule.categ_id || rule.categ_id.id === product?.categ_id?.id)
             ) || [];
 
-        // We take in first assigned product rules instead of common one.
-        let commonRule = "";
-        let productVariantRule = "";
-        let productTemplateRule = "";
-        for (const rule of rules) {
-            if (!rule.product_id && !rule.product_tmpl_id) {
-                commonRule = rule;
-            }
-            if (rule.product_id?.id === product?.id) {
-                productVariantRule = rule;
-                break;
-            }
-            if (rule.product_tmpl_id?.id === productTmpl.id) {
-                // Prefer the rule with the highest `min_quantity`
-                if (!productTemplateRule || productTemplateRule.min_quantity < rule.min_quantity) {
-                    productTemplateRule = rule;
-                }
-            }
-        }
-
-        const rule = productVariantRule || productTemplateRule || commonRule;
+        const rule = rules.length && rules[0];
         if (!rule) {
             return price;
         }


### PR DESCRIPTION
When multiple pricelist rules with different minimum quantities existed (global or category-based), the incorrect rule was being selected. This was caused by an unnecessary search on already filtered and priority-sorted pricelist rules.

Now we simply select the first matching rule, respecting the priority.

opw-4609371

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
