### PR TITLE
[FIX] l10n_eg_edi_eta: fix traceback when sending invoices to sign

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_move.py
+++ b/addons/l10n_eg_edi_eta/models/account_move.py
@@ -89,7 +89,7 @@ class AccountMove(models.Model):
         if not drive_id.certificate:
             raise ValidationError(_('Please setup the certificate on the thumb drive menu'))
 
-        self.write({'l10n_eg_signing_time': datetime.utcnow()})
+        invoices.write({'l10n_eg_signing_time': datetime.utcnow()})
 
         for invoice in invoices:
             eta_invoice = self.env['account.edi.format']._l10n_eg_eta_prepare_eta_invoice(invoice)
@@ -103,7 +103,7 @@ class AccountMove(models.Model):
                     'description': _('Egyptian Tax authority JSON invoice generated for %s.', invoice.name),
                 })
             invoice.l10n_eg_eta_json_doc_id = attachment.id
-        return drive_id.action_sign_invoices(self)
+        return drive_id.action_sign_invoices(invoices)
 
     def action_get_eta_invoice_pdf(self):
         """ This is a pdf with the structure from the government.  While we can use our own format,


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to send multiple invoices 
to sign in the list view, which includes draft invoices.

Error:- 
```
TypeError: the JSON object must be str, bytes or bytearray, not bool
```

Cause:-

When the user resets an Egyptian invoice to draft status, the value 
of `l10n_eg_eta_json_doc_id` is set to False as seen in the following line

https://github.com/odoo/odoo/blob/26d8a505ab540dfff3ee20e9c83f43b61dc743a8/addons/l10n_eg_edi_eta/models/account_move.py#L66-L67

After that when the user attempts to sign the document through the list view, it leads to the  traceback.

This happens because we are passing self instead of the invoices to the method `action_sign_invoices`.
https://github.com/odoo/odoo/blob/26d8a505ab540dfff3ee20e9c83f43b61dc743a8/addons/l10n_eg_edi_eta/models/account_move.py#L73
https://github.com/odoo/odoo/blob/26d8a505ab540dfff3ee20e9c83f43b61dc743a8/addons/l10n_eg_edi_eta/models/account_move.py#L106
As a result, self contains all draft invoices (if selected by the user), leading to the traceback since the value of l10n_eg_eta_json_doc_id is False for the reset draft invoice.

https://github.com/odoo/odoo/blob/26d8a505ab540dfff3ee20e9c83f43b61dc743a8/addons/l10n_eg_edi_eta/models/eta_thumb_drive.py#L34-L35

sentry-6448238266
