### PR TITLE
[FIX] html_editor: empty doc selection at preserveSelection

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -554,7 +554,8 @@ export class SelectionPlugin extends Plugin {
      * @returns {Cursors}
      */
     preserveSelection() {
-        const hadSelection = this.document.getSelection().anchorNode !== null;
+        const hadSelection =
+            this.document.getSelection() && this.document.getSelection().anchorNode !== null;
         const selectionData = this.getSelectionData();
         const selection = selectionData.editableSelection;
         const anchor = { node: selection.anchorNode, offset: selection.anchorOffset };


### PR DESCRIPTION
Before this commit: this.document.getSelection() can return null and causes traceback when accessing anchorNode at preserveSelection

After this commit: ensure document selection is not empty



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
