### PR TITLE
[IMP] base_geolocalize: add reverse geolocation for openstreetmap

### DIFF
--- a/addons/base_geolocalize/models/base_geocoder.py
+++ b/addons/base_geolocalize/models/base_geocoder.py
@@ -3,8 +3,9 @@
 import requests
 import logging
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, modules, tools, _
 from odoo.exceptions import UserError
+from odoo.http import request
 
 
 _logger = logging.getLogger(__name__)
@@ -99,6 +100,40 @@ class BaseGeocoder(models.AbstractModel):
         return float(geo['lat']), float(geo['lon'])
 
     @api.model
+    def _call_openstreetmap_reverse(self, lat, lon):
+        """
+        Use Openstreemap Nominatim service to retrieve location from latitude and longitude
+        :param lat: Latitude
+        :param lon: Longitude
+        :return: Address string or None if not found
+
+        """
+        if not (lat and lon):
+            _logger.info("invalid latitude or longitude given")
+            return None
+        if tools.config['test_enable'] or modules.module.current_test:
+            raise UserError(_("OpenStreetMap calls disabled in testing environment."))
+        try:
+            headers = {"User-Agent": "Odoo (http://www.odoo.com/contactus)"}
+            response = requests.get(
+                "https://nominatim.openstreetmap.org/reverse",
+                headers=headers,
+                params={"format": "json", "lat": lat, "lon": lon},
+                timeout=10,
+            )
+            _logger.info("openstreetmap nominatim service called")
+            if response.status_code != 200:
+                _logger.warning(
+                    "Request to openstreetmap failed.\nCode: %s\nContent: %s",
+                    response.status_code,
+                    response.content,
+                )
+            result = response.json()
+        except Exception as e:  # noqa: BLE001
+            self._raise_query_error(e)
+        return result
+
+    @api.model
     def _call_googlemap(self, addr, **kw):
         """ Use google maps API. It won't work without a valid API key.
         :return: (latitude, longitude) or None if not found
@@ -157,3 +192,28 @@ class BaseGeocoder(models.AbstractModel):
 
     def _raise_query_error(self, error):
         raise UserError(_('Error with geolocation server: %s', error))
+
+    def _get_localisation(self, latitude, longitude):
+        # try to get city and/or country from request.geoip first
+        # if not possible, get them from latitude and longitude
+        city = request.geoip.city.name
+        country_code = request.geoip.country_code
+        postcode = False
+        if not (city and country_code):
+            # for now, we use openstreetmap, if needed, we will add a setting like "partner geolocation" that let the
+            # user decide wich provider to use to localise the partner.
+            result = self._call_openstreetmap_reverse(latitude, longitude)
+            if result and (address := result.get("address")):
+                country_code = address.get("country_code")
+                city = address.get("city_district") or address.get("town") or address.get("village") or address.get("city")
+                postcode = address.get("postcode")
+
+        country = self.env["res.country"].search([("code", "=", country_code.upper())], limit=1) if country_code else False
+
+        res = postcode or ""
+        if city:
+            res += f" {city}" if res else city
+        if country:
+            res += f", {country.name}" if res else country.name
+
+        return res or _("Unknown")

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -164,7 +164,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     content: 'Convert the todo to a task',
     run: "click",
 }, {
-    trigger: ".o_project_task_form_view .breadcrumb-item:last-child",
+    trigger: ".o_form_view .breadcrumb-item:last-child",
     content: markup("Let's go back to the <b>kanban view</b> to have an overview of tasks linked to project chosen."),
     run: "click",
 }, {

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -1051,7 +1051,7 @@ stepUtils.autoExpandMoreButtons(true),
     run: "click",
 },
 {
-    trigger: '.o_project_task_form_view div.o_notebook_headers',
+    trigger: '.o_form_view div.o_notebook_headers',
 },
 {
     trigger: 'a.nav-link:contains(Timesheets)',


### PR DESCRIPTION
[IMP] base_geolocalize: add reverse geolocation for openstreetmap
[FIX] project_todo: change tour trigger

In this commit:
- _get_localisation to try to get city and/or country from request.geoip first
if not possible, get them from openstreetmap from latitude and longitude.
- The trigger o_project_task_form_view is changed to o_form_view, because
if the form view is inherited and the js_class is changed in another module, the
class will change dynamically, example: o_fsm_project_task_form_view
trigger changed to o_form_view is fixed and doesn't change.

related Prs:
- enterprise: https://github.com/odoo/enterprise/pull/81889

task-4546189