### PR TITLE
[FIX] hr_holidays : Prevent rounding hours up when flexible calendars

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -432,7 +432,7 @@ class HolidaysRequest(models.Model):
             if calendar.flexible_hours:
                 days = (leave.date_to - leave.date_from).days + (1 if not leave.request_unit_half else 0.5)
                 hours = min(leave.request_hour_to - leave.request_hour_from, calendar.hours_per_day) if leave.request_unit_hours \
-                    else ceil(days * calendar.hours_per_day)
+                    else (days * calendar.hours_per_day)
                 result[leave.id] = (days, hours)
                 continue
             hours, days = (0, 0)

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1415,3 +1415,20 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 .with_company(new_company)
                 .with_context({"default_holiday_status_id": new_leave_type.id})) as leave_form:
             self.assertEqual(leave_form.employee_id, new_employee)
+
+    def test_time_off_hours_when_flexible(self):
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Test calendar',
+            'hours_per_day': 8.5,
+            'flexible_hours': True
+        })
+
+        self.employee_emp.resource_calendar_id = calendar
+        leave = self.env['hr.leave'].create({
+            'name': 'Test leave',
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.holidays_type_2.id,
+            'date_from': (datetime.today() - relativedelta(days=2)),
+            'date_to': datetime.today()
+        })
+        self.assertEqual(leave.number_of_hours, 8.5)


### PR DESCRIPTION
### Steps to reproduce:
	- Create a flexible working schedule with not even hours per day (e.g. 9:15)
	- Assign this working schedule to one of the employees
	- Create a time off type its request unit is hours
	- Create a time off for the employee that has the flexible calendar for one day
	- Notice the duration of the leave is rounded up

### Cause:
This is happening because when calculating the leave duration for a flexible resource we are using ceil() to round up the hours variable https://github.com/odoo/odoo/blob/ece2a795a303a1ce1b837a4b65e1cf99f1b717b5/addons/hr_holidays/models/hr_leave.py#L428-L429

### Fix:
Since we are not really benefiting from using ceil() as we are not
using it anyways in case of half-days so it is better to avoid rounding
the hours up.

opw-4640130