### PR TITLE
[FIX] website_cf_turnstile: show spinner when token expires

### DIFF
--- a/addons/website_cf_turnstile/static/src/js/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/js/turnstile.js
@@ -16,6 +16,7 @@ export const turnStile = {
                 beforeInteractiveGlobalCallback: "turnstileBecomeVisible",
                 errorGlobalCallback: "throwTurnstileErrorCode",
                 executeGlobalCallback: "turnstileSuccess",
+                expiredCallback: "turnstileExpired",
                 sitekey: session.turnstile_site_key,
                 style: "display: none;",
             });
@@ -28,15 +29,20 @@ export const turnStile = {
                 error.code = code;
                 throw error;
             };
-            // `this` is bound to the turnstile widget calling the callback
-            globalThis.turnstileSuccess = function () {
-                const turnstileContainer = this.wrapper.parentElement;
+            const toggleSpinner = (turnstileContainer, show) => {
                 const form = turnstileContainer.parentElement;
                 const spinner = form.querySelector("i.turnstile-spinner");
                 const button = spinner.parentElement;
-                button.disabled = false;
-                button.classList.remove("disabled");
-                spinner.remove();
+                button.disabled = show;
+                button.classList.toggle("disabled", show);
+                spinner.classList.toggle("d-none", !show);
+            };
+            // `this` is bound to the turnstile widget calling the callback
+            globalThis.turnstileSuccess = function () {
+                toggleSpinner(this.wrapper.parentElement, false);
+            };
+            globalThis.turnstileExpired = function () {
+                toggleSpinner(this.wrapper.parentElement, true);
             };
             globalThis.turnstileBecomeVisible = function () {
                 const turnstileContainer = this.wrapper.parentElement;

--- a/addons/website_cf_turnstile/static/src/xml/turnstile.xml
+++ b/addons/website_cf_turnstile/static/src/xml/turnstile.xml
@@ -7,6 +7,7 @@
             t-att-data-appearance="appeareance || 'interaction-only'"
             t-att-data-before-interactive-callback="beforeInteractiveGlobalCallback || '() => {}'"
             t-att-data-callback="executeGlobalCallback || '() => {}'"
+            t-att-data-expired-callback="expiredCallback || '() => {}'"
             t-att-data-error-callback="errorGlobalCallback || '() => {}'"
             data-response-field-name="turnstile_captcha"
             t-att-data-sitekey="sitekey"


### PR DESCRIPTION
__Current behavior before commit:__
The Cloudflare Turnstile token expires every 300 seconds (see
[Cloudflare doc][1]) which makes the widget reload.
There was currently no callback handling this event.

If the check had already succeeded, the spinner of the button would have
been removed. Thus the second time `turnstileSuccess` would be called,
`spinner` would be `null` and it would throw an error when reading
`spinner.parentElement`.

__Description of the fix:__
Hid the spinner in `turnstileSuccess` instead of removing it.
Added an `expired-callback` to show the spinner back on the button.

__Steps to reproduce the issue on runbot:__
1. Enable and configure Cloudflare Turnstile
2. Go to the `/contactus` page
3. Check the box, wait 5 minutes and check the box again

[1]: https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#:~:text=the%20next%20300%20seconds

opw-4629962
opw-4681945
opw-4620019
opw-4615863
opw-4640032