### PR TITLE
[FIX] web_editor: no data-snippet on t-call in snippet

### DIFF
--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -61,17 +61,6 @@ class IrQWeb(models.AbstractModel):
                 snippet_name = compile_context.get('snippet-name')
                 if snippet_name and 'data-name' not in snippet_base_node.attrib:
                     snippet_base_node.attrib['data-name'] = snippet_name
-
-            sub_call = el.get('t-call')
-            # If the node is a t-call, we create the snippet-sub-call-key 
-            # to still be able to add the "data-snippet" attrib of the sub 
-            # called snippet
-            if sub_call:
-                el.set(
-                    't-options',
-                    f"{{'snippet-key': '{snippet_key}', 'snippet-sub-call-key': '{sub_call}'}}"
-                )
-
         return super()._compile_node(el, compile_context, indent)
 
     # compile directives

--- a/addons/web_editor/tests/__init__.py
+++ b/addons/web_editor/tests/__init__.py
@@ -5,5 +5,6 @@ from . import test_controller
 from . import test_converter
 from . import test_odoo_editor
 from . import test_diff_utils
+from . import test_snippets
 from . import test_views
 from . import test_tools

--- a/addons/web_editor/tests/test_snippets.py
+++ b/addons/web_editor/tests/test_snippets.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from lxml import etree
+
+from odoo.tests import TransactionCase
+
+
+class TestViews(TransactionCase):
+
+    def _assertXmlEqual(self, result, expectation):
+        parser = etree.XMLParser(remove_blank_text=True)
+        result = etree.tostring(
+            etree.fromstring(result, parser=parser)
+        )
+        expectation = etree.tostring(
+            etree.fromstring(expectation, parser=parser)
+        )
+        self.assertEqual(result, expectation)
+
+    def test_data_snippet_inheritance(self):
+        View = self.env['ir.ui.view']
+        snippets = View.create({
+            'name': 'TestSnippets',
+            'type': 'qweb',
+            'arch': '''<snippets id="snippet_test_structure" string="Test Panel">
+                           <t t-snippet="web_editor.test_snippet"/>
+                           <t t-snippet="web_editor.test_snippet_call"/>
+                       </snippets>
+                    ''',
+            'key': 'web_editor.test_snippets',
+        })
+        snippet = View.create({
+            'name': 'TestSnippet',
+            'type': 'qweb',
+            'arch': '''<div id="a">
+                           <div id="b">hello</div>
+                           <div id="c"><t t-call="web_editor.test_t_call"/></div>
+                           <div id="d"><t t-out="0"/></div>
+                       </div>
+                    ''',
+            'key': 'web_editor.test_snippet',
+        })
+        View.create({
+            'name': 'TestTCall',
+            'type': 'qweb',
+            'arch': '<div id="e">world</div>',
+            'key': 'web_editor.test_t_call',
+        })
+        t_snippet_call = View.create({
+            'name': 'TestTSnippetCall',
+            'type': 'qweb',
+            'arch': '''<div id="f">
+                           <div id="g">!</div>
+                           <div id="h">
+                               <t t-snippet-call="web_editor.test_snippet"><div id="i">to everyone</div></t>
+                           </div>
+                       </div>
+                    ''',
+            'key': 'web_editor.test_snippet_call',
+        })
+
+        self._assertXmlEqual(
+            self.env['ir.qweb']._render('web_editor.test_snippets'),
+            f'''
+            <snippets id="snippet_test_structure" string="Test Panel">
+                <div name="TestSnippet" data-oe-type="snippet" data-o-image-preview="" data-oe-thumbnail="oe-thumbnail" data-oe-snippet-id="{snippet.id}" data-oe-keywords="">
+                     <div id="a" data-snippet="test_snippet"><div id="b">hello</div><div id="c"><div id="e">world</div></div><div id="d"/></div>
+                </div>
+                <div name="TestTSnippetCall" data-oe-type="snippet" data-o-image-preview="" data-oe-thumbnail="oe-thumbnail" data-oe-snippet-id="{t_snippet_call.id}" data-oe-keywords="">
+                    <div id="f" data-snippet="test_snippet_call">
+                        <div id="g">!</div>
+                        <div id="h">
+                            <div id="a" data-snippet="test_snippet"><div id="b">hello</div><div id="c"><div id="e">world</div></div><div id="d"><div id="i">to everyone</div></div></div>
+                        </div>
+                    </div>
+                </div>
+            </snippets>
+            '''
+        )


### PR DESCRIPTION
Scenario:
- add a snippet subscription
- select it in editor
- click on "Replace by new version" in "THIS BLOCK IS OUTDATED" message

Result: traceback "Cannot read properties of undefined (reading
'querySelectorAll')".

Issue: in 6d5c741820cb69f7619e2cf49bce1457b2cd1efd the code adding
data-snippet was changed, and it now set "data-snippet" in code t-called
inside a snippet to template name that are not snippet. This cause the
snippet code to be applied without a snippet existing.

In this case, there is a snippet "s_newsletter_block_default_template"
but that's just the name of the t-call'ed template.

Fix: remove the code that apply t-snippet-call attribute to t-call
inside a snippet.

opw-4648786

**PR note**: the forward-port of the mentioned PR commit `https://github.com/odoo/odoo/pull/200690` has already received this change, so besides the test this PR seems only necessary in 18.0