### PR TITLE
[FIX] sale_{mrp,stock}_renting: explode kit moves in pickup rental

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -517,7 +517,7 @@ class StockMove(models.Model):
         moves_ids_to_unlink = OrderedSet()
         phantom_moves_vals_list = []
         for move in self:
-            if (not move.picking_type_id and not self.env.context.get('is_scrap')) or (move.production_id and move.production_id.product_id == move.product_id):
+            if (not move.picking_type_id and not (self.env.context.get('is_scrap') or self.env.context.get('skip_picking_assignation'))) or (move.production_id and move.production_id.product_id == move.product_id):
                 moves_ids_to_return.add(move.id)
                 continue
             bom = self.env['mrp.bom'].sudo()._bom_find(move.product_id, company_id=move.company_id.id, bom_type='phantom')[move.product_id]


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - Can be rented: True
    - tracked by quantity
    - BoM:
        - type: kit
        - component: C1

- Create a rental order with one unit of P1
- confirm it
- Click on pickup:
    - validate the wizard

Problem:
A user error is triggered:

"You should update the components' quantity instead of directly updating the quantity of the kit product."

This happens because the system attempts to update the available quantity of the kit product in the quants.

opw-4572337
