### PR TITLE
[FIX] mail: generic followers automated action name

### DIFF
--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -119,7 +119,7 @@ class IrActionsServer(models.Model):
             case 'followers':
                 if self.followers_type == 'generic':
                     _field_chain, field_chain_str = self._get_relation_chain("followers_partner_field_name")
-                    self.name = _(
+                    return _(
                         'Add followers based on field: %(field_chain_str)s',
                         field_chain_str=field_chain_str
                     )
@@ -131,7 +131,7 @@ class IrActionsServer(models.Model):
             case 'remove_followers':
                 if self.followers_type == 'generic':
                     _field_chain, field_chain_str = self._get_relation_chain("followers_partner_field_name")
-                    self.name = _(
+                    return _(
                         'Remove followers based on field: %(field_chain_str)s',
                         field_chain_str=field_chain_str
                     )


### PR DESCRIPTION
Before this commit the server actions automated naming was not properly working for server actions of type add/remove followers in case of a 'generic' followers action type.

This commit fixes this issue (introduced with [1])

[1] https://github.com/odoo/odoo/pull/190709