### PR TITLE
[FIX] Fixed an issue causing the weight field on sale reports for POS…

### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -66,8 +66,8 @@ class SaleReport(models.Model):
             partner.country_id AS country_id,
             partner.industry_id AS industry_id,
             partner.commercial_partner_id AS commercial_partner_id,
-            (SUM(p.weight) * l.qty / u.factor) AS weight,
-            (SUM(p.volume) * l.qty / u.factor) AS volume,
+            (SUM(p.weight) * l.qty) AS weight,
+            (SUM(p.volume) * l.qty) AS volume,
             l.discount AS discount,
             SUM((l.price_unit * l.discount * l.qty / 100.0
                 / {self._case_value_or_one('pos.currency_rate')}

--- a/addons/pos_sale/tests/test_pos_sale_report.py
+++ b/addons/pos_sale/tests/test_pos_sale_report.py
@@ -13,6 +13,8 @@ class TestPoSSaleReport(TestPoSCommon):
         super(TestPoSSaleReport, self).setUp()
         self.config = self.basic_config
         self.product0 = self.create_product('Product 0', self.categ_basic, 0.0, 0.0)
+        # Ensure that adding a uom to the product with a factor != 1 does not cause an error in weight and volume calculation
+        self.product0.uom_id = self.env['uom.uom'].search([('name', '=', 'Dozens')], limit=1)
 
     def test_weight_and_volume(self):
         self.product0.product_tmpl_id.weight = 3


### PR DESCRIPTION
… orders to be wrong when the product has a uom with a factor not equal to 1. task-4452892

Description of the issue/feature this PR addresses:
Issue with the weight field (Gross Weight) in sale report specifically for POS orders being an order of magnitude off from expected.

Current behavior before PR:
When viewing gross weight field in sale report for POS orders, the number is wrong when the product has a UOM with a factor which is not equal to one. For example, if I have a UOM called 25kg which will be bigger than the base unit kg by a ratio of 25, its factor will be 1/25 or 0.04. If I have a product with this UOM of 25kg and I also set the products weight to 25kg and then I buy 4 of this product, the gross weight calculation is 4 (items) * 25kg (weight) / 0.04 (factor) which leads to the incorrect gross weight of 2500kg. The expected weight would be 100kg (4 items * 25 kg). 

Desired behavior after PR is merged:
This PR will fix the above mentioned issue for POS order reporting by removing the divide by the factor field of UOM. 
This change is correct if we assume the sales order report weight calculation is correct. 
![image](https://github.com/user-attachments/assets/304c3611-2037-4e72-807d-7112715fa126)
In calculating the weight for sales orders we divide by `u.factor * u2.factor`. `u` is the UOM of the sale order line and `u2` is the UOM of the product template. When the UOM factor is the same for `u` and `u2` (eg. when both UOM are the same), `/ u.factor * u2.factor` is trivially always one. Then the calculation for weight is just product weight * qty ordered. Since in POS orders we cannot change the order line UOM, `u` and `u2` will always be the same for POS orders. Therefore, if we treat the sales order calculation as the ground truth, the correct calculation for weight in POS should just be product weight * qty ordered.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
