### PR TITLE
[FIX] stock: allow inventory adjustments for products in non-company specific location

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -307,7 +307,7 @@ class StockQuant(models.Model):
                 quant = super().create(vals)
                 _add_to_cache(quant)
                 quants |= quant
-                if self._is_inventory_mode():
+                if self._is_inventory_mode() and quant.company_id:
                     quant._check_company()
         return quants
 

--- a/addons/stock/tests/test_robustness.py
+++ b/addons/stock/tests/test_robustness.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import TransactionCase
 
@@ -385,3 +386,40 @@ class TestRobustness(TransactionCase):
         self.env['stock.quant']._clean_reservations()
         # the reserved quantity should be cleaned to the quantity reserved by the move
         self.assertEqual(quant.reserved_quantity, 0.1)
+
+    def test_clean_quants_synch_in_non_company_specific_locations(self):
+        """
+        Accessing the inventory view will add an inventory_mode in the context
+        and launch a call of the `_clean_reservation`.
+
+        This checks that the _clean_reservation method does not raise user errors if it
+        plans to create a quants in a non-company specific location.
+        """
+        product_without_quant = self.env['product.product'].create({
+            'name': 'Product reserved without quant',
+            'is_storable': True,
+            'company_id': self.stock_location.company_id.id,
+        })
+        reservation_move = self.env['stock.move'].create({
+            'name': 'Lovely move',
+            'company_id': self.stock_location.company_id.id,
+            'location_id': self.ref('stock.stock_location_inter_company'),
+            'location_dest_id': self.stock_location.id,
+            'product_id': product_without_quant.id,
+            'product_uom': product_without_quant.uom_id.id,
+            'product_uom_qty': 5.0,
+        })
+
+        reservation_move._action_confirm()
+        reservation_move.quantity = 5
+        self.assertRecordValues(product_without_quant.stock_quant_ids, [
+            {'location_id': self.ref('stock.stock_location_inter_company'), 'reserved_quantity': 5.0}
+        ])
+        # create a syncj issue
+        product_without_quant.stock_quant_ids.unlink()
+        self.assertFalse(product_without_quant.stock_quant_ids)
+        # acces the quant view to provoke a quant synch
+        self.env['stock.quant'].action_view_quants()
+        self.assertRecordValues(product_without_quant.stock_quant_ids, [
+            {'location_id': self.ref('stock.stock_location_inter_company'), 'reserved_quantity': 5.0}
+        ])


### PR DESCRIPTION
### Issue:

It happens due to many reasons that the `stock.quant` object and the `stock.move.line` loose their synchronization and it could have a difference between the sum of `stock.move.line` and the quantity/reserved quantity on the stock.quant.
Starting from 18.0: Commit 766ec99dbc2701a237f082f3fb124793d9dfe596 the action `_clean_reservations` is called in the `_quant_tasks` to reconcile both. However, this action is performed in `inventory_mode` when we access quant view:
https://github.com/odoo/odoo/blob/82aa55b90e64defb6dd6707c5cebf74fba6b74d3/addons/stock/models/stock_quant.py#L394-L398 https://github.com/odoo/odoo/blob/82aa55b90e64defb6dd6707c5cebf74fba6b74d3/addons/stock/models/stock_quant.py#L1301-L1304 In certain cases this causes an invalid operation. For instance because we can not create a quants in a location that does not belong to a company`inventory_move`. This happens because the company_id of the quant will be false:
https://github.com/odoo/odoo/blob/82aa55b90e64defb6dd6707c5cebf74fba6b74d3/addons/stock/models/stock_quant.py#L57 But the `company_id` of the product will not and hence will fail the `check_company` performed for inventory_move:
https://github.com/odoo/odoo/blob/82aa55b90e64defb6dd6707c5cebf74fba6b74d3/addons/stock/models/stock_quant.py#L306-L311 https://github.com/odoo/odoo/blob/82aa55b90e64defb6dd6707c5cebf74fba6b74d3/odoo/models.py#L4354-L4355

### Steps to reproduce:

- In the settings enable intercompany transactions and multi-step routes
- Create a storable product P and set the product company_id
- Create an internal transfer from the inter-company transit to stock for 1 unit of P
- Confirm the picking and set a quantity of 1
- Delete the quant that was created in inter-company transit with a reserved quantity of 1 (this can be done via a server action).
- Inventory > Reporting > Locations
> Invalid operation: inter-company transit belongs to company "False"
and product "P" belongs to an other company.

opw-4635684
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
