### PR TITLE
[FIX] sale_timesheet, _*: fix duplicate Sale Order creation on the fly

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -160,6 +160,7 @@
                 <attribute name="invisible">not allow_billable</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="after">
+                <!-- TODO: remove project_sale_order_id in master -->
                 <field name="project_sale_order_id" invisible="1"/>
                 <field name="sale_order_id" invisible="True" groups="sales_team.group_sale_salesman"/>
                 <field name="sale_line_id"
@@ -177,7 +178,7 @@
                         'form_view_ref': 'sale_project.sale_order_line_view_form_editable',
                         'default_partner_id': partner_id,
                         'default_company_id': company_id,
-                        'default_order_id': project_sale_order_id,
+                        'default_order_id': sale_order_id,
                     }"
                     placeholder="Non-billable"
                     readonly="0"

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -175,6 +175,7 @@
                         'form_view_ref': 'sale_project.sale_order_line_view_form_editable',
                         'default_partner_id': partner_id,
                         'company_id': company_id,
+                        'default_order_id': sale_order_id,
                     }</attribute>
                 </xpath>
             </field>


### PR DESCRIPTION
_*= sale_project
**Issue:**
When a new sale order line is created on the fly, a new Sale Order is being created instead of reusing an existing one.

**Root Cause:** 
This happens when the project_sale_order is not being passed correctly in the context, causing a new Sale Order to be created.

**Fix:**
Explicitly pass the default_order_id in the context. If an existing Sale Order is found, it will be reused instead of creating a new one.

**Technical Details:**
Updated the `default_order_id` to use sale_order_id instead of `project_sale_order_id` in `sale_project`. This ensures that the field functions correctly even when `project_sale_order_id` is empty.

**task-4276677**


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
