### PR TITLE
[FIX] mail: several discuss style improvements

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -65,8 +65,9 @@
 .o-mail-ChatBubble-counter {
     z-index: 7;
     top: -3px;
-    right: -2px;
+    right: -4px;
     display: inline-flex;
+    outline: 1px solid $gray-300;
 }
 
 .o-mail-ChatBubble-preview {

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ChatBubble">
-        <div class="o-mail-ChatBubble bg-view position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': popover.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
+        <div class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': popover.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-50': thread?.isUnread and !thread?.importantCounter, 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
-            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent"/>
+            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent">
+                <t t-set-slot="pre_icon">
+                    <i class="fa fa-circle position-absolute text-300" style="font-size: 18px; right: 1px; bottom: 0px; z-index: -1;"/>
+                </t>
+            </ImStatus>
             <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border'"/>
-            <button class="o-mail-ChatHub-bubbleBtn btn bg-view">
+            <button class="o-mail-ChatHub-bubbleBtn btn bg-view shadow">
                 <img class="o-mail-ChatBubble-avatar rounded-circle o_object_fit_cover" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>
         </div>

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -37,7 +37,7 @@
             <div t-if="compactCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow">
                 <t t-out="compactCounter"/>
             </div>
-            <button class="o-mail-ChatHub-bubbleBtn btn fs-2" t-on-click="expand">
+            <button class="o-mail-ChatHub-bubbleBtn btn fs-2 shadow" t-on-click="expand">
                 <i class="o-mail-ChatHub-hiddenBtnIcon d-flex justify-content-center align-items-center btn rounded-circle shadow-sm fa fa-commenting"/>
             </button>
         </div>
@@ -50,7 +50,7 @@
             <div t-if="hiddenCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow">
                 <t t-out="hiddenCounter"/>
             </div>
-            <button class="o-mail-ChatHub-bubbleBtn btn outline-0">
+            <button class="o-mail-ChatHub-bubbleBtn btn outline-0 shadow">
                 <span class="o-mail-ChatHub-hiddenBtnIcon d-flex justify-content-center align-items-center btn rounded-circle shadow-sm fs-2" t-att-class="{ 'o-active': more.isOpen }">+<t t-esc="chatHub.folded.slice(chatHub.maxFolded).length"/></span>
             </button>
         </div>

--- a/addons/mail/static/src/core/common/chat_window.dark.scss
+++ b/addons/mail/static/src/core/common/chat_window.dark.scss
@@ -1,7 +1,3 @@
-.o-mail-ChatWindow {
-    --mail-ChatWindow-borderDesktopOpacity: .1;
-}
-
 .o-mail-ChatWindow-command {
     --mail-ChatWindow-commandHoverColor: white;
 }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -3,7 +3,7 @@
 
     z-index: $zindex-sticky;
     &:not(.o-mobile) {
-        --border-opacity: var(--mail-ChatWindow-borderDesktopOpacity, .15);
+        --border-opacity: .15;
         aspect-ratio: 9 / 15;
     }
     outline: none;
@@ -47,9 +47,13 @@
     width: 24px;
 }
 
-.o-mail-ChatWindow-header .o-mail-ChatWindow-threadAvatar img {
-    height: $o-mail-Avatar-sizeSmall;
-    width: $o-mail-Avatar-sizeSmall;
+.o-mail-ChatWindow-header {
+    --border-opacity: .25;
+
+    .o-mail-ChatWindow-threadAvatar img {
+        height: $o-mail-Avatar-sizeSmall;
+        width: $o-mail-Avatar-sizeSmall;
+    }
 }
 
 .o-mail-ChatWindow-typing {

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -12,7 +12,7 @@
         t-on-keydown="onKeydown"
         tabindex="1"
     >
-        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1 shadow-sm" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and !props.chatWindow.actionsDisabled }">
+        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1 border-bottom border-secondary" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and !props.chatWindow.actionsDisabled }">
             <t t-if="hasActionsMenu">
                 <div class="d-flex text-truncate">
                     <Dropdown position="ui.isSmall ? 'bottom-end' : 'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0 bg-100 border-secondary'">

--- a/addons/mail/static/src/core/common/composer.dark.scss
+++ b/addons/mail/static/src/core/common/composer.dark.scss
@@ -3,7 +3,7 @@
 }
 
 .o-mail-Composer-bg {
-    --border-opacity: 0;
+    --border-opacity: 0.25;
 }
 
 .o-mail-Composer-actions {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -41,7 +41,7 @@
                 <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => props.messageToReplyTo.cancel()"/>
             </div>
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended or props.composer.message }">
-                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border shadow-sm border-secondary rounded-3"
+                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border border-secondary rounded-3"
                     t-att-class="{
                         'o-iosPwa': isIosPwa,
                         'align-self-stretch' : extended,

--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -1,5 +1,5 @@
 .o-mail-discussSidebarBgColor {
-    background-color: mix($o-gray-100, $o-gray-200, 15%);
+    background-color: $o-webclient-background-color;
 }
 
 a.o_mail_redirect, a.o_channel_redirect {

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -13,15 +13,21 @@ $o-discuss-talkingColor: lighten($success, 10%);
 }
 
 .o-discuss-badge {
-    --o-discuss-badge-bg: #{$o-success}; // sync with --o-navbar-badge-bg
-    color: white !important;
-    background-color: var(--o-discuss-badge-bg) !important;
-    align-items: center;
-    justify-content: center;
-    padding: 3px 4px;
+    &, & .o-innerBadge {
+        --o-discuss-badge-bg: #{$o-success}; // sync with --o-navbar-badge-bg
+        color: white !important;
+        background-color: var(--o-discuss-badge-bg) !important;
+        align-items: center;
+        justify-content: center;
+        padding: 3px 4px;
+    
+        &.o-muted {
+            --o-discuss-badge-bg: #{$gray-400};
+        }
+    }
 
-    &.o-muted {
-        --o-discuss-badge-bg: #{$gray-400};
+    & .o-innerBadge {
+        min-width: 2.7ch; // same as .badge, without using .badge to keep semantics of a single .badge
     }
 }
 
@@ -34,10 +40,12 @@ $o-discuss-talkingColor: lighten($success, 10%);
 }
 
 .o-discuss-badge, .o-discuss-badgeShape {
-    display: flex;
-    transform: translate(0, 0) !important; // cancel systray style on badge
-    font-size: .78572 * $font-size-base !important; // roughly 11px, small but readable
-    user-select: none;
+    &, & .o-innerBadge {
+        display: flex;
+        transform: translate(0, 0) !important; // cancel systray style on badge
+        font-size: .78572 * $font-size-base !important; // roughly 11px, small but readable
+        user-select: none;
+    }
 }
 
 .o-min-height-0 {

--- a/addons/mail/static/src/core/common/date_section.xml
+++ b/addons/mail/static/src/core/common/date_section.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.DateSection">
     <div class="o-mail-DateSection d-flex align-items-center w-100 fw-bold z-1" t-attf-class="{{ props.className }}">
         <hr class="o-discuss-separator flex-grow-1"/>
-        <span class="px-2 smaller text-muted opacity-75" t-att-class="{ 'user-select-none': isMobileOS }"><t t-esc="props.date"/></span>
+        <span class="px-2 smaller text-muted opacity-50" t-att-class="{ 'user-select-none': isMobileOS }"><t t-esc="props.date"/></span>
         <hr class="o-discuss-separator flex-grow-1"/>
     </div>
 </t>

--- a/addons/mail/static/src/core/common/im_status.js
+++ b/addons/mail/static/src/core/common/im_status.js
@@ -2,7 +2,7 @@ import { Component } from "@odoo/owl";
 import { Typing } from "@mail/discuss/typing/common/typing";
 
 export class ImStatus extends Component {
-    static props = ["persona?", "className?", "style?", "member?", "size?"];
+    static props = ["persona?", "className?", "style?", "member?", "slots?", "size?"];
     static template = "mail.ImStatus";
     static defaultProps = { className: "", style: "", size: "lg" };
     static components = { Typing };

--- a/addons/mail/static/src/core/common/im_status.xml
+++ b/addons/mail/static/src/core/common/im_status.xml
@@ -6,18 +6,21 @@
             'o-md': props.size === 'md' or props.size === 'medium',
             'o-sm': props.size === 'sm' or props.size === 'small',
         }">
-            <span class="d-flex flex-column" name="icon" t-att-class="{
+            <span class="d-flex flex-column" t-att-class="{
                 'smaller': props.size === 'md' or props.size === 'medium',
                 'o-xsmaller': props.size === 'sm' or props.size === 'small',
             }">
-                <t t-if="(!props.member or !props.member.isTyping) and persona">
-                    <i t-if="persona.im_status === 'online'" class="fa fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
-                    <i t-elif="persona.im_status === 'away'" class="fa fa-circle o-away" title="Idle" role="img" aria-label="User is idle"/>
-                    <i t-elif="persona.im_status === 'offline'" class="fa fa-circle-o text-700 opacity-75" title="Offline" role="img" aria-label="User is offline"/>
-                    <i t-elif="persona.im_status === 'bot'" class="fa fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
-                    <i t-else="" class="fa fa-fw fa-question-circle opacity-75" title="No IM status available"/>
+                <t t-slot="pre_icon"/>
+                <t name="icon">
+                    <t t-if="(!props.member or !props.member.isTyping) and persona">
+                        <i t-if="persona.im_status === 'online'" class="fa fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
+                        <i t-elif="persona.im_status === 'away'" class="fa fa-circle o-away" title="Idle" role="img" aria-label="User is idle"/>
+                        <i t-elif="persona.im_status === 'offline'" class="fa fa-circle-o text-700 opacity-75" title="Offline" role="img" aria-label="User is offline"/>
+                        <i t-elif="persona.im_status === 'bot'" class="fa fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
+                        <i t-else="" class="fa fa-fw fa-question-circle opacity-75" title="No IM status available"/>
+                    </t>
+                    <Typing t-if="props.member?.isTyping" member="props.member" channel="props.member.threadAsTyping" size="'medium'" displayText="false" />
                 </t>
-                <Typing t-if="props.member?.isTyping" member="props.member" channel="props.member.threadAsTyping" size="'medium'" displayText="false" />
             </span>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -201,7 +201,7 @@ export class Message extends Component {
     get attClass() {
         return {
             [this.props.className]: true,
-            "o-card p-2 mt-2 border border-secondary": this.props.asCard,
+            "o-card p-2 ps-1 mx-1 mt-2 mb-2 border border-secondary rounded-3": this.props.asCard,
             "pt-1": !this.props.asCard,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,
             "o-selected": this.props.messageToReplyTo?.isSelected(

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -90,7 +90,7 @@
 .o-mail-Message-bubble {
     &.o-blue {
         background-color: mix($o-view-background-color, $info, 87.5%) !important;
-        border-color: darken(mix($o-view-background-color, $info, 87.5%), 5%) !important;
+        border-color: darken(mix($o-view-background-color, $info, 87.5%), 10%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $info, 87.5%)) !important;
@@ -98,7 +98,7 @@
     }
     &.o-green {
         background-color: mix($o-view-background-color, $success, 87.5%) !important;
-        border-color: darken(mix($o-view-background-color, $success, 87.5%), 5%) !important;
+        border-color: darken(mix($o-view-background-color, $success, 87.5%), 10%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $success, 87.5%)) !important;
@@ -106,7 +106,7 @@
     }
     &.o-orange {
         background-color: mix($o-view-background-color, $warning, 75%) !important;
-        border-color: darken(mix($o-view-background-color, $warning, 75%), 5%) !important;
+        border-color: darken(mix($o-view-background-color, $warning, 75%), 10%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $warning, 75%), 85%) !important;

--- a/addons/mail/static/src/core/common/message_card_list.xml
+++ b/addons/mail/static/src/core/common/message_card_list.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
     <t t-name="mail.MessageCardList">
         <div class="o-mail-MessageCardList d-flex flex-column" t-att-class="{ 'justify-content-center flex-grow-1': props.messages.length === 0 }" t-ref="message-list">
-            <div class="card mb-2" t-foreach="props.messages" t-as="message" t-key="message.id">
-                <div class="card-body py-2">
-                    <div class="position-absolute top-0 end-0 z-1 mx-2 my-1">
+            <div class="card mb-2 rounded-3 border-secondary" t-foreach="props.messages" t-as="message" t-key="message.id">
+                <div class="card-body ps-0 py-2 rounded-3">
+                    <div class="position-absolute top-0 end-0 z-1 mx-2 my-1 d-flex align-items-center">
                         <a role="button" class="o-mail-MessageCard-jump rounded bg-400 badge opacity-0" t-att-class="{ 'opacity-100 py-1 px-2': ui.isSmall }" t-on-click="() => this.onClickJump(message)">Jump</a>
-                        <button t-if="props.mode === 'pin'" class="btn btn-link text-reset ms-2 p-0" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">
+                        <button t-if="props.mode === 'pin'" class="btn btn-link text-reset ms-2 p-0 opacity-25 opacity-100-hover" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">
                             <i class="oi oi-close"/>
                         </button>
                     </div>

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <template xml:space="preserve">
     <t t-name="mail.MessageReactionList">
-        <Dropdown state="preview" position="'top-middle'" menuClass="'bg-view border-0 p-0 mt-1 overflow-visible shadow-sm'" manual="true">
+        <Dropdown state="preview" position="'top-middle'" menuClass="'bg-view border-secondary p-0 mt-1 overflow-visible shadow-sm'" manual="true">
             <t t-call="mail.MessageReactionList.button" />
             <t t-set-slot="content">
                 <t t-call="mail.MessageReactionList.preview"/>
@@ -22,7 +22,7 @@
     </t>
     
     <t t-name="mail.MessageReactionList.preview">
-        <div class="o-mail-MessageReactionList-preview px-0 py-1 border cursor-pointer d-flex" t-on-click="(ev) => this.onClickReactionList(props.reaction)" t-ref="reactionList">
+        <div class="o-mail-MessageReactionList-preview px-0 py-1 cursor-pointer d-flex" t-on-click="(ev) => this.onClickReactionList(props.reaction)" t-ref="reactionList">
             <div class="d-flex align-items-center mx-2 gap-2">
                 <span class="fs-1" t-esc="props.reaction.content"/>
                 <span class="o-mail-MessageReactionList-previewText small me-1" t-esc="previewText(props.reaction)"/>

--- a/addons/mail/static/src/core/common/search_message_input.xml
+++ b/addons/mail/static/src/core/common/search_message_input.xml
@@ -5,7 +5,7 @@
             <div class="input-group">
                 <div class="o_searchview form-control d-flex align-items-center bg-view p-0" role="search" aria-autocomplete="list">
                     <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 h-100">
-                        <input type="text" class="o_searchview_input flex-grow-1 w-auto border-0 rounded-start px-2" accesskey="Q" placeholder="Search" t-model="state.searchTerm" t-on-keydown="onKeydownSearch" t-ref="autofocus" role="searchbox"/>
+                        <input type="text" class="o_searchview_input flex-grow-1 w-auto border-0 rounded-start px-2 bg-view" accesskey="Q" placeholder="Search" t-model="state.searchTerm" t-on-keydown="onKeydownSearch" t-ref="autofocus" role="searchbox"/>
                     </div>
                 </div>
                 <button class="btn" t-att-class="state.searchedTerm === state.searchTerm ? 'btn-outline-secondary' : 'btn-secondary'" t-on-click="() => this.search()" aria-label="Search button">

--- a/addons/mail/static/src/core/common/search_message_result.xml
+++ b/addons/mail/static/src/core/common/search_message_result.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.SearchMessageResult">
         <div class="o-mail-SearchMessageResult">
-            <p t-if="MESSAGE_FOUND" class="o-mail-SearchMessagesPanel-title py-1 mb-0 fw-bolder text-center text-uppercase text-muted">
+            <p t-if="MESSAGE_FOUND" class="o-mail-SearchMessagesPanel-title py-1 mb-0 fw-bolder text-center text-uppercase text-muted smaller">
                 <t t-out="MESSAGE_FOUND" />
             </p>
             <MessageCardList 

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -78,4 +78,17 @@
         </button>
     </div>
 </t>
+
+<!--
+    @param {Number} counter
+    @param {string} [badgeClass]
+    @param {string} [iconClass]
+    @param {boolean} [floating=false]
+-->
+<t t-name="mail.discuss_badge">
+    <span class="badge rounded-pill o-discuss-badge flex-shrink-0 bg-inherit d-flex align-items-center justify-content-center" t-attf-class="{{ badgeClass }}" t-att-style="'margin: 0px; background-color: inherit !important;' + (floating ? 'padding: 1px;' : 'padding: 0px;')">
+        <span class="rounded-pill o-innerBadge" t-attf-class="{{ counterClass }}" t-esc="counter" style="top: 0 !important;"/>
+    </span>
+</t>
+
 </templates>

--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -1,26 +1,32 @@
 .o-mail-Discuss {
     --mail-Discuss-coreBgColor: #{mix($body-bg, $gray-200, 75%)};
+    --mail-Discuss-headerActionsGroupBorderOpacity: .1;
 }
 
 .o-mail-Discuss-header {
-    --border-opacity: 0;
-    background-color: mix($o-gray-100, $o-gray-200, 15%);
+    background-color: $o-webclient-background-color;
 }
 
 .o-mail-Discuss-headerActions button {
-    background-color: mix($gray-100, $gray-200);
 
     &:not(.o-isActive):hover {
-        background-color: mix($gray-200, $gray-300);
+        background-color: mix($gray-200, $gray-300) !important;
     }
     &.o-isActive {
-        background-color: $gray-300;
+        background-color: $gray-300 !important;
     }
     &.o-isActive:hover {
-        background-color: mix($gray-300, $gray-400);
+        background-color: mix($gray-300, $gray-400) !important;
     }
 }
 
-.o-mail-Discuss-panelContainer {
-    --border-opacity: 0;
+.o_web_client:has(.o-mail-Discuss) {
+
+    .o_main_navbar {
+        background-color: unset;
+    }
+
+    .o_control_panel {
+        background-color: unset;
+    }
 }

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -23,33 +23,33 @@
 .o-mail-Discuss-header {
     background-color: $white;
     box-shadow: 0px 1px 6px -3px rgba(50, 50, 50, 0.15);
-    --border-opacity: .25;
+    --border-opacity: .35;
 }
 
 .o-mail-Discuss-headerActions button {
     --btn-disabled-opacity: 0.25;
     opacity: 75%;
+    background-color: transparent !important;
 
     &:hover, &.o-isActive {
         opacity: 100%;
     }
     &:not(.o-isActive):hover {
-        background-color: $gray-200;
+        background-color: $gray-200 !important;
     }
     &.o-isActive {
-        background-color: $gray-300;
-        outline: $border-width solid $gray-500;
+        background-color: $gray-200 !important;
+        outline: $border-width solid mix($gray-300, $gray-400);
         outline-offset: -$border-width;
         opacity: 100%;
     }
     &.o-isActive:hover {
-        background-color: $gray-300;
+        background-color: $gray-300 !important;
     }
 }
 
 .o-mail-Discuss-headerActionsGroup {
-    --border-opacity: 0;
-    background-color: mix($gray-100, $gray-200, 75%);
+    --border-opacity: var(--mail-Discuss-headerActionsGroupBorderOpacity, .075);
 }
 
 .o-mail-Discuss-headerCountry {
@@ -79,4 +79,8 @@
             }
         }
     }
+}
+
+.o_web_client:has(.o-mail-Discuss) .o_control_panel {
+    --ControlPanel-border-bottom: #{$border-width} solid #{rgba($border-color, .35)};
 }

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -47,7 +47,7 @@
                         </t>
                     </div>
                     <div class="o-mail-Discuss-headerActions flex-shrink-0 d-flex align-items-center ms-1">
-                        <span t-if="partitionedActions.quick.length" class="o-mail-Discuss-headerActionsGroup btn-group border border-dark">
+                        <span t-if="partitionedActions.quick.length" class="o-mail-Discuss-headerActionsGroup btn-group border border-dark rounded-3">
                             <t t-set="groupBefore" t-value="true"/>
                             <t t-foreach="partitionedActions.quick" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                 <t t-set="action" t-value="action"/>
@@ -55,7 +55,7 @@
                         </span>
                         <t t-else="" t-set="groupBefore" t-value="false"/>
                         <span t-if="groupBefore" class="text-muted align-self-stretch ms-2 me-1"/>
-                        <span t-if="partitionedActions.other.length" class="o-mail-Discuss-headerActionsGroup btn-group border border-dark">
+                        <span t-if="partitionedActions.other.length" class="o-mail-Discuss-headerActionsGroup btn-group border border-dark rounded-3">
                          <t t-set="groupBefore" t-value="true"/>
                             <t t-foreach="partitionedActions.other" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                 <t t-set="action" t-value="action"/>
@@ -64,7 +64,7 @@
                         <t t-else="" t-set="groupBefore" t-value="false"/>
                         <span t-if="groupBefore" class="text-muted align-self-stretch ms-2 me-1"/>
                         <t t-foreach="partitionedActions.group.slice().reverse()" t-as="group" t-key="group_index">
-                            <span t-if="group.length" class="o-mail-Discuss-headerActionsGroup btn-group border border-dark">
+                            <span t-if="group.length" class="o-mail-Discuss-headerActionsGroup btn-group border border-dark rounded-3">
                                 <t t-foreach="group" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                     <t t-set="action" t-value="action"/>
                                 </t>

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.dark.scss
@@ -1,3 +1,0 @@
-.o-mail-DiscussSidebar {
-    --border-opacity: 0;
-}

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -52,5 +52,8 @@
         .o-mail-DiscussSidebarChannel-itemName {
             filter: brightness(1.1);
         }
+        img {
+            box-shadow: $box-shadow !important;
+        }
     }
 }

--- a/addons/mail/static/src/core/public_web/messaging_menu.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.scss
@@ -17,3 +17,7 @@
         border-top-color: var(--mail-MessagingMenu-activeBorderTopColor, rgba($primary, .75)) !important;
     }
 }
+
+.o_popover:has(.o-mail-MessagingMenu) {
+    --popover-border-color: #{$secondary};
+}

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -41,12 +41,16 @@
 }
 
 .o-mail-NotificationItem-markAsRead {
-    background-color: transparent !important;
+    background-color: rgba($success, .1) !important;
     font-size: 0.85rem !important;
     color: $success !important;
+    outline: 1px solid rgba($success, .25);
+    outline-offset: -1px;
+    padding: map-get($spacers, 1) / 2;
 
     &:hover {
-        background-color: rgba(0, 0, 0, 0.075) !important;
+        outline-color: rgba(darken($success, 10%), .5);
+        background-color: transparent !important;
     }
 }
 

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border rounded py-2" t-on-click="onClick" t-ref="root" t-att-class="{
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border rounded-3 py-2" t-on-click="onClick" t-ref="root" t-att-class="{
             'o-important': props.muted === 0,
             'text-muted border-transparent': props.muted === 1,
             'opacity-50 border-transparent': props.muted === 2,
@@ -24,7 +24,7 @@
                     <span class="flex-grow-1"/>
                     <div class="d-flex align-items-center">
                         <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
-                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
+                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 badge rounded-3 fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
                     </div>
                 </div>
                 <div class="d-flex">

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.DiscussSidebarMailboxes">
-        <div class="d-flex flex-column flex-grow-0 o-gap-0_5 mt-1">
+        <div class="d-flex flex-column flex-grow-0 o-gap-0_5 mt-1 bg-inherit">
             <Mailbox mailbox="store.inbox"/>
             <Mailbox mailbox="store.starred"/>
             <Mailbox mailbox="store.history"/>
@@ -41,12 +41,12 @@
                 <div class="me-2 text-truncate text-muted small" t-esc="mailbox.display_name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>
             </t>
-            <span
-                t-if="mailbox.counter > 0"
-                class="o-mail-DiscussSidebar-badge o-discuss-badge badge rounded-pill fw-bold"
-                t-att-class="{ 'o-muted': mailbox.id === 'starred', 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }"
-                t-esc="mailbox.counter"
-            />
+            <t t-if="mailbox.counter > 0" t-call="mail.discuss_badge">
+                <t t-set="counter" t-value="mailbox.counter"/>
+                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebar-badge ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'mx-1')"/>
+                <t t-set="counterClass" t-value="(mailbox.id === 'starred' ? 'o-muted' : '')"/>
+                <t t-set="floating" t-value="store.discuss.isSidebarCompact"/>
+            </t>
         </button>
     </t>
 

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -40,7 +40,7 @@
                     <i t-if="state.sidebar" class="o-discuss-Call-sidebarToggler p-2 fs-5 cursor-pointer position-absolute oi oi-arrow-right" title="Hide sidebar" t-on-click="() => this.state.sidebar = false"/>
                     <i t-else="" class="o-discuss-Call-sidebarToggler p-2 fs-5 cursor-pointer position-absolute oi oi-arrow-left" title="Show sidebar" t-on-click="() => this.state.sidebar = true"/>
                 </t>
-                <div t-if="state.overlay or !isControllerFloating" class="o-discuss-Call-overlay d-flex justify-content-center w-100 pb-1" t-att-class="{ 'o-isFloating position-absolute z-2 bottom-0 pb-3': isControllerFloating }">
+                <div t-if="state.overlay or !isControllerFloating" class="o-discuss-Call-overlay d-flex justify-content-center w-100 pb-1" t-att-class="{ 'o-isFloating position-absolute z-2 bottom-0 pb-2': isControllerFloating }">
                     <div t-on-mousemove="onMousemoveOverlay">
                         <CallActionList thread="props.thread" compact="props.compact" fullscreen="{ isActive: state.isFullscreen, enter: () => this.enterFullScreen(), exit: () => this.exitFullScreen() }"/>
                     </div>

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -9,7 +9,7 @@
                         <t t-call="discuss.CallActionList.actionButton" />
                     </t>
                     <Dropdown position="'top-end'" menuClass="'d-flex flex-column py-0'">
-                        <button t-att-class="`btn smaller d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover align-items-center ${ isSmall ? 'p-0' : 'p-1' }`" t-att-title="MORE">
+                        <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover align-items-center p-0" t-att-title="MORE">
                             <i class="fa fa-ellipsis-v m-2 fa-fw" t-att-class="{ 'fa-lg': !isSmall }"/>
                         </button>
                         <t t-set-slot="content">
@@ -23,16 +23,14 @@
                         </t>
                     </Dropdown>
                 </t>
-                <button t-if="props.thread.rtcInvitingSession and !isOfActiveCall" class="btn smaller btn-danger d-flex m-1 border-0 rounded-circle shadow-none align-items-center"
-                    t-att-class="{ 'p-0': isSmall, 'p-1': !isSmall }"
+                <button t-if="props.thread.rtcInvitingSession and !isOfActiveCall" class="btn smaller btn-danger d-flex m-1 border-0 rounded-circle shadow-none align-items-center p-0"
                     aria-label="Reject"
                     title="Reject"
                     t-att-disabled="rtc.state.hasPendingRequest"
                     t-on-click="onClickRejectCall">
                     <i class="oi oi-close fa-fw m-2" t-att-class="{ 'fa-lg': !isSmall }"/>
                 </button>
-                <button t-if="props.thread.rtcInvitingSession?.is_camera_on" class="btn smaller btn-success d-flex m-1 border-0 rounded-circle shadow-none align-items-center"
-                    t-att-class="{ 'p-0': isSmall, 'p-1': !isSmall }"
+                <button t-if="props.thread.rtcInvitingSession?.is_camera_on" class="btn smaller btn-success d-flex m-1 border-0 rounded-circle shadow-none align-items-center p-0"
                     aria-label="Accept with camera"
                     title="Accept with camera"
                     t-att-disabled="rtc.state.hasPendingRequest"
@@ -41,9 +39,9 @@
                 </button>
                 <t t-if="props.thread.eq(rtc.channel)" t-set="callText">Disconnect</t>
                 <t t-else="" t-set="callText">Join Call</t>
-                <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none align-items-center"
+                <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none align-items-center p-0"
                     t-att-aria-label="callText"
-                    t-att-class="{ 'btn-danger': isOfActiveCall, 'p-0': isSmall, 'p-1': !isSmall, 'btn-success': !isOfActiveCall }"
+                    t-att-class="{ 'btn-danger': isOfActiveCall, 'btn-success': !isOfActiveCall }"
                     t-att-disabled="rtc.state.hasPendingRequest"
                     t-att-title="callText"
                     t-on-click="onClickToggleAudioCall">
@@ -62,8 +60,8 @@
     </t>
 
     <t t-name="discuss.CallActionList.actionButton">
-        <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none opacity-75-hover align-items-center"
-            t-att-class="{ 'p-0': isSmall, 'p-1': !isSmall, 'bg-600 opacity-75': !action.available, 'opacity-100': action.available }"
+        <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none opacity-75-hover align-items-center p-0"
+            t-att-class="{ 'bg-600 opacity-75': !action.available, 'opacity-100': action.available }"
             t-att-aria-label="action.name"
             t-att-title="action.name"
             t-on-click="action.select">

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -26,9 +26,7 @@ threadActionsRegistry
     })
     .add("camera-call", {
         condition(component) {
-            return (
-                component.thread?.allowCalls && !component.thread?.eq(component.rtc.state.channel)
-            );
+            return component.thread?.allowCalls && !component.thread?.eq(component.rtc.channel);
         },
         icon: "fa fa-fw fa-video-camera",
         iconLarge: "fa fa-fw fa-lg fa-video-camera",

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCallIndicator">
-        <div t-if="props.thread.rtcSessions.length > 0" title="Ongoing call" class="o-mail-DiscussSidebarCallIndicator o-py-0_5 fa-fw rounded-circle fa fa-volume-up" t-att-class="{
-            'o-discuss-inCallIconColor opacity-75': props.thread.eq(rtc.channel),
+        <div t-if="props.thread.rtcSessions.length > 0" title="Ongoing call" class="o-mail-DiscussSidebarCallIndicator fa-fw rounded-circle fa fa-volume-up" style="padding-top: 1px; padding-bottom: 1px;" t-att-class="{
+            'o-discuss-inCallIconColor': props.thread.eq(rtc.channel),
             'opacity-50': !props.thread.eq(rtc.channel),
             'me-2': !store.discuss.isSidebarCompact and props.thread.importantCounter === 0,
         }"/>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -22,7 +22,7 @@
             'ps-4 pe-2': props.compact === undefined and !compact,
             'px-2': props.compact === false,
             'rounded-3': props.compact === undefined,
-            'opacity-75': props.thread.notEq(rtc.state.channel) and compact,
+            'opacity-75': props.thread.notEq(rtc.channel) and compact,
         }" style="margin: 1px;">
             <button class="o-mail-DiscussSidebarCallParticipants-expandBtn btn btn-link p-1 my-n1 ms-n1 me-0 align-self-start d-flex rounded-circle" t-if="!compact" t-on-click="() => state.expanded = !state.expanded">
                 <i class="oi o-xxsmaller text-muted text-dark" t-att-class="{'oi-chevron-right': !state.expanded, 'oi-chevron-down': state.expanded}" t-att-title="title"/>

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -22,6 +22,8 @@ export class ActionPanel extends Component {
     get classNames() {
         return `o-mail-ActionPanel overflow-auto d-flex flex-column flex-shrink-0 position-relative py-2 pt-0 h-100 bg-inherit ${
             !this.env.inChatter ? " px-2" : " o-mail-ActionPanel-chatter"
-        } ${this.env.inDiscussApp ? " o-mail-discussSidebarBgColor" : ""}`;
+        } ${this.env.inDiscussApp ? " o-mail-discussSidebarBgColor" : ""} ${
+            this.props.resizable ? "" : "rounded"
+        }`;
     }
 }

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -12,11 +12,11 @@
 
     <t t-name="mail.ActionPanel.content">
         <div class="o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-1 d-flex flex-column bg-inherit smaller" t-att-class="{ 'px-1': env.inChatWindow, 'pe-2': !env.inChatWindow }">
-            <div class="d-flex align-items-baseline gap-1">
+            <div class="d-flex align-items-center gap-1">
                 <button t-if="env.closeActionPanel" class="btn p-1 opacity-75 opacity-100-hover" title="Close panel" t-on-click.stop="env.closeActionPanel">
                     <i class="oi oi-arrow-left fa-fw"/>
                 </button>
-                <i t-if="props.icon" class="text-muted opacity-50" t-att-class="props.icon"/>
+                <i t-if="props.icon" class="text-muted opacity-50 fa-fw fa-lg" t-att-class="props.icon"/>
                 <p t-if="props.title" class="fw-bold text-uppercase m-0 text-muted opacity-75 flex-grow-1" t-esc="props.title"/>
             </div>
             <t t-slot="header"/>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -11,7 +11,7 @@
     <t t-name="discuss.ChannelInvitation.main">
         <div class="d-flex flex-column flex-grow-1 bg-inherit" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.thread }">
             <t t-if="store.self.type === 'partner'">
-                <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-white" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
+                <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 }">
                     <div t-if="selectablePartners.length === 0" class="small text-muted mx-1 fst-italic">
                         <t t-if="props.thread">No user found that is not already a member of this channel.</t>
@@ -50,7 +50,7 @@
                     </button>
                 </t>
                 <div t-if="props.thread?.invitationLink" class="input-group">
-                    <input class="border border-secondary form-control lh-1 px-2 py-0 opacity-75" type="text" t-att-value="props.thread.invitationLink" readonly="" t-on-focus="onFocusInvitationLinkInput"/>
+                    <input class="border border-secondary form-control lh-1 px-2 py-0 opacity-75 bg-view" type="text" t-att-value="props.thread.invitationLink" readonly="" t-on-focus="onFocusInvitationLinkInput"/>
                     <button class="btn btn-primary px-2 py-1" t-on-click="onClickCopy">
                         <i class="fa fa-copy"/>
                     </button>

--- a/addons/mail/static/src/discuss/core/common/notification_settings.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.scss
@@ -7,8 +7,10 @@
         min-width: 20px;
     }
 
-    button:hover {
-        background-color: var(--mail-NotificationSettings-btnHoverBg, $gray-200);
+    button {
+        &:hover, &.show {
+            background-color: var(--mail-NotificationSettings-btnHoverBg, $gray-200);
+        }
     }
 }
 

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -8,7 +8,7 @@
                     <span><i class="fa fa-exclamation-triangle"/> <a href="#" t-on-click="onClickAllConversationsMuted">All conversations have been muted</a></span>
                 </div>
                 <t t-if="props.thread.mute_until_dt">
-                    <button class="btn w-100 d-flex p-1 opacity-75" t-on-click="()=>this.setMute(false)">
+                    <button class="btn w-100 d-flex p-1 opacity-75 border-0" t-on-click="()=>this.setMute(false)">
                         <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
                             <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Conversation</span>
                             <span class="fw-normal smaller text-start" t-out="store.settings.getMuteUntilText(props.thread.mute_until_dt)"/>
@@ -16,12 +16,12 @@
                     </button>
                 </t>
                 <div t-elif="!store.settings.mute_until_dt" class="d-flex">
-                    <Dropdown position="ui.isSmall ? 'bottom-end' : 'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0'">
-                        <button class="btn w-100 d-flex p-1 opacity-75">
-                            <div class="d-flex flex-grow-1 align-items-center px-2 py-1 w-100 rounded">
+                    <Dropdown position="ui.isSmall ? 'bottom-end' : 'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0 bg-100 border-secondary'">
+                        <button class="btn w-100 d-flex p-1 opacity-75 border-0">
+                            <div class="d-flex flex-grow-1 align-items-center px-0 py-1 w-100 rounded">
                                 <span class="text-wrap text-start text-break">Mute Conversation</span>
                                 <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                                <i class="oi oi-arrow-right ms-2"/>
+                                <i class="oi oi-arrow-right ms-2 me-1"/>
                             </div>
                         </button>
                         <t t-set-slot="content">
@@ -32,8 +32,8 @@
                     </Dropdown>
                 </div>
                 <t t-if="props.thread.channel_type === 'channel' and !store.settings.mute_until_dt">
-                    <hr class="solid m-2"/>
-                    <button class="btn d-flex w-100 px-1 py-0" t-on-click="() => store.settings.setCustomNotifications(false, props.thread)">
+                    <hr class="solid mx-1 my-2"/>
+                    <button class="btn d-flex w-100 p-0 border-0" t-on-click="() => store.settings.setCustomNotifications(false, props.thread)">
                         <div class="d-flex flex-grow-1 align-items-center px-2 rounded">
                             <div class="d-flex flex-column align-items-start">
                                 <span class="fs-6 text-wrap text-start text-break">Use Default</span>
@@ -44,7 +44,7 @@
                         </div>
                     </button>
                     <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
-                        <button class="btn w-100 d-flex px-1 py-0" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.thread)">
+                        <button class="btn w-100 d-flex p-0 border-0" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.thread)">
                             <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
                                 <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="notif.name"/>
                                 <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
@@ -1,4 +1,4 @@
 .o-mail-DiscussSidebar-item {
-    --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-200, $gray-300)};
+    --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-200, $gray-300, 25%)};
     --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .25)};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
@@ -13,6 +13,4 @@
 
 .o-mail-DiscussSidebarCategories-search {
     --border-opacity: .5;
-    --mail-DiscussSidebarCategories-searchContainerBg: #{$white};
-    --mail-DiscussSidebarCategories-searchContainerBgHover: #{$gray-100};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -58,7 +58,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 }
 
 .o-mail-DiscussSidebarChannel-indicatorCompact {
-    top: 3px;
+    top: 1px;
     left: 3px;
 }
 
@@ -82,12 +82,12 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 
 .o-mail-DiscussSidebarCategories-search {
     &, & input {
-        background-color: var(--mail-DiscussSidebarCategories-searchContainerBg, $gray-100) !important;
+        background-color: $o-view-background-color !important;
     }
 
     &:has(.o-mail-DiscussSidebarCategories-searchClickable:hover) {
         &, & input {
-            background-color: var(--mail-DiscussSidebarCategories-searchContainerBgHover, mix($gray-100, $gray-200)) !important;
+            background-color: mix($gray-100, $gray-200) !important;
         }
     }
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
         <Dropdown t-if="store.discuss.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm'" manual="true">
-            <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-lg fa-fw fa-search"/></button>
+            <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75 bg-transparent" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-lg fa-fw fa-search"/></button>
             <t t-set-slot="content">
                 <div class="p-2" t-ref="search-floating">
                     <span class="text-muted user-select-none">Find or start a conversation</span>
@@ -155,7 +155,7 @@
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
                 <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5" style="width:32px;height:32px;" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
-                    <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                    <img class="w-100 h-100 rounded o_object_fit_cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>
                 </div>
@@ -175,7 +175,11 @@
                 </div>
             </t>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
-            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge flex-shrink-0 fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 me-2': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
+            <t t-if="thread.importantCounter > 0" t-call="mail.discuss_badge">
+                <t t-set="counter" t-value="thread.importantCounter"/>
+                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge flex-shrink-0 fw-bold ' + (thread.isMuted ? 'o-muted' : '') + ' ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'ms-1 me-2')"/>
+                <t t-set="floating" t-value="store.discuss.isSidebarCompact"/>
+            </t>
         </button>
     </t>
 

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.scss
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.scss
@@ -1,5 +1,6 @@
 .o-mail-SubChannelList-thread {
-    --border-opacity: .5;
+    background-color: mix($gray-100, $gray-200);
+    --border-opacity: .75;
 
     &:hover {
         background-color: $gray-100 !important;
@@ -8,6 +9,6 @@
 
 .o-mail-SubChannelList-threadLastMessage {
     display: -webkit-box;
-    -webkit-line-clamp: 1;
+    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
 }

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -7,7 +7,7 @@
                     <div class="input-group ms-2 my-2">
                         <div class="form-control d-flex align-items-center p-0 bg-view" role="search" aria-autocomplete="list">
                             <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 h-100">
-                                <input t-ref="search" t-model="state.searchTerm" type="text" class="o_searchview_input rounded flex-grow-1 w-auto border-0 px-2" t-on-keydown="onKeydownSearch" placeholder="Search by name"/>
+                                <input t-ref="search" t-model="state.searchTerm" type="text" class="o_searchview_input rounded flex-grow-1 w-auto border-0 px-2 bg-view" t-on-keydown="onKeydownSearch" placeholder="Search by name"/>
                             </div>
                         </div>
                         <button class="btn btn-outline-secondary px-2 py-1" aria-label="Search button" t-on-click="search">
@@ -25,10 +25,10 @@
                         <t t-else="">This channel has no thread yet.</t>
                     </p>
                 </div>
-                <div class="d-flex flex-column flex-grow-1 gap-1">
+                <div class="d-flex flex-column flex-grow-1 gap-2">
                     <t t-foreach="state.subChannels" t-as="thread" t-key="thread.localId">
                         <t t-set="message" t-value="thread.newestPersistentOfAllMessage ?? thread.from_message_id"/>
-                        <button class="o-mail-SubChannelList-thread btn btn-light d-flex flex-column border border-secondary mx-1 px-2 py-1" t-on-click="() => this.onClickSubThread(thread)">
+                        <button class="o-mail-SubChannelList-thread btn btn-light-subtle d-flex flex-column border border-secondary mx-1 px-2 py-1" t-on-click="() => this.onClickSubThread(thread)">
                             <div class="d-flex w-100">
                                 <span class="fw-bold text-truncate small" t-esc="thread.displayName"/>
                                 <span class="flex-grow-1"/>

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
@@ -22,3 +22,7 @@
         max-width: 90vw;
     }
 }
+
+.o_popover:has(.o_card_avatar) {
+    --popover-border-color: #{$secondary};
+}

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.dark.scss
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.dark.scss
@@ -2,3 +2,7 @@
     --EmojiPicker-placeholderOpacity: #{75%};
     --EmojiPicker-active: #{mix($gray-300, $gray-400, 75%)};
 }
+
+.o-EmojiPicker-searchContour {
+    --border-opacity: .5;
+}

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -9,7 +9,7 @@
         </t>
         <t t-else="">
             <div class="o-EmojiPicker-search d-flex align-items-center mx-2 mt-2 rounded">
-                <span class="d-flex mx-1 w-100 rounded o-active align-items-center justify-content-center border border-secondary bg-white">
+                <span class="o-EmojiPicker-searchContour d-flex mx-1 w-100 rounded o-active align-items-center justify-content-center border border-secondary bg-view">
                     <t t-call="web.EmojiPicker.searchInput">
                         <t t-if="props.state" t-set="localState" t-value="props.state"/>
                         <t t-else="" t-set="localState" t-value="state"/>


### PR DESCRIPTION
- discuss popovers in dark theme have softer borders
- chat window in dark theme have slightly more visible border
- chat bubble have shadow
- input are lighter in dark theme
- composer input no longer has shadow
- chat window header has its shadow replaced by thin border
- thread actions in discuss app header has their style more fused with bg
- discuss app in dark theme is overall slightly darker
- discuss app control panel and discuss UI have much softer border separation
- message card layout is rounder and has better spacing (messages in mailboxes & discuss side-panel)
- discuss side-panel title icon is bigger
- date section opacity has been reduced slightly
- badge discuss sidebar compact and chat bubble has an outline to separate from avatar and bg
- IM status on chat bubble now has outline too for same reason
- mark as read button on unread messaging menu item looks more like a button
- call indicator and participant in discuss sidebar compact is slightly more visible
- call action list buttons in desktop is smaller
- message border in white theme is more visible