### PR TITLE
[FIX] account: not display placeholder sequence on draft PDF

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -61,7 +61,7 @@
                             <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">Cancelled Credit Note</span>
                             <span t-elif="o.move_type == 'in_refund'">Vendor Credit Note</span>
                             <span t-elif="o.move_type == 'in_invoice'">Vendor Bill</span>
-                            <span t-if="o.name != '/'" t-field="o.name">INV/2023/0001</span>
+                            <span t-if="o.name and o.name != '/'" t-field="o.name">INV/2023/0001</span>
                         </t>
                         <div class="oe_structure"></div>
                         <div id="informations" class="row mb-4">


### PR DESCRIPTION
### Steps to reproduce:
- Create a new draft invoice
- In the actions click "PDF without Payment"
- In the PDF the name is "Draft Invoice INV/2023/0001"
- It should only be "Draft Invoice"

### Cause:
"INV/2023/0001" is the placeholders in the XML. It is displayed because the name for draft moves is no longer '/' but null.

### Solution:
Change the condition to also check if `o.name` exists.

opw-4607518