### PR TITLE
[FIX] website: fix computing the carousel item min-height

### DIFF
--- a/addons/website/static/src/interactions/carousel/carousel_slider.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.js
@@ -12,7 +12,7 @@ export class CarouselSlider extends Interaction {
         },
         ".carousel-item": {
             "t-att-style": () => ({
-                "min-height": `${this.maxHeight}px`,
+                "min-height": this.maxHeight ? `${this.maxHeight}px` : "",
             }),
         },
     };
@@ -31,6 +31,9 @@ export class CarouselSlider extends Interaction {
 
     computeMaxHeight() {
         this.maxHeight = undefined;
+        // "updateContent()" is necessary to reset the min-height before the
+        // following check.
+        this.updateContent();
         for (const itemEl of this.el.querySelectorAll(".carousel-item")) {
             const isActive = itemEl.classList.contains("active");
             itemEl.classList.add("active");


### PR DESCRIPTION
Steps to reproduce the bug:

- Enter website edit mode. -Drag and drop a "Carousel" snippet onto the page. -Strongly reduce the window width to make the carousel's min-height exceed 1000px.
- Resize the window back to its original size.
- Bug: The carousel height remains too large.

Since commit [1], which introduced the bug, the "min-height" of the carousel items was no longer removed before checking their height in the "computeMaxHeight" function.

[1]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f

task-4662034