### PR TITLE
[FIX] l10n_ee: Add KMD5 specs needed from 01.01.2025

### DIFF
--- a/addons/l10n_ee/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_ee/data/account_fiscal_position_template_data.xml
@@ -107,6 +107,13 @@
         <field name="tax_dest_id" ref="l10n_ee_vat_out_0_eu_s"/>
     </record>
 
+    <!-- Sales of Services 13% -> Sales of Services in EU 0% IC -->
+    <record id="afptt_eu_ic_17" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_eu_ic"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_out_13_s"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_out_0_eu_s"/>
+    </record>
+
     <!-- Sales of Goods 9% -> Sales of Goods in EU 0% IC -->
     <record id="afptt_eu_ic_3" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
@@ -167,6 +174,13 @@
     <record id="afptt_eu_ic_10_22" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_22_s"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_22"/>
+    </record>
+
+    <!-- Purchase of Services 13% -> Purchase of Services in EU 0% IC -->
+    <record id="afptt_eu_ic_18" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_eu_ic"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_in_13_s"/>
         <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_22"/>
     </record>
 
@@ -249,6 +263,13 @@
         <field name="tax_dest_id" ref="l10n_ee_vat_out_0_exp_g"/>
     </record>
 
+    <!-- Sales of Services 13% -> Export of Services 0% -->
+    <record id="afptt_imp_exp_17" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_imp_exp"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_out_13_s"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_out_0_exp_s"/>
+    </record>
+
     <!-- Sales of Services 9% -> Export of Services 0% -->
     <record id="afptt_imp_exp_4" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_imp_exp"/>
@@ -310,6 +331,13 @@
         <field name="position_id" ref="afpt_imp_exp"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_22_s"/>
         <field name="tax_dest_id" ref="l10n_ee_vat_in_22_imp_kms_38"/>
+    </record>
+
+    <!-- Purchase of Services 13% -> Import 13% -->
+    <record id="afptt_imp_exp_18" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="afpt_imp_exp"/>
+        <field name="tax_src_id" ref="l10n_ee_vat_in_13_s"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_13_imp_kms_38"/>
     </record>
 
     <!-- Purchase of Goods 9% -> Import 9% -->

--- a/addons/l10n_ee/data/account_tax_group_data.xml
+++ b/addons/l10n_ee/data/account_tax_group_data.xml
@@ -11,6 +11,11 @@
             <field name="country_id" ref="base.ee"/>
         </record>
 
+        <record id="tax_group_vat_13" model="account.tax.group">
+            <field name="name">VAT 13%</field>
+            <field name="country_id" ref="base.ee"/>
+        </record>
+
         <record id="tax_group_vat_9" model="account.tax.group">
             <field name="name">VAT 9%</field>
             <field name="country_id" ref="base.ee"/>

--- a/addons/l10n_ee/data/account_tax_report_data.xml
+++ b/addons/l10n_ee/data/account_tax_report_data.xml
@@ -57,6 +57,17 @@
                     </record>
                 </field>
             </record>
+            <record id="tax_report_line_2_2" model="account.report.line">
+                <field name="name">2² - Acts and transactions subject to tax at a rate of 13%</field>
+                <field name="code">l10n_ee_vat_2_2</field>
+                <field name="expression_ids">
+                    <record id="tax_report_line_2_2_tag" model="account.report.expression">
+                        <field name="label">balance</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">2_2</field>
+                    </record>
+                </field>
+            </record>
             <record id="tax_report_line_3" model="account.report.line">
                 <field name="name">3 - Acts and transactions subject to tax at a rate of 0%, incl.</field>
                 <field name="code">l10n_ee_vat_3</field>
@@ -157,7 +168,7 @@
                     <record id="tax_report_line_4_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">aggregation</field>
-                        <field name="formula">l10n_ee_vat_1.balance * 0.22 + l10n_ee_vat_1_1.balance * 0.2 + l10n_ee_vat_2.balance * 0.09 + l10n_ee_vat_2_1.balance * 0.05</field>
+                        <field name="formula">l10n_ee_vat_1.balance * 0.22 + l10n_ee_vat_1_1.balance * 0.2 + l10n_ee_vat_2.balance * 0.09 + l10n_ee_vat_2_1.balance * 0.05 + l10n_ee_vat_2_2.balance * 0.13</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_ee/data/account_tax_template_data.xml
+++ b/addons/l10n_ee/data/account_tax_template_data.xml
@@ -262,6 +262,39 @@
         ]"/>
     </record>
 
+    <!-- Sales of Services 13% -->
+    <record id="l10n_ee_vat_out_13_s" model="account.tax.template">
+        <field name="sequence">66</field>
+        <field name="name">13% S</field>
+        <field name="type_tax_use">sale</field>
+        <field name="amount">13</field>
+        <field name="amount_type">percent</field>
+        <field name="description">13%</field>
+        <field name="active" eval="False"/>
+        <field name="tax_group_id" ref="tax_group_vat_13"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_expression_ids': [ref('tax_report_line_2_2_tag')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [ref('tax_report_line_2_2_tag')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+    </record>
+
     <!-- Sales of Goods 0% -->
     <record id="l10n_ee_vat_out_0_g" model="account.tax.template">
         <field name="sequence">70</field>
@@ -840,6 +873,35 @@
         ]"/>
     </record>
 
+    <!-- Purchase of Services 13% -->
+    <record id="l10n_ee_vat_in_13_s" model="account.tax.template">
+        <field name="sequence">225</field>
+        <field name="name">13% S</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">13</field>
+        <field name="amount_type">percent</field>
+        <field name="description">13%</field>
+        <field name="active" eval="False"/>
+        <field name="tax_group_id" ref="tax_group_vat_13"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+        ]"/>
+    </record>
+
     <!-- Purchase of Goods 0% -->
     <record id="l10n_ee_vat_in_0_g" model="account.tax.template">
         <field name="sequence">230</field>
@@ -1395,6 +1457,53 @@
         <field name="description">22%</field>
         <field name="active" eval="False"/>
         <field name="tax_group_id" ref="tax_group_vat_22"/>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [
+                    ref('tax_report_line_5_1_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+                'minus_report_expression_ids': [ref('tax_report_line_4_1_tag')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, { 'repartition_type': 'base' }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [
+                    ref('tax_report_line_5_1_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+                'plus_report_expression_ids': [ref('tax_report_line_4_1_tag')],
+            }),
+        ]"/>
+    </record>
+
+    <!-- Import 13% (KMS §38 - Reverse Charge) -->
+    <record id="l10n_ee_vat_in_13_imp_kms_38" model="account.tax.template">
+        <field name="sequence">312</field>
+        <field name="name">13% EX KMS §38</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">13</field>
+        <field name="amount_type">percent</field>
+        <field name="description">13% EX KMS §38</field>
+        <field name="active" eval="False"/>
+        <field name="tax_group_id" ref="tax_group_vat_13"/>
         <field name="chart_template_id" ref="l10nee_chart_template"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, { 'repartition_type': 'base' }),

--- a/addons/l10n_ee/i18n/et.po
+++ b/addons/l10n_ee/i18n/et.po
@@ -190,6 +190,11 @@ msgid "2 - Acts and transactions subject to tax at a rate of 9%"
 msgstr "2 - 9% määraga maksustatavad toimingud ja tehingud"
 
 #. module: l10n_ee
+#: model:account.report.line,name:l10n_ee.tax_report_line_2_2
+msgid "2² - Acts and transactions subject to tax at a rate of 13%"
+msgstr "2² - 13% määraga maksustatavad toimingud ja tehingud"
+
+#. module: l10n_ee
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_20_assets
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_20_car
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_20_car_part

--- a/addons/l10n_ee/i18n/l10n_ee.pot
+++ b/addons/l10n_ee/i18n/l10n_ee.pot
@@ -188,6 +188,11 @@ msgid "2 - Acts and transactions subject to tax at a rate of 9%"
 msgstr ""
 
 #. module: l10n_ee
+#: model:account.report.line,name:l10n_ee.tax_report_line_2_2
+msgid "2² - Acts and transactions subject to tax at a rate of 13%"
+msgstr ""
+
+#. module: l10n_ee
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_20_assets
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_20_car
 #: model:account.tax,description:l10n_ee.1_l10n_ee_vat_in_20_car_part


### PR DESCRIPTION
Estonia updated their tax report scheme to KMD5, mandatory from 01/01/2025

More info:
https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax#from-01012025 https://www.emta.ee/en/business-client/e-services-training-courses/how-use-e-services/technical-information-services#tsd https://www.emta.ee/sites/default/files/documents/2025-02/vorm_kmd_2025_eng.pdf

Backport of e2d795e9b15b1c522fe60e1cf38041e16ac73743

opw-4587040
opw-4610009
