### PR TITLE
[FIX] pos_sale: fix error on weight field on sale report for pos orders

### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -66,8 +66,8 @@ class SaleReport(models.Model):
             partner.country_id AS country_id,
             partner.industry_id AS industry_id,
             partner.commercial_partner_id AS commercial_partner_id,
-            (SUM(p.weight) * l.qty / u.factor) AS weight,
-            (SUM(p.volume) * l.qty / u.factor) AS volume,
+            (SUM(p.weight) * l.qty) AS weight,
+            (SUM(p.volume) * l.qty) AS volume,
             l.discount AS discount,
             SUM((l.price_unit * l.discount * l.qty / 100.0
                 / {self._case_value_or_one('pos.currency_rate')}

--- a/addons/pos_sale/tests/test_pos_sale_report.py
+++ b/addons/pos_sale/tests/test_pos_sale_report.py
@@ -13,6 +13,9 @@ class TestPoSSaleReport(TestPoSCommon):
         super(TestPoSSaleReport, self).setUp()
         self.config = self.basic_config
         self.product0 = self.create_product('Product 0', self.categ_basic, 0.0, 0.0)
+        # Ensure that adding a uom to the product with a factor != 1 
+        # does not cause an error in weight and volume calculation
+        self.product0.uom_id = self.env['uom.uom'].search([('name', '=', 'Dozens')], limit=1)
 
     def test_weight_and_volume(self):
         self.product0.product_tmpl_id.weight = 3


### PR DESCRIPTION
When viewing sale report for POS orders, the gross weight number will
be off by a factor of how much larger/smaller the UOM ratio is
compared to the base. For example, if we sell 1 qty of product with a
weight of 25kg and a UOM of 25kg (25 * 1kg), the gross weight field
will be 1 * 25kg * 25kg or 625kg instead of the expected 1 * 25kg or
25kg. This fix removes the UOM factor from being taken into account
when calculating gross weight for POS orders. This is a valid solution
because if we treat 'SUM(p.weight * l.product_uom_qty / u.factor *
u2.factor)' as the ground truth from sale report for sale orders, the
'/ u.factor * u2.factor' portion of the calculation will cancel out
to 1 for POS orders. This is because the only time 'u2.factor/u.factor'
is not 1 for sale orders is when the product template's UOM factor is
different from the sale order line's UOM factor. Since we can not
change the UOM of pos order lines, the pos order line's factor will
always be the same as the product template's therefore
'u2.factor / u.factor' for pos orders will always be 1 and can be
ignored.

To reproduce error on blank DB:
1) For a product, change its UOM to a UOM with a ratio not equal to 1
2) For the same product, change its weight in the inventory tab to
a number not equal to 0
3) In POS make a sale with this product and confirm the order
4) Check the gross weight of the product just sold through POS by
going to sales->reporting->list view and adding gross weight to the
view through studio

opw-4452892
