### PR TITLE
[FIX] mail: self-call session status should sync in crosstab

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1098,7 +1098,7 @@ export class Rtc extends Record {
                 const session = await this.store["discuss.channel.rtc.session"].getWhenReady(
                     Number(id)
                 );
-                if (!session || !this.state.channel) {
+                if (!session || !this.channel) {
                     return;
                 }
                 if (


### PR DESCRIPTION
Before this commit, when current user is in a discuss call and have many tabs open, the self-call session status (mute/deafen) was not properly synced.

This lead to problem like some tabs showing "muted" but not others, which even prevent toggling status from some tabs.

This happens because when making an action, this action is sent to the tab that is actually making the call, and then the new state is broadcasted to other tabs with `change_info`.

The handling of `change_info` was mistakenly silently ignored when the current tab was not making the call. As a result, these tabs were not updated, and when attempting to click on action, it sends the opposite value to the tab making the call, so in the end these actions were stuck to their state unless the user interacts on the tab making the actual call.

This commit fixes the issue by taking `info_change` into account when this comes from a known call session and current user is in a call, regardless of the tab making the call. This is the way to update call session states in real-time.