### PR TITLE
[FIX] website_sale: dark mode attribute filter

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -958,7 +958,7 @@ a.no-decoration {
         background-image: escape-svg($accordion-button-icon);
     }
 
-    #product_accordion {
+    #product_accordion, #wsale_products_attributes_collapse h6, #o_wsale_price_range_option h6 {
         --accordion-active-bg: inherit;
         --accordion-active-color: var(--accordion-btn-color);
         --accordion-btn-padding-x : 0;


### PR DESCRIPTION
When a user changes the theme colors and applies a dark background the attribute filters will not be apparent

Also the color applied to text is not applied to the attributes only if the accordion is active

As a fix now the accordion headers will match the updated text color from the theme

opw-4559710

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
