### PR TITLE
[IMP] spreadsheet: add `odoo_geo` chart type

### DIFF
--- a/addons/spreadsheet/static/src/chart/index.js
+++ b/addons/spreadsheet/static/src/chart/index.js
@@ -11,6 +11,7 @@ chartComponentRegistry.add("odoo_waterfall", ChartJsComponent);
 chartComponentRegistry.add("odoo_pyramid", ChartJsComponent);
 chartComponentRegistry.add("odoo_scatter", ChartJsComponent);
 chartComponentRegistry.add("odoo_combo", ChartJsComponent);
+chartComponentRegistry.add("odoo_geo", ChartJsComponent);
 
 import { OdooChartCorePlugin } from "./plugins/odoo_chart_core_plugin";
 import { ChartOdooMenuPlugin } from "./plugins/chart_odoo_menu_plugin";

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_helpers.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_helpers.js
@@ -49,6 +49,23 @@ export function onWaterfallOdooChartItemClick(getters, chart) {
     });
 }
 
+export function onGeoOdooChartItemClick(getters, chart) {
+    return navigateInOdooMenuOnClick(getters, chart, (chartJsItem) => {
+        const label = chartJsItem.element.feature.properties.name;
+        const { datasets, labels } = chart.dataSource.getData();
+        const index = labels.indexOf(label);
+        if (index === -1) {
+            return {};
+        }
+        const dataset = datasets[0];
+        let name = labels[index];
+        if (dataset.label) {
+            name += ` / ${dataset.label}`;
+        }
+        return { name, domain: dataset.domains[index] };
+    });
+}
+
 function navigateInOdooMenuOnClick(getters, chart, getDomainFromChartItem) {
     return async (event, items) => {
         const env = getters.getOdooEnv();
@@ -59,6 +76,9 @@ function navigateInOdooMenuOnClick(getters, chart, getDomainFromChartItem) {
             return;
         }
         const { name, domain } = getDomainFromChartItem(items[0]);
+        if (!domain || !name) {
+            return;
+        }
         await navigateTo(
             env,
             chart.actionXmlId,
@@ -80,6 +100,23 @@ function navigateInOdooMenuOnClick(getters, chart, getDomainFromChartItem) {
 export function onOdooChartItemHover() {
     return (event, items) => {
         if (items.length > 0) {
+            event.native.target.style.cursor = "pointer";
+        } else {
+            event.native.target.style.cursor = "";
+        }
+    };
+}
+
+export function onGeoOdooChartItemHover() {
+    return (event, items) => {
+        if (!items.length) {
+            event.native.target.style.cursor = "";
+            return;
+        }
+
+        const item = items[0];
+        const data = event.chart.data.datasets?.[item.datasetIndex]?.data?.[item.index];
+        if (data?.value !== undefined) {
             event.native.target.style.cursor = "pointer";
         } else {
             event.native.target.style.cursor = "";

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_geo_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_geo_chart.js
@@ -1,0 +1,82 @@
+import { registries, chartHelpers } from "@odoo/o-spreadsheet";
+import { _t } from "@web/core/l10n/translation";
+import { OdooChart } from "./odoo_chart";
+import { onGeoOdooChartItemHover, onGeoOdooChartItemClick } from "./odoo_chart_helpers";
+
+const { chartRegistry } = registries;
+
+const {
+    getGeoChartDatasets,
+    CHART_COMMON_OPTIONS,
+    getChartLayout,
+    getChartTitle,
+    getGeoChartScales,
+    getGeoChartTooltip,
+} = chartHelpers;
+
+export class OdooGeoChart extends OdooChart {
+    constructor(definition, sheetId, getters) {
+        super(definition, sheetId, getters);
+        this.colorScale = definition.colorScale;
+        this.missingValueColor = definition.missingValueColor;
+        this.region = definition.region;
+    }
+
+    getDefinition() {
+        return {
+            ...super.getDefinition(),
+            colorScale: this.colorScale,
+            missingValueColor: this.missingValueColor,
+            region: this.region,
+        };
+    }
+}
+
+chartRegistry.add("odoo_geo", {
+    match: (type) => type === "odoo_geo",
+    createChart: (definition, sheetId, getters) => new OdooGeoChart(definition, sheetId, getters),
+    getChartRuntime: createOdooChartRuntime,
+    validateChartDefinition: (validator, definition) =>
+        OdooGeoChart.validateChartDefinition(validator, definition),
+    transformDefinition: (definition) => OdooGeoChart.transformDefinition(definition),
+    getChartDefinitionFromContextCreation: () => OdooGeoChart.getDefinitionFromContextCreation(),
+    name: _t("Geo"),
+});
+
+function createOdooChartRuntime(chart, getters) {
+    const background = chart.background || "#FFFFFF";
+    const { datasets, labels } = chart.dataSource.getData();
+
+    const definition = chart.getDefinition();
+    const locale = getters.getLocale();
+
+    const chartData = {
+        labels,
+        dataSetsValues: datasets.map((ds) => ({ data: ds.data, label: ds.label })),
+        locale,
+        availableRegions: getters.getGeoChartAvailableRegions(),
+        geoFeatureNameToId: getters.geoFeatureNameToId,
+        getGeoJsonFeatures: getters.getGeoJsonFeatures,
+    };
+
+    const config = {
+        type: "choropleth",
+        data: {
+            datasets: getGeoChartDatasets(definition, chartData),
+        },
+        options: {
+            ...CHART_COMMON_OPTIONS,
+            layout: getChartLayout(definition),
+            scales: getGeoChartScales(definition, chartData),
+            plugins: {
+                title: getChartTitle(definition),
+                tooltip: getGeoChartTooltip(definition, chartData),
+                legend: { display: false },
+            },
+            onHover: onGeoOdooChartItemHover(),
+            onClick: onGeoOdooChartItemClick(getters, chart),
+        },
+    };
+
+    return { background, chartJsConfig: config };
+}

--- a/addons/spreadsheet/static/tests/helpers/data.js
+++ b/addons/spreadsheet/static/tests/helpers/data.js
@@ -292,6 +292,32 @@ export class ResCurrency extends models.Model {
     ];
 }
 
+export class ResCountry extends webModels.ResCountry {
+    _name = "res.country";
+    name = fields.Char({ string: "Country" });
+    code = fields.Char({ string: "Code" });
+
+    _records = [
+        { id: 1, name: "Belgium", code: "BE" },
+        { id: 2, name: "France", code: "FR" },
+        { id: 3, name: "United States", code: "US" },
+    ];
+}
+
+export class ResCountryState extends models.Model {
+    _name = "res.country.state";
+    name = fields.Char({ string: "Name" });
+    code = fields.Char({ string: "Code" });
+    country_id = fields.Many2one({ relation: "res.country" });
+    display_name = fields.Char({ string: "Display Name" });
+
+    _records = [
+        { id: 1, name: "California", code: "CA", country_id: 3, display_name: "California (US)" },
+        { id: 2, name: "New York", code: "NY", country_id: 3, display_name: "New York (US)" },
+        { id: 3, name: "Texas", code: "TX", country_id: 3, display_name: "Texas (US)" },
+    ];
+}
+
 export class Partner extends models.Model {
     _name = "partner";
 
@@ -525,6 +551,8 @@ export const SpreadsheetModels = {
     IrActions,
     ResGroup,
     ResUsers,
+    ResCountry,
+    ResCountryState,
     SpreadsheetMixin,
     ResCurrency,
     Partner,


### PR DESCRIPTION
### [IMP] spreadsheet: add `odoo_geo` chart type

This commit adds the possibility to create a geo chart with odoo data.
The option is only available when the data is grouped by `res.country`
or `res.country.state`.

Task: [4661689](https://www.odoo.com/web#id=4661689&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
