### PR TITLE
[FIX] mail: Discuss on Mobile - Enter key behavior

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -452,6 +452,9 @@ export class Composer extends Component {
                     ev.preventDefault();
                     return;
                 }
+                if (this.isMobileOS()) {
+                    return;
+                }
                 const shouldPost = this.props.mode === "extended" ? ev.ctrlKey : !ev.shiftKey;
                 if (!shouldPost) {
                     return;

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -114,7 +114,7 @@
 
 <t t-name="mail.Composer.sendButton">
     <button class="o-mail-Composer-send btn"
-        t-att-class="{'btn-primary': extended, 'p-1 rounded-pill': !extended, 'btn-link': !extended, 'border-start-0 me-2': env.inDiscussApp}"
+        t-att-class="{'btn-primary': extended or (ui.isSmall and !isSendButtonDisabled), 'p-1 rounded-pill': !extended, 'btn-link': !extended and !(ui.isSmall and !isSendButtonDisabled), 'border-start-0 me-2': env.inDiscussApp}"
         t-on-click="sendMessage"
         t-att-disabled="isSendButtonDisabled"
         t-att-aria-label="SEND_TEXT"

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -2,6 +2,7 @@ import {
     click,
     contains,
     defineMailModels,
+    insertText,
     onRpcBefore,
     openDiscuss,
     patchUiSize,
@@ -9,9 +10,10 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
 
-describe.current.tags("desktop");
+describe.current.tags("mobile");
 defineMailModels();
 
 test("auto-select 'Inbox' when discuss had channel as active thread", async () => {
@@ -49,4 +51,18 @@ test("show loading on initial opening", async () => {
     def.resolve();
     await contains(".o-mail-MessagingMenu .fa.fa-circle-o-notch.fa-spin", { count: 0 });
     await contains(".o-mail-NotificationItem", { text: "General" });
+});
+
+test("enter key should create a newline in composer", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-MessagingMenu-tab", { text: "Channel" });
+    await click(".o-mail-NotificationItem", { text: "General" });
+    await insertText(".o-mail-Composer-input", "Test\n");
+    await press("Enter");
+    await insertText(".o-mail-Composer-input", "Other");
+    await click(".o-mail-Composer-send");
+    await contains(".o-mail-Message-body:has(br)", { textContent: "TestOther" });
 });


### PR DESCRIPTION
The composer should not send the current input on Enter key when being on a mobile device, since it is impossible for them to create a new line with either ctrl-Enter or alt-enter.

[FIX] mail: Discuss on Mobile - Enter key behavior

The composer should not send the current input on Enter key when being on a mobile device, since it is impossible for them to create a new line with either ctrl-Enter or alt-enter.

The style of send button in mobile was too subtle between active and inactive. Since this button becomes the only way to send message in mobile, its visual as been adapted to make it more obvious.

Task-4209142

Before / After (visual)
![Screenshot 2025-03-21 at 14 20 39](https://github.com/user-attachments/assets/82d8f9bc-538f-4148-a00a-d5e9799acf9d)
![Screenshot 2025-03-21 at 14 20 02](https://github.com/user-attachments/assets/6e75721d-b7f6-4036-b938-ce428844f5d2)
