### PR TITLE
[FIX] sale: discount lines persisting when no product in order line

### DIFF
--- a/doc/cla/individual/rushil-b-patel.md
+++ b/doc/cla/individual/rushil-b-patel.md
@@ -1,0 +1,11 @@
+India, 2025-03-20
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Rushil Patel rushil13579@gmail.com https://github.com/rushil-b-patel


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:
Ensured that the discount line is removed when all products are deleted from the sale order.

## Current behavior before PR:
have a look at [this](https://excalidraw.com/#json=FsEs8xRNq5druyUCVA0yF,8aHZoS4w1p8SWKRPr4WPEQ) 

## Desired behavior after PR is merged:
Discount(Global/Fixed) lines will be deleted if there are no products in the order line



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
