### PR TITLE
[IMP] sale_project: return sol based on partner associations in so

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -19,7 +19,9 @@ class ProjectProject(models.Model):
             self.env['sale.order.line']._sellable_lines_domain(),
             self.env['sale.order.line']._domain_sale_line_service(),
             [
-                ('order_partner_id', '=?', unquote("partner_id")),
+            '|',
+                ('order_partner_id.commercial_partner_id.id', 'parent_of', unquote('partner_id if partner_id else []')),
+                ('order_partner_id', '=?', unquote('partner_id')),
             ],
         ])
         return domain


### PR DESCRIPTION
Before this commit:
Sales order lines linked to the sale orders of child and parent partners do not
return to the project.

After this commit:
Sales order lines linked to the sale orders of child and parent partners now
return to the project.

task-4581748