### PR TITLE
[FIX] account: reset payment without JE on unreconcile of the statement

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -106,6 +106,9 @@ class AccountPartialReconcile(models.Model):
         if not self:
             return True
 
+        # Get the payments without journal entry to reset once the amount residual is reset
+        to_update_payments = self._get_to_update_payments(from_state='paid')
+
         # Retrieve the matching number to unlink.
         full_to_unlink = self.full_reconcile_id
         all_reconciled = self.debit_move_id + self.credit_move_id
@@ -130,28 +133,30 @@ class AccountPartialReconcile(models.Model):
             moves_to_reverse._reverse_moves(default_values_list, cancel=True)
 
         self._update_matching_number(all_reconciled)
+        to_update_payments.state = 'in_process'
         return res
 
     @api.model_create_multi
     def create(self, vals_list):
         partials = super().create(vals_list)
-        self._pay_matched_payment(partials)
+        partials._get_to_update_payments(from_state='in_process').state = 'paid'
         self._update_matching_number(partials.debit_move_id + partials.credit_move_id)
         return partials
 
-    @api.model
-    def _pay_matched_payment(self, partials):
-        for partial in partials:
+    def _get_to_update_payments(self, from_state):
+        to_update = []
+        for partial in self:
             matched_payments = (partial.credit_move_id | partial.debit_move_id).move_id.matched_payment_ids
-            to_check_payments = matched_payments.filtered(lambda payment: not payment.outstanding_account_id and payment.state == 'in_process')
+            to_check_payments = matched_payments.filtered(lambda payment: not payment.outstanding_account_id and payment.state == from_state)
             for payment in to_check_payments:
                 if payment.payment_type == 'inbound':
                     amount = partial.debit_amount_currency
                 else:
                     amount = -partial.credit_amount_currency
                 if not payment.currency_id.compare_amounts(payment.amount_signed, amount):
-                    payment.state = 'paid'
+                    to_update.append(payment)
                     break
+        return self.env['account.payment'].union(*to_update)
 
     @api.model
     def _update_matching_number(self, amls):

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -5261,3 +5261,8 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             self.assertEqual(payment2.state, 'paid')
             reconcile_move(payment1.move_id, 12, lines_filter=lambda l: l.account_id.account_type not in ('asset_receivable', 'liability_payable'))
             self.assertEqual(payment1.state, 'paid')
+            customer_invoice_outstanding.line_ids.remove_move_reconcile()
+            self.assertEqual(payment1.state, 'paid')
+            self.assertEqual(payment2.state, 'in_process')
+            payment1.move_id.line_ids.filtered(lambda l: l.account_id.account_type not in ('asset_receivable', 'liability_payable')).remove_move_reconcile()
+            self.assertEqual(payment1.state, 'in_process')


### PR DESCRIPTION
Before this commit, when doing the reconciliation of a statement line with an invoice without a journal entry, we were trying to find a matching payment for that statement line and setting it as paid. However, it didn't do the opposite when breaking the matching between the invoice and the statement line.

This commit adds that opposite behavior.

