### PR TITLE
[FIX] mail: 'family' emoji is 1 emoji rather than 4, remove 'wales' flag

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -50,9 +50,9 @@
 @font-face {
     font-family: "text-emoji";
     src: local('Segoe UI'),
-         local('Apple Color Emoji'),
+         local('Apple Emoji'),
          local('Android Emoji'),
-         local('Noto Color Emoji'),
+         local('Noto Emoji'),
          local('Twitter Color Emoji'),
          local('Twitter Color'),
          local('EmojiOne Color'),

--- a/addons/web/static/src/core/emoji_picker/emoji_data.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_data.js
@@ -21860,42 +21860,6 @@ const _getEmojisData8 = () => `{
     "shortcodes": [
         ":pirate_flag:"
     ]
-},
-{
-    "category": "Symbols",
-    "codepoints": "🏴󠁧󠁢󠁥󠁮󠁧󠁿",
-    "emoticons": [],
-    "keywords": [
-        "` + _t("flag") + `"
-    ],
-    "name": "` + _t("flag: England") + `",
-    "shortcodes": [
-        ":england:"
-    ]
-},
-{
-    "category": "Symbols",
-    "codepoints": "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
-    "emoticons": [],
-    "keywords": [
-        "` + _t("flag") + `"
-    ],
-    "name": "` + _t("flag: Scotland") + `",
-    "shortcodes": [
-        ":scotland:"
-    ]
-},
-{
-    "category": "Symbols",
-    "codepoints": "🏴󠁧󠁢󠁷󠁬󠁳󠁿",
-    "emoticons": [],
-    "keywords": [
-        "` + _t("flag") + `"
-    ],
-    "name": "` + _t("flag: Wales") + `",
-    "shortcodes": [
-        ":wales:"
-    ]
 }`;
 
 /** @type {string} */


### PR DESCRIPTION
Before this commit, inserting emoji in composer resulted in inserted several other different emojis.

Steps to reproduce:
- open a composer in Discuss
- type `:family`
- pick the `:family:_man,_woman,_girl,_boy:` suggestion => composer contains 👨👩👧👦 rather than 👨‍👩‍👧‍👦 (this is a single emoji visually, as long as you use a modern font and text visualizer).

This happens because this single emoji that represents a household composition is actually represented as 4 simpler emojis. When using a modern font, this is transformed into a single emoji. With non-modern fonts that have basic support of emojis, this is shown as the 4 emojis, as an attempt to keep the same semantics even with the lack of support of this modern emoji.

In discuss, there's a custom font-face to size emojis bigger than pure text, so that emojis are more visible. The list of font family provided used "Color Emoji" variants on apple devices and Linux distributions, which somehow lack some modern emoji like the family household composition above.

This commit fixes them trivially by using the non-color "Emoji" variants of these font families.
Windows uses "Segoe UI" and didn't have the issue.

This problem was also affecting the few regional flag that were supported in Discuss like `:wales:`, which was displayed as 🏴 rather than the 🏴󠁧󠁢󠁷󠁬󠁳󠁿. While the current change fixes it for apple devices and Linux distributions, the bug was still present on Windows. It looks like there's no font on Windows that support them, thus we decide to remove them like all other regional flags. As a reminder, the regional flags are not present in emoji picker because Windows made the intentional decision to not support them [1] [2] for geopolitical reasons.

[1]: https://devblogs.microsoft.com/oldnewthing/20030822-00/?p=42823
[2]: https://x.com/JenMsft/status/1399979907338309633?t=jdMssoDqJ6UjML-gu9pFig&s=19

Before / After
<img width="261" alt="Screenshot 2025-03-20 at 18 48 09" src="https://github.com/user-attachments/assets/4e2e4059-6376-4882-b24c-5556f8d08339" /> <img width="258" alt="Screenshot 2025-03-20 at 18 48 22" src="https://github.com/user-attachments/assets/92fee8d9-0973-4672-8320-0e019bc4b35c" />

