### PR TITLE
[FIX] point_of_sale: ensure search field visible in mobile view

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.scss
@@ -52,6 +52,7 @@
     }
     .pos .orders {
         position: sticky;
+        z-index: 1;
     }
 
     .controls {
@@ -59,6 +60,9 @@
         grid-template-areas: 
             "buttons pagination"
             "search search";
+    }
+    .search .fields {
+        z-index: 2;
     }
 }
 


### PR DESCRIPTION
The search field dropdown was being rendered behind the orders list in mobile view, making it unusable. This commit adds a higher z-index to the search field dropdown to ensure it's rendered above the orders list.

opw-4654710

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
