### PR TITLE
[FIX] sale: fix tour 'mail_attachment_removal_tour'

### DIFF
--- a/addons/sale/static/tests/tours/mail_attachment_removal_test_tour.js
+++ b/addons/sale/static/tests/tours/mail_attachment_removal_test_tour.js
@@ -25,7 +25,7 @@ registry.category("web_tour.tours").add("mail_attachment_removal_tour", {
     },
     {
         content: "confirm quotation",
-        trigger: ".o_menu_brand",
+        trigger: "button[name='action_confirm']",
         run: "click"
     }
 ]


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/194593

This PR added test coverage for the fix, but it failed at the last step '.o_menu_brand' to confirm the quotation.

The intent is to save to quotation, but it relies on implicit action to quit (and save) the record from the app icon, which acts as a "go to main page of app".

This button is not present in tours for some reasons, hence the step failing. This commit fixes it by manually confirming the quotation by clicking on the dedicated button, which is present in practice and in the tour.

runbot-161274

In practice
![Screenshot 2025-03-21 at 11 11 33](https://github.com/user-attachments/assets/26db7ce6-75d7-446e-b275-2d6aad09e3c0)

In tour
<img width="558" alt="Screenshot 2025-03-21 at 11 13 11" src="https://github.com/user-attachments/assets/8013a70a-0a0a-4a73-8820-d49678af84a5" />
