### PR TITLE
[FIX] mail: properly align badges & actions in discuss sidebar

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
@@ -4,7 +4,7 @@
         <div t-if="props.thread.rtcSessions.length > 0" title="Ongoing call" class="o-mail-DiscussSidebarCallIndicator o-py-0_5 fa-fw rounded-circle fa fa-volume-up" t-att-class="{
             'o-discuss-inCallIconColor opacity-75': props.thread.eq(rtc.state.channel),
             'opacity-50': !props.thread.eq(rtc.channel),
-            'me-2': !store.discuss.isSidebarCompact,
+            'me-2': !store.discuss.isSidebarCompact and props.thread.importantCounter === 0,
         }"/>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -37,7 +37,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 }
 
 .o-mail-DiscussSidebarCategory-chevronCompact {
-    left: map-get($spacers, 1);
+    left: - map-get($spacers, 1)/2;
 }
 
 .o-mail-DiscussSidebarCategory-toggler {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -43,7 +43,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory.main">
-        <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'mx-1 my-2 position-relative': store.discuss.isSidebarCompact, 'mt-1 ms-1 me-2': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
+        <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'm-2 position-relative': store.discuss.isSidebarCompact, 'mt-1 ms-1 me-2 pe-1': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
             <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start opacity-100-hover" t-att-class="{ 'align-items-baseline opacity-75 o-gap-0_5': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact opacity-50 gap-1': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
                 <t t-if="store.discuss.isSidebarCompact">
                     <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xxsmaller" t-att-class="{
@@ -67,7 +67,7 @@
 
     <t t-name="mail.DiscussSidebarCategory.actions">
         <div class="d-flex">
-            <div class="o-mail-DiscussSidebarCategory-actions" t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm mx-1 o-gap-0_5': !store.discuss.isSidebarCompact }">
+            <div class="o-mail-DiscussSidebarCategory-actions" t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm ms-1 o-gap-0_5': !store.discuss.isSidebarCompact }">
                 <t name="action-group">
                     <t t-foreach="actions" t-as="action" t-key="action_index">
                         <button class="btn w-100 o-opacity-35 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">


### PR DESCRIPTION
Before / After (expanded)
<img width="303" alt="Screenshot 2025-03-20 at 12 21 24" src="https://github.com/user-attachments/assets/bc6c0841-aec6-4cf4-8ed8-6cee26b53a9a" /> <img width="301" alt="Screenshot 2025-03-20 at 12 19 22" src="https://github.com/user-attachments/assets/82225946-0b90-4c84-b5c9-77f0c92065a9" />

Before / After (compact)
<img width="63" alt="Screenshot 2025-03-20 at 21 48 44" src="https://github.com/user-attachments/assets/2ddff447-d06a-462b-b4b0-0a725e65b100" /> <img width="59" alt="Screenshot 2025-03-20 at 21 47 22" src="https://github.com/user-attachments/assets/c08aa09a-be62-4800-b1d5-4c8b705f098c" />
