### PR TITLE
[FIX] pos_loyalty: tb when no expiry date set

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -99,7 +99,7 @@ patch(PaymentScreen.prototype, {
                 agg[pe.coupon_id].partner_id = partner.id;
             }
             if (program.program_type != "loyalty") {
-                agg[pe.coupon_id].expiration_date = program.date_to;
+                agg[pe.coupon_id].expiration_date = program.date_to || pe.expiration_date;
             }
             return agg;
         }, {});

--- a/addons/pos_loyalty/static/src/utils/manage_giftcard_popup/manage_giftcard_popup.js
+++ b/addons/pos_loyalty/static/src/utils/manage_giftcard_popup/manage_giftcard_popup.js
@@ -50,7 +50,7 @@ export class ManageGiftCardPopup extends Component {
         this.props.getPayload(
             this.state.inputValue,
             parseFloat(this.state.amountValue),
-            serializeDate(this.state.expirationDate)
+            this.state.expirationDate ? serializeDate(this.state.expirationDate) : false
         );
         this.props.close();
     }


### PR DESCRIPTION
Steps to reproduce:
--------------------------
- Install the pos_loyalty module.
- Open register & add physical giftcard to the cart.
- On configuration popup don't set the expiry date & click on Add Balance.

Issue:
--------
- There is a tb instead of adding the balance to giftcard.
- The selected expiration date is not set on the backend.

Cause:
---------
- Trying to serialize null expiration date value.
- Not set from the correct variable.

Fix:
-----
- Expiration date should be serialized only if selected.
- Correctly mapped the value of expiration date from right variable.

Task: 4664094
