### PR TITLE
[FIX] point_of_sale: fix rounding test ambiguous product name

### DIFF
--- a/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
@@ -128,7 +128,7 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingHalfUp", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            ProductScreen.addOrderline("Product Test 1.2", "1"),
+            ProductScreen.addOrderline("Product Test 1.20", "1"),
             ProductScreen.clickPayButton(),
 
             PaymentScreen.totalIs("1.20"),
@@ -155,7 +155,7 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingHalfUp", {
             Chrome.clickMenuOption("Orders"),
             Chrome.createFloatingOrder(),
 
-            ProductScreen.addOrderline("Product Test 1.2", "1"),
+            ProductScreen.addOrderline("Product Test 1.20", "1"),
             ProductScreen.clickPayButton(),
 
             PaymentScreen.totalIs("1.20"),

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -763,7 +763,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.env['product.product'].create({
-            'name': 'Product Test 1.2',
+            'name': 'Product Test 1.20',
             'available_in_pos': True,
             'list_price': 1.2,
             'taxes_id': False,


### PR DESCRIPTION
Before this commit:

The test `test_rounding_half_up` do un-consistantly fail on the `totalIs("1.20")` check.
According to the screenshot, the total value is 1.25

This may be related to a rounding issue, but I suspect that another test product is wrongly selected instead.
The test select a product with a name containing `Product Test 1.2` this is expected to select the product with the exact same name. But I do suspect that it can also sometime wrongly select the product `Product Test 1.25` as it starts the same.

After this commit:
The name of the product is modified in the demo data and test to avoid ambiguity with the contains operator

Note: I don't really know why the issue start to happen only now

rb-161265