### PR TITLE
[FIX] point_of_sale: Fix pos product image class

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -12,7 +12,7 @@
                 <i class="product-information-tag-logo fa fa-info" role="img" aria-label="Product Information" title="Product Information" />
             </div>
             <div t-if="props.imageUrl" class="product-img rounded-top rounded-3">
-                <img class="w-100 bg-100" t-att-src="props.imageUrl" t-att-alt="props.name" />
+                <img class="w-100 bg-100" t-att-src="props.imageUrl" t-att-alt="props.name" style="object-fit: scale-down;"/>
             </div>
             <div class="product-content d-flex flex-row px-2 justify-content-between rounded-bottom rounded-3 flex-shrink-1" t-att-class="{'h-100' : !props.imageUrl}">
                 <div class="overflow-hidden lh-sm product-name my-2"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

> - When we open the POS register, products get cropped and zoomed in version 18.0

Link to OPW :[4571051](https://www.odoo.com/odoo/project/70/tasks/4571051)

**Steps:**

> - Install module: point_of_sale
> - Open Point of sale -> Continue selling in dashboard -> and show the images

Current behavior before PR:

    Before fix:
![POS_BEFORE](https://github.com/user-attachments/assets/c4ca301a-e364-4963-9bba-48c506b5f714)

    After fix:
![POS AFTER](https://github.com/user-attachments/assets/1428a9be-ba8f-47ea-b0f5-110c0f09b7ec)


Desired behavior after PR is merged:

     - All product images are appropriately shown after my fix
     - The issue comes in version 18.0, saas~18.1 and saas~18.2


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
