### PR TITLE
[FIX] sale_timesheet: button type missing in xml view

### DIFF
--- a/addons/sale_timesheet/views/sale_order_views.xml
+++ b/addons/sale_timesheet/views/sale_order_views.xml
@@ -9,6 +9,7 @@
             <button name="action_view_task" position="after">
                 <button
                     name="action_view_timesheet"
+                    type="object"
                     class="oe_stat_button"
                     icon="fa-clock-o"
                     invisible="not show_hours_recorded_button"


### PR DESCRIPTION
The 'type' is missing in the definition of the button used for the 'action_view_timesheet' in the sale order view. This lead to a traceback.
Adds the type=object to fix the issue.

