### PR TITLE
[FIX] pos_loyalty: fix incorrect grammar

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
@@ -151,7 +151,7 @@ patch(OrderSummary.prototype, {
                     []
                 );
                 if (res.length > 0) {
-                    this.notification.add(_t("This Gift card is already been sold."), {
+                    this.notification.add(_t("This Gift card has already been sold."), {
                         type: "danger",
                     });
                     return;


### PR DESCRIPTION
Before this commit, the error message shown when a gift card had already been sold contained incorrect grammar:
"This Gift card is already been sold."

opw-4656131


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
