### PR TITLE
[FIX] mail: correctly populate references for log notes with email noti

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2821,11 +2821,10 @@ class MailThread(models.AbstractModel):
                 ('model', '=', message_sudo.model), ('res_id', '=', message_sudo.res_id),
                 ('message_type', 'in', outgoing_types),
                 ('id', '!=', message_sudo.id),
-                ('subtype_id', '!=', note_type.id),  # filters out notes, using subtype which is indexed
             ], limit=16, order='id DESC',
         )
         # filter out internal messages that are not notes, manually because of indexes
-        ancestors = ancestors.filtered(lambda m: not m.is_internal and m.subtype_id and not m.subtype_id.internal)[:3]
+        ancestors = ancestors.filtered(lambda m: not m.is_internal and m.subtype_id)[:3]
         # order frrom oldest to newest
         references = ' '.join(m.message_id for m in (ancestors[::-1] + message_sudo))
         # prepare notification mail values


### PR DESCRIPTION
Log notes that were sent through email notifications were not threading together on email clients because they had no references that were similar when they were sent. This was behavior was changed here https://github.com/odoo/odoo/pull/197127. However, it would not include notes when getting ancestors to populate the references which caused this issue.

Removing the filter on notes and subtypes with internal allowed the message_ids from these older log notes to be used in the reference header and thus allowing emails to thread again for log note notifications.

opw-4591482
