### PR TITLE
[IMP] web: calendar: align day number in month view

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -442,6 +442,7 @@
                         aspect-ratio: 1/1;
                         border-radius: 50%;
                         background: var(--o-cw-bg, none);
+                        text-align: center;
                     }
 
                     &.fc-day-today {


### PR DESCRIPTION
This commits follows the changes made into commit odoo/odoo@00f1d2215825fb3f2af4f53c815d087dac4064cc to center day number and the red circle in month view.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
