### PR TITLE
[FIX] mail: add `:triumph:` to emoji shortcodes

### DIFF
--- a/addons/web/static/src/core/emoji_picker/emoji_data.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_data.js
@@ -1483,7 +1483,8 @@ const _getEmojisData1 = () => `{
     ],
     "name": "` + _t("face with steam from nose") + `",
     "shortcodes": [
-        ":face_with_steam_from_nose:"
+        ":face_with_steam_from_nose:",
+        ":triumph:"
     ]
 },
 {


### PR DESCRIPTION
The :face_with_steam_from_nose: emoji shows literally a "face with steam from nose", but it also means "triumph". This is an original way to show proudness and uncultured people can learn it thanks from this additional shortcode.

![Screenshot 2025-03-21 at 11 43 44](https://github.com/user-attachments/assets/1be8c898-a1d0-4d53-beed-da1a612e3d32)
