### PR TITLE
[FIX] l10n_jo_edi: Fixed non-sequential counter values

### DIFF
--- a/addons/l10n_jo_edi/migrations/1.1/pre-migrate.py
+++ b/addons/l10n_jo_edi/migrations/1.1/pre-migrate.py
@@ -1,0 +1,8 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    for company in env['res.company'].search([('chart_template', '=', 'jo_standard')]):
+        sent_invoices_count = env['account.move'].search_count([('company_id', '=', company.id), ('l10n_jo_edi_state', '=', 'sent')])
+        env['ir.config_parameter'].set_param(company._get_jo_icv_param_name(), sent_invoices_count)

--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -353,7 +353,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
     def _get_additional_document_reference_list(self, invoice):
         return [{
             'id': 'ICV',
-            'uuid': invoice.id,
+            'uuid': invoice.l10n_jo_edi_invoice_counter,
         }]
 
     def _get_seller_supplier_party_vals(self, invoice):

--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -353,7 +353,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
     def _get_additional_document_reference_list(self, invoice):
         return [{
             'id': 'ICV',
-            'uuid': invoice.l10n_jo_edi_invoice_counter,
+            'uuid': invoice._get_next_jo_icv(),
         }]
 
     def _get_seller_supplier_party_vals(self, invoice):

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -14,6 +14,7 @@ class AccountMove(models.Model):
 
     l10n_jo_edi_uuid = fields.Char(string="Invoice UUID", copy=False, compute="_compute_l10n_jo_edi_uuid", store=True)
     l10n_jo_edi_qr = fields.Char(string="QR", copy=False)
+    l10n_jo_edi_invoice_counter = fields.Integer(compute='_compute_l10n_jo_edi_invoice_counter')
 
     l10n_jo_edi_is_needed = fields.Boolean(
         compute="_compute_l10n_jo_edi_is_needed",
@@ -50,6 +51,11 @@ class AccountMove(models.Model):
         help="Jordan: e-invoice XML.",
     )
     reversed_entry_id = fields.Many2one(tracking=True)
+
+    def _compute_l10n_jo_edi_invoice_counter(self):
+        next_counter = self.env['account.move'].search_count([('company_id', '=', self.company_id.id), ('l10n_jo_edi_state', '=', 'sent')]) + 1
+        for move in self:
+            move.l10n_jo_edi_invoice_counter = next_counter
 
     @api.depends("country_code", "move_type")
     def _compute_l10n_jo_edi_is_needed(self):

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -14,7 +14,6 @@ class AccountMove(models.Model):
 
     l10n_jo_edi_uuid = fields.Char(string="Invoice UUID", copy=False, compute="_compute_l10n_jo_edi_uuid", store=True)
     l10n_jo_edi_qr = fields.Char(string="QR", copy=False)
-    l10n_jo_edi_invoice_counter = fields.Integer(compute='_compute_l10n_jo_edi_invoice_counter')
 
     l10n_jo_edi_is_needed = fields.Boolean(
         compute="_compute_l10n_jo_edi_is_needed",
@@ -51,11 +50,6 @@ class AccountMove(models.Model):
         help="Jordan: e-invoice XML.",
     )
     reversed_entry_id = fields.Many2one(tracking=True)
-
-    def _compute_l10n_jo_edi_invoice_counter(self):
-        next_counter = self.env['account.move'].search_count([('company_id', '=', self.company_id.id), ('l10n_jo_edi_state', '=', 'sent')]) + 1
-        for move in self:
-            move.l10n_jo_edi_invoice_counter = next_counter
 
     @api.depends("country_code", "move_type")
     def _compute_l10n_jo_edi_is_needed(self):
@@ -124,6 +118,14 @@ class AccountMove(models.Model):
         for invoice in self.filtered('l10n_jo_edi_is_needed'):
             invoice.l10n_jo_edi_state = 'to_send'
         return super()._post(soft)
+
+    def write(self, vals):
+        sent_count = len(self.filtered(lambda move: move.l10n_jo_edi_state == 'sent'))
+        res = super().write(vals)
+        sent_count_diff = len(self.filtered(lambda move: move.l10n_jo_edi_state == 'sent')) - sent_count
+        if self.company_id:
+            self.company_id._increment_jo_icv(sent_count_diff)
+        return res
 
     def _get_name_invoice_report(self):
         # EXTENDS account

--- a/addons/l10n_jo_edi/models/res_company.py
+++ b/addons/l10n_jo_edi/models/res_company.py
@@ -12,3 +12,15 @@ class ResCompany(models.Model):
         ('sales', "Registered in the sales tax"),
         ('special', "Registered in the special sales tax"),
     ])
+
+    def _get_jo_icv_param_name(self):
+        return f'l10n_jo_edi.icv_{self.id}'
+
+    def _get_next_jo_icv(self):
+        param_name = self._get_jo_icv_param_name()
+        return self.env['ir.config_parameter'].sudo().get_param(param_name, default='1')
+
+    def _increment_jo_icv(self, increment=1):
+        previous_icv = int(self._get_next_jo_icv())
+        param_name = self._get_jo_icv_param_name()
+        self.env['ir.config_parameter'].sudo().set_param(param_name, previous_icv + increment)


### PR DESCRIPTION
Before this commit, the invoice counter in the XML submitted to JoFotara was set to the move id. The problem with the move id is that it's not guaranteed that submitted counters would be sequential; they may contain gaps or even be out of order.
The ISTD expects counters to be sequential.

This commit solves this issue by relying on a computed field in assigning invoice counter in the EDI XML.

task-4632768




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
