### PR TITLE
[FIX] website: trigger animation when showing s_popup

### DIFF
--- a/addons/website/static/src/interactions/popup/popup.js
+++ b/addons/website/static/src/interactions/popup/popup.js
@@ -102,6 +102,7 @@ export class Popup extends Interaction {
             // animations here, bypass the issue with ._hideModal().
             // Additionally, .hide() triggers `hide.bs.modal`, which triggers
             // onHideModal() and sets a cookie: we don't want that on destroy.
+            this.modalEl.classList.remove("show");
             this.bsModal._hideModal();
         });
     }

--- a/addons/website/static/src/interactions/popup/shared_popup.js
+++ b/addons/website/static/src/interactions/popup/shared_popup.js
@@ -18,7 +18,13 @@ export class SharedPopup extends Interaction {
         // ugly white bar.
         // tl;dr: this is keeping those 2 elements visibility synchronized.
         _root: {
-            "t-on-show.bs.modal": () => this.popupShown = true,
+            "t-on-show.bs.modal.noUpdate": () => {
+                this.popupShown = true;
+                // Combining noUpdate and `this.updateContent()` forces a
+                // repaint immediately to remove `.d-none` before the transition
+                // happens. Otherwise, the transition isn't visible.
+                this.updateContent();
+            },
             "t-on-shown.bs.modal": () => this.popupShown = true,
             "t-on-hidden.bs.modal": this.onModalHidden,
             "t-att-class": () => ({


### PR DESCRIPTION
When a popup snippet appears on a page, it should appear with an animation. That behavior is broken since the introduction of interactions in [b9b3a605].

[b9b3a605]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f