### PR TITLE
[FIX] l10n_it_edi: Lock move before sending to SDI

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1353,6 +1353,7 @@ class AccountMove(models.Model):
         }
 
     def _l10n_it_edi_send(self, attachments_vals):
+        self.env['res.company']._with_locked_records(self)
         files_to_upload = []
         filename_move = {}
 


### PR DESCRIPTION
Currently, if a serialization error occurs right after sending an invoice to SDI, Odoo retries the submission.

This causes issues as the move’s transaction ID will be updated to the second attempt, not the first.
Additionally, SDI will detect a duplicate submission and return a "notificaScarto" status.

Since only the second transaction ID is stored,
Odoo will incorrectly display the invoice as rejected, even though the first submission was actually accepted.

This fix ensures the move is locked before sending to SDI, preventing this issue.

opw-4643686