### PR TITLE
[FIX] web: proper interpolation in CSS custom properties

### DIFF
--- a/addons/web/static/src/search/search_panel/search_view.scss
+++ b/addons/web/static/src/search/search_panel/search_view.scss
@@ -1,5 +1,5 @@
 .o_searchview {
-    --SearchBar-background-color: $input-focus-bg;
+    --SearchBar-background-color: #{$input-focus-bg};
     
     background-color: var(--SearchBar-background-color);
     border: $input-border-width solid $border-color;


### PR DESCRIPTION
This commit fixes improper interpolation of SCSS variables assigned to CSS custom properties, leading to malformed generated CSS rules (i.e. `--my-prop: $my-value` in the CSS bundle).

Quote from the SASS/SCSS documentation:
> CSS custom properties, also known as CSS variables, have an unusual
> declaration syntax: they allow almost any text at all in their
> declaration values. (...) Because of this, Sass parses custom property
> declarations differently than other property declarations. All tokens,
> including those that look like SassScript, are passed through to CSS
> as-is. The only exception is interpolation, which is the only way to
> inject dynamic values into a custom property.

Reference:
https://sass-lang.com/documentation/style-rules/declarations/#custom-properties
