### PR TITLE
[FIX] project: personal stage if no project

### DIFF
--- a/addons/project/models/project_task_type.py
+++ b/addons/project/models/project_task_type.py
@@ -17,7 +17,7 @@ class ProjectTaskType(models.Model):
         return [default_project_id] if default_project_id else None
 
     def _default_user_id(self):
-        return 'default_project_id' not in self.env.context and self.env.uid
+        return not self.env.context.get('default_project_id', False) and self.env.uid
 
     active = fields.Boolean('Active', default=True)
     name = fields.Char(string='Name', required=True, translate=True)


### PR DESCRIPTION
Steps:
- create a stage from "To-Do" app
- reload the page

Actual result:
- stage disappear

Expected result:
- stage is shown as personal stage

opw-4637169