### PR TITLE
[FIX] sale: stop forbidden SO modifications

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -5158,6 +5158,12 @@ msgid ""
 msgstr ""
 
 #. module: sale
+#. odoo-python
+#: code:addons/sale/models/sale_order_line.py:0
+msgid "You cannot modify the product of this order line."
+msgstr ""
+
+#. module: sale
 #: model:ir.model.constraint,message:sale.constraint_res_company_check_quotation_validity_days
 msgid ""
 "You cannot set a negative number for the default quotation validity. Leave "

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1217,6 +1217,13 @@ class SaleOrderLine(models.Model):
         if 'display_type' in values and self.filtered(lambda line: line.display_type != values.get('display_type')):
             raise UserError(_("You cannot change the type of a sale order line. Instead you should delete the current line and create a new line of the proper type."))
 
+        if 'product_id' in values and any(
+            sol.product_id.id != values['product_id']
+            and not sol.product_updatable
+            for sol in self
+        ):
+            raise UserError(_("You cannot modify the product of this order line."))
+
         if 'product_uom_qty' in values:
             precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
             self.filtered(

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -193,7 +193,7 @@ class TestRoutes(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon, PaymentHttpCo
 
         # Replace VIP ticket with 2 regular tickets
         self.so.order_line.write({
-            'product_id': self.ticket.product_id,
+            'product_id': self.ticket.product_id.id,
             'product_uom_qty': 2,
             'event_id': self.event.id,
             'event_ticket_id': self.ticket.id,


### PR DESCRIPTION
If you open the same SO in two different tabs, confirming it in one tab while further modifying it in the other, the readonly restriction won't be considered and you might shoot yourself in the foot by modifying something you shouldn't have.

This commit makes sure the product cannot be modified on order lines where it's not supposed to be possible (unless you try to be smart/dumb by opening it in two tabs, or two salesmen are modifying it separately).

opw-4595008

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
