### PR TITLE
[FIX] point_of_sale: discount removed if no product in product line

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -1,5 +1,5 @@
 import { usePos } from "@point_of_sale/app/store/pos_hook";
-import { Component } from "@odoo/owl";
+import { Component, useEffect } from "@odoo/owl";
 import { Orderline } from "@point_of_sale/app/generic_components/orderline/orderline";
 import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
 import { useService } from "@web/core/utils/hooks";
@@ -27,6 +27,18 @@ export class OrderSummary extends Component {
             triggerAtInput: (...args) => this.updateSelectedOrderline(...args),
             useWithBarcode: true,
         });
+        this.product = this.pos.config.discount_product_id;
+        this.lines = this.currentOrder?.lines;
+        useEffect(
+            () => {
+                if (this.lines.length === 1 && this.lines[0].full_product_name === "Discount") {
+                    this.lines
+                        .filter((line) => line.get_product() === this.product)
+                        .forEach((line) => line.delete());
+                }
+            },
+            () => [this.lines.length]
+        );
     }
 
     get currentOrder() {

--- a/doc/cla/individual/rushil-b-patel.md
+++ b/doc/cla/individual/rushil-b-patel.md
@@ -1,0 +1,11 @@
+India, 2025-03-20
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Rushil Patel rushil13579@gmail.com https://github.com/rushil-b-patel


### PR DESCRIPTION
## Current behavior before PR:
The global discount (if configured) in the POS module persist in the order line (summary order) even when there is no product present in it.

## Steps to reproduce / Description of the issue feature this PR addresses:

- Install `POS` module
- Go to `POS` -> `Configuration` -> `Settings`
- Search for `Global Discount` check the tick mark and save it
- Open that particular shop for which Global Discount is configured
- Add some products to the cart
- Apply Global Discount to the order(`Actions` -> `Discount`)
- Remove all the products from the cart except the discount and then checkout that cart, it will let you do the payment.

## Desired behavior after PR is merged:
If global discount is applied to the cart and if user removes the product then discount order line won't persist anymore.










---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
