### PR TITLE
[FIX] mail: add message author as a member when creating a thread

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1158,14 +1158,13 @@ class Channel(models.Model):
             message = self.env["mail.message"].search([("id", "=", from_message_id)])
         sub_channel = self.create(
             {
-                "channel_member_ids": [Command.create({"partner_id": self.env.user.partner_id.id})],
                 "channel_type": "channel",
                 "from_message_id": message.id,
                 "name": name or (message.body.striptags()[:30] if message.body else _("New Thread")),
                 "parent_channel_id": self.id,
             }
         )
-        self.env.user.partner_id._bus_send_store(Store(sub_channel))
+        sub_channel.add_members(partner_ids=(self.env.user.partner_id | message.author_id).ids, post_joined_message=False)
         notification = (
             Markup('<div class="o_mail_notification">%s</div>')
             % _(

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
+
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 
@@ -133,3 +135,14 @@ class TestDiscussSubChannels(HttpCase):
         self.assertIn(bob_user.partner_id, parent_1_sub_channel_2.channel_member_ids.partner_id)
         self.assertIn(baz_user.partner_id, parent_2_sub_channel.channel_member_ids.partner_id)
         self.assertIn(bob_user.partner_id, parent_3_sub_channel.channel_member_ids.partner_id)
+
+    def test_08_sub_channel_message_author_member(self):
+        bob_user = new_test_user(self.env, "bob_user", groups="base.group_user")
+        parent = self.env["discuss.channel"].create({
+            "name": "General",
+            "channel_member_ids": [Command.create({"partner_id": bob_user.partner_id.id})],
+        })
+        message = parent.with_user(bob_user).message_post(body="Hello there!")
+        sub_channel = parent._create_sub_channel(from_message_id=message.id)
+        self.assertIn(bob_user.partner_id, sub_channel.channel_member_ids.partner_id)
+        self.assertEqual(len(sub_channel.channel_member_ids), 2)


### PR DESCRIPTION
**Current behavior before PR:**

When a thread is created from a message, the message author
is not automatically added as a member of the thread.

**Desired behavior after PR is merged:**

The message author is implicitly added as a member when a
thread is created from message.

**Task**-4656632


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
