### PR TITLE
[FIX] website_sale: Remove original price if prevent sale

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -536,6 +536,9 @@ class ProductTemplate(models.Model):
             'taxes': taxes,  # taxes after fpos mapping
         })
 
+        if combination_info['prevent_zero_price_sale']:
+            combination_info['compare_list_price'] = 0
+
         if pricelist.discount_policy != 'without_discount':
             # Leftover from before cleanup, different behavior between ecommerce & backend configurator
             # probably to keep product sales price hidden from customers ?

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1318,7 +1318,13 @@
     </template>
 
     <template id="product_price">
-        <div itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer" t-attf-class="product_price mt-2 mb-3 {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-block'}}">
+        <div
+            t-if="not combination_info['prevent_zero_price_sale']"
+            itemprop="offers"
+            itemscope="itemscope"
+            itemtype="http://schema.org/Offer"
+            t-attf-class="product_price mt-2 mb-3 d-inline-block"
+        >
             <h3 class="css_editable_mode_hidden">
                 <span class="oe_price"
                       style="white-space: nowrap;"


### PR DESCRIPTION
If prevent zero sale is active, prices should be hidden from the page

opw-4650460

See also: https://github.com/odoo/enterprise/pull/82082

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
