### PR TITLE
[IMP] {im,website}_livechat: no read access to livechat channels for users

### DIFF
--- a/addons/im_livechat/models/__init__.py
+++ b/addons/im_livechat/models/__init__.py
@@ -5,6 +5,7 @@ from . import chatbot_script
 from . import chatbot_script_answer
 from . import chatbot_script_step
 from . import res_users
+from . import res_groups
 from . import res_partner
 from . import im_livechat_channel
 from . import im_livechat_expertise

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -65,7 +65,7 @@ class DiscussChannel(models.Model):
             "livechat_operator_id",
         ]
         if self.env.user._is_internal():
-            fields.append(Store.One("livechat_channel_id", ["name"]))
+            fields.append(Store.One("livechat_channel_id", ["name"], sudo=True))
         return super()._to_store_defaults(for_current_user=for_current_user) + fields
 
     def _to_store(self, store: Store, fields):

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -181,7 +181,7 @@ class Im_LivechatChannel(models.Model):
         self.ensure_one()
         # sudo: im_livechat.channel - users can leave channels
         self.sudo().user_ids = [Command.unlink(self.env.user.id)]
-        self.env.user._bus_send_store(self, ["are_you_inside", "name"])
+        self.env.user._bus_send_store(self.sudo(), ["are_you_inside", "name"])
 
     def action_view_rating(self):
         """ Action to display the rating relative to the channel, so all rating of the

--- a/addons/im_livechat/models/res_groups.py
+++ b/addons/im_livechat/models/res_groups.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.fields import Command
+
+
+class ResGroups(models.Model):
+    """ Update of res.users class
+        - add a preference about username for livechat purpose
+    """
+    _inherit = "res.groups"
+
+    def write(self, vals):
+        if vals.get("user_ids"):
+            operator_group = self.env.ref("im_livechat.im_livechat_group_user")
+            if operator_group in self.all_implied_ids:
+                operators = operator_group.all_user_ids
+                result = super().write(vals)
+                lost_operators = operators - operator_group.all_user_ids
+                # sudo - im_livechat.channel: user manager can remove user from livechat channels
+                self.env["im_livechat.channel"].sudo() \
+                    .search([("user_ids", "in", lost_operators.ids)]) \
+                    .write({"user_ids": [Command.unlink(operator.id) for operator in lost_operators]})
+                return result
+        return super().write(vals)

--- a/addons/im_livechat/security/ir.model.access.csv
+++ b/addons/im_livechat/security/ir.model.access.csv
@@ -1,13 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_livechat_channel_public,im_livechat.channel,model_im_livechat_channel,base.group_public,1,0,0,0
-access_livechat_channel_portal,im_livechat.channel,model_im_livechat_channel,base.group_portal,1,0,0,0
-access_livechat_channel_employee,im_livechat.channel,model_im_livechat_channel,base.group_user,1,0,0,0
 access_livechat_channel_user,im_livechat.channel.user,model_im_livechat_channel,im_livechat_group_user,1,0,0,0
 access_livechat_channel_manager,im_livechat.channel.manager,model_im_livechat_channel,im_livechat_group_manager,1,1,1,1
 access_livechat_support_report_channel,im_livechat.report.channel,model_im_livechat_report_channel,im_livechat_group_manager,1,0,0,0
-access_livechat_channel_rule_public,im_livechat.channel.rule,model_im_livechat_channel_rule,base.group_public,1,0,0,0
-access_livechat_channel_rule_portal,im_livechat.channel.rule,model_im_livechat_channel_rule,base.group_portal,1,0,0,0
-access_livechat_channel_rule_employee,im_livechat.channel.rule,model_im_livechat_channel_rule,base.group_user,1,0,0,0
 access_livechat_channel_rule_user,im_livechat.channel.rule,model_im_livechat_channel_rule,im_livechat_group_user,1,1,1,0
 access_livechat_channel_rule_manager,im_livechat.channel.rule,model_im_livechat_channel_rule,im_livechat_group_manager,1,1,1,1
 access_livechat_expertise_internal_user,im_livechat.expertise.internal.user,model_im_livechat_expertise,base.group_user,1,0,0,0

--- a/addons/im_livechat/tests/test_im_livechat_channel.py
+++ b/addons/im_livechat/tests/test_im_livechat_channel.py
@@ -1,6 +1,7 @@
 from odoo.tests import new_test_user, tagged
 from odoo.exceptions import AccessError
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
+from odoo.fields import Command
 
 
 @tagged("-at_install", "post_install")
@@ -18,4 +19,72 @@ class TestImLivechatChannel(TestImLivechatCommon):
         self.livechat_channel.with_user(bob_operator).action_join()
         self.assertIn(bob_operator, self.livechat_channel.user_ids)
         self.livechat_channel.with_user(bob_operator).action_quit()
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+
+    def test_leave_livechat_channels_when_operator_access_revoked(self):
+        bob_operator = new_test_user(
+            self.env, "bob_user", groups="im_livechat.im_livechat_group_user"
+        )
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+        self.livechat_channel.with_user(bob_operator).action_join()
+        self.assertIn(bob_operator, self.livechat_channel.user_ids)
+        livechat_operator_group = self.env.ref("im_livechat.im_livechat_group_user")
+        bob_operator.write({
+            "group_ids": [Command.unlink(livechat_operator_group.id)],
+        })
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+        bob_operator.write({
+            "group_ids": [Command.link(livechat_operator_group.id)],
+        })
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+
+    def test_leave_livechat_channels_when_manager_access_revoked(self):
+        bob_operator = new_test_user(
+            self.env, "bob_user", groups="im_livechat.im_livechat_group_manager"
+        )
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+        self.livechat_channel.with_user(bob_operator).action_join()
+        self.assertIn(bob_operator, self.livechat_channel.user_ids)
+        livechat_manager_group = self.env.ref("im_livechat.im_livechat_group_manager")
+        bob_operator.write({
+            "group_ids": [Command.unlink(livechat_manager_group.id)],
+        })
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+        bob_operator.write({
+            "group_ids": [Command.link(livechat_manager_group.id)],
+        })
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+
+    def test_leave_livechat_channels_when_operator_removed_from_group(self):
+        bob_operator = new_test_user(
+            self.env, "bob_user", groups="im_livechat.im_livechat_group_user"
+        )
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+        self.livechat_channel.with_user(bob_operator).action_join()
+        self.assertIn(bob_operator, self.livechat_channel.user_ids)
+        livechat_operator_group = self.env.ref("im_livechat.im_livechat_group_user")
+        livechat_operator_group.write({
+            "user_ids": [Command.unlink(bob_operator.id)],
+        })
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+        livechat_operator_group.write({
+            "user_ids": [Command.link(bob_operator.id)],
+        })
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+
+    def test_leave_livechat_channels_when_manager_removed_from_group(self):
+        bob_operator = new_test_user(
+            self.env, "bob_user", groups="im_livechat.im_livechat_group_manager"
+        )
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+        self.livechat_channel.with_user(bob_operator).action_join()
+        self.assertIn(bob_operator, self.livechat_channel.user_ids)
+        livechat_manager_group = self.env.ref("im_livechat.im_livechat_group_manager")
+        livechat_manager_group.write({
+            "user_ids": [Command.unlink(bob_operator.id)],
+        })
+        self.assertNotIn(bob_operator, self.livechat_channel.user_ids)
+        livechat_manager_group.write({
+            "user_ids": [Command.link(bob_operator.id)],
+        })
         self.assertNotIn(bob_operator, self.livechat_channel.user_ids)

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -96,7 +96,7 @@
                         </div>
                         <notebook>
                             <page string="Operators" name="operators">
-                                    <field name="user_ids" nolabel="1" colspan="2" domain="[['all_group_ids', 'not in', %(base.group_portal)d]]">
+                                    <field name="user_ids" nolabel="1" colspan="2" domain="[['all_group_ids', 'in', %(im_livechat.im_livechat_group_user)d]]">
                                         <kanban>
                                             <templates>
                                                 <t t-name="card" class="flex-row">

--- a/addons/website_livechat/security/ir.model.access.csv
+++ b/addons/website_livechat/security/ir.model.access.csv
@@ -1,4 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_im_livechat_channel_public_employee,im_livechat.channel.public,im_livechat.model_im_livechat_channel,base.group_user,1,0,0,0
 access_website_visitor_livechat_users,website.visitor.livechat.users,model_website_visitor,im_livechat.im_livechat_group_user,1,0,0,0
 access_website_track_livechat_users,website.track.livechat.users,website.model_website_track,im_livechat.im_livechat_group_user,1,0,0,0

--- a/addons/website_livechat/views/res_config_settings_views.xml
+++ b/addons/website_livechat/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="website.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <setting id="livechat" position="inside">
-                <div class="content-group mt16">
+                <div class="content-group mt16" groups="im_livechat.im_livechat_group_manager">
                     <div class="row">
                         <label class="col-lg-3 o_light_label" string="Channel" for="channel_id"/>
                         <field name="channel_id" class="oe_inline"/>


### PR DESCRIPTION
Before this commit, public/portal/internal users had read access to live chat channels and channel rules.
This commit restricts live chat channels access to live chat operators.
