### PR TITLE
[IMP] website_hr_recruitment: Move short introduction to chatter

### DIFF
--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -306,6 +306,14 @@ class WebsiteHrRecruitment(WebsiteForm):
             )
         }
 
+    def extract_data(self, model_sudo, values):
+        short_introduction = values.get("short_introduction", None)
+        data = super().extract_data(model_sudo, values)
+        if short_introduction:
+            introduction_label = self.env._("Short introduction from applicant")
+            data["custom"] = data["custom"].replace("short_introduction", introduction_label)
+        return data
+
     def _should_log_authenticate_message(self, record):
         if record._name == "hr.applicant" and not request.session.uid:
             return False

--- a/addons/website_hr_recruitment/data/config_data.xml
+++ b/addons/website_hr_recruitment/data/config_data.xml
@@ -33,7 +33,6 @@
                 'department_id',
                 'linkedin_profile',
                 'applicant_properties',
-                'applicant_notes',
             ]"/>
         </function>
     </data>

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -33,7 +33,7 @@ function applyForAJob(jobName, application) {
         run: `edit linkedin.com/in/${application.name.toLowerCase().replace(' ', '-')}`,
     }, {
         content: "Complete Subject",
-        trigger: "textarea[name=applicant_notes]",
+        trigger: "textarea[name=short_introduction]",
         run: `edit ${application.subject}`,
     }, { // TODO: Upload a file ?
         content: "Send the form",

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -33,14 +33,20 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
         self.assertEqual(guru_applicant.partner_name, 'John Smith')
         self.assertEqual(guru_applicant.email_from, 'john@smith.com')
         self.assertEqual(guru_applicant.partner_phone, '118.218')
-        self.assertEqual(html2plaintext(guru_applicant.applicant_notes), '### [GURU] HR RECRUITMENT TEST DATA ###')
+        self.assertTrue(
+            "Other Information:\n___________\n\nShort introduction from applicant : ### [GURU] HR RECRUITMENT TEST DATA ###"
+            in guru_applicant.message_ids.mapped(lambda m: html2plaintext(m.body))
+        )
         self.assertEqual(guru_applicant.job_id, job_guru)
 
         internship_applicant = capt.records[1]
         self.assertEqual(internship_applicant.partner_name, 'Jack Doe')
         self.assertEqual(internship_applicant.email_from, 'jack@doe.com')
         self.assertEqual(internship_applicant.partner_phone, '118.712')
-        self.assertEqual(html2plaintext(internship_applicant.applicant_notes), '### HR [INTERN] RECRUITMENT TEST DATA ###')
+        self.assertTrue(
+            "Other Information:\n___________\n\nShort introduction from applicant : ### HR [INTERN] RECRUITMENT TEST DATA ###"
+            in internship_applicant.message_ids.mapped(lambda m: html2plaintext(m.body))
+        )
         self.assertEqual(internship_applicant.job_id, job_intern)
 
     def test_jobs_listing_city_unspecified(self):

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -286,7 +286,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-12 mb-0 py-2 s_website_form_field"
+                                    <div class="col-12 mb-0 py-2 s_website_form_field s_website_form_custom"
                                         data-type="text" data-name="Field">
                                         <div class="row s_col_no_resize s_col_no_bgcolor">
                                             <label class="col-4 col-sm-auto s_website_form_label" style="width: 200px" for="recruitment5">
@@ -296,7 +296,7 @@
                                                 <textarea id="recruitment5"
                                                     class="form-control s_website_form_input"
                                                     placeholder="Optional introduction, or any question you might have about the job…"
-                                                    name="applicant_notes"  rows="5"></textarea>
+                                                    name="short_introduction" rows="5"></textarea>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
This PR makes the contents of the `Short introduction` on the job application form appear in the chatter rather than the `applicant_notes` field.

task-4661944

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
