### PR TITLE
[FIX] marketing_card: require sync if template change

### DIFF
--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -113,7 +113,8 @@ class CardCampaign(models.Model):
             'content_header_dyn', 'content_header_path', 'content_header_color', 'content_sub_header',
             'content_sub_header_dyn', 'content_sub_header_path', 'content_section', 'content_section_dyn',
             'content_section_path', 'content_sub_section1', 'content_sub_section1_dyn', 'content_sub_header_color',
-            'content_sub_section1_path', 'content_sub_section2', 'content_sub_section2_dyn', 'content_sub_section2_path'
+            'content_sub_section1_path', 'content_sub_section2', 'content_sub_section2_dyn', 'content_sub_section2_path',
+            'card_template_id',
         ]
 
     def _check_access_right_dynamic_template(self):


### PR DESCRIPTION
Changing the template of marketing card will not mark the existing card "to update", leading to wrong template used.

Steps:
- Open marketing card
- Open Employee Card
- Ensure a template is selected (Center)
- Click on Send
- Click on "Update 128 cards"
- Download a card (/cards/1/card.jpg)
    - Template is well "Center"
- Change Sub-Header value
- Click on Send
    - You can update 128 cards
    - Update them
    - Download a card (/cards/1/card.jpg)
        - Sub-Header is updated
        - Template is still "Center"
- Change the template to "Drawing"
- Click on Send

Actual result:
- You can't update cards, require_sync field is false
- Download a card (/cards/1/card.jpg)
    - Template is still "Center"
- Sending email will not update them
- https://github.com/odoo/odoo/blob/4970215142d11efedc5ddc1d82ef7d671e7f0eeb/addons/marketing_card/models/card_campaign.py##L180-L181

Expected result:
- You can update cards, require_sync field is true
- Card template should be considered as a render field
