### PR TITLE
[FIX] l10n_ar_withholding: ensure retention computation uses company-branch environment

### DIFF
--- a/addons/l10n_ar_withholding/wizards/l10n_ar_payment_register_withholding.py
+++ b/addons/l10n_ar_withholding/wizards/l10n_ar_payment_register_withholding.py
@@ -36,24 +36,24 @@ class l10nArPaymentRegisterWithholding(models.TransientModel):
             from_date = to_date + relativedelta(day=1)
             # We search for the payments in the same month of the same regimen and the same code.
             domain_same_period_withholdings = [
-                *self.env['account.move.line']._check_company_domain(self.tax_id.company_id),
+                ('company_id', 'child_of', self.tax_id.company_id.id),
                 ('parent_state', '=', 'posted'),
                 ('tax_line_id.l10n_ar_code', '=', self.tax_id.l10n_ar_code),
                 ('tax_line_id.l10n_ar_tax_type', 'in', ['earnings', 'earnings_scale']),
                 ('partner_id', '=', self.payment_register_id.partner_id.commercial_partner_id.id),
                 ('date', '<=', to_date), ('date', '>=', from_date)]
-            if same_period_partner_withholdings := self.env['account.move.line']._read_group(domain_same_period_withholdings, ['partner_id'], ['balance:sum']):
+            if same_period_partner_withholdings := self.env['account.move.line'].sudo()._read_group(domain_same_period_withholdings, ['partner_id'], ['balance:sum']):
                 same_period_withholdings = abs(same_period_partner_withholdings[0][1])
             else:
                 same_period_withholdings = 0.0
             domain_same_period_base = [
-                *self.env['account.move.line']._check_company_domain(self.tax_id.company_id),
+                ('company_id', 'child_of', self.tax_id.company_id.id),
                 ('parent_state', '=', 'posted'),
                 ('tax_ids.l10n_ar_code', '=', self.tax_id.l10n_ar_code),
                 ('tax_ids.l10n_ar_tax_type', 'in', ['earnings', 'earnings_scale']),
                 ('partner_id', '=', self.payment_register_id.partner_id.commercial_partner_id.id),
                 ('date', '<=', to_date), ('date', '>=', from_date)]
-            if same_period_partner_base := self.env['account.move.line']._read_group(domain_same_period_base, ['partner_id'], ['balance:sum']):
+            if same_period_partner_base := self.env['account.move.line'].sudo()._read_group(domain_same_period_base, ['partner_id'], ['balance:sum']):
                 same_period_base = abs(same_period_partner_base[0][1])
             else:
                 same_period_base = 0.0


### PR DESCRIPTION
When calculating earnings-based withholdings in company-branch setups, the logic incorrectly referenced accounting entries from the mother company if the user belonged to a branch. This led to incorrect accumulation of taxable base amounts and previously withheld amounts, especially when vendor bills or payments were made in a branch.

This fix ensures that:
- The accumulation logic in `_tax_compute_all_helper` correctly scopes move line searches using the user's company.

As a result, withholding retention now behaves correctly in company-branch environments.

opw-4581579

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
