### PR TITLE
[FIX] im_livechat: chats displayed under wrong side bar category

### DIFF
--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -17,6 +17,7 @@ import { rpc } from "@web/core/network/rpc";
 import { url } from "@web/core/utils/urls";
 import { defineLivechatModels } from "./livechat_test_helpers";
 import { press } from "@odoo/hoot-dom";
+import { browser } from "@web/core/browser/browser";
 
 describe.current.tags("desktop");
 defineLivechatModels();
@@ -443,4 +444,27 @@ test("Local sidebar category state is shared between tabs", async () => {
     await click(".o-mail-DiscussSidebarCategory-livechat .btn", { target: env1 });
     await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-right", { target: env1 });
     await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-right", { target: env2 });
+});
+
+test("live chat is displayed below its category", async () => {
+    const pyEnv = await startServer();
+    const livechatChannelId = pyEnv["im_livechat.channel"].create({ name: "Helpdesk" });
+    browser.localStorage.setItem(
+        `discuss_sidebar_category_im_livechat.category_${livechatChannelId}_open`,
+        false
+    );
+    pyEnv["discuss.channel"].create({
+        channel_type: "livechat",
+        livechat_channel_id: livechatChannelId,
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: pyEnv["mail.guest"].create({ name: "Visitor #12" }) }),
+        ],
+    });
+    await start();
+    await openDiscuss();
+    await click(".o-mail-DiscussSidebarCategory .btn", { text: "Helpdesk" });
+    await contains(
+        ".o-mail-DiscussSidebarCategory:contains(Helpdesk) + .o-mail-DiscussSidebarChannel-container:contains(Visitor #12)"
+    );
 });

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -13,7 +13,7 @@
             <input class="form-control rounded-3 border-0 bg-inherit" t-att-class="{ 'lh-1': !ui.isSmall }" disabled="true" placeholder="Find or start a conversation" tabindex="0"/>
             <div class="o-mail-DiscussSidebarCategories-searchClickable position-absolute z-1 opacity-0 cursor-pointer w-100 h-100"/>
         </div>
-        <t t-foreach="store.discuss.allCategories" t-as="cat" t-key="cat_index">
+        <t t-foreach="store.discuss.allCategories" t-as="cat" t-key="cat.id">
             <t t-if="cat.isVisible" t-call="mail.DiscussSidebarCategories.category">
                 <t t-set="category" t-value="cat"/>
             </t>


### PR DESCRIPTION
Before this PR, live chats were sometimes displayed under the wrong category.

Steps to reproduce:
- Ensure you have one live chat pinned in the sidebar.
- Go to the inbox, fold the live chat category.
- Reload the page.
- Open the live chat category.
- The chat is displayed under the wrong category.

This occurs because the t-key used in the side bar template is the index of the category which is not reliable. Change it to the id field which is also unique but more reliable.
![chrome-capture-2025-3-24](https://github.com/user-attachments/assets/13fe7c25-4c6c-4bd7-ba25-16eaf6b9a1cd)


