### PR TITLE
[FIX] account: don't try being smart when importing multiple files

### DIFF
--- a/addons/account/models/ir_attachment.py
+++ b/addons/account/models/ir_attachment.py
@@ -150,6 +150,7 @@ class IrAttachment(models.Model):
         * pdf_reader:       The pdf_reader if type is pdf.
         * attachment:       The associated ir.attachment if any
         * sort_weight:      The associated weigth used for sorting the arrays
+        * originator_pdf:   The origin pdf filename in case of an embedded xml file
         """
         to_process = []
 


### PR DESCRIPTION
In case of multiple files being imported at the same time (for example, when an email with several attachments was received on a journal mail alias), the previous code was trying to detect if the given files were for the same invoice or not... But it was doing it wrongly and the processing order of attachment mattered, causing a diferent behaviour in one case or another. This bug just enlighted the fact we were trying too hard to do something smart here, where we'd actually don't need it.

So it has been decided to simplify things, and the algorithm will now simply create one invoice per valid attached file. Point. And if people have more complex needs, they should/can install the document app to handle them.

Use case:
* send an email to a mail alias with, attached in this specific order, a PDF (embedding an xml file) and a XLS.
* verify that odoo created 2 invoices, each linked to one of the files
* send an email to the same mail alias, with the same 2 files but attached on the mail in the inverse order: first the XLS and then the PDF
* odoo will create a single invoice, attaching the 2 files to it.

The reason is that
* the embedded XML is always done first
* in case 1 - PDF then XLS 

> Decoding of XML as invoice 1
> Decoding of PDF skipped because embedded XML was already imported as invoice 1 |Decoding of XLS as invoice 2 because the condition
> ```
>       # When receiving multiple files, if they have a different type, we supposed they are all linked
>       # to the same invoice.
>       if (
>           passed_file_data_list
>           and passed_file_data_list[-1]['filename'] != file_data['filename']
>           and passed_file_data_list[-1]['sort_weight'] != file_data['sort_weight']
>       ):
> ```
> 
>   is FALSE: passed_file_data_list[-1]['sort_weight'] == file_data['sort_weight'] == 100

* in case 2 - XLS then PDF 

> Decoding of XML as invoice 1
> Decoding of XLS as invoice 1 skipped because the same condition
> ```
>       # When receiving multiple files, if they have a different type, we supposed they are all linked
>       # to the same invoice.
>       if (
>           passed_file_data_list
>           and passed_file_data_list[-1]['filename'] != file_data['filename']
>           and passed_file_data_list[-1]['sort_weight'] != file_data['sort_weight']
>       ):
> ```
>  is now TRUE: passed_file_data_list[-1]['sort_weight'] == 20 and file_data['sort_weight'] == 100
> Decoding of PDF skipped because the embedded XML was already imported as invoice 1

ticket - 4510745


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
