### PR TITLE
[IMP] l10n_in: QR Code shown on invoices only if UPI ID is set

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -146,7 +146,7 @@ class ResCompany(models.Model):
     incoterm_id = fields.Many2one('account.incoterms', string='Default incoterm',
         help='International Commercial Terms are a series of predefined commercial terms used in international transactions.')
 
-    qr_code = fields.Boolean(string='Display QR-code on invoices')
+    qr_code = fields.Boolean(string='Display QR-code on invoices', compute='_compute_qr_code', store=True, readonly=False)
     link_qr_code = fields.Boolean(string='Display Link QR-code')
 
     display_invoice_amount_total_words = fields.Boolean(string='Total amount of invoice in letters')
@@ -463,6 +463,9 @@ class ResCompany(models.Model):
     def _compute_display_account_storno(self):
         for company in self:
             company.display_account_storno = company.account_fiscal_country_id.code in STORNO_MANDATORY_COUNTRIES | STORNO_OPTIONAL_COUNTRIES
+
+    def _compute_qr_code(self):
+        pass
 
     def _initiate_account_onboardings(self):
         account_onboarding_routes = [

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -599,7 +599,11 @@ class AccountMove(models.Model):
 
     def _generate_qr_code(self, silent_errors=False):
         self.ensure_one()
-        if self.company_id.country_code == 'IN' and self.company_id.l10n_in_upi_id:
+        if (
+            self.company_id.l10n_in_upi_id
+            and self.amount_residual
+            and self.move_type == 'out_invoice'
+        ):
             payment_url = 'upi://pay?pa=%s&pn=%s&am=%s&tr=%s&tn=%s' % (
                 self.company_id.l10n_in_upi_id,
                 self.company_id.name,

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -76,6 +76,14 @@ class ResCompany(models.Model):
     )
     l10n_in_gstin_status_feature = fields.Boolean(string="Check GST Number Status")
 
+    @api.depends('l10n_in_upi_id')
+    def _compute_qr_code(self):
+        # EXTENDS 'account'
+        indian_companies = self.filtered(lambda c: c.country_code == 'IN')
+        for company in indian_companies:
+            company.qr_code = bool(company.l10n_in_upi_id)
+        super(ResCompany, self - indian_companies)._compute_qr_code()
+
     def _inverse_l10n_in_tds_feature(self):
         for company in self:
             if company.l10n_in_tds_feature:

--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -22,6 +22,10 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.l10n_in_hsn_code_digit',
         readonly=False
     )
+    l10n_in_upi_id = fields.Char(
+        related='company_id.l10n_in_upi_id',
+        readonly=False
+    )
 
     # TDS/TCS settings
     l10n_in_tds_feature = fields.Boolean(

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -134,6 +134,17 @@
                     </div>
                 </setting>
             </block>
+            <xpath expr="//setting[@id='qr_code_invoices']" position="attributes">
+                <attribute name="invisible">country_code == 'IN'</attribute>
+            </xpath>
+            <block id="pay_invoice_online_setting_container" position="inside">
+                <setting string="UPI ID"
+                         help="Add a payment QR-code to your invoices."
+                         company_dependent="1"
+                         invisible="country_code != 'IN'">
+                    <field name="l10n_in_upi_id" placeholder="Add UPI ID"/>
+                </setting>
+            </block>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
With this PR, the QR Code is shown on invoices only when a UPI ID is set,
replacing the previous logic based on the `qr_code` boolean field. Additionally,
the `qr_code` field has been hidden from the settings for India country.

task-4396931