### PR TITLE
[FIX] spreadsheet: reload cumulative data

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
@@ -47,6 +47,7 @@ export class OdooChartUIPlugin extends UIPlugin {
                         const chart = this.getters.getChart(cmd.id);
                         if (
                             cmd.definition.type !== chart.type ||
+                            chart.cumulative !== cmd.definition.cumulative ||
                             dataSource.getInitialDomainString() !==
                                 new Domain(cmd.definition.searchParams.domain).toString()
                         ) {

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
@@ -516,6 +516,7 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
             id: chartId,
             sheetId,
         });
+        await waitForDataSourcesLoaded(model);
         assert.deepEqual(
             model.getters.getChartRuntime(chartId).chartJsConfig.data.datasets[0].data,
             [1, 4]
@@ -528,6 +529,7 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
             id: chartId,
             sheetId,
         });
+        await waitForDataSourcesLoaded(model);
         assert.deepEqual(
             model.getters.getChartRuntime(chartId).chartJsConfig.data.datasets[0].data,
             [1, 3]
@@ -574,6 +576,66 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
         const chartId = model.getters.getChartIds(sheetId)[0];
         await waitForDataSourcesLoaded(model);
 
+        assert.deepEqual(
+            model.getters.getChartRuntime(chartId).chartJsConfig.data.datasets[0].data,
+            [15, 19, 24]
+        );
+    });
+
+    QUnit.test("update existing chart to cumulate past data", async (assert) => {
+        const serverData = getBasicServerData();
+        serverData.models.partner.records = [
+            { date: "2020-01-01", probability: 10 },
+            { date: "2021-01-01", probability: 2 },
+            { date: "2022-01-01", probability: 3 },
+            { date: "2022-03-01", probability: 4 },
+            { date: "2022-06-01", probability: 5 },
+        ];
+        const definition = {
+            type: "odoo_line",
+            metaData: {
+                groupBy: ["date"],
+                measure: "probability",
+                order: null,
+                resModel: "partner",
+            },
+            searchParams: {
+                comparison: null,
+                context: {},
+                domain: [
+                    ["date", ">=", "2022-01-01"],
+                    ["date", "<=", "2022-12-31"],
+                ],
+                groupBy: [],
+                orderBy: [],
+            },
+            cumulative: false,
+            title: "Partners",
+            dataSourceId: "42",
+            id: "42",
+        };
+        const { model } = await createSpreadsheetWithChart({
+            type: "odoo_line",
+            serverData,
+            definition,
+        });
+        const sheetId = model.getters.getActiveSheetId();
+        const chartId = model.getters.getChartIds(sheetId)[0];
+        await waitForDataSourcesLoaded(model);
+        assert.deepEqual(
+            model.getters.getChartRuntime(chartId).chartJsConfig.data.datasets[0].data,
+            [3, 4, 5]
+        );
+
+        model.dispatch("UPDATE_CHART", {
+            definition: {
+                ...definition,
+                cumulative: true,
+            },
+            id: chartId,
+            sheetId,
+        });
+        await waitForDataSourcesLoaded(model);
         assert.deepEqual(
             model.getters.getChartRuntime(chartId).chartJsConfig.data.datasets[0].data,
             [15, 19, 24]


### PR DESCRIPTION
Steps to reproduce:

- insert a line chart into a spreadsheet with the horizontal axis being a time axis
- ensures a domain is applied such that at least some past data is excluded
- open the configuration side panel
- check the "Cumulative data" checkbox

=> the chart doesn't take into account past data. When reloading it works.

opw-4646477


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
