### PR TITLE
[FIX] sale: add optional (sub)total column to SO form

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -4390,8 +4390,18 @@ msgid "Tax Country"
 msgstr ""
 
 #. module: sale
+#: model_terms:ir.ui.view,arch_db:sale.view_order_form
+msgid "Tax Excl."
+msgstr ""
+
+#. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
 msgid "Tax ID"
+msgstr ""
+
+#. module: sale
+#: model_terms:ir.ui.view,arch_db:sale.view_order_form
+msgid "Tax Incl."
 msgstr ""
 
 #. module: sale

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -660,6 +660,17 @@
                                        column_invisible="parent.company_price_include == 'tax_excluded'"
                                        invisible="is_downpayment"
                                        string="Amount"/>
+                                <!-- Optional amounts -->
+                                <field name="price_total"
+                                       column_invisible="parent.company_price_include == 'tax_included'"
+                                       optional="hide"
+                                       invisible="is_downpayment"
+                                       string="Tax Incl."/>
+                                <field name="price_subtotal"
+                                       column_invisible="parent.company_price_include == 'tax_excluded'"
+                                       optional="hide"
+                                       invisible="is_downpayment"
+                                       string="Tax Excl."/>
                                 <!-- Others fields -->
                                 <field name="tax_calculation_rounding_method" column_invisible="True"/>
                                 <field name="state" column_invisible="True"/>


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Create a quotation;
2. add a product with taxes.

Issue
-----
Depending on the company tax setting, the only "Amount" viewable from the sale order line view is either `price_total` or `price_subtotal`.

There's no way to easily add the other column to the view.

Cause
-----
The Pricepocalypse changed the view in commit 5bfd603d0cae5 to make only one "Amount" column available.

Solution
--------
Add the other amount as an optional field.

opw-4574399