### PR TITLE
[IMP] point_of_sale: when user enter cash amount, replace '.' by decimal point character

### DIFF
--- a/addons/point_of_sale/static/src/js/custom_hooks.js
+++ b/addons/point_of_sale/static/src/js/custom_hooks.js
@@ -133,6 +133,7 @@ odoo.define('point_of_sale.custom_hooks', function (require) {
             return ![decimalPoint, '-'].includes(inputValue) && floatRegex.test(inputValue);
         }
         function handleCashInputChange(event) {
+            event.target.value = event.target.value.replace(".", decimalPoint)
             let inputValue = (event.target.value || "").trim();
 
             // Check if the current input value is a valid float


### PR DESCRIPTION
**rational**: 
when decimal point is not '.' but ',' (for exemple, in France), user can not user keyboard pad to enter amount. that is a classic usage. With that patch, '.' will be replaced by the correct decimal point. depending on the localization.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
