### PR TITLE
[FIX] pos_self_order: prevent error with multi attribute in combo

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -61,6 +61,25 @@ export class ComboPage extends Component {
         );
     }
 
+    getGroupedSelectedValues(attrValIds) {
+        const selectedValues = this.getSelectedValues(attrValIds);
+        const groupedByAttribute = {};
+
+        for (const value of selectedValues) {
+            const attrId = value.attribute_id.id;
+
+            if (!groupedByAttribute[attrId]) {
+                groupedByAttribute[attrId] = {
+                    attribute_id: value.attribute_id,
+                    values: [],
+                };
+            }
+
+            groupedByAttribute[attrId].values.push(value);
+        }
+        return Object.values(groupedByAttribute);
+    }
+
     isEveryValueSelected() {
         return Object.values(this.state.selectedValues).every((value) => value);
     }
@@ -96,7 +115,16 @@ export class ComboPage extends Component {
             combo_item_id: comboItem,
             configuration: {
                 attribute_custom_values: Object.values(this.env.customValues),
-                attribute_value_ids: Object.values(this.env.selectedValues).map((s) => parseInt(s)),
+                attribute_value_ids: Object.values(this.env.selectedValues).flatMap((value) => {
+                    if (typeof value === "string") {
+                        return [parseInt(value)];
+                    } else if (typeof value === "object") {
+                        return Object.keys(value)
+                            .filter((nestedKey) => value[nestedKey] === true)
+                            .map((nestedKey) => parseInt(nestedKey));
+                    }
+                    return [];
+                }),
                 price_extra: 0,
             },
         };

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -86,9 +86,15 @@
                             <div>
                                 <span class="fs-4" t-esc="combo.combo_item_id.product_id.display_name"/>
                                 <ul t-if="combo.configuration.attribute_value_ids.length > 0">
-                                    <li t-foreach="this.getSelectedValues(combo.configuration.attribute_value_ids)" t-as="attrVal" t-key="attrVal.attribute_id.id">
-                                        <span t-esc="attrVal.attribute_id.name" /> : <span t-esc="attrVal.name" />
-                                    </li>
+                                    <t t-foreach="this.getGroupedSelectedValues(combo.configuration.attribute_value_ids)" t-as="attrVal" t-key="attrVal.attribute_id.id">
+                                        <li>
+                                            <span t-esc="attrVal.attribute_id.name" /> : 
+                                            <t t-foreach="attrVal.values" t-as="value" t-key="value.id">
+                                                <span t-esc="value.name" />
+                                                <t t-if="!value_last">, </t>
+                                            </t>
+                                        </li>
+                                    </t>
                                 </ul>
                             </div>
                         </div>


### PR DESCRIPTION
Before this commit, if a combo product contains a product with multi options attribute, you will have an error when proceeding the order.

opw-4637372

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
