### PR TITLE
[FIX] hr_expense: Fix bad url

### DIFF
--- a/addons/hr_expense/data/mail_templates.xml
+++ b/addons/hr_expense/data/mail_templates.xml
@@ -38,7 +38,7 @@
                 New expenses are awaiting your approval.
                 You can review them by following this link
             </p>
-            <a t-att-href="'/odoo/expenses-to-process'" class="o_expense_button_mail">View expenses</a>
+            <a t-att-href="url" class="o_expense_button_mail">View expenses</a>
         </template>
 
         <template id="hr_expense_template_register_no_user">

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1035,9 +1035,14 @@ class HrExpense(models.Model):
                 for manager, expenses_submitted in expenses_submitted_per_company.grouped('manager_id').items():
                     manager_langs = tuple(lang for lang in manager.partner_id.mapped('lang') if lang)
                     mail_lang = (manager_langs and manager_langs[0]) or self.env.lang or 'en_US'
+                    departments = expenses_submitted.department_id
+                    if len(departments) > 1:
+                        url = '/expenses-to-process'
+                    else:
+                        url = f'/departments/{departments.id}/expenses-to-approve'
                     body = self.env['ir.qweb']._render(
                         template='hr_expense.hr_expense_template_submitted_expenses',
-                        values={'manager_name': manager.name, 'url': '/expenses-to-approve'},
+                        values={'manager_name': manager.name, 'url': url},
                         lang=mail_lang,
                     )
                     new_mails.append({

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -608,8 +608,8 @@
         </record>
 
         <record id="action_hr_expense_department_to_approve" model="ir.actions.act_window">
-            <field name="name">Expense to Approve</field>
-            <field name="path">expense-to-approve</field>
+            <field name="name">Expenses to Approve</field>
+            <field name="path">expenses-to-approve</field>
             <field name="res_model">hr.expense</field>
             <field name="view_mode">list,kanban,form,pivot,graph</field>
             <field name="search_view_id" ref="hr_expense_view_search_with_panel"/>


### PR DESCRIPTION
Fix a small mistake introduced by 704a5a1, where the URL specified is hardcoded in the mail template.
This introduce the intended flow of reviewing expenses from the manager department that are submitted
(defaulting on the full view if there are more than one).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
