### PR TITLE
[IMP] pos_sale: reflect custom description in invoice

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -159,6 +159,7 @@ class PosOrder(models.Model):
 
         if pos_line.sale_order_origin_id:
             origin_line = pos_line.sale_order_line_id
+            inv_line_vals["name"] = origin_line.name
             origin_line._set_analytic_distribution(inv_line_vals)
 
         return inv_line_vals


### PR DESCRIPTION
In this commit:
-------------------
- If we have custom description applied in the sale order for any product that custom description
  would be reflected as it is on the invoice when we settle that SO from POS.

Task - 4645762
