### PR TITLE
[FIX] base_import_module: sort imported modules by topological order

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -21,6 +21,7 @@ from odoo.modules.module import adapt_version, MANIFEST_NAMES
 from odoo.release import major_version
 from odoo.tools import convert_csv_import, convert_sql_import, convert_xml_import, exception_to_unicode
 from odoo.tools import file_open, file_open_temporary_directory, ormcache
+from odoo.tools.misc import topological_sort
 
 _logger = logging.getLogger(__name__)
 
@@ -273,16 +274,16 @@ class IrModuleModule(models.Model):
                     raise UserError(_("File '%s' exceed maximum allowed file size", zf.filename))
 
             with file_open_temporary_directory(self.env) as module_dir:
-                manifest_files = [
-                    file
+                manifest_files = sorted(
+                    (file.filename.split('/')[0], file)
                     for file in z.infolist()
                     if file.filename.count('/') == 1
                     and file.filename.split('/')[1] in MANIFEST_NAMES
-                ]
+                )
                 module_data_files = defaultdict(list)
-                for manifest in manifest_files:
+                dependencies = defaultdict(list)
+                for mod_name, manifest in manifest_files:
                     manifest_path = z.extract(manifest, module_dir)
-                    mod_name = manifest.filename.split('/')[0]
                     try:
                         with file_open(manifest_path, 'rb', env=self.env) as f:
                             terp = ast.literal_eval(f.read().decode())
@@ -295,6 +296,16 @@ class IrModuleModule(models.Model):
                         if os.path.splitext(filename)[1].lower() not in ('.xml', '.csv', '.sql'):
                             continue
                         module_data_files[mod_name].append('%s/%s' % (mod_name, filename))
+                    dependencies[mod_name] = terp.get('depends', [])
+
+                dirs = {d for d in os.listdir(module_dir) if os.path.isdir(opj(module_dir, d))}
+                sorted_dirs = topological_sort(dependencies)
+                if wrong_modules := dirs.difference(sorted_dirs):
+                    raise UserError(_(
+                        "No manifest found in '%(modules)s'. Can't import the zip file.",
+                        modules=", ".join(wrong_modules)
+                    ))
+
                 for file in z.infolist():
                     filename = file.filename
                     mod_name = filename.split('/')[0]
@@ -304,8 +315,7 @@ class IrModuleModule(models.Model):
                     if is_data_file or is_static or is_translation:
                         z.extract(file, module_dir)
 
-                dirs = [d for d in os.listdir(module_dir) if os.path.isdir(opj(module_dir, d))]
-                for mod_name in dirs:
+                for mod_name in sorted_dirs:
                     module_names.append(mod_name)
                     try:
                         # assert mod_name.startswith('theme_')

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -516,6 +516,7 @@ class IrModuleModule(models.Model):
                 if file.filename.count('/') == 1
                 and file.filename.split('/')[1] in MANIFEST_NAMES
             ]
+            modules_in_zip = {manifest.filename.split('/')[0] for manifest in manifest_files}
             for manifest_file in manifest_files:
                 if manifest_file.file_size > MAX_FILE_SIZE:
                     raise UserError(_("File '%s' exceed maximum allowed file size", manifest_file.filename))
@@ -524,7 +525,7 @@ class IrModuleModule(models.Model):
                         terp = ast.literal_eval(manifest.read().decode())
                 except Exception:
                     continue
-                unmet_dependencies = set(terp.get('depends', [])).difference(installed_mods)
+                unmet_dependencies = set(terp.get('depends', [])).difference(installed_mods, modules_in_zip)
                 dependencies_to_install |= known_mods.filtered(lambda m: m.name in unmet_dependencies)
                 not_found_modules |= set(
                     mod for mod in unmet_dependencies if mod not in dependencies_to_install.mapped('name')


### PR DESCRIPTION
**[FIX] base_import_module: sort imported modules by topological order**

In base_import_module, it is possible to import a zip with multiple modules. However, the list of installation was determined by `os.listdir`, which is arbitrary. This can cause problems if the order of installation is important, notably with inter-dependencies between those imported modules.

This commit sorts topologically the modules with a valid manifest, such that dependent modules are installed before a module that relies on it. Non-valid modules (without manifest) raise an error before extraction.

**[FIX] base_import_module: allow dependency between industries**

Before this commit, installing an industry module that depends on another data module would fail, eventhough the zip file contains the dependent module. The reason is that the check for dependencies did not take into account the other modules from the zip file.

This commit makes sure that other modules in the zip file are taken into account when installing an industry, and that a dependency to a module that is present in the imported zip file would not raise an error.

task-4575230