### PR TITLE
[FIX] point_of_sale: ensure loading accessible products

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -788,12 +788,11 @@ class PosConfig(models.Model):
             self.get_limited_product_count(),
         )
         product_ids = [r[0] for r in self.env.execute_query(sql)]
-        special_products = self._get_special_products().filtered(
-            lambda product: not product.sudo().company_id
-                            or product.sudo().company_id == self.company_id
-        )
-        product_ids.extend(special_products.ids)
-        products = self.env['product.product'].browse(product_ids)
+        product_ids.extend(self._get_special_products().ids)
+        products = self.env['product.product'].search([('id', 'in', product_ids)])
+        # sort products by product_ids order
+        id_to_index = {pid: index for index, pid in enumerate(product_ids)}
+        products = products.sorted(key=lambda p: id_to_index[p.id])
         product_combo = products.filtered(lambda p: p['type'] == 'combo')
         product_in_combo = product_combo.combo_ids.combo_item_ids.product_id
         products_available = products | product_in_combo

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -1217,3 +1217,24 @@ class TestPoSBasicConfig(TestPoSCommon):
         self.assertFalse(pm_3.journal_id)
         self.assertTrue(pm_4)
         self.assertEqual(pm_4.journal_id.type, "bank")
+
+    def test_loading_products_with_access_right_issue(self):
+        product = self.env['product.product'].create({
+            'name': 'Product with access right issue',
+            'available_in_pos': True,
+            'type': 'consu',
+        })
+
+        self.env['ir.rule'].create({
+            'name': 'Test',
+            'model_id': self.env['ir.model']._get('product.product').id,
+            'domain_force': '[(\'id\', \'!=\', %s)]' % product.id,
+            'groups': [(4, self.env.ref('base.group_user').id)]
+        })
+
+        session = self.open_new_session()
+
+        data = session.load_data([])
+
+        self.assertNotIn(product.id, [p['id'] for p in data['product.product']['data']])
+        self.assertTrue(data['product.product']['data'])


### PR DESCRIPTION
Before this commit, if you defined a record rule on products, none of the products would be loaded in the POS. This commit fixes this issue by using search over browse because search automatically applies access rights filtering, returning only products the current user has access. This approach avoids the previous all-or-nothing behavior where a single inaccessible product would prevent all products from loading.

opw-4662433

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
