### PR TITLE
[IMP] pos_self_order: display i button on configuring combo product

### DIFF
--- a/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.js
+++ b/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.js
@@ -1,6 +1,8 @@
 import { Component } from "@odoo/owl";
 import { useSelfOrder } from "@pos_self_order/app/self_order_service";
 import { AttributeSelection } from "@pos_self_order/app/components/attribute_selection/attribute_selection";
+import { useService } from "@web/core/utils/hooks";
+import { ProductInfoPopup } from "@pos_self_order/app/components/product_info_popup/product_info_popup";
 
 export class ComboSelection extends Component {
     static template = "pos_self_order.ComboSelection";
@@ -9,6 +11,7 @@ export class ComboSelection extends Component {
 
     setup() {
         this.selfOrder = useSelfOrder();
+        this.dialog = useService("dialog");
     }
 
     productClicked(line) {
@@ -30,5 +33,15 @@ export class ComboSelection extends Component {
             return;
         }
         this.props.comboState.showQtyButtons = true;
+    }
+
+    showProductInfo(line) {
+        this.dialog.add(ProductInfoPopup, {
+            product: line.product_id,
+            isComboLine: true,
+            addToCart: () => {
+                this.productClicked(line);
+            },
+        });
     }
 }

--- a/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.xml
@@ -14,6 +14,9 @@
                             class="self_order_product_card d-flex flex-row-reverse flex-md-column align-items-start gap-2 user-select-none"
                             role="button"
                             >
+                            <div t-if="line.product_id.public_description" class="product-information-tag" t-on-click.prevent.stop="() => this.showProductInfo(line)">
+                                <i class="product-information-tag-logo fa fa-info fs-4" role="img" aria-label="Product Information" title="Product Information" />
+                            </div>
                             <div class="ratio ratio-1x1 w-25 w-sm-50 w-md-100" t-att-class="{'d-none d-md-block': !product.image_128}">
                                 <div class="placeholder-glow">
                                     <div class="placeholder w-100 h-100 bg-300 rounded"/>

--- a/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.js
@@ -2,7 +2,12 @@ import { Component, useExternalListener, useState } from "@odoo/owl";
 
 export class ProductInfoPopup extends Component {
     static template = "pos_self_order.ProductInfoPopup";
-    static props = ["product", "addToCart", "close"];
+    static props = {
+        product: Object,
+        addToCart: Function,
+        close: Function,
+        isComboLine: { type: Boolean, optional: true },
+    };
 
     setup() {
         useExternalListener(window, "click", this.props.close);

--- a/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
@@ -12,7 +12,7 @@
                         <span class="modal-body o_self_order_main_desc fs-3 p-4 ps-5 overflow-auto" t-out="props.product.public_description" />
                         <div class="modal-footer d-flex flex-row-reverse justify-content-between align-items-center">
                             <button type="button" class="btn btn-primary" t-on-click.stop="() => this.addToCartAndClose()">Add to Cart</button>
-                            <div t-if="!props.product.isCombo() and !props.product.isConfigurable() > 0" class="o_self_order_incr_button btn-group " role="group" aria-label="Quantity select" >
+                            <div t-if="!props.product.isCombo() and !props.product.isConfigurable() > 0 and !props.isComboLine" class="o_self_order_incr_button btn-group " role="group" aria-label="Quantity select" >
                                 <button type="button"
                                     t-on-click = "() => this.changeQuantity(false)"
                                     class="btn btn-secondary"><span class="fs-2 lh-1 fa-fw d-inline-block">－</span></button>


### PR DESCRIPTION
Before this commit:
- No `I` button was displayed on configuring combo products

Following this commit:
- The `I` button is made visible when configuring combo products.

task-4654063
