### PR TITLE
[FIX] survey: prevent alert mesage being overlap comment field

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -492,7 +492,7 @@
                         <span class="ms-2" t-out="question.comments_message or default_comments_message" />
                     </label>
                 </div>
-                <div t-attf-class="o_survey_comment_container mt-3 py-0 px-1 #{'d-none' if not comment_line else ''}">
+                <div t-attf-class="o_survey_comment_container mt-3 py-0 px-1 h-auto #{'d-none' if not comment_line else ''}">
                     <textarea type="text" class="form-control o_survey_question_text_box bg-transparent rounded-0 p-0"
                         t-att-disabled="None if comment_line else 'disabled'"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
                 </div>


### PR DESCRIPTION
Steps to reproduce:
1. Create a survey with 'multiple choice: only one answer' question no.1
2. Go to the question's options Tab > enable these three options 'Show comment field' & 'Comment is an answer' & 'Mandatory answer'. (For question no.1)
3. Add a second question to that survey. (any type)
4. Test the survey.
5. Click on the continue button without selecting the answer.
6. The error message overlaps the comment field

Technical reason:
The height of the `<div>` containing the <textarea> was not properly set.

After this commit:
The alert message should be displayed below the comment field.

Task-4663115