### PR TITLE
[FIX] web: propagate no_breadcrumbs to switch view

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -273,6 +273,10 @@ function makeActionManager(env) {
                 const searchViewId = action.search_view_id ? action.search_view_id[0] : false;
                 action.views.push([searchViewId, "search"]);
             }
+            if ("no_breadcrumbs" in action.context) {
+                action._noBreadcrumbs = action.context.no_breadcrumbs;
+                delete action.context.no_breadcrumbs;
+            }
         }
         return action;
     }
@@ -541,8 +545,7 @@ function makeActionManager(env) {
         }
 
         viewProps.noBreadcrumbs =
-            "no_breadcrumbs" in action.context ? action.context.no_breadcrumbs : target === "new";
-        delete action.context.no_breadcrumbs;
+            "_noBreadcrumbs" in action ? action._noBreadcrumbs : target === "new";
         return {
             props: viewProps,
             config: {

--- a/addons/web/static/tests/webclient/actions/misc_tests.js
+++ b/addons/web/static/tests/webclient/actions/misc_tests.js
@@ -203,6 +203,10 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsOnce(target, ".o_control_panel .o_breadcrumb");
         // push another action flagged with 'no_breadcrumbs=true'
         await doAction(webClient, 4);
+        assert.containsOnce(target, ".o_kanban_view");
+        assert.containsNone(target, ".o_control_panel .o_breadcrumb");
+        await click(target, ".o_switch_view.o_list");
+        assert.containsOnce(target, ".o_list_view");
         assert.containsNone(target, ".o_control_panel .o_breadcrumb");
     });
 


### PR DESCRIPTION
Have an action with multiple views (eg form,kanban,list)

When the action spawns on its first view, the feature worked well: there were no breadcrumbs. Click on the view switcher to another view type.

Before this commit, the breadcrumbs appeared for that step on.

After this commit, the breadcrumbs do not appear for the whole action.

task-4583126

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
