### PR TITLE
[FIX] web_editor: ensure visibility of "Autoconvert to Relative Link"

### DIFF
--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -136,8 +136,8 @@
             </we-row>
             <we-row class="o_strip_domain d-none" t-attf-class="#{state.isButton ? ' d-none' : ''}">
                 <we-button class="o_we_user_value_widget o_we_checkbox_wrapper o_we_sublevel_1 active">
-                    <we-title class="o_long_title">Autoconvert to Relative Link</we-title>
-                        <div class="o_switch">
+                    <we-title class="o_long_title flex-fill">Autoconvert to Relative Link</we-title>
+                        <div class="o_switch" style="min-width: fit-content;">
                             <we-checkbox name="do_strip_domain"/>
                         </div>
                 </we-button>


### PR DESCRIPTION
**Problem**:
When the text is long, the switch for "Autoconvert to Relative Link" is not visible.

**Solution**:
Adjust CSS to properly display the switch when the text is long.

**Before**:
![image](https://github.com/user-attachments/assets/324db4ab-70cc-4e88-8ecc-6df89e9fd54f)

**After**:
![image](https://github.com/user-attachments/assets/6ab270c3-00a5-49cf-8b71-2f5dc2bbde0a)

**Steps to Reproduce**:
1. Change language to **Dutch**.
2. Open the **website editor**.
3. Click on any **link**.
4. Copy your current link and paste it into the link input to trigger the "Autoconvert to Relative Link" switch.
   - **Issue**: The switch is not visible.

**opw-4558476**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
