### PR TITLE
[REF] mail, various: do not autosubscribe customers to records

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -369,8 +369,8 @@
             <field name="model_id" ref="calendar.model_calendar_event"/>
             <field name="subject">{{object.name}}: Event update</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted or '') }}</field>
-            <field name="email_to">{{ object._get_attendee_emails() }}</field>
-            <field name="use_default_to" eval="False"/>
+            <field name="email_to" eval="False"/>
+            <field name="use_default_to" eval="True"/>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="description">Used to manually notifiy attendees</field>
             <field name="body_html" type="html">
@@ -463,7 +463,8 @@
             <field name="model_id" ref="calendar.model_calendar_event"/>
             <field name="subject">Deleted event: {{ object.name }}</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted or '') }}</field>
-            <field name="email_to">{{ object._get_attendee_emails() }}</field>
+            <field name="email_to" eval="False"/>
+            <field name="use_default_to" eval="True"/>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="description">Used to manually notify attendees</field>
             <field name="body_html" type="html">

--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -66,9 +66,7 @@ class CalendarAttendee(models.Model):
                 email = [x for x in common_nameval if '@' in x]
                 values['email'] = email[0] if email else ''
                 values['common_name'] = values.get("common_name")
-        attendees = super().create(vals_list)
-        attendees._subscribe_partner()
-        return attendees
+        return super().create(vals_list)
 
     def unlink(self):
         self._unsubscribe_partner()
@@ -76,18 +74,6 @@ class CalendarAttendee(models.Model):
 
     def copy(self, default=None):
         raise UserError(_('You cannot duplicate a calendar attendee.'))
-
-    def _subscribe_partner(self):
-        mapped_followers = defaultdict(lambda: self.env['calendar.event'])
-        for event in self.event_id:
-            partners = (event.attendee_ids & self).partner_id - event.message_partner_ids
-            # current user is automatically added as followers, don't add it twice.
-            partners -= self.env.user.partner_id
-            mapped_followers[partners] |= event
-        for partners, events in mapped_followers.items():
-            if not partners:
-                continue
-            events.message_subscribe(partner_ids=partners.ids)
 
     def _unsubscribe_partner(self):
         for event in self.event_id:

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -881,7 +881,7 @@ class CalendarEvent(models.Model):
                 'default_use_template': bool(template),
                 'default_template_id': template.id,
                 'default_attendee_id': attendee_id,
-                'default_record': self.id,
+                'default_calendar_event_id': self.id,
                 'default_recurrence': recurrence,
                 'model_description': self.with_context(lang=lang),
             }

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1077,15 +1077,6 @@ class CalendarEvent(models.Model):
         """Overridable getter to identify whether to send invitation/cancelation emails."""
         return False
 
-    def _get_attendee_emails(self):
-        """ Get comma-separated attendee email addresses. """
-        self.ensure_one()
-        defaults = self._message_get_default_recipients()[self.id]
-        email_to = defaults['email_to'] or ''
-        if defaults['partner_ids']:
-            email_to += ','.join(self.env['res.partner'].browse(defaults['partner_ids']).mapped('email'))
-        return email_to
-
     def _get_mail_tz(self):
         self.ensure_one()
         return self.event_tz or self.env.user.tz

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
@@ -120,7 +120,7 @@ export class AttendeeCalendarController extends CalendarController {
                 view_mode: "form",
                 name: "Delete Recurring Event",
                 context: {
-                    default_record: record.id,
+                    default_calendar_event_id: record.id,
                     default_attendee_id: record.attendeeId,
                     form_view_ref: 'calendar.calendar_popover_delete_view',
                 },

--- a/addons/calendar/tests/test_attendees.py
+++ b/addons/calendar/tests/test_attendees.py
@@ -37,7 +37,7 @@ class TestEventNotifications(TransactionCase):
         })
         self.assertTrue(event.attendee_ids, "It should have created an attendee")
         self.assertEqual(event.attendee_ids.partner_id, self.partner, "It should be linked to the partner")
-        self.assertIn(self.partner, event.message_follower_ids.partner_id, "He should be follower of the event")
+        self.assertNotIn(self.partner, event.message_follower_ids.partner_id, "He should not be automatically added in followers, no need")
 
     def test_attendee_added_create_with_specific_states(self):
         """

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -623,7 +623,7 @@ class TestEventNotifications(CalendarMailCommon):
 
         # Deleting the next occurrence of the event using the delete wizard.
         wizard = self.env['calendar.popover.delete.wizard'].with_context(
-            form_view_ref='calendar.calendar_popover_delete_view').create({'record': event.id})
+            form_view_ref='calendar.calendar_popover_delete_view').create({'calendar_event_id': event.id})
         form = Form(wizard)
         form.delete = 'next'
         form.save()
@@ -632,7 +632,7 @@ class TestEventNotifications(CalendarMailCommon):
         # Unlink the event and send a cancellation notification.
         event.action_unlink_event()
         wizard = self.env['calendar.popover.delete.wizard'].create({
-            'record': event.id,
+            'calendar_event_id': event.id,
             'subject': 'Event Cancellation',
             'body': 'The event has been cancelled.',
             'recipient_ids': [(6, 0, [user_admin.partner_id.id])],

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -80,7 +80,6 @@ class TestCalendarMail(CalendarMailCommon):
         cls.event.write({
             'partner_ids': [(4, p.id) for p in cls.user_employee_2.partner_id + cls.customers],
         })
-        cls.event.message_unsubscribe(partner_ids=cls.event.message_partner_ids.ids)
 
     def test_assert_initial_values(self):
         self.assertFalse(self.event.message_partner_ids)

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -751,7 +751,7 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
 
         # Step 1: Use the popover delete wizard to delete the next occurrence of the event.
         wizard = self.env['calendar.popover.delete.wizard'].with_context(
-            form_view_ref='calendar.calendar_popover_delete_view').create({'record': event.id})
+            form_view_ref='calendar.calendar_popover_delete_view').create({'calendar_event_id': event.id})
         form = Form(wizard)
         form.delete = 'next'
         form.save()
@@ -761,7 +761,7 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         wizard_delete = self.env['calendar.popover.delete.wizard'].with_context(
             form_view_ref='calendar.view_event_delete_wizard_form',
             default_recurrence='next'
-        ).create({'record': event.id})
+        ).create({'calendar_event_id': event.id})
         form_delete = Form(wizard_delete)
         form_delete.save()
 
@@ -778,7 +778,7 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
 
         # Step 1: Use the popover delete wizard to delete all occurrences of the event.
         wizard = self.env['calendar.popover.delete.wizard'].with_context(
-            form_view_ref='calendar.calendar_popover_delete_view').create({'record': event.id})
+            form_view_ref='calendar.calendar_popover_delete_view').create({'calendar_event_id': event.id})
         form = Form(wizard)
         form.delete = 'all'
         form.save()
@@ -788,7 +788,7 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         wizard_delete = self.env['calendar.popover.delete.wizard'].with_context(
             form_view_ref='calendar.view_event_delete_wizard_form',
             default_recurrence='all'
-        ).create({'record': event.id})
+        ).create({'calendar_event_id': event.id})
         form_delete = Form(wizard_delete)
         form_delete.save()
 

--- a/addons/calendar/wizard/calendar_popover_delete_wizard.py
+++ b/addons/calendar/wizard/calendar_popover_delete_wizard.py
@@ -37,7 +37,7 @@ class CalendarPopoverDeleteWizard(models.TransientModel):
     def _compute_recipient_ids(self):
         """ Compute the recipients by combining the record's partner and message partners. """
         for wizard in self:
-            wizard.recipient_ids = wizard.record.partner_id | wizard.record.message_partner_ids
+            wizard.recipient_ids = wizard.record.partner_id | wizard.record.attendee_ids.partner_id
 
     @api.depends('record')
     def _compute_subject(self):

--- a/addons/calendar/wizard/calendar_popover_delete_wizard.py
+++ b/addons/calendar/wizard/calendar_popover_delete_wizard.py
@@ -8,8 +8,7 @@ class CalendarPopoverDeleteWizard(models.TransientModel):
     _inherit = ['mail.composer.mixin']
     _description = 'Calendar Popover Delete Wizard'
 
-
-    record = fields.Many2one('calendar.event', 'Calendar Event')
+    calendar_event_id = fields.Many2one('calendar.event', 'Calendar Event')
     delete = fields.Selection([('one', 'Delete this event'), ('next', 'Delete this and following events'), ('all', 'Delete all the events')], default='one')
     recipient_ids = fields.Many2many(
         'res.partner',
@@ -20,46 +19,46 @@ class CalendarPopoverDeleteWizard(models.TransientModel):
 
     def close(self):
         # Return if there are multiple attendees or if the organizer's partner_id differs
-        if self.record.attendees_count != 1 or self.record.user_id.partner_id != self.record.partner_ids:
-            return self.record.action_unlink_event(self.record.partner_id.id, self.delete)
-        if not self.record or not self.delete:
+        if self.calendar_event_id.attendees_count != 1 or self.calendar_event_id.user_id.partner_id != self.calendar_event_id.partner_ids:
+            return self.calendar_event_id.action_unlink_event(self.calendar_event_id.partner_id.id, self.delete)
+        if not self.calendar_event_id or not self.delete:
             pass
         elif self.delete == 'one':
-            self.record.unlink()
+            self.calendar_event_id.unlink()
         else:
             switch = {
                 'next': 'future_events',
                 'all': 'all_events'
             }
-            self.record.action_mass_deletion(switch.get(self.delete, ''))
+            self.calendar_event_id.action_mass_deletion(switch.get(self.delete, ''))
 
-    @api.depends('record')
+    @api.depends('calendar_event_id')
     def _compute_recipient_ids(self):
-        """ Compute the recipients by combining the record's partner and message partners. """
+        """ Compute the recipients by combining the record's partner and attendees partners. """
         for wizard in self:
-            wizard.recipient_ids = wizard.record.partner_id | wizard.record.attendee_ids.partner_id
+            wizard.recipient_ids = wizard.calendar_event_id.partner_id | wizard.calendar_event_id.attendee_ids.partner_id
 
-    @api.depends('record')
+    @api.depends('calendar_event_id')
     def _compute_subject(self):
-        """ Compute the subject by rendering the template's subject field based on the record. """
+        """ Compute the subject by rendering the template's subject field based on the event. """
         for wizard in self.filtered('template_id'):
             wizard.subject = wizard.template_id._render_field(
                 'subject',
-                [wizard.record.id],
+                [wizard.calendar_event_id.id],
                 compute_lang=True,
                 options={'post_process': True},
-            )[wizard.record.id]
+            )[wizard.calendar_event_id.id]
 
-    @api.depends('record')
+    @api.depends('calendar_event_id')
     def _compute_body(self):
-        """ Compute the body by rendering the template's body HTML field based on the record. """
+        """ Compute the body by rendering the template's body HTML field based on the event. """
         for wizard in self.filtered('template_id'):
             wizard.body = wizard.template_id._render_field(
                 'body_html',
-                [wizard.record.id],
+                [wizard.calendar_event_id.id],
                 compute_lang=True,
                 options={'post_process': True},
-            )[wizard.record.id]
+            )[wizard.calendar_event_id.id]
 
     def action_delete(self):
         """
@@ -68,7 +67,7 @@ class CalendarPopoverDeleteWizard(models.TransientModel):
         :return: Action URL to redirect to the calendar view
         """
         self.ensure_one()
-        event = self.record
+        event = self.calendar_event_id
         deletion_type = self._context.get('default_recurrence')
 
         # Unlink recurrent events.
@@ -89,6 +88,6 @@ class CalendarPopoverDeleteWizard(models.TransientModel):
     def action_send_mail_and_delete(self):
         """ Send email notification and delete the event based on the specified deletion type. """
         self.env.ref('calendar.calendar_template_delete_event').send_mail(
-            self.record.id, email_layout_xmlid='mail.mail_notification_light', force_send=True
+            self.calendar_event_id.id, email_layout_xmlid='mail.mail_notification_light', force_send=True
         )
         return self.action_delete()

--- a/addons/calendar/wizard/calendar_popover_delete_wizard.xml
+++ b/addons/calendar/wizard/calendar_popover_delete_wizard.xml
@@ -19,7 +19,7 @@
         <field name="model">calendar.popover.delete.wizard</field>
         <field name="arch" type="xml">
             <form string="Delete Event">
-                <field name="record" invisible="1"/>
+                <field name="calendar_event_id" invisible="1"/>
                 <div col="2" class="alert alert-warning" role="alert">
                     <span>Are you sure you want to delete this event? <br/></span>
                 </div>

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
 import re
 
-from collections import defaultdict
 from pytz import timezone, UTC
 from datetime import datetime, time
 from random import choice
@@ -625,9 +623,6 @@ class HrEmployee(models.Model):
                         if vals['work_contact_id']:
                             bank_account.partner_id = vals['work_contact_id']
             self.message_unsubscribe(self.work_contact_id.ids)
-            if vals['work_contact_id']:
-                # TDE FIXME: should be suggested, to check in master
-                self._message_subscribe([vals['work_contact_id']])
         if vals.get('user_id'):
             # Update the profile pictures with user, except if provided
             user = self.env['res.users'].browse(vals['user_id'])

--- a/addons/hr/tests/__init__.py
+++ b/addons/hr/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_hr_employee
 from . import test_channel
 from . import test_self_user_access
 from . import test_mail_activity_plan
+from . import test_mail_features
 from . import test_multi_company
 from . import test_resource
 from . import test_ui

--- a/addons/hr/tests/common.py
+++ b/addons/hr/tests/common.py
@@ -9,6 +9,12 @@ class TestHrCommon(common.TransactionCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestHrCommon, cls).setUpClass()
+        super().setUpClass()
 
-        cls.res_users_hr_officer = mail_new_test_user(cls.env, login='hro', groups='base.group_user,hr.group_hr_user', name='HR Officer', email='hro@example.com')
+        cls.res_users_hr_officer = mail_new_test_user(
+            cls.env,
+            email='hro@example.com',
+            login='hro',
+            groups='base.group_user,hr.group_hr_user,base.group_partner_manager',
+            name='HR Officer',
+        )

--- a/addons/hr/tests/test_mail_features.py
+++ b/addons/hr/tests/test_mail_features.py
@@ -1,0 +1,69 @@
+from odoo.addons.hr.tests.common import TestHrCommon
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.tests.common import tagged
+
+
+@tagged('post_install', '-at_install', 'mail_flow')
+class TestHrEmployeeMail(TestHrCommon, MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.test_template_employee = cls.env['mail.template'].with_user(cls.user_admin).create({
+            'auto_delete': True,
+            'body_html': '<p>Hello <t t-out="object.name"/></p>',
+            'email_from': '{{ object.user_id.email_formatted or user.email_formatted or "" }}',
+            'model_id': cls.env['ir.model']._get_id('hr.employee'),
+            'name': 'Test Hr Template',
+            'subject': 'Test {{ object.name }}',
+            'use_default_to': True,
+        })
+        # note: email and phone are user related fields
+        cls.test_employee = cls.env['hr.employee'].create([
+            {
+                'company_id': cls.company_admin.id,
+                'country_id': cls.env.ref('base.be').id,
+                'name': 'QuickEmployee',
+                'work_email': 'quick.employee@test.example.com',
+                'work_phone': '+32455001122',
+            },
+        ])
+
+    def test_assert_initial_values(self):
+        self.assertTrue(self.test_employee.work_contact_id)
+        self.assertFalse(self.test_employee.message_partner_ids)
+        self.assertFalse(self.test_employee.email)
+        self.assertFalse(self.test_employee.phone)
+        self.assertFalse(self.test_employee.user_id)
+
+    def test_employee_get_default_recipients(self):
+        employee = self.test_employee.with_user(self.res_users_hr_officer)
+        defaults = employee._message_get_default_recipients()
+        self.assertDictEqual(
+            defaults[employee.id],
+            {'email_cc': '', 'email_to': '', 'partner_ids': self.test_employee.work_contact_id.ids},
+        )
+
+    def test_employee_get_suggested_recipients(self):
+        employee = self.test_employee.with_user(self.res_users_hr_officer)
+        suggested = employee._message_get_suggested_recipients()
+        self.assertListEqual(suggested, [
+            {
+                'create_values': {},
+                'email': self.test_employee.work_contact_id.email_normalized,
+                'name': self.test_employee.work_contact_id.name,
+                'partner_id': self.test_employee.work_contact_id.id,
+            },
+        ])
+
+    def test_employee_template(self):
+        employee, template = self.test_employee.with_user(self.res_users_hr_officer), self.test_template_employee.with_user(self.res_users_hr_officer)
+        message = employee.message_post_with_source(
+            template,
+            message_type='comment',
+            subtype_id=self.env.ref('mail.mt_comment').id,
+        )
+        self.assertEqual(
+            message.notified_partner_ids, self.test_employee.work_contact_id,
+            'Matches suggested recipients',
+        )


### PR DESCRIPTION
Since [1] customers are given as default or suggested recipients for
communications. Both chatter and templates proposes them by default. Followers
should now be mostly be internal users that want to receive news from a record
while customers should be actively displayed and chosen.

In this PR calendar mainly is updated. We know correctly use attendees when
mailing events instead or relying always on followers and forced subscription.
See also [2] and [3] that already worked on that specific issue.

Task-4655022

[1] odoo/odoo#185240
[2] odoo/odoo#201514
[3] odoo/odoo#204326
