### PR TITLE
[FIX] mrp: allow attribute lines field in test form

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4387,6 +4387,8 @@ class TestMrpOrder(TestMrpCommon):
         """
         Test updating an MO from BoM when the finished product has a kit with variants as a component.
         """
+        # Enable variants
+        self.env.user.groups_id += self.env.ref('product.group_product_variant')
         # Create an attribute for variants
         color_attribute = self.env['product.attribute'].create({
             'name': 'Variant Color',


### PR DESCRIPTION
Test introduced in 6a4c02e6 fails because the `attribute_line_ids` field is not visible by default in product forms.

Fixes [runbot error 161456](https://runbot.odoo.com/odoo/runbot.build.error/161456)