### PR TITLE
[IMP] web, *: cache actions and views

### DIFF
--- a/addons/board/static/src/board_controller.js
+++ b/addons/board/static/src/board_controller.js
@@ -3,7 +3,7 @@ import { browser } from "@web/core/browser/browser";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { rpc } from "@web/core/network/rpc";
+import { rpc, rpcBus } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
 import { renderToString } from "@web/core/utils/render";
 import { useSortable } from "@web/core/utils/sortable_owl";
@@ -126,7 +126,7 @@ export class BoardController extends Component {
             custom_id: this.board.customViewId,
             arch,
         });
-        this.env.bus.trigger("CLEAR-CACHES");
+        rpcBus.trigger("CLEAR-CACHES");
     }
 }
 

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -944,7 +944,10 @@ test("Notification settings rendering in chatwindow", async () => {
 
 test("open channel in chat window from push notification", async () => {
     patchWithCleanup(window.navigator, {
-        serviceWorker: Object.assign(new EventBus(), { register: () => Promise.resolve() }),
+        serviceWorker: Object.assign(new EventBus(), {
+            register: () => Promise.resolve(),
+            ready: Promise.resolve(),
+        }),
     });
     const pyEnv = await startServer();
     const [channelId, salesId] = pyEnv["discuss.channel"].create([

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -505,6 +505,7 @@ test("expand call participants when joining a call", async () => {
 test("start call when accepting from push notification", async () => {
     const serviceWorker = Object.assign(new EventTarget(), {
         register: () => Promise.resolve(),
+        ready: Promise.resolve(),
     });
     patchWithCleanup(window.navigator, { serviceWorker });
     const pyEnv = await startServer();

--- a/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
@@ -82,7 +82,10 @@ test.skip("bus subscription kept after receiving a message as non member", async
 
 test("open channel in discuss from push notification", async () => {
     patchWithCleanup(window.navigator, {
-        serviceWorker: Object.assign(new EventBus(), { register: () => Promise.resolve() }),
+        serviceWorker: Object.assign(new EventBus(), {
+            register: () => Promise.resolve(),
+            ready: Promise.resolve(),
+        }),
     });
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1430,6 +1430,7 @@ test("message sound on receiving new message (push notif enabled)", async () => 
     patchWithCleanup(window.navigator, {
         serviceWorker: Object.assign(new EventBus(), {
             register: () => Promise.resolve(),
+            ready: Promise.resolve(),
             getRegistration: async () => ({
                 get pushManager() {
                     return Promise.resolve({ getSubscription: async () => ({}) });

--- a/addons/spreadsheet/static/src/model_display_name_service.js
+++ b/addons/spreadsheet/static/src/model_display_name_service.js
@@ -1,5 +1,6 @@
 import { Cache } from "@web/core/utils/cache";
 import { registry } from "@web/core/registry";
+import { rpcBus } from "@web/core/network/rpc";
 
 export const modelDisplayNameService = {
     dependencies: ["orm"],
@@ -17,7 +18,7 @@ export const modelDisplayNameService = {
             (model) => model
         );
 
-        env.bus.addEventListener("CLEAR-CACHES", () => cache.invalidate());
+        rpcBus.addEventListener("CLEAR-CACHES", () => cache.invalidate());
 
         /**
          * @param {string} model

--- a/addons/web/static/src/core/field_service.js
+++ b/addons/web/static/src/core/field_service.js
@@ -1,6 +1,7 @@
 import { Cache } from "@web/core/utils/cache";
 import { Domain } from "@web/core/domain";
 import { registry } from "@web/core/registry";
+import { rpcBus } from "./network/rpc";
 
 /**
  * @typedef {Object} LoadFieldsOptions
@@ -13,19 +14,18 @@ export const fieldService = {
     async: ["loadFields", "loadPath", "loadPropertyDefinitions"],
     start(env, { orm }) {
         const cache = new Cache(
-            (resModel, options) => {
-                return orm
+            (resModel, options) =>
+                orm
                     .call(resModel, "fields_get", [options.fieldNames, options.attributes])
                     .catch((error) => {
                         cache.clear(resModel, options);
                         return Promise.reject(error);
-                    });
-            },
+                    }),
             (resModel, options) =>
                 JSON.stringify([resModel, options.fieldNames, options.attributes])
         );
 
-        env.bus.addEventListener("CLEAR-CACHES", () => cache.invalidate());
+        rpcBus.addEventListener("CLEAR-CACHES", () => cache.invalidate());
 
         /**
          * @param {string} resModel

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -99,11 +99,17 @@ export class ORM {
         this.rpc = rpc; // to be overridable by the SampleORM
         /** @protected */
         this._silent = false;
+        this._cached = false;
     }
 
     /** @returns {ORM} */
     get silent() {
         return Object.assign(Object.create(this), { _silent: true });
+    }
+
+    /** @returns {ORM} */
+    get cached() {
+        return Object.assign(Object.create(this), { _cached: true });
     }
 
     /**
@@ -124,7 +130,7 @@ export class ORM {
             args,
             kwargs: fullKwargs,
         };
-        return this.rpc(url, params, { silent: this._silent });
+        return this.rpc(url, params, { silent: this._silent, cached: this._cached });
     }
 
     /**
@@ -159,7 +165,7 @@ export class ORM {
         return this.call(model, "read", [ids, fields], kwargs);
     }
 
-     /**
+    /**
      * @param {string} model
      * @param {import("@web/core/domain").DomainListRepr} domain
      * @param {string[]} fields

--- a/addons/web/static/src/core/utils/indexed_db.js
+++ b/addons/web/static/src/core/utils/indexed_db.js
@@ -1,0 +1,217 @@
+import { Mutex } from "./concurrency";
+
+const VERSION_TABLE = "__DBVersion__";
+const VERSION_KEY = "__version__";
+
+export class IndexedDB {
+    constructor(name, version) {
+        this.name = name;
+        this._tables = new Set([VERSION_TABLE]);
+        this._IDBversion = undefined;
+        this.mutex = new Mutex();
+        this.mutex.exec(() => this._checkVersion(version));
+    }
+
+    // -------------------------------------------------------------------------
+    // Public
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reads data from a given table.
+     *
+     * @param {string} table
+     * @param {string} key
+     * @returns Promise
+     */
+    async read(table, key) {
+        this._tables.add(table);
+        return this.execute((db) => {
+            if (db) {
+                return this._read(db, table, key);
+            }
+        });
+    }
+
+    /**
+     * Write data into the given table
+     *
+     * @param {string} table
+     * @param {string} key
+     * @param  {any} value
+     * @returns Promise
+     */
+    async write(table, key, value) {
+        this._tables.add(table);
+        return this.execute((db) => {
+            if (db) {
+                this._write(db, table, key, value);
+            }
+        });
+    }
+
+    /**
+     * Invalidates a table, or the whole database.
+     *
+     * @param {string} [table] if not given, the whole database is invalidated
+     * @returns Promise
+     */
+    async invalidate(table = null) {
+        return this.execute((db) => {
+            if (db) {
+                return this._invalidate(db, table);
+            }
+        });
+    }
+
+    /**
+     * Delete the whole database
+     *
+     * @returns Promise
+     */
+    async deleteDatabase() {
+        return this.mutex.exec(() => this._deleteDatabase(() => {}));
+    }
+
+    /**
+     * open the database and execute the callback with the db as parameter.
+     *
+     * @params {Function} callback
+     * @returns Promise
+     */
+    async execute(callback) {
+        return this.mutex.exec(() => this._execute(callback));
+    }
+
+    // -------------------------------------------------------------------------
+    // Protected
+    // -------------------------------------------------------------------------
+
+    async _deleteDatabase(callback) {
+        return new Promise((resolve) => {
+            const request = indexedDB.deleteDatabase(this.name);
+            request.onsuccess = () => {
+                Promise.resolve(callback()).then(resolve);
+            };
+            request.onerror = (event) => {
+                console.error(`IndexedDB delete error: ${event.target.error?.message}`);
+                Promise.resolve(callback()).then(resolve);
+            };
+        });
+    }
+
+    async _checkVersion(version) {
+        return new Promise((resolve) => {
+            this._execute((db) => {
+                if (db) {
+                    return this._read(db, VERSION_TABLE, VERSION_KEY);
+                }
+            }).then((currentVersion) => {
+                if (!currentVersion) {
+                    this._execute((db) => {
+                        if (db) {
+                            this._write(db, VERSION_TABLE, VERSION_KEY, version);
+                        }
+                    }).then(resolve);
+                } else if (currentVersion !== version) {
+                    this._deleteDatabase(() => {
+                        this._execute((db) => {
+                            if (db) {
+                                this._write(db, VERSION_TABLE, VERSION_KEY, version);
+                            }
+                        });
+                    }).then(resolve);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
+    async _execute(callback) {
+        return new Promise((resolve) => {
+            const request = indexedDB.open(this.name, this._IDBversion);
+            request.onupgradeneeded = (event) => {
+                const db = event.target.result;
+                const dbTables = new Set(db.objectStoreNames);
+                const newTables = this._tables.difference(dbTables);
+                newTables.forEach((table) => db.createObjectStore(table));
+            };
+            request.onsuccess = (event) => {
+                const db = event.target.result;
+                this._IDBversion = db.version;
+                const dbTables = new Set(db.objectStoreNames);
+                const newTables = this._tables.difference(dbTables);
+                if (newTables.size !== 0) {
+                    db.close();
+                    this._IDBversion++;
+                    return this._execute(callback).then(resolve);
+                }
+                Promise.resolve(callback(db)).then((result) => {
+                    db.close();
+                    resolve(result);
+                });
+            };
+            request.onerror = (event) => {
+                console.error(`IndexedDB error: ${event.target.error?.message}`);
+                Promise.resolve(callback()).then(resolve);
+            };
+        });
+    }
+
+    async _write(db, table, key, record) {
+        return new Promise((resolve, reject) => {
+            // Relaxed durability improves the write performances
+            // https://nolanlawson.com/2021/08/22/speeding-up-indexeddb-reads-and-writes/
+            // https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/durability
+            const transaction = db.transaction(table, "readwrite", { durability: "relaxed" });
+            const objectStore = transaction.objectStore(table);
+            const request = objectStore.put(record, key); // put to allow updates
+            request.onsuccess = resolve;
+            transaction.onerror = () => reject(transaction.error);
+
+            // Force the changes to be committed to the database asap
+            // https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/commit
+            transaction.commit();
+        });
+    }
+
+    async _invalidate(db, table) {
+        return new Promise((resolve, reject) => {
+            const objectStoreNames = [...db.objectStoreNames].filter(
+                (table) => table !== VERSION_TABLE
+            );
+            const tables = table && objectStoreNames.includes(table) ? [table] : objectStoreNames;
+            if (tables.length === 0) {
+                return resolve();
+            }
+            // Relaxed durability improves the write performances
+            // https://nolanlawson.com/2021/08/22/speeding-up-indexeddb-reads-and-writes/
+            // https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/durability
+            const transaction = db.transaction(tables, "readwrite", { durability: "relaxed" });
+            const proms = tables.map(
+                (table) =>
+                    new Promise((resolve) => {
+                        const objectStore = transaction.objectStore(table);
+                        const request = objectStore.clear();
+                        request.onsuccess = resolve;
+                    })
+            );
+            transaction.onerror = () => reject(transaction.error);
+            Promise.all(proms).then(resolve);
+
+            // Force the changes to be committed to the database asap
+            // https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/commit
+            transaction.commit();
+        });
+    }
+
+    async _read(db, table, key) {
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction(table, "readonly");
+            const objectStore = transaction.objectStore(table);
+            const r = objectStore.get(key);
+            r.onsuccess = () => resolve(r.result);
+            transaction.onerror = () => reject(transaction.error);
+        });
+    }
+}

--- a/addons/web/static/src/core/utils/persistent_cache.js
+++ b/addons/web/static/src/core/utils/persistent_cache.js
@@ -1,0 +1,71 @@
+import { Deferred } from "@web/core/utils/concurrency";
+import { IndexedDB } from "@web/core/utils/indexed_db";
+
+class RamCache {
+    constructor() {
+        this.ram = {};
+    }
+
+    write(table, key, value) {
+        if (!(table in this.ram)) {
+            this.ram[table] = {};
+        }
+        this.ram[table][key] = value;
+    }
+
+    read(table, key) {
+        return this.ram[table]?.[key];
+    }
+
+    delete(table, key) {
+        delete this.ram[table]?.[key];
+    }
+
+    invalidate(table) {
+        if (table) {
+            if (table in this.ram) {
+                this.ram[table] = {};
+            }
+        } else {
+            this.ram = {};
+        }
+    }
+}
+
+export class PersistentCache {
+    constructor(name, version) {
+        this.indexedDB = new IndexedDB(name, version);
+        this.ramCache = new RamCache();
+    }
+
+    read(table, key, fallback) {
+        const ramValue = this.ramCache.read(table, key);
+        if (ramValue) {
+            return ramValue;
+        }
+
+        const def = new Deferred();
+        this.indexedDB.read(table, key).then((result) => {
+            if (result) {
+                def.resolve(result);
+            }
+        });
+        const prom = fallback()
+            .then((result) => {
+                this.indexedDB.write(table, key, result);
+                def.resolve(result);
+                return result;
+            })
+            .catch((error) => {
+                this.ramCache.delete(table, key);
+                def.reject(error);
+            });
+        this.ramCache.write(table, key, prom);
+        return def;
+    }
+
+    invalidate(table) {
+        this.indexedDB.invalidate(table);
+        this.ramCache.invalidate(table);
+    }
+}

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -22,6 +22,7 @@ import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_se
 import { _t } from "@web/core/l10n/translation";
 import { domainFromTree, treeFromDomain } from "@web/core/tree_editor/condition_tree";
 import { useGetTreeDescription, useMakeGetFieldDef } from "@web/core/tree_editor/utils";
+import { rpcBus } from "@web/core/network/rpc";
 
 const { DateTime } = luxon;
 const SPECIAL = Symbol("special");
@@ -518,7 +519,7 @@ export class SearchModel extends EventBus {
 
     async _createIrFilters(irFilter) {
         const serverSideIds = await this.orm.call("ir.filters", "create_filter", [irFilter]);
-        this.env.bus.trigger("CLEAR-CACHES");
+        rpcBus.trigger("CLEAR-CACHES", "get_views");
         return serverSideIds[0];
     }
 

--- a/addons/web/static/src/start.js
+++ b/addons/web/static/src/start.js
@@ -4,6 +4,8 @@ import { session } from "@web/session";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { user } from "@web/core/user";
 import { Component, whenReady } from "@odoo/owl";
+import { rpc } from "./core/network/rpc";
+import { PersistentCache } from "./core/utils/persistent_cache";
 
 /**
  * Function to start a webclient.
@@ -21,6 +23,8 @@ export async function startWebClient(Webclient) {
         isEnterprise: session.server_version_info.slice(-1)[0] === "e",
     };
     odoo.isReady = false;
+
+    rpc.setCache(new PersistentCache("rpc", session.server_version));
 
     await whenReady();
     const app = await mountComponent(Webclient, document.body, { name: "Odoo Web Client" });

--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -10,6 +10,7 @@ import { NavBar } from "./navbar/navbar";
 import { Component, onMounted, onWillStart, useExternalListener, useState } from "@odoo/owl";
 import { router, routerBus } from "@web/core/browser/router";
 import { browser } from "@web/core/browser/browser";
+import { rpcBus } from "@web/core/network/rpc";
 
 export class WebClient extends Component {
     static template = "web.WebClient";
@@ -156,6 +157,14 @@ export class WebClient extends Component {
         if (navigator.serviceWorker) {
             navigator.serviceWorker
                 .register("/web/service-worker.js", { scope: "/odoo" })
+                .then(() => {
+                    navigator.serviceWorker.ready.then(() => {
+                        if (!navigator.serviceWorker.controller) {
+                            // https://stackoverflow.com/questions/51597231/register-service-worker-after-hard-refresh
+                            rpcBus.trigger("CLEAR-CACHES");
+                        }
+                    });
+                })
                 .catch((error) => {
                     console.error("Service worker registration failed, error:", error);
                 });

--- a/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
+++ b/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
@@ -1,0 +1,38 @@
+export function mockIndexedDB(_name, { fn }) {
+    return (requireModule, ...args) => {
+        const indexedDBModule = fn(requireModule, ...args);
+
+        const { IndexedDB } = indexedDBModule;
+        class MockedIndexedDB {
+            constructor() {
+                this.mockIndexedDB = {};
+            }
+
+            write(table, key, value) {
+                if (!(table in this.mockIndexedDB)) {
+                    this.mockIndexedDB[table] = {};
+                }
+                this.mockIndexedDB[table][key] = value;
+            }
+
+            read(table, key) {
+                return Promise.resolve(this.mockIndexedDB[table]?.[key]);
+            }
+
+            invalidate(table) {
+                if (table) {
+                    if (table in this.mockIndexedDB) {
+                        this.mockIndexedDB[table] = {};
+                    }
+                } else {
+                    this.mockIndexedDB = {};
+                }
+            }
+        }
+
+        return Object.assign(indexedDBModule, {
+            IndexedDB: MockedIndexedDB,
+            _OriginalIndexedDB: IndexedDB,
+        });
+    };
+}

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -1,6 +1,13 @@
-import { before, createJobScopedGetter, expect, getCurrent, registerDebugInfo } from "@odoo/hoot";
+import {
+    after,
+    before,
+    createJobScopedGetter,
+    expect,
+    getCurrent,
+    registerDebugInfo,
+} from "@odoo/hoot";
 import { mockFetch, mockWebSocket } from "@odoo/hoot-mock";
-import { RPCError } from "@web/core/network/rpc";
+import { rpc, RPCError } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { ensureArray, isIterable } from "@web/core/utils/arrays";
 import { isObject } from "@web/core/utils/objects";
@@ -14,6 +21,7 @@ import {
     makeServerError,
     safeSplit,
 } from "./mock_server_utils";
+import { PersistentCache } from "@web/core/utils/persistent_cache";
 
 const { DateTime } = luxon;
 
@@ -390,6 +398,10 @@ export class MockServer {
     websockets = [];
 
     constructor() {
+        // Add RPC cache
+        rpc.setCache(new PersistentCache("mockRpc", 1));
+        after(() => rpc.setCache(null));
+
         // Set default routes
         this._onRoute(["/web/action/load"], this.loadAction);
         this._onRoute(["/web/action/load_breadcrumbs"], this.loadActionBreadcrumbs);

--- a/addons/web/static/tests/_framework/module_set.hoot.js
+++ b/addons/web/static/tests/_framework/module_set.hoot.js
@@ -10,6 +10,7 @@ import { mockCurrencyFactory } from "./mock_currency.hoot";
 import { mockSessionFactory } from "./mock_session.hoot";
 import { makeTemplateFactory } from "./mock_templates.hoot";
 import { mockUserFactory } from "./mock_user.hoot";
+import { mockIndexedDB } from "./mock_indexed_db.hoot";
 
 /**
  * @typedef {{
@@ -437,6 +438,7 @@ const MODULE_MOCKS_BY_NAME = new Map([
     ["@web/core/template_inheritance", makeFixedFactory],
     // Other mocks
     ["@web/core/browser/browser", mockBrowserFactory],
+    ["@web/core/utils/indexed_db", mockIndexedDB],
     ["@web/core/currency", mockCurrencyFactory],
     ["@web/core/templates", makeTemplateFactory],
     ["@web/core/user", mockUserFactory],

--- a/addons/web/static/tests/core/utils/indexed_db.test.js
+++ b/addons/web/static/tests/core/utils/indexed_db.test.js
@@ -1,0 +1,224 @@
+import { _OriginalIndexedDB as IndexedDB } from "@web/core/utils/indexed_db";
+
+import { describe, expect, onError, test } from "@odoo/hoot";
+
+describe.current.tags("headless");
+
+const CACHE_NAME = "unit_test_disk_cache";
+
+function deleteCacheDB() {
+    return new Promise((resolve) => {
+        const request = indexedDB.deleteDatabase(CACHE_NAME);
+        request.onerror = (error) => console.error(error);
+        request.onsuccess = resolve;
+    });
+}
+
+async function ensureDbIsAbsent() {
+    const databases = await window.indexedDB.databases();
+    expect(databases.filter((db) => db.name === CACHE_NAME).length).toBe(0, {
+        message: "DB is correctly cleaned",
+    });
+}
+
+test("one cache, read", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    const indexedDB = new IndexedDB(CACHE_NAME, 1);
+
+    expect(await indexedDB.read("mytable", "test")).toBe(undefined);
+
+    await indexedDB.write("mytable", "test", "value for 'test'");
+    expect(await indexedDB.read("mytable", "test")).toBe("value for 'test'");
+
+    await indexedDB.deleteDatabase();
+    await ensureDbIsAbsent();
+});
+
+test("two caches, read", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    // having 2 caches simulates 2 tabs, each one accessing the same indexeddb
+    const indexedDB1 = new IndexedDB(CACHE_NAME, 1);
+    await indexedDB1.write("mytable", "test", "value for 'test'");
+    expect(await indexedDB1.read("mytable", "test")).toBe("value for 'test'");
+
+    const indexedDB2 = new IndexedDB(CACHE_NAME, 1);
+    expect(await indexedDB2.read("mytable", "test")).toBe("value for 'test'");
+
+    await indexedDB1.deleteDatabase();
+    await indexedDB2.deleteDatabase(); // deleting twice the same DB don't throw error !
+    await ensureDbIsAbsent();
+});
+
+test("one cache, invalidate", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    const indexedDB = new IndexedDB(CACHE_NAME, 1);
+
+    // populate the table
+    await indexedDB.write("mytable", "test", "value for 'test'");
+    await indexedDB.write("mytable", "test2", "value for 'test2'");
+    expect(await indexedDB.read("mytable", "test")).toBe("value for 'test'");
+    expect(await indexedDB.read("mytable", "test2")).toBe("value for 'test2'");
+
+    await indexedDB.invalidate("mytable");
+    expect(await indexedDB.read("mytable", "test")).toBe(undefined);
+    expect(await indexedDB.read("mytable", "test2")).toBe(undefined);
+
+    await indexedDB.deleteDatabase();
+    await ensureDbIsAbsent();
+});
+
+test("one cache, invalidate all tables", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    const indexedDB = new IndexedDB(CACHE_NAME, 1);
+
+    // populate the table
+    await indexedDB.write("mytable", "test", "value for 'test'");
+    await indexedDB.write("mytable2", "test2", "value for 'test2'");
+    expect(await indexedDB.read("mytable", "test")).toBe("value for 'test'");
+    expect(await indexedDB.read("mytable2", "test2")).toBe("value for 'test2'");
+
+    await indexedDB.invalidate();
+    expect(await indexedDB.read("mytable", "test")).toBe(undefined);
+    expect(await indexedDB.read("mytable2", "test2")).toBe(undefined);
+
+    await indexedDB.deleteDatabase();
+    await ensureDbIsAbsent();
+});
+
+test("invalidate all tables, empty cache", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    //The indexedDB __DBVersion__ is not invalidated
+    const indexedDB = new IndexedDB(CACHE_NAME, 1);
+    await indexedDB.execute((db) => {
+        expect([...db.objectStoreNames]).toEqual(["__DBVersion__"]);
+    });
+    expect(await indexedDB.read("__DBVersion__", "__version__")).toBe(1);
+    await indexedDB.invalidate();
+    await indexedDB.execute((db) => {
+        expect([...db.objectStoreNames]).toEqual(["__DBVersion__"]);
+    });
+    expect(await indexedDB.read("__DBVersion__", "__version__")).toBe(1);
+
+    await indexedDB.deleteDatabase();
+    await ensureDbIsAbsent();
+});
+
+test("invalidate non existing table", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    const indexedDB = new IndexedDB(CACHE_NAME, 1);
+    await indexedDB.execute((db) => {
+        expect([...db.objectStoreNames]).toEqual(["__DBVersion__"]);
+    });
+    await indexedDB.invalidate("nonExistingTable");
+    await indexedDB.execute((db) => {
+        expect([...db.objectStoreNames]).toEqual(["__DBVersion__"]);
+    });
+
+    await indexedDB.deleteDatabase();
+    await ensureDbIsAbsent();
+});
+
+test("two caches, invalidate", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    // having 2 caches simulates 2 tabs, each one accessing the same indexeddb
+    const indexedDB1 = new IndexedDB(CACHE_NAME, 1);
+    const indexedDB2 = new IndexedDB(CACHE_NAME, 1);
+
+    // populate the table
+    await indexedDB1.write("mytable", "test", "value for 'test'");
+    await indexedDB1.write("mytable", "test2", "value for 'test2'");
+    expect(await indexedDB1.read("mytable", "test")).toBe("value for 'test'");
+    expect(await indexedDB1.read("mytable", "test2")).toBe("value for 'test2'");
+    expect(await indexedDB2.read("mytable", "test")).toBe("value for 'test'");
+    expect(await indexedDB2.read("mytable", "test2")).toBe("value for 'test2'");
+
+    await indexedDB1.invalidate("mytable");
+    expect(await indexedDB1.read("mytable", "test")).toBe(undefined);
+    expect(await indexedDB1.read("mytable", "test2")).toBe(undefined);
+    expect(await indexedDB2.read("mytable", "test")).toBe(undefined);
+    expect(await indexedDB2.read("mytable", "test2")).toBe(undefined);
+
+    await indexedDB1.deleteDatabase();
+    await indexedDB2.deleteDatabase();
+    await ensureDbIsAbsent();
+});
+
+test("two caches, new DB version", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    const indexedDB1 = new IndexedDB(CACHE_NAME, 1);
+    // populate the table
+    await indexedDB1.write("mytable", "test", "value for 'test'");
+    await indexedDB1.write("mytable", "test2", "value for 'test2'");
+    expect(await indexedDB1.read("mytable", "test")).toBe("value for 'test'");
+    expect(await indexedDB1.read("mytable", "test2")).toBe("value for 'test2'");
+
+    // simulate a new page, with a new version number for the given databases
+    const indexedDB2 = new IndexedDB(CACHE_NAME, 2);
+    // await new Promise((r) => setTimeout(r, 1));
+    // DB should not contain tables !
+    await indexedDB2.execute((db) => {
+        expect([...db.objectStoreNames]).toEqual(["__DBVersion__"]);
+    });
+    await indexedDB2.execute((db) => {
+        expect([...db.objectStoreNames]).toEqual(["__DBVersion__"]);
+    });
+    expect(await indexedDB2.read("mytable", "test")).toBe(undefined);
+    expect(await indexedDB2.read("mytable", "test2")).toBe(undefined);
+
+    await indexedDB1.deleteDatabase();
+    await indexedDB2.deleteDatabase();
+    await ensureDbIsAbsent();
+});
+
+test("several tables", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    const indexedDB = new IndexedDB(CACHE_NAME, 1);
+
+    await indexedDB.write("table1", "test", "value for 'test'");
+    await indexedDB.write("table2", "test2", "value for 'test2'");
+    expect(await indexedDB.read("table1", "test")).toBe("value for 'test'");
+    expect(await indexedDB.read("table2", "test2")).toBe("value for 'test2'");
+
+    await indexedDB.deleteDatabase();
+    await ensureDbIsAbsent();
+});
+
+test("several caches, several tables", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    const indexedDB1 = new IndexedDB(CACHE_NAME, 1);
+    await indexedDB1.write("table1", "test", "value for 'test'");
+    expect(await indexedDB1.read("table1", "test")).toBe("value for 'test'");
+
+    const indexedDB2 = new IndexedDB(CACHE_NAME, 1);
+    await indexedDB2.write("table2", "test", "value for 'test'");
+    expect(await indexedDB2.read("table1", "test")).toBe("value for 'test'");
+    expect(await indexedDB2.read("table2", "test")).toBe("value for 'test'");
+
+    // check that second table has been correctly setup
+    const diskCache3 = new IndexedDB(CACHE_NAME, 1);
+    expect(await diskCache3.read("table2", "test")).toBe("value for 'test'");
+
+    await indexedDB1.deleteDatabase();
+    await indexedDB2.deleteDatabase();
+    await ensureDbIsAbsent();
+});

--- a/addons/web/static/tests/core/utils/persistent_cache.test.js
+++ b/addons/web/static/tests/core/utils/persistent_cache.test.js
@@ -1,0 +1,96 @@
+import { expect, test } from "@odoo/hoot";
+import { Deferred, microTick } from "@odoo/hoot-mock";
+import { PersistentCache } from "@web/core/utils/persistent_cache";
+
+const symbol = Symbol("Promise");
+
+function promiseState(promise) {
+    return Promise.race([promise, Promise.resolve(symbol)]).then(
+        (value) => (value === symbol ? { status: "pending" } : { status: "fulfilled", value }),
+        (reason) => ({ status: "rejected", reason })
+    );
+}
+test("RamCache: can cache a simple call", async () => {
+    // The fist call to persistentCache.read will save the result on the RamCache.
+    // Each next call will retrive the ram cache independently, without executing the fallback
+    const persistentCache = new PersistentCache("mockRpc", 1);
+    const persistentCacheRead = (number) =>
+        persistentCache.read("table", "key", () => {
+            expect.step("fallback");
+            return Promise.resolve({ test: number });
+        });
+    expect(await persistentCacheRead(123)).toEqual({ test: 123 });
+    expect(await persistentCacheRead(456)).toEqual({ test: 123 });
+    expect(await persistentCacheRead(789)).toEqual({ test: 123 });
+    expect.verifySteps(["fallback"]);
+});
+
+test("RamCache: ram is set with promises", async () => {
+    const def = new Deferred();
+    const persistentCache = new PersistentCache("mockRpc", 1);
+
+    // If two identical calls are made in succession, only one fallback will be made.
+    // The second call will get the result of the first call (or a promise if the first call is not yet finish).
+    const promFirst = persistentCache.read("table", "key", () => def);
+    const promsSecond = persistentCache.read("table", "key", () => def);
+
+    // Only one record in cache
+    expect(Object.keys(persistentCache.ramCache.ram.table).length).toBe(1);
+    let promInRamCache = persistentCache.ramCache.ram.table.key;
+
+    // Note that proms, promisea and promiseb are the same promise.
+    expect(await promiseState(promInRamCache)).toEqual({ status: "pending" });
+    expect(await promiseState(promFirst)).toEqual({ status: "pending" });
+    expect(await promiseState(promsSecond)).toEqual({ status: "pending" });
+
+    def.resolve({ test: 123 });
+    await microTick();
+
+    // The cache is updated when the fetch is back
+    promInRamCache = persistentCache.ramCache.ram.table.key;
+    expect(await promInRamCache).toEqual({ test: 123 });
+    expect(await promFirst).toEqual({ test: 123 });
+    expect(await promsSecond).toEqual({ test: 123 });
+});
+
+test("PersistentCache: can cache a simple call", async () => {
+    const persistentCache = new PersistentCache("mockRpc", 1);
+
+    expect(
+        await persistentCache.read("table", "key", () => Promise.resolve({ test: 123 }))
+    ).toEqual({
+        test: 123,
+    });
+    // Both caches are correctly updated with the fetch values
+    expect(persistentCache.indexedDB.mockIndexedDB.table.key).toEqual({ test: 123 });
+    await microTick();
+    expect(await promiseState(persistentCache.ramCache.ram.table.key)).toEqual({
+        status: "fulfilled",
+        value: { test: 123 },
+    });
+
+    // Simulate a reload (Clear the Ram Cache)
+    persistentCache.ramCache.invalidate();
+    expect(persistentCache.ramCache.ram).toEqual({});
+    const def = new Deferred();
+
+    // we return the disk cache value.
+    expect(
+        await persistentCache.read("table", "key", () => {
+            expect.step("Fallback");
+            return Promise.resolve(def);
+        })
+    ).toEqual({ test: 123 });
+    expect.verifySteps(["Fallback"]);
+
+    // the fallback returned a different value
+    def.resolve({ test: 456 });
+    await microTick();
+    // Both caches are updated with the last value
+    expect(persistentCache.indexedDB.mockIndexedDB.table.key).toEqual({ test: 456 });
+    await microTick();
+    expect(await promiseState(persistentCache.ramCache.ram.table.key)).toEqual({
+        status: "fulfilled",
+        value: { test: 456 },
+    });
+});

--- a/addons/web/static/tests/search/custom_favorite_item.test.js
+++ b/addons/web/static/tests/search/custom_favorite_item.test.js
@@ -20,6 +20,7 @@ import {
 import { useSetupAction } from "@web/search/action_hook";
 import { SearchBar } from "@web/search/search_bar/search_bar";
 import { SearchBarMenu } from "@web/search/search_bar_menu/search_bar_menu";
+import { rpcBus } from "@web/core/network/rpc";
 
 class Foo extends models.Model {
     bar = fields.Many2one({ relation: "partner" });
@@ -75,14 +76,14 @@ test("save filter", async () => {
         return [7]; // fake serverSideId
     });
 
-    const component = await mountWithSearch(TestComponent, {
+    await mountWithSearch(TestComponent, {
         resModel: "foo",
         context: { someOtherKey: "bar" }, // should not end up in filter's context
         searchViewId: false,
     });
     const clearCacheListener = () => expect.step("CLEAR-CACHES");
-    component.env.bus.addEventListener("CLEAR-CACHES", clearCacheListener);
-    after(() => component.env.bus.removeEventListener("CLEAR-CACHES", clearCacheListener));
+    rpcBus.addEventListener("CLEAR-CACHES", clearCacheListener);
+    after(() => rpcBus.removeEventListener("CLEAR-CACHES", clearCacheListener));
     expect.verifySteps([]);
 
     await toggleSearchBarMenu();
@@ -124,14 +125,14 @@ test("save and edit filter", async () => {
         },
     });
 
-    const component = await mountWithSearch(TestComponent, {
+    await mountWithSearch(TestComponent, {
         resModel: "foo",
         context: { someOtherKey: "bar" }, // should not end up in filter's context
         searchViewId: false,
     });
     const clearCacheListener = () => expect.step("CLEAR-CACHES");
-    component.env.bus.addEventListener("CLEAR-CACHES", clearCacheListener);
-    after(() => component.env.bus.removeEventListener("CLEAR-CACHES", clearCacheListener));
+    rpcBus.addEventListener("CLEAR-CACHES", clearCacheListener);
+    after(() => rpcBus.removeEventListener("CLEAR-CACHES", clearCacheListener));
     expect.verifySteps([]);
 
     await toggleSearchBarMenu();

--- a/addons/web/static/tests/webclient/clickbot.test.js
+++ b/addons/web/static/tests/webclient/clickbot.test.js
@@ -428,7 +428,7 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
                 },
             },
         },
-        settings: { silent: false },
+        settings: { silent: false, cached: false },
         error: {
             name: "RPC_ERROR",
             type: "server",


### PR DESCRIPTION
*: [board, mail, spreadsheet]

Before this commit, actions, and views were cached in RAM in their respective
services. This enhanced the system's performance when loading the same
actions/views. However,  the RAM cache was flushed on reload (or when the tab
was closed). Additionally,  it was not shared between tabs.

This commit introduces a new caching system, which will have two caches: a RAM
cache as before, and a new disk cache (using the IndexedDB API [1]). To utilise
the new caching system, you can add a `cached: true` setting on the rpc, or a
`cached` property on the orm:

```js
this.orm.cached.call(....
```
```js
rpc(url, params, { cached: true });
```

The caching system will behave as follows:
- If a value is found in the RAM cache, it will be used (as it was before).
- Otherwise: If a value is found in the disk cache, is that value that will be
    used. The key difference is that, the RPC will also be performed, and the
    caches will be updated.

This disk cache will be shared between tabs, and it will not be flushed during
a reload (or when closing of the browser). Please note that a hard reload
(Ctrl + F5) will flush all the caches. Another advantage of this new cached
system is that it is developed on a central place, and the developers will not
need to re-develop their own cache system as it's the case now.

This new caching system will not lower the quantities of RPC performed, but it
will not wait until the return of the RPC to continue the rendering, which will
speed up the rendering of already visited pages.

task-id 4251018

[1]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API