### PR TITLE
[IMP] POS: Allow Searching New Partners with Custom Fields.

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -186,28 +186,40 @@ export class PartnerListScreen extends Component {
         }
         return result;
     }
+    /**
+     * Returns the default search fields for filtering partners.
+    */
+    defaultSearchFields() {
+        return [
+            "name",
+            "parent_name",
+            "phone",
+            "mobile",
+            "email",
+            "barcode",
+            "street",
+            "zip",
+            "city",
+            "state_id",
+            "country_id",
+            "vat",
+       ];
+    }
+    /**
+     * Builds the dynamic search domain based on the current query.
+     */
+    _buildPartnerDomain() {
+        const search_fields = this.defaultSearchFields();
+        return [
+           ...Array(search_fields.length - 1).fill('|'),
+           ...search_fields.map(field => [field, "ilike", this.state.query + "%"])
+        ];
+    }
     async getNewPartners() {
         let domain = [];
         const limit = 30;
         if (this.state.query) {
-            const search_fields = [
-                "name",
-                "parent_name",
-                "phone",
-                "mobile",
-                "email",
-                "barcode",
-                "street",
-                "zip",
-                "city",
-                "state_id",
-                "country_id",
-                "vat",
-            ];
-            domain = [
-                ...Array(search_fields.length - 1).fill('|'),
-                ...search_fields.map(field => [field, "ilike", this.state.query + "%"])
-            ];
+            domain = this._buildPartnerDomain();
         }
         // FIXME POSREF timeout
         const result = await this.orm.silent.call(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- POS: Allow Searching New Partners with Custom Fields.


Current behavior before PR:

- Currently, in Odoo POS, we are unable to search for new partners using custom fields. The existing method does not support dynamic field extensions.


Desired behavior after PR is merged:

- We override the method to allow adding new fields dynamically.
- The domain is now customizable, ensuring searches include newly added fields.

- This improvement allows modules to extend both search fields and domains without modifying core code.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

CLA Ref: https://github.com/odoo/odoo/pull/202642
