### PR TITLE
[FIX] stock_account: prevent zerodivisionerror in lot stock valuation

### DIFF
--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -4,7 +4,7 @@ from ast import literal_eval
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_compare, float_round
+from odoo.tools import float_compare, float_round, float_is_zero
 
 
 class StockLot(models.Model):
@@ -124,6 +124,8 @@ class StockLot(models.Model):
         # Cannot hide the button in list view for non required field in groupby
         if not self:
             raise UserError(_("Select an existing lot/serial number to be reevaluated"))
+        elif all(float_is_zero(layer.remaining_qty, precision_rounding=self.product_id.uom_id.rounding) for layer in self.stock_valuation_layer_ids):
+            raise UserError(_("You cannot adjust the valuation of a layer with zero quantity"))
         self.ensure_one()
         ctx = dict(self._context, default_lot_id=self.id, default_company_id=self.env.company.id)
         return {

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -710,3 +710,28 @@ class TestLotValuation(TestStockValuationCommon):
         self.product1.lot_valuated = True
         return_pick_ids = self._make_return(out_move, 1)
         self.assertTrue(return_pick_ids)
+
+    def test_lot_revaluation_with_remaining_qty(self):
+        """
+            Test manual lot revaluation behavior:
+            - It should proceed if the sum of `remaining_qty` of selected layers is not zero.
+            - It should raise a `UserError` if the sum of `remaining_qty` of selected layers is zero.
+        """
+        self.product1.categ_id.property_cost_method = 'average'
+
+        self._make_in_move(self.product1, 7, lot_ids=[self.lot1])
+        layers = self.product1.stock_valuation_layer_ids
+        self.assertEqual(len(layers), 1)
+        self.assertNotEqual(sum(layers.mapped('remaining_qty')), 0)
+
+        # Revaluation should NOT raise an error when selected layers have remaining_qty > 0.
+        self.lot1.action_revaluation()
+
+        self.product1.lot_valuated = False
+        total_layers = self.product1.stock_valuation_layer_ids
+        self.assertEqual(len(total_layers), 3)
+        layers_with_lot = total_layers.filtered(lambda lot: lot.lot_id)
+        self.assertEqual(sum(layers_with_lot.mapped('remaining_qty')), 0)
+        # Revaluation should now raise a UserError when selected layers' remaining_qty = 0
+        with self.assertRaises(UserError):
+            self.lot1.action_revaluation()


### PR DESCRIPTION
Issue Before This Commit:
============================

When attempting to add a new valuation for a lot/serial-tracked product using the 'Add Manual Valuation' button while the 'Group By Lot' filter is applied, a 'ZeroDivisionError: float division by zero' traceback occurs.

Steps to Reproduce:
============================

- Install the stock_account module.
- Create a product, enable Lot/Serial tracking, and assign it to the Furniture category.
- Update the quantity and assign a lot/serial number, which creates a valuation layer for this lot-tracked product.
- Disable Valuation by Lot/Serial Number for the product.
- Go to Valuation, apply the Group By Lot filter, and try to create a new valuation by clicking Add Manual Valuation.
- Click on the Revalue button it will give an Error.

With This Commit:
============================

The issue occurs because when revaluing layers using the 'Add Manual Valuation' button, all layers have 0 remaining quantity. This happens if 'Valuation by Lot/Serial Number' was initially enabled, creating valuation layers for lot/serial-tracked products, and later disabled. As a result, all valuation layers associated with lot/serial numbers have zero remaining quantity. When attempting to revalue these layers while using the 'Group By Lot' filter, the error occurs.

This commit ensures that if all layers have 0 remaining quantity, a validation error is raised to prevent the issue.

task - [4668497](https://www.odoo.com/odoo/my-tasks/4668497)

