### PR TITLE
[FIX] mail: wrap emoji with title failing on firefox

### DIFF
--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -323,7 +323,7 @@ export function wrapEmojisWithTitles(content) {
         return content;
     }
     const doc = createDocumentFragmentFromContent(content);
-    const nodes = document.evaluate(
+    const nodes = doc.evaluate(
         ".//text()",
         doc.body,
         null,


### PR DESCRIPTION
Before this PR, opening the general channel on firefox would fail. This occurs because the `wrapEmojiWithTitle` function creates a document from the message body, then uses an XPath to locate text nodes. However, the `evaluate` function is used on the global document while the node belongs to the document created from the body. As a result, a `DOMException` is raised.

This PR fixes the issue by invoking the `evaluate` method of the newly created document.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
