### PR TITLE
[FIX] mrp: prevent error when date is out of range

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -5346,6 +5346,15 @@ msgstr ""
 
 #. module: mrp
 #. odoo-python
+#: code:addons/mrp/models/mrp_production.py:0
+#, python-format
+msgid ""
+"The Expected duration is too long, resulting in an invalid date. Please "
+"enter a valid duration."
+msgstr ""
+
+#. module: mrp
+#. odoo-python
 #: code:addons/mrp/models/mrp_bom.py:0 code:addons/mrp/models/mrp_bom.py:0
 #, python-format
 msgid ""
@@ -5390,6 +5399,25 @@ msgstr ""
 msgid ""
 "The current configuration is incorrect because it would create a cycle "
 "between these products: %s."
+msgstr ""
+
+#. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/mrp_workcenter.py:0
+#: code:addons/mrp/models/mrp_workorder.py:0
+#, python-format
+msgid ""
+"The duration is too long, resulting in an invalid date. Please enter a valid"
+" duration."
+msgstr ""
+
+#. module: mrp_workorder
+#. odoo-python
+#: code:addons/mrp_workorder/models/mrp_workorder.py:0
+#, python-format
+msgid ""
+"The expected duration is too long, resulting in an invalid date. Please "
+"enter a valid duration."
 msgstr ""
 
 #. module: mrp

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -733,7 +733,10 @@ class MrpProduction(models.Model):
             date_finished = production.date_start + relativedelta(days=days_delay)
             if production._should_postpone_date_finished(date_finished):
                 workorder_expected_duration = sum(self.workorder_ids.mapped('duration_expected'))
-                date_finished = date_finished + relativedelta(minutes=workorder_expected_duration or 60)
+                try:
+                    date_finished = date_finished + relativedelta(minutes=workorder_expected_duration or 60)
+                except OverflowError:
+                    raise UserError(_("The Expected duration is too long, resulting in an invalid date. Please enter a valid duration."))
             production.date_finished = date_finished
 
     @api.depends('company_id', 'bom_id', 'product_id', 'product_qty', 'product_uom_id', 'location_src_id')

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -418,7 +418,10 @@ class MrpWorkcenterProductivity(models.Model):
 
     @api.onchange('duration')
     def _duration_changed(self):
-        self.date_start = self.date_end - timedelta(minutes=self.duration)
+        try:
+            self.date_start = self.date_end - timedelta(minutes=self.duration)
+        except OverflowError:
+            raise UserError(_("The duration is too long, resulting in an invalid date. Please enter a valid duration."))
         self._loss_type_change()
 
     @api.onchange('date_start')

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -329,7 +329,10 @@ class MrpWorkorder(models.Model):
 
             if delta_duration > 0:
                 enddate = datetime.now()
-                date_start = enddate - timedelta(seconds=_float_duration_to_second(delta_duration))
+                try:
+                    date_start = enddate - timedelta(seconds=_float_duration_to_second(delta_duration))
+                except OverflowError:
+                    raise UserError(_("The duration is too long, resulting in an invalid date. Please enter a valid duration."))
                 if order.duration_expected >= new_order_duration or old_order_duration >= order.duration_expected:
                     # either only productive or only performance (i.e. reduced speed) time respectively
                     self.env['mrp.workcenter.productivity'].create(


### PR DESCRIPTION
Currently, an exception is raised when a user enters an excessively long Expected Duration for a work order.

Steps to Reproduce:

1. Install `mrp_workorder` module
2. Create MO with product(eg: Screw)
3. Now add a line in Work Orders and set Expected Duration(2122105303.16)
4. Go to Operations -> Work Orders -> Open Work Order of Created MO
5. Click Action -> Mark as Done.
6. An error occurs

Error:
```ValueError
year -2010 is out of range
```

This issue [1] occurs when the Expected Duration is too large, causing the computed timestamp to result in a negative year, which is outside the valid range for datetime calculations.

[1]- https://github.com/odoo/enterprise/blob/ed956dd63e041ada964a60a7669df57811aab6d7/mrp_workorder/models/mrp_workorder.py#L847

This fix resolves the issue by raising a `UserError` when the Expected Duration is too long.

Related Enterprise PR:-  https://github.com/odoo/enterprise/pull/82041

sentry-6450643998

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
