### PR TITLE
[IMP] spreadsheet_account: add balance tag formula

### DIFF
--- a/addons/spreadsheet_account/static/src/accounting_functions.js
+++ b/addons/spreadsheet_account/static/src/accounting_functions.js
@@ -432,3 +432,49 @@ functionRegistry.add("ODOO.PARTNER.BALANCE", {
         };
     },
 })
+
+functionRegistry.add("ODOO.BALANCE.TAG", {
+    description: _t("Return the balance of accounts for the specified tag(s) and period"),
+    args: [
+        arg("account_tag_ids (string)", _t("The tag ids (separated by a comma).")),
+        arg(
+            "date_range (string, date, optional)",
+            _t(`The date range. Supported formats are "21/12/2022", "Q1/2022", "12/2022", and "2022".`)
+        ),
+        YEAR_OFFSET_ARG,
+        COMPANY_ARG,
+        POSTED_ARG,
+    ],
+    category: "Odoo",
+    returns: ["NUMBER"],
+    compute: function (
+        accountTagIds,
+        dateRange,
+        offset = { value: 0 },
+        companyId = { value: null },
+        includeUnposted = { value: false }
+    ) {
+        const _accountTagIds = toString(accountTagIds)
+            .split(",")
+            .map((accountTagId) => toNumber(accountTagId, this.locale))
+            .sort();
+        const _offset = toNumber(offset, this.locale);
+
+        if ( !dateRange?.value ) {
+            dateRange = { value: new Date().getFullYear() }
+        }
+        const _dateRange = parseAccountingDate(dateRange, this.locale);
+        const _companyId = toNumber(companyId, this.locale);
+        const _includeUnposted = toBoolean(includeUnposted);
+        return {
+            value: this.getters.getAccountTagData(
+                _accountTagIds,
+                _dateRange,
+                _offset,
+                _companyId,
+                _includeUnposted,
+            ),
+            format: this.getters.getCompanyCurrencyFormat(_companyId) || "#,##0.00",
+        };
+    },
+})

--- a/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
+++ b/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
@@ -19,6 +19,7 @@ export class AccountingPlugin extends OdooUIPlugin {
         "getFiscalEndDate",
         "getAccountResidual",
         "getAccountPartnerData",
+        "getAccountTagData",
     ]);
     constructor(config) {
         super(config);
@@ -197,6 +198,37 @@ export class AccountingPlugin extends OdooUIPlugin {
         );
         if (result === false) {
             throw new EvaluationError(_t("The balance for given partners could not be computed."));
+        }
+        return result.balance;
+    }
+
+    /**
+     * Fetch the balance for a given account tag
+     * @private
+     * @param {number[]} accountTagIds ids of the account tags
+     * @param {DateRange} dateRange start date of the period to look
+     * @param {number} offset year offset of the period to look
+     * @param {number | null} companyId specific companyId to target
+     * @param {boolean} includeUnposted wether or not select unposted entries
+     * @returns {number | undefined}
+     */
+    getAccountTagData(accountTagIds, dateRange, offset, companyId, includeUnposted) {
+        dateRange = deepCopy(dateRange);
+        dateRange.year += offset;
+        // Excel dates start at 1899-12-30, we should not support date ranges
+        // that do not cover dates prior to it.
+        // Unfortunately, this check needs to be done right before the server
+        // call as a date too low (year <= 1) can raise an error server side.
+        if (dateRange.year < 1900) {
+            throw new EvaluationError(_t("%s is not a valid year.", dateRange.year));
+        }
+        const result = this.serverData.batch.get(
+            "account.account",
+            "spreadsheet_fetch_balance_tag",
+            camelToSnakeObject({ accountTagIds, dateRange, companyId, includeUnposted })
+        );
+        if (result === false) {
+            throw new EvaluationError(_t("The balance for given account tag could not be computed."));
         }
         return result.balance;
     }

--- a/addons/spreadsheet_account/static/src/utils.js
+++ b/addons/spreadsheet_account/static/src/utils.js
@@ -14,7 +14,7 @@ const { getFunctionsFromTokens } = helpers;
  * @returns {number}
  */
 export function getNumberOfAccountFormulas(tokens) {
-    return getFunctionsFromTokens(tokens, ["ODOO.BALANCE", "ODOO.CREDIT", "ODOO.DEBIT", "ODOO.RESIDUAL", "ODOO.PARTNER.BALANCE"]).length;
+    return getFunctionsFromTokens(tokens, ["ODOO.BALANCE", "ODOO.CREDIT", "ODOO.DEBIT", "ODOO.RESIDUAL", "ODOO.PARTNER.BALANCE", "ODOO.BALANCE.TAG"]).length;
 }
 
 /**
@@ -24,5 +24,5 @@ export function getNumberOfAccountFormulas(tokens) {
  * @returns {OdooFunctionDescription | undefined}
  */
 export function getFirstAccountFunction(tokens) {
-    return getFunctionsFromTokens(tokens, ["ODOO.BALANCE", "ODOO.CREDIT", "ODOO.DEBIT", "ODOO.RESIDUAL", "ODOO.PARTNER.BALANCE"])[0];
+    return getFunctionsFromTokens(tokens, ["ODOO.BALANCE", "ODOO.CREDIT", "ODOO.DEBIT", "ODOO.RESIDUAL", "ODOO.PARTNER.BALANCE", "ODOO.BALANCE.TAG"])[0];
 }

--- a/addons/spreadsheet_account/static/tests/model/balance_tag.test.js
+++ b/addons/spreadsheet_account/static/tests/model/balance_tag.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { setCellContent } from "@spreadsheet/../tests/helpers/commands";
+import { getCellValue, getEvaluatedCell } from "@spreadsheet/../tests/helpers/getters";
+import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
+import { defineSpreadsheetAccountModels } from "@spreadsheet_account/../tests/accounting_test_data";
+import { waitForDataLoaded } from "@spreadsheet/helpers/model";
+
+describe.current.tags("headless");
+defineSpreadsheetAccountModels();
+
+test("Basic evaluation", async () => {
+    const { model } = await createModelWithDataSource({
+        mockRPC: async function (route, args) {
+            if (args.method === "spreadsheet_fetch_balance_tag") {
+                expect.step("spreadsheet_fetch_balance_tag");
+                expect(args.args[0]).toEqual([
+                    {
+                        account_tag_ids: [10, 14],
+                        date_range: {
+                            range_type: "year",
+                            year: 2025,
+                        },
+                        company_id: 0,
+                        include_unposted: false,
+                    },
+                ]);
+                return [{ balance: 100.0 }];
+            }
+        },
+    });
+    setCellContent(model, "A1", `=ODOO.BALANCE.TAG("10, 14", 2025)`);
+    await waitForDataLoaded(model);
+    expect.verifySteps(["spreadsheet_fetch_balance_tag"]);
+    expect(getCellValue(model, "A1")).toBe(100.0);
+});
+
+test("with wrong date format", async () => {
+    const { model } = await createModelWithDataSource();
+    setCellContent(model, "A1", `=ODOO.BALANCE.TAG("10, 14", "This is not a valid date")`);
+    await waitForDataLoaded(model);
+    expect(getEvaluatedCell(model, "A1").message).toBe(
+        "'This is not a valid date' is not a valid period. Supported formats are \"21/12/2022\", \"Q1/2022\", \"12/2022\", and \"2022\"."
+    );
+});
+
+test("with no date", async () => {
+    const { model } = await createModelWithDataSource({
+        mockRPC: async function (route, args) {
+            if (args.method === "spreadsheet_fetch_balance_tag") {
+                expect.step("spreadsheet_fetch_balance_tag");
+                expect(args.args[0]).toEqual([
+                    {
+                        account_tag_ids: [10, 14],
+                        date_range: {
+                            range_type: "year",
+                            year: new Date().getFullYear(),
+                        },
+                        company_id: 0,
+                        include_unposted: false,
+                    },
+                ]);
+                return [{ balance: 100.0 }];
+            }
+        },
+    });
+    setCellContent(model, "A1", `=ODOO.BALANCE.TAG("10, 14")`);
+    await waitForDataLoaded(model);
+    expect.verifySteps(["spreadsheet_fetch_balance_tag"]);
+    expect(getCellValue(model, "A1")).toBe(100.0);
+});

--- a/addons/spreadsheet_account/tests/__init__.py
+++ b/addons/spreadsheet_account/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_account_group
+from . import test_balance_tag
 from . import test_debit_credit
 from . import test_company_fiscal_year
 from . import test_residual_amount

--- a/addons/spreadsheet_account/tests/test_balance_tag.py
+++ b/addons/spreadsheet_account/tests/test_balance_tag.py
@@ -1,0 +1,123 @@
+from odoo import Command
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install', '-at_install')
+class SpreadsheetAccountingBalanceTagFunctionTest(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.tag_1 = cls._create_account_tag('tag_1')
+        cls.tag_2 = cls._create_account_tag('tag_2')
+
+        cls.company_data['default_account_receivable'].tag_ids |= cls.tag_1
+        cls.company_data['default_account_revenue'].tag_ids |= cls.tag_1
+        cls.company_data['default_account_expense'].tag_ids |= cls.tag_2
+
+        cls.posted_move = cls.env['account.move'].create({
+            'company_id': cls.company_data['company'].id,
+            'move_type': 'entry',
+            'date': '2025-01-01',
+            'line_ids': [
+                Command.create({
+                    'name': "posted line debit 1",
+                    'account_id': cls.company_data['default_account_receivable'].id,
+                    'debit': 100,
+                    'company_id': cls.company_data['company'].id,
+                }),
+                Command.create({
+                    'name': "posted line debit 2",
+                    'account_id': cls.company_data['default_account_revenue'].id,
+                    'debit': 50,
+                    'company_id': cls.company_data['company'].id,
+                }),
+                Command.create({
+                    'name': "posted line credit 1",
+                    'account_id': cls.company_data['default_account_expense'].id,
+                    'credit': 150,
+                    'company_id': cls.company_data['company'].id,
+                }),
+            ],
+        })
+        cls.posted_move.action_post()
+
+        cls.draft_move = cls.env['account.move'].create({
+            'company_id': cls.company_data['company'].id,
+            'move_type': 'entry',
+            'date': '2024-01-01',
+            'line_ids': [
+                Command.create({
+                    'name': "draft line debit 1",
+                    'account_id': cls.company_data['default_account_receivable'].id,
+                    'debit': 100,
+                    'company_id': cls.company_data['company'].id,
+                }),
+                Command.create({
+                    'name': "draft line credit 1",
+                    'account_id': cls.company_data['default_account_expense'].id,
+                    'credit': 100,
+                    'company_id': cls.company_data['company'].id,
+                }),
+            ],
+        })
+
+    @classmethod
+    def _create_account_tag(cls, tag_name):
+        return cls.env['account.account.tag'].create([{
+            'name': tag_name,
+            'applicability': 'accounts',
+        }])
+
+    def test_sreadsheet_balance_tags_empty_payload(self):
+        self.assertEqual(
+            self.env["account.account"].spreadsheet_fetch_balance_tag([]), []
+        )
+
+    def test_spreadsheet_balance_tags(self):
+        tag_balances = self.env["account.account"].spreadsheet_fetch_balance_tag([
+            {
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2025,
+                },
+                'account_tag_ids': self.tag_1.ids,
+                'company_id': None,
+                'include_unposted': False,
+            },
+            {
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2025,
+                },
+                'account_tag_ids': (self.tag_1 + self.tag_2).ids,
+                'company_id': None,
+                'include_unposted': False,
+            },
+            {
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2024,
+                },
+                'account_tag_ids': self.tag_1.ids,
+                'company_id': None,
+                'include_unposted': False,
+            },
+            {
+                'date_range': {
+                    'range_type': 'year',
+                    'year': 2024,
+                },
+                'account_tag_ids': self.tag_1.ids,
+                'company_id': None,
+                'include_unposted': True,
+            },
+        ])
+
+        self.assertEqual(tag_balances, [
+            {'balance': 150.0},    # year 2025, tag_1
+            {'balance': 0.0},      # year 2025, tag_1 & tag_2
+            {'balance': 0.0},      # year 2024, tag_1, posted_only
+            {'balance': 100.0},    # year 2024, tag_1, draft included
+        ])


### PR DESCRIPTION
To easily manage some ratio and dashboard, we need a formula to find the balance of all accounts with the same tag. While it could have been a new arguments to the ODOO.BALANCE existing function, it was decided to make a new one for this specific case to avoid any confusion and make it less invasive with the existing formula.

Here are the parameters of the new ODOO.BALANCE.TAG function:
 - tag ids (mandatory)
 - date_range (21/12/2022,Q1 2022, 12/2022, 2022)
 - offset (default: 0)
 - company_id (default: current company)
 - include_unposted (default: false)

 task-4147944

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
