### PR TITLE
[FIX] website_sale_{,stock_}wishlist: shrink Add to Cart button

### DIFF
--- a/addons/website_sale_stock_wishlist/i18n/website_sale_stock_wishlist.pot
+++ b/addons/website_sale_stock_wishlist/i18n/website_sale_stock_wishlist.pot
@@ -41,8 +41,8 @@ msgstr ""
 #. module: website_sale_stock_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_stock_wishlist.product_wishlist
 msgid ""
-"Add\n"
-"                <span class=\"d-none d-md-inline\">to Cart</span>"
+"<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
+"                <span class=\"d-none d-md-inline\">Add</span>"
 msgstr ""
 
 #. module: website_sale_stock_wishlist

--- a/addons/website_sale_stock_wishlist/views/website_sale_stock_wishlist_templates.xml
+++ b/addons/website_sale_stock_wishlist/views/website_sale_stock_wishlist_templates.xml
@@ -49,8 +49,8 @@
             <button t-if="not combination_info['prevent_zero_price_sale']" id="add_to_cart_button"
                     class="btn btn-secondary btn-block o_wish_add mb4"
                     t-att-disabled="is_sold_out">
-                Add
-                <span class='d-none d-md-inline'>to Cart</span>
+                <span class="fa fa-fw fa-shopping-cart"/>
+                <span class="d-none d-md-inline">Add</span>
             </button>
         </xpath>
     </template>

--- a/addons/website_sale_wishlist/i18n/website_sale_wishlist.pot
+++ b/addons/website_sale_wishlist/i18n/website_sale_wishlist.pot
@@ -35,6 +35,13 @@ msgid "<small><i class=\"fa fa-trash-o\"/> Remove</small>"
 msgstr ""
 
 #. module: website_sale_wishlist
+#: model_terms:ir.ui.view,arch_db:website_sale_wishlist.product_wishlist
+msgid ""
+"<span class=\"fa fa-fw fa-shopping-cart\"/>\n"
+"                                                <span class=\"d-none d-md-inline\">Add</span>"
+msgstr ""
+
+#. module: website_sale_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_wishlist.add_to_wishlist
 msgid "<span class=\"fa fa-heart\" role=\"img\" aria-label=\"Add to wishlist\"/>"
 msgstr ""
@@ -42,11 +49,6 @@ msgstr ""
 #. module: website_sale_wishlist
 #: model:ir.model.fields,field_description:website_sale_wishlist.field_product_wishlist__active
 msgid "Active"
-msgstr ""
-
-#. module: website_sale_wishlist
-#: model_terms:ir.ui.view,arch_db:website_sale_wishlist.product_wishlist
-msgid "Add <span class=\"d-none d-md-inline\">to Cart</span>"
 msgstr ""
 
 #. module: website_sale_wishlist

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -230,7 +230,8 @@
                                             <input name="product_id" t-att-value="wish.product_id.id" type="hidden"/>
                                             <a t-if="combination_info['prevent_zero_price_sale']" t-att-href="website.contact_us_button_url" class="btn btn-primary btn_cta">Contact Us</a>
                                             <button id="add_to_cart_button" t-else="" type="button" role="button" class="btn btn-secondary btn-block o_wish_add mb4" >
-                                                Add <span class='d-none d-md-inline'>to Cart</span>
+                                                <span class="fa fa-fw fa-shopping-cart"/>
+                                                <span class="d-none d-md-inline">Add</span>
                                             </button>
                                         </td>
                                     </tr>


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Open website in French;
2. select a pricelist using CHF as currency;
3. add a product to the wishlist;
4. open wishlist in mobile view.

Issue
-----
With the increased amount of space the currency symbol needs, along with the translation of "Add", the view gets truncated.

Cause
-----
View was probably designed with only English & USD in mind.

Solution
--------
Same approach as commit ba2a0d7e33e8 took for the product configurator:
- In full view, display `<fa-shopping-cart> Add`
- On mobile, display `<fa-shopping-cart>`

opw-4624112