### PR TITLE
18.0 fix donation button preview on drag bvr

### DIFF
--- a/addons/website_payment/static/src/snippets/s_donation/000.scss
+++ b/addons/website_payment/static/src/snippets/s_donation/000.scss
@@ -53,4 +53,14 @@
             }
         }
     }
+
+    // TODO: Remove in Master. It is necessary to hide the prefilled button when
+    // previewing the donation button while dragging it onto the page from the
+    // snippet menu. In the case where "display options" is not True, they are
+    // removed in "start()" anyway.
+    &:not([data-display-options="true"]) {
+        .s_donation_prefilled_buttons {
+            display: none;
+        }
+    }
 }


### PR DESCRIPTION
**[FIX] website_payment: fix donation button preview on drag**

Steps to reproduce:

- Enter edit mode.
- If not already installed, click the "Donation Button" in the snippet
menu to install the "website_payment" app.
- Start dragging the "Donation Button" without dropping it onto the page
to display its preview.
- Bug: Prefilled buttons are displayed in the preview when they
shouldn't be.

This bug was introduced by commit [1], where the prefilled buttons were
added to the "s_donation" snippet template so that they would be visible
in the "s_donation" preview in the snippets dialog. Unfortunately, this
change also made them visible for the inner "Donation Button" snippet,
which shouldn't be the case.

[1]: https://github.com/odoo/odoo/commit/edf81c13d8f2f6d29a77d68cbfa0dc9216da3c2a