### PR TITLE
[FIX] Fixed an issue causing the weight field on sale reports for POS…

### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -66,8 +66,8 @@ class SaleReport(models.Model):
             partner.country_id AS country_id,
             partner.industry_id AS industry_id,
             partner.commercial_partner_id AS commercial_partner_id,
-            (SUM(p.weight) * l.qty / u.factor) AS weight,
-            (SUM(p.volume) * l.qty / u.factor) AS volume,
+            (SUM(p.weight) * l.qty) AS weight,
+            (SUM(p.volume) * l.qty) AS volume,
             l.discount AS discount,
             SUM((l.price_unit * l.discount * l.qty / 100.0
                 / {self._case_value_or_one('pos.currency_rate')}

--- a/addons/pos_sale/tests/test_pos_sale_report.py
+++ b/addons/pos_sale/tests/test_pos_sale_report.py
@@ -13,6 +13,8 @@ class TestPoSSaleReport(TestPoSCommon):
         super(TestPoSSaleReport, self).setUp()
         self.config = self.basic_config
         self.product0 = self.create_product('Product 0', self.categ_basic, 0.0, 0.0)
+        # Ensure that adding a uom to the product with a factor != 1 does not cause an error in weight and volume calculation
+        self.product0.uom_id = self.env['uom.uom'].search([('name', '=', 'Dozens')], limit=1)
 
     def test_weight_and_volume(self):
         self.product0.product_tmpl_id.weight = 3


### PR DESCRIPTION
… orders to be wrong when the product has a uom with a factor not equal to 1. task-4452892

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
