### PR TITLE
[FIX] marketing_card: avoid pylint false positive

### DIFF
--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -373,7 +373,7 @@ class CardCampaign(models.Model):
         """Helper to get the right value for dynamic fields."""
         self.ensure_one()
         result = {
-            'image1': images[0] if (images := self.content_image1_path and record.mapped(self.content_image1_path)) else False,
+            'image1': images[0] if (images := self.content_image1_path and record.mapped(self.content_image1_path)) else False,  # pylint:disable=E0601
             'image2': images[0] if (images := self.content_image2_path and record.mapped(self.content_image2_path)) else False,
         }
         campaign_text_element_fields = (


### PR DESCRIPTION
Pylint < 2.16.2 detects a variable referenced before assignment when the walrus operator is used in dictionary.

As Jammy provides pylint 2.12.2 and our tests should work with this distribution, let's skip it.

Fixed in pylint-dev/pylint#8176