### PR TITLE
[FIX] mail: self-in-call sidebar icon has correct color in all tabs

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCallIndicator">
         <div t-if="props.thread.rtcSessions.length > 0" title="Ongoing call" class="o-mail-DiscussSidebarCallIndicator o-py-0_5 fa-fw rounded-circle fa fa-volume-up" t-att-class="{
-            'o-discuss-inCallIconColor opacity-75': props.thread.eq(rtc.state.channel),
+            'o-discuss-inCallIconColor opacity-75': props.thread.eq(rtc.channel),
             'opacity-50': !props.thread.eq(rtc.channel),
             'me-2': !store.discuss.isSidebarCompact,
         }"/>


### PR DESCRIPTION
Before this commit, the "ongoing call" icon in discuss sidebar has a different color when the current user is in call or not.

This was working well on the tab making the call, but not on the other tab.

This happens because the condition was on `rtc.state.channel` rather than `rtc.channel`. Both means the channel with self user in ongoing call but the former is set when the tab is actually making the call, whereas the later is when any tab is making the call. The indicator is meant to show when any tab is in an ongoing call, hence the fix in this commit.

Before
<img width="1046" alt="Screenshot 2025-03-20 at 11 39 10" src="https://github.com/user-attachments/assets/57a80274-7bb1-4ad3-a4af-80bf53c58fd1" />
After
<img width="1042" alt="Screenshot 2025-03-20 at 11 38 06" src="https://github.com/user-attachments/assets/2e5748f5-9323-46c7-a2e5-624312b5e9eb" />
