### PR TITLE
[FIX] l10n_it_edi_nnd: correctly import l10n_it_payment_method

### DIFF
--- a/addons/l10n_it_edi_ndd/models/account_move.py
+++ b/addons/l10n_it_edi_ndd/models/account_move.py
@@ -1,6 +1,7 @@
 from odoo import api, fields, models
 from odoo.tools.sql import column_exists, create_column
 from odoo.addons.l10n_it_edi_ndd.models.account_payment_methode_line import L10N_IT_PAYMENT_METHOD_SELECTION
+from odoo.addons.l10n_it_edi.models.account_move import get_text
 
 
 class AccountMove(models.Model):
@@ -80,3 +81,16 @@ class AccountMove(models.Model):
         for move in reverse_moves:
             move.l10n_it_document_type = False
         return reverse_moves
+
+    def _l10n_it_edi_import_invoice(self, invoice, data, is_new):
+        res = super()._l10n_it_edi_import_invoice(invoice=invoice, data=data, is_new=is_new)
+        if not res:
+            return
+        self = res
+
+        #l10n_it_payment_method
+        if payment_method := get_text(data['xml_tree'], '//DatiPagamento/DettaglioPagamento/ModalitaPagamento'):
+            if payment_method in self.env['account.payment.method.line']._get_l10n_it_payment_method_selection_code():
+                self.l10n_it_payment_method = payment_method
+
+        return self

--- a/addons/l10n_it_edi_ndd/models/account_payment_methode_line.py
+++ b/addons/l10n_it_edi_ndd/models/account_payment_methode_line.py
@@ -35,3 +35,6 @@ class AccountPaymentMethodLine(models.Model):
         string="Italian Payment Method",
         default='MP05',
     )
+
+    def _get_l10n_it_payment_method_selection_code(self):
+        return [payment_method[0] for payment_method in L10N_IT_PAYMENT_METHOD_SELECTION]

--- a/addons/l10n_it_edi_ndd/tests/__init__.py
+++ b/addons/l10n_it_edi_ndd/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_account_move_payment_method
+from . import test_edi_import

--- a/addons/l10n_it_edi_ndd/tests/import_xmls/IT01234567888_FPR01.xml
+++ b/addons/l10n_it_edi_ndd/tests/import_xmls/IT01234567888_FPR01.xml
@@ -1,0 +1,133 @@
+<p:FatturaElettronica versione="FPR12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                      xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>00001</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>ABC1234</CodiceDestinatario>
+            <ContattiTrasmittente/>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>00313371213</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>93026890017</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF19</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIALE ROMA 543</Indirizzo>
+                <CAP>07100</CAP>
+                <Comune>SASSARI</Comune>
+                <Provincia>SS</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>DITTA BETA</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIA TORINO 38-B</Indirizzo>
+                <CAP>00145</CAP>
+                <Comune>ROMA</Comune>
+                <Provincia>RM</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2014-12-18</Data>
+                <Numero>01234567888</Numero>
+                <Causale>LA FATTURA FA RIFERIMENTO AD UNA OPERAZIONE AAAA BBBBBBBBBBBBBBBBBB CCC DDDDDDDDDDDDDDD E
+                    FFFFFFFFFFFFFFFFFFFF GGGGGGGGGG HHHHHHH II LLLLLLLLLLLLLLLLL MMM NNNNN OO PPPPPPPPPPP QQQQ RRRR
+                    SSSSSSSSSSSSSS
+                </Causale>
+                <Causale>SEGUE DESCRIZIONE CAUSALE NEL CASO IN CUI NON SIANO STATI SUFFICIENTI 200 CARATTERI AAAAAAAAAAA
+                    BBBBBBBBBBBBBBBBB
+                </Causale>
+            </DatiGeneraliDocumento>
+            <DatiOrdineAcquisto>
+                <RiferimentoNumeroLinea>1</RiferimentoNumeroLinea>
+                <IdDocumento>66685</IdDocumento>
+                <NumItem>1</NumItem>
+            </DatiOrdineAcquisto>
+            <DatiContratto>
+                <RiferimentoNumeroLinea>1</RiferimentoNumeroLinea>
+                <IdDocumento>01234567890</IdDocumento>
+                <Data>2012-09-01</Data>
+                <NumItem>5</NumItem>
+                <CodiceCUP>01234567890abc</CodiceCUP>
+                <CodiceCIG>456def</CodiceCIG>
+            </DatiContratto>
+            <DatiTrasporto>
+                <DatiAnagraficiVettore>
+                    <IdFiscaleIVA>
+                        <IdPaese>IT</IdPaese>
+                        <IdCodice>24681012141</IdCodice>
+                    </IdFiscaleIVA>
+                    <Anagrafica>
+                        <Denominazione>Trasporto spa</Denominazione>
+                    </Anagrafica>
+                </DatiAnagraficiVettore>
+                <DataOraConsegna>2012-10-22T16:46:12.000+02:00</DataOraConsegna>
+            </DatiTrasporto>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>Cool stuff</Descrizione>
+                <Quantita>5.00</Quantita>
+                <PrezzoUnitario>1.00</PrezzoUnitario>
+                <PrezzoTotale>5.00</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>2</NumeroLinea>
+                <Descrizione>OtherAccount</Descrizione>
+                <Quantita>3.00</Quantita>
+                <PrezzoUnitario>8.00</PrezzoUnitario>
+                <PrezzoTotale>24.00</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>3</NumeroLinea>
+                <Descrizione>GuessTaxes</Descrizione>
+                <Quantita>1.00</Quantita>
+                <PrezzoUnitario>10.00</PrezzoUnitario>
+                <PrezzoTotale>10.00</PrezzoTotale>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>29.00</ImponibileImporto>
+                <Imposta>6.38</Imposta>
+                <EsigibilitaIVA>I</EsigibilitaIVA>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP01</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP01</ModalitaPagamento>
+                <DataScadenzaPagamento>2015-01-30</DataScadenzaPagamento>
+                <ImportoPagamento>36.48</ImportoPagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/addons/l10n_it_edi_ndd/tests/test_edi_import.py
+++ b/addons/l10n_it_edi_ndd/tests/test_edi_import.py
@@ -1,0 +1,28 @@
+import uuid
+from freezegun import freeze_time
+from unittest.mock import patch
+
+from odoo import fields, sql_db, tools, Command
+from odoo.tests import new_test_user, tagged
+from odoo.addons.l10n_it_edi.tests.common import TestItEdi
+
+import logging
+_logger = logging.getLogger(__name__)
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestItEdiImportNdd(TestItEdi):
+
+    def test_l10n_it_payment_method_correctly_imported(self):
+        self._assert_import_invoice('IT01234567890_FPR01.xml', [{
+            'move_type': 'in_invoice',
+            'invoice_date': fields.Date.from_string('2014-12-18'),
+            'amount_untaxed': 5.0,
+            'amount_tax': 1.1,
+            'invoice_line_ids': [{
+                'quantity': 5.0,
+                'price_unit': 1.0,
+                'debit': 5.0,
+            }],
+            'l10n_it_payment_method': 'MP01',
+        }])


### PR DESCRIPTION
- With a IT company, create a vendor bill with a line with the tax 22% G RC and set l10n_it_payment_method to MP01.
- Export the bill with "Send Tax Integration".
- Import the xml generated.

The l10n_it_payment_method field is not set to MP01. In the l10n_it_edi_import_invoice, the l10n_it_payment_method field was not imported

opw-4646816

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
