### PR TITLE
[FIX] im_livechat: access error after operator left

### DIFF
--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -46,7 +46,8 @@ class DiscussChannel(models.Model):
             return [
                 Store.Attr(
                     "requested_by_operator",
-                    lambda channel: channel.create_uid in channel.livechat_operator_id.user_ids,
+                    # sudo - res.users: can access operator's user even if he left the channel.
+                    lambda channel: channel.create_uid in channel.livechat_operator_id.sudo().user_ids,
                     predicate=lambda channel: channel.livechat_visitor_id,
                 ),
             ]

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -283,6 +283,56 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             },
         )
 
+    def test_channel_to_store_after_operator_left(self):
+        channel = self._common_basic_flow()
+        guest = self.env["mail.guest"].search([], order="id desc", limit=1)
+        channel.with_user(self.operator).action_unfollow()
+        self._reset_bus()
+        self.assertFalse(
+            channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
+        )
+        self.assertEqual(
+            Store(channel.with_context(guest=guest).with_user(self.user_public)).get_result()["discuss.channel"],
+            self._filter_channels_fields(
+                {
+                    "anonymous_country": False,
+                    "anonymous_name": f"Visitor #{self.visitor.id}",
+                    "authorizedGroupFullName": False,
+                    "avatar_cache_key": "no-avatar",
+                    "channel_type": "livechat",
+                    "create_uid": self.user_public.id,
+                    "custom_channel_name": False,
+                    "custom_notifications": False,
+                    "default_display_mode": False,
+                    "description": False,
+                    "fetchChannelInfoState": "fetched",
+                    "from_message_id": False,
+                    "group_based_subscription": False,
+                    "id": channel.id,
+                    "invitedMembers": [("ADD", [])],
+                    "is_editable": False,
+                    "is_pinned": True,
+                    "last_interest_dt": fields.Datetime.to_string(channel.last_interest_dt),
+                    "livechat_active": False,
+                    "livechat_operator_id": {
+                        "id": self.operator.partner_id.id,
+                        "type": "partner",
+                    },
+                    "member_count": 1,
+                    "message_needaction_counter": 0,
+                    "message_needaction_counter_bus_id": 0,
+                    "mute_until_dt": False,
+                    "name": f"Visitor #{self.visitor.id} El Deboulonnator",
+                    "parent_channel_id": False,
+                    "requested_by_operator": False,
+                    "rtcSessions": [("ADD", [])],
+                    "uuid": channel.uuid,
+                    "whatsapp_channel_valid_until": False,
+                    "whatsapp_partner_id": False,
+                }
+            ),
+        )
+
 
 @tests.tagged('post_install', '-at_install')
 class TestLivechatBasicFlowHttpCaseMobile(HttpCaseWithUserDemo, TestLivechatCommon):


### PR DESCRIPTION
Before this PR, access error could occur when the live chat operator left and the visitor refreshed the page. This occur because one can access a partner as long as there is a common channel, which might not be the case after the operator left.

Steps to reproduce the issue:
- Open two browsers: admin, visitor on the website.
- Navigate to a tracked page with the visitor (e.g. contactus and back on home page): this will create a website visitor which is a condition for the "requested_by_operator" field to be added.
- Open a chat, send a message.
- Leave with admin.
- Reload the page with the visitor.
- It's not possible to open a chat anymore due to an access error.

This PR adds a missing sudo when computing "requested_by_operator" on channel which solves the issue. This PR also adds a test to ensure that `channel._to_store` still works after the operator left, preventing other errors in the future.

task-4663990

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
