### PR TITLE
[PERF] account: Speed-up duplicate bills lookup in list view

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -749,6 +749,13 @@ class AccountMove(models.Model):
             expressions=['journal_id', 'company_id', 'date'],
             where="made_sequence_gap = TRUE",
         )  # used in <account.journal>._query_has_sequence_holes
+        create_index(
+            self.env.cr,
+            indexname='account_move_duplicate_bills_idx',
+            tablename='account_move',
+            expressions=['ref'],
+            where="move_type IN ('in_invoice', 'in_refund')",
+        )
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
@@ -1879,6 +1886,7 @@ class AccountMove(models.Model):
         if in_moves:
             in_moves_sql_condition = SQL("""
                 move.move_type in ('in_invoice', 'in_refund')
+                AND duplicate_move.move_type in ('in_invoice', 'in_refund')
                 AND (
                    move.ref = duplicate_move.ref
                    AND (


### PR DESCRIPTION
Description:
------------
Following commit 4e7b5e44b292dc41217e4c50048b8bb8408246f5, the list view for bills now shows a colored highlight on the bill's reference if there is a potential duplicate, and the matching on the invoice date was relaxed to include potential bills from the same year.

This caused a performance regression, as the index on `invoice_date` could no longer be used since the year is now extracted from it.

This patch adds a partial 'btree' index on the `ref` field specifically for bills, as it is the most discriminatory factor when identifying potential duplicates.

Benchmark:
----------
On a database with 6M `account_move` records, 230k of which are `'in_invoice'` & `'in_refund'`, `_fetch_duplicate_reference`, triggered when opening the list view of bills, took:

| Before | After | Speedup |
|--------|-------|---------|
| 19.8s  | 20ms  | 990x    |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
