### PR TITLE
[FIX] mail: unread channel threads should be fully visible

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -130,7 +130,7 @@
                 'o-active': thread.eq(this.store.discuss.thread),
                 'px-1 py-2 mx-1 text-wrap word-break lh-1': store.discuss.isSidebarCompact,
                 'o-nonCompact me-1 p-0 ps-1': !store.discuss.isSidebarCompact,
-                'o-item-unread': thread.selfMember?.message_unread_counter > 0 and !thread.isMuted,
+                'o-unread': thread.selfMember?.message_unread_counter > 0 and !thread.isMuted,
             }">
                 <span class="text-truncate" t-esc="thread.displayName" t-att-class="{
                     'fw-bolder': thread.selfMember?.message_unread_counter > 0,
@@ -160,7 +160,7 @@
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>
                 </div>
-                <span t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted ? 'o-item-unread fw-bolder' : 'text-muted'">
+                <span t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted ? 'o-unread fw-bolder' : 'text-muted'">
                     <t t-esc="thread.displayName"/>
                 </span>
             </div>


### PR DESCRIPTION
Before this commit, channel threads that are unread had a 75% opacity in the discuss sidebar when the sidebar is compact.

When a sidebar item is neither active and has no unread messages, they are intended to have 75% opacity, so that the active item is easier to spot and they are less distracting compared to message avatars in the selected conversation. This is specific to discuss compact mode because of avatars next to conversation, but also the compact layout shows less of bg of selected item, so the same bg color is not as visible as in expanded mode.

This worked for all items but channel threads before this commit. This happens because the feature to but opacity-100% on unread conversations in discuss sidebar relies on `o-unread` classname, but channel thread had `o-item-unread`.

There's no reason to have a different classname, thus this commit fixes the issue by using `o-unread`, which makes them reuse the existing style of all other discuss items that have unread messages.

Before / After
<img width="64" alt="Screenshot 2025-03-20 at 12 10 29" src="https://github.com/user-attachments/assets/60662d82-da39-404d-b3d5-258e5af6618d" /> <img width="61" alt="Screenshot 2025-03-20 at 12 10 55" src="https://github.com/user-attachments/assets/24d16e87-6702-42cb-8416-bf5ef3174b9d" />
