### PR TITLE
[FIX] hr_attendance: prevent error when creating attendance without check in

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -97,7 +97,7 @@ class HrAttendance(models.Model):
         day_starts = {
             att: self._get_day_start_and_day(att.employee_id, att.check_in)
             for att in self
-            if att.employee_id
+            if att.employee_id and att.check_in
         }
         if not day_starts:
             return


### PR DESCRIPTION
When user tries to create an attendance without check in,
A traceback will appear.

Steps to reproduce the error:
- Go to Attendances > Create a new attendance
- Remove Check In time > Save & Close

Error:
```
File "/home/odoo/src/odoo/saas-18.2/addons/hr_attendance/models/hr_attendance.py", line 98, in _compute_overtime_hours
    att: self._get_day_start_and_day(att.employee_id, att.check_in)
  File "/home/odoo/src/odoo/saas-18.2/addons/hr_attendance/models/hr_attendance.py", line 268, in _get_day_start_and_day
    if not dt.tzinfo:
AttributeError: 'bool' object has no attribute 'tzinfo'
```

When user creates attendance, ``_compute_overtime_hours`` method will be called. https://github.com/odoo/odoo/blob/74be92ad3b26c60ccb222492e5fb770174f95d11/addons/hr_attendance/models/hr_attendance.py#L95-L100
Here, ``_compute_overtime_hours`` method will call  ``_get_day_start_and_day``
without checking ``check_in``.
So, It will lead to the above Traceback.

sentry-6452618270

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
