### PR TITLE
[FIX] point_of_sale: sanitize data cache clear

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -292,7 +292,17 @@ export class PosData extends Reactive {
         this.models.loadData({ "pos.order": order, "pos.order.line": orderlines });
         const dbData = await this.loadIndexedDBData();
         this.loadedIndexedDBProducts = dbData ? dbData["product.product"] : [];
+        this.sanitizeData();
         this.network.loading = false;
+    }
+
+    sanitizeData() {
+        const order_to_delete = this.models["pos.order"].filter((order) =>
+            order.lines.some((line) => line.is_reward_line && !line.coupon_id)
+        );
+        for (const order of order_to_delete) {
+            order.lines.forEach((line) => line.delete());
+        }
     }
 
     async execute({


### PR DESCRIPTION
After clearing the cache you can have inconsistent reward lines that have no coupon associated with them.

Steps to reproduce:
-------------------
* Create an order and add any reward (Buy X Get Y for example)
* Go to the backend to make sure the order is saved in the database
* Go back to the POS and clear the cache
> Observation: You are stuck on the loading screen

Why the fix:
------------
To avoid having inconsistent reward lines that have no coupon associated with them, we delete all the lines of an order that contains wrong data. As this is not supposed to happen (clearing the cache is a debug functionality), we can safely delete the lines because it's wont impact the real workflow of the users.

opw-4655422