### PR TITLE
[FIX] hr_skills_slides: get course url in sudo

### DIFF
--- a/addons/hr_skills_slides/models/hr_resume_line.py
+++ b/addons/hr_skills_slides/models/hr_resume_line.py
@@ -15,6 +15,6 @@ class HrResumeLine(models.Model):
     def _compute_course_url(self):
         for line in self:
             if line.display_type == 'course':
-                line.course_url = line.channel_id.website_absolute_url
+                line.course_url = line.sudo().channel_id.website_absolute_url
             else:
                 line.course_url = False


### PR DESCRIPTION
Since there are read access restrictions on the courses (for exemple courses visible only for attendees), when someone wants to see an employee havin finished one of this course, he gets an access error to the employee form because he has no access to the course.

So we are getting the value in sudo as it only display a link to the course but does not do anything else.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
