### PR TITLE
[FIX] sale: corrected calculation of the uninvoiced balance field

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1082,8 +1082,7 @@ class SaleOrderLine(models.Model):
                 uom_qty_to_consider = line.qty_delivered if line.product_id.invoice_policy == 'delivery' else line.product_uom_qty
                 qty_to_invoice = uom_qty_to_consider - line.qty_invoiced_posted
                 unit_price_total = line.price_total / line.product_uom_qty
-                price_reduce = unit_price_total * (1 - (line.discount or 0.0) / 100.0)
-                line.amount_to_invoice = price_reduce * qty_to_invoice
+                line.amount_to_invoice = unit_price_total * qty_to_invoice
             else:
                 line.amount_to_invoice = 0.0
 

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -1160,6 +1160,31 @@ class TestSaleToInvoice(TestSaleCommon):
         self.assertEqual(sol_prod_deliver.amount_to_invoice, 0.0)
         self.assertEqual(sol_prod_deliver.amount_invoiced, sol_prod_deliver.price_total / 2)
 
+    def test_amount_to_invoice_with_discount(self):
+        """ Test the amount_to_invoice field when a discount is applied on the SO line. """
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.company_data['product_order_no'].id,
+                    'product_uom_qty': 5,
+                    'price_unit': 100,
+                    'discount': 10,
+                }),
+            ],
+        })
+
+        so.action_confirm()
+
+        self.assertEqual(so.amount_to_invoice, 450.0, "The amount to invoice should be 450.0")
+
+        invoice = so._create_invoices()
+        invoice.invoice_line_ids.quantity = 3
+        invoice.action_post()
+
+        self.assertEqual(so.amount_to_invoice, 180.0, "The amount to invoice should be 180.0")
+
     def test_invoice_line_name_has_product_name(self):
         """ Testing that when invoicing a sales order, the invoice line name ALWAYS contains the product name. """
         so = self.sale_order


### PR DESCRIPTION
Steps to reproduce:
- Create SO with two products.
- Apply 10% discount to both lines.
- Confirm SO and create an invoice.
- Confirm invoice for only one SOL.
- Go to 'Orders to Invoice' and add uninvoiced-balance field to the view using Studio.
- Check value of the uninvoiced-balance field.

Issue:
- The uninvoiced-balance field is not calculated correctly.

Cause:
- line.price_total already includes the discount, so applying the discount again results in an incorrect calculation.

Fix:
- Remove price_reduce and directly multiply unit_price_total by qty_to_invoice to ensure the correct calculation of amount_to_invoice.

opw-4567563

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
