### PR TITLE
[FIX] website_sale_wishlist: add space "add to wishlist"


### DIFF
--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -63,7 +63,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "check the first variant is already in wishlist",
-            trigger: '#product_detail .o_add_wishlist_dyn:disabled',
+            trigger: '#product_detail .o_add_wishlist_dyn.disabled',
         },
         {
             trigger: "#product_detail label:contains(Aluminium) input",
@@ -74,7 +74,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             run: "click",
         },
         {
-            trigger: "#product_detail .o_add_wishlist_dyn:not(:disabled)",
+            trigger: "#product_detail .o_add_wishlist_dyn:not(.disabled)",
         },
         {
             content: "wait button enable and click on add to wishlist",

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -53,10 +53,9 @@
             <t t-nocache="The wishlist depends on the user and must not be shared with other users. The product come from the controller.">
                 <t t-set="product_variant" t-value="product_variant or product._create_first_product_variant()"/>
                 <t t-set="in_wish" t-value="product_variant and product_variant._is_in_wishlist()"/>
-                <button
+                <!-- using A instead of BUTTON so space character works when editing -->
+                <a
                     t-if="product_variant"
-                    type="button"
-                    role="button"
                     class="btn btn-link px-0 pe-3 o_add_wishlist_dyn"
                     t-att-disabled="in_wish"
                     t-att-data-product-template-id="product.id"
@@ -66,7 +65,7 @@
                 >
                     <i class="fa fa-heart-o me-2" role="img" aria-label="Add to wishlist"/>
                     Add to wishlist
-                </button>
+                </a>
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
Scenario:
- edit product page with wishlist enabled
- add a space in the "Add to wishlist" string

Result: space are not added, because when pressing space in a button,
the browser sends a click event to activates it and ignore the input.
The button activation is prevented by the editor.

Fix: if we want to improve this, there doesn't see a good way besides
replacing the button by a link with button style. This could be risky
to change the tag so this is targetting master. Alternatives for stables
could be to implement this fix, copy paste a string containing a space,
or edit the source code directly (by "HTML / CSS Editor").

opw-4656215

**PR note:** reproduction of the issue on jsfiddle https://jsfiddle.net/x6ae7kLt/