### PR TITLE
[IMP] l10n_es_edi_tbai: provide better error msgs for Batuz

### DIFF
--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -218,9 +218,9 @@ class L10nEsEdiTbaiDocument(models.Model):
                 error_code = response_headers['eus-bizkaia-n3-codigo-respuesta']
                 error_msg = response_headers['eus-bizkaia-n3-mensaje-respuesta']
                 errors.append(error_code + ": " + error_msg)
-            if errors:
-                return False, errors
-            return self._process_post_response_xml_bi(env, response_xml)
+            success, errors_add = self._process_post_response_xml_bi(env, response_xml)
+            errors += errors_add
+            return success, errors
 
     def _prepare_post_params_ar_gi(self):
         """Web service parameters for Araba and Gipuzkoa."""
@@ -307,6 +307,8 @@ class L10nEsEdiTbaiDocument(models.Model):
     @api.model
     def _process_post_response_xml_bi(self, env, response_xml):
         """Government response processing for Bizkaia."""
+        if response_xml is None:
+            return False, []
         success = response_xml.findtext('.//EstadoRegistro') == "Correcto"
 
         if success:


### PR DESCRIPTION
Before version 18, even if the response was Incorrect in the headers, it would still process the XML itself to see if e.g. there was a more detailed error message in there.

Here, we just add the errors together again: the one from the header and the one from the response.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
