### PR TITLE
[IMP] orm: use naive datetime in columns

### DIFF
--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -101,7 +101,11 @@ class ResPartner(models.Model):
         :return dict[int, <calendar.event>]:
         """
         events = self.env['calendar.event'].search([
-            ('stop', '>=', start_datetime), ('start', '<=', end_datetime), ('partner_ids', 'in', self.ids), ('show_as', '=', 'busy')])
+            ('stop', '>=', start_datetime.replace(tzinfo=None)),
+            ('start', '<=', end_datetime.replace(tzinfo=None)),
+            ('partner_ids', 'in', self.ids),
+            ('show_as', '=', 'busy'),
+        ])
 
         event_by_partner_id = defaultdict(lambda: self.env['calendar.event'])
         for event in events:

--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.js
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.js
@@ -73,16 +73,16 @@ export class LeaveStatsComponent extends Component {
             return;
         }
 
-        const dateFrom = date.startOf("month");
-        const dateTo = date.endOf("month");
+        const dateFrom = date.startOf("month").setZone(null);
+        const dateTo = dateFrom.plus({'months': 1});
 
         const departmentLeaves = await this.orm.searchRead(
             "hr.leave",
             [
                 ["department_id", "=", department[0]],
                 ["state", "=", "validate"],
-                ["date_from", "<=", dateTo],
-                ["date_to", ">=", dateFrom],
+                ["date_from", "<", serializeDateTime(dateTo)],
+                ["date_to", ">=", serializeDateTime(dateFrom)],
             ],
             [
                 "employee_id",
@@ -126,14 +126,14 @@ export class LeaveStatsComponent extends Component {
             return;
         }
 
-        const dateFrom = date.startOf("year");
-        const dateTo = date.endOf("year");
+        const dateFrom = date.startOf("year").setZone(null);
+        const dateTo = dateFrom.plus({"years": 1});
         this.state.leaves = await this.orm.formattedReadGroup(
             "hr.leave",
             [
                 ["employee_id", "=", employee[0]],
                 ["state", "=", "validate"],
-                ["date_from", "<=", serializeDateTime(dateTo)],
+                ["date_from", "<", serializeDateTime(dateTo)],
                 ["date_to", ">=", serializeDateTime(dateFrom)],
             ],
             ["holiday_status_id"],

--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -82,8 +82,8 @@ class HrContract(models.Model):
     def _get_leave_domain(self, start_dt, end_dt):
         domain = [
             ('resource_id', 'in', [False] + self.employee_id.resource_id.ids),
-            ('date_from', '<=', end_dt),
-            ('date_to', '>=', start_dt),
+            ('date_from', '<=', end_dt.replace(tzinfo=None)),
+            ('date_to', '>=', start_dt.replace(tzinfo=None)),
             ('company_id', 'in', [False, self.company_id.id]),
         ]
         return expression.AND([domain, self._get_sub_leave_domain()])
@@ -92,6 +92,7 @@ class HrContract(models.Model):
         return self.env['resource.calendar.leaves'].search(self._get_leave_domain(start_dt, end_dt))
 
     def _get_attendance_intervals(self, start_dt, end_dt):
+        assert start_dt.tzinfo and end_dt.tzinfo, "function expects localized date"
         # {resource: intervals}
         employees_by_calendar = defaultdict(lambda: self.env['hr.employee'])
         for contract in self:

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -58,7 +58,7 @@ import logging
 import operator
 import typing
 import warnings
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 
 from odoo.exceptions import UserError
 from odoo.tools import SQL, OrderedSet, Query, classproperty, partition, str2bool
@@ -1315,10 +1315,17 @@ def _optimize_type_date(condition, _):
 
 
 def _value_to_datetime(value):
-    if isinstance(value, (SQL, datetime)) or value is False:
+    if isinstance(value, datetime):
+        if value.tzinfo:
+            # cast to a naive datetime
+            warnings.warn("Use naive datetimes in domains")
+            value = value.astimezone(timezone.utc).replace(tzinfo=None)
+        return value, False
+    if isinstance(value, SQL) or value is False:
         return value, False
     if isinstance(value, str):
-        return datetime.fromisoformat(value), len(value) == 10
+        dt, _ = _value_to_datetime(datetime.fromisoformat(value))
+        return dt, len(value) == 10
     if isinstance(value, date):
         return datetime.combine(value, time.min), True
     if isinstance(value, COLLECTION_TYPES):

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1214,8 +1214,13 @@ class Field(typing.Generic[T]):
     def _condition_to_sql(self, field_expr: str, operator: str, value, model: BaseModel, alias: str, query: Query) -> SQL:
         sql_field = model._field_to_sql(alias, field_expr, query)
 
-        def _value_to_column(v):
-            return self.convert_to_column(v, model, validate=False)
+        if field_expr == self.name:
+            def _value_to_column(v):
+                return self.convert_to_column(v, model, validate=False)
+        else:
+            # reading a property, keep value as-is
+            def _value_to_column(v):
+                return v
 
         # support for SQL value
         # TODO deprecate this usage


### PR DESCRIPTION
When converting datetimes to column value, make sure the timezone is not
set.  Then, we can send directly `datetime` objects to psycopg and avoid
converting them to strings.  This also allows to factor convert to
column for both Date and DateTime.

We need to adapt some code that used non-naive datetimes in domains.

odoo/enterprise#81970

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
