### PR TITLE
[FIX] l10n_fr: fix rounding and sum issues

### DIFF
--- a/addons/l10n_fr/data/tax_report_data.xml
+++ b/addons/l10n_fr/data/tax_report_data.xml
@@ -11,6 +11,10 @@
                 <field name="name">Balance</field>
                 <field name="expression_label">balance</field>
             </record>
+            <record id="tax_report_adjustment" model="account.report.column">
+                <field name="name">Adjustment</field>
+                <field name="expression_label">adjustment</field>
+            </record>
         </field>
         <field name="line_ids">
             <record id="tax_report_montant_op_realisees" model="account.report.line">
@@ -26,8 +30,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_A1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_A1.balance_from_tags + box_A1.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_A1_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">A1</field>
+                                    </record>
+                                    <record id="tax_report_A1_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -37,8 +53,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_A2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_A2.balance_from_tags + box_A2.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_A2_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">A2</field>
+                                    </record>
+                                    <record id="tax_report_A2_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -48,8 +76,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_A3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_A3.balance_from_tags + box_A3.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_A3_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">A3</field>
+                                    </record>
+                                    <record id="tax_report_A3_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -59,8 +99,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_A4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_A4.balance_from_tags + box_A4.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_A4_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">A4</field>
+                                    </record>
+                                    <record id="tax_report_A4_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -70,8 +122,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_A5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_A5.balance_from_tags + box_A5.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_A5_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">A5</field>
+                                    </record>
+                                    <record id="tax_report_A5_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -81,8 +145,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_B1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_B1.balance_from_tags + box_B1.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_B1_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">B1</field>
+                                    </record>
+                                    <record id="tax_report_B1_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -92,8 +168,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_B2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_B2.balance_from_tags + box_B2.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_B2_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">B2</field>
+                                    </record>
+                                    <record id="tax_report_B2_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -103,8 +191,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_B3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_B3.balance_from_tags + box_B3.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_B3_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">B3</field>
+                                    </record>
+                                    <record id="tax_report_B3_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -114,8 +214,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_B4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_B4.balance_from_tags + box_B4.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_B4_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">B4</field>
+                                    </record>
+                                    <record id="tax_report_B4_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -125,8 +237,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_B5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_B5.balance_from_tags + box_B5.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_B5_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">B5</field>
+                                    </record>
+                                    <record id="tax_report_B5_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -141,8 +265,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_E1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_E1.balance_from_tags + box_E1.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_E1_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">E1</field>
+                                    </record>
+                                    <record id="tax_report_E1_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -152,8 +288,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_E2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_E2.balance_from_tags + box_E2.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_E2_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">E2</field>
+                                    </record>
+                                    <record id="tax_report_E2_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -163,8 +311,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_E3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_E3.balance_from_tags + box_E3.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_E3_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">E3</field>
+                                    </record>
+                                    <record id="tax_report_E3_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -174,8 +334,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_E4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_E4.balance_from_tags + box_E4.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_E4_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">E4</field>
+                                    </record>
+                                    <record id="tax_report_E4_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -185,8 +357,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_E5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_E5.balance_from_tags + box_E5.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_E5_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">E5</field>
+                                    </record>
+                                    <record id="tax_report_E5_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -196,8 +380,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_E6_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_E6.balance_from_tags + box_E6.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_E6_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">E6</field>
+                                    </record>
+                                    <record id="tax_report_E6_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -207,8 +403,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_F1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_F1.balance_from_tags + box_F1.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_F1_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">F1</field>
+                                    </record>
+                                    <record id="tax_report_F1_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -218,8 +426,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_F2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_F2.balance_from_tags + box_F2.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_F2_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">F2</field>
+                                    </record>
+                                    <record id="tax_report_F2_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -229,8 +449,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_F3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_F3.balance_from_tags + box_F3.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_F3_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">F3</field>
+                                    </record>
+                                    <record id="tax_report_F3_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -240,8 +472,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_F4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_F4.balance_from_tags + box_F4.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_F4_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">F4</field>
+                                    </record>
+                                    <record id="tax_report_F4_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -251,8 +495,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_F5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_F5.balance_from_tags + box_F5.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_F5_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">F5</field>
+                                    </record>
+                                    <record id="tax_report_F5_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -262,8 +518,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_F6_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_F6.balance_from_tags + box_F6.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_F6_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">F6</field>
+                                    </record>
+                                    <record id="tax_report_F6_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -273,8 +541,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_F7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_F7.balance_from_tags + box_F7.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_F7_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">F7</field>
+                                    </record>
+                                    <record id="tax_report_F7_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -284,8 +564,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_F8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_7B.balance_from_tags + box_7B.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_F8_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">7B</field>
+                                    </record>
+                                    <record id="tax_report_F8_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -295,8 +587,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_F9_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_F9.balance_from_tags + box_F9.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_F9_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">F9</field>
+                                    </record>
+                                    <record id="tax_report_F9_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -320,8 +624,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_08_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_08_base.balance_from_tags + box_08_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_08_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">08_base</field>
+                                    </record>
+                                    <record id="tax_report_08_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -333,6 +649,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_08_base.balance * 0.2</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_08_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -347,8 +664,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_09_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_09_base.balance_from_tags + box_09_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_09_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">09_base</field>
+                                    </record>
+                                    <record id="tax_report_09_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -360,6 +689,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_09_base.balance * 0.055</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_09_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -374,8 +704,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_9B_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_9B_base.balance_from_tags + box_9B_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_9B_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">9B_base</field>
+                                    </record>
+                                    <record id="tax_report_9B_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -387,6 +729,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_9B_base.balance * 0.1</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_9B_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -406,8 +749,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_10_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_10_base.balance_from_tags + box_10_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_10_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">10_base</field>
+                                    </record>
+                                    <record id="tax_report_10_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -419,6 +774,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_10_base.balance * 0.085</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_10_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -433,8 +789,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_11_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_11_base.balance_from_tags + box_11_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_11_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">11_base</field>
+                                    </record>
+                                    <record id="tax_report_11_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -446,6 +814,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_11_base.balance * 0.021</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_11_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -465,8 +834,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_T1_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_T1_base.balance_from_tags + box_T1_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_T1_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">T1_base</field>
+                                    </record>
+                                    <record id="tax_report_T1_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -478,6 +859,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_T1_base.balance * 0.0175</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_T1_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -492,8 +874,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_T2_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_T2_base.balance_from_tags + box_T2_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_T2_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">T2_base</field>
+                                    </record>
+                                    <record id="tax_report_T2_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -505,6 +899,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_T2_base.balance * 0.0105</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_T2_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -519,8 +914,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_T3_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_T3_base.balance_from_tags + box_T3_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_T3_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">T3_base</field>
+                                    </record>
+                                    <record id="tax_report_T3_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -532,6 +939,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_T3_base.balance * 0.1</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_T3_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -546,8 +954,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_T4_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_T4_base.balance_from_tags + box_T4_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_T4_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">T4_base</field>
+                                    </record>
+                                    <record id="tax_report_T4_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -559,6 +979,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_T4_base.balance * 0.021</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_T4_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -573,8 +994,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_T5_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_T5_base.balance_from_tags + box_T5_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_T5_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">T5_base</field>
+                                    </record>
+                                    <record id="tax_report_T5_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -586,6 +1019,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_T5_base.balance * 0.009</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_T5_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -600,8 +1034,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_T6_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_T6_base.balance_from_tags + box_T6_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_T6_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">T6_base</field>
+                                    </record>
+                                    <record id="tax_report_T6_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -613,6 +1059,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_T6_base.balance * 0.021</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_T6_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -627,8 +1074,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_T7_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_T7_base.balance_from_tags + box_T7_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_T7_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">T7_base</field>
+                                    </record>
+                                    <record id="tax_report_T7_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -649,8 +1108,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_13_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_13_base.balance_from_tags + box_13_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_13_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">13_base</field>
+                                    </record>
+                                    <record id="tax_report_13_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -671,8 +1142,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_14_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_14_base.balance_from_tags + box_14_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_14_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">14_base</field>
+                                    </record>
+                                    <record id="tax_report_14_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -698,8 +1181,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_P1_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_P1_base.balance_from_tags + box_P1_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_P1_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">P1_base</field>
+                                    </record>
+                                    <record id="tax_report_P1_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -711,6 +1206,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_P1_base.balance * 0.2</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_P1_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -725,8 +1221,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_P2_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_P2_base.balance_from_tags + box_P2_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_P2_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">P2_base</field>
+                                    </record>
+                                    <record id="tax_report_P2_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -738,6 +1246,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_P2_base.balance * 0.13</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_P2_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -757,8 +1266,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_I1_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_I1_base.balance_from_tags + box_I1_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_I1_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">I1_base</field>
+                                    </record>
+                                    <record id="tax_report_I1_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -770,6 +1291,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_I1_base.balance * 0.2</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_I1_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -784,8 +1306,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_I2_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_I2_base.balance_from_tags + box_I2_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_I2_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">I2_base</field>
+                                    </record>
+                                    <record id="tax_report_I2_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -797,6 +1331,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_I2_base.balance * 0.1</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_I2_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -811,8 +1346,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_I3_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_I3_base.balance_from_tags + box_I3_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_I3_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">I3_base</field>
+                                    </record>
+                                    <record id="tax_report_I3_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -824,6 +1371,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_I3_base.balance * 0.085</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_I3_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -838,8 +1386,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_I4_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_I4_base.balance_from_tags + box_I4_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_I4_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">I4_base</field>
+                                    </record>
+                                    <record id="tax_report_I4_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -851,6 +1411,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_I4_base.balance * 0.055</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_I4_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -865,8 +1426,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_I5_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_I5_base.balance_from_tags + box_I5_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_I5_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">I5_base</field>
+                                    </record>
+                                    <record id="tax_report_I5_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -878,6 +1451,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_I5_base.balance * 0.021</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_I5_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -892,8 +1466,20 @@
                                 <field name="expression_ids">
                                     <record id="tax_report_I6_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_I6_base.balance_from_tags + box_I6_base.adjustment</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                    <record id="tax_report_I6_base_balance_from_tags" model="account.report.expression">
+                                        <field name="label">balance_from_tags</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">I6_base</field>
+                                    </record>
+                                    <record id="tax_report_I6_base_adjustment" model="account.report.expression">
+                                        <field name="label">adjustment</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=0</field>
                                     </record>
                                 </field>
                             </record>
@@ -905,6 +1491,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_I6_base.balance * 0.0105</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                     <record id="tax_report_I6_taxe_tag_no_rounding" model="account.report.expression">
                                         <field name="label">balance_from_tags</field>
@@ -962,7 +1549,15 @@
                             <record id="tax_report_16" model="account.report.line">
                                 <field name="name">16 - Total gross VAT due</field>
                                 <field name="code">box_16</field>
-                                <field name="aggregation_formula">box_08_taxe.balance_from_tags + box_09_taxe.balance_from_tags + box_9B_taxe.balance_from_tags + box_10_taxe.balance_from_tags + box_11_taxe.balance_from_tags + box_13_taxe.balance + box_14_taxe.balance + box_T1_taxe.balance_from_tags + box_T2_taxe.balance_from_tags + box_T3_taxe.balance_from_tags + box_T4_taxe.balance_from_tags + box_T5_taxe.balance_from_tags + box_T6_taxe.balance_from_tags + box_T7_taxe.balance + box_P1_taxe.balance_from_tags + box_P2_taxe.balance_from_tags + box_I1_taxe.balance_from_tags + box_I2_taxe.balance_from_tags + box_I3_taxe.balance_from_tags + box_I4_taxe.balance_from_tags + box_I5_taxe.balance_from_tags + box_I6_taxe.balance_from_tags + box_15.balance + box_5B.balance</field>
+                                <field name="aggregation_formula"></field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_16_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_08_taxe.balance + box_09_taxe.balance + box_9B_taxe.balance + box_10_taxe.balance + box_11_taxe.balance + box_13_taxe.balance + box_14_taxe.balance + box_T1_taxe.balance + box_T2_taxe.balance + box_T3_taxe.balance + box_T4_taxe.balance + box_T5_taxe.balance + box_T6_taxe.balance + box_T7_taxe.balance + box_P1_taxe.balance + box_P2_taxe.balance + box_I1_taxe.balance + box_I2_taxe.balance + box_I3_taxe.balance + box_I4_taxe.balance + box_I5_taxe.balance + box_I6_taxe.balance + box_15.balance + box_5B.balance</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                </field>
                             </record>
                             <record id="tax_report_17" model="account.report.line">
                                 <field name="name">17 - Of which VAT on intra-Community acquisitions</field>
@@ -1043,6 +1638,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">box_22.tag + box_22._applied_carryover_balance</field>
+                                        <field name="subformula">round(0)</field>
                                     </record>
                                 </field>
                             </record>
@@ -1071,7 +1667,15 @@
                             <record id="tax_report_23" model="account.report.line">
                                 <field name="name">23 - Total deductible VAT</field>
                                 <field name="code">box_23</field>
-                                <field name="aggregation_formula">box_19.balance + box_20.balance + box_21.balance + box_22.balance + box_2C.balance</field>
+                                <field name="aggregation_formula"></field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_23_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_19.balance + box_20.balance + box_21.balance + box_22.balance + box_2C.balance</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                </field>
                             </record>
                             <record id="tax_report_24" model="account.report.line">
                                 <field name="name">24 - Of which deductible VAT on imports</field>
@@ -1172,7 +1776,15 @@
                             <record id="tax_report_TIC_total" model="account.report.line">
                                 <field name="name">Total</field>
                                 <field name="code">box_TIC_total</field>
-                                <field name="aggregation_formula">box_TICFE.balance + box_TICGN.balance + box_TICC.balance</field>
+                                <field name="aggregation_formula"></field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_TIC_total_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_TICFE.balance + box_TICGN.balance + box_TICC.balance</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                </field>
                             </record>
                         </field>
                     </record>
@@ -1215,7 +1827,15 @@
                             <record id="tax_report_X4" model="account.report.line">
                                 <field name="name">X4</field>
                                 <field name="code">box_X4</field>
-                                <field name="aggregation_formula">box_X1.balance + box_X2.balance + box_X3.balance</field>
+                                <field name="aggregation_formula"></field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_X4_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_X1.balance + box_X2.balance + box_X3.balance</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                </field>
                             </record>
                         </field>
                     </record>
@@ -1225,17 +1845,41 @@
                             <record id="tax_report_Y1" model="account.report.line">
                                 <field name="name">Y1</field>
                                 <field name="code">box_Y1</field>
-                                <field name="aggregation_formula">box_TICFE.balance - box_X1.balance</field>
+                                <field name="aggregation_formula"></field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_Y1_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_TICFE.balance - box_X1.balance</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                </field>
                             </record>
                             <record id="tax_report_Y2" model="account.report.line">
                                 <field name="name">Y2</field>
                                 <field name="code">box_Y2</field>
-                                <field name="aggregation_formula">box_TICGN.balance - box_X2.balance</field>
+                                <field name="aggregation_formula"></field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_Y2_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_TICGN.balance - box_X2.balance</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                </field>
                             </record>
                             <record id="tax_report_Y3" model="account.report.line">
                                 <field name="name">Y3</field>
                                 <field name="code">box_Y3</field>
-                                <field name="aggregation_formula">box_TICC.balance - box_X3.balance</field>
+                                <field name="aggregation_formula"></field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_Y3_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_TICC.balance - box_X3.balance</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                </field>
                             </record>
                             <record id="tax_report_Y4" model="account.report.line">
                                 <field name="name">Y4</field>
@@ -1283,7 +1927,15 @@
                             <record id="tax_report_Z4" model="account.report.line">
                                 <field name="name">Z4</field>
                                 <field name="code">box_Z4</field>
-                                <field name="aggregation_formula">box_Z1.balance + box_Z2.balance + box_Z3.balance</field>
+                                <field name="aggregation_formula"></field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_Z4_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">box_Z1.balance + box_Z2.balance + box_Z3.balance</field>
+                                        <field name="subformula">round(0)</field>
+                                    </record>
+                                </field>
                             </record>
                         </field>
                     </record>
@@ -1322,6 +1974,12 @@
                         <field name="expression_ids">
                             <record id="tax_report_27_formula" model="account.report.expression">
                                 <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">box_27._balance_temp</field>
+                                <field name="subformula">round(0)</field>
+                            </record>
+                            <record id="tax_report_27_formula_temp" model="account.report.expression">
+                                <field name="label">_balance_temp</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">box_25.balance - box_26.balance - box_AA.balance</field>
                                 <field name="subformula">if_above(EUR(0))</field>
@@ -1384,7 +2042,15 @@
                     <record id="tax_report_32" model="account.report.line">
                         <field name="name">32 - Total payable</field>
                         <field name="code">box_32</field>
-                        <field name="aggregation_formula">box_28.balance + box_29.balance + box_Z5.balance</field>
+                        <field name="aggregation_formula"></field>
+                        <field name="expression_ids">
+                            <record id="tax_report_32_formula" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">box_28.balance + box_29.balance + box_Z5.balance</field>
+                                <field name="subformula">round(0)</field>
+                            </record>
+                        </field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_fr/i18n/fr.po
+++ b/addons/l10n_fr/i18n/fr.po
@@ -251,6 +251,11 @@ msgid "Account Chart Template"
 msgstr "Modèle de plan comptable"
 
 #. module: l10n_fr
+#: model:account.report.column,name:l10n_fr.tax_report_adjustment
+msgid "Adjustment"
+msgstr "Ajustement"
+
+#. module: l10n_fr
 #: model:account.report.line,name:l10n_fr.tax_report_decompte_tva
 msgid "B. Settlement of VAT to be paid"
 msgstr "B. Décompte de la TVA à payer"
@@ -500,14 +505,14 @@ msgid "Imports"
 msgstr "Importations"
 
 #. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company__l10n_fr_rounding_difference_loss_account_id
-msgid "L10N Fr Rounding Difference Loss Account"
-msgstr "L10N Fr Compte de pertes sur différence d'arrondi"
-
-#. module: l10n_fr
 #: model:ir.model.fields,field_description:l10n_fr.field_res_company__is_france_country
 msgid "Is Part of DOM-TOM"
 msgstr "Fait partie de DOM-TOM"
+
+#. module: l10n_fr
+#: model:ir.model.fields,field_description:l10n_fr.field_res_company__l10n_fr_rounding_difference_loss_account_id
+msgid "L10N Fr Rounding Difference Loss Account"
+msgstr "L10N Fr Compte de pertes sur différence d'arrondi"
 
 #. module: l10n_fr
 #: model:ir.model.fields,field_description:l10n_fr.field_res_company__l10n_fr_rounding_difference_profit_account_id

--- a/addons/l10n_fr/i18n/l10n_fr.pot
+++ b/addons/l10n_fr/i18n/l10n_fr.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-12 08:51+0000\n"
-"PO-Revision-Date: 2024-11-12 08:51+0000\n"
+"POT-Creation-Date: 2025-04-04 13:48+0000\n"
+"PO-Revision-Date: 2025-04-04 13:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -240,6 +240,11 @@ msgstr ""
 #. module: l10n_fr
 #: model:ir.model,name:l10n_fr.model_account_chart_template
 msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_fr
+#: model:account.report.column,name:l10n_fr.tax_report_adjustment
+msgid "Adjustment"
 msgstr ""
 
 #. module: l10n_fr
@@ -479,13 +484,13 @@ msgid "Imports"
 msgstr ""
 
 #. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company__l10n_fr_rounding_difference_loss_account_id
-msgid "L10N Fr Rounding Difference Loss Account"
+#: model:ir.model.fields,field_description:l10n_fr.field_res_company__is_france_country
+msgid "Is Part of DOM-TOM"
 msgstr ""
 
 #. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company__is_france_country
-msgid "Is Part of DOM-TOM"
+#: model:ir.model.fields,field_description:l10n_fr.field_res_company__l10n_fr_rounding_difference_loss_account_id
+msgid "L10N Fr Rounding Difference Loss Account"
 msgstr ""
 
 #. module: l10n_fr


### PR DESCRIPTION
DGI only wants units without any decimals. 
That was already done. 
But they want these amounts to be the base for the other computations. 
For instance tax amount is simply ratio * total base for this tax. 
So we need all the lines to take the rounding into account, which is done with the subformula.

We also add the possibility for the client to fix some values by adding an editable second column.
The idea is that the sum of the bases for the rates must be equal to the sum of the bases for the types.
We can't guarantee it due to the rounding and we can't fix it automatically. 
The client then needs to modify the lines himself.

opw-4590719




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
