### PR TITLE
[FIX] calendar,hr_homeworking_calendar: fix props validation

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
@@ -7,7 +7,7 @@ import { CalendarQuickCreate } from "@calendar/views/calendar_form/calendar_quic
 export class AttendeeCalendarController extends CalendarController {
     static template = "calendar.AttendeeCalendarController";
     static components = {
-        ...AttendeeCalendarController.components,
+        ...CalendarController.components,
         QuickCreateFormView: CalendarQuickCreate,
     };
 

--- a/addons/hr_homeworking_calendar/static/src/calendar/year/calendar_year_renderer.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/year/calendar_year_renderer.js
@@ -1,0 +1,3 @@
+import { AttendeeCalendarYearRenderer } from "@calendar/views/attendee_calendar/year/attendee_calendar_year_renderer";
+
+AttendeeCalendarYearRenderer.props.openWorkLocationWizard = { type: Function, optional: true };


### PR DESCRIPTION
This commit fixes the props validation for the calendar app in year scale when the module `hr_homeworking` is installed

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
