### PR TITLE
[IMP] project_todo: remove `Archived` filter to be consistent with task

### DIFF
--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -239,7 +239,6 @@
                 <separator/>
                 <filter name="date_deadline" string="Deadline" domain="[('date_deadline', '!=', False)]" date="date_deadline"/>
                 <separator/>
-                <filter name="active_false" string="Archived" domain="[('active', '=', False)]"/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"
                         domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"
                         help="Show all records which has next action date is before today"/>


### PR DESCRIPTION
This commit removes `Archived` filter in search view of todo app to be consistent with tasks search view in project app and also to reduce a bit the number of filters inside the search view. Moreover, the `Archived` feature is a bit redundant with the closing state.
