### PR TITLE
[IMP] mail,im_livechat: shortcut to partner form view

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -59,6 +59,7 @@ Help your customers with this chat, and analyse their feedback.
         "demo/im_livechat_channel/im_livechat_session_12.xml",
         "demo/im_livechat_channel/im_livechat_session_13.xml",
         "demo/im_livechat_channel/im_livechat_session_14.xml",
+        "demo/im_livechat_channel/im_livechat_session_15.xml",
         "demo/im_livechat_channel/im_livechat_support_bot.xml",
         "demo/im_livechat_channel/im_livechat_support_bot_session_1.xml",
         "demo/im_livechat_channel/im_livechat_support_bot_session_2.xml",

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_15.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_15.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record id="livechat_channel_session_15" model="discuss.channel">
+            <field name="channel_type">livechat</field>
+            <field name="livechat_lang_id" ref="base.lang_en"/>
+            <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
+            <field name="livechat_operator_id" ref="base.partner_admin"/>
+            <field name="livechat_failure">no_failure</field>
+            <field name="name">Joel Willis, Mitchell Admin</field>
+            <field name="anonymous_name">Joel Willis</field>
+        </record>
+        <record id="im_livechat.livechat_channel_session_15_member_admin" model="discuss.channel.member">
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="channel_id" ref="im_livechat.livechat_channel_session_15"/>
+            <field name="livechat_member_type">agent</field>
+        </record>
+        <record id="im_livechat.livechat_channel_session_15_member_portal" model="discuss.channel.member">
+            <field name="partner_id" ref="base.partner_demo_portal"/>
+            <field name="channel_id" ref="im_livechat.livechat_channel_session_15"/>
+            <field name="livechat_member_type">visitor</field>
+        </record>
+        <record id="livechat_channel_session_15_message_1" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="im_livechat.livechat_channel_session_15" />
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body">Hello, How can I help you?</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="date" eval="DateTime.now() + timedelta(seconds=5)"/>
+            <field name="create_date" eval="DateTime.now() + timedelta(seconds=5)"/>
+        </record>
+        <record id="livechat_channel_session_15_message_2" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="im_livechat.livechat_channel_session_15"/>
+            <field name="author_id" ref="base.partner_demo_portal"/>
+            <field name="body">I need help regarding onboarding...</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="date" eval="DateTime.now() + timedelta(seconds=10)"/>
+            <field name="create_date" eval="DateTime.now() + timedelta(seconds=10)"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -5,6 +5,8 @@ import { Component } from "@odoo/owl";
 
 import { rpc } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
+import { url } from "@web/core/utils/urls";
+import { startUrl } from "@web/core/browser/router";
 
 export class LivechatChannelInfoList extends Component {
     static components = { ActionPanel };
@@ -14,11 +16,28 @@ export class LivechatChannelInfoList extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
+        this.ui = useService("ui");
     }
 
     onBlurNote() {
         prettifyMessageContent(this.props.thread.livechatNoteText).then((note) => {
             rpc("/im_livechat/session/update_note", { channel_id: this.props.thread.id, note });
         });
+    }
+
+    openVisitorProfile() {
+        if (this.ui.isSmall) {
+            this.store.ChatWindow.get({ thread: this.props.thread })?.fold();
+        } else {
+            this.props.thread.openChatWindow({ focus: true });
+        }
+    }
+
+    get visitorProfileURL() {
+        const visitorPersona = this.props.thread?.livechatVisitorMember?.persona;
+        if (visitorPersona?.type === "partner") {
+            return url(`/${startUrl()}/res.partner/${visitorPersona.id}`);
+        }
+        return null;
     }
 }

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -2,6 +2,9 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatChannelInfoList">
         <ActionPanel title.translate="Information" minWidth="200" initialWidth="250" icon="'fa fa-info'">
+            <a t-if="visitorProfileURL" class="btn btn-primary mt-1" t-on-click="openVisitorProfile" t-att-href="visitorProfileURL" title="View Contact">
+                View Contact
+            </a>
             <div t-if="!props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
                 <h3 class="pt-3">Status</h3>
                 <t t-call="im_livechat.LivechatStatusSelection">

--- a/addons/im_livechat/static/tests/discuss_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_patch.test.js
@@ -151,3 +151,20 @@ test("sidebar search finds livechats", async () => {
     await click("a", { text: "Visitor 11" });
     await contains(".o-mail-Discuss-threadName[title='Visitor 11']");
 });
+
+test("open visitor's partner profile if visitor has one", async () => {
+    const pyEnv = await startServer();
+    const livechatPartner = pyEnv["res.partner"].create({ name: "Joel Willis" });
+    const channel = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: livechatPartner }),
+        ],
+        channel_type: "livechat",
+        livechat_operator_id: serverState.partnerId,
+    });
+    await start();
+    await openDiscuss(channel);
+    await click("a[title='View Contact']");
+    await contains("div.o_field_widget > input:value(Joel Willis)");
+});


### PR DESCRIPTION
For Livechat Conversations:
Add a "View Contact" action that opens then partner record form view of the visitor, if the visitor has a partner record linked it it.

Enterprise PR: https://github.com/odoo/enterprise/pull/82059

task-4607618