### PR TITLE
[FIX] website_sale_collect: unavailable product error on shop_payment_validate

### DIFF
--- a/addons/website_sale_collect/controllers/main.py
+++ b/addons/website_sale_collect/controllers/main.py
@@ -39,7 +39,11 @@ class WebsiteSaleCollect(WebsiteSale):
         """ Override of `website_sale` to includes errors if no pickup location is selected or some
         products are unavailable. """
         errors = super()._get_shop_payment_errors(order)
-        if order._has_deliverable_products() and order.carrier_id.delivery_type == 'in_store':
+        if (
+            order.state != 'sale'
+            and order._has_deliverable_products()
+            and order.carrier_id.delivery_type == 'in_store'
+        ):
             if not order.pickup_location_data:
                 errors.append((
                     _("Sorry, we are unable to ship your order."),


### PR DESCRIPTION
Steps:
1. Create a Storable product and update quantity to 1
2. Buy the product in shop and go to checkout page
3. Select pick up in store and pay

Issue:
- "Some products are not available in the selected store" error on payment validate page

Cause:
- `_get_shop_payment_error` check for product's availability on shop_payment and shop_payment_validate page where in former stock is available but in later since the order is confirmed stock is unavailable

Fix:
- `_get_shop_payment_error` will only check for stock related errors on confirmed orders

opw-4647225

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
