### PR TITLE
[IMP] tests: block unknown http requests during tests

### DIFF
--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -77,7 +77,6 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         Ensure that an invoice with an early discount payment term
         and no invoice date can be previewed or printed.
         """
-        self.registry_enter_test_mode()
         out_invoice = self.env['account.move'].create([{
             'move_type': 'out_invoice',
             'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
@@ -89,12 +88,14 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         # Assert that the invoice date is not set
         self.assertEqual(out_invoice.invoice_date, False)
 
-        report = self.env['ir.actions.report'].with_context(force_report_rendering=True)._render_qweb_pdf('account.account_invoices', res_ids=out_invoice.id)
+        with self.allow_pdf_render():
+            report = self.env['ir.actions.report'].with_context(force_report_rendering=True)._render_qweb_pdf('account.account_invoices', res_ids=out_invoice.id)
         self.assertTrue(report)
 
         #Test for invoices with multiple due dates and no early discount
         out_invoice.invoice_payment_term_id = self.pay_30_percents_now_balance_60_days
-        new_report = self.env['ir.actions.report']._render_qweb_pdf('account.account_invoices', res_ids=out_invoice.id)
+        with self.allow_pdf_render():
+            new_report = self.env['ir.actions.report']._render_qweb_pdf('account.account_invoices', res_ids=out_invoice.id)
         self.assertTrue(new_report)
 
     # ========================== Tests Taxes Amounts =============================

--- a/addons/account/tests/test_portal_attachment.py
+++ b/addons/account/tests/test_portal_attachment.py
@@ -100,7 +100,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         self.assertEqual(res_image.content, b'<svg></svg>')
 
         # Test attachment can't be removed without valid token
-        res = self.opener.post(
+        res = self.url_open(
             url=f'{self.invoice_base_url}/mail/attachment/delete',
             json={
                 'params': {
@@ -114,7 +114,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         self.assertIn("The requested URL was not found on the server.", res.text)
 
         # Test attachment can be removed with token if "pending" state
-        res = self.opener.post(
+        res = self.url_open(
             url=f'{self.invoice_base_url}/mail/attachment/delete',
             json={
                 'params': {
@@ -131,7 +131,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
             'name': 'an attachment',
             'access_token': self.env['ir.attachment']._generate_access_token(),
         })
-        res = self.opener.post(
+        res = self.url_open(
             url=f'{self.invoice_base_url}/mail/attachment/delete',
             json={
                 'params': {
@@ -153,7 +153,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         message = self.env['mail.message'].create({
             'attachment_ids': [(6, 0, attachment.ids)],
         })
-        res = self.opener.post(
+        res = self.url_open(
             url=f'{self.invoice_base_url}/mail/attachment/delete',
             json={
                 'params': {
@@ -173,7 +173,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
             'res_model': 'mail.compose.message',
             'res_id': 0,
         })
-        res = self.opener.post(
+        res = self.url_open(
             url=f'{self.invoice_base_url}/mail/message/post',
             json={
                 'params': {
@@ -191,7 +191,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         self.assertIn("The attachment %s does not exist or you do not have the rights to access it." % attachment.id, res.text)
 
         # Test attachment can't be associated if no main document token
-        res = self.opener.post(
+        res = self.url_open(
             url=f'{self.invoice_base_url}/mail/message/post',
             json={
                 'params': {
@@ -210,7 +210,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         self.assertFalse(
             self.out_invoice.message_ids.filtered(lambda m: m.author_id == self.partner_a))
         attachment.write({'res_model': 'model'})
-        res = self.opener.post(
+        res = self.url_open(
             url=f'{self.invoice_base_url}/mail/message/post',
             json={
                 'params': {
@@ -232,7 +232,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
 
         # Test attachment can't be associated if not correct user
         attachment.write({'res_model': 'mail.compose.message'})
-        res = self.opener.post(
+        res = self.url_open(
             url=f'{self.invoice_base_url}/mail/message/post',
             json={
                 'params': {
@@ -270,7 +270,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         create_res = json.loads(res.content.decode('utf-8'))['data']['ir.attachment'][0]
         self.assertEqual(create_res['name'], "final attachment")
 
-        res = self.opener.post(
+        res = self.url_open(
             url=f'{self.invoice_base_url}/mail/message/post',
             json={
                 'params': {

--- a/addons/auth_ldap/tests/test_auth_ldap.py
+++ b/addons/auth_ldap/tests/test_auth_ldap.py
@@ -62,7 +62,7 @@ class TestAuthLDAP(BaseCase):
 
         with patch.object(self.registry["res.company.ldap"], "_get_ldap_dicts", _get_ldap_dicts),\
             patch.object(self.registry["res.company.ldap"], "_authenticate", _authenticate):
-            res = self.opener.post(
+            res = self.url_open(
                 f"{self.base_url()}/web/login",
                 data={
                     "login": "test_ldap_user",

--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -32,7 +32,6 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         self.assertIsNotNone(result)
 
     def test_websocket_peek_session_expired_login(self):
-        session = self.authenticate(None, None)
         # first rpc should be fine
         self.make_jsonrpc_request('/websocket/peek_notifications', {
             'channels': [],
@@ -42,16 +41,15 @@ class TestWebsocketController(HttpCaseWithUserDemo):
 
         self.authenticate('admin', 'admin')
         # rpc with outdated session should lead to error.
-        headers = {'Cookie': f'session_id={session.sid};'}
         with self.assertRaises(JsonRpcException, msg='odoo.http.SessionExpiredException'):
             self.make_jsonrpc_request('/websocket/peek_notifications', {
                 'channels': [],
                 'last': 0,
                 'is_first_poll': False,
-            }, headers=headers)
+            })
 
     def test_websocket_peek_session_expired_logout(self):
-        session = self.authenticate('demo', 'demo')
+        self.authenticate('demo', 'demo')
         # first rpc should be fine
         self.make_jsonrpc_request('/websocket/peek_notifications', {
             'channels': [],
@@ -60,10 +58,9 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         })
         self.url_open('/web/session/logout')
         # rpc with outdated session should lead to error.
-        headers = {'Cookie': f'session_id={session.sid};'}
         with self.assertRaises(JsonRpcException, msg='odoo.http.SessionExpiredException'):
             self.make_jsonrpc_request('/websocket/peek_notifications', {
                 'channels': [],
                 'last': 0,
                 'is_first_poll': False,
-            }, headers=headers)
+            })

--- a/addons/digest/tests/test_digest.py
+++ b/addons/digest/tests/test_digest.py
@@ -326,7 +326,7 @@ class TestUnsubscribe(MailCommon, HttpCaseWithUserDemo):
             headers = literal_eval(mail.headers)
             unsubscribe_url = headers.get("List-Unsubscribe", "").strip("<>")
             self.assertTrue(unsubscribe_url)
-            self.opener.post(unsubscribe_url)
+            self.url_open(unsubscribe_url, method='POST')
 
         self.assertFalse(digest.user_ids, "Users should have been unsubscribed from digest")
 
@@ -387,8 +387,4 @@ class TestUnsubscribe(MailCommon, HttpCaseWithUserDemo):
             unsubscribe_route = "unsubscribe"
 
         url = url_join(self.base_url, f'digest/{self.test_digest.id}/{unsubscribe_route}?{url_encode(url_params)}')
-        if method == 'GET':
-            return self.opener.get(url, timeout=10, allow_redirects=True)
-        if method == 'POST':
-            return self.opener.post(url, timeout=10, allow_redirects=True)
-        raise Exception(f'Invalid method {method}')
+        return self.url_open(url, timeout=10, allow_redirects=True, method=method)

--- a/addons/im_livechat/tests/test_cors_livechat.py
+++ b/addons/im_livechat/tests/test_cors_livechat.py
@@ -43,7 +43,7 @@ class TestCorsLivechat(HttpCase):
                 "channel_id": self.livechat_channel.id,
                 "persisted": True,
             },
-            headers={"Cookie": f"{guest._cookie_name}={guest.id}{guest._cookie_separator}{guest.access_token};"},
+            cookies={guest._cookie_name: f'{guest.id}{guest._cookie_separator}{guest.access_token}'}
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         channel_guest = channel.channel_member_ids.filtered(lambda member: member.guest_id).guest_id

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -58,7 +58,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
         self.assertEqual(user.livechat_username, 'New username')
 
     def test_chatbot_message_format(self):
-        session = self.authenticate(self.users[0].login, self.password)
+        self.authenticate(self.users[0].login, self.password)
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {
@@ -66,9 +66,6 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                 "channel_id": self.livechat_channel.id,
                 "chatbot_script_id": self.chatbot_script.id,
                 "persisted": True,
-            },
-            headers={
-                "Cookie": f"session_id={session.sid};",
             },
         )
         discuss_channel = self.env['discuss.channel'].browse(data["store_data"]["discuss.channel"][0]["id"])

--- a/addons/link_tracker/tests/test_mail_render_mixin.py
+++ b/addons/link_tracker/tests/test_mail_render_mixin.py
@@ -44,7 +44,8 @@ class TestMailRenderMixin(common.HttpCase):
             '<a >Without href</a>'
         ]
 
-        self.env["mail.render.mixin"]._shorten_links("".join(test_links), {})
+        with self.allow_requests(all_requests=True):  # Creating link will query url to infer title
+            self.env["mail.render.mixin"]._shorten_links("".join(test_links), {})
 
         trackers_to_find = [
             [("url", "=", "https://gitlab.com"), ("label", "=", "test_label")],
@@ -177,7 +178,8 @@ And a 7th: <a href="{self.base_url}/r/(\w+)">Here2</a><br/>
 And a last, more complex: <a href="{self.base_url}/r/(\w+)">There!</a>
 </p>"""
         )
-        new_content = self.env["mail.render.mixin"]._shorten_links(content, {})
+        with self.allow_requests(all_requests=True):  # shorten_links queries the url
+            new_content = self.env["mail.render.mixin"]._shorten_links(content, {})
 
         self.assertRegex(new_content, expected_pattern)
         matches = expected_pattern.search(new_content).groups()
@@ -235,7 +237,8 @@ A third: {self.base_url}/r/(\w+)
 A forth: {self.base_url}/r/(\w+)
 And a last, with question mark: {self.base_url}/r/(\w+)"""
         )
-        new_content = self.env["mail.render.mixin"]._shorten_links_text(content, {})
+        with self.allow_requests(all_requests=True):  # Creating link will query url to infer title
+            new_content = self.env["mail.render.mixin"]._shorten_links_text(content, {})
 
         self.assertRegex(new_content, expected_pattern)
         matches = expected_pattern.search(new_content).groups()

--- a/addons/mail/tests/discuss/test_guest_feature.py
+++ b/addons/mail/tests/discuss/test_guest_feature.py
@@ -28,9 +28,7 @@ class TestGuestFeature(WebsocketCase, MailCommon):
                 "channel_id": channel.id,
                 "last_message_id": channel.message_ids[0].id,
             },
-            headers={
-                "Cookie": f"{guest._cookie_name}={guest._format_auth_cookie()};"
-            },
+            cookies={guest._cookie_name: guest._format_auth_cookie()}
         )
         self.assertEqual(guest_member.seen_message_id, channel.message_ids[0])
 

--- a/addons/mail/tests/discuss/test_toggle_upload.py
+++ b/addons/mail/tests/discuss/test_toggle_upload.py
@@ -23,6 +23,6 @@ class TestToggleUpload(HttpCase):
                     "thread_model": "discuss.channel",
                 },
                 files={"ufile": file},
-                headers={"Cookie": f"session_id={self.session.sid};{guest._cookie_name}={guest._format_auth_cookie()};"},
+                cookies={guest._cookie_name: guest._format_auth_cookie()}
             )
         self.assertEqual(response.status_code, 200)

--- a/addons/mail_group/tests/test_mail_group_mailing.py
+++ b/addons/mail_group/tests/test_mail_group_mailing.py
@@ -29,7 +29,7 @@ class TestMailGroupMailing(TestMailListCommon, HttpCase):
         for member in expected_recipients:
             mail = self._find_mail_mail_wemail(member.email, "outgoing")
             unsubscribe_url = literal_eval(mail.headers).get("List-Unsubscribe").strip('<>')
-            _response = self.opener.post(unsubscribe_url)
+            _response = self.url_open(unsubscribe_url, method='POST')
 
         self.assertEqual(test_group.member_ids, self.test_group_member_4_emp,
                          "Mail Group: people should have been unsubscribed")

--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -245,7 +245,7 @@ class TestMarketingCardRouting(HttpCase, MarketingCardCommon):
         redirect_response = self.url_open(card._get_redirect_url(), allow_redirects=False)
         self.assertEqual(redirect_response.status_code, 303)
         self.assertEqual(redirect_response._next.url, self.campaign.link_tracker_id.short_url)
-        self.opener.send(redirect_response._next, allow_redirects=False)
+        self.url_open(redirect_response._next.url, allow_redirects=False)
         self.assertEqual(self.campaign.target_url_click_count, 1)
 
         cards[1:10].share_status = 'visited'

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -832,7 +832,7 @@ class TestMailingHeaders(MassMailCommon, HttpCase):
 
             # unsubscribe in one-click
             unsubscribe_oneclick_url = headers["List-Unsubscribe"].strip("<>")
-            self.opener.post(unsubscribe_oneclick_url)
+            self.url_open(unsubscribe_oneclick_url, method='POST')
 
             # should be unsubscribed
             self.assertTrue(contact.subscription_ids.opt_out)

--- a/addons/mass_mailing_sms/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_controllers.py
@@ -36,7 +36,7 @@ class TestMailingListSms(HttpCase, MassSMSCommon):
         self.assertEqual(trace.sms_number, '+911234657890')
 
         unsubscribe_url = werkzeug.urls.url_join(mailing.get_base_url(), f'/sms/{mailing.id}/unsubscribe/{trace.sms_code}')
-        response = self.opener.get(url=unsubscribe_url, data={'sms_number': trace.sms_number})
+        response = self.url_open(url=unsubscribe_url, data={'sms_number': trace.sms_number}, method='GET')
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(partner.phone_blacklisted, 'Partner not unsubscribed')

--- a/addons/payment/tests/http_common.py
+++ b/addons/payment/tests/http_common.py
@@ -32,7 +32,7 @@ class PaymentHttpCommon(PaymentCommon, HttpCase):
         :rtype: :class:`requests.models.Response`
         """
         formatted_params = self._format_http_request_payload(payload=params)
-        return self.opener.get(url, params=formatted_params)
+        return self.url_open(url, params=formatted_params)
 
     def _make_http_post_request(self, url, data=None):
         """ Make an HTTP POST request to the provided URL.
@@ -43,7 +43,7 @@ class PaymentHttpCommon(PaymentCommon, HttpCase):
         :rtype: :class:`requests.models.Response`
         """
         formatted_data = self._format_http_request_payload(payload=data)
-        return self.opener.post(url, data=formatted_data)
+        return self.url_open(url, data=formatted_data, method='POST')
 
     def _format_http_request_payload(self, payload=None):
         """ Format a request payload to replace float values by their string representation.
@@ -66,7 +66,7 @@ class PaymentHttpCommon(PaymentCommon, HttpCase):
         :return: The response of the request
         :rtype: :class:`requests.models.Response`
         """
-        return self.opener.post(url, json=data)
+        return self.url_open(url, json=data)
 
     @contextmanager
     def _assertNotFound(self):

--- a/addons/portal/tests/test_addresses.py
+++ b/addons/portal/tests/test_addresses.py
@@ -63,7 +63,7 @@ class TestPortalAddresses(BaseCommon, HttpCase):
         :rtype: :class:`requests.models.Response`
         """
         formatted_data = self._format_http_request_payload(payload=data)
-        return self.opener.post(url, data=formatted_data)
+        return self.url_open(url, data=formatted_data)
 
     def _format_http_request_payload(self, payload=None):
         """ Format a request payload to replace float values by their string representation.

--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -179,14 +179,15 @@ class TestAPIKeys(common.HttpCase):
         def get_json_data():
             raise ValueError("There is no json here")
         # needs a fake request in order to call methods protected with check_identity
+        self.http_request_key = self.canonical_tag
         fake_req = DotDict({
             # various things go and access request items
             'httprequest': DotDict({
                 'environ': {'REMOTE_ADDR': 'localhost'},
-                'cookies': {},
+                'cookies': {common.TEST_CURSOR_COOKIE_NAME: self.canonical_tag},
                 'args': {},
             }),
-            'cookies': {},
+            'cookies': {common.TEST_CURSOR_COOKIE_NAME: self.canonical_tag},
             # bypass check_identity flow
             'session': {'identity-check-last': time.time()},
             'geoip': {},

--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -141,7 +141,7 @@ class TestXMLRPC(common.HttpCase):
         )
 
     def _json_call(self, *args):
-        self.opener.post(f"{self.base_url()}/jsonrpc", json={
+        self.url_open(f"{self.base_url()}/jsonrpc", json={
             'jsonrpc': '2.0',
             'id': None,
             'method': 'call',

--- a/addons/sale/tests/test_product_configurator_data.py
+++ b/addons/sale/tests/test_product_configurator_data.py
@@ -16,7 +16,7 @@ class TestProductConfiguratorData(HttpCaseWithUserDemo, ProductVariantsCommon, S
 
     def request_get_values(self, product_template, ptav_ids=None):
         base_url = product_template.get_base_url()
-        response = self.opener.post(
+        response = self.url_open(
             url=base_url + '/sale/product_configurator/get_values',
             json={
                 'params': {

--- a/addons/survey/tests/common.py
+++ b/addons/survey/tests/common.py
@@ -169,13 +169,13 @@ class SurveyCase(common.TransactionCase):
             return self.url_open('/survey/%s/%s' % (survey.access_token, token))
 
     def _access_begin(self, survey, token):
-        url = survey.get_base_url() + f'/survey/begin/%s/%s' % (survey.access_token, token)
-        return self.opener.post(url=url, json={'params': {'lang_code': 'en_US'}})
+        url = survey.get_base_url() + f'/survey/begin/{survey.access_token}/{token}'
+        return self.url_open(url, json={'params': {'lang_code': 'en_US'}})
 
     def _access_submit(self, survey, token, post_data, query_count=None):
         url = survey.get_base_url() + '/survey/submit/%s/%s' % (survey.access_token, token)
         with self.assertQueryCount(query_count) if query_count else nullcontext():
-            return self.opener.post(url=url, json={'params': post_data})
+            return self.url_open(url, json={'params': post_data})
 
     def _find_csrf_token(self, text):
         csrf_token_re = re.compile("(input.+csrf_token.+value=\")([a-f0-9]{40}o[0-9]*)", re.MULTILINE)

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -1683,7 +1683,8 @@ class TestHttp(common.HttpCase):
             "webhook_url": automation_receiver.url,
         })
 
-        obj.name = "new_name"
+        with self.allow_requests(all_requests=True):  # Changing the name will make an http request.
+            obj.name = "new_name"
         self.cr.flush()
         self.cr.clear()
         self.assertEqual(json.loads(obj.another_field), {

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -253,7 +253,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             },
             "thread_id": self.channel_livechat_2.id,
             "thread_model": "discuss.channel",
-        }, headers={"Cookie": f"{self.guest._cookie_name}={self.guest._format_auth_cookie()};"})
+        }, cookies={
+            self.guest._cookie_name: self.guest._format_auth_cookie(),
+        })
         # add needaction
         self.users[0].notification_type = 'inbox'
         message_0 = self.channel_channel_public_1.message_post(

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -112,7 +112,7 @@ class TestPortalControllers(TestPortal):
         post_url = f"{self.record_portal.get_base_url()}/mail/message/post"
         pid = self.partner_2.id
         _hash = self.record_portal._sign_token(pid)
-        res = self.opener.post(
+        res = self.url_open(
             url=post_url,
             json={
                 'params': {
@@ -153,7 +153,7 @@ class TestPortalControllers(TestPortal):
         post_url = f"{self.record_portal.get_base_url()}/mail/message/post"
 
         # test as not logged
-        self.opener.post(
+        self.url_open(
             url=post_url,
             json={
                 'params': {

--- a/addons/utm/tests/test_routes.py
+++ b/addons/utm/tests/test_routes.py
@@ -11,5 +11,5 @@ class TestRoutes(HttpCaseWithUserDemo):
     def test_01_web_session_destroy(self):
         base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         self.authenticate('demo', 'demo')
-        res = self.opener.post(url=base_url + '/web/session/destroy', json={})
+        res = self.url_open(url=base_url + '/web/session/destroy', json={})
         self.assertEqual(res.status_code, 200)

--- a/addons/web/tests/test_login.py
+++ b/addons/web/tests/test_login.py
@@ -16,7 +16,7 @@ class TestWebLoginCommon(HttpCase):
         super().setUp()
         self.session = http.root.session_store.new()
         self.session.update(http.get_default_session(), db=get_db_name())
-        self.opener = Opener(self.env.cr)
+        self.opener = Opener(self)
         self.opener.cookies.set('session_id', self.session.sid, domain=HOST, path='/')
 
     def login(self, username, password, csrf_token=None):

--- a/addons/web/tests/test_reports.py
+++ b/addons/web/tests/test_reports.py
@@ -113,7 +113,7 @@ class TestReports(odoo.tests.HttpCase):
         report = report.with_user(admin)
 
         with (MockRequest(report.env) as mock_request,
-            patch('subprocess.Popen') as mock_popen,
+            patch('subprocess.run') as mock_popen,
             patch.object(root.session_store, 'delete') as mock_delete,
             patch.object(os, 'unlink') as mock_unlink):
 
@@ -121,7 +121,7 @@ class TestReports(odoo.tests.HttpCase):
 
             mock_process = Mock()
             mock_process.returncode = -1
-            mock_process.communicate.return_value = ("output", "")
+            mock_process.stderr = ""
             mock_popen.return_value = mock_process
 
             with self.assertRaises(UserError):

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -29,11 +29,11 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
         self.assertEqual(req.status_code, 200)
 
         base = self.base_url()
-        req = self.opener.get(base + '/web/image/test.an_image_redirect_301', allow_redirects=False)
+        req = self.url_open(base + '/web/image/test.an_image_redirect_301', allow_redirects=False)
         self.assertEqual(req.status_code, 301)
         self.assertURLEqual(req.headers['Location'], '/web/image/test.an_image_url')
 
-        req = self.opener.get(base + '/web/image/test.an_image_redirect_301', allow_redirects=True)
+        req = self.url_open(base + '/web/image/test.an_image_redirect_301', allow_redirects=True)
         self.assertEqual(req.status_code, 200)
 
     def test_02_image_quality(self):

--- a/addons/website/tests/test_controllers.py
+++ b/addons/website/tests/test_controllers.py
@@ -38,11 +38,11 @@ class TestControllers(tests.HttpCase):
             else:
                 last_5_url_edited.append(new_page.url)
 
-        self.opener.post(url=suggested_links_url, json={'params': {'needle': '/'}})
+        self.url_open(url=suggested_links_url, json={'params': {'needle': '/'}})
         # mark as old
         old_pages._write({'write_date': '2020-01-01'})
 
-        res = self.opener.post(url=suggested_links_url, json={'params': {'needle': '/'}})
+        res = self.url_open(url=suggested_links_url, json={'params': {'needle': '/'}})
         resp = json.loads(res.content)
         assert 'result' in resp
         suggested_links = resp['result']

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -132,7 +132,7 @@ class TestControllerRedirect(TestLangUrl):
             if not msg:
                 msg = 'Url <%s> differ from <%s>.' % (url, expected_url)
 
-            r = self.url_open(url, head=True)
+            r = self.url_open(url, method='HEAD', allow_redirects=False)
             self.assertEqual(r.status_code, code)
             parsed_location = urlparse(r.headers.get('Location', ''))
             parsed_expected_url = urlparse(expected_url)

--- a/addons/website/tests/test_res_users.py
+++ b/addons/website/tests/test_res_users.py
@@ -51,8 +51,8 @@ class TestWebsiteResUsers(TransactionCase):
 
     def test_same_website_message(self):
         # Use a test cursor because retrying() does commit.
-        with self.enter_registry_test_mode():
-            env = self.env(context={'lang': 'en_US'}, cr=self.env.registry.cursor())
+        with self.enter_registry_test_mode(), self.env.registry.cursor() as cr:
+            env = self.env(context={'lang': 'en_US'}, cr=cr)
 
             def create_user_pou():
                 return new_test_user(env, login='Pou', website_id=self.website_1.id, groups='base.group_portal')

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -1271,7 +1271,7 @@ class Crawler(HttpCase):
         # Test controller
         url = base_url + '/website/get_switchable_related_views'
         json = {'params': {'key': '_website_event.index'}}
-        response = self.opener.post(url=url, json=json)
+        response = self.url_open(url=url, json=json)
         res = response.json()['result']
 
         self.assertEqual(
@@ -1309,7 +1309,7 @@ class Crawler(HttpCase):
         # Test controller
         url = base_url + '/website/get_switchable_related_views'
         json = {'params': {'key': '_website_event.index'}}
-        response = self.opener.post(url=url, json=json)
+        response = self.url_open(url=url, json=json)
         res = response.json()['result']
         self.assertEqual(
             [v['name'] for v in res],
@@ -1344,7 +1344,7 @@ class Crawler(HttpCase):
         # Test controller
         url = base_url + '/website/get_switchable_related_views'
         json = {'params': {'key': '_website_event.index'}}
-        response = self.opener.post(url=url, json=json)
+        response = self.url_open(url=url, json=json)
         res = response.json()['result']
         self.assertEqual(
             [v['name'] for v in res],
@@ -1482,7 +1482,7 @@ class Crawler(HttpCase):
         # Test controller
         url = base_url + '/website/get_switchable_related_views'
         json = {'params': {'key': '_website_sale.products'}}
-        response = self.opener.post(url=url, json=json)
+        response = self.url_open(url=url, json=json)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()['result']), 1, "Only '_theme_kea_sale.products' should be returned as it is the only customize_show related view in website 2 context")
         self.assertEqual(response.json()['result'][0]['key'], '_theme_kea_sale.products', "Only '_theme_kea_sale.products' should be returned")
@@ -1493,7 +1493,7 @@ class Crawler(HttpCase):
         # Test controller
         url = base_url + '/website/get_switchable_related_views'
         json = {'params': {'key': '_website_sale.products'}}
-        response = self.opener.post(url=url, json=json)
+        response = self.url_open(url=url, json=json)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()['result']), 1, "Only '_website_sale.child_view_w1' should be returned as it is the only customize_show related view in website 1 context")
         self.assertEqual(response.json()['result'][0]['key'], '_website_sale.child_view_w1', "Only '_website_sale.child_view_w1' should be returned")

--- a/addons/website_links/tests/test_controller.py
+++ b/addons/website_links/tests/test_controller.py
@@ -16,6 +16,7 @@ class TestWebsiteLinksRussian(HttpCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.link = cls.env['link.tracker'].create({
+            'title': '/web/health',
             'url': cls.base_url() + '/web/health',  # no-op route
         })
 

--- a/addons/website_livechat/tests/common.py
+++ b/addons/website_livechat/tests/common.py
@@ -80,7 +80,7 @@ class TestLivechatCommon(MailCommon, TransactionCaseWithUserDemo):
         channel_messages_count = len(channel.message_ids)
 
         rating_to_emoji = {1: "😞", 3: "😐", 5: "😊"}
-        self.opener.post(url=self.send_feedback_url, json={'params': {
+        self.url_open(url=self.send_feedback_url, json={'params': {
             'channel_id': channel.id,
             'rate': rating_value,
             'reason': reason,

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -47,7 +47,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
 
     def test_livechat_username(self):
         # Open a new live chat
-        res = self.opener.post(url=self.open_chat_url, json=self.open_chat_params)
+        res = self.url_open(url=self.open_chat_url, json=self.open_chat_params)
         self.assertEqual(res.status_code, 200)
         channel_1 = self.env['discuss.channel'].search([('livechat_visitor_id', '=', self.visitor.id), ('livechat_active', '=', True)], limit=1)
 
@@ -65,7 +65,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         self.operator.name
 
         # Open a new live chat
-        res = self.opener.post(url=self.open_chat_url, json=self.open_chat_params)
+        res = self.url_open(url=self.open_chat_url, json=self.open_chat_params)
         self.assertEqual(res.status_code, 200)
         channel_2 = self.env['discuss.channel'].search([('livechat_visitor_id', '=', self.visitor.id), ('livechat_active', '=', True)], limit=1)
 
@@ -115,7 +115,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
 
     def _common_basic_flow(self):
         # Open a new live chat
-        res = self.opener.post(url=self.open_chat_url, json=self.open_chat_params)
+        res = self.url_open(url=self.open_chat_url, json=self.open_chat_params)
         self.assertEqual(res.status_code, 200)
 
         channel = self.env['discuss.channel'].search([('livechat_visitor_id', '=', self.visitor.id), ('livechat_active', '=', True)], limit=1)

--- a/addons/website_livechat/tests/test_livechat_request.py
+++ b/addons/website_livechat/tests/test_livechat_request.py
@@ -42,7 +42,7 @@ class TestLivechatRequestHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         self.assertEqual(chat_request.livechat_operator_id, self.operator_b.partner_id, "Operator for active livechat session must be Operator Marc")
 
         # Click on livechatbutton at client side
-        res = self.opener.post(url=self.open_chat_url, json=self.open_chat_params)
+        res = self.url_open(url=self.open_chat_url, json=self.open_chat_params)
         self.assertEqual(res.status_code, 200)
         channel = self.env['discuss.channel'].search([('livechat_visitor_id', '=', self.visitor.id),
                                                    ('livechat_active', '=', True)])

--- a/addons/website_livechat/tests/test_livechat_request.py
+++ b/addons/website_livechat/tests/test_livechat_request.py
@@ -93,6 +93,6 @@ class TestLivechatRequestHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         self.make_jsonrpc_request(
             "/mail/action",
             {"fetch_params": [["init_livechat", self.livechat_channel.id]]},
-            headers={"Cookie": f"{guest._cookie_name}={guest._format_auth_cookie()};"},
+            cookies={guest._cookie_name: guest._format_auth_cookie()},
         )
         self.assertEqual(chat_request.channel_member_ids.guest_id, guest)

--- a/addons/website_slides/tests/test_security.py
+++ b/addons/website_slides/tests/test_security.py
@@ -535,7 +535,7 @@ class TestReview(common.SlidesCase, HttpCase):
     def test_channel_multiple_reviews(self):
         self.authenticate("admin", "admin")
 
-        res1 = self.opener.post(
+        res1 = self.url_open(
             url="%s/mail/message/post" % self.base_url(),
             json={
                 "params": {
@@ -552,8 +552,7 @@ class TestReview(common.SlidesCase, HttpCase):
         )
         self.assertIn("My first review :)", res1.text)
 
-
-        res2 = self.opener.post(
+        res2 = self.url_open(
             url="%s/mail/message/post" % self.base_url(),
             json={
                 "params": {

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -62,6 +62,21 @@ def _get_wkhtmltopdf_bin():
     return find_in_path('wkhtmltopdf')
 
 
+def _run_wkhtmltopdf(args):
+    """
+    Runs the given arguments against the wkhtmltopdf binary.
+
+    Returns:
+        The process
+    """
+    return subprocess.run(
+        [_get_wkhtmltopdf_bin(), *args],
+        capture_output=True,
+        encoding='utf-8',
+        check=False,
+    )
+
+
 def _get_wkhtmltoimage_bin():
     return find_in_path('wkhtmltoimage')
 
@@ -595,9 +610,8 @@ class IrActionsReport(models.Model):
             os.close(pdf_report_fd)
             stack.callback(delete_file, pdf_report_path)
 
-            wkhtmltopdf = [_get_wkhtmltopdf_bin()] + command_args + files_command_args + paths + [pdf_report_path]
-            process = subprocess.Popen(wkhtmltopdf, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
-            _out, err = process.communicate()
+            process = _run_wkhtmltopdf(command_args + files_command_args + paths + [pdf_report_path])
+            err = process.stderr
 
             match process.returncode:
                 case 0:

--- a/odoo/addons/base/tests/test_http_case.py
+++ b/odoo/addons/base/tests/test_http_case.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
+import requests
+import threading
 
-from odoo.tests.common import HttpCase, tagged, ChromeBrowser
+from odoo.http import route, Controller, request
+from odoo.tests.common import HttpCase, tagged, ChromeBrowser, TEST_CURSOR_COOKIE_NAME
 from odoo.tools import config
 from unittest.mock import patch
+
+_logger = logging.getLogger(__name__)
+
 
 @tagged('-at_install', 'post_install')
 class TestHttpCase(HttpCase):
@@ -85,3 +91,147 @@ class TestChromeBrowser(HttpCase):
         code = "setTimeout(() => console.log('test successful'), 2000); setInterval(() => document.body.innerText = (new Date()).getTime(), 100);"
         self.browser._wait_code_ok(code, 10)
         self.browser.screencaster.save()
+
+
+class TestRequestRemainingCommon(HttpCase):
+    # This test case tries to reproduce the case where a request is lost between two test and is execute during the secone one.
+    #
+    # - Test A browser js finishes with a pending request
+    # - _wait_remaining_requests misses the request since the thread may not be totally spawned (or correctly named)
+    # - Test B starts and a SELECT is executed
+    # - The request is executed and makes a concurrent fetchall
+    # - The test B tries to fetchall and fails since the cursor is already used by the request
+    #
+    # Note that similar cases can also consume savepoint, make the main cursor readonly, ...
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.thread_a = None
+        # this lock is used to ensure the request is executed after test b starts
+        cls.main_lock = threading.Lock()
+        cls.main_lock.acquire()
+
+        class Dummycontroller(Controller):
+            @route('/web/concurrent', type='http', auth='public', sitemap=False)
+            def wait(c, **params):
+                assert request.env.cr.__class__.__name__ == 'TestCursor'
+                request.env.cr.execute('SELECT 1')
+                request.env.cr.fetchall()
+                # not that the previous queries are not really needed since the http stack will check the registry
+                # but this makes the test more clear and robust
+                _logger.info('B finish')
+
+        cls.env.registry.clear_cache('routing')
+        cls.addClassCleanup(cls.env.registry.clear_cache, 'routing')
+
+    def _test_requests_a(self, cookie=False):
+
+        def late_request_thread():
+            # In some rare case the request may arrive after _wait_remaining_requests.
+            # this thread is trying to reproduce this case.
+            _logger.info('Waiting for B to start')
+            if self.main_lock.acquire(timeout=10):
+                _logger.info('Opening url')
+                # don't use url_open since it simulates a lost request from chrome and url_open would wait to aquire the lock
+                s = requests.Session()
+                if cookie:
+                    s.cookies.set(TEST_CURSOR_COOKIE_NAME, self.canonical_tag)
+                s.get(self.base_url() + "/web/concurrent", timeout=10)
+            else:
+                _logger.error('Something went wrong and thread was not able to aquire lock')
+
+        type(self).thread_a = threading.Thread(target=late_request_thread)
+        self.thread_a.start()
+
+    def _test_requests_b(self):
+        self.env.cr.execute('SELECT 1')
+        self.main_lock.release()
+        _logger.info('B started, waiting for A to finish')
+        self.thread_a.join()
+        self.env.cr.fetchall()
+
+
+class TestRequestRemainingNoCookie(TestRequestRemainingCommon):
+    def test_requests_a(self):
+        self._test_requests_a()
+
+    def test_requests_b(self):
+        with self.assertLogs('odoo.tests.common', 'ERROR') as log_catcher:
+            self._test_requests_b()
+        self.assertEqual(
+            log_catcher.output,
+            ['ERROR:odoo.tests.common:Request with path /web/concurrent has been ignored during test as it it does not contain the test_cursor cookie or it is expired. '
+             '(required "None (request are not enabled)", got "None")'],
+        )
+
+
+class TestRequestRemainingNotEnabled(TestRequestRemainingCommon):
+    def test_requests_a(self):
+        self._test_requests_a(cookie=True)
+
+    def test_requests_b(self):
+        with self.assertLogs('odoo.tests.common', 'ERROR') as log_catcher:
+            self._test_requests_b()
+        self.assertEqual(
+            log_catcher.output,
+            ['ERROR:odoo.tests.common:Request with path /web/concurrent has been ignored during test as it it does not contain the test_cursor cookie or it is expired. '
+             '(required "None (request are not enabled)", got "/base/tests/test_http_case.py:TestRequestRemainingNotEnabled.test_requests_a")'],
+        )
+
+
+class TestRequestRemainingStartDuringNext(TestRequestRemainingCommon):
+    def test_requests_a(self):
+        self._test_requests_a(cookie=True)
+
+    def test_requests_b(self):
+        with self.assertLogs('odoo.tests.common', 'ERROR') as log_catcher, self.allow_requests():
+            self._test_requests_b()
+        self.assertEqual(
+            log_catcher.output,
+            ['ERROR:odoo.tests.common:Request with path /web/concurrent has been ignored during test as it it does not contain the test_cursor cookie or it is expired. '
+             '(required "/base/tests/test_http_case.py:TestRequestRemainingStartDuringNext.test_requests_b__0", got "/base/tests/test_http_case.py:TestRequestRemainingStartDuringNext.test_requests_a")'],
+        )
+
+
+class TestRequestRemainingAfterFirstCheck(TestRequestRemainingCommon):
+    """
+    This test is more specific to the current implem and check what happens if the lock is aquired after the next thread
+    Scenario:
+        - test_requests_a closes browser js, aquire the lock
+        - a ghost request tries to open a test curso, makes the first check (assertCanOpenTestCursor)
+        - the next test enables resquest (here using url_open) releasing the lock
+        - the pending request is executed but detects the test change
+    """
+    def test_requests_a(self, cookie=False):
+        self.http_request_key = self.canonical_tag
+
+        def late_request_thread():
+            _logger.info('Opening url')
+            # don't use url_open since it simulates a lost request from chrome and url_open would wait to aquire the lock
+            s = requests.Session()
+            s.cookies.set(TEST_CURSOR_COOKIE_NAME, self.http_request_key)
+            # we exceptc the request to be stuck when aquiring the registry lock
+            s.get(self.base_url() + "/web/concurrent", timeout=10)
+
+        type(self).thread_a = threading.Thread(target=late_request_thread)
+        self.thread_a.start()
+        # we need to ensure that the first check is made and that we are aquiring the lock
+        self.main_lock.acquire()
+
+    def assertCanOpenTestCursor(self):
+        super().assertCanOpenTestCursor()
+        # the first time we check assertCanOpenTestCursor we need release the lock (lowks ensure we are still inside test_requests_a)
+        if self.main_lock:
+            self.main_lock.release()
+            self.main_lock = None
+
+    def test_requests_b(self):
+        _logger.info('B started, waiting for A to finish')
+        # url_open will simulate a enabled request
+        with self.assertLogs('odoo.tests.common', 'ERROR') as log_catcher, self.allow_requests():
+            self.thread_a.join()
+        self.assertEqual(
+            log_catcher.output,
+            ['ERROR:odoo.tests.common:Trying to open a test cursor for /base/tests/test_http_case.py:TestRequestRemainingAfterFirstCheck.test_requests_a while already in a test /base/tests/test_http_case.py:TestRequestRemainingAfterFirstCheck.test_requests_b'],
+        )

--- a/odoo/addons/base/tests/test_ir_cron.py
+++ b/odoo/addons/base/tests/test_ir_cron.py
@@ -303,9 +303,10 @@ class TestIrCron(TransactionCase, CronMixinCase):
                 with self.enter_registry_test_mode():
                     cb, state = cb(self.cron)
                     with mute_logger('odoo.addons.base.models.ir_cron'),\
-                            patch.object(self.registry['ir.actions.server'], 'run', cb):
+                            patch.object(self.registry['ir.actions.server'], 'run', cb),\
+                            self.registry.cursor() as cr:
                         self.registry['ir.cron']._process_job(
-                            self.registry.cursor(),
+                            cr,
                             {**self.cron.read(load=None)[0], **default_progress_values}
                         )
                 self.cron.invalidate_recordset()
@@ -339,11 +340,12 @@ class TestIrCron(TransactionCase, CronMixinCase):
         with (
             self.enter_registry_test_mode(),
             patch.object(self.registry['ir.actions.server'], 'run', mocked_run),
+            self.registry.cursor() as cr,
         ):
             # make each run 2 seconds, so that it is run 10 times, 20 seconds in total
             mocked_run_state['duration'] = 2
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**self.cron.read(load=None)[0], **default_progress_values}
             )
 
@@ -364,11 +366,12 @@ class TestIrCron(TransactionCase, CronMixinCase):
         with (
             self.enter_registry_test_mode(),
             patch.object(self.registry['ir.actions.server'], 'run', mocked_run),
+            self.registry.cursor() as cr,
         ):
             # make each run 0.5 seconds, so that it is run 20 times, 10 seconds in total
             mocked_run_state['duration'] = 0.5
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**self.cron.read(load=None)[0], **default_progress_values}
             )
 
@@ -389,9 +392,10 @@ class TestIrCron(TransactionCase, CronMixinCase):
         with (
             self.enter_registry_test_mode(),
             patch.object(self.registry['ir.actions.server'], 'run', mocked_run),
+            self.registry.cursor() as cr,
         ):
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**self.cron.read(load=None)[0], **default_progress_values}
             )
 
@@ -418,9 +422,10 @@ class TestIrCron(TransactionCase, CronMixinCase):
                 patch.object(self.registry['ir.cron'], '_callback', side_effect=Exception),
                 patch.object(self.registry['ir.cron'], '_notify_admin') as notify,
                 mute_logger('odoo.addons.base.models.ir_cron'),
+                self.registry.cursor() as cr,
             ):
                 self.registry['ir.cron']._process_job(
-                    self.registry.cursor(),
+                    cr,
                     {**self.cron.read(load=None)[0], **default_progress}
                 )
 
@@ -438,9 +443,10 @@ class TestIrCron(TransactionCase, CronMixinCase):
             patch.object(self.registry['ir.cron'], '_callback', side_effect=Exception),
             patch.object(self.registry['ir.cron'], '_notify_admin') as notify,
             mute_logger('odoo.addons.base.models.ir_cron'),
+            self.registry.cursor() as cr,
         ):
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**self.cron.read(load=None)[0], **default_progress}
             )
 
@@ -459,9 +465,10 @@ class TestIrCron(TransactionCase, CronMixinCase):
             patch.object(self.registry['ir.cron'], '_callback', side_effect=Exception),
             patch.object(self.registry['ir.cron'], '_notify_admin') as notify,
             mute_logger('odoo.addons.base.models.ir_cron'),
+            self.registry.cursor() as cr,
         ):
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**self.cron.read(load=None)[0], **default_progress}
             )
 
@@ -479,9 +486,9 @@ class TestIrCron(TransactionCase, CronMixinCase):
                 'timed_out_counter': 3,
         }])
         self.env.flush_all()
-        with self.enter_registry_test_mode(), mute_logger('odoo.addons.base.models.ir_cron'):
+        with self.enter_registry_test_mode(), mute_logger('odoo.addons.base.models.ir_cron'), self.registry.cursor() as cr:
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**progress.read(fields=['done', 'remaining', 'timed_out_counter'], load=None)[0], 'progress_id': progress.id, **self.cron.read(load=None)[0]}
             )
 
@@ -490,9 +497,9 @@ class TestIrCron(TransactionCase, CronMixinCase):
         self.assertEqual(self.cron.active, True, 'The cron should still be active')
 
         self.cron._trigger()
-        with self.enter_registry_test_mode():
+        with self.enter_registry_test_mode(), self.registry.cursor() as cr:
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**progress.read(fields=['done', 'remaining', 'timed_out_counter'], load=None)[0], 'progress_id': progress.id, **self.cron.read(load=None)[0]}
             )
 
@@ -508,9 +515,9 @@ class TestIrCron(TransactionCase, CronMixinCase):
                 'timed_out_counter': 3,
         }])
         self.env.flush_all()
-        with self.enter_registry_test_mode(), mute_logger('odoo.addons.base.models.ir_cron'):
+        with self.enter_registry_test_mode(), mute_logger('odoo.addons.base.models.ir_cron'), self.registry.cursor() as cr:
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**progress.read(fields=['done', 'remaining', 'timed_out_counter'], load=None)[0], 'progress_id': progress.id, **self.cron.read(load=None)[0]}
             )
 
@@ -519,9 +526,9 @@ class TestIrCron(TransactionCase, CronMixinCase):
         self.assertEqual(self.cron.active, True, 'The cron should still be active')
 
         self.cron._trigger()
-        with self.enter_registry_test_mode():
+        with self.enter_registry_test_mode(), self.registry.cursor() as cr:
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**progress.read(fields=['done', 'remaining', 'timed_out_counter'], load=None)[0], 'progress_id': progress.id, **self.cron.read(load=None)[0]}
             )
 
@@ -637,9 +644,9 @@ class TestIrCron(TransactionCase, CronMixinCase):
 
         self.cron._trigger()
         self.env.flush_all()
-        with self.enter_registry_test_mode(), patch.object(self.registry['ir.actions.server'], 'run', mocked_run):
+        with self.enter_registry_test_mode(), patch.object(self.registry['ir.actions.server'], 'run', mocked_run), self.registry.cursor() as cr:
             self.registry['ir.cron']._process_job(
-                self.registry.cursor(),
+                cr,
                 {**self.cron.read(load=None)[0], **default_progress_values}
             )
 

--- a/odoo/addons/base/tests/test_test_suite.py
+++ b/odoo/addons/base/tests/test_test_suite.py
@@ -11,7 +11,7 @@ from unittest import SkipTest, skip
 from unittest.mock import patch
 
 from odoo.tests.case import TestCase
-from odoo.tests.common import BaseCase, TransactionCase, users, warmup
+from odoo.tests.common import BaseCase, TransactionCase, users, warmup, RegistryRLock
 from odoo.tests.result import OdooTestResult
 
 _logger = logging.getLogger(__name__)
@@ -530,3 +530,15 @@ class TestSkipMethof(BaseCase):
     @skip
     def test_skip_method(self):
         raise Exception('This should be skipped')
+
+
+class TestRegistryRLock(BaseCase):
+
+    def test_registry_rlock_count(self):
+        lock = RegistryRLock()
+        for i in range(5):
+            self.assertEqual(lock.count, i)
+            lock.acquire()
+        for i in range(5):
+            self.assertEqual(lock.count, 5 - i)
+            lock.release()

--- a/odoo/addons/test_auth_custom/tests/test_endpoints.py
+++ b/odoo/addons/test_auth_custom/tests/test_endpoints.py
@@ -16,7 +16,7 @@ class TestCustomAuth(HttpCase):
         # but preflight should work
         self.env.flush_all()
         url = f"{self.base_url()}/test_auth_custom/json"
-        r = self.opener.options(url, headers={
+        r = self.url_open(url, method='OPTIONS', headers={
             'Origin': 'localhost',
             'Access-Control-Request-Method': 'QUX',
             'Access-Control-Request-Headers': 'XYZ',
@@ -35,7 +35,7 @@ class TestCustomAuth(HttpCase):
         # but preflight should work
         self.env.flush_all()
         url = f"{self.base_url()}/test_auth_custom/http"
-        r = self.opener.options(url, headers={
+        r = self.url_open(url, method='OPTIONS', headers={
             'Origin': 'localhost',
             'Access-Control-Request-Method': 'QUX',
             'Access-Control-Request-Headers': 'XYZ',

--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -153,7 +153,7 @@ class TestHttpMisc(TestHttpBase):
 @tagged('post_install', '-at_install')
 class TestHttpCors(TestHttpBase):
     def test_cors0_http_default(self):
-        res_opt = self.opener.options(f'{self.base_url()}/test_http/cors_http_default', timeout=10, allow_redirects=False)
+        res_opt = self.url_open(f'{self.base_url()}/test_http/cors_http_default', timeout=10, method='OPTIONS')
         self.assertIn(res_opt.status_code, (200, 204))
         self.assertEqual(res_opt.headers.get('Access-Control-Allow-Origin'), '*')
         self.assertEqual(res_opt.headers.get('Access-Control-Allow-Methods'), 'GET, POST')
@@ -166,7 +166,7 @@ class TestHttpCors(TestHttpBase):
         self.assertEqual(res_get.headers.get('Access-Control-Allow-Methods'), 'GET, POST')
 
     def test_cors1_http_methods(self):
-        res_opt = self.opener.options(f'{self.base_url()}/test_http/cors_http_methods', timeout=10, allow_redirects=False)
+        res_opt = self.url_open(f'{self.base_url()}/test_http/cors_http_methods', timeout=10, method='OPTIONS')
         self.assertIn(res_opt.status_code, (200, 204))
         self.assertEqual(res_opt.headers.get('Access-Control-Allow-Origin'), '*')
         self.assertEqual(res_opt.headers.get('Access-Control-Allow-Methods'), 'GET, PUT')
@@ -179,7 +179,7 @@ class TestHttpCors(TestHttpBase):
         self.assertEqual(res_post.headers.get('Access-Control-Allow-Methods'), 'GET, PUT')
 
     def test_cors2_json(self):
-        res_opt = self.opener.options(f'{self.base_url()}/test_http/cors_json', timeout=10, allow_redirects=False)
+        res_opt = self.url_open(f'{self.base_url()}/test_http/cors_json', timeout=10, method='OPTIONS')
         self.assertIn(res_opt.status_code, (200, 204), res_opt.text)
         self.assertEqual(res_opt.headers.get('Access-Control-Allow-Origin'), '*')
         self.assertEqual(res_opt.headers.get('Access-Control-Allow-Methods'), 'POST')

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -666,7 +666,7 @@ class TestHttpStaticUpload(TestHttpStaticCommon):
             file_content = file.read()
             file_size = len(file_content)
             file.seek(0)
-            res = self.opener.post(
+            res = self.url_open(
                 f'{self.base_url()}/web/binary/upload_attachment',
                 files={'ufile': file},
                 data={
@@ -712,7 +712,7 @@ class TestHttpStaticUpload(TestHttpStaticCommon):
             self.env['ir.config_parameter'].sudo().set_param(
                 'web.max_file_upload_size', file_size - 1,
             )
-            res = self.opener.post(
+            res = self.url_open(
                 f'{self.base_url()}/web/binary/upload_attachment',
                 files={'ufile': file},
                 data={

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -138,6 +138,8 @@ def get_db_name():
 
 standalone_tests = defaultdict(list)
 
+_registry_test_lock = threading.RLock()
+
 
 def standalone(*tags):
     """ Decorator for standalone test functions.  This is somewhat dedicated to
@@ -777,10 +779,9 @@ class BaseCase(case.TestCase):
         Returns the patches required for entering registry test mode.
         The patches are not started.
         """
-        test_lock = threading.RLock()
         def _patched_cursor(readonly: bool = False):
             return test_cursor.TestCursor(
-                cr, test_lock, readonly and cls._registry_readonly_enabled
+                cr, _registry_test_lock, readonly and cls._registry_readonly_enabled
             )
         return [
             # New cursor should point to the test's cursor

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2004,14 +2004,13 @@ class HttpCase(TransactionCase):
             "params": params or {},
         }
 
-    def url_open(self, url, data=None, files=None, timeout=12, headers=None, allow_redirects=True, head=False):
+    def url_open(self, url, data=None, files=None, timeout=12, headers=None, json=None, params=None, allow_redirects=True, cookies=None, method: str | None = None):
+        if not method and (data or files or json):
+            method = 'POST'
+        method = method or 'GET'
         if url.startswith('/'):
             url = self.base_url() + url
-        if head:
-            return self.opener.head(url, data=data, files=files, timeout=timeout, headers=headers, allow_redirects=False)
-        if data or files:
-            return self.opener.post(url, data=data, files=files, timeout=timeout, headers=headers, allow_redirects=allow_redirects)
-        return self.opener.get(url, timeout=timeout, headers=headers, allow_redirects=allow_redirects)
+        return self.opener.request(method, url, params=params, data=data, json=json, files=files, timeout=timeout, headers=headers, cookies=cookies, allow_redirects=allow_redirects)
 
     def _wait_remaining_requests(self, timeout=10):
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2240,7 +2240,7 @@ class HttpCase(TransactionCase):
             return _route_profiler
         return profiler.Nested(_profiler, patch('odoo.http.Request._get_profiler_context_manager', route_profiler))
 
-    def make_jsonrpc_request(self, route, params=None, headers=None):
+    def make_jsonrpc_request(self, route, params=None, headers=None, cookies=None):
         """Make a JSON-RPC request to the server.
 
         :raises requests.HTTPError: if one occurred
@@ -2251,7 +2251,7 @@ class HttpCase(TransactionCase):
             'jsonrpc': '2.0',
             'method': 'call',
             'params': params or {},
-        }, headers=headers)
+        }, headers=headers, cookies=cookies)
         response.raise_for_status()
         decoded_response = response.json()
         if 'error' in decoded_response:

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2267,8 +2267,8 @@ class HttpCase(TransactionCase):
         with self.allow_requests(browser=browser):
             try:
                 if "bus.bus" in self.env.registry:
-                    from odoo.addons.bus.websocket import CloseCode, _kick_all, WebsocketConnectionHandler
-                    from odoo.addons.bus.models.bus import BusBus
+                    from odoo.addons.bus.websocket import CloseCode, _kick_all, WebsocketConnectionHandler  # noqa: PLC0415
+                    from odoo.addons.bus.models.bus import BusBus  # noqa: PLC0415
 
                     kick_all_websockets = partial(_kick_all, CloseCode.KILL_NOW)
                     original_send_one = BusBus._sendone


### PR DESCRIPTION
The goal of this PR is to have more control on who can do http requests during tests.
API has been added to allow requests to be made for code that require it.

This should solve most of the "no result to fetch" errors usually caused by a TestCursor conflicting with the base cursor.