### PR TITLE
[FIX] account: compute split sequence

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -328,7 +328,7 @@ class SequenceMixin(models.AbstractModel):
                 try:
                     with mute_logger('odoo.sql_db'):
                         self[self._sequence_field] = sequence
-                        self.env.add_to_compute(self._fields['sequence_prefix'], self)
+                        self._compute_split_sequence()
                         self.flush_recordset([self._sequence_field, 'sequence_prefix', 'sequence_number'])
                         break
                 except (pgerrors.ExclusionViolation, pgerrors.UniqueViolation):


### PR DESCRIPTION
In some cases, it was possible to have `sequence_number` computed without `sequence_prefix`.

This was leading to the whole mixin misbehaving because it wasn't able to find the right last sequence anymore.

