### PR TITLE
[FIX] web_tour: skip unit test

### DIFF
--- a/addons/web_tour/static/tests/check_undeterminisms.test.js
+++ b/addons/web_tour/static/tests/check_undeterminisms.test.js
@@ -204,7 +204,7 @@ ${expectedError}`,
     ]);
 });
 
-test("snapshot is the same but has mutated", async () => {
+test.skip("snapshot is the same but has mutated", async () => {
     macro.onStep = async (step, el, index) => {
         if (index === 2) {
             setTimeout(() => {


### PR DESCRIPTION
We're skipping the unit test to check for indeterminisms with mutations. Indeed, the strategy for detecting this kind of indeterminism needs to be rethought, and for the moment, this test is failing in an indeterministic way (lol) in master.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
