### PR TITLE
[FIX] account: Consider employee partner without users as internal user

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5192,7 +5192,10 @@ class AccountMove(models.Model):
 
         def is_internal_partner(partner):
             # Helper to know if the partner is an internal one.
-            return partner == company.partner_id or (partner.user_ids and all(user._is_internal() for user in partner.user_ids))
+            return (
+                    company.partner_id in (partner | partner.parent_id)
+                    or (partner.user_ids and all(user._is_internal() for user in partner.user_ids))
+            )
 
         extra_domain = False
         if custom_values.get('company_id'):


### PR DESCRIPTION
The aim of this commit is to allow non-users employee to be considered as "forwarding" vendor bills instead of sending it in their name, as the vendor would be the company anyway

Steps to reproduce:
- Create a fresh db with the mailing aliases setup and employee and account apps installed
- Choose a demo data employee that has no user and set the parent_id as the db company.
- Make sure the company doesn't have an email set.
- Send an email from that employee work_email to the email alias of the Vendor Bills journal.

Problem, the created bill has the employee set as the vendor.

Expected behavior is that no vendor is set.

opw-4516730

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
