### PR TITLE
[IMP] point_of_sale: presets menu visibility

### DIFF
--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -119,6 +119,7 @@ class ResConfigSettings(models.TransientModel):
     pos_orderlines_sequence_in_cart_by_category = fields.Boolean(related='pos_config_id.orderlines_sequence_in_cart_by_category', readonly=False)
     pos_basic_receipt = fields.Boolean(related='pos_config_id.basic_receipt', readonly=False)
     pos_fallback_nomenclature_id = fields.Many2one(related='pos_config_id.fallback_nomenclature_id', domain="[('id', '!=', barcode_nomenclature_id)]", readonly=False)
+    group_pos_preset = fields.Boolean(string="Presets", implied_group="point_of_sale.group_pos_preset", help="Hide or show the Presets menu in the Point of Sale configuration.")
 
     def open_payment_method_form(self):
         bank_journal = self.env['account.journal'].search([('type', '=', 'bank'), ('company_id', 'in', self.env.company.parent_ids.ids)], limit=1)
@@ -152,6 +153,9 @@ class ResConfigSettings(models.TransientModel):
 
                 if vals.get('pos_use_pricelist'):
                     vals['group_product_pricelist'] = True
+
+                if vals.get('pos_use_presets') is not None:
+                    vals["group_pos_preset"] = bool(self.env["pos.config"].search_count([("use_presets", "=", True), ("id", "!=", pos_config_id)])) or vals['pos_use_presets']
 
                 for field in self._fields.values():
                     if field.name == 'pos_config_id':

--- a/addons/point_of_sale/security/point_of_sale_security.xml
+++ b/addons/point_of_sale/security/point_of_sale_security.xml
@@ -18,6 +18,12 @@
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 
+    <record id="group_pos_preset" model="res.groups">
+        <field name="name">Preset Menu</field>
+        <field name="sequence">30</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
     <data noupdate="1">
 
     <record id="rule_pos_bank_statement_account_user" model="ir.rule">

--- a/addons/point_of_sale/views/pos_preset_view.xml
+++ b/addons/point_of_sale/views/pos_preset_view.xml
@@ -90,5 +90,5 @@
         </field>
     </record>
 
-    <menuitem id="menu_pos_preset" parent="menu_point_config_product" action="action_pos_preset_form" sequence="3" groups="group_pos_manager,group_pos_user"/>
+    <menuitem id="menu_pos_preset" parent="menu_point_config_product" action="action_pos_preset_form" sequence="3" groups="group_pos_preset"/>
 </odoo>

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -131,6 +131,9 @@ class PosConfig(models.Model):
             'record': config,
             'noupdate': True,
         }])
+        if default_preset:
+            # Ensure the "Presets" menu is visible when installing the restaurant scenario
+            self.env.ref("point_of_sale.group_pos_preset").implied_by_ids |= self.env.ref("base.group_user")
         if not self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False):
             convert.convert_file(self._env_with_clean_context(), 'pos_restaurant', 'data/scenarios/restaurant_floor.xml', idref=None, mode='init', noupdate=True)
         config_floors = [(5, 0)]


### PR DESCRIPTION
After this commit:
===
- `presets` menu visible only when any one shop has enabled presets.
- Fixed menu visibility when installing a restaurant via scenario.

Task: 4523232
Related PR: odoo/odoo#196800