### PR TITLE
[FIX] hr_holidays: prevent error on updating allocation time without an employee

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -201,9 +201,11 @@ class HolidaysAllocation(models.Model):
         for allocation in self:
             allocation.number_of_days_display = allocation.number_of_days
 
-    @api.depends('number_of_days')
+    @api.depends('number_of_days', 'employee_id')
     def _compute_number_of_hours_display(self):
         for allocation in self:
+            if not allocation.employee_id:
+                continue
             allocation.number_of_hours_display = (allocation.number_of_days * allocation.employee_id._get_hours_per_day(allocation.date_from))
 
     @api.depends('number_of_hours_display', 'number_of_days_display')


### PR DESCRIPTION
An error occurs when updating the **Allocation** field in a time-off allocation record that does not have an assigned employee.

**Steps to reproduce:**
- Install the `hr_holidays` module.
- Navigate to `Time Off > Management > Allocations` (form view).
- Remove the employee and modify the **Allocation** field.
- Observe the error.

**Error:**
KeyError - False

The issue occurs because `_compute_number_of_hours_display` depends on `employee_id._get_hours_per_day(allocation.date_from)`, when `employee_id` 
is empty, attempting to access `self.id` at [1] results in a key error.

[1] - https://github.com/odoo/odoo/blob/51097d978a698fa94d021ca72bcd69c24d9c768b/addons/hr_holidays/models/hr_employee.py#L349

This commit ensures that the computation of `number_of_hours_display` checks if `employee_id` exists before proceeding. If no employee is assigned, it will be skipped.

Sentry - 6423050142