### PR TITLE
[FIX] point_of_sale: ensure loading variant cost

### DIFF
--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -13,7 +13,7 @@ class ProductProduct(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'lst_price', 'display_name', 'product_tmpl_id', 'product_template_variant_value_ids', 'barcode', 'product_tag_ids', 'default_code']
+        return ['id', 'lst_price', 'display_name', 'product_tmpl_id', 'product_template_variant_value_ids', 'barcode', 'product_tag_ids', 'default_code', 'standard_price']
 
     def _load_pos_data(self, data):
         products = super()._load_pos_data(data)


### PR DESCRIPTION
Before this commit, if a pricelist was based on the product cost, it wasn't working as it didn't load the cost of the product variants.

opw-4654773

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
