### PR TITLE
[IMP] point_of_sale: add performance tests for pos ui

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/pos_performance_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_performance_tour.js
@@ -1,0 +1,29 @@
+import { registry } from "@web/core/registry";
+import { waitFor } from "@odoo/hoot-dom";
+
+function logText(displayText) {
+    console.log(
+        "\n\n┏" + "━".repeat(displayText.length) + "┓",
+        `\n┃${displayText}┃`,
+        "\n┗" + "━".repeat(displayText.length) + "┛\n"
+    );
+}
+
+registry.category("web_tour.tours").add("tourSessionOpenProductPerformance", {
+    steps: () =>
+        [
+            {
+                trigger: "body",
+                timeout: 25000,
+                async run() {
+                    await waitFor("body:not(:has(.pos-loader))", { timeout: 20000 });
+                    const startTime = performance.timeOrigin;
+                    const endTime = Date.now();
+                    const loadingTimeSec = (endTime - startTime) / 1000;
+                    logText(
+                        ` POS loading time: ${loadingTimeSec.toFixed(2)} seconds for 20000 products`
+                    );
+                },
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -3,6 +3,7 @@
 from . import common_setup_methods
 from . import test_point_of_sale_flow
 from . import test_frontend
+from . import test_performances
 from . import test_point_of_sale_ui
 from . import test_anglo_saxon
 from . import test_point_of_sale

--- a/addons/point_of_sale/tests/test_performances.py
+++ b/addons/point_of_sale/tests/test_performances.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+from unittest import skipIf
+
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+from odoo.cli.populate import Populate
+from odoo.tests.common import tagged
+from odoo.tools import mute_logger, config
+
+_logger = logging.getLogger(__name__)
+
+
+@skipIf('pos_performance' not in config['test_tags'], "This test is intended for local performance testing of POS with a large dataset.")
+@tagged('pos_performance', 'post_install', '-at_install')
+class TestPosPerformance(TestPointOfSaleHttpCommon):
+    """
+    These tests are designed for local performance testing only and will be skipped
+    unless the 'pos_performance' tag is explicitly included in the test tags.
+
+    To execute these tests locally, use the 'pos_performance' tag before the test name.
+    Example:
+        --test-tags pos_performance.test_pos_session_open_product_performance
+    """
+
+    def __populate_model(self, model_name, total_count):
+        before_count = self.env[model_name].search_count([])
+        if not before_count:
+            return False
+        populate_count = round(total_count / before_count) - 1
+        Populate.populate(self.env, {model_name: populate_count}, 1)
+
+        after_count = self.env[model_name].search_count([])
+        _logger.info("\n\nBefore %s Count: %s\nAfter %s Count: %s\n\n", model_name, before_count, model_name, after_count)
+        return True
+
+    @mute_logger('odoo.models.unlink', 'odoo.cli.populate', 'odoo.tools.populate', 'odoo.tests.common', 'werkzeug')
+    def test_pos_session_open_product_performance(self):
+        self.env['ir.config_parameter'].sudo().set_param('point_of_sale.limited_product_count', 20000)
+        if not self.__populate_model('product.template', 20000):
+            _logger.warning("The product.template model must contain at least one record before it can be populated.")
+            return
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('tourSessionOpenProductPerformance', timeout=2000)


### PR DESCRIPTION
In this commit:
==========
- Introduces performance tests for the POS UI to measure key metrics, such as loading times with large datasets.
- To run these tests, use the `pos_performance` test tag:
  - Run a specific test: `--test-tags pos_performance.test_name`
  - Run all tests: `--test-tags pos_performance`

**Note**: These tests are meant for local execution only and will not run on Runbot.

Task: 4610539
