### PR TITLE
[FIX] point_of_sale: set default name value for offline orders

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -26,6 +26,7 @@ export class PosOrder extends Base {
 
         // Data present in python model
         this.date_order = vals.date_order || serializeDateTime(luxon.DateTime.now());
+        this.name = vals.name || "/";
         this.nb_print = vals.nb_print || 0;
         this.to_invoice = vals.to_invoice || false;
         this.shipping_date = vals.shipping_date || false;


### PR DESCRIPTION
Currently, an exception is generated in the log when the users create a POS order as follows

- Install module pos_restaurant.
- Open `POS Restaurant`.
- Add some products to the order go to `Payments`, and select card(Pick any table)
- Open Inspect, go to the Network tab and enable Offline Mode.
- Click Validate, go to Orders, and click Load Order.
- Add Products to the Orders and click on Order.
- In the Network tab, enable No Throttling and click on Orders again.
- Do the above step one more time `on the same table`.

This error occurs when the system tries to fetch the order reference name in 
offline mode, it receives False instead of the default value '/', because the 
name field is initialized in Python at [1] as fields.Char(default='/').

To resolve this, the commit initializes the `name` on the server side to ensure it defaults to "/".


Ref: https://github.com/odoo/odoo/pull/202525

Link [1]: https://github.com/odoo/odoo/blob/2aa8c180b33ed17d35b8fadc3ef4ad267e6c523d/addons/point_of_sale/models/pos_order.py#L254

Sentry - 6365371665

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
