### PR TITLE
[FIX] setup.py: find namespace packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # ruff: noqa: F821
 # (ruff don't see read variables from release.py)
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 from os.path import join, dirname
 
 
@@ -21,7 +21,7 @@ setup(
     classifiers=[c for c in classifiers.split('\n') if c],
     license=license,
     scripts=['setup/odoo'],
-    packages=find_packages(),
+    packages=find_namespace_packages(),
     package_dir={'%s' % lib_name: 'odoo'},
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Since b6f792fe, we use PEP420 native namespaces.

However, it broke the pip installs with `pip install -e .` or similar, resulting in :

```
$ odoo
Traceback (most recent call last):
  File "/home/odoo/.local/bin/odoo", line 3, in <module>
    import odoo.cli
ModuleNotFoundError: No module named 'odoo'
```

This commit fixes the issue by using the correct method to find the packages.

Docs: https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-namespace-packages

ping @kmagusiak 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
