### PR TITLE
[IMP] stock_account: change default pivot view measures

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -131,7 +131,7 @@ class StockValuationLayer(models.Model):
         #  Handler called when the user clicked on the 'Valuation at Date' button.
         #  Opens wizard to display, at choice, the products inventory or a computed
         #  inventory at a given date.
-        context = {}
+        context = {"pivot_measures": ["quantity", "value"]}
         if ("default_product_id" in self.env.context):
             context["product_id"] = self.env.context["default_product_id"]
         elif ("default_product_tmpl_id" in self.env.context):


### PR DESCRIPTION
When viewing the valuation in the past, the default measures 'Remaining Qty' and 'Remaining Value' are irrelevant. Instead, display the 'Quantity' and 'Total Value' measures by default.

opw-4517548