### PR TITLE
[FIX] web: show module error on ui only in debug mode

### DIFF
--- a/addons/web/static/src/module_loader.js
+++ b/addons/web/static/src/module_loader.js
@@ -144,33 +144,44 @@
             if (!failed.length && !unloaded.length) {
                 return;
             }
+            const debug = new URLSearchParams(location.search).get("debug");
+            if (debug && debug !== "0") {
+                const style = document.createElement("style");
+                style.textContent = `
+                    body::before {
+                        font-weight: bold;
+                        content: "An error occurred while loading javascript modules, you may find more information in the devtools console";
+                        position: fixed;
+                        left: 0;
+                        bottom: 0;
+                        z-index: 100000000000;
+                        background-color: #C00;
+                        color: #DDD;
+                    }
+                `;
+                document.head.appendChild(style);
+            }
 
-            const style = document.createElement("style");
-            style.textContent = `
-                body::before {
-                    font-weight: bold;
-                    content: "An error occurred while loading javascript modules, you may find more information in the devtools console";
-                    position: fixed;
-                    left: 0;
-                    bottom: 0;
-                    z-index: 100000000000;
-                    background-color: #C00;
-                    color: #DDD;
-                }
-            `;
-
-            document.head.appendChild(style);
             if (failed.length) {
-                console.error("The following modules failed to load because of an error:", failed)
+                console.error("The following modules failed to load because of an error:", failed);
             }
             if (missing) {
-                console.error("The following modules are needed by other modules but have not been defined, they may not be present in the correct asset bundle:", missing);
+                console.error(
+                    "The following modules are needed by other modules but have not been defined, they may not be present in the correct asset bundle:",
+                    missing
+                );
             }
             if (cycle) {
-                console.error("The following modules could not be loaded because they form a dependency cycle:", cycle);
+                console.error(
+                    "The following modules could not be loaded because they form a dependency cycle:",
+                    cycle
+                );
             }
             if (unloaded) {
-                console.error("The following modules could not be loaded because they have unmet dependencies, this is a secondary error which is likely caused by one of the above problems:", unloaded);
+                console.error(
+                    "The following modules could not be loaded because they have unmet dependencies, this is a secondary error which is likely caused by one of the above problems:",
+                    unloaded
+                );
             }
         }
     }


### PR DESCRIPTION
Before this commit, when there is a module_loader error, the error was shown on the ui for everyone, even the public users.

Now, the error will be shown on the ui only if we are in debug mode

TASK-ID: 4600145



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
