### PR TITLE
[FIX] sale: compute invoice quantities for combo products

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -944,15 +944,28 @@ class SaleOrderLine(models.Model):
         """
         Compute the quantity to invoice. If the invoice policy is order, the quantity to invoice is
         calculated from the ordered quantity. Otherwise, the quantity delivered is used.
+        For combo product lines, first compute all other lines, and then set quantity to invoice
+        only if at least one of its combo item lines is invoiceable.
         """
+        combo_lines = []
         for line in self:
             if line.state == 'sale' and not line.display_type:
-                if line.product_id.invoice_policy == 'order':
+                if line.product_id.type == 'combo':
+                    combo_lines.append(line)
+                elif line.product_id.invoice_policy == 'order':
                     line.qty_to_invoice = line.product_uom_qty - line.qty_invoiced
                 else:
                     line.qty_to_invoice = line.qty_delivered - line.qty_invoiced
             else:
                 line.qty_to_invoice = 0
+        for combo_line in combo_lines:
+            if any(
+                line.combo_item_id and line.qty_to_invoice
+                for line in combo_line.linked_line_ids
+            ):
+                combo_line.qty_to_invoice = combo_line.product_uom_qty - combo_line.qty_invoiced
+            else:
+                combo_line.qty_to_invoice = 0
 
     @api.depends('state', 'product_uom_qty', 'qty_delivered', 'qty_to_invoice', 'qty_invoiced')
     def _compute_invoice_status(self):
@@ -1365,6 +1378,10 @@ class SaleOrderLine(models.Model):
                 'display_type': 'line_section',
                 'sequence': self.sequence,
                 'name': f'{self.product_id.name} x {qty_to_invoice}',
+                'product_uom_id': self.product_uom.id,
+                'quantity': self.qty_to_invoice,
+                'sale_line_ids': [Command.link(self.id)],
+                **optional_values,
             }
         res = {
             'display_type': self.display_type or 'product',

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -572,22 +572,16 @@ class TestSaleToInvoice(TestSaleCommon):
                     'price_unit': 0,
                     'tax_id': [],
                 }),
-                Command.create({
-                    'name': 'Horse-meat burger',
-                    'product_id': product_a.id,
-                    'product_uom_qty': 3,
-                    'price_unit': 5.0,
-                    'tax_id': [],
-                }),
-                Command.create({
-                    'name': 'French fries',
-                    'product_id': product_b.id,
-                    'product_uom_qty': 3,
-                    'price_unit': 5.0,
-                    'tax_id': [],
-                }),
             ]
         })
+        sale_order.order_line = [Command.create({
+            'product_id': product.id,
+            'product_uom_qty': 3,
+            'price_unit': 5.0,
+            'tax_id': [],
+            'combo_item_id': combo.combo_item_ids.id,
+            'linked_line_id': sale_order.order_line.id,
+        }) for product, combo in zip(product_a + product_b, combo_a + combo_b)]
 
         # Confirm the SO
         sale_order.action_confirm()
@@ -613,22 +607,42 @@ class TestSaleToInvoice(TestSaleCommon):
                 'name': 'Meal Menu x 3',
                 'display_type': 'line_section',
                 'product_id': False,
-                'quantity': 0,
+                'quantity': 3,
                 'price_unit': 0,
+                'sequence': 0,
             },
             {
                 'name': 'Horse-meat burger',
                 'display_type': 'product',
                 'product_id': product_a.id,
                 'quantity': 3,
-                'price_unit': 5.0
+                'price_unit': 5.0,
+                'sequence': 1,
             },
             {
                 'name': 'French fries',
                 'display_type': 'product',
                 'product_id': product_b.id,
                 'quantity': 3,
-                'price_unit': 5.0
+                'price_unit': 5.0,
+                'sequence': 2,
+            },
+        ])
+        self.assertRecordValues(sale_order.order_line, [
+            {
+                'product_id': product_combo.id,
+                'qty_to_invoice': 0,
+                'qty_invoiced': 3,
+            },
+            {
+                'product_id': product_a.id,
+                'qty_to_invoice': 0,
+                'qty_invoiced': 3,
+            },
+            {
+                'product_id': product_b.id,
+                'qty_to_invoice': 0,
+                'qty_invoiced': 3,
             },
         ])
 


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a combo product;
2. confirm a quotation with the combo product;
3. fully invoice confirmed quotation;
4. go back to quotation.

Issue
-----
The "Create Invoice" button is still visible. Clicking on it will create an invoice with only the combo product on it (none of its constituent products).

Cause
-----
Commit 602ef86b8dcad changed how combo product lines get invoiced. Instead of display type `product`, they get displayed as `line_section` lines.

The `_compute_qty_invoiced` method requires the line to have linked `invoice_lines` that have a `quantity` value to properly calculate the quantity invoiced, and later on, the quantity to invoice: https://github.com/odoo/odoo/blob/bac9ed6d84ff64ef39741cb66afdf565c7e9f221/addons/sale/models/sale_order_line.py#L907-L913

Because these values aren't passed when creating an invoice line, the `qty_to_invoice` value of the combo product line will never be 0.

Solution
--------
Pass the requisite fields to the invoice line create values, along with the `optional_values` to ensure the correct `sequence` value gets used.

opw-4633972