### PR TITLE
[FIX] l10n_ro_edi: use default XML as fallback

### DIFF
--- a/addons/l10n_ro_edi/models/account_move_send.py
+++ b/addons/l10n_ro_edi/models/account_move_send.py
@@ -49,9 +49,9 @@ class AccountMoveSend(models.AbstractModel):
             if 'ro_edi' in invoice_data['extra_edis']:
                 if invoice_data.get('ubl_cii_xml_attachment_values'):
                     xml_data = invoice_data['ubl_cii_xml_attachment_values']['raw']
-                elif invoice.l10n_ro_edi_document_ids:
-                    # If a document is on the invoice but the invoice's l10n_ro_edi_state is False,
-                    # this means that the previously sent XML are invalid and have to be rebuilt
+                elif invoice.ubl_cii_xml_id:
+                    xml_data = invoice.ubl_cii_xml_id.raw
+                else:
                     xml_data, build_errors = self.env['account.edi.xml.ubl_ro']._export_invoice(invoice)
                     if build_errors:
                         invoice_data['error'] = {
@@ -59,10 +59,6 @@ class AccountMoveSend(models.AbstractModel):
                             'errors': build_errors,
                         }
                         continue
-                elif invoice.ubl_cii_xml_id:
-                    xml_data = invoice.ubl_cii_xml_id.raw
-                else:
-                    xml_data = None
 
                 invoice._l10n_ro_edi_send_invoice(xml_data)
                 active_document = invoice.l10n_ro_edi_document_ids.sorted()[0]


### PR DESCRIPTION
Currently, if we try to send an invoice without defining an EDI format on the invoice's partner and attempt to send it to the SPV, we get the error: "CIUS-RO XML attachment not found."

Steps to reproduce:
- Install l10n_ro_edi
- Create an invoice
  - Do not set the eInvoice format on the partner
- Send it to the SPV
- You will get the error: "CIUS-RO XML attachment not found."

This fix, using "account.edi.xml.ubl_ro" as a fallback, makes sense because currently, when invoices are sent in batch mode, Odoo commits the issue stating that the CIUS-RO XML is missing. As a result, when we retry sending the invoice, "account.edi.xml.ubl_ro" will also be generated because the l10n_ro_edi_document_ids will not be empty.

opw-4623492