### PR TITLE
[FIX] hr_holidays: fix allocation without employee

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -1615,6 +1615,12 @@ msgid "Employee accrue"
 msgstr ""
 
 #. module: hr_holidays
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
+#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_kanban_approve_department
+msgid "Employee's image"
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__emp
 msgid "Employee(s)"
 msgstr ""
@@ -3447,6 +3453,13 @@ msgstr ""
 msgid ""
 "This area is automatically filled by the user who validates the allocation "
 "with second level (If time off type need second validation)"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid "This company does not have any employees."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -347,5 +347,6 @@ class HrEmployee(models.Model):
 
     def _get_hours_per_day(self, date_from):
         ''' Return 24H to handle the case of Fully Flexible (ones without a working calendar)'''
+        self.ensure_one()
         calendars = self._get_calendars(date_from)
         return calendars[self.id].hours_per_day if calendars[self.id] else 24

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -116,6 +116,12 @@ class HolidaysRequest(models.Model):
             del values['date_to']
         return values
 
+    def _default_employee_id(self):
+        employee = self.env.user.employee_id or self.env['hr.employee'].search(self._get_employee_domain(), limit=1)
+        if not employee:
+            raise UserError(_("This company does not have any employees."))
+        return employee
+
     # description
     name = fields.Char('Description', compute='_compute_description', inverse='_inverse_description', search='_search_description', compute_sudo=False, copy=False)
     private_name = fields.Char('Time Off Description', groups='hr_holidays.group_hr_holidays_user')
@@ -150,7 +156,7 @@ class HolidaysRequest(models.Model):
 
     employee_id = fields.Many2one(
         'hr.employee', string='Employee', index=True, ondelete="restrict", required=True,
-        tracking=True, domain=lambda self: self._get_employee_domain(), default=lambda self: self.env.user.employee_id)
+        tracking=True, domain=lambda self: self._get_employee_domain(), default=_default_employee_id)
     employee_company_id = fields.Many2one(related='employee_id.company_id', string="Employee Company", store=True)
     company_id = fields.Many2one('res.company', compute='_compute_company_id', store=True)
     active_employee = fields.Boolean(related='employee_id.active', string='Employee Active')

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -43,6 +43,12 @@ class HolidaysAllocation(models.Model):
             ]
         return domain
 
+    def _default_employee_id(self):
+        employee = self.env.user.employee_id or self.env['hr.employee'].search(self._domain_employee_id(), limit=1)
+        if not employee:
+            raise UserError(_("This company does not have any employees."))
+        return employee
+
     name = fields.Char(
         string='Description',
         compute='_compute_description',
@@ -68,7 +74,7 @@ class HolidaysAllocation(models.Model):
         domain=_domain_holiday_status_id,
         default=_default_holiday_status_id)
     employee_id = fields.Many2one(
-        'hr.employee', string='Employee', default=lambda self: self.env.user.employee_id,
+        'hr.employee', string='Employee', default=_default_employee_id,
         index=True, ondelete="restrict", required=True, tracking=True, domain=_domain_employee_id)
     employee_company_id = fields.Many2one(related='employee_id.company_id', readonly=True, store=True)
     active_employee = fields.Boolean('Active Employee', related='employee_id.active', readonly=True)

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -2,10 +2,11 @@ from datetime import date
 
 from freezegun import freeze_time
 
-from odoo.exceptions import ValidationError
+from odoo.exceptions import ValidationError, UserError
 from odoo.tests import Form, tagged, users
 
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+from odoo.addons.mail.tests.common import mail_new_test_user
 
 
 @tagged('allocation')
@@ -385,3 +386,34 @@ class TestAllocations(TestHrHolidaysCommon):
         })
 
         self.assertEqual(allocation.allocation_type, 'regular')
+
+    def test_allocation_default_employee(self):
+        """
+        Make sure that the default employee is set on the allocation
+        """
+        with Form(self.env['hr.leave.allocation']
+                  .with_user(self.user_hrmanager)
+                  .with_context({"default_holiday_status_id": self.leave_type.id})) as allocation_form:
+            self.assertEqual(allocation_form.employee_id, self.user_hrmanager.employee_id)
+
+        new_company = self.env['res.company'].create({'name': 'Test company 2'})
+        new_leave_type = self.env['hr.leave.type'].create({
+            'name': 'Time Off with no validation for approval',
+            'time_type': 'leave',
+            'requires_allocation': 'yes',
+            'allocation_validation_type': 'no_validation',
+            'company_id': new_company.id,
+        })
+        with self.assertRaises(UserError, msg="This company does not have any employees."):
+            Form(self.env['hr.leave.allocation']
+                    .with_company(new_company)
+                    .with_context({"default_holiday_status_id": new_leave_type.id}))
+
+        new_employee = self.env['hr.employee'].create({
+            'name': 'My Employee',
+            'company_id': new_company.id,
+        })
+        with Form(self.env['hr.leave.allocation']
+                .with_company(new_company)
+                .with_context({"default_holiday_status_id": new_leave_type.id})) as allocation_form:
+            self.assertEqual(allocation_form.employee_id, new_employee)


### PR DESCRIPTION
Issue: if user does not have employee in the current company in managment the allocation will try to load his employee calendar which raise the error

Fix: check if there is an employee for the user before trying to fetch the data

Task:  4660184


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
