### PR TITLE
[IMP] l10n_id: show DPP value

### DIFF
--- a/addons/l10n_id/__init__.py
+++ b/addons/l10n_id/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, SUPERUSER_ID
+from . import models
 
 def load_translations(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})

--- a/addons/l10n_id/__manifest__.py
+++ b/addons/l10n_id/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Indonesian - Accounting',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 This is the latest Indonesian Odoo localisation necessary to run Odoo accounting for SMEs with:

--- a/addons/l10n_id/data/account_tax_group.xml
+++ b/addons/l10n_id/data/account_tax_group.xml
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
     <record id="l10n_id_tax_group_luxury_goods" model="account.tax.group">
-        <field name="name">Luxury Good Taxes (ID)</field>
+        <field name="name">Luxury Good Taxes</field>
         <field name="sequence">1</field>
+        <field name="country_id" ref="base.id"/>
+    </record>
+    <record id="l10n_id_tax_group_non_luxury_goods" model="account.tax.group">
+        <field name="name">Non-luxury Good Taxes</field>
+        <field name="sequence">2</field>
+        <field name="country_id" ref="base.id"/>
+    </record>
+    <record id="l10n_id_tax_group_0" model="account.tax.group">
+        <field name="name">Zero-rated Taxes</field>
+        <field name="sequence">3</field>
+        <field name="country_id" ref="base.id"/>
+    </record>
+    <record id="l10n_id_tax_group_exempt" model="account.tax.group">
+        <field name="name">Tax Exempted</field>
+        <field name="sequence">4</field>
+        <field name="country_id" ref="base.id"/>
     </record>
 </odoo>

--- a/addons/l10n_id/data/account_tax_template_data.xml
+++ b/addons/l10n_id/data/account_tax_template_data.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
     <record id="ppn_tag" model="account.account.tag">
         <field name="name">PPN - 08</field>
         <field name="applicability">taxes</field>
         <field name="country_id" ref="base.id"/>
     </record>
     <record id="tax_ST1" model="account.tax.template">
-        <field name="description">11%</field>
+        <field name="description">12%</field>
+        <field name="tax_group_id" ref="l10n_id.l10n_id_tax_group_non_luxury_goods"/>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">sale</field>
         <field name="name">11%</field>
@@ -34,8 +35,9 @@
         ]"/>
     </record>
     <record id="tax_PT1" model="account.tax.template">
-        <field name="description">11%</field>
+        <field name="description">12%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
+        <field name="tax_group_id" ref="l10n_id.l10n_id_tax_group_non_luxury_goods"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">11%</field>
         <field name="amount_type">percent</field>
@@ -64,6 +66,7 @@
     <record id="tax_ST0" model="account.tax.template">
         <field name="description">0%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
+        <field name="tax_group_id" ref="l10n_id.l10n_id_tax_group_0"/>
         <field name="type_tax_use">sale</field>
         <field name="name">0%</field>
         <field name="amount_type">percent</field>
@@ -86,6 +89,7 @@
     <record id="tax_ST2" model="account.tax.template">
         <field name="description">0%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
+        <field name="tax_group_id" ref="l10n_id.l10n_id_tax_group_exempt"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Exempt</field>
         <field name="amount_type">percent</field>
@@ -108,6 +112,7 @@
     <record id="tax_PT2" model="account.tax.template">
         <field name="description">0%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
+        <field name="tax_group_id" ref="l10n_id.l10n_id_tax_group_exempt"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Exempt</field>
         <field name="amount_type">percent</field>
@@ -130,6 +135,7 @@
     <record id="tax_PT0" model="account.tax.template">
         <field name="description">0%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
+        <field name="tax_group_id" ref="l10n_id.l10n_id_tax_group_0"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">0%</field>
         <field name="amount_type">percent</field>
@@ -152,6 +158,7 @@
     <record id="tax_ST3" model="account.tax.template">
         <field name="description">12%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
+        <field name="tax_group_id" ref="l10n_id.l10n_id_tax_group_luxury_goods"/>
         <field name="type_tax_use">sale</field>
         <field name="name">12%</field>
         <field name="amount_type">percent</field>
@@ -180,6 +187,7 @@
     <record id="tax_PT3" model="account.tax.template">
         <field name="description">12%</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
+        <field name="tax_group_id" ref="l10n_id.l10n_id_tax_group_luxury_goods"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">12%</field>
         <field name="amount_type">percent</field>

--- a/addons/l10n_id/i18n_extra/id.po
+++ b/addons/l10n_id/i18n_extra/id.po
@@ -827,3 +827,23 @@ msgstr "PDAM"
 #: model:account.account.template,name:l10n_id.a_6_110007
 msgid "Work Uniform"
 msgstr "Pakaian Kerja"
+
+#. module: l10n_id
+#: model:account.tax.group,name:l10n_id.l10n_id_tax_group_luxury_goods
+msgid "Luxury Good Taxes"
+msgstr "Pajak Barang Mewah"
+
+#. module: l10n_id
+#: model:account.tax.group,name:l10n_id.l10n_id_tax_group_non_luxury_goods
+msgid "Non-luxury Good Taxes"
+msgstr "Pajak Barang"
+
+#. module: l10n_id
+#: model:account.tax.group,name:l10n_id.l10n_id_tax_group_exempt
+msgid "Tax Exempted"
+msgstr "Bebas Pajak"
+
+#. module: l10n_id
+#: model:account.tax.group,name:l10n_id.l10n_id_tax_group_0
+msgid "Zero-rated Taxes"
+msgstr "Pajak Nol"

--- a/addons/l10n_id/i18n_extra/l10n_id.pot
+++ b/addons/l10n_id/i18n_extra/l10n_id.pot
@@ -826,3 +826,23 @@ msgstr ""
 #: model:account.account.template,name:l10n_id.a_6_110007
 msgid "Work Uniform"
 msgstr ""
+
+#. module: l10n_id
+#: model:account.tax.group,name:l10n_id.l10n_id_tax_group_luxury_goods
+msgid "Luxury Good Taxes"
+msgstr ""
+
+#. module: l10n_id
+#: model:account.tax.group,name:l10n_id.l10n_id_tax_group_non_luxury_goods
+msgid "Non-luxury Good Taxes"
+msgstr ""
+
+#. module: l10n_id
+#: model:account.tax.group,name:l10n_id.l10n_id_tax_group_exempt
+msgid "Tax Exempted"
+msgstr ""
+
+#. module: l10n_id
+#: model:account.tax.group,name:l10n_id.l10n_id_tax_group_0
+msgid "Zero-rated Taxes"
+msgstr ""

--- a/addons/l10n_id/migrations/1.2/end-migrate_update_taxes.py
+++ b/addons/l10n_id/migrations/1.2/end-migrate_update_taxes.py
@@ -1,0 +1,43 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    # Tax groups to create in format of [(xml_id, name)]
+    tax_group_info = [
+        ("l10n_id_tax_group_non_luxury_goods", "Non-luxury Good Taxes"),
+        ("l10n_id_tax_group_0", "Zero-rated Taxes"),
+        ("l10n_id_tax_group_exempt", "Tax Exempted"),
+    ]
+
+    for xmlid, name in tax_group_info:
+        if not env.ref(f"l10n_id.{xmlid}", raise_if_not_found=False):
+            env['ir.model.data'].create({
+                "name": xmlid,
+                "module": "l10n_id",
+                "model": "account.tax.group",
+                "res_id": env['account.tax.group'].create({'name': name}).id,
+                'noupdate': True
+            })
+
+    # For all taxes linked to the tax_ST1 and tax_PT1, set the tax group to non-luxury goods
+    # if no changes to amount and tax group yet
+    tax_group_id = env.ref("l10n_id.l10n_id_tax_group_non_luxury_goods")
+    default_group = env['account.tax']._default_tax_group()
+    id_chart = env.ref("l10n_id.l10n_id_chart", raise_if_not_found=False)
+
+    if not id_chart:
+        return
+
+    companies = env['res.company'].search([('chart_template_id', 'child_of', id_chart.id)])
+    for company in companies:
+        tax_xml_ids = [
+            f"l10n_id.{company.id}_tax_ST1",
+            f"l10n_id.{company.id}_tax_PT1",
+        ]
+        for tax_xml_id in tax_xml_ids:
+            tax = env.ref(tax_xml_id, raise_if_not_found=False)
+            if tax and tax.amount == 11.0 and tax.tax_group_id == default_group:
+                tax.update({"tax_group_id": tax_group_id.id, "description": "12%"})

--- a/addons/l10n_id/models/__init__.py
+++ b/addons/l10n_id/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move

--- a/addons/l10n_id/models/account_move.py
+++ b/addons/l10n_id/models/account_move.py
@@ -1,0 +1,36 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+from odoo.tools.misc import formatLang
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _compute_tax_totals(self):
+        """ OVERRIDE
+
+        For invoices based on ID company as of January 2025, there is a separate tax base computation for nun-luxury goods.
+        Tax base is supposed to be 11/12 of original while tax amount is increased from 11% to 12% hence effectively
+        maintaining 11% tax amount.
+
+        We change tax totals section to display adjusted base amount on invoice PDF for special non-luxury goods tax group.
+        """
+        super()._compute_tax_totals()
+        non_luxury_tax_group = self.env.ref('l10n_id.l10n_id_tax_group_non_luxury_goods', raise_if_not_found=False)
+        if not non_luxury_tax_group:
+            return
+        for move in self.filtered(lambda m: m.is_sale_document()):
+            if move.invoice_date and move.invoice_date < fields.Date.to_date('2025-01-01'):
+                continue
+            for subtotal_group in move.tax_totals['groups_by_subtotal'].values():
+                for group in subtotal_group:
+                    if group['tax_group_id'] == non_luxury_tax_group.id:
+                        dpp = group['tax_group_base_amount'] * (11 / 12)
+                        # adding (DPP) information to make it clearer for users why the number is different from the Untaxed Amount
+                        group.update({
+                            'tax_group_base_amount': dpp,
+                            'formatted_tax_group_base_amount': formatLang(self.env, dpp, currency_obj=move.currency_id),
+                            'tax_group_name': group['tax_group_name'] + ' (on DPP)',
+                        })
+                        move.tax_totals['display_tax_base'] = True

--- a/addons/l10n_id_efaktur_coretax/models/account_move.py
+++ b/addons/l10n_id_efaktur_coretax/models/account_move.py
@@ -2,7 +2,6 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError, RedirectWarning
-from odoo.tools import cleanup_xml_node
 
 COUNTRY_CODE_MAP = {
     "BD": "BGD", "BE": "BEL", "BF": "BFA", "BG": "BGR", "BA": "BIH", "BB": "BRB", "WF": "WLF", "BL": "BLM", "BM": "BMU",

--- a/addons/l10n_id_efaktur_coretax/tests/test_l10n_id_efaktur_coretax.py
+++ b/addons/l10n_id_efaktur_coretax/tests/test_l10n_id_efaktur_coretax.py
@@ -531,7 +531,6 @@ class TestEfakturCoretax(AccountTestInvoicingCommon):
             </xpath>
             '''
         )
-
         self.assertXmlTreeEqual(result_tree, expected_tree)
 
     def test_invoice_user_main_contact(self):


### PR DESCRIPTION
Due to government regulations, tax base amount is multiplied by factor of 11/12 and tax value of 12% resulting to essentially 11% of tax. We need to display this DPP value both on invoice form view and reports

4485693

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
