### PR TITLE
[FIX] sale,stock: fix active_test issue

### DIFF
--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -6,7 +6,7 @@
         <field name="res_model">sale.order</field>
         <field name="view_mode">list,kanban,form,graph</field>
         <field name="domain">[('partner_id', 'child_of', active_ids)]</field>
-        <field name="context">{'default_partner_id': active_id, 'active_test': False}</field>
+        <field name="context">{'default_partner_id': active_id}</field>
         <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/stock/report/stock_lot_customer.xml
+++ b/addons/stock/report/stock_lot_customer.xml
@@ -22,7 +22,7 @@
         <field name="res_model">stock.lot.report</field>
         <field name="view_mode">list</field>
         <field name="domain">[('partner_id', 'child_of', active_ids)]</field>
-        <field name="context">{'search_default_filter_not_has_return': True, 'active_test': False}</field>
+        <field name="context">{'search_default_filter_not_has_return': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No data yet!


### PR DESCRIPTION
Steps:
- Install sales and contact app.
- Create a price-list and archive it.
- Go to contact form and click on Sale stat button.
- Create an SO and click on price-list field.

Issue:
- Archive price-list are visible in price-list field.

Cause:
- In [PR] added active_test and because of that user can select archive records from this 
action like price-list in our case.

Fix:
- Remove active_test context from these actions since active_test context already added
on child_ids field definition in [commit].

[PR]: https://github.com/odoo/odoo/pull/189270
[commit]: https://github.com/odoo/odoo/pull/165127/commits/310a8ab2a408d17d86026afc2c59063f5891bf3d

opw-4657678