### PR TITLE
[FIX] sale_mrp: rework test to work without demo data

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -664,6 +664,7 @@ class TestSaleMrpKitBom(TransactionCase):
         Test that the delivered quantity is updated on a sale order line when selling a kit
         through an inter-company transaction.
         """
+        self.env.user.write({'groups_id': [(4, self.env.ref('base.group_multi_company').id)]})
         # Create the kit product and BoM
         kit_product = self._create_product('Kit', 'product', 1)
         component_product = self._create_product('Component', 'product', 1)


### PR DESCRIPTION
The base.group_multi_company group is needed when the test is run without the demo data. Adding this group allows the stock.stock_location_customers location to be added to the stock rule’s search domain. This location is necessary for the stock rule to be found.

Runbot error: 161249

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
