### PR TITLE
[FIX] spreadsheet_dashboard: ensure correct dashboard loads after reload

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/assets/dashboard_action_loader.js
+++ b/addons/spreadsheet_dashboard/static/src/assets/dashboard_action_loader.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { addSpreadsheetActionLazyLoader } from "@spreadsheet/assets_backend/spreadsheet_action_loader";
 
-addSpreadsheetActionLazyLoader("action_spreadsheet_dashboard");
+addSpreadsheetActionLazyLoader("action_spreadsheet_dashboard", "dashboards", _t("Dashboards"));

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { DashboardLoader, Status } from "./dashboard_loader";
@@ -28,6 +29,7 @@ export class SpreadsheetDashboardAction extends Component {
         SpreadsheetShareButton,
     };
     static props = { ...standardActionServiceProps };
+    static displayName = _t("Dashboards");
 
     setup() {
         this.Status = Status;
@@ -74,12 +76,10 @@ export class SpreadsheetDashboardAction extends Component {
             }
         );
         useSetupAction({
-            getLocalState: () => {
-                return {
-                    activeDashboardId: this.activeDashboardId,
-                    dashboardLoader: this.loader.getState(),
-                };
-            },
+            getLocalState: () => ({
+                activeDashboardId: this.activeDashboardId,
+                dashboardLoader: this.loader.getState(),
+            }),
         });
         useSpreadsheetPrint(() => this.state.activeDashboard?.model);
         /** @type {{ activeDashboard: import("./dashboard_loader").Dashboard}} */


### PR DESCRIPTION
## Description:

Previously, when switching dashboards multiple times and reloading the page, the wrong dashboard was loaded.

This issue occurred because the `addSpreadsheetActionLazyLoader` function was missing the correct `dashboards` path, which is defined in the XML client action.

To resolve this, the correct `dashboards` path has been added to the `addSpreadsheetActionLazyLoader` function.

Task: 4636576




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
