### PR TITLE
[FIX] resource,hr: fix some issues with flexible resources/employees

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -265,7 +265,7 @@ class HrEmployeeBase(models.AbstractModel):
             employee.hr_icon_display = 'presence_' + employee.hr_presence_state
             employee.show_hr_icon_display = bool(employee.user_id)
 
-    @api.depends('resource_calendar_id')
+    @api.depends('resource_calendar_id.flexible_hours')
     def _compute_is_flexible(self):
         for employee in self:
             employee.is_fully_flexible = not employee.resource_calendar_id

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -442,3 +442,19 @@ class TestHrEmployee(TestHrCommon):
         employee_form.save()
 
         self.assertEqual(employee_form.barcode, 'Testbadge2')
+
+    def test_is_flexible(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'Employee',
+        })
+        self.assertTrue(employee.resource_calendar_id)
+        self.assertFalse(employee.is_flexible)
+        self.assertFalse(employee.is_fully_flexible)
+
+        employee.resource_calendar_id.flexible_hours = True
+        self.assertTrue(employee.is_flexible)
+        self.assertFalse(employee.is_fully_flexible)
+
+        employee.resource_calendar_id = False
+        self.assertTrue(employee.is_flexible)
+        self.assertTrue(employee.is_fully_flexible)

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -518,8 +518,8 @@ class ResourceCalendar(models.Model):
             # take durations in days proportionally to what is left of the interval.
             interval_hours = (stop - start).total_seconds() / 3600
             day_hours[start.date()] += interval_hours
-            if len(self) == 1 and self.flexible_hours and self.hours_per_day:
-                day_days[start.date()] += interval_hours / self.hours_per_day
+            if len(self) == 1 and self.flexible_hours:
+                day_days[start.date()] += interval_hours / self.hours_per_day if self.hours_per_day else 0
             else:
                 day_days[start.date()] += sum(meta.mapped('duration_days')) * interval_hours / sum(meta.mapped('duration_hours'))
 


### PR DESCRIPTION
## [FIX] resource: make sure flexible resource don't use attendances

This commit makes sure the resource calendar attendance is not used for
a flexible resource even if that resource has a working schedule
with hours per day equals to 0 hour.

## [FIX] hr: recompute is_flexible when working schedule becomes flexible

Before this commit, when the user sets a working schedule to an employee
and convert that working schedule into a flexible working schedule, the
employee is not considered as working with flexible hours.

This commit makes sure the `_compute_is_flexible` method defined in
`hr.employee` model is triggered when the `flexible_hours` field of the
working schedule linked to the employee is altered.

Steps to reproduce the issue:
-----------------------------

0. Install Attendance app (`hr_attendance` module).
1. Set a working schedule A to employee E
2. Go to the form view of the working schedule A and check `Flexible
   Hours` field to convert the working schedule as flexible working
   schedule.
3. Go to Attendance app

Expected Behavior:
-----------------

The Attendance app should loaded without any issue.

Current Behavior:
----------------

A traceback is occurred saying we have a division by zero.

opw-4492625