### PR TITLE
[FIX] l10n_in_edi: fix traceback when generating an e-waybill

### DIFF
--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -157,6 +157,7 @@ class AccountMove(models.Model):
         self.ensure_one()
         if self.l10n_in_edi_attachment_id:
             return json.loads(self.l10n_in_edi_attachment_id.sudo().raw.decode("utf-8"))
+        return {}
 
     def _l10n_in_lock_invoice(self):
         try:


### PR DESCRIPTION
Currently, atraceback is occurring when the user tries to generate an e-Waybill.

To reproduce this issue:

1) Install `l10n_in_ewaybill_irn` and switch to Indian company 
2) Create a posted customer Invoice with aml containing taxes 
3) Click `Create e-Waybill` button and provide the required values. 
4) Now click on the `Generate e-Waybill` button

Error:- 
```
AttributeError: 'NoneType' object has no attribute 'get'
```

This error occurred after the refactoring was done from the commit(https://github.com/odoo/odoo/pull/191920/commits/c985becafc4a1245c441451e9ca0d2b2c4efda21)

But in the previous version an else block was there to pass and empty dict if there is no indian edi.
https://github.com/odoo/odoo/blob/eb4a03f4e00c35b74aafa16533c8c8b74004542f/addons/l10n_in_edi/models/account_move.py#L49-L52 

However after the above commit, it was removed

https://github.com/odoo/odoo/blob/3be945c89dcd1276551a855189f2d5f908908651/addons/l10n_in_edi/models/account_move.py#L156-L159 

This leads to the above traceback from the below line.
https://github.com/odoo/odoo/blob/3be945c89dcd1276551a855189f2d5f908908651/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py#L45

sentry-6442414522

