### PR TITLE
[FIX] l10n_ke_edi_tremol: use currency precision when sending to fiscal device

### DIFF
--- a/addons/l10n_ke_edi_tremol/models/account_move.py
+++ b/addons/l10n_ke_edi_tremol/models/account_move.py
@@ -176,7 +176,7 @@ class AccountMove(models.Model):
                     price_total = abs(line_tax_details['base_amount_currency']) + abs(line_tax_details['tax_amount_currency'])
                     percentage = tax['tax'].amount
 
-            price = round(price_total / abs(line.quantity) * 100 / (100 - line.discount), 2) * currency_rate
+            price = round(price_total / abs(line.quantity) * 100 / (100 - line.discount), line.currency_id.decimal_places) * currency_rate
             price = ('%.5f' % price).rstrip('0').rstrip('.')
 
             # Letter to classify tax, 0% taxes are handled conditionally, as the tax can be zero-rated or exempt


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_ke_edi_tremol
- Switch to a Kenyan company (e.g. KE Company)
- Configure USD currency:
  * Rounding Factor: 0.000100
  * Decimal Places: 4
  * Rate: 0.007729205731 Unit per KES 129.379400000000 KES per Unit
- Create a product with decimal in the price (e.g. 1234.56)
- Create an invoice:
  * Customer: [a Kenyan customer]
  * Currency: USD
  * Product: [the created product]
  * Taxes: 16%
- Confirm the invoice
- Send the invoice to fiscal device (It will not be possible without some credentials. However, if a breakpoint is set at the last line ("return" line) of "_l10n_ke_cu_lines_messages" method, the total amount in KSh sent to the fiscal device can be checked.)

**Issue:**
The total amount in KSh sent to the fiscal device is different than the total amount in USD converted to KSh with the used currency rate.

**Cause:**
In the "_l10n_ke_cu_lines_messages" method (the method used to compute the amounts sent to the fiscal device), a rounding is done by forcing the number of decimal to 2 without taking into account the configuration of the currency when computing the price.

opw-4567098




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
