### PR TITLE
[FIX] html_editor: fix failing tests due to improper element targeting

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -13,6 +13,7 @@ import {
     onWillDestroy,
     markup,
     useExternalListener,
+    status,
 } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { scrollTo, closestScrollableY } from "@web/core/utils/scrolling";
@@ -142,6 +143,11 @@ export class ImageCrop extends Component {
         await this.scrollToInvisibleImage();
         // Replacing the src with the original's so that the layout is correct.
         await loadImage(this.originalSrc, this.media);
+        if (status(this) !== "mounted") {
+            // Abort if the component has been destroyed in the meantime
+            // since `this.imageRef.el` is `null` when it is not mounted.
+            return;
+        }
         const cropperImage = this.imageRef.el;
         [cropperImage.style.width, cropperImage.style.height] = [
             this.media.width + "px",


### PR DESCRIPTION
**Problem**:
Tests introduced in commit [`b7a63f7d60494c65889ba6ce3fa18847a0abbb62`] (https://github.com/odoo/odoo/commit/b7a63f7d60494c65889ba6ce3fa18847a0abbb62) are failing on **runbot** due to improper element selection and handling of image loading when the component is destroyed.

**Solution**:
- Ensure the test properly targets the correct elements.
- Handle cases where the image is still loading while the component is destroyed, preventing potential tracebacks.

**Steps to Reproduce**:
1. Run the test suite on runbot.
2. Observe test failures related to incorrect element selection or missing image references due to component destruction.

**opw-4607020**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
