### PR TITLE
[FIX] project : Differentiate between invisibility of the parent and child div

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -126,7 +126,7 @@
                                     </div>
                                 </group>
                                 <group name="group_time_managment" string="Time Management" invisible="1" col="1" class="row mt16 o_settings_container"/>
-                                <group name="group_documents_analytics" string="Analytics" col="1" class="row mt16 o_settings_container" invisible="not rating_active">
+                                <group name="group_documents_analytics" string="Analytics" col="1" class="row mt16 o_settings_container" groups="project.group_project_rating">
                                     <div>
                                         <field name="rating_active" invisible="1"/>
                                         <setting class="col-lg-12" name="analytic_div" help="Get customer feedback and evaluate the performance of your employees" groups="project.group_project_rating">


### PR DESCRIPTION
### Steps to reproduce:
	- Enable Customer Ratings in general settings
	- Uninstall Documents module
	- Navigate to any project's settings and customer rating option
	- Notice the whole option got disappeared instead of just hiding the child options

### Cause:
This is happening because after this commit https://github.com/odoo-dev/odoo/commit/16ca5b73646749d1a9341bbc02c6ca048feb66c2#diff-54a713792b3dba141af5416c4b89973ddf662cfad2bb65c642ad4534dddec626 we removed allow_rating and we are using rating_active which is the setting field for each project separately for showing both divs or not

https://github.com/odoo/odoo/blob/c68ec0aaed70973f65d46d75875c59f5bc10f23b/addons/project/views/project_project_views.xml#L129

https://github.com/odoo/odoo/blob/c68ec0aaed70973f65d46d75875c59f5bc10f23b/addons/project/views/project_project_views.xml#L134

### Fix:
For the parent div we will be using the groups attribute instead
of invisible attribute

opw-4633771