### PR TITLE
[IMP] product: remove Product Variants menu and easy edit view

### DIFF
--- a/addons/hr_expense/views/product_product_views.xml
+++ b/addons/hr_expense/views/product_product_views.xml
@@ -86,6 +86,9 @@
             <field name="mode">primary</field>
             <field name="model">product.product</field>
             <field name="arch" type="xml">
+                <kanban position="attributes">
+                    <attribute name="create">true</attribute>
+                </kanban>
                 <xpath expr="//main" position="inside">
                     <span>
                         Cost: <field name="standard_price"/>

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -30,7 +30,6 @@
         <record id="mrp_product_product_search_view" model="ir.ui.view">
             <field name="name">mrp.product.product.search</field>
             <field name="model">product.product</field>
-            <field name="mode">primary</field>
             <field name="inherit_id" ref="product.product_search_form_view"/>
             <field name="arch" type="xml">
                 <filter name="combo" position="after">
@@ -82,16 +81,6 @@
             action="product_template_action"
             parent="menu_mrp_bom" sequence="1"/>
 
-        <record id="mrp_product_variant_action" model="ir.actions.act_window">
-            <field name="name">Product Variants</field>
-            <field name="res_model">product.product</field>
-            <field name="search_view_id" ref="mrp_product_product_search_view"/>
-            <field name="view_mode">kanban,list,form</field>
-        </record>
-
-        <menuitem id="product_variant_mrp" name="Product Variants"
-            action="mrp_product_variant_action"
-            parent="menu_mrp_bom" groups="product.group_product_variant" sequence="2"/>
 
 
         <record id="product_template_form_view_bom_button" model="ir.ui.view">

--- a/addons/mrp_account/views/product_views.xml
+++ b/addons/mrp_account/views/product_views.xml
@@ -43,29 +43,6 @@
             </field>
         </record>
 
-        <record id="product_variant_easy_edit_view_bom_inherit" model="ir.ui.view">
-            <field name="name">product.product.product.view.form.easy.bom.inherit</field>
-            <field name="model">product.product</field>
-            <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
-            <field name="arch" type="xml">
-                <data>
-                <xpath expr="//field[@name='standard_price']" position="after">
-                    <t groups="mrp.group_mrp_manager">
-                        <field name="bom_count" invisible="1"/>
-                        <field name="cost_method" invisible="1"/>
-                        <field name="valuation" invisible="1"/>
-                        <button name="button_bom_cost"
-                            string="Compute Price from BoM"
-                            type="object"
-                            invisible="bom_count == 0 or valuation == 'real_time' and cost_method == 'fifo'"
-                            help="Compute the price of the product using products and operations of related bill of materials, for manufactured products only."
-                            class="oe_link pt-0"/>
-                    </t>
-                </xpath>
-                </data>
-            </field>
-        </record>
-
         <record id="view_category_property_form" model="ir.ui.view">
             <field name="name">product.category.stock.property.form.inherit</field>
             <field name="model">product.category</field>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -30,22 +30,6 @@
             </p>
         </field>
     </record>
-    <record id="product_product_action" model="ir.actions.act_window">
-        <field name="name">Product Variants</field>
-        <field name="res_model">product.product</field>
-        <field name="view_mode">kanban,list,form,activity</field>
-        <field name="context">{'search_default_filter_to_availabe_pos': 1, 'default_available_in_pos': True}</field>
-        <field name="search_view_id" eval="False"/> <!-- Force empty -->
-        <field name="view_id" ref="product.product_product_tree_view"/>
-        <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                Create a new product variant
-            </p><p>
-                You must define a product for everything you sell through
-                the point of sale interface.
-            </p>
-        </field>
-    </record>
     <record id="product_category_action" model="ir.actions.act_window">
         <field name="name">Internal Categories</field>
         <field name="res_model">product.category</field>
@@ -120,12 +104,6 @@
         action="product_template_action_pos_product"
         parent="point_of_sale.pos_config_menu_catalog"
         sequence="5"/>
-    <menuitem id="pos_config_menu_action_product_product"
-        name="Product Variants"
-        parent="point_of_sale.pos_config_menu_catalog"
-        action="product_product_action"
-        groups="product.group_product_variant"
-        sequence="10"/>
     <menuitem id="point_of_sale.menu_product_combo"
         name="Combo Choices"
         parent="point_of_sale.pos_config_menu_catalog"

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -300,103 +300,6 @@
         </record>
 
 
-        <record id="product_variant_easy_edit_view" model="ir.ui.view">
-            <field name="name">product.product.view.form.easy</field>
-            <field name="model">product.product</field>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <form string="Variant Information" duplicate="false">
-                    <sheet>
-                        <div class="oe_button_box" name="button_box"/>
-                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                        <field name="active" invisible="1"/>
-                        <field name="id" invisible="1"/>
-                        <field name="company_id" invisible="1"/>
-                        <field name="image_1920" widget="image" class="oe_avatar" options="{'convert_to_webp': True,'preview_image': 'image_128'}"/>
-                        <div class="oe_title">
-                            <label for="name" string="Product Name"/>
-                            <h1><field name="name" readonly="1" placeholder="e.g. Odoo Enterprise Subscription"/></h1>
-                            <field name="product_template_attribute_value_ids" widget="many2many_tags" readonly="1"/>
-                            <p>
-                                <span>All general settings about this product are managed on</span>
-                                <button name="open_product_template" type="object" string="the product template." class="oe_link oe_link_product ps-0 ms-1 mb-1"/>
-                            </p>
-                        </div>
-                        <group>
-                            <group name="codes" string="Codes">
-                                <field name="default_code"/>
-                                <field name="barcode"/>
-                                <field name="type" invisible="1"/>
-                            </group>
-                            <group name="pricing" string="Pricing">
-                                <field name="product_variant_count" invisible="1"/>
-                                <label for="lst_price" string="Sales Price"/>
-                                <div class="o_row">
-                                    <field name="lst_price" class="oe_inline" widget='monetary' options="{'currency_field': 'currency_id', 'field_digits': True}" readonly="product_variant_count &gt; 1"/>
-                                </div>
-                                <label for="standard_price"/>
-                                <div class="o_row">
-                                    <field name="standard_price"
-                                        class="oe_inline"
-                                        widget="monetary"
-                                        options="{'currency_field': 'cost_currency_id', 'field_digits': True}"/>
-                                </div>
-                                <field name="currency_id" invisible='1'/>
-                                <field name="cost_currency_id" invisible="1"/>
-                            </group>
-                        </group>
-                        <group>
-                            <group name="weight" string="Logistics" invisible="type != 'consu'">
-                                <label for="volume"/>
-                                <div class="d-flex">
-                                    <field name="volume" class="oe_inline"/>
-                                    <field name="volume_uom_name"/>
-                                </div>
-                                <label for="weight"/>
-                                <div class="d-flex">
-                                    <field name="weight" class="oe_inline"/>
-                                    <field name="weight_uom_name"/>
-                                </div>
-                            </group>
-                            <group name="sales" string="Sales">
-                                <field
-                                    name="uom_ids"
-                                    widget="many2many_uom_tags"
-                                    options="{'no_quick_create': True, 'edit_tags': True}"
-                                    groups="uom.group_uom"
-                                    force_save="1"
-                                    context="{'product_id': id}"/>
-                                <field name="product_tag_ids" widget="many2many_tags" readonly="1"/>
-                                <field name="additional_product_tag_ids" widget="many2many_tags" context="{'product_variant_id': id}"/>
-                            </group>
-                        </group>
-                    </sheet>
-                </form>
-            </field>
-        </record>
-
-        <record id="product_variant_action" model="ir.actions.act_window">
-            <field name="name">Product Variants</field>
-            <field name="res_model">product.product</field>
-            <field name="context">{'search_default_product_tmpl_id': [active_id], 'default_product_tmpl_id': active_id, 'create': False}</field>
-            <field name="search_view_id" ref="product_search_form_view"/>
-            <field name="view_ids"
-                   eval="[(5, 0, 0),
-                          (0, 0, {'view_mode': 'list'}),
-                          (0, 0, {'view_mode': 'form', 'view_id': ref('product_variant_easy_edit_view')}),
-                          (0, 0, {'view_mode': 'kanban'})]"/>
-             <field name="help" type="html">
-              <p class="o_view_nocontent_smiling_face">
-                Create a new product variant
-              </p><p>
-                You must define a product for everything you sell or purchase,
-                whether it's a storable product, a consumable or a service.
-                The product form contains information to simplify the sale process:
-                price, notes in the quotation, accounting data, procurement methods, etc.
-              </p>
-            </field>
-        </record>
-
         <record id="product_product_tree_view" model="ir.ui.view">
             <field name="name">product.product.list</field>
             <field name="model">product.product</field>
@@ -495,6 +398,29 @@
                 <field name="uom_ids" position="attributes">
                     <attribute name="context">{'product_id': id}</attribute>
                 </field> 
+            </field>
+        </record>
+
+        <record id="product_variant_action" model="ir.actions.act_window">
+            <field name="name">Product Variants</field>
+            <field name="res_model">product.product</field>
+            <field name="context">{'search_default_product_tmpl_id': [active_id], 'default_product_tmpl_id': active_id, 'create': False}</field>
+            <field name="search_view_id" ref="product_search_form_view"/>
+            <field name="view_ids"
+                   eval="[(5, 0, 0),
+                          (0, 0, {'view_mode': 'list'}),
+                          (0, 0, {'view_mode': 'form', 'view_id': ref('product_normal_form_view')}),
+                          (0, 0, {'view_mode': 'kanban'}),
+                          (0, 0, {'view_mode': 'activity'})]"/>
+             <field name="help" type="html">
+              <p class="o_view_nocontent_smiling_face">
+                Create a new product variant
+              </p><p>
+                You must define a product for everything you sell or purchase,
+                whether it's a storable product, a consumable or a service.
+                The product form contains information to simplify the sale process:
+                price, notes in the quotation, accounting data, procurement methods, etc.
+              </p>
             </field>
         </record>
 

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -299,21 +299,6 @@
             </field>
         </record>
 
-        <record id="product_normal_action" model="ir.actions.act_window">
-            <field name="name">Product Variants</field>
-            <field name="res_model">product.product</field>
-            <field name="view_mode">list,form,kanban,activity</field>
-            <field name="search_view_id" ref="product_search_form_view"/>
-            <field name="view_id" eval="False"/> <!-- Force empty -->
-            <field name="help" type="html">
-              <p class="o_view_nocontent_smiling_face">
-                Create a new product variant
-              </p><p>
-                You must define a product for everything you sell or purchase,
-                whether it's a storable product, a consumable or a service.
-              </p>
-            </field>
-        </record>
 
         <record id="product_variant_easy_edit_view" model="ir.ui.view">
             <field name="name">product.product.view.form.easy</field>
@@ -592,24 +577,6 @@
             </field>
         </record>
 
-        <record id="product_normal_action_sell" model="ir.actions.act_window">
-            <field name="name">Product Variants</field>
-            <field name="res_model">product.product</field>
-            <field name="view_mode">kanban,list,form,activity</field>
-            <field name="context">{"search_default_filter_to_sell":1}</field>
-            <field name="view_id" ref="product_product_tree_view"/>
-            <field name="search_view_id" ref="product_search_form_view"/>
-            <field name="help" type="html">
-              <p class="o_view_nocontent_smiling_face">
-                Create a new product variant
-              </p><p>
-                You must define a product for everything you sell, whether it's a physical product,
-                a consumable or a service you offer to customers.
-                The product form contains information to simplify the sale process:
-                price, notes in the quotation, accounting data, procurement methods, etc.
-              </p>
-            </field>
-        </record>
 
     <record id="action_product_print_labels" model="ir.actions.server">
         <field name="name">Print Labels</field>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -305,7 +305,7 @@
             <field name="model">product.product</field>
             <field eval="7" name="priority"/>
             <field name="arch" type="xml">
-                <list string="Product Variants" multi_edit="1" duplicate="false" sample="1" default_order="is_favorite desc, default_code, name, id">
+                <list string="Product Variants" create="0" multi_edit="1" duplicate="false" sample="1" default_order="is_favorite desc, default_code, name, id">
                     <field name="is_favorite" widget="boolean_favorite" nolabel="1" readonly="1"/>
                     <field name="default_code" optional="show" readonly="1"/>
                     <field name="barcode" optional="hide" readonly="1"/>
@@ -364,6 +364,7 @@
                 <form position="attributes">
                     <attribute name="string">Product Variant</attribute>
                     <attribute name="duplicate">false</attribute>
+                    <attribute name="create">false</attribute>
                 </form>
                 <xpath expr="//div[@name='standard_price_uom']" position="after">
                     <field name="default_code"/>
@@ -404,7 +405,7 @@
         <record id="product_variant_action" model="ir.actions.act_window">
             <field name="name">Product Variants</field>
             <field name="res_model">product.product</field>
-            <field name="context">{'search_default_product_tmpl_id': [active_id], 'default_product_tmpl_id': active_id, 'create': False}</field>
+            <field name="context">{'search_default_product_tmpl_id': [active_id], 'default_product_tmpl_id': active_id}</field>
             <field name="search_view_id" ref="product_search_form_view"/>
             <field name="view_ids"
                    eval="[(5, 0, 0),
@@ -453,7 +454,7 @@
             <field name="name">Product Kanban</field>
             <field name="model">product.product</field>
             <field name="arch" type="xml">
-                <kanban sample="1" default_order="is_favorite desc, default_code, name, id">
+                <kanban create="0" sample="1" default_order="is_favorite desc, default_code, name, id">
                     <field name="activity_state"/>
                     <field name="color"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -70,24 +70,6 @@
       <menuitem name="Products" id="menu_procurement_partner_contact_form" action="product_normal_action_puchased"
           parent="menu_purchase_products" sequence="20"/>
 
-        <record id="product_product_action" model="ir.actions.act_window">
-            <field name="name">Product Variants</field>
-            <field name="res_model">product.product</field>
-            <field name="view_mode">list,kanban,form,activity</field>
-            <field name="search_view_id" ref="product.product_search_form_view"/>
-            <field name="context">{"search_default_filter_to_purchase": 1}</field>
-            <field name="help" type="html">
-              <p class="o_view_nocontent_smiling_face">
-                Create a new product variant
-              </p><p>
-                You must define a product for everything you sell or purchase,
-                whether it's a storable product, a consumable or a service.
-              </p>
-            </field>
-        </record>
-
-        <menuitem id="product_product_menu" name="Product Variants" action="product_product_action"
-            parent="menu_purchase_products" sequence="21" groups="product.group_product_variant"/>
 
         <record model="ir.ui.view" id="purchase_order_calendar">
             <field name="name">purchase.order.calendar</field>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -395,8 +395,6 @@
 
         <menuitem id="repair_menu_product_template" name="Products" action="stock.product_template_action_product"
             parent="repair_menu_config" sequence="2"/>
-        <menuitem id="repair_menu_product_product" name="Product Variants" action="stock.stock_product_normal_action"
-            parent="repair_menu_config" sequence="3" groups="product.group_product_variant"/>
         <menuitem id="repair_menu_tag" name="Repair Orders Tags" parent="repair_menu_config"
             action="action_repair_order_tag" sequence="1000" groups="base.group_no_one"/>
     </data>

--- a/addons/sale/views/sale_menus.xml
+++ b/addons/sale/views/sale_menus.xml
@@ -58,10 +58,6 @@
             <menuitem id="menu_product_template_action"
                 action="product_template_action"
                 sequence="10"/>
-            <menuitem id="menu_products"
-                action="product.product_normal_action_sell"
-                groups="product.group_product_variant"
-                sequence="20"/>
             <menuitem id="menu_product_pricelist_main"
                 name="Pricelists"
                 action="product.product_pricelist_action2"

--- a/addons/sale_gelato/views/product_product_views.xml
+++ b/addons/sale_gelato/views/product_product_views.xml
@@ -16,19 +16,4 @@
         </field>
     </record>
 
-    <record id="product_product_easy_form" model="ir.ui.view">
-        <field name="name">Product Product Easy Form</field>
-        <field name="model">product.product</field>
-        <field name="inherit_id" ref="product.product_variant_easy_edit_view"></field>
-        <field name="arch" type="xml">
-            <group name="sales" position="after">
-                <group
-                    string="Gelato" invisible="not gelato_product_uid" groups="base.group_no_one"
-                >
-                    <field string="Product UID" name="gelato_product_uid"/>
-                </group>
-            </group>
-        </field>
-    </record>
-
 </odoo>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -143,7 +143,6 @@
         <record id="stock_product_search_form_view" model="ir.ui.view">
             <field name="name">product.product.search.stock.form</field>
             <field name="model">product.product</field>
-            <field name="mode">primary</field>
             <field name="inherit_id" ref="product.product_search_form_view"/>
             <field name="arch" type="xml">
                 <xpath expr="//filter[@name='inactive']" position="after">
@@ -627,17 +626,9 @@
             </field>
         </record>
 
-        <record id="stock_product_normal_action" model="ir.actions.act_window">
-            <field name="name">Product Variants</field>
-            <field name="res_model">product.product</field>
-            <field name="view_mode">list,form,kanban</field>
-            <field name="search_view_id" ref="stock_product_search_form_view"/>
-        </record>
 
         <menuitem id="menu_product_variant_config_stock" name="Products" action="product_template_action_product"
             parent="stock.menu_stock_inventory_control" sequence="1"/>
-        <menuitem id="product_product_menu" name="Product Variants" action="stock_product_normal_action"
-            parent="menu_stock_inventory_control" sequence="2" groups="product.group_product_variant"/>
         <menuitem id="menu_product_stock" name="Stock" action="stock.action_product_stock_view"
         parent="stock.menu_warehouse_report" sequence="5"/>
 

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -136,24 +136,6 @@
         </field>
     </record>
 
-    <record id="product_product_normal_website_form_view" model="ir.ui.view">
-        <field name="name">product.product.normal.view.website</field>
-        <field name="model">product.product</field>
-        <field name="inherit_id" ref="product.product_normal_form_view"/>
-        <field name="arch" type="xml">
-            <field name="categ_id" position="before">
-                <label for="base_unit_count" groups="website_sale.group_show_uom_price"/>
-                <div name="base_unit_price" groups="website_sale.group_show_uom_price" class="d-flex flex-row">
-                    <field name="base_unit_count" style="width: 4rem;"/>
-                    <field name="base_unit_id" options="{'no_open': True}" placeholder="Specify unit" style="width: 10rem;"/>
-                    <div class="d-flex flex-row" invisible="base_unit_price == 0">
-                        (<field name="base_unit_price" class="oe_inline"/> / <field name="base_unit_name" class="oe_inline"/>)
-                    </div>
-                </div>
-            </field>
-        </field>
-    </record>
-
     <record id="product_template_form_view" model="ir.ui.view">
         <field name="name">product.template.product.website.form</field>
         <field name="model">product.template</field>
@@ -224,12 +206,12 @@
         </field>
     </record>
 
-    <record id="product_product_view_form_easy_inherit_website_sale" model="ir.ui.view">
-        <field name="name">product.product.view.form.easy.inherit.website_sale</field>
+    <record id="product_product_normal_website_form_view" model="ir.ui.view">
+        <field name="name">product.product.normal.view.website</field>
         <field name="model">product.product</field>
-        <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
         <field name="arch" type="xml">
-            <group name="pricing" position="inside">
+            <field name="categ_id" position="before">
                 <label for="base_unit_count" groups="website_sale.group_show_uom_price"/>
                 <div name="base_unit_price" groups="website_sale.group_show_uom_price" class="d-flex flex-row">
                     <field name="base_unit_count" style="width: 4rem;"/>
@@ -238,14 +220,16 @@
                         (<field name="base_unit_price" class="oe_inline"/> / <field name="base_unit_name" class="oe_inline"/>)
                     </div>
                 </div>
-            </group>
-            <group name="sales" position="inside">
-                <field name="website_ribbon_id" options="{'no_open': True}" readonly="True"/>
+            </field>
+            <field name="website_ribbon_id" position="attributes">
+                <attribute name="readonly">True</attribute>
+            </field>
+            <field name="website_ribbon_id" position="after">
                 <field name="variant_ribbon_id" options="{'no_quick_create': True}"/>
-            </group>
-            <group name="sales" position="after">
+            </field>
+            <group name="product_template_images" position="after">
                 <group colspan="2" name="product_variant_images" string="Extra Variant Media">
-                    <field name="product_variant_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add Media" nolabel="1" widget="x2_many_media_viewer" options="{'convert_to_webp': True}"/>
+                    <field colspan="2" name="product_variant_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add Media" nolabel="1" widget="x2_many_media_viewer" options="{'convert_to_webp': True}"/>
                 </group>
             </group>
         </field>


### PR DESCRIPTION
Before This Commit:
---------------------------
- The Product Variants menu was available in multiple modules (Sales, Purchase, 
Inventory, Manufacturing, Repair, POS), leading to redundant access points.
- Accessing variants from the menu did not allow editing attribute values 
directly—you had to go back to the parent product via the Products menu.
- The Variants smart button opened a custom `product_variant_easy_edit_view`, 
which had limited functionality and lacked key actions like Update Quantity,
Reordering Rules etc.
- The context `create: false` was set on the `product_variant_action`, 
unintentionally blocking unrelated operations like Update Quantity.

After this commit:
---------------------------
- The Product Variants menu has been removed from all modules to simplify 
navigation.
- Variants are now accessed only via the smart button on the product form.
- The smart button now opens the standard `product_normal_form_view`, providing 
full functionality and consistent UX.
- The custom `product_variant_easy_edit_view` has been deleted, as it's no 
longer serves a purpose.
- The restriction on manual creation (create: false) is now applied directly at
 the view level (tree, form, kanban of product.product), preventing side effects
and preserving functionality like Update Quantity.
- This streamlines the variant management experience, consolidates functionality
into a single view, and avoids redundant UI elements.

task-4423965