### PR TITLE
[FIX] website_sale: price unit computation in mobile

### DIFF
--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -67,6 +67,7 @@
                             <field name="company_id" invisible="1"/>
                             <field name="tax_country_id" invisible="1"/>
                             <field name="price_unit"/>
+                            <field name="technical_price_unit" invisible="1"/>
                             <field name="discount" groups="sale.group_discount_per_so_line"/>
                             <field name="price_subtotal"
                                    string="Amount"

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -399,6 +399,7 @@
                             mode="list,kanban"
                             readonly="state == 'cancel' or locked">
                             <form>
+                                <field name="technical_price_unit" invisible="1"/>
                                 <field name="display_type" invisible="1"/>
                                 <field name="is_downpayment" invisible="1"/>
                                 <!--


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Create a pricelist with any discount on all products with a minimum quantity of 5;
2. Create a new sale order in mobile view;
3. Create a new sale order line, select any product and set a quantity higher than 5.

Issue
-----
The price unit isn't discounted as expected.

Cause
-----
`_compute_price_unit` needs `technical_price_unit` which is missing from the mobile view.

Solution
--------
Add `technical_price_unit` to mobile sale order views.

opw-4569731

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
