### PR TITLE
[FIX] Web: Fix styling for table header color in layout

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -887,6 +887,10 @@
                     .o_company_tagline {
                         color: <t t-esc='primary'/>
                     }
+
+                    thead th {
+                            color: <t t-esc="secondary"/>
+                        }
             <t t-if="layout == 'web.external_layout_boxed'">
                 &amp;.o_report_layout_boxed {
                     #total .o_total td {


### PR DESCRIPTION
Before version 18.0, the secondary color was applied to `<thead><th>`. However, after this commit https://github.com/odoo/odoo/commit/d492a35b3d070c997ceb9ba4a9d9617eb11fa21d, the secondary color was not applied properly for layouts.

Current visual result:

| Before fix | After fix |
| --- | --- | 
| ![image](https://github.com/user-attachments/assets/3c5f1ae7-bfb4-4667-9a01-578416d5a23c)| ![after_fix_color_style](https://github.com/user-attachments/assets/a626ffb9-f879-4caf-9f71-19eb0b570bb5)|

- OPW: 4649140


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
