### PR TITLE
[FIX] POS: Fix divide by zero in price unit computation

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -10,7 +10,7 @@ export const computeComboItems = (
     const comboItems = [];
     const parentLstPrice = parentProduct.get_price(pricelist, 1);
     const originalTotal = childLineConf.reduce((acc, conf) => {
-        const originalPrice = conf.combo_item_id.combo_id.base_price;
+        const originalPrice = conf.combo_item_id.combo_id.base_price || 0;
         return acc + originalPrice;
     }, 0);
 
@@ -19,7 +19,7 @@ export const computeComboItems = (
         const comboItem = conf.combo_item_id;
         const combo = comboItem.combo_id;
         let priceUnit = roundDecimals(
-            (combo.base_price * parentLstPrice) / originalTotal,
+            originalTotal ? (combo.base_price * parentLstPrice) / originalTotal : 0.0,
             decimalPrecision.find((dp) => dp.name === "Product Price").digits
         );
         remainingTotal -= priceUnit;


### PR DESCRIPTION
there was a divide by zero  in the price unit computation when the originalTotal is 0 which lead to infinity price unit and a crash in the POS order summary result.

opw-4650315

