### PR TITLE
[FIX] point_of_sale: remove price info on basic receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -34,7 +34,7 @@
                             <i class="fa fa-tag pe-1"/><em><t t-esc="discount" />% </em> discount off on <t t-esc="env.utils.formatCurrency(line.allPrices.priceWithTaxBeforeDiscount)"/>
                         </t>
                     </li>
-                    <li class="price-per-unit" t-if="props.mode == 'receipt' || line.price_type !== 'original'">
+                    <li class="price-per-unit" t-if="!props.basic_receipt and (props.mode == 'receipt' || line.price_type !== 'original')">
                         <t t-if="line.price !== 0">
                             <i class="fa fa-money center pe-1"/>
                             <t t-esc="formatCurrency(line.unitDisplayPrice)" />

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
@@ -9,6 +11,9 @@ import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
+import { run } from "@point_of_sale/../tests/generic_helpers/utils";
+import { renderToElement } from "@web/core/utils/render";
+import { formatCurrency } from "@web/core/currency";
 
 registry.category("web_tour.tours").add("ReceiptScreenTour", {
     checkDelay: 50,
@@ -173,5 +178,40 @@ registry.category("web_tour.tours").add("ReceiptTrackingMethodTour", {
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.trackingMethodIsLot(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("point_of_sale.test_printed_receipt_tour", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Desk Pad", "1", "5"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptIsThere(),
+            run(() => {
+                const line = posmodel.getOrder().lines[0];
+                const context = {
+                    line,
+                    props: { basic_receipt: true },
+                    formatCurrency: (amount) => formatCurrency(amount, line.currency.id),
+                };
+
+                const rendered = renderToElement("point_of_sale.Orderline", {
+                    this: context,
+                    ...context,
+                });
+
+                if (!rendered.innerHTML.includes("Desk Pad")) {
+                    throw new Error("Desk Pad is not present on the ticket");
+                }
+
+                if (rendered.innerHTML.includes("5.00 / Units")) {
+                    throw new Error("The price should not be included on a basic receipt");
+                }
+            }, "Basic receipt doesn't have price"),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1171,6 +1171,10 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ReceiptTrackingMethodTour', login="pos_user")
 
+    def test_printed_receipt_tour(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("point_of_sale.test_printed_receipt_tour")
+
     def test_limited_product_pricelist_loading(self):
         self.env['ir.config_parameter'].sudo().set_param('point_of_sale.limited_product_count', '1')
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Enable "basic receipt" from pos configs
2. Make an order and on the ticket screen, click "Print basic receipt"

-> The price info are shown on the printed receipt, even though it shouldn't be the case since a basic ticket is meant for gifts for instance.

Reason and fix:
---------------
Commit b83b13030d8fbc1ca51731c13d88b194d93945ac showed some prices infor without taking into consideration the prop `basic_receipt`, which was fixed by this commit.

opw-4652730