### PR TITLE
[FIX] sale_stock_margin: make purchase_price overwrite consistent

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -11,18 +11,20 @@ class SaleOrderLine(models.Model):
     def _compute_purchase_price(self):
         line_ids_to_pass = set()
         for line in self:
-            # ignore lines without moves or lines for std cost products (no valuation action needed)
-            if (not line.has_valued_move_ids() or
-                line.product_id.with_company(line.company_id).categ_id.property_cost_method == 'standard'
-            ):
-                line_ids_to_pass.add(line.id)
-                continue
             product = line.product_id.with_company(line.company_id)
-            purch_price = product._compute_average_price(0, line.product_uom_qty, line.move_ids)
-            if line.product_uom != product.uom_id:
-                purch_price = product.uom_id._compute_price(purch_price, line.product_uom)
-            line.purchase_price = line._convert_to_sol_currency(
-                purch_price,
-                product.cost_currency_id,
-            )
+            if not line.has_valued_move_ids():
+                line_ids_to_pass.add(line.id)
+            elif (
+                # don't overwrite any existing value unless non-standard cost method
+                (line.product_id and line.product_id.categ_id.property_cost_method != 'standard') or
+                # if line added from delivery, allow recomputation
+                (not line.product_uom_qty and line.qty_delivered)
+            ):
+                purch_price = product._compute_average_price(0, line.product_uom_qty or line.qty_to_invoice, line.move_ids)
+                if line.product_uom != product.uom_id:
+                    purch_price = product.uom_id._compute_price(purch_price, line.product_uom)
+                line.purchase_price = line._convert_to_sol_currency(
+                    purch_price,
+                    product.cost_currency_id,
+                )
         return super(SaleOrderLine, self.browse(line_ids_to_pass))._compute_purchase_price()

--- a/addons/sale_stock_margin/tests/test_sale_stock_margin.py
+++ b/addons/sale_stock_margin/tests/test_sale_stock_margin.py
@@ -318,6 +318,8 @@ class TestSaleStockMargin(TestStockValuationCommon):
 
         self.assertEqual(so.state, 'sent')
         self.assertEqual(so.order_line[0].purchase_price, 15)
+        so.action_confirm()
+        self.assertEqual(so.order_line[0].purchase_price, 15)
 
     def test_add_product_on_delivery_price_unit_on_sale(self):
         """ Adding a product directly on a sale order's delivery should result in the new SOL


### PR DESCRIPTION
Since `purchase_price` depends on their
`move_ids.picking_id.state`, we risk overwriting manual edits to
the field at various points in an ordinary processing of a sale,
here specifically during order confirmation.

Prior to commit: e24d922 standard cost method product lines
would not have their `purchase_price` recomputed, while
non-standard product would (meaning manual edits will only be
saved for standard cost lines).

This is a partial revert of that commit to bring back the
behavior of non recomputed standard cost lines' `purchase_price`

Additionally, we re-fix the use-case from the aforementioned
commit by allowing `purchase_price` recomputation (and
overwrites) when a line has no product qty but does have
delivered qty (indicating it was added from the delivery rather
than directly on the sale order itself.