### PR TITLE
[FIX] web: report background-size typo

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -102,7 +102,7 @@ li.oe-nested {
 }
 
 .o_report_layout_background {
-    background-size: contains;
+    background-size: contain;
     background-position: center 300px;
     background-repeat: no-repeat;
 }


### PR DESCRIPTION
In commit [1] a typo was introduce on the background-image property, making it fallback to `auto` instead of the desired `contain`.

Since customers have already uploaded there image with the `auto` behavior and it looks good for small to medium images, we target master to avoid frustration.

task-4663877

[1]: odoo/odoo@87258f05c7398173d3df6ec39869f52031502ede


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
