### PR TITLE
[FIX] base_import: prevent index out of range error during import

### DIFF
--- a/addons/base_import/i18n/base_import.pot
+++ b/addons/base_import/i18n/base_import.pot
@@ -270,6 +270,15 @@ msgstr ""
 #: code:addons/base_import/models/base_import.py:0
 #, python-format
 msgid ""
+"Error while importing records: all rows should be of the same size, but some"
+" rows have different sizes."
+msgstr ""
+
+#. module: base_import
+#. odoo-python
+#: code:addons/base_import/models/base_import.py:0
+#, python-format
+msgid ""
 "Error while importing records: all rows should be of the same size, but the "
 "title row has %d entries while the first row has %d. You may need to change "
 "the separator character."

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1107,6 +1107,11 @@ class Import(models.TransientModel):
             raise ImportValidationError(
                 _("Error while importing records: all rows should be of the same size, but the title row has %d entries while the first row has %d. You may need to change the separator character.", len(fields), len(rows_to_import[0]))
             )
+        
+        if any(len(row) != len(fields) for row in rows_to_import):
+            raise ImportValidationError(
+                _("Error while importing records: all rows should be of the same size, but some rows have different sizes.")
+            )
 
         if options.get('has_headers'):
             rows_to_import = rows_to_import[1:]


### PR DESCRIPTION
Currently, an exception is generated when a user imports a CSV file, and the system tries to access an index beyond the length of a row.

Steps to Produce:

1. Install `contacts` module.
2. Navigate to Contacts -> Import records.
3. Import this file [1]
4. An error occurs.

Error:
```
IndexError
list index out of range
```
This issue [2] occurs when a user imports a CSV file where a row has fewer values than the expected field length. When the system processes the file using the mapper function, it tries to access missing indexes, causing an error.

[1] - https://drive.google.com/file/d/1qZLCGKSjitqclaXy9Gvzn6_4CIDNzZ3K/view?usp=sharing
[2] - https://github.com/odoo/odoo/blob/9c3c32e0083cf3242c75da1664bb9dfda0c2d73d/addons/base_import/models/base_import.py#L1113-L1118

This commit resolves the issue by raising an `ImportValidationError` when any row in the import file has a length that does not match the length of the fields.

sentry-6251128895

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
