### PR TITLE
[FIX] web_editor: replace `nbsp` with spaces when copying text

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4085,7 +4085,7 @@ export class OdooEditor extends EventTarget {
         const dataHtmlElement = document.createElement('data');
         dataHtmlElement.append(rangeContent);
         const odooHtml = dataHtmlElement.innerHTML.replace(/\uFEFF/g, "");
-        const odooText = selection.toString().replace(/\uFEFF/g, "");
+        const odooText = selection.toString().replace(/\uFEFF/g, "").replace(/\u00A0/g, " ");
         clipboardEvent.clipboardData.setData('text/plain', odooText);
         clipboardEvent.clipboardData.setData('text/html', odooHtml);
         clipboardEvent.clipboardData.setData('text/odoo-editor', odooHtml);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -167,6 +167,17 @@ describe('Copy', () => {
                 },
             });
         });
+
+        it('should replace NBSP characters with space when copying text', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>[content\u00A0]</p>',
+                stepFunction: async editor => {
+                    const clipboardData = new DataTransfer();
+                    triggerEvent(editor.editable, 'copy', { clipboardData });
+                    window.chai.expect(clipboardData.getData('text/plain')).to.be.equal('content ');
+                },
+            });
+        });
     });
 });
 describe('Cut', () => {


### PR DESCRIPTION
**Problem**:
When copying text from the editor that contains `nbsp`, pasting it into a code editor results in invalid characters, causing issues like compilation errors.

**Solution**:
Replace `nbsp` with normal spaces when copying text.

**Steps to Reproduce**:
1. Add text: `"a  b"` (with double spaces).
2. Copy the text.
3. Paste it into a **code editor**.
   - **Issue**: The invisible `nbsp` causes compilation errors.

**opw-4645678**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
