### PR TITLE
[FIX] product: handle cartesian product of multi-select attrs

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1261,6 +1261,8 @@ class ProductTemplate(models.Model):
         value_index_per_line = [-1] * len(product_template_attribute_values_per_line)
         # determines which line line we're working on
         line_index = 0
+        # determines which ptav we're working on
+        current_ptav = None
 
         while True:
             current_line_values = product_template_attribute_values_per_line[line_index]
@@ -1271,11 +1273,12 @@ class ProductTemplate(models.Model):
                 if line_index == len(product_template_attribute_values_per_line) - 1:
                     # submit combination if we're on the last line
                     yield partial_combination
+                    # will break or continue further down as current_ptav_index is always -1 here
                 else:
                     line_index += 1
                     continue
-
-            current_ptav = current_line_values[current_ptav_index]
+            else:
+                current_ptav = current_line_values[current_ptav_index]
 
             # removing exclusions from current_ptav as we're removing it from partial_combination
             if current_ptav_index >= 0:

--- a/addons/product/tests/test_product_attribute_value_config.py
+++ b/addons/product/tests/test_product_attribute_value_config.py
@@ -31,6 +31,7 @@ class TestProductAttributeValueCommon(TransactionCase):
             cls.ram_attribute,
             cls.hdd_attribute,
             cls.size_attribute,
+            cls.extras_attribute,
         ) = cls.env['product.attribute'].create([{
             'name': 'Memory',
             'sequence': 1,
@@ -95,12 +96,28 @@ class TestProductAttributeValueCommon(TransactionCase):
                     'sequence': 3,
                 }),
             ],
+        }, {
+            'name': "Extras",
+            'sequence': 5,
+            'display_type': 'multi',
+            'create_variant': 'no_variant',
+            'value_ids': [
+                Command.create({
+                    'name': "CPU overclock",
+                    'sequence': 1,
+                }),
+                Command.create({
+                    'name': "RAM overclock",
+                    'sequence': 2,
+                }),
+            ],
         }])
 
         cls.ssd_256, cls.ssd_512 = cls.ssd_attribute.value_ids
         cls.ram_8, cls.ram_16, cls.ram_32 = cls.ram_attribute.value_ids
         cls.hdd_1, cls.hdd_2, cls.hdd_4 = cls.hdd_attribute.value_ids
         cls.size_m, cls.size_l, cls.size_xl = cls.size_attribute.value_ids
+        cls.extra_cpu, cls.extra_ram = cls.extras_attribute.value_ids
 
         cls.COMPUTER_SSD_PTAL_VALUES = {
             'product_tmpl_id': cls.computer.id,
@@ -116,6 +133,11 @@ class TestProductAttributeValueCommon(TransactionCase):
             'product_tmpl_id': cls.computer.id,
             'attribute_id': cls.hdd_attribute.id,
             'value_ids': [Command.set([cls.hdd_1.id, cls.hdd_2.id, cls.hdd_4.id])],
+        }
+        cls.COMPUTER_EXTRAS_PTAL_VALUES = {
+            'product_tmpl_id': cls.computer.id,
+            'attribute_id': cls.extras_attribute.id,
+            'value_ids': [Command.set([cls.extra_cpu.id, cls.extra_ram.id])],
         }
 
         cls._add_computer_attribute_lines()
@@ -137,10 +159,12 @@ class TestProductAttributeValueCommon(TransactionCase):
             cls.computer_ssd_attribute_lines,
             cls.computer_ram_attribute_lines,
             cls.computer_hdd_attribute_lines,
+            cls.computer_extras_attribute_lines,
         ) = cls.env['product.template.attribute.line'].create([
             cls.COMPUTER_SSD_PTAL_VALUES,
             cls.COMPUTER_RAM_PTAL_VALUES,
             cls.COMPUTER_HDD_PTAL_VALUES,
+            cls.COMPUTER_EXTRAS_PTAL_VALUES,
         ])
 
         # Setup extra prices


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Create a product with 3 attributes;
2. add a never-create multi-select attribute;
3. archive the first two variants;
4. publish the product to eCommerce;
5. open /shop.

Issue
-----
> 500: Internal Server Error

Cause
-----
Commit 30994723e9ee5 updated the `_cartesian_product` method to handle `multi`-type attributes. When these are on the last attribute line, the method will yield the current partial combination.

Issue is when continuing after the `yield`, it attempts to get the `current_ptav_index` from the `current_line_values` recordset, which is empty for `multi`-type attributes. This causes an `IndexError`.

Solution
--------
Only assign the `current_ptav` variable if `current_line_values` is not falsey, i.e. isn't on a `multi` attribute line.

Because `current_ptav_index` will always be `-1` in this scenario, it will skip over the conditional branches where `current_ptav` gets used, and instead go to either `continue` or `break`.

opw-4653696