### PR TITLE
[FIX] im_livechat: close live chat session during GC

### DIFF
--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -21,8 +21,11 @@ class DiscussChannelMember(models.Model):
         ])
         sessions_to_be_unpinned = members.filtered(lambda m: m.message_unread_counter == 0)
         sessions_to_be_unpinned.write({'unpin_dt': fields.Datetime.now()})
+        sessions_to_be_unpinned.channel_id.livechat_active = False
         for member in sessions_to_be_unpinned:
             member._bus_send("discuss.channel/unpin", {"id": member.channel_id.id})
+        for channel in sessions_to_be_unpinned.channel_id:
+            channel._bus_send_store(channel, "livechat_active")
 
     def _to_store_defaults(self):
         # sudo: discuss.channel - reading livechat channel to check whether current member is a bot is allowed

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -321,6 +321,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         with freeze_time(fields.Datetime.to_string(fields.Datetime.now() + timedelta(days=1))):
             member_of_operator._gc_unpin_livechat_sessions()
         self.assertFalse(member_of_operator.is_pinned, "read channel should be unpinned after one day")
+        self.assertFalse(member_of_operator.channel_id.livechat_active)
 
     def test_unread_channel_not_unpined_for_operator_after_autovacuum(self):
         data = self.make_jsonrpc_request('/im_livechat/get_session', {'anonymous_name': 'visitor', 'channel_id': self.livechat_channel.id})
@@ -334,6 +335,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         with freeze_time(fields.Datetime.to_string(fields.Datetime.now() + timedelta(days=1))):
             member_of_operator._gc_unpin_livechat_sessions()
         self.assertTrue(member_of_operator.is_pinned, "unread channel should not be unpinned after autovacuum")
+        self.assertTrue(member_of_operator.channel_id.livechat_active)
 
     def test_livechat_manager_can_invite_anyone(self):
         channel = self.env["discuss.channel"].create(


### PR DESCRIPTION
Since [1], operators now leave live chats instead of just unpinning them. When this happens, the chat is marked as inactive, preventing visitors from sending more messages—giving operators better control over their chats.

However, the GC, which unpins old chats after one day of inactivity, was not updated accordingly. As a result, chats were unpinned for operators but remained accessible to visitors.

This commit updates the GC process to align with the new behavior, ensuring visitors can no longer send messages after GC.

task-4509885

[1]: https://github.com/odoo/odoo/pull/192378

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
