### PR TITLE
[IMP] project: adapt text of 'log note' onboarding tour step

### DIFF
--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -121,7 +121,7 @@ registry.category("web_tour.tours").add('project_tour', {
 },
 {
     trigger: "button.o-mail-Chatter-logNote",
-    content: markup(_t("<b>Log notes</b> for internal communications <i>(the people following this task won't be notified of the note you are logging unless you specifically tag them)</i>. Use @ <b>mentions</b> to ping a colleague or # <b>mentions</b> to reach an entire team.")),
+    content: markup(_t("<b>Log internal notes</b> and use @<b>mentions</b> to notify your colleagues.")),
     tooltipPosition: "bottom",
     run: "click",
 },


### PR DESCRIPTION
This commit adapts a step asking to click on `log note` button to send an internal note. We no longer mention the user can select a channel because that feature does not ping the users inside the channel selected, it is just to have a button to redirect the user to that channel.

task-4662201