### PR TITLE
[IMP] core: add cache for exists() call

### DIFF
--- a/addons/account/wizard/account_merge_wizard.py
+++ b/addons/account/wizard/account_merge_wizard.py
@@ -203,6 +203,7 @@ class AccountMergeWizard(models.TransientModel):
 
         # Clear ir.model.data ormcache
         self.env.registry.clear_cache()
+        self.env.cr.cache.pop('cache_exists', None)
 
         # Step 5: Write company_ids and codes on the account
         for company, code in code_by_company.items():

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -164,6 +164,7 @@ class AssetsBundle(object):
         self.env.cr.execute(f"""DELETE FROM {attachments._table} WHERE id IN (
             SELECT id FROM {attachments._table} WHERE id in %s FOR NO KEY UPDATE SKIP LOCKED
         )""", [tuple(attachments.ids)])
+        self.env.cr.cache.pop('cache_exists', None)
         for fpath in to_delete:
             attachments._file_delete(fpath)
 

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -156,6 +156,7 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
                     # keeping record with nonexistent partner_id is useless, better delete it
                     query = 'DELETE FROM "%(table)s" WHERE "%(column)s" IN %%s' % query_dic
                     self._cr.execute(query, (tuple(src_records.ids),))
+                    self.env.cr.cache.pop('cache_exists', None)
 
     @api.model
     def _update_reference_fields_generic(self, referenced_model, src_records, dst_record, additional_update_records=None):

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -330,6 +330,7 @@ class PropertiesCase(TestPropertiesMixin):
         ]
 
         self.env.invalidate_all()
+        self.env.cr.cache.pop('cache_exists', None)
         with self.assertQueryCount(5), self.assertQueries(expected_queries):
             self.message_1.read(['attributes'])
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1039,6 +1039,7 @@ class TransactionCase(BaseCase):
         finally:
             self.registry_leave_test_mode()
             env.invalidate_all()
+            env.cr.cache.clear()  # Cannot trust the cache anymore
 
 
 class SingleTransactionCase(BaseCase):


### PR DESCRIPTION
We want create a proper `Properties.convert_to_record()` method, but the only obstacle is for batching and cached the `exists()` call for relational property field.

Then we add a transactional cache for `exists()`.
This solution is clearly not perfect but it is quite simple. This cache is only populated by the `exists()` method. It can also possible to potulate it during _fetch_query (internal method of search/read/...) but it is not necessary and may cost too much memory/postprocess for very small increase of the hit rate.

Note that this cache may also help when the usage of `ref` is called inside a loop.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
