### PR TITLE
[FIX] point_of_sale: wrong order time on ticket screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -435,7 +435,7 @@ export class TicketScreen extends Component {
         }
     }
     getTime(order) {
-        return parseUTCString(order.date_order).toFormat("hh:mm");
+        return parseUTCString(order.date_order).setZone("local").toFormat("hh:mm");
     }
     getTotal(order) {
         return this.env.utils.formatCurrency(order.getTotalWithTax());


### PR DESCRIPTION
Before this commit:
==========
- The order time was displayed in UTC on the ticket screen, which could confuse users in different time zones.

After this commit:
==========
- The order time will be displayed in the user's local timezone for better clarity and consistency.

task-4661637
