### PR TITLE
[IMP] mail: refine default recipients

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -108,14 +108,14 @@ class CalendarAttendee(models.Model):
             "use_default_to": True,
         }
 
-    def _message_get_default_recipients(self, with_cc=False, all_tos=False):
+    def _message_add_default_recipients(self):
         # override: partner_id being the only stored field, we can currently
         # simplify computation, we have no other choice than relying on it
         return {
             attendee.id: {
                 'partner_ids': attendee.partner_id.ids,
-                'email_to': False,
-                'email_cc': False
+                'email_to_lst': [],
+                'email_cc_lst': [],
             } for attendee in self
         }
 

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1062,7 +1062,11 @@ class CalendarEvent(models.Model):
     def _get_attendee_emails(self):
         """ Get comma-separated attendee email addresses. """
         self.ensure_one()
-        return ",".join([e for e in self.attendee_ids.mapped("email") if e])
+        defaults = self._message_get_default_recipients()[self.id]
+        email_to = defaults['email_to'] or ''
+        if defaults['partner_ids']:
+            email_to += ','.join(self.env['res.partner'].browse(defaults['partner_ids']).mapped('email'))
+        return email_to
 
     def _get_mail_tz(self):
         self.ensure_one()

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -12,19 +12,130 @@ from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.mail.tests.common import MailCase, MockEmail
 
 
-@tagged('post_install', '-at_install', 'mail_flow')
-class TestEventNotifications(TransactionCase, MailCase, MockEmail, CronMixinCase):
+class CalendarMailCommon(TransactionCase, MailCase, MockEmail, CronMixinCase):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # give default values for all email aliases and domain
+        cls._init_mail_gateway()
+        cls._init_mail_servers()
+
+        cls.test_alias = cls.env['mail.alias'].create({
+            'alias_domain_id': cls.mail_alias_domain.id,
+            'alias_model_id': cls.env['ir.model']._get_id('calendar.event'),
+            'alias_name': 'test.alias.event',
+        })
         cls.event = cls.env['calendar.event'].create({
             'name': "Doom's day",
             'start': datetime(2019, 10, 25, 8, 0),
             'stop': datetime(2019, 10, 27, 18, 0),
-        }).with_context(mail_notrack=True)
-        cls.user = new_test_user(cls.env, 'xav', email='em@il.com', notification_type='inbox')
+        })
+        cls.user = new_test_user(
+            cls.env,
+            'xav',
+            email='em@il.com',
+            notification_type='inbox',
+        )
+        cls.user_employee_2 = new_test_user(
+            cls.env,
+            email='employee.2@test.mycompany.com',
+            groups='base.group_user,base.group_partner_manager',
+            login='employee.2@test.mycompany.com',
+            notification_type='email',
+        )
+        cls.user_admin = cls.env.ref('base.user_admin')
+        cls.user_root = cls.env.ref('base.user_root')
+
+        cls.customers = cls.env['res.partner'].create([
+            {
+                'email': 'test.customer@example.com',
+                'name': 'Customer Email',
+            }, {
+                'email': 'wrong',
+                'name': 'Wrong Email',
+            }, {
+                'email': f'"Alias Customer" <{cls.test_alias.alias_full_name}>',
+                'name': 'Alias Email',
+            },
+        ])
+
+
+@tagged('post_install', '-at_install', 'mail_flow')
+class TestCalendarMail(CalendarMailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_employee = cls.user
+        cls.test_template_event = cls.env['mail.template'].with_user(cls.user_admin).create({
+            'auto_delete': True,
+            'body_html': '<p>Hello <t t-out="object.partner_id.name"/></p>',
+            'email_from': '{{ object.user_id.email_formatted or user.email_formatted or "" }}',
+            'model_id': cls.env['ir.model']._get_id('calendar.event'),
+            'name': 'Test Event Template',
+            'subject': 'Test {{ object.name }}',
+            'use_default_to': True,
+        })
+        cls.event.write({
+            'partner_ids': [(4, p.id) for p in cls.user_employee_2.partner_id + cls.customers],
+        })
+        cls.event.message_unsubscribe(partner_ids=cls.event.message_partner_ids.ids)
+
+    def test_assert_initial_values(self):
+        self.assertFalse(self.event.message_partner_ids)
+        self.assertEqual(self.event.partner_ids, self.user_employee_2.partner_id + self.customers)
+        self.assertEqual(self.event.user_id, self.user_root)
+
+    def test_event_get_default_recipients(self):
+        event = self.event.with_user(self.user_employee)
+        defaults = event._message_get_default_recipients()
+        self.assertDictEqual(
+            defaults[event.id],
+            {'email_cc': '', 'email_to': '', 'partner_ids': (self.user_root.partner_id + self.customers[2] + self.customers[0] + self.user_employee_2.partner_id).ids},
+            'FIXME: currently using partner_id + partner_ids field with valid email, does not filter'
+        )
+
+    def test_event_get_suggested_recipients(self):
+        event = self.event.with_user(self.user_employee)
+        suggested = event._message_get_suggested_recipients()
+        self.assertListEqual(suggested, [
+            {
+                'create_values': {},
+                'email': self.customers[0].email_normalized,
+                'name': self.customers[0].name,
+                'partner_id': self.customers[0].id,
+            }, {
+                'create_values': {},
+                'email': self.user_employee_2.partner_id.email_normalized,
+                'name': self.user_employee_2.partner_id.name,
+                'partner_id': self.user_employee_2.partner_id.id,
+            },
+        ], 'Correctly filters out robodoo and aliases')
+
+    def test_event_template(self):
+        event, template = self.event.with_user(self.user_employee), self.test_template_event.with_user(self.user_employee)
+        message = event.message_post_with_source(
+            template,
+            message_type='comment',
+            subtype_id=self.env.ref('mail.mt_comment').id,
+        )
+        self.assertEqual(
+            message.notified_partner_ids, self.customers[0] + self.user_employee_2.partner_id,
+            'Matches suggested recipients',
+        )
+
+
+@tagged('post_install', '-at_install', 'mail_flow')
+class TestEventNotifications(CalendarMailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         cls.partner = cls.user.partner_id
+
+    def test_assert_initial_values(self):
+        self.assertFalse(self.event.partner_ids)
 
     def test_message_invite(self):
         self.env['ir.config_parameter'].sudo().set_param('mail.mail_force_send_limit', None)

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -92,8 +92,8 @@ class TestCalendarMail(CalendarMailCommon):
         defaults = event._message_get_default_recipients()
         self.assertDictEqual(
             defaults[event.id],
-            {'email_cc': '', 'email_to': '', 'partner_ids': (self.user_root.partner_id + self.customers[2] + self.customers[0] + self.user_employee_2.partner_id).ids},
-            'FIXME: currently using partner_id + partner_ids field with valid email, does not filter'
+            {'email_cc': '', 'email_to': '', 'partner_ids': (self.customers[0] + self.user_employee_2.partner_id).ids},
+            'Correctly filters out robodoo and aliases'
         )
 
     def test_event_get_suggested_recipients(self):
@@ -105,6 +105,11 @@ class TestCalendarMail(CalendarMailCommon):
                 'email': self.customers[0].email_normalized,
                 'name': self.customers[0].name,
                 'partner_id': self.customers[0].id,
+            }, {  # wrong email suggested, can be corrected ?
+                'create_values': {},
+                'email': self.customers[1].email_normalized,
+                'name': self.customers[1].name,
+                'partner_id': self.customers[1].id,
             }, {
                 'create_values': {},
                 'email': self.user_employee_2.partner_id.email_normalized,
@@ -121,7 +126,7 @@ class TestCalendarMail(CalendarMailCommon):
             subtype_id=self.env.ref('mail.mt_comment').id,
         )
         self.assertEqual(
-            message.notified_partner_ids, self.customers[0] + self.user_employee_2.partner_id,
+            message.notified_partner_ids, self.customers[0] + self.customers[1] + self.user_employee_2.partner_id,
             'Matches suggested recipients',
         )
 

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -698,17 +698,6 @@ class EventEvent(models.Model):
         return self.with_context(tz=self.date_tz or 'UTC')
 
     # ------------------------------------------------------------
-    # MAILING
-    # ------------------------------------------------------------
-
-    def _message_add_suggested_recipients(self, force_primary_email=False):
-        # override to suggested organizer instead of adding them as follower
-        suggested = super()._message_add_suggested_recipients(force_primary_email=force_primary_email)
-        for event in self.filtered('organizer_id'):
-            suggested[event.id]['partners'] |= event.organizer_id
-        return suggested
-
-    # ------------------------------------------------------------
     # ACTIONS
     # ------------------------------------------------------------
 

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -360,17 +360,16 @@ class EventRegistration(models.Model):
             registration_id=self.id,
         )
 
-    def _message_get_default_recipients(self, with_cc=False, all_tos=False):
+    def _message_add_default_recipients(self):
         # Prioritize registration email over partner_id, which may be shared when a single
         # partner booked multiple seats
-        results = super()._message_get_default_recipients(with_cc=with_cc, all_tos=all_tos)
+        results = super()._message_add_default_recipients()
         for record in self:
-            email_to = results[record.id]['email_to']
-            if email_to:
-                results[record.id]['email_to'] = ','.join(
-                    formataddr((record.name or "", email))
-                    for email in email_normalize_all(email_to) if email
-                )
+            email_to_lst = results[record.id]['email_to_lst']
+            if len(email_to_lst) == 1:
+                email_normalized = email_normalize(email_to_lst[0])
+                if email_normalized and email_normalized == email_normalize(record.email):
+                    results[record.id]['email_to_lst'] = [formataddr((record.name or "", email_normalized))]
         return results
 
     def _message_post_after_hook(self, message, msg_vals):

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -632,7 +632,7 @@ class TestMailSchedule(EventMailCommon):
         ]})
         self.env.invalidate_all()
         # event 50
-        with self.assertQueryCount(68), \
+        with self.assertQueryCount(71), \
              self.mock_datetime_and_now(reference_now + relativedelta(minutes=10)), \
              self.mock_mail_gateway():
             _new = self.env['event.registration'].create([

--- a/addons/event/tests/test_mailing.py
+++ b/addons/event/tests/test_mailing.py
@@ -108,13 +108,13 @@ class TestMailing(EventCase, MockEmail):
     @users("user_eventmanager")
     def test_event_mail_recipients(self):
         """ Check default / suggested recipients """
-        default_organizer = self.user_eventmanager.company_id.partner_id
+        _default_organizer = self.user_eventmanager.company_id.partner_id
         for event_values, exp_followers, exp_defaults, exp_suggested in [
             (
                 {"organizer_id": self.event_organizer.id, "user_id": self.user_eventuser.id},
                 self.user_eventmanager.partner_id + self.user_eventuser.partner_id,
                 {"email_cc": "", "email_to": "", "partner_ids": []},
-                [{'email': self.event_organizer.email, 'name': self.event_organizer.name, 'partner_id': self.event_organizer.id, 'create_values': {}}],
+                [],
             ),
             (
                 {"organizer_id": False, "user_id": self.user_eventuser.id},
@@ -126,7 +126,7 @@ class TestMailing(EventCase, MockEmail):
                 {},
                 self.user_eventmanager.partner_id,
                 {"email_cc": "", "email_to": "", "partner_ids": []},
-                [{'email': default_organizer.email, 'name': default_organizer.name, 'partner_id': default_organizer.id, 'create_values': {}}],
+                [],
             ),
         ]:
             with self.subTest(event_values=event_values):

--- a/addons/mail/models/mail_thread_cc.py
+++ b/addons/mail/models/mail_thread_cc.py
@@ -45,7 +45,6 @@ class MailThreadCc(models.AbstractModel):
 
     def _message_add_suggested_recipients(self, force_primary_email=False):
         suggested = super()._message_add_suggested_recipients(force_primary_email=force_primary_email)
-        for record in self:
-            if record.email_cc:
-                suggested[record.id]['email_to_lst'].append(record.email_cc)
+        for record in self.filtered('email_cc'):
+            suggested[record.id]['email_to_lst'] += tools.mail.email_split_and_format_normalize(record.email_cc)
         return suggested

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -223,42 +223,22 @@ class Base(models.AbstractModel):
             sequence = 100
         return sequence
 
-    def _message_get_default_recipients(self, with_cc=False, all_tos=False):
+    def _message_add_default_recipients(self):
         """ Generic implementation for finding default recipient to mail on
         a recordset. This method is a generic implementation available for
         all models as we could send an email through mail templates on models
-        not inheriting from mail.thread.
-
-        Heuristics is to find a customer (res.partner record) holding a
-        email. Then we fallback on email fields, beginning with field optionally
-        defined using `_primary_email` attribute. Email can be prioritized
-        compared to partner if `_mail_defaults_to_email` class parameter is set.
+        not inheriting from mail.thread. For that purpose we use mail methods
+        to find partners (customers) and primary emails.
 
         Override this method on a specific model to implement model-specific
-        behavior. Also consider inheriting from ``mail.thread``.
-
-        :param with_cc: take into account CC-like field. By default those are
-          not considered as valid for 'default recipients' e.g. in mailings,
-          automated actions, ...
-        :param all_tos: fetch all TOs, not only email or customer. Both are
-          fine. Used notably when default acts for suggested and should be
-          broader;
-        """
+        behavior. """
         res = {}
         customers = self._mail_get_partners()
-        prioritize_email = getattr(self, '_mail_defaults_to_email', False)
         primary_emails = self._mail_get_primary_email()
         for record in self:
             email_cc_lst, email_to_lst = [], []
-            # main recipients (res.partner) (filter twice, otherwise prefetch is lost /shrug)
-            if all_tos:
-                # consider caller is going to filter / handle so don't filter anything
-                recipients_all = customers.get(record.id)
-                recipients = customers.get(record.id).filtered(lambda p: p.email_normalized)
-            else:
-                # pure default recipients, skip public
-                recipients_all = customers.get(record.id).filtered(lambda p: not p.is_public)
-                recipients = customers.get(record.id).filtered(lambda p: not p.is_public and p.email_normalized)
+            # consider caller is going to filter / handle so don't filter anything
+            recipients_all = customers.get(record.id)
             # to computation
             email_to = primary_emails[record.id]
             if not email_to:
@@ -281,15 +261,64 @@ class Base(models.AbstractModel):
                     fname for fname in ['email_cc', 'partner_email_cc', 'x_email_cc']
                     if fname in record and record[fname]
                 ), False
-            ) if with_cc else ''
+            )
             if cc_fn:
                 email_cc_lst = tools.mail.email_split_and_format_normalize(record[cc_fn]) or [record[cc_fn]]
-            # take all default recipients
-            if all_tos:
-                partner_ids = recipients.ids or recipients_all.ids
-                email_to = ','.join(email_to_lst)
+
+            res[record.id] = {
+                'email_cc_lst': email_cc_lst,
+                'email_to_lst': email_to_lst,
+                'partners': recipients_all,
+            }
+        return res
+
+    def _message_get_default_recipients(self, with_cc=False, all_tos=False):
+        """ Compute and filter default recipients to mail on a recordset.
+        Heuristics is to find a customer (res.partner record) holding a
+        email. Then we fallback on email fields, beginning with field optionally
+        defined using `_primary_email` attribute. Email can be prioritized
+        compared to partner if `_mail_defaults_to_email` class parameter is set.
+
+        :param with_cc: take into account CC-like field. By default those are
+          not considered as valid for 'default recipients' e.g. in mailings,
+          automated actions, ...
+        :param all_tos: DEPRECATED
+        """
+        def email_key(email):
+            return email_normalize(email, strict=False) or email.strip()
+
+        res = {}
+        prioritize_email = getattr(self, '_mail_defaults_to_email', False)
+        found = self._message_add_default_recipients()
+
+        # ban emails: never propose odoobot nor aliases
+        all_emails = []
+        for defaults in found.values():
+            all_emails += defaults['email_to_lst']
+            if with_cc:
+                all_emails += defaults['email_cc_lst']
+            all_emails += defaults['partners'].mapped('email_normalized')
+        ban_emails = [self.env.ref('base.partner_root').email_normalized]
+        ban_emails += self.env['mail.alias.domain'].sudo()._find_aliases(
+            [email_key(e) for e in all_emails if e and e.strip()]
+        )
+
+        # fetch default recipients for each record
+        for record in self:
+            defaults = found[record.id]
+            customers = defaults['partners']
+            email_cc_lst = defaults['email_cc_lst'] if with_cc else []
+            email_to_lst = defaults['email_to_lst']
+
+            # pure default recipients, skip public and banned emails
+            recipients_all = customers.filtered(lambda p: not p.is_public and (not p.email_normalized or p.email_normalized not in ban_emails))
+            recipients = customers.filtered(lambda p: not p.is_public and p.email_normalized and p.email_normalized not in ban_emails)
+            # filter emails, skip banned mails
+            email_cc_lst = [e for e in email_cc_lst if e not in ban_emails]
+            email_to_lst = [e for e in email_to_lst if e not in ban_emails]
+
             # prioritize recipients: default unless asked through '_mail_defaults_to_email', or when no email_to
-            elif not prioritize_email or not email_to_lst:
+            if not prioritize_email or not email_to_lst:
                 # if no valid recipients nor emails, fallback on recipients even
                 # invalid to have at least some information
                 if recipients:
@@ -321,11 +350,13 @@ class Base(models.AbstractModel):
         return res
 
     def _message_add_suggested_recipients(self, force_primary_email=False):
+        """ Generic implementation for finding suggested recipient to mail on
+        a recordset. """
         suggested = {
             record.id: {'email_to_lst': [], 'partners': self.env['res.partner']}
             for record in self
         }
-        defaults = self._message_get_default_recipients(with_cc=False, all_tos=True)
+        defaults = self._message_add_default_recipients()
 
         # add responsible
         user_field = self._fields.get('user_id')
@@ -336,26 +367,28 @@ class Base(models.AbstractModel):
 
         # add customers
         for record_id, values in defaults.items():
-            suggested[record_id]['partners'] += self.env['res.partner'].browse(values['partner_ids'])
+            suggested[record_id]['partners'] |= values['partners']
 
         # add email
         for record in self:
             if force_primary_email:
-                suggested[record.id]['email_to_lst'].append(force_primary_email)
+                suggested[record.id]['email_to_lst'] += tools.mail.email_split_and_format_normalize(force_primary_email)
             else:
-                suggested[record.id]['email_to_lst'].append(defaults[record.id]['email_to'])
+                suggested[record.id]['email_to_lst'] += defaults[record.id]['email_to_lst']
 
         return suggested
 
     def _message_get_suggested_recipients_batch(self, reply_discussion=False, reply_message=None,
                                                 no_create=True, primary_email=False, additional_partners=None):
         """ Get suggested recipients, contextualized depending on discussion.
+        This method automatically filters out emails and partners linked to
+        aliases or alias domains.
 
         :param bool reply_discussion: consider user replies to the discussion.
           Last relevant message is fetched and used to search for additional
           'To' and 'Cc' to propose;
-        :param bool reply_message: specific message user is replying-to. Bypasses
-          'reply_discussion';
+        :param <mail.message> reply_message: specific message user is replying-to.
+          Bypasses 'reply_discussion';
         :param bool no_create: do not create partners when emails are not linked
           to existing partners, see '_partner_find_from_emails';
         :param bool primary_email: new primary_email that isn't stored inside DB;

--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -82,7 +82,7 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
             mailing.action_update_cards()
         self.assertEqual(len(self._wkhtmltoimage_bodies), 5)
 
-        with self.mock_mail_gateway(), self.assertQueryCount(61):
+        with self.mock_mail_gateway(), self.assertQueryCount(64):
             mailing._action_send_mail()
 
         cards = self.env['card.card'].search([('campaign_id', '=', campaign.id)])

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -308,6 +308,15 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                             'partner_id': author.id,  # already created by project upon initial email reception
                         }
                     ]
+                elif test_user == self.user_portal:
+                    expected_all = [
+                        {  # customer is proposed, even if follower, because shared
+                            'create_values': {},
+                            'email': self.user_portal.email_normalized,
+                            'name': self.user_portal.name,
+                            'partner_id': self.user_portal.partner_id.id,
+                        }
+                    ]
                 expected_all += [
                     {  # mail.thread.cc: email_cc field
                         'create_values': {},

--- a/addons/survey/tests/test_certification_flow.py
+++ b/addons/survey/tests/test_certification_flow.py
@@ -121,7 +121,7 @@ class TestCertificationFlow(common.TestSurveyCommon, MockEmail, HttpCase):
             self._answer_question(q05, q05_answers, answer_token, csrf_token,
                                   submit_query_count=28, access_page_query_count=24)
             self._answer_question(q06, q06.suggested_answer_ids.ids[0], answer_token, csrf_token,
-                                  submit_query_count=104, access_page_query_count=24)
+                                  submit_query_count=108, access_page_query_count=24)
 
         user_inputs.invalidate_recordset()
         # Check that certification is successfully passed

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -401,7 +401,7 @@ class TestAPI(MailCommon, TestRecipients):
 
         # test default computation of recipients
         self.env.invalidate_all()
-        with self.assertQueryCount(20):
+        with self.assertQueryCount(22):
             defaults_withcc = test_records.with_context()._message_get_default_recipients(with_cc=True)
             defaults_withoutcc = test_records.with_context()._message_get_default_recipients()
         for record, expected in zip(test_records, [
@@ -462,6 +462,7 @@ class TestAPI(MailCommon, TestRecipients):
             # do not propose alias domain emails
             {
                 'email_from': self.mail_alias_domain.catchall_email,
+                'name': 'Alias domain email',
             },
             # do not propose when partner = alias
             {
@@ -492,22 +493,22 @@ class TestAPI(MailCommon, TestRecipients):
         expected_all = [
             # nobody to suggest (no public !)
             {'email_cc': '', 'email_to': '', 'partner_ids': []},
-            # FIXME should be nobody to suggest (no root !)
-            {'email_cc': '', 'email_to': '', 'partner_ids': [self.partner_root.id]},
-            # FIXME alias domain email is not ok
-            {'email_cc': '', 'email_to': 'catchall.test@test.mycompany.com', 'partner_ids': []},
-            # FIXME partner with alias email is not ok
-            {'email_cc': '', 'email_to': '', 'partner_ids': [self.test_partner_alias.id]},
-            # FIXME alias email is not ok
-            {'email_cc': '', 'email_to': 'test.alias.free@test.mycompany.com', 'partner_ids': []},
-            # FIXME alias email is not ok even if linked to partner
-            {'email_cc': '', 'email_to': 'test.alias.partner@test.mycompany.com', 'partner_ids': []},
+            # should be nobody to suggest (no root !)
+            {'email_cc': '', 'email_to': '', 'partner_ids': []},
+            # alias domain email is not ok
+            {'email_cc': '', 'email_to': '', 'partner_ids': []},
+            # partner with alias email is not ok
+            {'email_cc': '', 'email_to': '', 'partner_ids': []},
+            # alias email is not ok
+            {'email_cc': '', 'email_to': '', 'partner_ids': []},
+            # alias email is not ok even if linked to partner
+            {'email_cc': '', 'email_to': '', 'partner_ids': []},
             # archived is ok, customer
             {'email_cc': '', 'email_to': '', 'partner_ids': [self.test_partner_archived.id]},
             # active based on archived user is ok, customer
             {'email_cc': '', 'email_to': '', 'partner_ids': [self.partner_employee_archived.id]},
         ]
-        defaults = tickets._message_get_default_recipients(all_tos=False)
+        defaults = tickets._message_get_default_recipients()
         for ticket, expected in zip(tickets, expected_all, strict=True):
             with self.subTest(ticket_name=ticket.name):
                 self.assertDictEqual(defaults[ticket.id], expected)

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -539,6 +539,7 @@ class TestAPI(MailCommon, TestRecipients):
         ticket_partner_email = self.env['mail.test.ticket.mc'].create({
             'customer_id': False,
             'email_from': self.test_partner.email_formatted,
+            'name': 'Partner email',
             'phone_number': '+33199001015',
             'user_id': self.env.user.id,  # should not be proposed, already follower
         })
@@ -546,20 +547,42 @@ class TestAPI(MailCommon, TestRecipients):
         ticket_partner = self.env['mail.test.ticket.mc'].create({
             'customer_id': self.test_partner.id,
             'email_from': self.test_partner.email_formatted,
+            'name': 'Partner',
         })
-        for ticket in ticket_partner_email + ticket_partner:
+        # existing partner in followers -> should not propose it
+        ticket_partner_fol = self.env['mail.test.ticket.mc'].create({
+            'customer_id': self.test_partner.id,
+            'email_from': self.test_partner.email_formatted,
+            'name': 'Partner follower',
+        })
+        # existing partner in followers -> should not propose it
+        ticket_partner_fol_user = self.env['mail.test.ticket.mc'].create({
+            'customer_id': self.partner_employee.id,
+            'email_from': self.partner_employee.email_formatted,
+            'name': 'Partner follower (user)',
+        })
+        ticket_partner_fol.message_subscribe(partner_ids=self.test_partner.ids)
+        ticket_partner_fol.message_subscribe(partner_ids=self.partner_employee.ids)
+        for ticket, sugg_partner in zip(
+            ticket_partner_email + ticket_partner + ticket_partner_fol + ticket_partner_fol_user,
+            (self.test_partner, self.test_partner, False, False),
+            strict=True,
+        ):
             with self.subTest(ticket=ticket.name):
                 suggestions = ticket._message_get_suggested_recipients(no_create=True)
-                self.assertEqual(len(suggestions), 1)
-                self.assertDictEqual(
-                    suggestions[0],
-                    {
-                        'create_values': {},
-                        'email': self.test_partner.email_normalized,
-                        'name': self.test_partner.name,
-                        'partner_id': self.test_partner.id,
-                    }
-                )
+                if sugg_partner:
+                    self.assertEqual(len(suggestions), 1)
+                    self.assertDictEqual(
+                        suggestions[0],
+                        {
+                            'create_values': {},
+                            'email': sugg_partner.email_normalized,
+                            'name': sugg_partner.name,
+                            'partner_id': sugg_partner.id,
+                        }
+                    )
+                else:
+                    self.assertEqual(len(suggestions), 0)
 
     @users("employee")
     def test_message_get_suggested_recipients_banned(self):

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -566,7 +566,7 @@ class TestAPI(MailCommon, TestRecipients):
         ticket_partner_fol.message_subscribe(partner_ids=self.partner_employee.ids)
         for ticket, sugg_partner in zip(
             ticket_partner_email + ticket_partner + ticket_partner_fol + ticket_partner_fol_user,
-            (self.test_partner, self.test_partner, False, False),
+            (self.test_partner, self.test_partner, self.test_partner, False),
             strict=True,
         ):
             with self.subTest(ticket=ticket.name):

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -455,7 +455,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=50, employee=50), self.mock_mail_gateway():
+        with self.assertQueryCount(admin=55, employee=55), self.mock_mail_gateway():
             composer._action_send_mail()
 
         self.assertEqual(len(self._new_mails), 10)
@@ -909,7 +909,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_default_recipients(self):
         record = self.test_records_recipients[0].with_env(self.env)
-        with self.assertQueryCount(employee=1):
+        with self.assertQueryCount(employee=7):
             defaults = record._message_get_default_recipients()
         self.assertDictEqual(defaults, {record.id: {
             'email_cc': '', 'email_to': 'only.email.1@test.example.com', 'partner_ids': [],
@@ -919,7 +919,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_default_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=4):
+        with self.assertQueryCount(employee=9):
             defaults = records._message_get_default_recipients()
         self.assertDictEqual(defaults, {
             records[0].id: {
@@ -963,7 +963,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=29):  # tm: 22
+        with self.assertQueryCount(employee=31):  # tm: 22
             _recipients = records._message_get_suggested_recipients_batch(no_create=False)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -47,7 +47,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +101 compared to local
-        with self.assertQueryCount(__system__=1280, marketing=1281):  # 1179, 1180
+        with self.assertQueryCount(__system__=1284, marketing=1286):  # 1179, 1180
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -90,7 +90,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +101 compared to local
-        with self.assertQueryCount(__system__=1319, marketing=1320):  # 1217, 1218
+        with self.assertQueryCount(__system__=1327, marketing=1329):  # 1217, 1218
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -474,14 +474,11 @@ class EventTrack(models.Model):
     # MESSAGING
     # ------------------------------------------------------------
 
-    def _message_get_default_recipients(self, with_cc=False, all_tos=False):
-        recipients = super()._message_get_default_recipients(with_cc=with_cc, all_tos=all_tos)
+    def _message_add_default_recipients(self):
+        recipients = super()._message_add_default_recipients()
         for track in self.filtered(lambda t: not t.partner_id.email_normalized and not email_normalize(t.contact_email) and t.partner_email):
             info = recipients[track.id]
-            info['email_to'] = ','.join(tools.mail.email_split_and_format_normalize(track.partner_email)) or track.partner_email
-            # default only: email is sufficient, otherwise propose even "wrong" partners
-            if not all_tos:
-                info['partner_ids'] = []
+            info['email_to_lst'] = tools.mail.email_split_and_format_normalize(track.partner_email) or [track.partner_email]
         return recipients
 
     def _message_post_after_hook(self, message, msg_vals):

--- a/addons/website_slides/tests/test_gamification_karma.py
+++ b/addons/website_slides/tests/test_gamification_karma.py
@@ -128,7 +128,7 @@ class TestKarmaGain(common.SlidesCase):
         self.assertEqual(len(channel_partners), 4)
 
         # Set courses as completed and update karma
-        with self.assertQueryCount(57):  # com 55
+        with self.assertQueryCount(65):  # com 55
             channel_partners._post_completion_update_hook()
 
         computed_karma = self.channel.karma_gen_channel_finish + self.channel_2.karma_gen_channel_finish


### PR DESCRIPTION
In order to correctly filter recipients in both default and suggested
computation, it is easier to do it in two steps. First one is to compute
all potential recipients, then filter them.

Default and suggested recipients now both filter aliases or alias
domains emails.

Todo for master: somehow make code and return types coherent between
default and suggested recipients computation.

Task-4668703