### PR TITLE
[FIX] event_booth_sale: make quantity field readonly for reward sol

### DIFF
--- a/addons/event_booth_sale/views/sale_order_views.xml
+++ b/addons/event_booth_sale/views/sale_order_views.xml
@@ -19,7 +19,7 @@
                 <field name="event_booth_pending_ids" optional="hide"/>
             </xpath>
             <xpath expr="//field[@name='order_line']//tree//field[@name='product_uom_qty']" position="attributes">
-                <attribute name="readonly">is_event_booth</attribute>
+                <attribute name="readonly" add="is_event_booth" separator=" or "/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Steps to reproduce:
- Install event_booth_sale module
- Create SO.
- Add product and apply any reward or promotion.
- Try changing the quantity of the reward line.

Issue:
- Quantity of reward line is editable when event_booth_sale module is installed.

Cause:
- The readonly attribute was completely overridden instead of adding condition.
- As a result, the quantity is only set to readonly when is_event_booth is True.

Fix:
- Update the readonly attribute by including the is_event_booth condition using the 'or' operator, ensuring that quantity of reward lines remain readonly as intended.

opw-4585797

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
