### PR TITLE
[IMP] web: allow showing empty data points in bar chart

### DIFF
--- a/addons/web/static/src/views/graph/graph_controller.js
+++ b/addons/web/static/src/views/graph/graph_controller.js
@@ -61,6 +61,8 @@ export class GraphController extends Component {
             context.graph_stacked = this.model.metaData.stacked;
             if (mode === "line") {
                 context.graph_cumulated = this.model.metaData.cumulated;
+            } else if (mode === "bar") {
+                context.graph_show_empty = this.model.metaData.showEmpty;
             }
         }
         return context;

--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -28,6 +28,11 @@
                 t-on-click="toggleStacked"
                 t-att-class="{ active: model.metaData.stacked }"
             />
+            <button class="btn btn-secondary fa fa-circle-o o_graph_button" data-tooltip="Empty Datapoints" aria-label="Empty Datapoints"
+                t-on-click="toggleShowEmpty"
+                t-att-class="{ active: model.metaData.showEmpty }"
+                t-att-disabled="!model.metaData.hasEmpty"
+            />
         </div>
         <div t-if="model.metaData.mode === 'line'" class="btn-group" role="toolbar" aria-label="Change graph">
             <button class="btn btn-secondary fa fa-database o_graph_button" data-tooltip="Stacked" aria-label="Stacked"

--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -117,6 +117,8 @@ export class GraphModel extends Model {
             if (metaData.mode === "line") {
                 metaData.cumulated =
                     "graph_cumulated" in context ? context.graph_cumulated : metaData.cumulated;
+            } else if (metaData.mode === "bar") {
+                metaData.showEmpty = context.graph_show_empty || metaData.showEmpty;
             }
         }
 
@@ -270,7 +272,7 @@ export class GraphModel extends Model {
      * @returns {Object[]}
      */
     _getProcessedDataPoints() {
-        const { groupBy, mode, order } = this.metaData;
+        const { groupBy, mode, order, showEmpty } = this.metaData;
         let processedDataPoints = [];
         if (mode === "line") {
             processedDataPoints = this.dataPoints.filter(
@@ -281,7 +283,9 @@ export class GraphModel extends Model {
                 (dataPoint) => dataPoint.value > 0 && dataPoint.count !== 0
             );
         } else {
-            processedDataPoints = this.dataPoints.filter((dataPoint) => dataPoint.count !== 0);
+            const nonEmptyPoints = this.dataPoints.filter((dataPoint) => dataPoint.count !== 0);
+            this.metaData.hasEmpty = nonEmptyPoints.length < this.dataPoints.length;
+            processedDataPoints = showEmpty ? this.dataPoints : nonEmptyPoints;
         }
 
         if (order !== null && mode !== "pie" && groupBy.length > 0) {

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -924,4 +924,9 @@ export class GraphRenderer extends Component {
         const { cumulated } = this.model.metaData;
         this.model.updateMetaData({ cumulated: !cumulated });
     }
+
+    toggleShowEmpty() {
+        const { showEmpty } = this.model.metaData;
+        this.model.updateMetaData({ showEmpty: !showEmpty });
+    }
 }


### PR DESCRIPTION
Steps
-----
1. Go to Sales;
2. open reporting;
3. show bar chart.

Issue
-----
Unlike 16.0, the chart only shows data points where sales occurred.

Cause
-----
The v16.0 behavior was/is actually a bug. It only shows data points where `dataPoint.count !== 0`, but this attribute is actually `undefined` for empty data points, meaning they weren't filtered out as intended.

Commit cdebf336a506f changed the way `read_group` handles pseudo-fields like `__count`, meaning the `count` attribute now is initialized to 0, and the data points get hidden.

Solution
--------
Turn the bug into a feature: add a button to toggle the old behavior for bar charts.

opw-4538287