### PR TITLE
[IMP] mail: allow customization of message notification styling

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -191,7 +191,7 @@
 
 <t t-name="mail.Message.notification">
     <div t-if="message.thread?.eq(props.thread) and message.notification_ids.length > 0" class="mx-1">
-        <span class="o-mail-Message-notification cursor-pointer opacity-100-hover" t-att-class="message.failureNotifications.length > 0 ? 'text-danger opacity-75' : 'opacity-50'" role="button" tabindex="0" t-on-click="onClickNotification">
+        <span class="o-mail-Message-notification cursor-pointer opacity-100-hover" t-att-class="message.notification_ids[0].statusClass" role="button" tabindex="0" t-on-click="onClickNotification">
             <i t-att-class="message.notification_ids[0].icon" role="img" aria-label="Delivery failure"/> <span class="fw-bold small" t-if="message.notification_ids[0].label" t-out="message.notification_ids[0].label"/>
         </span>
     </div>

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -82,6 +82,13 @@ export class Notification extends Record {
         );
     }
 
+    get statusClass() {
+        if (this.isFailure) {
+            return "text-danger opacity-75";
+        }
+        return "opacity-50";
+    }
+
     get statusIcon() {
         switch (this.notification_status) {
             case "process":


### PR DESCRIPTION
This commit introduces a `statusClass` for message notifications, allowing for easier customization of notification styling. It also enables other modules to extend and override the status logic, providing more flexibility in handling different notification states.

Task-4267356