### PR TITLE
[PERF] product: speedup product.attribute _compute_products

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -86,8 +86,16 @@ class ProductAttribute(models.Model):
 
     @api.depends('attribute_line_ids.active', 'attribute_line_ids.product_tmpl_id')
     def _compute_products(self):
+        templates_by_attribute = {
+            attribute.id: templates
+            for attribute, templates in self.env['product.template.attribute.line']._read_group(
+                domain=[('attribute_id', 'in', self.ids)],
+                groupby=['attribute_id'],
+                aggregates=['product_tmpl_id:recordset']
+            )
+        }
         for pa in self:
-            pa.with_context(active_test=False).product_tmpl_ids = pa.attribute_line_ids.product_tmpl_id
+            pa.with_context(active_test=False).product_tmpl_ids = templates_by_attribute.get(pa.id, False)
 
     # === ONCHANGE METHODS === #
 


### PR DESCRIPTION
When there are lots of `product_template_attribute_lines` the computation of the `product_tmpl_ids` field of
`product.attribute` can take a bit of time. This in turn slows down the editing of attribute/attribute_values on product.template's FormView.

This commit changes the compute method by first doing a `_read_group` to retrieve the templates by attribute. This skips the `__get__` call on `product_attribute.product_attribute_line_ids`. A compound index on `product_template_attribute_line` is also added to speedup the `_read_group` mentioned above.

#### speedup

Customer database with close to 900 000 product_template_attribute_lines and an average of 100 000 product_template_attribute_lines by attribute_id.

Adding a new attribute in a template FormView: 3s -> 500ms.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
