### PR TITLE
[FIX] web: calendar: single day events over two days

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -6,7 +6,7 @@ import { useBus } from "@web/core/utils/hooks";
 import { renderToFragment, renderToString } from "@web/core/utils/render";
 import { makeWeekColumn } from "@web/views/calendar/calendar_common/calendar_common_week_column";
 import { CalendarCommonPopover } from "@web/views/calendar/calendar_common/calendar_common_popover";
-import { getColor } from "@web/views/calendar/utils";
+import { convertRecordToEvent, getColor } from "@web/views/calendar/utils";
 import { useCalendarPopover } from "@web/views/calendar/hooks/calendar_popover_hook";
 import { useFullCalendar } from "@web/views/calendar/hooks/full_calendar_hook";
 import { useSquareSelection } from "@web/views/calendar/hooks/square_selection_hook";
@@ -176,19 +176,7 @@ export class CalendarCommonRenderer extends Component {
         return Object.values(this.props.model.records).map((r) => this.convertRecordToEvent(r));
     }
     convertRecordToEvent(record) {
-        const allDay = record.isAllDay || record.end.diff(record.start, "hours").hours >= 24;
-        return {
-            id: record.id,
-            title: record.title,
-            start: record.start.toISO(),
-            end:
-                (["week", "month"].includes(this.props.model.scale) && allDay) ||
-                record.isAllDay ||
-                (allDay && record.end.toMillis() !== record.end.startOf("day").toMillis())
-                    ? record.end.plus({ days: 1 }).toISO()
-                    : record.end.toISO(),
-            allDay: allDay,
-        };
+        return convertRecordToEvent(record);
     }
     getPopoverProps(record) {
         return {

--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
@@ -1,7 +1,7 @@
 import { getLocalYearAndWeek } from "@web/core/l10n/dates";
 import { localization } from "@web/core/l10n/localization";
 import { useDebounced } from "@web/core/utils/timing";
-import { getColor } from "@web/views/calendar/utils";
+import { convertRecordToEvent, getColor } from "@web/views/calendar/utils";
 import { useCalendarPopover } from "@web/views/calendar/hooks/calendar_popover_hook";
 import { useFullCalendar } from "@web/views/calendar/hooks/full_calendar_hook";
 import { makeWeekColumn } from "@web/views/calendar/calendar_common/calendar_common_week_column";
@@ -101,11 +101,7 @@ export class CalendarYearRenderer extends Component {
     }
     convertRecordToEvent(record) {
         return {
-            id: record.id,
-            title: record.title,
-            start: record.start.toISO(),
-            end: record.end.plus({ day: 1 }).toISO(),
-            allDay: true,
+            ...convertRecordToEvent(record, true),
             display: "background",
         };
     }

--- a/addons/web/static/src/views/calendar/utils.js
+++ b/addons/web/static/src/views/calendar/utils.js
@@ -1,3 +1,19 @@
+export function convertRecordToEvent(record, forceAllDay = false) {
+    const allDay =
+        forceAllDay || record.isAllDay || record.end.diff(record.start, "hours").hours >= 24;
+    let end = record.end;
+    if (record.isAllDay || (allDay && end.toMillis() !== end.startOf("day").toMillis())) {
+        end = end.plus({ days: 1 });
+    }
+    return {
+        id: record.id,
+        title: record.title,
+        start: record.start.toISO(),
+        end: end.toISO(),
+        allDay,
+    };
+}
+
 const CSS_COLOR_REGEX =
     /^((#[A-F0-9]{3})|(#[A-F0-9]{6})|((hsl|rgb)a?\(\s*(?:(\s*\d{1,3}%?\s*),?){3}(\s*,[0-9.]{1,4})?\))|)$/i;
 const colorMap = new Map();


### PR DESCRIPTION
In the calendar view, have an event that lasts from midnight, to the next day at midnight (i.e. 24h). Before this commit, this event was displayed over two days (in all scales). This commit fixes the issue.

Task-4607251

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
