### PR TITLE
[FIX] sale_timesheet: prevent error on NewId partner in contact form

### DIFF
--- a/addons/sale_timesheet/models/project_task.py
+++ b/addons/sale_timesheet/models/project_task.py
@@ -90,7 +90,7 @@ class ProjectTask(models.Model):
             SaleOrderLine._domain_sale_line_service(),
             [
                 ('company_id', '=?', self.company_id.id),
-                ('order_partner_id', 'child_of', self.partner_id.commercial_partner_id.id),
+                ('order_partner_id', 'child_of', self.partner_id.commercial_partner_id.ids),
                 ('remaining_hours', '>', 0),
             ],
         ])


### PR DESCRIPTION
Issue:

Server error raised when selecting a project in a new task field added to a contact form

Steps to reproduce:

- Go to Contacts > select a contact
- Click on toggle studio
- Add the 'task' field in the contact form
- Go back to the contact
- In the task field, add a line
- Select a project

an error is raised

This fix is to properly handles NewId objects in the domain construction.

opw-4575975