### PR TITLE
[FIX] html_editor: prevent power buttons from overlapping placeholder

### DIFF
--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -49,6 +49,7 @@ export class PowerButtonsPlugin extends Plugin {
         "localOverlay",
         "powerbox",
         "userCommand",
+        "history",
     ];
     resources = {
         layout_geometry_change_handlers: this.updatePowerButtons.bind(this),
@@ -124,6 +125,19 @@ export class PowerButtonsPlugin extends Plugin {
         }
     }
 
+    getPlaceholderWidth(block) {
+        this.dependencies.history.disableObserver();
+        const clone = block.cloneNode(true);
+        clone.innerText = clone.getAttribute("placeholder");
+        clone.style.width = "fit-content";
+        clone.style.visibility = "hidden";
+        this.editable.appendChild(clone);
+        const { width } = clone.getBoundingClientRect();
+        this.editable.removeChild(clone);
+        this.dependencies.history.enableObserver();
+        return width;
+    }
+
     /**
      *
      * @param {HTMLElement} block
@@ -136,15 +150,12 @@ export class PowerButtonsPlugin extends Plugin {
         overlayStyles.left = "0px";
         const blockRect = block.getBoundingClientRect();
         const buttonsRect = this.powerButtonsContainer.getBoundingClientRect();
+        const placeholderWidth = this.getPlaceholderWidth(block) + 20;
         if (direction === "rtl") {
             overlayStyles.left =
-                blockRect.right -
-                buttonsRect.width -
-                buttonsRect.x -
-                buttonsRect.width * 0.85 +
-                "px";
+                blockRect.right - buttonsRect.width - buttonsRect.x - placeholderWidth + "px";
         } else {
-            overlayStyles.left = blockRect.left - buttonsRect.x + buttonsRect.width * 0.85 + "px";
+            overlayStyles.left = blockRect.left - buttonsRect.x + placeholderWidth + "px";
         }
         overlayStyles.top = blockRect.top - buttonsRect.top + "px";
         overlayStyles.height = blockRect.height + "px";

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -58,6 +58,23 @@ describe("visibility", () => {
         await setupEditor("<p>[]<br><br></p>");
         expect(".o_we_power_buttons").not.toBeVisible();
     });
+
+    test("should not overlap with long placeholders", async () => {
+        const placeholder = "This is a very very very very long placeholder";
+        const tempP = document.createElement("p");
+        tempP.innerText = placeholder;
+        tempP.style.width = "fit-content";
+        const { el } = await setupEditor(
+            `<p placeholder="${placeholder}" class="o-we-hint">[]<br></p>`
+        );
+        el.appendChild(tempP);
+        const placeholderWidth = tempP.getBoundingClientRect().width;
+        el.removeChild(tempP);
+        const powerButtons = document.querySelector(
+            'div[data-oe-local-overlay-id="oe-power-buttons-overlay"]'
+        );
+        expect(powerButtons.getBoundingClientRect().left).toEqual(placeholderWidth + 20);
+    });
 });
 
 describe.tags("desktop");


### PR DESCRIPTION
**Problem**:
Power buttons overlap long placeholders, causing UI issues.

**Solution**:
Adjust power button positioning based on the placeholder's width.

**Steps to Reproduce**:
1. Change language to **Spanish**.
2. Open the **editor**.
3. Focus on an input field.
   - **Issue**: Power buttons overlap the placeholder.

**opw-4584709**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
