### PR TITLE
[IMP] im_livechat, mail: do not show channel join/leave notification

### DIFF
--- a/addons/im_livechat/static/src/embed/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_model_patch.js
@@ -8,5 +8,12 @@ const messagePatch = {
         super.setup(...arguments);
         this.disableChatbotAnswers = false;
     },
+
+    get notificationHidden() {
+        if (this.thread.channel_type !== "livechat" || !this.notificationType) {
+            return super.notificationHidden;
+        }
+        return ["channel-joined", "channel-left"].includes(this.notificationType);
+    },
 };
 patch(Message.prototype, messagePatch);

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -190,7 +190,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             joined_message_data["mail.message"][0].update(
                 {
                     "author": {"id": self.partner_employee.id, "type": "partner"},
-                    "body": ["markup", "<div class=\"o_mail_notification\">joined the channel</div>"],
+                    "body": ["markup", "<div class=\"o_mail_notification\" data-oe-type=\"channel-joined\">joined the channel</div>"],
                     # thread not renamed yet at this step
                     "default_subject": "Testing Bot",
                     "record_name": "Testing Bot",

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -24,4 +24,7 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
         john.partner_id.user_livechat_username = "ELOPERADOR"
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         channel.add_members(partner_ids=john.partner_id.ids)
-        self.assertEqual(channel.message_ids[-1].body, f"<div class=\"o_mail_notification\">invited <a href=\"#\" data-oe-model=\"res.partner\" data-oe-id=\"{john.partner_id.id}\">@ELOPERADOR</a> to the channel</div>")
+        self.assertEqual(
+            channel.message_ids[-1].body,
+            f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{john.partner_id.id}">@ELOPERADOR</a> to the channel</div>',
+        )

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -454,7 +454,7 @@ class DiscussChannel(models.Model):
             (partner or guest)._bus_send_store(custom_store)
             return
         if post_leave_message:
-            notification = Markup('<div class="o_mail_notification">%s</div>') % _(
+            notification = Markup('<div class="o_mail_notification" data-oe-type="channel-left">%s</div>') % _(
                 "left the channel"
             )
             # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
@@ -519,7 +519,7 @@ class DiscussChannel(models.Model):
                         else _("invited %s to the channel", member._get_html_link(for_persona=True))
                     )
                     member.channel_id.message_post(
-                        body=Markup('<div class="o_mail_notification">%s</div>') % notification,
+                        body=Markup('<div class="o_mail_notification" data-oe-type="channel-joined">%s</div>') % notification,
                         message_type="notification",
                         subtype_xmlid="mail.mt_comment",
                     )

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -353,6 +353,10 @@ export class Message extends Record {
         return this.email_from;
     }
 
+    get notificationHidden() {
+        return false;
+    }
+
     get inlineBody() {
         if (this.notificationType === "call") {
             return _t("%(caller)s started a call", { caller: this.author.name });

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -22,9 +22,9 @@
                     <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1 px-2">
                         <hr class="flex-grow-1 border-danger opacity-100"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase">New</span>
                     </div>
-                    <NotificationMessage t-if="msg.isNotification" message="msg" thread="props.thread" registerMessageRef="registerMessageRef" />
+                    <NotificationMessage t-if="msg.isNotification and !msg.notificationHidden" message="msg" thread="props.thread" registerMessageRef="registerMessageRef" />
                     <Message
-                        t-else=""
+                        t-elif="!msg.isNotification"
                         asCard="props.thread.model === 'mail.box'"
                         className="getMessageClassName(msg)"
                         isInChatWindow="props.isInChatWindow"

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -112,7 +112,10 @@ export class DiscussCoreCommon {
                     channel.selfMember.syncUnread = true;
                     channel.scrollUnread = true;
                 }
-                if (notifId > channel.selfMember?.message_unread_counter_bus_id) {
+                if (
+                    notifId > channel.selfMember?.message_unread_counter_bus_id &&
+                    !message.isNotification
+                ) {
                     channel.selfMember.message_unread_counter++;
                 }
             }

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -91,7 +91,7 @@ const threadPatch = {
                 if (!this.selfMember) {
                     return null;
                 }
-                const messages = this.messages;
+                const messages = this.messages.filter((m) => !m.isNotification);
                 const separator = this.selfMember.localNewMessageSeparator;
                 if (separator === 0 && !this.loadOlder) {
                     return messages[0];

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -93,7 +93,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                         },
                                         "body": [
                                             "markup",
-                                            f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}">@Test Partner</a> to the channel</div>',
+                                            f'<div class="o_mail_notification" data-oe-type=\"channel-joined\">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}">@Test Partner</a> to the channel</div>',
                                         ],
                                         "create_date": fields.Datetime.to_string(
                                             message.create_date

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1323,7 +1323,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
                 "body": [
                     "markup",
-                    f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_9.partner_id.id}">@test9</a> to the channel</div>',
+                    f'<div class="o_mail_notification" data-oe-type=\"channel-joined\">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_9.partner_id.id}">@test9</a> to the channel</div>',
                 ],
                 "create_date": create_date,
                 "date": date,
@@ -1360,7 +1360,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
                 "body": [
                     "markup",
-                    f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_12.partner_id.id}">@test12</a> to the channel</div>',
+                    f'<div class="o_mail_notification" data-oe-type=\"channel-joined\">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_12.partner_id.id}">@test12</a> to the channel</div>',
                 ],
                 "create_date": create_date,
                 "date": date,
@@ -1397,7 +1397,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
                 "body": [
                     "markup",
-                    f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_13.partner_id.id}">@test13</a> to the channel</div>',
+                    f'<div class="o_mail_notification" data-oe-type=\"channel-joined\">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_13.partner_id.id}">@test13</a> to the channel</div>',
                 ],
                 "create_date": create_date,
                 "date": date,

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -248,8 +248,8 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 trigger: messagesContain("I will transfer you to a human."),
             },
             {
-                trigger:
-                    ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(joined the channel)",
+                // Wait for the operator to be added: composer is only enabled at that point.
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
             },
         ];
     },

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
@@ -20,11 +20,8 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_forward", {
             trigger: messagesContain("I'll forward you to an operator."),
         },
         {
-            trigger:
-                ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(joined the channel)",
-        },
-        {
-            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            // Wait for the operator to be added: composer is only enabled at that point.
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
             run: "edit Hello, I need help!",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_fw_operator_matching_lang.js
@@ -2,30 +2,16 @@
 
 import { registry } from "@web/core/registry";
 
-const commonSteps = [
-    { trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello! I'm a bot!')" },
-    {
-        trigger: ".o-livechat-root:shadow button:contains(I want to speak with an operator)",
-        run: "click",
-    },
-];
-
-registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang_en", {
+registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang", {
     steps: () => [
-        ...commonSteps,
+        { trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello! I'm a bot!')" },
         {
-            trigger:
-                ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(joined the channel)",
+            trigger: ".o-livechat-root:shadow button:contains(I want to speak with an operator)",
+            run: "click",
         },
-    ],
-});
-
-registry.category("web_tour.tours").add("chatbot_fw_operator_matching_lang_fr", {
-    steps: () => [
-        ...commonSteps,
         {
-            trigger:
-                ".o-livechat-root:shadow .o-mail-NotificationMessage:contains(a rejoint le canal)", // FIXME: lang is on behalf of who triggers the notification
+            // Wait for the operator to be added: composer is only enabled at that point.
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input:enabled",
         },
     ],
 });

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -211,12 +211,12 @@ class TestLivechatChatbotUI(TestGetOperatorCommon, TestWebsiteLivechatCommon, Ch
         )
         self.livechat_channel.user_ids = fr_op + en_op
         self.env["discuss.channel"].search([("livechat_channel_id", "=", self.livechat_channel.id)]).unlink()
-        self.start_tour("/fr", "chatbot_fw_operator_matching_lang_fr")
+        self.start_tour("/fr", "chatbot_fw_operator_matching_lang")
         channel = self.livechat_channel.channel_ids[0]
         self.assertIn(channel.channel_member_ids.partner_id.user_ids, fr_op)
         self.assertNotIn(channel.channel_member_ids.partner_id.user_ids, en_op)
         self.env["discuss.channel"].search([("livechat_channel_id", "=", self.livechat_channel.id)]).unlink()
-        self.start_tour("/en", "chatbot_fw_operator_matching_lang_en")
+        self.start_tour("/en", "chatbot_fw_operator_matching_lang")
         channel = self.livechat_channel.channel_ids[0]
         self.assertIn(channel.channel_member_ids.partner_id.user_ids, en_op)
         self.assertNotIn(channel.channel_member_ids.partner_id.user_ids, fr_op)


### PR DESCRIPTION
Hide channel join/leave notifications from the live chat visitor as it could give the impression that their conversation was abandoned.

task-4607295

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
