### PR TITLE
[FIX] website_sale: prevent traceback when adding out-of-stock products to cart

### DIFF
--- a/addons/website_sale/static/src/js/cart_service.js
+++ b/addons/website_sale/static/src/js/cart_service.js
@@ -455,7 +455,9 @@ export class CartService {
             this._updateCartIcon(data.cart_quantity);
         };
         this._showCartNotification(data.notification_info);
-        this._trackProducts(data.tracking_info);
+        if (data.quantity) {
+            this._trackProducts(data.tracking_info);
+        }
         return data.quantity;
     }
 


### PR DESCRIPTION
Steps to Reproduce:

- Install the website_sale_stock module.
- Ensure a product is in stock and disable the 'Continue Selling' option.
- Navigate to the product page.
- In another tab, set the product’s available quantity to 0.
- Attempt to add the product to the cart.
- A traceback error is displayed to the user.

Issue:
- Users encounter a traceback error when adding an out-of-stock product to the cart.

Root Cause:
- The cart service attempts to track products that are not present in the cart.

Fix:
- Ensure the cart service does not track products that are not added to the cart, preventing unnecessary errors

Affected Version: saas-18.2
opw: 4643442

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
