### PR TITLE
[IMP] l10n_id_efaktur_coretax: improvements to coretax

### DIFF
--- a/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
+++ b/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
@@ -19,13 +19,14 @@ class TestIndonesianEfaktur(common.TransactionCase):
 
         self.maxDiff = 1500
         # change company info for csv detai later
-        self.env.company.country_id = self.env.ref('base.id')
-        self.env.company.account_fiscal_country_id = self.env.company.country_id
+        indonesia = self.env.ref('base.id')
+        self.env.company.country_id = indonesia
+        self.env.company.account_fiscal_country_id = indonesia
         self.env.company.street = "test"
         self.env.company.phone = "12345"
         self.env.company.vat = "1234567890123456"
 
-        self.partner_id = self.env['res.partner'].create({"name": "l10ntest", "l10n_id_pkp": True, "l10n_id_kode_transaksi": "01", "l10n_id_nik": "12345", "vat": "000000000000000"})
+        self.partner_id = self.env['res.partner'].create({"name": "l10ntest", "l10n_id_pkp": True, "l10n_id_kode_transaksi": "01", "l10n_id_nik": "12345", "vat": "000000000000000", "country_id": indonesia.id})
         self.partner_id_vat = self.env['res.partner'].create({"name": "l10ntest3", "l10n_id_pkp": True, "l10n_id_kode_transaksi": "01", "l10n_id_nik": "67890", "vat": "010000000000000"})
         self.tax_id = self.env['account.tax'].create({"name": "test tax", "type_tax_use": "sale", "amount": 10.0, "price_include": True})
 
@@ -75,7 +76,7 @@ class TestIndonesianEfaktur(common.TransactionCase):
             _csv_row(OF_HEAD_LIST, ','),
         )
         # remaining lines
-        line_4 = '"FK","01","0","0000000000001","5","2019","1/5/2019","000000000000000","12345#NIK#NAMA#l10ntest","","100","10","0","","0","0","0","0","INV/2019/00001","0"\n'
+        line_4 = '"FK","01","0","0000000000001","5","2019","1/5/2019","000000000000000","12345#NIK#NAMA#l10ntest","Indonesia","100","10","0","","0","0","0","0","INV/2019/00001","0"\n'
         line_5 = '"OF","","","100.00","1.0","100.00","0","100.00","10.00","0","0"\n'
 
         efaktur_csv_expected = output_head + line_4 + line_5
@@ -98,7 +99,7 @@ class TestIndonesianEfaktur(common.TransactionCase):
             _csv_row(LT_HEAD_LIST, ','),
             _csv_row(OF_HEAD_LIST, ','),
         )
-        line_4 = '"FK","01","0","0000000000002","5","2019","1/5/2019","000000000000000","12345#NIK#NAMA#l10ntest","","40040","4004","0","","0","0","0","0","INV/2019/00002","0"\n'
+        line_4 = '"FK","01","0","0000000000002","5","2019","1/5/2019","000000000000000","12345#NIK#NAMA#l10ntest","Indonesia","40040","4004","0","","0","0","0","0","INV/2019/00002","0"\n'
         line_5 = '"OF","","","100.10","400.0","40040.00","0","40040.00","4004.00","0","0"\n'
 
         efaktur_csv_expected = output_head + line_4 + line_5

--- a/addons/l10n_id_efaktur_coretax/__manifest__.py
+++ b/addons/l10n_id_efaktur_coretax/__manifest__.py
@@ -28,9 +28,11 @@
         # Views
         "views/product_template.xml",
         "views/product_code.xml",
+        "views/uom_code.xml",
         "views/res_partner.xml",
         "views/account_move.xml",
         "views/efaktur_document.xml",
+        "views/uom_uom.xml",
     ],
     'installable': True,
     'auto_install': True,

--- a/addons/l10n_id_efaktur_coretax/data/efaktur_templates.xml
+++ b/addons/l10n_id_efaktur_coretax/data/efaktur_templates.xml
@@ -26,6 +26,7 @@
                 <TrxCode t-out="move['TrxCode']"/>
                 <AddInfo t-out="move['AddInfo']" />
                 <CustomDoc t-out="move['CustomDoc']"/>
+                <CustomDocMonthYear t-out="move['CustomDocMonthYear']"/>
                 <RefDesc t-out="move['RefDesc']"/>
                 <FacilityStamp t-out="move['FacilityStamp']"/>
                 <SellerIDTKU t-out="move['SellerIDTKU']"/>

--- a/addons/l10n_id_efaktur_coretax/models/account_move.py
+++ b/addons/l10n_id_efaktur_coretax/models/account_move.py
@@ -213,6 +213,8 @@ class AccountMove(models.Model):
                 err_messages.append(_("Document number for customer %s hasn't been filled in", comm.name))
             if not comm.vat:
                 err_messages.append(_("NPWP for customer %s hasn't been filled in yet", comm.name))
+            if not comm.country_id:
+                err_messages.append(_("No country is set for customer %s", comm.name))
 
         # check for every invoice
         for record in self:
@@ -268,7 +270,7 @@ class AccountMove(models.Model):
         """ Fill in vals with invoice-related information """
         self.ensure_one()
 
-        partner = self.partner_id.commercial_partner_id
+        partner = self.commercial_partner_id
         trx_code = self.l10n_id_kode_transaksi
 
         vals.update({
@@ -278,6 +280,7 @@ class AccountMove(models.Model):
             "TrxCode": trx_code,
             "AddInfo": "",
             "CustomDoc": self.l10n_id_coretax_custom_doc or "",
+            "CustomDocMonthYear": "",
             "FacilityStamp": "",
             "RefDesc": self.name,
             "SellerIDTKU": self.company_id.vat + self.company_id.partner_id.l10n_id_tku,
@@ -285,8 +288,8 @@ class AccountMove(models.Model):
             "BuyerTin": partner.vat if partner.l10n_id_buyer_document_type == "TIN" else "0000000000000000",
             "BuyerCountry": COUNTRY_CODE_MAP.get(partner.country_id.code),
             "BuyerDocumentNumber": partner.l10n_id_buyer_document_number if partner.l10n_id_buyer_document_type != "TIN" else "",
-            "BuyerName": partner.name,
-            "BuyerAdress": partner.contact_address.replace('\n', ' ').strip(),
+            "BuyerName": self.partner_id.name,
+            "BuyerAdress": self.partner_id.contact_address.replace('\n', ' ').strip(),
             "BuyerEmail": partner.email or "",
             "BuyerIDTKU": partner.vat + partner.l10n_id_tku,
         })

--- a/addons/l10n_id_efaktur_coretax/models/account_move_line.py
+++ b/addons/l10n_id_efaktur_coretax/models/account_move_line.py
@@ -21,14 +21,18 @@ class AccountMoveLine(models.Model):
         luxury_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id == luxury_tax_group)
         regular_tax = self.tax_ids - luxury_tax
 
+        # "Price" is unit price calculation excluding tax and discount
+        # "TotalDiscount" is total of "Price" * quantity * discount
+        tax_res = self.tax_ids.compute_all(self.price_unit, quantity=1, currency=self.currency_id, product=self.product_id, partner=self.partner_id, is_refund=self.is_refund)
+
         line_val = {
             "Opt": "B" if product.detailed_type == "service" else "A",  # A: goods, B: service
             "Code": product.l10n_id_product_code.code or self.env.ref('l10n_id_efaktur_coretax.product_code_000000_goods').code,
             "Name": product.name,
             "Unit": self.product_uom_id.l10n_id_uom_code.code,
-            "Price": idr.round(self.price_unit),
+            "Price": tax_res['total_excluded'],
             "Qty": self.quantity,
-            "TotalDiscount": idr.round(self.discount * self.quantity * self.price_unit / 100),
+            "TotalDiscount": idr.round(self.discount * tax_res['total_excluded'] * self.quantity / 100),
             "TaxBase": idr.round(self.price_subtotal),  # DPP
             "VATRate": 12,
             "STLGRate": luxury_tax.amount if luxury_tax else 0.0,

--- a/addons/l10n_id_efaktur_coretax/models/uom_code.py
+++ b/addons/l10n_id_efaktur_coretax/models/uom_code.py
@@ -8,3 +8,9 @@ class EfakturUomCode(models.Model):
 
     code = fields.Char()
     name = fields.Char()
+
+    def name_get(self):
+        result = []
+        for record in self:
+            result.append((record.id, f"{record.name} ({record.code})"))
+        return result

--- a/addons/l10n_id_efaktur_coretax/tests/results/sample.xml
+++ b/addons/l10n_id_efaktur_coretax/tests/results/sample.xml
@@ -8,14 +8,16 @@
       <TrxCode>04</TrxCode>
       <AddInfo/>
       <CustomDoc/>
+      <CustomDocMonthYear/>
       <RefDesc>INV/2019/00001</RefDesc>
       <FacilityStamp/>
       <SellerIDTKU>1234567890123456000000</SellerIDTKU>
       <BuyerTin>1234567890123457</BuyerTin>
       <BuyerDocument>TIN</BuyerDocument>
+      <BuyerCountry>IDN</BuyerCountry>
       <BuyerDocumentNumber/>
       <BuyerName>partner_a</BuyerName>
-      <BuyerAdress/>
+      <BuyerAdress>Indonesia</BuyerAdress>
       <BuyerEmail/>
       <BuyerIDTKU>1234567890123457000000</BuyerIDTKU>
       <ListOfGoodService>

--- a/addons/l10n_id_efaktur_coretax/views/uom_code.xml
+++ b/addons/l10n_id_efaktur_coretax/views/uom_code.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="uom_code_list" model="ir.ui.view">
+        <field name="name">uom.code.list</field>
+        <field name="model">l10n_id_efaktur_coretax.uom.code</field>
+        <field name="arch" type="xml">
+            <tree string="Product Codes">
+                <field name="code" />
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/l10n_id_efaktur_coretax/views/uom_uom.xml
+++ b/addons/l10n_id_efaktur_coretax/views/uom_uom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_uom_categ_form_view_inherit_coretax" model="ir.ui.view">
+        <field name="name">uom.category.form.inherit.coretax</field>
+        <field name="model">uom.category</field>
+        <field name="inherit_id" ref="uom.product_uom_categ_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='ratio']" position="before">
+                <field name="l10n_id_uom_code"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="product_uom_form_view_inherit_coretax" model="ir.ui.view">
+        <field name="name">uom.uom.form.inherit.coretax</field>
+        <field name="model">uom.uom</field>
+        <field name="inherit_id" ref="uom.product_uom_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='rounding']" position="after">
+                <field name="l10n_id_uom_code"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- adding a field to set the coretax UoM code from UoM form view
- raise error when country is not set on the customer
- use the main customer's address in invoice as address in e-Faktur instead of the main customer's
- fix calculation for tax incde in price configuration
- adding CustomDocMonthYear to the XML by parsing month and year from invoice_date

ticket-4622364

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
