### PR TITLE
[FIX] web: display contact and title on different levels in Bubble layout

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -728,12 +728,23 @@
              t-att-data-oe-model="o and o._name"
              t-att-data-oe-id="o and o.id"
              t-att-data-oe-lang="o and o.env.context.get('lang')">
-            <div t-att-class="not information_block and 'd-flex justify-content-between align-items-end'">
-                <t t-call="web.address_layout">
-                    <t t-set="custom_layout_address" t-value="true"/>
-                </t>
-                <h2 t-attf-class="{{not information_block and 'mb-4'}} text-nowrap text-end" t-out="layout_document_title"/>
-            </div>
+            <table class="o_ignore_layout_styling table table-borderless mb-0">
+                <tbody>
+                    <tr>
+                        <td t-call="web.address_layout" class="p-0">
+                            <t t-set="custom_layout_address" t-value="true"/>
+                        </td>
+                        <td t-if="not information_block" class="align-bottom p-0 ps-2">
+                            <h2 class="mb-4 text-nowrap text-end" t-out="layout_document_title"/>
+                        </td>
+                    </tr>
+                    <tr t-if="information_block">
+                        <td colspan="2" class="align-bottom p-0">
+                            <h2 class="text-nowrap text-end" t-out="layout_document_title"/>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
             <t t-out="0"/>
         </div>
 


### PR DESCRIPTION
### Steps to reproduce:
- Create a contact with a very very long name
- Change the layout of documents to "Bubble"
- Create an invoice with the new contact
- Confirm and Print
- The invoice title is unaligned or cropped

### Cause:
The layout is using a flexbox to display the contact and the title on the same level. But flex boxes are not supported by whtmltopdf so the result is random.

### Solution:
Use a `table` mimicking the flex display.

Before:
![image](https://github.com/user-attachments/assets/90bb01ad-f5b3-4321-aed9-766c4077f8ad)

After:
![image](https://github.com/user-attachments/assets/9debcb63-819b-4f75-a8cf-95bd1992b343)

opw-4653504