### PR TITLE
[FIX] mail: user-deleted message should not have 'Translate' feature

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -281,6 +281,7 @@ export class Message extends Record {
 
     isTranslatable(thread) {
         return (
+            !this.isEmpty &&
             this.store.hasMessageTranslationFeature &&
             !["discuss.channel", "mail.box"].includes(thread?.model)
         );

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1993,3 +1993,35 @@ test("Copy Message Link", async () => {
     await press("Enter");
     await contains(".o-mail-Message", { text: url(`/mail/message/${messageId_2}`) });
 });
+
+test("deleted message should not have translate feature", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "not empty",
+        message_type: "comment",
+        model: "res.partner",
+        res_id: partnerId,
+    });
+    await start();
+    await openFormView("res.partner", partnerId);
+    await contains(".o-mail-Message:contains('not empty')");
+    await click(".o-mail-Message [title='Expand']");
+    await contains(".dropdown-menu");
+    await contains(".dropdown-item:contains('Translate')");
+    await click(".dropdown-item:contains('Delete')");
+    await click("button:contains('Confirm')");
+    await contains(".o-mail-Message:contains('This message has been removed')");
+    await contains(".o-mail-Message [title='Add a Reaction']");
+    await contains(".o-mail-Message [title='Mark as Todo']");
+    await contains(".o-mail-Message [title*='Translate']", { count: 0 });
+    await animationFrame(); // in case some extra rendering for expand
+    if (queryFirst(".o-mail-Message [title='Expand']")) {
+        // Translate could hide itself in 'Expand' menu
+        await click(".o-mail-Message [title='Expand']");
+        await contains(".dropdown-menu");
+        await animationFrame(); // in case some rendering
+        await contains(".dropdown-item:contains('Translate')", { count: 0 });
+    }
+});


### PR DESCRIPTION
When a user deletes a user-message in discuss or chatter, the message content is replaced by "This message has been removed". Some actions are still possible on the message, such as adding reactions.

However some features do no make sense, like 'Translate', as the message has no content anymore and the "This message has been removed" is translated automatically to the user viewing this message.

This commit fixes the issue by not showing the 'Translate' message action on deleted messages.

Task-4661959