### PR TITLE
[FIX] stock: proper wrap-up after running anotherAction in multi_print

### DIFF
--- a/addons/stock/static/src/client_actions/multi_print.js
+++ b/addons/stock/static/src/client_actions/multi_print.js
@@ -26,8 +26,9 @@ async function doMultiPrint(env, action) {
         await env.services.action.doAction({ type: "ir.actions.report", ...report });
     }
     if (action.params.anotherAction) {
-        return env.services.action.doAction(action.params.anotherAction);
-    } else if (action.params.onClose) {
+        await env.services.action.doAction(action.params.anotherAction);
+    }
+    if (action.params.onClose) {
         // handle special cases such as barcode
         action.params.onClose()
     } else {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

I think the handling of anotherAction in the do_multi_print client action is not as intended right now. I came across this when trying to use anotherAction to run an act_url action to open an already created PDF stored as an attachment. This PDF is not generated by an ir.actions.report action, which means I can't simply add it as another report to the reports param of the do_multi_print client action. I was happy to see that do_multi_print supports anotherAction, thinking I could simply pass an act_url action there to additionally open my pre-generated attachment PDF. However, when I do this, it breaks the frontend in the barcode app, see below for details. To me, the handling seems like a bug unless I'm overlooking something. To unblock myself, I've implemented included code change for my project and I'm overriding the asset but I'd prefer to upstream this fix if it is indeed simply a bug.

Current behavior before PR:

When passing anotherAction using multi_print upon validation using the barcode app for a stock picking, the frontend does not update after having done anotherAction. This is confusing, as the transfer is validated but the user does not get a display notification and the transfer remains in place in the barcode app frontend.

Desired behavior after PR is merged:

Ensures the wrap-up continues after having run anotherAction.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
