### PR TITLE
[FIX] hw_drivers: fix displays under wayland

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -31,6 +31,8 @@ pos_display_template = jinja_env.get_template('pos_display.html')
 
 _logger = logging.getLogger(__name__)
 
+MIN_IMAGE_VERSION_WAYLAND = 25.03
+
 
 class DisplayDriver(Driver):
     connection_type = 'display'
@@ -121,8 +123,17 @@ class DisplayDriver(Driver):
 
         if type(orientation) is not Orientation:
             raise TypeError("orientation must be of type Orientation")
-        subprocess.run(['xrandr', '-o', orientation.value], check=True)
-        subprocess.run([file_path('hw_drivers/tools/sync_touchscreen.sh'), str(int(self._x_screen) + 1)], check=False)
+
+        if float(helpers.get_version()[1:]) >= MIN_IMAGE_VERSION_WAYLAND:
+            subprocess.run(['wlr-randr', '--output', self.device_identifier, '--transform', orientation.value], check=True)
+            # Update touchscreen mapping to this display
+            with helpers.writable():
+                subprocess.run(['sed', '-i', f's/HDMI-A-[12]/{self.device_identifier}/', '/home/odoo/.config/labwc/rc.xml'])
+            # Tell labwc to reload its configuration
+            subprocess.run(['pkill', '-HUP', 'labwc'])
+        else:
+            subprocess.run(['xrandr', '-o', orientation.name.lower()], check=True)
+            subprocess.run([file_path('hw_drivers/tools/sync_touchscreen.sh'), str(int(self._x_screen) + 1)], check=False)
         helpers.save_browser_state(orientation=orientation)
 
 

--- a/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import re
 import subprocess
 
 try:
@@ -13,12 +14,14 @@ except ImportError:
     from vcgencmd import Vcgencmd
 
 from odoo.addons.hw_drivers.interface import Interface
+from odoo.addons.hw_drivers.tools import helpers
 
 _logger = logging.getLogger(__name__)
 
+MIN_IMAGE_VERSION_WAYLAND = 25.03
 
 class DisplayInterface(Interface):
-    _loop_delay = 0
+    _loop_delay = 3
     connection_type = 'display'
 
     def get_devices(self):
@@ -42,6 +45,16 @@ class DisplayInterface(Interface):
                 _logger.warning('Vcgencmd "display_power_state" method call failed')
 
             return display_devices or dummy_display
+
+        if float(helpers.get_version()[1:]) >= MIN_IMAGE_VERSION_WAYLAND:
+            randr_result = subprocess.run(['wlr-randr'], capture_output=True, text=True)
+            if randr_result.returncode != 0:
+                return {}
+            displays = re.findall(r"(?<=\()HDMI-A-\d(?=\))", randr_result.stdout)
+            return {
+                monitor: self._add_device(monitor, x_screen)
+                for x_screen, monitor in enumerate(displays)
+            }
 
         try:
             os.environ['DISPLAY'] = ':0'

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -39,11 +39,11 @@ except ImportError:
 
 
 class Orientation(Enum):
-    """xrandr screen orientation for kiosk mode"""
+    """xrandr/wlr-randr screen orientation for kiosk mode"""
     NORMAL = 'normal'
-    INVERTED = 'inverted'
-    LEFT = 'left'
-    RIGHT = 'right'
+    INVERTED = '180'
+    LEFT = '90'
+    RIGHT = '270'
 
 
 class CertificateStatus(Enum):
@@ -614,7 +614,7 @@ def save_browser_state(url=None, orientation=None):
     """
     update_conf({
         'browser-url': url,
-        'screen-orientation': orientation.value if orientation else None,
+        'screen-orientation': orientation.name.lower() if orientation else None,
     })
 
 
@@ -624,8 +624,8 @@ def load_browser_state():
     :return: The URL the browser is on and the orientation of the screen (default to NORMAL)
     """
     url = get_conf('browser-url')
-    orientation = get_conf('screen-orientation') or Orientation.NORMAL
-    return url, Orientation(orientation)
+    orientation = get_conf('screen-orientation') or Orientation.NORMAL.name
+    return url, Orientation[orientation.upper()]
 
 
 def url_is_valid(url):

--- a/addons/hw_drivers/views/pos_display.html
+++ b/addons/hw_drivers/views/pos_display.html
@@ -71,6 +71,7 @@
         </style>
         <style>
             body {
+                cursor: none;
                 background: url('/hw_posbox_homepage/static/img/background-light.svg') no-repeat center center fixed;
                 background-size: cover;
                 height: 100vh;


### PR DESCRIPTION
This commit is a backport of the display driver
changes from commit 078533b. These changes allow
displays to be detected and rotated correctly
under Wayland.

task-4657986

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
