### PR TITLE
[FIX] point_of_sale: prevent flickering of combo selection dialog

### DIFF
--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -1,34 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ComboConfiguratorPopup">
-        <Dialog title="props.product.display_name" contentClass="'combo-configurator-popup'">
+        <Dialog t-if="this.hasMultipleChoices()" title="props.product.display_name" contentClass="'combo-configurator-popup'">
             <div t-if="isArchivedProductSelected()" class="alert alert-warning mt-3">
                 <span>This combination does not exist.</span>
             </div>
             <div t-foreach="props.product.combo_ids" t-as="combo" t-key="combo.id" class="d-flex flex-column m-3 mb-4">
-                <t t-if="shouldShowCombo(combo)">
-                    <h3 class="me-auto mb-3" t-esc="combo.name"/>
-                    <div class="product-list d-grid gap-1">
-                        <div t-foreach="combo.combo_line_ids" t-as="combo_line" t-key="combo_line.id" class="m-2" t-att-class="{'ptav-not-available' : isArchived(combo_line)}">
-                            <t t-set="product" t-value="combo_line.product_id"/>
-                            <input type="radio"
-                                t-attf-name="combo-{{combo.id}}"
-                                t-attf-id="combo-{{combo.id}}-combo_line-{{combo_line.id}}"
-                                t-attf-value="{{combo_line.id}}"
-                                t-model="state.combo[combo.id]"
-                                t-att-class="{ 'selected': state.combo[combo.id] == combo_line.id }" />
-                            <label t-attf-for="combo-{{combo.id}}-combo_line-{{combo_line.id}}" class="combo-line h-100 w-100 rounded cursor-pointer transition-base">
-                                <ProductCard name="product.display_name"
-                                    class="'flex-column h-100 border'"
-                                    productId="product.id"
-                                    product="product"
-                                    price="formattedComboPrice(combo_line)"
-                                    imageUrl="product.getImageUrl()"
-                                    onClick="(ev) => this.onClickProduct({ product, combo_line }, ev)" />
-                            </label>
-                        </div>
+                <h3 class="me-auto mb-3" t-esc="combo.name"/>
+                <div class="product-list d-grid gap-1">
+                    <div t-foreach="combo.combo_line_ids" t-as="combo_line" t-key="combo_line.id" class="m-2" t-att-class="{'ptav-not-available' : isArchived(combo_line)}">
+                        <t t-set="product" t-value="combo_line.product_id"/>
+                        <input type="radio"
+                            t-attf-name="combo-{{combo.id}}"
+                            t-attf-id="combo-{{combo.id}}-combo_line-{{combo_line.id}}"
+                            t-attf-value="{{combo_line.id}}"
+                            t-model="state.combo[combo.id]"
+                            t-att-class="{ 'selected': state.combo[combo.id] == combo_line.id }" />
+                        <label t-attf-for="combo-{{combo.id}}-combo_line-{{combo_line.id}}" class="combo-line h-100 w-100 rounded cursor-pointer transition-base">
+                            <ProductCard name="product.display_name"
+                                class="'flex-column h-100 border'"
+                                productId="product.id"
+                                product="product"
+                                price="formattedComboPrice(combo_line)"
+                                imageUrl="product.getImageUrl()"
+                                onClick="(ev) => this.onClickProduct({ product, combo_line }, ev)" />
+                        </label>
                     </div>
-                </t>
+                </div>
             </div>
             <t t-set-slot="footer">
                 <div class="d-flex w-100 justify-content-start gap-2">

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -93,7 +93,33 @@ export class ProductCard extends Component {
         }
 
         if (product.isCombo()) {
-            this.router.navigate("combo_selection", { id: product.id });
+            const selectedCombos = [];
+            let showComboSelectionPage = false;
+            for (const combo of product.combo_ids) {
+                const { combo_line_ids } = combo;
+                if (combo_line_ids.length > 1 || combo_line_ids[0]?.product_id.isConfigurable()) {
+                    showComboSelectionPage = true;
+                    break;
+                }
+                selectedCombos.push({
+                    combo_line_id: this.selfOrder.models["pos.combo.line"].get(
+                        combo_line_ids[0].id
+                    ),
+                    configuration: {
+                        attribute_custom_values: [],
+                        attribute_value_ids: [],
+                        price_extra: 0,
+                    },
+                });
+            }
+
+            if (showComboSelectionPage) {
+                this.router.navigate("combo_selection", { id: product.id });
+            } else {
+                this.flyToCart();
+                this.selfOrder.editedLine?.delete();
+                this.selfOrder.addToCart(product, 1, "", {}, {}, selectedCombos);
+            }
         } else if (product.isConfigurable()) {
             this.router.navigate("product", { id: product.id });
         } else {


### PR DESCRIPTION
Before this commit:
=====================
- The combo selection dialog flickered when a combo product had only one
  choice and was non-configurable, as it opened and closed rapidly.
- In self-order mode, a traceback occurred in this scenario, and the auto-
  selection of the combo choice was missing, unlike in the main POS.

After this commit:
==============
- The dialog no longer flickers and will not open if there is only one non-
  configurable choice. It now only opens when multiple choices are available or
  configuration is required.
- The auto-selection of the combo choice is now consistent between self-order
  mode and the main POS, preventing tracebacks.

Task-4664491