### PR TITLE
[FIX] pos_restaurant: tb while refunding when no table

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -191,12 +191,9 @@ patch(PosStore.prototype, {
     async setTable(table, orderUuid = null) {
         this.deviceSync.readDataFromServer();
         this.selectedTable = table;
-
-        const tableOrders = table.orders;
-
-        let currentOrder = tableOrders.find((order) =>
-            orderUuid ? order.uuid === orderUuid : !order.finalized
-        );
+        let currentOrder = table
+            ? table.orders.find((o) => o.uuid === orderUuid || !o.finalized)
+            : null;
 
         if (currentOrder) {
             this.set_order(currentOrder);


### PR DESCRIPTION
Steps to reproduce:
------------------------
- Install pos_restaurant. 
- Open a restaurant session without any table on the floor.
- Create an order from floating order & pay it.
- Go to orders apply paid filter and try to refund the order.

Issue:
--------
- We will have a tb on clicking on refund.

Cause:
----------
- We were trying to access the orders of the selected table (order's table or the first table of the restaurant).

Fix:
-----
- We will check if table exists or not if not than it will create a floating refund order without any tb.

Task - 4658258