### PR TITLE
[FIX] web: improve interaction documentation and fix example

### DIFF
--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -197,6 +197,8 @@ export class Interaction {
     /**
      * Mechanism to handle context-specific protection of a specific
      * chunk of synchronous code after returning from an asynchronous one.
+     * This method returns a function that will run the wrapped function in a
+     * protected context when it is called.
      * This should typically be used around code that follows an
      * await this.waitFor(...).
      *
@@ -214,8 +216,11 @@ export class Interaction {
      *     this.protectSyncAfterAsync(() => {
      *         // Code here is protected again, DOM can be updated
      *         doStuff(this.el);
-     *     });
+     *     })();
      * }
+     *
+     * @param {Function} fn function that needs to run in a protected context
+     * @return {Function} protected function
      */
     protectSyncAfterAsync(fn) {
         return this.__colibri__.protectSyncAfterAsync(this, "protectSyncAfterAsync", fn);


### PR DESCRIPTION
In [1] the documentation of `protectSyncAfterAsync` was improved. The introduced example contained a mistake and it did not make it clear that the function did return a function.

This commit fixes the example and insists on the fact that the return value is a function.

[1]: https://github.com/odoo/odoo/commit/94b84a25ead96e6217819d7d6b54e869e5a15c41

task-4367641
