### PR TITLE
[IMP] point_of_sale: add retry option for printing

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.js
@@ -1,0 +1,28 @@
+import { Component } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { _t } from "@web/core/l10n/translation";
+
+export class RetryPrintPopup extends Component {
+    static template = "point_of_sale.RetryPrintPopup";
+    static components = { Dialog };
+    static props = {
+        title: { type: String, optional: true },
+        message: { type: String, optional: true },
+        download: Function,
+        retry: Function,
+        close: Function,
+    };
+    static defaultProps = {
+        title: _t("Printing error"),
+    };
+
+    onClickDownload() {
+        this.props.download();
+        this.props.close();
+    }
+
+    onClickRetry() {
+        this.props.retry();
+        this.props.close();
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="point_of_sale.RetryPrintPopup">
+        <Dialog size="'md'" title="props.title">
+            <p t-if="props.message" t-out="props.message"/>
+            <p>Do you want to retry printing, or download it instead?</p>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary btn-lg" t-on-click="onClickRetry">Retry</button>
+                <button class="btn btn-secondary btn-lg" t-on-click="onClickDownload">Download</button>
+                <button class="btn btn-secondary btn-lg" t-on-click="props.close">Discard</button>
+            </t>
+        </Dialog>
+    </t>
+
+</templates>


### PR DESCRIPTION
Before this commit, when printing fails using an IoT box printer a dialog is shown with a button to print using the browser instead.

After this commit, there is an additional button to retry the print, and this can be done as many times as necessary. The wording of the dialog has also been tweaked to match.

task-4668317

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
