### PR TITLE
[IMP] web: enhance cell-level keyboard navigation in grouped list view

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1063,6 +1063,7 @@ export class ListRenderer extends Component {
         const children = [...row.children];
         const index = children.indexOf(cell);
         let futureCell;
+        let targetIndex;
         switch (direction) {
             case "up": {
                 let futureRow = row.previousElementSibling;
@@ -1074,10 +1075,15 @@ export class ListRenderer extends Component {
                     );
                     const nextIsGroup = futureRow.classList.contains("o_group_header");
                     const rowTypeSwitched = cellIsInGroupRow !== nextIsGroup;
-                    let defaultIndex = 0;
-                    if (cellIsInGroupRow) {
-                        defaultIndex = this.hasSelectors ? 1 : 0;
+                    const isGroupToGroup = cellIsInGroupRow && nextIsGroup;
+                    if (rowTypeSwitched || isGroupToGroup) {
+                        targetIndex = this.lastKnownIndex || 0;
+                    } else {
+                        this.lastKnownIndex = index;
                     }
+
+                    const defaultIndex = cellIsInGroupRow ? targetIndex : 0;
+
                     futureCell =
                         addCell ||
                         (futureRow && futureRow.children[rowTypeSwitched ? defaultIndex : index]);
@@ -1093,10 +1099,19 @@ export class ListRenderer extends Component {
                     );
                     const nextIsGroup = futureRow.classList.contains("o_group_header");
                     const rowTypeSwitched = cellIsInGroupRow !== nextIsGroup;
-                    let defaultIndex = 0;
-                    if (cellIsInGroupRow) {
-                        defaultIndex = this.hasSelectors ? 1 : 0;
+                    const isGroupToGroup = cellIsInGroupRow && nextIsGroup;
+                    const headerRow = this.tableRef.el.querySelector("thead tr");
+                    if (rowTypeSwitched || isGroupToGroup) {
+                        targetIndex = this.lastKnownIndex || 0;
+                    } else {
+                        this.lastKnownIndex = index;
                     }
+
+                    const defaultIndex = cellIsInGroupRow ? targetIndex : 0;
+                    if (headerRow == row) {
+                        this.lastKnownIndex = index;
+                    }
+
                     futureCell =
                         addCell ||
                         (futureRow && futureRow.children[rowTypeSwitched ? defaultIndex : index]);
@@ -1105,10 +1120,16 @@ export class ListRenderer extends Component {
             }
             case "left": {
                 futureCell = children[index - 1];
+                if (futureCell) {
+                    this.lastKnownIndex = index - 1;
+                }
                 break;
             }
             case "right": {
                 futureCell = children[index + 1];
+                if (futureCell) {
+                    this.lastKnownIndex = index + 1;
+                }
                 break;
             }
         }

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -13991,7 +13991,7 @@ test(`execute group header button with keyboard navigation`, async () => {
     // move to first record of opened group
     await press("ArrowDown");
     await animationFrame();
-    expect(`tbody .o_data_row:eq(0) td[name=foo]`).toBeFocused();
+    expect(`tbody tr:nth-child(2) td:nth-child(1) input`).toBeFocused();
 
     // move back to the group header
     await press("ArrowUp");
@@ -17934,4 +17934,128 @@ test("click on New while list is loading (editable)", async () => {
     expect(".o_list_view .o_list_renderer").toHaveCount(1);
     expect(".o_list_view .o_data_row").toHaveCount(5);
     expect(".o_list_view .o_data_row:eq(0)").toHaveClass("o_selected_row");
+});
+
+test.tags("desktop");
+test(`cell-level keyboard navigation in grouped list`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <field name="int_field"/>
+                <field name="bar"/>
+            </list>
+        `,
+        groupBy: ["bar"],
+    });
+
+    expect(`.o_data_row`).toHaveCount(0);
+    expect(`.o_group_header`).toHaveCount(2);
+
+    // Expand the first and second group
+    await contains(`.o_group_header:eq(0)`).click();
+    await contains(`.o_group_header:eq(1)`).click();
+    expect(`.o_data_row`).toHaveCount(4);
+    await contains(`table thead tr th:nth-child(2)`).click();
+
+    //Navigate downward from the last cell of the first group
+    await press("ArrowDown");
+    await animationFrame();
+
+    await press("ArrowDown");
+    await animationFrame();
+
+    // Move right to focus on the next cell in the same row
+    await press("ArrowRight");
+    await animationFrame();
+
+    await press("ArrowDown");
+    await animationFrame();
+
+    await press("ArrowDown");
+    await animationFrame();
+
+    //Ensure focus has moved to the same column in the second group
+    await animationFrame();
+    expect(`tbody tr:nth-child(4) td:nth-child(3)`).toBeFocused();
+
+    //Move back up within the second group
+    await press("ArrowUp");
+    await animationFrame();
+
+    //Verify that focus returns to the same column in the first group
+    await press("ArrowUp");
+    await animationFrame();
+    expect(`tbody tr:nth-child(2) td:nth-child(3)`).toBeFocused();
+});
+
+test.tags("desktop");
+test(`cell-level keyboard navigation in multiple grouped list`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <field name="int_field"/>
+                <field name="bar"/>
+            </list>
+        `,
+        groupBy: ["bar", "foo"],
+        noContentHelp: "<p>should not be displayed</p>",
+    });
+
+    expect(`.o_data_row`).toHaveCount(0);
+    expect(`.o_group_header`).toHaveCount(2);
+
+    // Expand the first and second group
+    await contains(`.o_group_header:eq(0)`).click();
+    await contains(`.o_group_header:eq(1)`).click();
+
+    await contains(`table thead tr th:nth-child(2)`).click();
+    //Navigate downward from the last cell of the sub group of first group
+    await press("ArrowDown");
+    await animationFrame();
+
+    await press("ArrowDown");
+    await animationFrame();
+
+    await press("ArrowDown");
+    await animationFrame();
+
+    // Move right to focus on the next cell in the same row
+    await press("ArrowRight");
+    await animationFrame();
+
+    await press("ArrowDown");
+    await animationFrame();
+
+    await press("Enter");
+    await animationFrame();
+
+    await press("ArrowDown");
+    await animationFrame();
+
+    await press("Enter");
+    await animationFrame();
+
+    await press("ArrowDown");
+    await animationFrame();
+
+    await animationFrame();
+    expect(`tbody tr:nth-child(6) td:nth-child(3)`).toBeFocused();
+
+    await press("ArrowUp");
+    await animationFrame();
+
+    await press("ArrowUp");
+    await animationFrame();
+
+    await press("ArrowUp");
+    await animationFrame();
+
+    await animationFrame();
+    expect(`tbody tr:nth-child(3) td:nth-child(3)`).toBeFocused();
 });


### PR DESCRIPTION
SPECIFICATION:

In a list view, the up and down arrow keys allow users to navigate through records. When the list is grouped, moving from one group to another ensures that the focus remains on the same column as in the previous group.

For example, if a list of employees is grouped by department and a user is focused on the "Salary" column in Group A (HR), pressing the down arrow key to move to Group B (IT) will keep the focus on the "Salary" column rather than reset to the first column.

Task-4522127

