### PR TITLE
[FIX] point_of_sale: correctly display the price for tax-exempt customers on products with tax-inclusive pricing 

### DIFF
--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -168,7 +168,7 @@ registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
             ProductScreen.clickDisplayedProduct("Product Test"),
             ProductScreen.totalAmountIs("100.00"),
             ProductScreen.clickFiscalPosition("No Tax"),
-            ProductScreen.totalAmountIs("100.00"),
+            ProductScreen.totalAmountIs("86.96"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
             PaymentScreen.clickValidate(),
@@ -180,7 +180,7 @@ registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
             TicketScreen.confirmRefund(),
             ProductScreen.isShown(),
             { ...ProductScreen.back(), isActive: ["mobile"] },
-            ProductScreen.totalAmountIs("100.00"),
+            ProductScreen.totalAmountIs("86.96"),
         ].flat(),
 });
 


### PR DESCRIPTION

**Issue:**
When selling a product with a tax-inclusive price to a customer who is tax-exempt (e.g., under a "Rest of the World" fiscal position with a 0% tax mapping), the Point of Sale displayed the tax-inclusive price instead of the correct tax-exclusive price.

**Steps to Reproduce:**
1. Install the Sales, Point of Sale, and Accounting applications.
2. Create a product with a price configured to include taxes (e.g., a 20% VAT included in the sale price).
3. Create a customer and assign them a fiscal position that maps the product's default inclusive tax to a 0% tax (e.g., a "Rest of the World" fiscal position).
4. Create a fiscal position tax rule for the "Rest of the World" position, mapping the inclusive tax on the created product to a 0% tax.
5. Open the Point of Sale interface.
6. Select the customer created in step 3.
7. Add the product created in step 2 to the order.
8. Observe the total price displayed for the product.

Expected Behavior:
The Point of Sale should display the price of the product excluding the previously included tax, reflecting the 0% tax rate for the selected customer.

Actual Behavior:
The Point of Sale incorrectly displayed the original tax-inclusive price, even though the applied tax amount was shown as $0.

**Root Cause:**
The `get_tax_details` method calculates the base price (tax-exclusive) after the product's taxes have already been potentially remapped to 0% based on the customer's fiscal position. Consequently, when a product with an inclusive price is sold to a tax-exempt customer, the `total_tax_amount` becomes zero. The logic in `get_tax_details`,at line 368, that intends to adjust the base price when taxes are included doesn't trigger correctly because `total_tax_amount` is already zero, leaving the `raw_base` (which is derived from the tax-inclusive `price_unit`) unchanged.

**Fix:**
To resolve this, when preparing the base lines for tax computation, the code now detects if a product originally had a tax-inclusive price and if the effective tax rate has become 0%. In such cases, the `price_unit` of the order line is explicitly adjusted to its tax-exclusive value by reversing the original tax inclusion. This ensures that subsequent tax calculations and the final displayed price correctly reflect the tax-exempt status of the customer.

Opw-4592602 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
