### PR TITLE
[FIX] sale: issue with combo type products

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1484,8 +1484,8 @@ class SaleOrder(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
 
         for line in self.order_line:
-            if line.display_type == 'line_section':
-                # Only invoice the section if one of its lines is invoiceable
+            if line.display_type == 'line_section' or line.product_type == 'combo':
+                # Only invoice the section or combo line if one of its lines is invoiceable
                 pending_section = line
                 continue
             if line.display_type != 'line_note' and float_is_zero(line.qty_to_invoice, precision_digits=precision):
@@ -1528,7 +1528,7 @@ class SaleOrder(models.Model):
 
         # 1) Create invoices.
         invoice_vals_list = []
-        invoice_item_sequence = 0 # Incremental sequencing to keep the lines order on the invoice.
+        invoice_item_sequence = 1 # Incremental sequencing to keep the lines order on the invoice.
         for order in self:
             if order.partner_invoice_id.lang:
                 order = order.with_context(lang=order.partner_invoice_id.lang)

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -610,7 +610,7 @@ class TestSaleToInvoice(TestSaleCommon):
 
         self.assertRecordValues(invoice.invoice_line_ids, [
             {
-                'name': 'Meal Menu x 3',
+                'name': 'Meal Menu',
                 'display_type': 'line_section',
                 'product_id': False,
                 'quantity': 0,


### PR DESCRIPTION
Steps:
- Install sales app.
- Create a combo type product with invoice_policy delivery.
- Create a sale order with product.

Issue:
- 1) Combo line is not adding when creating invoice.
- 2) Sequence of combo line always stays last even fro
order policy
- 3) If we change combo product policy to order then
`Create Invoice` stays primary even all the actual
line are not invoicable

Cause:
- Corner cases that left to handle for combo type products

Fix:
- Handle those cases.

opw-4640087