### PR TITLE
[IMP] pos_loyalty: enable selling backend-generated gift cards in PoS

### DIFF
--- a/addons/pos_loyalty/models/loyalty_card.py
+++ b/addons/pos_loyalty/models/loyalty_card.py
@@ -44,3 +44,20 @@ class LoyaltyCard(models.Model):
         count_per_coupon = {coupon.id: count for coupon, count in read_group_res}
         for card in self:
             card.use_count += count_per_coupon.get(card.id, 0)
+
+    @api.model
+    def validate_gift_card(self, gift_code):
+        gift_card = self.search([('code', '=', gift_code)], limit=1)
+        if [i for i in gift_card.history_ids.mapped('order_id') if i]:
+            return {
+                'status': False,
+                'id': gift_card.id,
+            }
+        else:
+            return {
+                'status': True,
+                'id': gift_card.id,
+                'code': gift_card.code,
+                'points': gift_card.points,
+                'expiration_date': gift_card.expiration_date,
+            }

--- a/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.js
+++ b/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.js
@@ -3,6 +3,8 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
 import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { serializeDate } from "@web/core/l10n/dates";
+import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+import { _t } from "@web/core/l10n/translation";
 
 export class ManageGiftCardPopup extends Component {
     static template = "pos_loyalty.ManageGiftCardPopup";
@@ -21,6 +23,7 @@ export class ManageGiftCardPopup extends Component {
     };
 
     setup() {
+        this.pos = usePos();
         this.ui = useService("ui");
         this.state = useState({
             inputValue: this.props.startingValue,
@@ -28,10 +31,44 @@ export class ManageGiftCardPopup extends Component {
             error: false,
             amountError: false,
             expirationDate: luxon.DateTime.now().plus({ year: 1 }),
+            existingGiftCardId: false,
         });
         this.inputRef = useRef("input");
         this.amountInputRef = useRef("amountInput");
         onMounted(this.onMounted);
+    }
+
+    async handleCodeInputEvents(event) {
+        clearTimeout(this.timeout);
+        this.timeout = setTimeout(async () => {
+            if (!this.inputRef.el) {
+                this.state.existingGiftCardId = false;
+                return;
+            }
+            this.state.existingGiftCardId = false;
+            const response = await this.pos.data.call("loyalty.card", "validate_gift_card", [
+                this.inputRef.el.value.trim(),
+            ]);
+            if (!response) {
+                return;
+            }
+
+            if (!response.status) {
+                this.state.existingGiftCardId = response.id;
+                return this.pos.notification.add(_t("This Gift Card has already been sold."), {
+                    type: "danger",
+                });
+            }
+            Object.assign(this.state, {
+                amountValue: response.points?.toString(),
+                expirationDate: response.expiration_date
+                    ? luxon.DateTime.fromFormat(response.expiration_date, "yyyy-MM-dd", {
+                          zone: "UTC",
+                      })
+                    : false,
+            });
+            this.state.existingGiftCardId = response.id;
+        }, 500);
     }
 
     onMounted() {
@@ -50,7 +87,8 @@ export class ManageGiftCardPopup extends Component {
         this.props.getPayload(
             this.state.inputValue,
             parseFloat(this.state.amountValue),
-            this.state.expirationDate ? serializeDate(this.state.expirationDate) : false
+            this.state.expirationDate ? serializeDate(this.state.expirationDate) : false,
+            this.state.existingGiftCardId
         );
         this.props.close();
     }

--- a/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.xml
+++ b/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.xml
@@ -2,28 +2,32 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_loyalty.ManageGiftCardPopup">
         <Dialog title="props.title" size="'md'">
-            <input id="code" t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" autocomplete="off" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-att-style="state.error ? 'border-color: red;' : ''" />
+            <input id="code" t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" autocomplete="off" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-att-style="state.error ? 'border-color: red;' : ''" t-on-input="handleCodeInputEvents"/>
             <div class="mt-3 d-flex">
                 <div t-attf-class="col align-items-center d-flex {{!ui.isSmall? 'me-2 w-50': ''}}">
-                    <div class="col-form-label text-center pe-0 me-4 fs-5">Amount</div>
+                    <div class="col-form-label text-center pe-0 me-4 fs-5" t-att-class="{ 'pe-none text-muted': state.existingGiftCardId }">Amount</div>
                     <div t-attf-class="{{ui.isSmall? 'flex-grow-1' : ''}}">
-                        <input id="amount" class="form-control form-control-lg" type="number" t-model="state.amountValue" t-ref="amountInput" placeholder="Enter amount" t-att-style="state.amountError ? 'border-color: red;' : ''"/>
+                        <input id="amount" class="form-control form-control-lg gift-card-amount" t-att-class="{'pe-none text-muted' : state.existingGiftCardId }" type="number" t-model="state.amountValue" t-ref="amountInput" placeholder="Enter amount" t-att-style="state.amountError ? 'border-color: red;' : ''"/>
                     </div>
                 </div>
-                <div t-if="!ui.isSmall" class="d-flex ms-2 w-50 o_exp_date_container">
-                    <div class="col-form-label text-center pe-0 me-4 fs-5">Expiration</div>
+                <div t-if="!ui.isSmall" class="d-flex ms-2 w-50 o_exp_date_container" >
+                    <div class="col-form-label text-center pe-0 me-4 fs-5" t-att-class="{'pe-none text-muted' : state.existingGiftCardId }">Expiration</div>
                     <DateTimeInput
                         type="'date'"
                         value="state.expirationDate"
-                        onChange.bind="onExpDateChange" />
+                        onChange.bind="onExpDateChange"
+                        class="(state.existingGiftCardId) ? 'text-muted pe-none' : ''"
+                        placeholder.translate="Not set" />
                 </div>
             </div>
             <div t-if="ui.isSmall" class="d-flex my-2 o_exp_date_container">
-                <div class="col-form-label text-center pe-0 me-2 fs-5">Expiration</div>
+                <div class="col-form-label text-center pe-0 me-2 fs-5" t-att-class="{ 'pe-none text-muted': state.existingGiftCardId }">Expiration</div>
                 <DateTimeInput
                     type="'date'"
                     value="state.expirationDate"
-                    onChange.bind="onExpDateChange" />
+                    onChange.bind="onExpDateChange"
+                    class="(state.existingGiftCardId) ? 'text-muted pe-none' : ''"
+                    placeholder.translate="Not set" />
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary o-default-button" t-on-click="addBalance">Add Balance</button>

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -890,7 +890,7 @@ patch(PosOrder.prototype, {
      * @param {String} newGiftCardCode gift card code as a string if new gift card to be created.
      * @param {number} points number of points to assign to the gift card.
      */
-    processGiftCard(newGiftCardCode, points, expirationDate) {
+    processGiftCard(newGiftCardCode, points, expirationDate, existingGiftCardId) {
         const partner_id = this.partner_id?.id || false;
         const product_id = this.getSelectedOrderline().product_id.id;
         const program =
@@ -903,6 +903,7 @@ patch(PosOrder.prototype, {
             points: points,
             manual: true,
             product_id: product_id,
+            existing_gift_card_id: existingGiftCardId,
         };
 
         // Fetch all coupon_ids for the specified points and not manually created, that are associated with the gift card program

--- a/addons/pos_loyalty/static/src/app/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order_line.js
@@ -38,6 +38,12 @@ patch(PosOrderline, {
             type: "many2one",
             local: true,
         },
+        _existing_gift_card_id: {
+            model: "pos.order.line",
+            name: "_existing_gift_card_id",
+            type: "int",
+            local: true,
+        },
     },
 });
 

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -209,10 +209,14 @@ patch(PosStore.prototype, {
                     };
                     if (program && program.program_type === "gift_card") {
                         couponPointChange.product_id = order.getSelectedOrderline()?.product_id.id;
-                        couponPointChange.expiration_date = serializeDate(
-                            luxon.DateTime.now().plus({ year: 1 })
-                        );
+                        if (!pa.manual) {
+                            couponPointChange.expiration_date = serializeDate(
+                                luxon.DateTime.now().plus({ year: 1 })
+                            );
+                        }
                         couponPointChange.code = order.getSelectedOrderline()?.gift_code;
+                        couponPointChange.existing_gift_card_id =
+                            order.getSelectedOrderline()?._existing_gift_card_id;
                         couponPointChange.partner_id = order.getPartner()?.id;
                     }
 

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -215,3 +215,38 @@ registry.category("web_tour.tours").add("EmptyProductScreenTour", {
             ProductScreen.loadSampleButtonIsThere(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_sell_backend_generated_gift_card", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Gift Card"),
+            {
+                trigger: `a:contains("Sell physical gift card?")`,
+                run: "click",
+            },
+            {
+                content: `Enter the backend-generated gift card code.`,
+                trigger: `input[id="code"]`,
+                run: `edit test-card-0002`,
+            },
+            {
+                trigger: ".col .col-form-label:contains('Amount')",
+                run: "click",
+            },
+            {
+                content: "Ensure the gift card amount is set to 100.",
+                trigger: "input.gift-card-amount:value(100)",
+            },
+            {
+                trigger: `.btn-primary:contains("Add Balance")`,
+                run: "click",
+            },
+            PosLoyalty.orderTotalIs("100.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});


### PR DESCRIPTION
Before this commit:
===========
- Users could only sell physical or standard gift cards in the PoS.
- Backend-generated gift cards were not available for sale.

After this commit:
==========
- Users can now sell backend-generated gift cards directly from the PoS.

task-4643992
