### PR TITLE
[IMP] orm: origin_ids performance

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -71,7 +71,7 @@ from .fields_textual import Char
 
 from .identifiers import NewId
 from .utils import (
-    OriginIds, check_object_name, origin_ids, parse_field_expr,
+    OriginIds, check_object_name, parse_field_expr,
     COLLECTION_TYPES, SQL_OPERATORS,
     READ_GROUP_ALL_TIME_GRANULARITY, READ_GROUP_TIME_GRANULARITY, READ_GROUP_NUMBER_GRANULARITY,
     SUPERUSER_ID,
@@ -5576,7 +5576,7 @@ class BaseModel(metaclass=MetaModel):
         """ Return the list of actual record ids corresponding to ``self``. """
         if all(self._ids):
             return list(self._ids)  # already real records
-        return list(origin_ids(self._ids))
+        return list(OriginIds(self._ids))
 
     # backward-compatibility with former browse records
     _cr = property(lambda self: self.env.cr)
@@ -6231,7 +6231,7 @@ class BaseModel(metaclass=MetaModel):
         """ Return the actual records corresponding to ``self``. """
         if all(self._ids):
             return self  # already real records
-        ids = tuple(origin_ids(self._ids))
+        ids = tuple(OriginIds(self._ids))
         prefetch_ids = OriginIds(self._prefetch_ids)
         return self.__class__(self.env, ids, prefetch_ids)
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5574,6 +5574,8 @@ class BaseModel(metaclass=MetaModel):
     @property
     def ids(self) -> list[int]:
         """ Return the list of actual record ids corresponding to ``self``. """
+        if all(self._ids):
+            return list(self._ids)  # already real records
         return list(origin_ids(self._ids))
 
     # backward-compatibility with former browse records
@@ -6227,6 +6229,8 @@ class BaseModel(metaclass=MetaModel):
     @property
     def _origin(self) -> Self:
         """ Return the actual records corresponding to ``self``. """
+        if all(self._ids):
+            return self  # already real records
         ids = tuple(origin_ids(self._ids))
         prefetch_ids = OriginIds(self._prefetch_ids)
         return self.__class__(self.env, ids, prefetch_ids)

--- a/odoo/orm/utils.py
+++ b/odoo/orm/utils.py
@@ -126,22 +126,24 @@ def expand_ids(id0, ids):
             seen.add(id_)
 
 
-def origin_ids(ids):
-    """ Return an iterator over the origin ids corresponding to ``ids``.
+class OriginIds:
+    """ A reversible iterable returning the origin ids of a collection of ``ids``.
         Actual ids are returned as is, and ids without origin are not returned.
     """
-    return ((id_ or id_.origin) for id_ in ids if (id_ or getattr(id_, "origin", None)))
-
-
-class OriginIds:
-    """ A reversible iterable returning the origin ids of a collection of ``ids``. """
     __slots__ = ['ids']
 
     def __init__(self, ids):
         self.ids = ids
 
     def __iter__(self):
-        return origin_ids(self.ids)
+        for id_ in self.ids:
+            if id_ := id_ or getattr(id_, 'origin', None):
+                yield id_
 
     def __reversed__(self):
-        return origin_ids(reversed(self.ids))
+        for id_ in reversed(self.ids):
+            if id_ := id_ or getattr(id_, 'origin', None):
+                yield id_
+
+
+origin_ids = OriginIds


### PR DESCRIPTION
Avoid calling `origin_ids` when we already have real ids.

Performance:
```
# before vs after, small recordset - bigger difference for bigger recordsets
In [1]: %timeit self.ids
189 ns ± 1.5 ns per loop
90.6 ns ± 0.499 ns per loop 

In [2]: %timeit self._origin
395 ns ± 5.43 ns per loop
35.6 ns ± 0.254 ns per loop
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
