### PR TITLE
[FIX] account_peppol: filter EDI users by proxy type

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -224,7 +224,7 @@ class AccountEdiProxyClientUser(models.Model):
                 )
 
     def _cron_peppol_get_participant_status(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', 'in', ['pending', 'not_verified', 'sent_verification'])])
+        edi_users = self.search([('company_id.account_peppol_proxy_state', 'in', ['pending', 'not_verified', 'sent_verification']), ('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_participant_status()
 
     def _peppol_get_participant_status(self):


### PR DESCRIPTION
Ensures only Peppol-type proxies are retrieved for updating participant status.

Steps to reproduce:
- Install Peppol and IT EDI
- Register Peppol and IT EDI users
- Go to Scheduled Actions and run “PEPPOL: update participant status”
- Error: “Error while updating Peppol participant status: The URL requested returned an error. The URL it tried to contact was False/api/peppol/1/participant_status”

opw-4624633

