### PR TITLE
[FIX] account_edi_ubl_cii: revert mandatory buyer ref sending rechnung

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
@@ -33,7 +33,6 @@ class AccountEdiXmlUBLDE(models.AbstractModel):
         constraints.update({
             'bis3_de_supplier_telephone_required': self._check_required_fields(vals['supplier'], ['phone', 'mobile']),
             'bis3_de_supplier_electronic_mail_required': self._check_required_fields(vals['supplier'], 'email'),
-            'bis3_de_buyer_reference_required': self._check_required_fields(vals['customer'], 'ref'),
         })
 
         return constraints

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
@@ -292,37 +292,3 @@ class TestUBLDE(TestUBLCommon):
         self._detach_attachment(attachment)
         created_bill.message_post(attachment_ids=[attachment.id])
         self.assertTrue(created_bill)
-
-    def test_ensure_buyer_reference_xrechnung_xml(self):
-        acc_bank = self.env['res.partner.bank'].create({
-            'acc_number': 'BE15001559627232',
-            'partner_id': self.company_data['company'].partner_id.id,
-        })
-
-        self.partner_1.ref = False
-        invoice = self._generate_move(
-            self.partner_1,
-            self.partner_2,
-            move_type='out_invoice',
-            partner_id=self.partner_1.id,
-            partner_bank_id=acc_bank.id,
-            invoice_date='2017-01-01',
-            date='2017-01-01',
-            invoice_line_ids=[{
-                'product_id': self.product_a.id,
-                'product_uom_id': self.env.ref('uom.product_uom_dozen').id,
-                'price_unit': 275.0,
-                'quantity': 5,
-                'discount': 20.0,
-                'tax_ids': [(6, 0, self.tax_19.ids)],
-            }],
-        )
-
-        with self.assertRaises(UserError):
-            self.env['account.move.send'].with_context(
-                active_model='account.move',
-                active_ids=invoice.ids,
-            ).create({
-                'checkbox_download': False,
-                'checkbox_send_mail': False,
-            }).action_send_and_print()


### PR DESCRIPTION
This commit reverts 5594b08f8bd399e7c653ca25e6211ae64ea7d898 because while buyer reference is mandatory for B2G it is not for B2C and B2B:

"The buyer reference must be indicated on every electronic invoice to public contracting authorities of the federal administration."

https://en.e-rechnung-bund.de/e-invoicing-faq/buyer-reference/

opw-4460079

X-original-commit: f6af0b3285b4835256fa1ab7b729dc3b334abe76

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
