### PR TITLE
[FIX] html_editor: ensure consistent `::marker` visibility and position

### DIFF
--- a/addons/html_editor/static/src/main/hint.scss
+++ b/addons/html_editor/static/src/main/hint.scss
@@ -5,12 +5,12 @@
         content: attr(o-we-hint-text);
         position: absolute;
         top: 0;
-        left: var(--placeholder-left, 0px);
+        left: 0;
         display: block;
         color: inherit;
         opacity: 0.4;
         pointer-events: none;
         text-align: inherit;
-        width: calc(100% - var(--placeholder-left, 0px));
+        width: 100%;
     }
 }

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -99,7 +99,6 @@ export class HintPlugin extends Plugin {
     removeHint(el) {
         el.removeAttribute("o-we-hint-text");
         removeClass(el, "o-we-hint");
-        this.getResource("system_style_properties").forEach((n) => el.style.removeProperty(n));
         if (this.hint === el) {
             this.hint = null;
         }

--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -2,6 +2,12 @@ li p {
     margin-bottom: 0px;
 }
 
+.odoo-editor-editable {
+    ol, ul {
+        padding-inline-start: 2rem;
+    }
+}
+
 // Checklist
 ul.o_checklist {
     > li {

--- a/addons/html_editor/static/src/main/list/utils.js
+++ b/addons/html_editor/static/src/main/list/utils.js
@@ -30,7 +30,6 @@ export function insertListAfter(document, afterNode, mode, content = []) {
                 } else if (fontSizeStyle.type === "class") {
                     li.classList.add(fontSizeStyle.value);
                 }
-                li.style.listStylePosition = "inside";
                 li.append(...c[0].childNodes);
             } else {
                 li.append(...[].concat(c));

--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -12,8 +12,7 @@ test("should apply font-size to completely selected list item", async () => {
     await testEditor({
         contentBefore: "<ol><li>[abc]</li><li>def</li></ol>",
         stepFunction: setFontSize("56px"),
-        contentAfter:
-            '<ol><li style="font-size: 56px; list-style-position: inside;">[abc]</li><li>def</li></ol>',
+        contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;">[abc]</li><li>def</li></ol>`,
     });
 });
 
@@ -22,8 +21,7 @@ test("should apply font-size to completely selected multiple list items", async 
         contentBefore: "<ul><li>[abc</li><li>def]</li></ul>",
         stepFunction: (editor) =>
             execCommand(editor, "formatFontSizeClassName", { className: "h2-fs" }),
-        contentAfter:
-            '<ul><li class="h2-fs" style="list-style-position: inside;">[abc</li><li class="h2-fs" style="list-style-position: inside;">def]</li></ul>',
+        contentAfter: '<ul><li class="h2-fs">[abc</li><li class="h2-fs">def]</li></ul>',
     });
 });
 
@@ -32,7 +30,7 @@ test("should apply font-size to completely selected and partially selected list 
         contentBefore: "<ol><li>[abc</li><li>def</li><li>gh]i</li></ol>",
         stepFunction: setFontSize("18px"),
         contentAfter:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">[abc</li><li style="font-size: 18px; list-style-position: inside;">def</li><li><span style="font-size: 18px;">gh]</span>i</li></ol>',
+            '<ol><li style="font-size: 18px;">[abc</li><li style="font-size: 18px;">def</li><li><span style="font-size: 18px;">gh]</span>i</li></ol>',
     });
 });
 
@@ -40,66 +38,58 @@ test("should apply font-size to completely selected list items and paragraph tag
     await testEditor({
         contentBefore: "<ul><li>[abc</li><li>def</li></ul><p>ghi]</p>",
         stepFunction: (editor) =>
-            execCommand(editor, "formatFontSizeClassName", { className: "display-3-fs" }),
-        contentAfter:
-            '<ul><li class="display-3-fs" style="list-style-position: inside;">[abc</li><li class="display-3-fs" style="list-style-position: inside;">def</li></ul><p><span class="display-3-fs">ghi]</span></p>',
+            execCommand(editor, "formatFontSizeClassName", { className: "h2-fs" }),
+        contentAfter: `<ul><li class="h2-fs">[abc</li><li class="h2-fs">def</li></ul><p><span class="h2-fs">ghi]</span></p>`,
     });
 });
 
 test("should carry list item font-size to new list item", async () => {
     await testEditor({
-        contentBefore:
-            '<ol><li>abc</li><li style="font-size: 18px; list-style-position: inside;">def[]</li></ol>',
+        contentBefore: '<ol><li>abc</li><li style="font-size: 18px;">def[]</li></ol>',
         stepFunction: splitBlock,
         contentAfter:
-            '<ol><li>abc</li><li style="font-size: 18px; list-style-position: inside;">def</li><li style="font-size: 18px; list-style-position: inside;">[]<br></li></ol>',
+            '<ol><li>abc</li><li style="font-size: 18px;">def</li><li style="font-size: 18px;">[]<br></li></ol>',
     });
 });
 
 test("should carry list item font-size to new list item (2)", async () => {
     await testEditor({
-        contentBefore:
-            '<ul><li class="display-3-fs" style="list-style-position: inside;">[]abc</li><li>def</li></ul>',
+        contentBefore: '<ul><li class="h2-fs">[]abc</li><li>def</li></ul>',
         stepFunction: splitBlock,
-        contentAfter:
-            '<ul><li class="display-3-fs" style="list-style-position: inside;"><br></li><li class="display-3-fs" style="list-style-position: inside;">[]abc</li><li>def</li></ul>',
+        contentAfter: `<ul><li class="h2-fs"><br></li><li class="h2-fs">[]abc</li><li>def</li></ul>`,
     });
 });
 
 test("should carry font-size of paragraph to list item", async () => {
     await testEditor({
-        contentBefore:
-            '<p><span style="font-size: 18px; list-style-position: inside;">[]abc</span></p>',
+        contentBefore: '<p><span style="font-size: 18px;">[]abc</span></p>',
         stepFunction: toggleUnorderedList,
-        contentAfter:
-            '<ul><li style="font-size: 18px; list-style-position: inside;">[]abc</li></ul>',
+        contentAfter: '<ul><li style="font-size: 18px;">[]abc</li></ul>',
     });
 });
 
 test("should carry font-size of paragraph to list item (2)", async () => {
     await testEditor({
         contentBefore:
-            '<ol><li class="h3-fs" style="list-style-position: inside;">abc</li></ol><p><span class="display-3-fs" style="list-style-position: inside;">[]def</span></p><ol><li>ghi</li></ol>',
+            '<ol><li class="h3-fs">abc</li></ol><p><span class="h2-fs">[]def</span></p><ol><li>ghi</li></ol>',
         stepFunction: toggleOrderedList,
-        contentAfter:
-            '<ol><li class="h3-fs" style="list-style-position: inside;">abc</li><li class="display-3-fs" style="list-style-position: inside;">[]def</li><li>ghi</li></ol>',
+        contentAfter: `<ol><li class="h3-fs">abc</li><li class="h2-fs">[]def</li><li>ghi</li></ol>`,
     });
 });
 
 test("should carry font-size of paragraph to list item (3)", async () => {
     await testEditor({
         contentBefore:
-            '<ul><li style="font-size: 18px; list-style-position: inside;">abc</li></ul><p>[]def</p><ul><li style="font-size: 18px; list-style-position: inside;">ghi</li></ul>',
+            '<ul><li style="font-size: 18px;">abc</li></ul><p>[]def</p><ul><li style="font-size: 18px;">ghi</li></ul>',
         stepFunction: toggleUnorderedList,
         contentAfter:
-            '<ul><li style="font-size: 18px; list-style-position: inside;">abc</li><li>[]def</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ul>',
+            '<ul><li style="font-size: 18px;">abc</li><li>[]def</li><li style="font-size: 18px;">ghi</li></ul>',
     });
 });
 
 test("should carry font-size of list item to paragraph", async () => {
     await testEditor({
-        contentBefore:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">[]abc</li><li>def</li></ol>',
+        contentBefore: '<ol><li style="font-size: 18px;">[]abc</li><li>def</li></ol>',
         stepFunction: toggleOrderedList,
         contentAfter: '<p><span style="font-size: 18px;">[]abc</span></p><ol><li>def</li></ol>',
     });
@@ -108,27 +98,25 @@ test("should carry font-size of list item to paragraph", async () => {
 test("should carry font-size of list item to paragraph (2)", async () => {
     await testEditor({
         contentBefore:
-            '<ul><li class="display-3-fs" style="list-style-position: inside;">abc</li><li class="display-3-fs" style="list-style-position: inside;">[]def</li><li>ghi</li></ul>',
+            '<ul><li class="h2-fs">abc</li><li class="h2-fs">[]def</li><li>ghi</li></ul>',
         stepFunction: toggleUnorderedList,
-        contentAfter:
-            '<ul><li class="display-3-fs" style="list-style-position: inside;">abc</li></ul><p><span class="display-3-fs">[]def</span></p><ul><li>ghi</li></ul>',
+        contentAfter: `<ul><li class="h2-fs">abc</li></ul><p><span class="h2-fs">[]def</span></p><ul><li>ghi</li></ul>`,
     });
 });
 
 test("should carry font-size of list item to paragraph (3)", async () => {
     await testEditor({
-        contentBefore:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">abc</li><li>[]def</li><li>ghi</li></ol>',
+        contentBefore: '<ol><li style="font-size: 18px;">abc</li><li>[]def</li><li>ghi</li></ol>',
         stepFunction: toggleOrderedList,
         contentAfter:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">abc</li></ol><p>[]def</p><ol><li>ghi</li></ol>',
+            '<ol><li style="font-size: 18px;">abc</li></ol><p>[]def</p><ol><li>ghi</li></ol>',
     });
 });
 
 test("should carry font-size of list item to paragraph (4)", async () => {
     await testEditor({
         contentBefore:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">abc<span style="font-size: 32px;">def</span>ghi[]</li></ol>',
+            '<ol><li style="font-size: 18px;">abc<span style="font-size: 32px;">def</span>ghi[]</li></ol>',
         stepFunction: toggleOrderedList,
         contentAfter:
             '<p><span style="font-size: 18px;">abc<span style="font-size: 32px;">def</span>ghi[]</span></p>',
@@ -138,70 +126,66 @@ test("should carry font-size of list item to paragraph (4)", async () => {
 test("should keep list item font-size on toggling list twice", async () => {
     await testEditor({
         contentBefore:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">[abc</li><li style="font-size: 32px; list-style-position: inside;">def]</li></ol>',
+            '<ol><li style="font-size: 18px;">[abc</li><li style="font-size: 32px;">def]</li></ol>',
         stepFunction: (editor) => {
             toggleOrderedList(editor);
             toggleOrderedList(editor);
         },
-        contentAfter:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">[abc</li><li style="font-size: 32px; list-style-position: inside;">def]</li></ol>',
+        contentAfter: `<ol style="padding-inline-start: 34px;"><li style="font-size: 18px;">[abc</li><li style="font-size: 32px;">def]</li></ol>`,
     });
 });
 
 test("should change font-size of a list item", async () => {
     await testEditor({
         contentBefore:
-            '<ul><li style="font-size: 18px; list-style-position: inside;">[abc]</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ul>',
+            '<ul><li style="font-size: 18px;">[abc]</li><li style="font-size: 18px;">ghi</li></ul>',
         stepFunction: setFontSize("32px"),
-        contentAfter:
-            '<ul><li style="font-size: 32px; list-style-position: inside;">[abc]</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ul>',
+        contentAfter: `<ul><li style="font-size: 32px;">[abc]</li><li style="font-size: 18px;">ghi</li></ul>`,
     });
 });
 
 test("should change font-size of a list item (2)", async () => {
     await testEditor({
         contentBefore:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">[abc</li><li style="font-size: 18px; list-style-position: inside;">ghi]</li></ol>',
+            '<ol><li style="font-size: 18px;">[abc</li><li style="font-size: 18px;">ghi]</li></ol>',
         stepFunction: setFontSize("32px"),
-        contentAfter:
-            '<ol><li style="font-size: 32px; list-style-position: inside;">[abc</li><li style="font-size: 32px; list-style-position: inside;">ghi]</li></ol>',
+        contentAfter: `<ol style="padding-inline-start: 34px;"><li style="font-size: 32px;">[abc</li><li style="font-size: 32px;">ghi]</li></ol>`,
     });
 });
 
 test("should change font-size of subpart of a list item", async () => {
     await testEditor({
         contentBefore:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">a[b]c</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ol>',
+            '<ol><li style="font-size: 18px;">a[b]c</li><li style="font-size: 18px;">ghi</li></ol>',
         stepFunction: setFontSize("32px"),
         contentAfter:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">a<span style="font-size: 32px;">[b]</span>c</li><li style="font-size: 18px; list-style-position: inside;">ghi</li></ol>',
+            '<ol><li style="font-size: 18px;">a<span style="font-size: 32px;">[b]</span>c</li><li style="font-size: 18px;">ghi</li></ol>',
     });
 });
 
 test("should change font-size of subpart of a list item (2)", async () => {
     await testEditor({
         contentBefore:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">a[bc</li><li style="font-size: 18px; list-style-position: inside;">gh]i</li></ol>',
+            '<ol><li style="font-size: 18px;">a[bc</li><li style="font-size: 18px;">gh]i</li></ol>',
         stepFunction: setFontSize("32px"),
         contentAfter:
-            '<ol><li style="font-size: 18px; list-style-position: inside;">a<span style="font-size: 32px;">[bc</span></li><li style="font-size: 18px; list-style-position: inside;"><span style="font-size: 32px;">gh]</span>i</li></ol>',
+            '<ol><li style="font-size: 18px;">a<span style="font-size: 32px;">[bc</span></li><li style="font-size: 18px;"><span style="font-size: 32px;">gh]</span>i</li></ol>',
     });
 });
 
-test("should remove font-size style on converting the text to a block tag", async () => {
+test("should pad list based on font-size", async () => {
+    const className = "h2-fs";
     await testEditor({
-        contentBefore:
-            '<ul><li style="font-size: 32px; list-style-position: inside;">a[]bc</li></ul>',
-        stepFunction: (editor) => editor.shared.dom.setTag({ tagName: "H1" }),
-        contentAfter: '<ul><li><h1><span style="font-size: 32px;">a[]bc</span></h1></li></ul>',
+        contentBefore: "<ol><li>[a]</li></ol>",
+        stepFunction: (editor) => execCommand(editor, "formatFontSizeClassName", { className }),
+        contentAfter: `<ol><li class="${className}">[a]</li></ol>`,
     });
 });
 
-test("should remove font-size class on converting the text to a block tag", async () => {
+test("should pad list based on font-size (2)", async () => {
     await testEditor({
-        contentBefore:
-            '<ul><li class="display-3-fs" style="list-style-position: inside;">a[]bc</li></ul>',
-        stepFunction: (editor) => editor.shared.dom.setTag({ tagName: "H1" }),
-        contentAfter: '<ul><li><h1><span class="display-3-fs">a[]bc</span></h1></li></ul>',
+        contentBefore: `<span style="font-size: 56px;">[a]</span>`,
+        stepFunction: toggleOrderedList,
+        contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;">[]a</li></ol>`,
     });
 });

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -390,7 +390,7 @@ describe("Selection collapsed", () => {
                             </ul>`),
                     stepFunction: splitBlock,
                     contentAfter: unformat(`
-                        <ul>
+                        <ul style="padding-inline-start: 36px;">
                             <li style="list-style: cambodian;">a</li>
                             <li style="list-style: cambodian;">[]<br></li>
                         </ul>`),


### PR DESCRIPTION
**Problem**:
- `::marker` elements are not properly visible when changing list font size.
- Inconsistencies in marker positioning as `list-style-position` is `inside` only when font size changes, but remains `outside` by default.

**Solution**:
As discussed with PO, we will always use `list-style-position: outside`. To ensure proper visibility for large font sizes, we adjust the `padding-left` of `ol`.

**Steps to Reproduce**:
1. Add text.
2. Transform text into a centered list.
   - Marker remains left-aligned (default behavior).
3. Change the text font size.
   - **Issue**: Marker moves inside the list, making it inconsistent.
4. Switch a numbered list to an unordered list, then back to numbered.
   - **Issue**: Marker moves out of the viewport.

**opw-4655466**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
