### PR TITLE
[FIX] loyalty: prevent archiving product used for specific discounts

### DIFF
--- a/addons/loyalty/models/product_product.py
+++ b/addons/loyalty/models/product_product.py
@@ -11,9 +11,12 @@ class ProductProduct(models.Model):
     def write(self, vals):
         if not vals.get('active', True) and any(product.active for product in self):
             # Prevent archiving products used for giving rewards
-            rewards = self.env['loyalty.reward'].sudo().search(
-                [('discount_line_product_id', 'in', self.ids), ('active', '=', True)], limit=1
-            )
+            rewards = self.env['loyalty.reward'].sudo().search([
+                ('active', '=', True),
+                '|',
+                ('discount_line_product_id', 'in', self.ids),
+                ('discount_product_ids', 'in', self.ids),
+            ], limit=1)
             if rewards:
                 raise ValidationError(_("This product may not be archived. It is being used for an active promotion program."))
         return super().write(vals)

--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -20,7 +20,11 @@ class TestLoyalty(TransactionCase):
             'name': 'Test Program',
             'reward_ids': [(0, 0, {})],
         })
-
+        cls.product = cls.env['product.product'].with_context(default_taxes_id=False).create({
+            'name': "Test Product",
+            'detailed_type': 'consu',
+            'list_price': 20.0,
+        })
 
     def test_discount_product_unlink(self):
         # Test that we can not unlink dicount line product id
@@ -141,11 +145,7 @@ class TestLoyalty(TransactionCase):
     def test_prevent_archiving_product_linked_to_active_loyalty_reward(self):
         self.program.program_type = 'promotion'
         self.program.flush_recordset()
-        product = self.env['product.product'].with_context(default_taxes_id=False).create({
-            'name': 'Test Product',
-            'detailed_type': 'consu',
-            'list_price': 20.0,
-        })
+        product = self.product
         reward = self.env['loyalty.reward'].create({
             'program_id': self.program.id,
             'discount_line_product_id': product.id,
@@ -158,18 +158,27 @@ class TestLoyalty(TransactionCase):
         self.program.action_archive()
         product.action_archive()
 
+    def test_prevent_archiving_product_used_for_discount_reward(self):
+        self.program.program_type = 'promotion'
+        self.program.write({
+            'reward_ids': [Command.create({
+                'discount': 50.0,
+                'discount_applicability': 'specific',
+                'discount_product_ids': self.product.ids,
+            })],
+        })
+        with self.assertRaises(ValidationError):
+            self.product.action_archive()
+        self.program.action_archive()
+        self.product.action_archive()
+
     def test_prevent_archiving_product_when_archiving_program(self):
         """
         Test prevent archiving a product when archiving a "Buy X Get Y" program.
         We just have to archive the free product that has been created while creating
         the program itself not the product we already had before.
         """
-        product = self.env['product.product'].with_context(default_taxes_id=False).create({
-            'name': 'Test Product',
-            'detailed_type': 'consu',
-            'list_price': 20.0,
-        })
-
+        product = self.product
         loyalty_program = self.env['loyalty.program'].create({
             'name': 'Test Program',
             'program_type': 'buy_x_get_y',
@@ -187,12 +196,8 @@ class TestLoyalty(TransactionCase):
 
     def test_card_description_on_tag_change(self):
         product_tag = self.env['product.tag'].create({'name': 'Multiple Products'})
-        product1 = self.env['product.product'].create({
-            'name': 'Test Product',
-            'detailed_type': 'consu',
-            'list_price': 20.0,
-            'product_tag_ids': product_tag,
-        })
+        product1 = self.product
+        product1.product_tag_ids = product_tag
         self.env['product.product'].create({
             'name': 'Test Product 2',
             'detailed_type': 'consu',


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Create a promotion program;
2. add a reward that offers a discount on a specific product;
3. specify a specific product;
4. archive the specified specific product;
5. create a sales order with a random product;
6. apply applicable rewards.

Issue
-----
The reward's specific discount has become applicable to all products.

Cause
-----
After archiving a product, the reward's `discount_product_ids` becomes empty unless `active_test=False` is added to the context.

With this field empty, and no otherwise specified product domain, the discount can be applied to any product.

Solution
--------
Prevent archiving products that have an active program applying a specific discount to them.

opw-4246768