### PR TITLE
[FIX] account,purchase: prevent accrued expense entry with different currencies

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -150,7 +150,8 @@ class AccruedExpenseRevenue(models.TransientModel):
 
         if orders.filtered(lambda o: o.company_id != self.company_id):
             raise UserError(_('Entries can only be created for a single company at a time.'))
-
+        if orders.currency_id and len(orders.currency_id) > 1:
+            raise UserError(_('Cannot create an accrual entry with orders in different currencies.'))
         orders_with_entries = []
         fnames = []
         total_balance = 0.0
@@ -252,10 +253,6 @@ class AccruedExpenseRevenue(models.TransientModel):
 
         if self.reversal_date <= self.date:
             raise UserError(_('Reversal date must be posterior to date.'))
-        orders = self.env[self._context['active_model']].with_company(self.company_id).browse(self._context['active_ids'])
-        if len({order.currency_id or order.company_id.currency_id for order in orders}) != 1:
-            raise UserError(_('Cannot create an accrual entry with orders in different currencies.'))
-
         move_vals, orders_with_entries = self._compute_move_vals()
         move = self.env['account.move'].create(move_vals)
         move._post()

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -180,3 +180,26 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             {'account_id': self.alt_exp_account.id, 'debit': 0.0, 'credit': 1000.0},
             {'account_id': self.account_revenue.id, 'debit': 6000.0, 'credit': 0.0},
         ])
+    
+    def test_error_when_different_currencies_accrued(self):
+        """
+        Tests that if two Purchase Orders with different currencies are selected for Accrued Expense Entry, 
+        a UserError is raised.
+        """
+        purchase_orders = self.env['purchase.order'].create([
+            {
+                'partner_id': self.partner_a.id,
+                'currency_id': self.company_data['currency'].id,
+            }, 
+            {
+                'partner_id': self.partner_a.id,
+                'currency_id': self.currency_data['currency'].id,
+            }
+        ])
+        purchase_orders.button_confirm()
+        accrued_wizard = self.env['account.accrued.orders.wizard'].with_context(
+            active_model='purchase.order',
+            active_ids=purchase_orders.ids,
+        ).new()
+        with self.assertRaises(UserError, msg="An error should be raised if two different currencies are used for Accrued Expense Entry."):
+            accrued_wizard._compute_move_vals()


### PR DESCRIPTION
**Problem:**
In the purchase app, when selecting 2 Purchase Orders that have
different currencies, and clicking Action then Accrued Expense
Entry, a traceback will appear. It works as intended if the two
Purchase Orders have the same currency, but if there is more than
one currency, the traceback will be displayed.

**Steps to reproduce:**
- Go to the purchase app and select two Purchase Orders that have
different currencies (you can make a group by Currencies).
- Click on Action then Accrued Expense Entry.
- The traceback appears.

**Cause of the issue:**
https://github.com/odoo/odoo/blob/a07a8589a8cb391a801ef1ffd60e02d83fc963f8/addons/account/wizard/accrued_orders.py#L246
The currency is given as a parameter to a function that requires
only one parameter. With this code, if there are multiple
currencies in orders, all of them will be given, which
creates a traceback.

**Fix:**
After checking with a PO, the multiple currency use case is not
supported. Hence make sure that there is only one currency in the
quotations we are trying to work with. If there is more than one,
we throw an error telling the user to only pick quotations with
the same currency.

opw-4562933