### PR TITLE
[FIX] hr_recruitment: make the partner_name as required in application

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -42,7 +42,7 @@ class HrApplicant(models.Model):
     active = fields.Boolean("Active", default=True, help="If the active field is set to false, it will allow you to hide the case without removing it.", index=True)
 
     partner_id = fields.Many2one('res.partner', "Contact", copy=False, index='btree_not_null')
-    partner_name = fields.Char("Applicant's Name")
+    partner_name = fields.Char("Applicant's Name", required=True)
     email_from = fields.Char(
         string="Email",
         size=128,


### PR DESCRIPTION
Currently, a traceback is occurring when trying to refuse an application.

To reproduce this issue:

1) Install `Recruitment`
2) Open any job position and create a new application record 
3) Without giving any values click on the refuse button

Error:- 
```
TypeError: sequence item 0: expected str instance, bool found
```

This issue was occurring because of the refactoring from the below commit(https://github.com/odoo/odoo/commit/e9bad7ebc795c34052a667a227c2103aa58fb861)

When the user clicks on the refuse button, _compute_applicant_without_email method triggers with the applicant as a new origin object.

Partner_name is not a required field and the applicant is a new origin object, So indeed we won't get any value for display_name or partner_name.

This leads to the above traceback from the below line

https://github.com/odoo/odoo/blob/1a1354727f965b018374aa2001b0bb7f981d1cc1/addons/hr_recruitment/wizard/applicant_refuse_reason.py#L38-L42

It is weird that not even a single field is required in the `hr.applicant` model.

This commit will make the `partner_name` as required.

Related Enterprise PR:- https://github.com/odoo/enterprise/pull/82049
sentry-6409185730

