### PR TITLE
[FIX] website_sale: prevent traceback in website editor

### DIFF
--- a/addons/website_sale/static/src/js/cart.js
+++ b/addons/website_sale/static/src/js/cart.js
@@ -139,7 +139,7 @@ publicWidget.registry.websiteSaleCartNavigation = publicWidget.Widget.extend({
      */
     destroy() {
         this.resizeObserver?.disconnect();
-        super.destroy();
+        this._super.apply(this, arguments);
     },
 });
 


### PR DESCRIPTION
Versions
--------
- saas-18.1+

Steps
-----
1. Go to /shop;
2. add product to cart;
3. go to checkout;
4. try to edit the page with the website editor.

Issue
-----
Traceback: `TypeError: super.destroy is not a function`

Cause
-----
`super.destroy` is not a function.

Solution
--------
Use `this._super.apply` instead of a direct call to `super`.

opw-4668627
opw-4669346
opw-4670159