### PR TITLE
[FIX] stock: add special default lot key to context when creating repair

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -82,7 +82,6 @@ class Repair(models.Model):
     product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
     lot_id = fields.Many2one(
         'stock.lot', 'Lot/Serial',
-        default=False,
         compute="compute_lot_id", store=True,
         domain="[('product_id','=', product_id), ('company_id', '=', company_id)]", check_company=True,
         help="Products repaired are all belonging to this lot")
@@ -291,6 +290,8 @@ class Repair(models.Model):
         res = super().default_get(fields_list)
         if 'picking_id' not in res and 'picking_id' in fields_list and 'default_repair_picking_id' in self.env.context:
             res['picking_id'] = self.env.context.get('default_repair_picking_id')
+        if 'lot_id' not in res and 'lot_id' in fields_list and 'default_repair_lot_id' in self.env.context:
+            res['lot_id'] = self.env.context.get('default_repair_lot_id')
         return res
 
     @api.model_create_multi

--- a/addons/repair/models/stock_lot.py
+++ b/addons/repair/models/stock_lot.py
@@ -45,7 +45,7 @@ class StockLot(models.Model):
             'domain': [('lot_id', '=', self.id)],
             'context': {
                 'default_product_id': self.product_id.id,
-                'default_lot_id': self.id,
+                'default_repair_lot_id': self.id,
                 'default_company_id': self.company_id.id,
             },
         })

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -777,3 +777,32 @@ class TestRepair(common.TransactionCase):
         self.assertFalse(move.repair_id)
         self.assertEqual(move.location_id, self.stock_warehouse.lot_stock_id)
         self.assertEqual(move.location_dest_id, self.stock_location_14)
+
+    def test_open_and_create_repair_from_lot(self):
+        """
+        Test that the repair order can be opened from the lot and that it is created correctly.
+        """
+        sn_1 = self.env['stock.lot'].create({'name': 'sn_1', 'product_id': self.product_storable_serial.id})
+        action = sn_1.action_lot_open_repairs()
+        context = action.get('context')
+        tracked_product_repair_line = self.env['product.product'].create({
+            'name': 'Test Product',
+            'type': 'product',
+            'tracking': 'serial',
+        })
+        tracked_product_sn = self.env['stock.lot'].create({'name': 'tracked_product_sn1', 'product_id': tracked_product_repair_line.id})
+        repair_order = self.env['repair.order'].with_context(context).create({
+            'product_id': self.product_storable_serial.id,
+            'product_uom': self.product_storable_serial.uom_id.id,
+            'location_id': self.stock_warehouse.lot_stock_id.id,
+            'lot_id': sn_1.id,
+            'picking_type_id': self.stock_warehouse.repair_type_id.id,
+        })
+        repair_order.with_context(context).move_ids = [Command.create({
+            'product_id': tracked_product_repair_line.id,
+            'product_uom_qty': 1.0,
+            'repair_line_type': 'add',
+            'lot_ids': [(4, tracked_product_sn.id)],
+            'quantity': 1.0,
+        })]
+        self.assertEqual(repair_order.lot_id, sn_1)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product P1:
    - Tracked by: Lot

- Update the quantity of P1 with one unit and Lot 1

- Create a storable product C1
    - Tracked by: Serial Number

- Update the quantity of C1 with one unit and SN1

- Navigate to Product P1 → Lot/SN → Click on Lot 1 → Repair Orders
- Create a repair order:
    - Add part: Select product C1 with SN1
- Try to save

Problem:
The lot "Lot 1" is incompatible with the product "C1".
 Since we access the Repair Order view from the Lot/SN view, a default
 key is added with "Lot 1". As a result, when trying to create the
 "stock.move.line" for C1, this incorrect lot is used.

opw-4576741
opw-4576004