### PR TITLE
[FIX] product, sale_product_configurator, website_sale: search on ref

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -550,11 +550,18 @@ class ProductTemplate(models.Model):
         # Only use the product.product heuristics if there is a search term and the domain
         # does not specify a match on `product.template` IDs.
         domain = domain or []
-        if not name or any(term[0] == 'id' for term in domain):
+        search_pp = self.env.context.get('search_product_product')
+        if not search_pp and (not name or any(term[0] == 'id' for term in domain)):
             return super()._name_search(name, domain, operator, limit, order)
 
         Product = self.env['product.product']
         templates = self.browse()
+
+        product_domain = domain.copy()
+        if search_pp:
+            for term in product_domain:  # Replace id related leaf to product_tmpl_id
+                if term[0] == 'id':
+                    term[0] = 'product_tmpl_id'
         while True:
             extra = templates and [('product_tmpl_id', 'not in', templates.ids)] or []
             # Pathological case: there is no limit, so we'll need to search on all products.
@@ -562,7 +569,7 @@ class ProductTemplate(models.Model):
             # performance regressions or OOM errors while manipulating extremely large list of ids.
             # For other cases, we use PREFETCH_MAX as an upper bound.
             search_limit = PREFETCH_MAX * 10 if not limit else PREFETCH_MAX
-            products_ids = Product._name_search(name, domain + extra, operator, limit=search_limit)
+            products_ids = Product._name_search(name, product_domain + extra, operator, limit=search_limit)
             products = Product.browse(products_ids)
             new_templates = products.product_tmpl_id
             if new_templates & templates:

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -44,12 +44,29 @@ class TestVariantsSearch(ProductVariantsCommon):
     def test_name_search(self):
         self.product_slip_template = self.env['product.template'].create({
             'name': 'Slip',
+            'default_code': 'ABC',
         })
         res = self.env['product.product'].name_search('Shirt', [], 'not ilike', None)
         res_ids = [r[0] for r in res]
         self.assertIn(self.product_slip_template.product_variant_ids.id, res_ids,
                       'Slip should be found searching \'not ilike\'')
 
+        templates = self.product_slip_template.name_search(
+            "ABC",
+            [['id', '!=', -1]],
+        )
+        self.assertFalse(templates, "Should not return template when searching on code")
+        templates = self.product_slip_template.with_context(search_product_product=True).name_search(
+            "ABC",
+            [['id', '!=', -1]],
+        )
+        self.assertTrue(templates, "Should return template when searching on code")
+
+        templates = self.product_slip_template.with_context(search_product_product=True).name_search(
+            "ABC",
+            [['id', '!=', self.product_slip_template.id]],
+        )
+        self.assertFalse(templates, "Should not return template.")
 
 @tagged('post_install', '-at_install')
 class TestVariants(ProductVariantsCommon):

--- a/addons/sale_product_configurator/views/product_template_views.xml
+++ b/addons/sale_product_configurator/views/product_template_views.xml
@@ -14,6 +14,7 @@
                     widget="many2many_tags"
                     options="{'color_field': 'color'}"
                     domain="[('id', '!=', id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
+                    context="{'search_product_product': True}"
                     placeholder="Recommend when 'Adding to Cart' or quotation"/>
             </group>
         </field>

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -154,6 +154,7 @@
                        placeholder="Suggested accessories in the eCommerce cart"/>
                 <field name="alternative_product_ids" widget="many2many_tags"
                        domain="[('id', '!=', id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
+                       context="{'search_product_product': True}"
                        invisible="not sale_ok"
                        placeholder="Displayed in bottom of product pages"/>
             </group>


### PR DESCRIPTION
Versions
--------
- 17.0
- saas-17.4

Fixed in 18.0+ via da7cf64756033

Steps
-----
1. Have products with a reference;
2. try to add them as optional or alternative product using the ref.

Issue
-----
Product doesn't show up.

Cause
-----
Domain contains `id` as leaf and `_name_search` was preventing orverride of `_name_search` to work.

Solution
--------
Backport da7cf64756033:
- Remove id domain from fields and pass id in context and exclude it from name_search
- Also replace id term with `product_tmpl_id` so when we are calling product's name search with template it call `name_search` with proper domain.

opw-4554539