### PR TITLE
[IMP] base: commit_progress always commits

### DIFF
--- a/addons/auth_signup/tests/test_auth_signup.py
+++ b/addons/auth_signup/tests/test_auth_signup.py
@@ -95,4 +95,5 @@ class TestAuthSignupFlow(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         ])
         for u in users:
             u.create_date = datetime.now() - timedelta(days=5, minutes=10)
-        users.send_unregistered_user_reminder(after_days=5, batch_size=100)
+        with self.registry.cursor() as cr:
+            users.with_env(users.env(cr=cr)).send_unregistered_user_reminder(after_days=5, batch_size=100)

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -150,7 +150,7 @@ class WebsiteVisitorTestsCommon(MockVisitor, HttpCaseWithUserDemo):
         inactive_visitor_ids = inactive_visitors.ids
         active_visitor_ids = active_visitors.ids
 
-        WebsiteVisitor._cron_unlink_old_visitors()
+        self.env.ref('website.website_visitor_cron').method_direct_trigger()
         if inactive_visitor_ids:
             # all inactive visitors should be deleted
             self.assertFalse(bool(WebsiteVisitor.search([('id', 'in', inactive_visitor_ids)])))

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -784,7 +784,7 @@ class IrCron(models.Model):
         is subtracted from the existing remaining count.
 
         If called from outside the cron job, the progress function call will
-        have no effect.
+        just commit.
 
         :param processed: number of processed items in this step
         :param remaining: set the remaining count to the given count
@@ -794,7 +794,8 @@ class IrCron(models.Model):
         ctx = self.env.context
         progress = self.env['ir.cron.progress'].sudo().browse(ctx.get('ir_cron_progress_id'))
         if not progress:
-            # not called during a cron, ignore
+            # not called during a cron, just commit
+            self.env.cr.commit()
             return float('inf')
         assert processed >= 0, 'processed must be positive'
         assert (remaining or 0) >= 0, "remaining must be positive"


### PR DESCRIPTION
Even when called from outside a cron job, the `_commit_progress` function should commit.

Existing usage examples:

    while x:
      try:
        ...
        cron._commit_progress()
      except:
        cr.rollback()

When called from outside of the cron job, such a function would never commit, but would rollback on errors.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
