### PR TITLE
[FIX] pos_restaurant: fix tb when idle timeout

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -78,7 +78,7 @@ patch(PosStore.prototype, {
         }
 
         const order = this.get_order();
-        if (order.finalized) {
+        if (!order || order.finalized) {
             return;
         }
         updateRewardsMutex.exec(() => {

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -18,6 +18,7 @@ patch(PosStore.prototype, {
             {
                 timeout: 180000, // 3 minutes
                 action: () =>
+                    this.dialog.closeAll() &&
                     this.config.module_pos_restaurant &&
                     this.mainScreen.component.name !== "PaymentScreen" &&
                     this.showScreen("FloorScreen"),


### PR DESCRIPTION
- Fix traceback appearing when after 3 minutes, we're automatically redirected to the floor screen and we had a combo selector popup opened. We were redirected to the floorscreen but the popup was still opened and when closing it it was throwing a traceback.
- Now just before redirecting idle user to the floorplan, we first close all opened modal.

Steps to reproduce :
- Open "Restaurant"
- Open an empty table
- Click combo product
- Wait 180s :d
- You'll be automatically redirected to floorplan, the combo selection popup is still opened
- When closing it you have a traceback

task-id: 4661502

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
