### PR TITLE
[IMP] account_reports: Activate filter_show_draft for all reports

### DIFF
--- a/addons/l10n_mx/data/account_report_diot.xml
+++ b/addons/l10n_mx/data/account_report_diot.xml
@@ -4,7 +4,7 @@
         <field name="name">DIOT</field>
         <field name="name@es_419">DIOT</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
-        <field name="filter_show_draft" eval="False"/>
+        <field name="filter_show_draft" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="load_more_limit" eval="80"/>
         <field name="filter_unfold_all" eval="False"/>


### PR DESCRIPTION
Before this commit, the Draft Entries filter on reports was randomly activated for some reports, but deactivated for others. Users may want to see the draft entries impacting their reports for a better control and verification before submitting it.

task-4661810





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
