### PR TITLE
[FIX] html_editor: fix traceback when user upload an url

### DIFF
--- a/addons/html_editor/i18n/html_editor.pot
+++ b/addons/html_editor/i18n/html_editor.pot
@@ -638,6 +638,12 @@ msgid "Extend to the farthest side"
 msgstr ""
 
 #. module: html_editor
+#. odoo-python
+#: code:addons/html_editor/controllers/main.py:0
+msgid "Failed to retrieve URL data. Please check the URL and try again later."
+msgstr ""
+
+#. module: html_editor
 #. odoo-javascript
 #: code:addons/html_editor/static/src/others/embedded_components/plugins/file_plugin/file_plugin.js:0
 msgid "File"


### PR DESCRIPTION
Currently, multiple tracebacks are occurring when the tries to add an image through URL.

Types of exceptions occurring currently are ConnectionError and TimeoutError.

https://github.com/odoo/odoo/blob/e0584a789b4bca0ab0d6691642440eec04433332/addons/html_editor/controllers/main.py#L255

We can resolve this issue by showing a user exception and a logger warning(for debugging) instead of a traceback.

sentry-6093300975

