### PR TITLE
[FIX] hr_recruitment: avoid traceback on applicant for interviewer

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -121,7 +121,8 @@
                         class="oe_stat_button"
                         icon="fa-users"
                         type="object"
-                        invisible="not id or is_pool_applicant or not is_applicant_in_pool">
+                        invisible="not id or is_pool_applicant or not is_applicant_in_pool"
+                        groups="hr_recruitment.group_hr_recruitment_user">
                         <field name="talent_pool_count" widget="statinfo" string="Talent Pools"/>
                     </button>
                 </div>


### PR DESCRIPTION
**Steps to reproduce**
1. Recruitment > All applications > Chose applicant
2. Add the applicant to a talent pool ("Add to Pool")
3. Also add  as an interviewer on the applicant  a user with the "Recruitment / Interviewer" group.
4. Now log in with that user and try to view the applicant. `Access Error: doesn't hae read access to Applicant (hr.applicant)

**Cause**
In `_compute_talent_pool_count`, error since the `hr.talent.pool` model is only accessible to users with at least "Officer" rights. https://github.com/odoo/odoo/blob/66856ad6a4dae3289593b55451e6c668a221fb8e/addons/hr_recruitment/models/hr_applicant.py#L166

**Solution**
Hide the smart button if users are only "Interviewers". Since the interviewer is not copied on the new `hr.applicant` record created for the talent pool, they do  not have access by default to the records accessible through the smart button anyway.

opw-4658919