### PR TITLE
[IMP] base, web: Add an Info type exception to support popups

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -35,6 +35,7 @@ export const odooExceptionTitleMap = new Map(
         "odoo.addons.web.controllers.action.MissingActionError": _t("Missing Action"),
         "odoo.exceptions.UserError": _t("Invalid Operation"),
         "odoo.exceptions.ValidationError": _t("Validation Error"),
+        "odoo.exceptions.InfoError": _t("Information"),
         "odoo.exceptions.AccessError": _t("Access Error"),
         "odoo.exceptions.Warning": _t("Warning"),
     })
@@ -226,6 +227,7 @@ registry
     .add("odoo.addons.web.controllers.action.MissingActionError", WarningDialog)
     .add("odoo.exceptions.UserError", WarningDialog)
     .add("odoo.exceptions.ValidationError", WarningDialog)
+    .add("odoo.exceptions.InfoError", WarningDialog)
     .add("odoo.exceptions.RedirectWarning", RedirectWarningDialog)
     .add("odoo.http.SessionExpiredException", SessionExpiredDialog)
     .add("werkzeug.exceptions.Forbidden", SessionExpiredDialog)

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -127,3 +127,11 @@ class ValidationError(UserError):
 
         When you try to create a new user with a login which already exist in the db.
     """
+
+class InfoError(UserError):
+    """A custom popup with a normal title.
+
+    .. admonition:: Example
+
+        If you finish an action and want to display information to the front-end.
+    """


### PR DESCRIPTION
Many times we need to display information to the user in a popup, the standard solution is using a UserError. This works however it means that there is always a title of "Invalid Operation" on the pop-up which can be confusing to end users if nothing bad happened.

This PR introduces a new exception type "InfoError" that can be used to create these popups with a more friendly title "Information".

task-4288536