### PR TITLE
[FIX] pos_loyalty: correctly remap `couponPointChanges`

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -395,9 +395,10 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                     continue;
                 }
                 const newId = nextId--;
-                delete this.oldCouponMapping[pe.coupon_id];
+                this.oldCouponMapping[pe.coupon_id] = newId;
                 pe.coupon_id = newId;
                 this.couponPointChanges[newId] = pe;
+                delete this.couponPointChanges[key];
             }
         }
         super.init_from_JSON(...arguments);


### PR DESCRIPTION
Before this commit, `couponPointChanges` was not properly remapped, which led to am error when refreshing the browser after applying a reward.

Steps to reproduce:

1. Create a promotion program with a free product for orders over $100.
2. In PoS, create an order meeting the $100 and apply the reward.
3. Validate the order and start a new one.
4. Again, make an order over $100 and apply the reward.
5. Refresh the browser at this point.

=> You will encounter the following error:
`Cannot read properties of undefined (reading 'appliedRules')`

opw-4644333

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
