### PR TITLE
[FIX] core: fix werkzeug version parsing

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -136,6 +136,7 @@ import functools
 import glob
 import hashlib
 import hmac
+import importlib.metadata
 import inspect
 import json
 import logging
@@ -145,7 +146,6 @@ import re
 import threading
 import time
 import traceback
-import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from hashlib import sha512
@@ -278,7 +278,7 @@ ROUTING_KEYS = {
     'alias', 'host', 'methods',
 }
 
-if parse_version(werkzeug.__version__) >= parse_version('2.0.2'):
+if parse_version(importlib.metadata.version('werkzeug')) >= parse_version('2.0.2'):
     # Werkzeug 2.0.2 adds the websocket option. If a websocket request
     # (ws/wss) is trying to access an HTTP route, a WebsocketMismatch
     # exception is raised. On the other hand, Werkzeug 0.16 does not


### PR DESCRIPTION
The werkzeug version is parsed by using the `__version__` attribute which is deprecated since 3.0.0.

This leads to an error when running Odoo in Debian trixie that provides werkzeug 3.1.3.

See
 - pallets/werkzeug#2772
 - https://packages.debian.org/trixie/python-werkzeug-doc

> Also remove the unused import of `warning`