### PR TITLE
[FIX] point_of_sale: Include company name in receipt header

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -6,7 +6,7 @@
         <div class="d-flex flex-column align-items-center">
             <div class="pos-receipt-contact">
                 <!-- contact address -->
-                <div t-if="order.company.partner_id?.[1]" t-esc="order.company.partner_id[1]" />
+                <div t-if="order.company?.name" t-esc="order.company.name" />
                 <t t-if="order.company.phone">
                     <div>Tel:<t t-esc="order.company.phone" /></div>
                 </t>


### PR DESCRIPTION
Issue:
order.company.partner_id[1] is undefined during the change to use `order` object as props component. in this PR: #189446

Purpose of this PR:
use order.company.name if it exists to include into the receipt header.

opw-4654437

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
