### PR TITLE
[FIX] mail: Discuss on Mobile - Enter key behavior

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -494,6 +494,9 @@ export class Composer extends Component {
                     ev.preventDefault();
                     return;
                 }
+                if (this.isMobileOS) {
+                    return;
+                }
                 const shouldPost = this.env.inChatter ? ev.ctrlKey : !ev.shiftKey;
                 if (!shouldPost) {
                     return;

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -3,6 +3,7 @@ import {
     click,
     contains,
     defineMailModels,
+    insertText,
     onRpcBefore,
     openDiscuss,
     patchUiSize,
@@ -10,9 +11,10 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
 
-describe.current.tags("desktop");
+describe.current.tags("mobile");
 defineMailModels();
 
 test("auto-select 'Inbox' when discuss had channel as active thread", async () => {
@@ -63,4 +65,16 @@ test("can leave channel in mobile", async () => {
     await contains(".o-mail-ChatWindow-command", { text: "General" });
     await click(".o-mail-ChatWindow-command", { text: "General" });
     await contains(".o-dropdown-item", { text: "Leave" });
+});
+
+test("enter key should create a newline in composer", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "Test\n");
+    await press("Enter");
+    await insertText(".o-mail-Composer-input", "Other");
+    await click(".fa-paper-plane-o");
+    await contains(".o-mail-Message-body:has(br)", { textContent: "TestOther" });
 });


### PR DESCRIPTION
The composer should not send the current input on Enter key when being on a mobile device, since it is impossible for them to create a new line with either ctrl-Enter or alt-enter.

[FIX] mail: Discuss on Mobile - Enter key behavior

The composer should not send the current input on Enter key when being on a mobile device, since it is impossible for them to create a new line with either ctrl-Enter or alt-enter.

Task-4209142