### PR TITLE
[FIX] base: server actions: update a o2m field

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -965,7 +965,7 @@ class IrActionsServer(models.Model):
     @api.depends('evaluation_type', 'update_field_id')
     def _compute_value_field_to_show(self):  # check if value_field_to_show can be removed and use ttype in xml view instead
         for action in self:
-            if action.update_field_id.ttype in ('many2one', 'many2many'):
+            if action.update_field_id.ttype in ('one2many', 'many2one', 'many2many'):
                 action.value_field_to_show = 'resource_ref'
             elif action.update_field_id.ttype == 'selection':
                 action.value_field_to_show = 'selection_value'
@@ -1000,7 +1000,7 @@ class IrActionsServer(models.Model):
             expr = action.value
             if action.evaluation_type == 'equation':
                 expr = safe_eval(action.value, eval_context)
-            elif action.update_field_id.ttype == 'many2many':
+            elif action.update_field_id.ttype in ['one2many', 'many2many']:
                 operation = action.update_m2m_operation
                 if operation == 'add':
                     expr = [Command.link(int(action.value))]

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -347,9 +347,9 @@
                             <field name="value_field_to_show" invisible="1"/>
                             <field name="update_related_model_id" invisible="1"/>
                             <field name="update_field_type" invisible="1"/>
-                            <span invisible="evaluation_type != 'value' or not update_field_type == 'many2many'">by</span>
-                            <field name="update_m2m_operation" class="oe_inline" invisible="evaluation_type != 'value' or not update_field_type == 'many2many'" required="update_field_type == 'many2many'"/>
-                            <span invisible="evaluation_type != 'value' or update_field_type == 'many2many'">to</span>
+                            <span invisible="evaluation_type != 'value' or update_field_type not in ['one2many', 'many2many']">by</span>
+                            <field name="update_m2m_operation" class="oe_inline" invisible="evaluation_type != 'value' or update_field_type not in ['one2many', 'many2many']" required="update_field_type in ['one2many', 'many2many']"/>
+                            <span invisible="evaluation_type != 'value' or update_field_type in ['one2many', 'many2many']">to</span>
                             <field name="value" class="oe_inline" placeholder="Set a value..." invisible="update_field_id == False or value_field_to_show != 'value' or evaluation_type != 'value'" string="Custom Value"/>
                             <field name="resource_ref" class="oe_inline" placeholder="Choose a value..." string="Custom Value" options="{'model_field': 'update_related_model_id', 'no_create': True, 'no_open': True}" invisible=" update_field_id == False or value_field_to_show != 'resource_ref' or evaluation_type == 'equation' or update_m2m_operation == 'clear'"/>
                             <field name="selection_value" class="oe_inline" placeholder="Choose a value..." options="{'no_create': True, 'no_open': True}" invisible=" update_field_id == False or value_field_to_show != 'selection_value' or evaluation_type == 'equation'"/>


### PR DESCRIPTION
Since [1] the widget displayed on a server action form view when it is set up as "Update a o2m field on a record" was not displaying the fields in the proper way.

Before: the value field was a text field expecting the user to input the record id by hand.

After: the value field is now a many2one selector.

[1]: https://github.com/odoo/odoo/commit/0a744accc2aaa965d5353e854317895d822ad954