### PR TITLE
[IMP] point_of_sale: enforce address requirement for preset orders

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -2422,6 +2422,12 @@ msgstr ""
 
 #. module: point_of_sale
 #. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/services/pos_store.js:0
+msgid "Customer address is required"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
 #. odoo-python
 #: code:addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js:0
 #: code:addons/point_of_sale/wizard/pos_payment.py:0

--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -51,7 +51,7 @@ class ResPartner(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'id', 'name', 'street', 'city', 'state_id', 'country_id', 'vat', 'lang', 'phone', 'zip', 'email',
+            'id', 'name', 'street', 'street2', 'city', 'state_id', 'country_id', 'vat', 'lang', 'phone', 'zip', 'email',
             'barcode', 'write_date', 'property_account_position_id', 'property_product_pricelist', 'parent_name',
             'pos_contact_address', 'invoice_emails', 'company_type'
         ]

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -129,7 +129,7 @@ export class PosOrder extends Base {
     get presetRequirementsFilled() {
         return (
             (!this.preset_id?.needsPartner ||
-                (this.partner_id?.name && this.partner_id?.pos_contact_address)) &&
+                (this.partner_id?.name && (this.partner_id?.street || this.partner_id?.street2))) &&
             (!this.preset_id?.needsName || this.partner_id?.name || this.floating_order_name) &&
             (!this.preset_id?.needsSlot || this.preset_time)
         );

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1920,10 +1920,14 @@ export class PosStore extends WithLazyGetterTrap {
         }
 
         if (preset) {
-            if (preset.identification === "address" && !order.partner_id) {
-                const partner = await this.selectPartner();
+            if (preset.needsPartner) {
+                const partner = order.partner_id || (await this.selectPartner());
                 if (!partner) {
                     return;
+                }
+                if (!(partner.street || partner.street2)) {
+                    this.notification.add(_t("Customer address is required"), { type: "warning" });
+                    await this.editPartner(partner);
                 }
             }
 


### PR DESCRIPTION
Before this commit:
===============
- A customer without an address could be selected when ordering presets that require an address

After this commit:
===============
- A warning notification is displayed if a customer with an empty address is selected for the address-required preset.
- The customer edit form automatically opens to prompt the user to add an address.

Task: 4664774
