### PR TITLE
[FIX] pos_sale: fix amount to invoice

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -40,8 +40,8 @@ class SaleOrder(models.Model):
         for order in self:
             if order.invoice_status == 'invoiced':
                 continue
-            # We need to account for the downpayment paid in POS with and without invoice
-            order_amount = sum(order.pos_order_line_ids.filtered(lambda pol: pol.sale_order_line_id.is_downpayment).mapped('price_subtotal_incl'))
+            # We need to account for all amount paid in POS with and without invoice
+            order_amount = sum(order.pos_order_line_ids.mapped('price_subtotal_incl'))
             order.amount_to_invoice -= order_amount
 
 

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1081,3 +1081,72 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.assertFalse(invoice.invoice_payment_term_id) 
 
         self.assertAlmostEqual(order.amount_total, invoice.amount_total, places=2, msg="Order and Invoice amounts do not match.")
+
+    def test_amount_to_invoice(self):
+        """
+        Checks that the amount to invoice is updated correctly when paying an order in the PoS
+        """
+
+        product_a = self.env['product.product'].create({
+            'name': 'Test service product',
+            'available_in_pos': True,
+            'type': 'service',
+            'invoice_policy': 'order',
+            'lst_price': 100.0,
+            'taxes_id': [],
+        })
+
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'product_uom': product_a.uom_id.id,
+                'price_unit': product_a.lst_price,
+            })],
+        })
+        self.main_pos_config.open_ui()
+        order_data = {
+            "amount_paid": 100,
+            "amount_tax": 0,
+            "amount_return": 0,
+            "amount_total": 100,
+            "pos_session_id": self.main_pos_config.current_session_id.id,
+            "date_order": fields.Datetime.to_string(fields.Datetime.now()),
+            "fiscal_position_id": False,
+            "lines": [
+                Command.create({
+                    "discount": 0,
+                    "pack_lot_ids": [],
+                    "price_unit": 100.0,
+                    "product_id": self.product_a.id,
+                    "price_subtotal": 100.0,
+                    "price_subtotal_incl": 100.0,
+                    "tax_ids": [],
+                    "sale_order_line_id": sale_order.order_line[0],
+                    "sale_order_origin_id": sale_order,
+                    "qty": 1,
+                }),
+            ],
+            "name": "Order 12345-123-1234",
+            "partner_id": self.partner_a.id,
+            "session_id": self.main_pos_config.current_session_id.id,
+            "sequence_number": 2,
+            "statement_ids": [
+                    Command.create({
+                        "amount": 100,
+                        "name": fields.Datetime.now(),
+                        "payment_method_id": self.main_pos_config.payment_method_ids[0].id,
+                    }),
+            ],
+            "uuid": "12345-123-1234",
+            "last_order_preparation_change": "{}",
+            "user_id": self.env.uid,
+            "to_invoice": True,
+        }
+        self.assertEqual(sale_order.amount_to_invoice, 100.0, "Amount to invoice should be 100.0")
+        self.env['pos.order'].create_from_ui([{"data": order_data}])
+        self.assertEqual(sale_order.amount_to_invoice, 0.0, "Amount to invoice should be 0.0")


### PR DESCRIPTION
When settling an order from the POS, the amount to invoice was not correctly computed.

Steps to reproduce:
-------------------
* Create a draft sale order with a product
* Go to the POS and select the order
* Pay for the order
* Go to the backend and check the amount to invoice
> Observation: The amount to invoice is still the full order amount

Why the fix:
------------
We should take into account the PoS payment lines when computing the amount to invoice of an order.

opw-4603671