### PR TITLE
[FIX] hr_holidays: Added filter in _prepare_holiday_values()

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -632,7 +632,7 @@ class HolidaysAllocation(models.Model):
             'date_from': self.date_from,
             'date_to': self.date_to,
             'accrual_plan_id': self.accrual_plan_id.id,
-        } for employee in employees]
+        } for employee in employees if (not employee.resource_calendar_id) or employee.resource_calendar_id.hours_per_day]
 
     def action_draft(self):
         if any(holiday.state not in ['confirm', 'refuse'] for holiday in self):

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -39,6 +39,15 @@ class TestCompanyLeave(TransactionCase):
             'tz': "Europe/Brussels",
         })
 
+        cls.paid_time_off_hours = cls.env['hr.leave.type'].create({
+            'name': 'Paid Time Off in Hours',
+            'request_unit': 'hour',
+            'leave_validation_type': 'no_validation',
+            'company_id': cls.company.id,
+            'time_type': 'other',
+            'requires_allocation': 'yes',
+        })
+
     def test_leave_whole_company_01(self):
         # TEST CASE 1: Leaves taken in days. Take a 3 days leave
         # Add a company leave on the second day.
@@ -467,3 +476,39 @@ class TestCompanyLeave(TransactionCase):
         self.assertEqual(employee_leaves[1].date_from, datetime(2020, 1, 7, 3, 30))
         self.assertEqual(employee_leaves[1].date_to, datetime(2020, 1, 7, 7, 0))
         self.assertEqual(employee_leaves[1].number_of_hours_display, 1.0)
+
+    def test_leave_whole_company_10(self):
+        """
+            Check leaves given in hours for a company,
+            Making sure no leaves are given for 0 Hours / Week employee(i.e. Contractors billed for hours).
+        """
+        employee_0_test_10, employee_1_test_10, employee_2_test_10 = self.env['hr.employee'].create([{
+            'name': 'My Employee 0',
+            'company_id': self.company.id,
+            'tz': "Europe/Brussels",
+        },{
+            'name': 'My Employee 1',
+            'company_id': self.company.id,
+            'tz': "Europe/Brussels",
+        },{
+            'name': 'My Employee 2',
+            'company_id': self.company.id,
+            'tz': "Europe/Brussels",
+        }])
+        zero_hours_working_schedule = self.env['resource.calendar'].create({
+            'name': 'Standard - Hours/Week',
+            'hours_per_day': 0,
+            'tz': "Europe/Brussels",
+        })
+        employee_0_test_10.resource_calendar_id = zero_hours_working_schedule
+        self.env['hr.leave.allocation'].create({
+            'name': 'Holiday (8 Hours)',
+            'holiday_status_id': self.paid_time_off_hours.id,
+            'holiday_type': 'company',
+            'mode_company_id': self.company.id,
+            'number_of_days': 1,
+        })
+        employee_leaves = self.env['hr.leave.allocation'].search([
+            ('name', '=', 'Holiday (8 Hours)'),
+            ('employee_id', 'in', [employee_0_test_10.id, employee_1_test_10.id, employee_2_test_10.id])])
+        self.assertEqual(len(employee_leaves), 2)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
  The system assigns 8 hours of leave to contractors by default. 
  This applies even if their schedule is set to 0 hours per week. 
  As a result, contractors may receive holiday pay like full-timers. 
  For example, a snowplow contractor with 0 hours in summer 
  could wrongly get a full day's holiday pay during that period.
![image](https://github.com/user-attachments/assets/d2d0bf8b-edad-4fa2-9755-71d737f49c83)
![image](https://github.com/user-attachments/assets/7d5ae37c-ebe2-4fe8-af2a-fe3f4913bbd0)
![image](https://github.com/user-attachments/assets/fd6e565c-17c3-41bc-bf15-7cbed563ddf0)

Current behavior before PR:
  A employee with 0 Hours/Week Working Schedule will receive
  max hours of a time off allocation.
![image](https://github.com/user-attachments/assets/5c234005-bcd1-4ced-a4aa-ac7406144aa0)

Desired behavior after PR is merged:
  A employee with 0 Hours/Week Working Schedule will not receive 
  max hours of a time off allocation.
  And no time off allocation should be created.

opw-4464317
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
