### PR TITLE
[IMP] web: datetime_picker: replace "close" and "apply" buttons

### DIFF
--- a/addons/event/static/src/js/tours/event_tour.js
+++ b/addons/event/static/src/js/tours/event_tour.js
@@ -47,10 +47,6 @@ registry.category("web_tour.tours").add('event_tour', {
     content: markup(_t("Open date range picker.<br/>Pick a Start and End date for your event.")),
     run: "click",
 }, {
-    content: _t("Apply change."),
-    trigger: '.o_datetime_picker .o_datetime_buttons .o_apply',
-    run: "click",
-}, {
     trigger: '.o_event_form_view div[name="event_ticket_ids"] .o_field_x2many_list_row_add a',
     content: markup(_t("Ticket types allow you to distinguish your attendees. Let's <b>create</b> a new one.")),
     run: "click",

--- a/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
@@ -13,7 +13,6 @@ const firstLeaveDateTo = "01/17/2022";
 const secondLeaveDateFrom = "01/18/2022";
 const secondLeaveDateTo = "01/18/2022";
 
-
 registry.category("web_tour.tours").add("hr_leave_type_tour", {
     url: "/web",
     steps: () => [
@@ -89,22 +88,10 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
             run: `edit ${firstLeaveDateFrom}`,
         },
         {
-            trigger: "button.o_apply",
-            content: "Confirm date selection",
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
             trigger: "input[data-field=request_date_to]",
             content: "Select the end date of the leave",
             tooltipPosition: "right",
             run: `edit ${firstLeaveDateTo}`,
-        },
-        {
-            trigger: "button.o_apply",
-            content: "Confirm date selection",
-            tooltipPosition: "bottom",
-            run: "click",
         },
         {
             trigger: 'button[name="action_approve"]',
@@ -114,7 +101,8 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
         },
         {
             trigger: 'button[name="action_cancel"]',
-            content: "Make sure that the leave is approved by checking that the cancel button appears",
+            content:
+                "Make sure that the leave is approved by checking that the cancel button appears",
         },
         {
             trigger: ".o_switch_company_menu button",
@@ -142,7 +130,8 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
         },
         {
             trigger: 'div[name="holiday_status_id"] input',
-            content: "Select leave_type_2 from the list. It should be available now because company_2 is selected",
+            content:
+                "Select leave_type_2 from the list. It should be available now because company_2 is selected",
             tooltipPosition: "bottom",
             run: `edit ${leaveType2}`,
         },
@@ -162,22 +151,10 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
             run: `edit ${secondLeaveDateFrom}`,
         },
         {
-            trigger: "button.o_apply",
-            content: "Confirm date selection",
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
             trigger: "input[data-field=request_date_to]",
             content: "Select the end date of the leave",
             tooltipPosition: "right",
             run: `edit ${secondLeaveDateTo}`,
-        },
-        {
-            trigger: "button.o_apply",
-            content: "Confirm date selection",
-            tooltipPosition: "bottom",
-            run: "click",
         },
         {
             trigger: 'button[name="action_approve"]',
@@ -187,7 +164,8 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
         },
         {
             trigger: 'button[name="action_cancel"]',
-            content: "Make sure that the leave is approved by checking that the cancel button appears",
+            content:
+                "Make sure that the leave is approved by checking that the cancel button appears",
         },
     ],
 });

--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -315,10 +315,7 @@ export class DateTimePicker extends Component {
         rounding: { type: Number, optional: true },
         slots: {
             type: Object,
-            shape: {
-                bottom_left: { type: Object, optional: true },
-                buttons: { type: Object, optional: true },
-            },
+            shape: { buttons: { type: Object, optional: true } },
             optional: true,
         },
         type: { type: [{ value: "date" }, { value: "datetime" }], optional: true },

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -66,9 +66,6 @@
                 </t>
             </div>
 
-            <div t-attf-class="o_datetime_buttons {{ props.type === 'datetime' ? 'position-md-absolute h-100 start-0' : '' }}">
-                <t t-slot="bottom_left" />
-            </div>
             <div t-attf-class="o_datetime_buttons {{ props.type === 'datetime' ? 'position-md-absolute h-100 end-0' : '' }}">
                 <t t-slot="buttons" />
             </div>

--- a/addons/web/static/src/core/datetime/datetime_picker_popover.js
+++ b/addons/web/static/src/core/datetime/datetime_picker_popover.js
@@ -21,13 +21,6 @@ export class DateTimePickerPopover extends Component {
 
     static template = "web.DateTimePickerPopover";
 
-    get isDateTimeRange() {
-        return (
-            this.props.pickerProps.type === "datetime" ||
-            Array.isArray(this.props.pickerProps.value)
-        );
-    }
-
     //-------------------------------------------------------------------------
     // Lifecycle
     //-------------------------------------------------------------------------

--- a/addons/web/static/src/core/datetime/datetime_picker_popover.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker_popover.xml
@@ -3,27 +3,14 @@
     <t t-name="web.DateTimePickerPopover">
         <DateTimePicker t-props="props.pickerProps">
             <t t-set-slot="buttons">
-                <t t-if="isDateTimeRange">
-                    <button
-                        class="o_apply btn btn-primary btn-sm h-100 w-100 w-md-auto d-flex align-items-center justify-content-center gap-1"
-                        tabindex="-1"
-                        t-on-click="props.close"
-                    >
-                        <i class="fa fa-check" />
-                        <span>Apply</span>
-                    </button>
-                </t>
-            </t>
-            <t t-set-slot="bottom_left">
-                <t t-if="isDateTimeRange">
-                    <button
-                        class="btn btn-secondary btn-sm h-100 w-100 w-md-auto d-flex align-items-center justify-content-center"
-                        tabindex="-1"
-                        t-on-click="props.close"
-                    >
-                        <span>Close</span>
-                    </button>
-                </t>
+                <button
+                    class="btn btn-secondary btn-sm h-100 w-100 w-md-auto d-flex align-items-center justify-content-center gap-1"
+                    tabindex="-1"
+                    t-on-click="() => props.pickerProps.range ? props.pickerProps.onSelect([false, false]) : props.pickerProps.onSelect(false)"
+                >
+                    <i class="fa fa-eraser" />
+                    <span>Clear</span>
+                </button>
             </t>
         </DateTimePicker>
     </t>

--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -361,7 +361,9 @@ export const datetimePickerService = {
 
                     if (unit !== "time") {
                         if (pickerProps.range && source === "picker") {
-                            if (
+                            if (!value[0] || !value[1]) {
+                                pickerProps.focusedDateIndex = 0;
+                            } else if (
                                 pickerProps.focusedDateIndex === 0 ||
                                 (value[0] && value[1] && value[1] < value[0])
                             ) {

--- a/addons/web/static/src/core/time_picker/time_picker.scss
+++ b/addons/web/static/src/core/time_picker/time_picker.scss
@@ -1,5 +1,7 @@
 
 .o_time_picker_input {
+    width: 8rem;
+
     transition: all .1s ease-in-out;
     transition-property: color, background-color, border-bottom-color;
     color: $btn-color;

--- a/addons/web/static/tests/core/components/datetime/datetime_input.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_input.test.js
@@ -422,7 +422,7 @@ describe("DateTimeInput (datetime)", () => {
     });
 
     test("Datepicker works with norwegian locale", async () => {
-        expect.assertions(7);
+        expect.assertions(5);
 
         await changeLang("nb");
 
@@ -449,10 +449,6 @@ describe("DateTimeInput (datetime)", () => {
 
         await contains(getPickerCell("1")).click();
         expect(".o_datetime_input").toHaveValue("01 apr., 1997");
-        expect.verifySteps(["datetime-changed"]);
-
-        await click(".o_apply");
-        await animationFrame();
         expect.verifySteps(["datetime-changed"]);
     });
 
@@ -502,7 +498,7 @@ describe("DateTimeInput (datetime)", () => {
         expect(".o_datetime_input").toHaveValue("08/02/1997 15:45");
     });
 
-    test("Clicking close button closes datetime picker", async () => {
+    test("Clicking clear button doesn't close datetime picker", async () => {
         await mountWithCleanup(DateTimeInputComp, {
             props: {
                 value: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
@@ -513,7 +509,7 @@ describe("DateTimeInput (datetime)", () => {
         await contains(".o_datetime_input").click();
         await contains(".o_datetime_picker .o_datetime_buttons .btn-secondary").click();
 
-        expect(".o_datetime_picker").toHaveCount(0);
+        expect(".o_datetime_picker").toHaveCount(1);
     });
 
     test("check datepicker in localization with textual month format", async () => {

--- a/addons/web/static/tests/core/datetime/datetime_test_helpers.js
+++ b/addons/web/static/tests/core/datetime/datetime_test_helpers.js
@@ -1,5 +1,5 @@
 import { expect } from "@odoo/hoot";
-import { click, edit, queryAll, queryAllTexts, queryFirst, queryText } from "@odoo/hoot-dom";
+import { click, edit, queryAll, queryAllTexts, queryText } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 
 const PICKER_COLS = 7;
@@ -144,10 +144,6 @@ export function getPickerCell(expr, inBounds = false) {
         }:contains("/^${expr}$/")`
     );
     return cells.length === 1 ? cells[0] : cells;
-}
-
-export function getPickerApplyButton() {
-    return queryFirst(".o_datetime_picker .o_datetime_buttons .o_apply");
 }
 
 export async function zoomOut() {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -1,12 +1,9 @@
 import { expect, test } from "@odoo/hoot";
-import { queryAll, queryAllAttributes, queryAllTexts } from "@odoo/hoot-dom";
+import { press, queryAll, queryAllAttributes, queryAllTexts } from "@odoo/hoot-dom";
 import { animationFrame, mockDate, mockTimeZone, runAllTimers } from "@odoo/hoot-mock";
 import { Component, useState, xml } from "@odoo/owl";
 
-import {
-    getPickerApplyButton,
-    getPickerCell,
-} from "@web/../tests/core/datetime/datetime_test_helpers";
+import { getPickerCell } from "@web/../tests/core/datetime/datetime_test_helpers";
 import {
     Partner,
     Product,
@@ -167,7 +164,7 @@ test("building a domain with a datetime", async () => {
     // Change the date in the datepicker
     await contains(".o_datetime_input").click();
     await contains(getPickerCell("26")).click();
-    await contains(getPickerApplyButton()).click();
+    await press("enter");
 
     // The input field should display the date and time in the user's timezone
     expect(".o_datetime_input").toHaveValue("03/26/2017 16:42");

--- a/addons/web/static/tests/legacy/core/datetime/datetime_test_helpers.js
+++ b/addons/web/static/tests/legacy/core/datetime/datetime_test_helpers.js
@@ -150,10 +150,6 @@ export function assertDateTimePicker(expectedParams) {
     assert.containsN(fixture, ".o_today", todayCells);
 }
 
-export function getPickerApplyButton() {
-    return select(".o_datetime_picker .o_datetime_buttons .o_apply").at(0);
-}
-
 /**
  * @param {RegExp | string} expr
  */

--- a/addons/web/static/tests/views/calendar/calendar_test_helpers.js
+++ b/addons/web/static/tests/views/calendar/calendar_test_helpers.js
@@ -516,7 +516,6 @@ export async function selectHourOnPicker(selectedValue) {
     await animationFrame();
     await edit(selectedValue, { confirm: "enter" });
     await animationFrame();
-    await contains(".o_datetime_picker .o_apply").click();
 }
 
 /**

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1,6 +1,7 @@
 import { beforeEach, expect, test } from "@odoo/hoot";
 import {
     click,
+    press,
     queryAll,
     queryAllProperties,
     queryAllTexts,
@@ -1031,7 +1032,7 @@ test("date values are selected eagerly and do not flicker", async () => {
     await contains(".o_field_datetime input").click();
     await contains(getPickerCell("19")).click();
     await contains(".o_add_date:enabled").click();
-    await contains(".btn:contains(Apply)").click();
+    await press("enter");
 
     expect(queryAllValues(".o_field_datetime input")).toEqual([
         "02/19/2017 15:30",

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -13,7 +13,6 @@ import {
 
 import {
     editTime,
-    getPickerApplyButton,
     getPickerCell,
     zoomOut,
 } from "@web/../tests/core/datetime/datetime_test_helpers";
@@ -220,11 +219,7 @@ test("DatetimeField in editable list view", async () => {
     await click(getPickerCell("22"));
     await animationFrame();
     await editTime("8:25");
-    // Apply changes
-
-    await click(getPickerApplyButton());
     await animationFrame();
-    expect(".o_datetime_picker").toHaveCount(0, { message: "datepicker should be closed" });
 
     const newExpectedDateString = "04/22/2018 08:25";
 

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -16,11 +16,7 @@ import {
     waitFor,
 } from "@odoo/hoot-dom";
 import { animationFrame, mockDate, runAllTimers } from "@odoo/hoot-mock";
-import {
-    editTime,
-    getPickerApplyButton,
-    getPickerCell,
-} from "@web/../tests/core/datetime/datetime_test_helpers";
+import { editTime, getPickerCell } from "@web/../tests/core/datetime/datetime_test_helpers";
 import {
     clickCancel,
     clickSave,
@@ -396,8 +392,6 @@ test("properties: access to parent", async () => {
     await click(getPickerCell("3"));
     await animationFrame();
     expect(".o_datetime_picker").toHaveCount(1);
-
-    await click(getPickerApplyButton());
 
     expect(".o_property_field_popover").toHaveCount(1, {
         message: "Should not close the definition popover after selecting a date",

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -29,10 +29,7 @@ import {
     tick,
 } from "@odoo/hoot-mock";
 import { Component, markup, onRendered, onWillStart, useRef, xml } from "@odoo/owl";
-import {
-    getPickerApplyButton,
-    getPickerCell,
-} from "@web/../tests/core/datetime/datetime_test_helpers";
+import { getPickerCell } from "@web/../tests/core/datetime/datetime_test_helpers";
 import {
     clickFieldDropdown,
     clickModalButton,
@@ -10367,10 +10364,10 @@ test(`multi edit field with daterange widget`, async () => {
     // change dates range
     await contains(getPickerCell("16").at(0)).click();
     await contains(getPickerCell("12").at(1)).click();
-    expect(getPickerApplyButton()).not.toHaveAttribute("disabled");
 
     // Apply the changes
-    await contains(getPickerApplyButton()).click();
+    await contains(`.o_list_view`).click();
+
     expect(`.modal`).toHaveCount(1, {
         message: "The confirm dialog should appear to confirm the multi edition.",
     });


### PR DESCRIPTION
- As "close" and "apply" buttons are both closing the popover, it seems not useful. Wen can still close this popover by clicking on "esc" or by clicking away.

- A "reset" button has been added.

task-4613140

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
