### PR TITLE
[FIX] mail: member is typing bg matches conversation bg

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -103,8 +103,8 @@
                 </div>
                 <t t-elif="thread">
                     <Thread isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/>
-                    <div t-if="thread.hasOtherMembersTyping" class="d-flex bg-view position-relative">
-                        <div class="o-mail-ChatWindow-typing d-flex px-2 position-absolute bottom-0 start-0 w-100 bg-view align-items-center">
+                    <div t-if="thread.hasOtherMembersTyping" class="d-flex bg-inherit position-relative">
+                        <div class="o-mail-ChatWindow-typing d-flex px-2 position-absolute bottom-0 start-0 w-100 bg-inherit align-items-center">
                             <Typing channel="thread" size="'medium'"/>
                         </div>
                     </div>

--- a/addons/mail/static/src/discuss/typing/common/typing.xml
+++ b/addons/mail/static/src/discuss/typing/common/typing.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.Typing">
         <t t-if="props.member ? props.member.isTyping : props.channel.hasOtherMembersTyping">
-            <div class="o-discuss-Typing-icon d-flex align-items-center" t-attf-class="{{ className }}" t-att-title="text">
+            <div class="o-discuss-Typing-icon d-flex align-items-center bg-inherit" t-attf-class="{{ className }}" t-att-title="text">
                 <span class="o-discuss-Typing-dot d-flex flex-shrink-0 rounded-pill bg-500"
                       t-att-class="{
                              'o-sizeMedium': props.size === 'medium',


### PR DESCRIPTION
Before this commit, when someone is typing in conversation in a chat window, the "is typing" notification has a `.bg-view`.

Problem is that `.bg-view` doesn't match the conversation bg, especially in dark theme where the conversation bg is dark and this is greyish. In chat window this takes the whole width, making it hard to distinguish the rounded rectangle shape of chat window.

This commit fixes the issue by replacing the `.bg-view` to `.bg-inherit`, so that the text bg color of "is typing" matches the conversation bg.

Before / After
![Screenshot 2025-03-19 at 18 52 36](https://github.com/user-attachments/assets/10220818-3740-4ef1-963b-08e2554115b0) ![Screenshot 2025-03-19 at 18 52 17](https://github.com/user-attachments/assets/db6e0ce2-8589-4827-bf78-78878eeda2dc)

