### PR TITLE
[FIX] website: show success message on form send

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -24,6 +24,10 @@ const { DateTime } = luxon;
 
 export class Form extends Interaction {
     static selector = ".s_website_form form, form.s_website_form"; // !compatibility
+    dynamicSelectors = {
+        ...this.dynamicSelectors,
+        _endMessage: () => this.el.parentNode.querySelector(".s_website_form_end_message"),
+    };
     dynamicContent = {
         ".s_website_form_send, .o_website_form_send": { "t-on-click.prevent": this.send }, // !compatibility
         _root: {
@@ -32,7 +36,7 @@ export class Form extends Interaction {
                 "d-none": this.isHidden,
             })
         },
-        ".s_website_form_end_message": {
+        _endMessage: {
             "t-att-class": () => ({
                 "d-none": !this.isHidden,
             })
@@ -435,7 +439,7 @@ export class Form extends Interaction {
                             // Prevent double-clicking on the send button and
                             // add a upload loading effect (delay before success
                             // message)
-                            await delay(400);
+                            await this.waitFor(delay(400));
 
                             this.isHidden = true;
                             break;


### PR DESCRIPTION
Steps to reproduce:
1. Drop website form snippet
2. Change the success method to `Show message`
3. Submit the form

Issue 1: Form is not being submited on 1st click
Issue 2: Success message is not appear.

With the conversion of `publicWidget` into `Interaction`, the success
message was not displayed correctly, and the form required multiple
clicks to submit.

The issue occurred because the selector for the success message in
`dynamicContent` was outside the scope of the Form interaction,
preventing the state from updating properly.

This commit ensures that the success message is correctly displayed
form submission.

task-4663558
