### PR TITLE
[IMP] project: add color to project.task.type and project.stage

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -133,6 +133,7 @@ class CrmLead(models.Model):
         compute='_compute_stage_id', readonly=False, store=True,
         copy=False, group_expand='_read_group_stage_ids', ondelete='restrict',
         domain="['|', ('team_id', '=', False), ('team_id', '=', team_id)]")
+    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     tag_ids = fields.Many2many(
         'crm.tag', 'crm_tag_rel', 'lead_id', 'tag_id', string='Tags',
         help="Classify and analyze your lead/opportunity categories like: Training, Service")

--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -44,6 +44,7 @@ class CrmStage(models.Model):
         help='This stage is folded in the kanban view when there are no records in that stage to display.')
     # This field for interface only
     team_count = fields.Integer('team_count', compute='_compute_team_count')
+    color = fields.Integer(string='Color', export_string_translation=False)
 
     @api.depends('team_id')
     def _compute_team_count(self):

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -528,7 +528,8 @@
                                 <div class="d-flex justify-content-between">
                                     <field name="partner_id" muted="1" display="full" class="o_text_block"/>
                                     <div class="m-1"/>
-                                    <field name="stage_id" widget="badge"/>
+                                    <field name="stage_id_color" invisible="1"/>
+                                    <field name="stage_id" widget="badge" options="{'color_field': 'stage_id_color'}"/>
                                 </div>
                             </div>
                         </div>
@@ -775,7 +776,8 @@
                     <field name="recurring_revenue" sum="Recurring Revenue" optional="hide" widget="monetary"
                         options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
                     <field name="recurring_plan" optional="hide" groups="crm.group_use_recurring_revenues"/>
-                    <field name="stage_id" optional="show" decoration-bf="1"/>
+                    <field name="stage_id_color" column_invisible="1"/>
+                    <field name="stage_id" optional="show" widget="selection_badge" options="{'color_field': 'stage_id_color'}"/>
                     <field name="active" column_invisible="True"/>
                     <field name="probability" string="Probability (%)" optional="hide"/>
                     <field name="lost_reason_id" optional="hide"/>

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -24,6 +24,7 @@
                 <field name="name" readonly="1"/>
                 <field name="is_won"/>
                 <field name="team_id"/>
+                <field name="color" optional="hide" widget="color_picker"/>
             </list>
         </field>
     </record>
@@ -45,6 +46,7 @@
                         <group>
                             <field name="is_won"/>
                             <field name="fold"/>
+                            <field name="color" widget="color_picker"/>
                             <field name="team_id" options='{"no_open": True, "no_create": True}' invisible="team_count &lt;= 1" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                         </group>
                         <field name="team_count" invisible="1"/>

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -175,6 +175,7 @@ class ProjectProject(models.Model):
     # Not `required` since this is an option to enable in project settings.
     stage_id = fields.Many2one('project.project.stage', string='Stage', ondelete='restrict', groups="project.group_project_stages",
         tracking=True, index=True, copy=False, default=_default_stage_id, group_expand='_read_group_expand_full')
+    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     duration_tracking = fields.Json(groups="project.group_project_stages")
 
     update_ids = fields.One2many('project.update', 'project_id', export_string_translation=False)

--- a/addons/project/models/project_project_stage.py
+++ b/addons/project/models/project_project_stage.py
@@ -18,6 +18,7 @@ class ProjectProjectStage(models.Model):
     fold = fields.Boolean('Folded in Kanban',
         help="If enabled, this stage will be displayed as folded in the Kanban view of your projects. Projects in a folded stage are considered as closed.")
     company_id = fields.Many2one('res.company', string="Company")
+    color = fields.Integer(string='Color', export_string_translation=False)
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -56,6 +56,7 @@ PROJECT_TASK_READABLE_FIELDS = {
     'display_follow_button',
     'is_template',
     'has_template_ancestor',
+    'stage_id_color',
 }
 
 PROJECT_TASK_WRITABLE_FIELDS = {
@@ -154,6 +155,7 @@ class ProjectTask(models.Model):
         store=True, readonly=False, ondelete='restrict', tracking=True, index=True,
         default=_get_default_stage_id, group_expand='_read_group_stage_ids',
         domain="[('project_ids', '=', project_id)]")
+    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     tag_ids = fields.Many2many('project.tags', string='Tags')
 
     state = fields.Selection([

--- a/addons/project/models/project_task_type.py
+++ b/addons/project/models/project_task_type.py
@@ -31,6 +31,7 @@ class ProjectTaskType(models.Model):
         string='Email Template',
         domain=[('model', '=', 'project.task')],
         help="If set, an email will be automatically sent to the customer when the task reaches this stage.")
+    color = fields.Integer(string='Color', export_string_translation=False)
     fold = fields.Boolean(string='Folded in Kanban')
     rating_template_id = fields.Many2one(
         'mail.template',

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -13,6 +13,11 @@
             t-attf-class="#{'fa' if task.state in ['1_done','1_canceled','04_waiting_normal'] else 'o_status rounded-circle' } #{'fa-check-circle text-success' if task.state == '1_done' else 'fa-times-circle text-danger' if task.state == '1_canceled' else 'bg-warning' if task.state == '02_changes_requested' else 'bg-success' if task.state == '03_approved' else 'fa-hourglass-o' if task.state == '04_waiting_normal' else ''}"
         />
     </template>
+    <template id="portal_my_tasks_badge_widget_template" name="badge Widget Template">
+        <span t-attf-class="badge rounded-pill o_tag o_badge_color_#{task.stage_id_color}"
+            t-attf-title="#{task.stage_id.name}" t-out="task.stage_id.name"
+        />
+    </template>
 
     <template id="portal_tasks_list" name="Tasks List">
         <t t-if="grouped_tasks">
@@ -110,7 +115,7 @@
                                     </t>
                                 </td>
                                 <td t-if="groupby != 'stage_id'" class="text-end lh-1">
-                                    <span class="fw-normal o_text_overflow" t-attf-title="#{task.stage_id.name}" t-out="task.stage_id.name"/>
+                                    <t t-call="project.portal_my_tasks_badge_widget_template"/>
                                 </td>
                             </tr>
                         </t>
@@ -239,7 +244,7 @@
                                 </div>
                                 <div class="col-auto">
                                     <small class="text-end">Stage:</small>
-                                    <span t-field="task.stage_id.name" class=" badge rounded-pill text-bg-info" title="Current stage of this task"/>
+                                    <t t-call="project.portal_my_tasks_badge_widget_template"/>
                                 </div>
                             </div>
                         </div>

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -9,6 +9,7 @@
                 <field name="name" placeholder="e.g. To Do"/>
                 <field name="mail_template_id" optional="hide" context="{'default_model': 'project.project'}"/>
                 <field name="company_id" optional="hide" groups="base.group_multi_company" options="{'no_create': True}"/>
+                <field name="color" optional="hide" widget="color_picker"/>
                 <field name="fold" optional="show"/>
             </list>
         </field>
@@ -40,6 +41,7 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="mail_template_id" context="{'default_model': 'project.project'}"/>
+                            <field name="color" widget="color_picker"/>
                             <field name="sequence" groups="base.group_no_one"/>
                         </group>
                         <group>
@@ -56,8 +58,11 @@
         <field name="name">project.project.stage.view.kanban</field>
         <field name="model">project.project.stage</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_mobile" sample="1" quick_create_view="project.project_project_stage_view_form_quick_create">
+            <kanban highlight_color="color" class="o_kanban_mobile" sample="1" quick_create_view="project.project_project_stage_view_form_quick_create">
                 <templates>
+                    <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
+                        <field name="color" widget="kanban_color_picker"/>
+                    </t>
                     <t t-name="card">
                         <field name="name" class="fw-bolder mb-4"/>
                         <field name="mail_template_id" class="text-muted mb-2" invisible="not mail_template_id"/>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -240,7 +240,8 @@
                     <field name="last_update_color" column_invisible="True"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                     <field name="last_update_status" string="Status" nolabel="1" width="20px" optional="show" widget="project_state_selection" invisible="is_template"/>
-                    <field name="stage_id" options="{'no_open': True}" domain="[('company_id', 'in', (company_id, False))]" optional="show"/>
+                    <field name="stage_id_color" column_invisible="1"/>
+                    <field name="stage_id" domain="[('company_id', 'in', (company_id, False))]" optional="show" widget="badge" options="{'no_open': True, 'color_field': 'stage_id_color'}" />
                     <button string="View Tasks" name="action_view_tasks" type="object"/>
                 </list>
             </field>
@@ -551,11 +552,12 @@
                     scales="month,year"
                     event_open_popup="true"
                     quick_create="0"
-                    color="color"
+                    color="stage_id_color"
                     js_class="project_project_calendar">
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="user_id" widget="many2one_avatar_user" invisible="not user_id"/>
                     <field name="is_favorite" widget="project_is_favorite" nolabel="1" string="Favorite"/>
+                    <field name="stage_id_color" invisible="1"/>
                     <field name="stage_id" groups="project.group_project_stages" invisible="not stage_id"/>
                     <field name="last_update_color" invisible="1"/>
                     <field name="last_update_status" string="Status" widget="status_with_color" invisible="last_update_status == 'to_define'"/>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -42,6 +42,7 @@
                                     <field name="disabled_rating_warning" class="mb-0" />
                                 </div>
                                 <field name="auto_validation_state" invisible="not rating_template_id" groups="project.group_project_rating"/>
+                                <field name="color" widget="color_picker"/>
                                 <field name="sequence" groups="base.group_no_one"/>
                             </group>
                             <group>
@@ -65,6 +66,7 @@
                     <field name="name" placeholder="e.g. To Do"/>
                     <field name="mail_template_id" optional="hide"/>
                     <field name="project_ids" required="1" optional="show" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    <field name="color" optional="hide" widget="color_picker"/>
                     <field name="fold" optional="show"/>
                 </list>
             </field>
@@ -86,8 +88,11 @@
             <field name="name">project.task.type.kanban</field>
             <field name="model">project.task.type</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_mobile" sample="1" default_group_by="project_ids">
+                <kanban highlight_color="color" class="o_kanban_mobile" sample="1" default_group_by="project_ids">
                     <templates>
+                        <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
+                            <field name="color" widget="kanban_color_picker"/>
+                        </t>
                         <t t-name="card">
                             <field name="name" class="fw-bolder text-truncate"/>
                             <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -746,7 +746,8 @@
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
                     <field name="date_last_stage_update" optional="hide" column_invisible="context.get('default_is_template', False)"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
-                    <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show"/>
+                    <field name="stage_id_color" column_invisible="1"/>
+                    <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show" widget="selection_badge" options="{'color_field': 'stage_id_color'}"/>
                 </list>
             </field>
         </record>
@@ -806,7 +807,7 @@
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
                 <calendar date_start="date_deadline" string="Tasks" mode="month"
-                          color="stage_id" event_limit="5" hide_time="true"
+                          color="stage_id_color" event_limit="5" hide_time="true"
                           event_open_popup="true" quick_create="0" show_unusual_days="True"
                           js_class="project_task_calendar"
                           scales="day,week,month,year">
@@ -819,7 +820,8 @@
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="priority" widget="priority" readonly="1"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not tag_ids"/>
-                    <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection"/>
+                    <field name="stage_id_color" invisible="1"/>
+                    <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection" filters="1"/>
                     <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="project_id or not personal_stage_id"/>
                     <field name="task_properties" invisible="not task_properties"/>
                 </calendar>
@@ -837,6 +839,9 @@
                 </xpath>
                 <xpath expr="//field[@name='project_id']" position="attributes">
                     <attribute name="filters">1</attribute>
+                </xpath>
+                <xpath expr="//field[@name='stage_id']" position="replace">
+                    <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection"/>
                 </xpath>
             </field>
         </record>

--- a/addons/web/static/src/core/badge/badge.scss
+++ b/addons/web/static/src/core/badge/badge.scss
@@ -1,0 +1,8 @@
+.badge {
+    @for $size from 1 through length($o-colors) {
+        &.o_badge_color_#{$size - 1} {
+            background-color: adjust-color(nth($o-colors, $size), $lightness: 25%, $saturation: 15%) !important;
+            color: adjust-color(nth($o-colors, $size), $lightness: -40%, $saturation: -15%) !important;
+        }
+    }
+}

--- a/addons/web/static/src/views/fields/badge/badge_field.js
+++ b/addons/web/static/src/views/fields/badge/badge_field.js
@@ -11,6 +11,7 @@ export class BadgeField extends Component {
     static props = {
         ...standardFieldProps,
         decorations: { type: Object, optional: true },
+        colorField: { type: String, optional: true },
     };
     static defaultProps = {
         decorations: {},
@@ -23,7 +24,10 @@ export class BadgeField extends Component {
         });
     }
 
-    get classFromDecoration() {
+    get badgeClass() {
+        if (this.props.colorField) {
+            return `o_badge_color_${this.props.record.data[this.props.colorField]}`;
+        }
         const evalContext = this.props.record.evalContextWithVirtualIds;
         for (const decorationName in this.props.decorations) {
             if (evaluateBooleanExpr(this.props.decorations[decorationName], evalContext)) {
@@ -42,8 +46,20 @@ export const badgeField = {
     component: BadgeField,
     displayName: _t("Badge"),
     supportedTypes: ["selection", "many2one", "char"],
-    extractProps: ({ decorations }) => {
-        return { decorations };
+    supportedOptions: [
+        {
+            label: _t("Color field"),
+            name: "color_field",
+            type: "field",
+            availableTypes: ["integer"],
+            help: _t("Set an integer field to use colors with the badge."),
+        },
+    ],
+    extractProps: ({ decorations, options }) => {
+        return {
+            decorations,
+            colorField: options.color_field,
+        };
     },
 };
 

--- a/addons/web/static/src/views/fields/badge/badge_field.xml
+++ b/addons/web/static/src/views/fields/badge/badge_field.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="web.BadgeField">
-        <span t-if="props.record.data[props.name]" class="badge rounded-pill" t-att-class="classFromDecoration" t-esc="formattedValue" />
+        <span t-if="props.record.data[props.name]" class="badge rounded-pill" t-att-class="badgeClass" t-esc="formattedValue" />
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/badge_selection/badge_selection.scss
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection.scss
@@ -1,0 +1,6 @@
+.o_field_selection_badge {
+    .o_badge_border {
+        outline: 2px solid #02c7b5;
+        outline-offset: -1px;
+    }
+}

--- a/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
@@ -16,6 +16,7 @@ export class BadgeSelectionField extends Component {
             validate: (s) => ["sm", "md", "lg"].includes(s),
             default: "md",
         },
+        colorField: { type: String, optional: true },
     };
 
     setup() {
@@ -63,6 +64,18 @@ export class BadgeSelectionField extends Component {
         return JSON.stringify(value);
     }
 
+    get badgeColor() {
+        if (this.props.record.data[this.props.name]) {
+            if (this.props.colorField) {
+                return `o_badge_color_${
+                    this.props.record.data[this.props.colorField]
+                }`;
+            }
+            return "btn btn-secondary";
+        }
+        return "";
+    }
+
     /**
      * @param {string | number | false} value
      */
@@ -108,11 +121,19 @@ export const badgeSelectionField = {
             ],
             default: "md",
         },
+        {
+            label: _t("Color field"),
+            name: "color_field",
+            type: "field",
+            availableTypes: ["integer"],
+            help: _t("Set an integer field to use colors with the badge."),
+        },
     ],
     isEmpty: (record, fieldName) => record.data[fieldName] === false,
     extractProps: (fieldInfo, dynamicInfo) => ({
         domain: dynamicInfo.domain,
         size: fieldInfo.options.size,
+        colorField: fieldInfo.options.color_field,
     }),
 };
 

--- a/addons/web/static/src/views/fields/badge_selection/badge_selection_field.xml
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection_field.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <div t-name="web.BadgeSelectionField" class="d-flex flex-wrap gap-1 mb-3">
+    <div t-name="web.BadgeSelectionField" class="d-flex flex-wrap gap-1">
         <t t-if="props.readonly">
-            <span t-esc="string" t-att-raw-value="value" />
+            <span t-esc="string" class="badge rounded-pill" t-att-class="badgeColor" t-att-raw-value="value" />
         </t>
         <t t-else="">
             <t t-foreach="options" t-as="option" t-key="option[0]">
                 <span
-                    class="o_selection_badge btn btn-secondary mb-1"
-                    t-att-class="{ 'active': value === option[0], 'btn-sm': props.size === 'sm', 'btn-lg': props.size === 'lg' }"
+                    class="o_selection_badge btn btn-secondary mb-1 badge rounded-pill"
+                    t-att-class="{ 'o_badge_border active': value === option[0], 'btn-sm': props.size === 'sm', 'btn-lg': props.size === 'lg' }"
                     t-att-value="stringify(option[0])"
                     t-esc="option[1]"
                     t-on-click="() => this.onChange(option[0])"

--- a/addons/web/static/tests/views/fields/badge_field.test.js
+++ b/addons/web/static/tests/views/fields/badge_field.test.js
@@ -95,3 +95,22 @@ test("BadgeField component with decoration-xxx attributes", async () => {
     expect(`.o_field_badge[name="display_name"] .text-bg-danger`).toHaveCount(1);
     expect(`.o_field_badge[name="display_name"] .text-bg-warning`).toHaveCount(1);
 });
+
+test("BadgeField component with color_field option", async () => {
+    await mountView({
+        resModel: "res.partner",
+        type: "list",
+        arch: `
+            <list>
+                <field name="id" column_invisible="1"/>
+                <field name="display_name" widget="badge" options="{'color_field': 'id'}"/>
+            </list>
+        `,
+    });
+
+    expect(`.o_field_badge[name="display_name"]`).toHaveCount(4);
+    expect(`.o_field_badge[name="display_name"] .o_badge_color_1`).toHaveCount(1);
+    expect(`.o_field_badge[name="display_name"] .o_badge_color_2`).toHaveCount(1);
+    expect(`.o_field_badge[name="display_name"] .o_badge_color_3`).toHaveCount(0); //empty value
+    expect(`.o_field_badge[name="display_name"] .o_badge_color_4`).toHaveCount(1);
+});


### PR DESCRIPTION
This commit's purpose is to add a color consistency for task stage and project stage. This will help to tell with one glance in which stage the task/project is.

The badge widget was updated in order to have a wider choice of color for the background of the pill.

