### PR TITLE
[FIX] hr_expense: prevent OCR overriding expense name

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1176,6 +1176,11 @@ class HrExpense(models.Model):
         self._message_set_main_attachment_id(self.env["ir.attachment"].browse(kwargs['attachment_ids'][-1:]), force=True)
 
     @api.model
+    def _get_untitled_expense_name(self):
+        """ Done in a specific function to be called by hr_expense_extract to keep the same translation """
+        return _("Untitled Expense")
+
+    @api.model
     def create_expense_from_attachments(self, attachment_ids=None, view_type='list'):
         """
             Create the expenses from files.
@@ -1198,7 +1203,7 @@ class HrExpense(models.Model):
 
         for attachment in attachments:
             vals = {
-                'name': _("Untitled Expense %s", format_date(self.env, fields.Date.context_today(self))),
+                'name':  f"{self._get_untitled_expense_name()} {format_date(self.env, fields.Date.context_today(self))}",
                 'price_unit': 0,
                 'product_id': product.id,
             }


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/commit/ca1f644a3c15f17482f56a2ece2a57f0f03098ff introduced the "untitled expense" title for expense when being uploaded. The user can then change manually the name. However, if the OCR is called after, it overrides the name previously set by the user. Therefore, if the name of an expense starts with "Untitled Expense", the OCR should not override the name. In this community PR, we define a new function to keep the same translation for "Untitled Expense".

task-4653999


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
