### PR TITLE
[FIX] mail: discuss sidebar channel thread line style

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -102,7 +102,7 @@
                 <t t-else="" t-call="mail.DiscussSidebarChannel.main"/>
                 <ul t-if="subChannels?.length > 0" class="list-unstyled position-relative flex-grow-1" t-att-class="{ 'my-1 d-flex flex-column gap-1': store.discuss.isSidebarCompact, 'my-0 d-flex flex-column gap-1': !store.discuss.isSidebarCompact }">
                     <t t-foreach="subChannels" t-as="sub" t-key="sub.localId">
-                        <DiscussSidebarSubchannel t-if="showThread(sub)" thread="sub" isFirst="sub_first or !isCategoryOpen"/>
+                        <DiscussSidebarSubchannel t-if="showThread(sub)" thread="sub" isFirst="sub_first or !thread.discussAppCategory.open"/>
                     </t>
                 </ul>
             </t>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/200310

PR above made a small typo: it removed `isCategoryOpen` which was alias for `thread.discussAppCategory.open` in template, but this was still mistakenly used in the `isFirst` props of a sub-thread template.

As a result, the list of pinned thread was not shown correctly, as all items we wrongly flagged as the first item.

Before / After
![Screenshot 2025-03-21 at 18 10 52](https://github.com/user-attachments/assets/444b1821-1426-4995-9e74-3eecaa5b4bbd) ![Screenshot 2025-03-21 at 18 11 55](https://github.com/user-attachments/assets/e4ca9ee2-c0f8-4353-9140-12f812d0fa38)

