### PR TITLE
[IMP] hr_work_entry_contract: filter no contract employees in work entry regenration wizard

### DIFF
--- a/addons/hr_work_entry_contract/wizard/hr_work_entry_regeneration_wizard_views.xml
+++ b/addons/hr_work_entry_contract/wizard/hr_work_entry_regeneration_wizard_views.xml
@@ -7,7 +7,8 @@
             <form string="Regenerate Employee Work Entries">
                 <group>
                     <group>
-                        <field name="employee_ids" widget="many2many_avatar_employee"/>
+                        <field name="employee_ids" widget="many2many_avatar_employee"
+                            domain="[('company_id', 'in', allowed_company_ids), ('contract_ids.id','!=', False)]"/>
                         <label for="date_from"></label>
                         <div name="date_from">
                             <div class="text-info" invisible="earliest_available_date_message == ''">


### PR DESCRIPTION
This commit filters out employees without a contract from the selection list when regenerating work entries.

task-4660041

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
