### PR TITLE
[IMP] account, mrp, product, purchase, sale: support sections in product catalog

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -127,6 +127,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/helpers/*.js',
         ],
         'web.assets_tests': [
+            'account/static/src/js/tours/tour_utils.js',
             'account/static/tests/tours/**/*',
         ],
         'web.report_assets_common': [

--- a/addons/account/static/src/js/tours/tour_utils.js
+++ b/addons/account/static/src/js/tours/tour_utils.js
@@ -1,0 +1,54 @@
+export function addSectionFromProductCatalog() {
+    let steps = [];
+    steps.push({
+        content: "Click Catalog Button",
+        trigger: 'button[name=action_add_from_catalog]',
+        run: 'click',
+    });
+    steps.push({
+        content: "Click 'Add Section' button",
+        trigger: '.o_search_panel_sections button:contains("+ Add Section")',
+        run: 'click',
+    });
+    steps.push({
+        content: "Type new section name",
+        trigger: 'input.o_section_input',
+        run: 'edit Section A',
+    });
+    steps.push({
+        content: "Click anywhere to add the section",
+        trigger: '.o_search_panel',
+        run: 'click',
+    })
+    steps.push({
+        content: "Check section A is selected",
+        trigger: '.o_search_panel_sections .o_selected_section:contains(Section A)',
+    })
+    steps.push({
+        content: "Add a Product",
+        trigger: '.o_kanban_record:contains(Test Product)',
+        run: function () {
+            setTimeout(() => {
+                document.querySelectorAll('.o_kanban_record')[0].click();
+            }, 500);
+        },
+    });
+    steps.push({
+        content: "Wait for product to be added",
+        trigger: '.o_kanban_record:contains("Test Product"):not(:has(.fa-shopping-cart))',
+    });
+    steps.push({
+        content: "Close the catalog",
+        trigger: '.o-kanban-button-back',
+        run: 'click',
+    });
+    steps.push({
+        content: "Ensure Section is first row",
+        trigger: '.o_section_and_note_list_view tr:nth-child(1).o_is_line_section',
+    });
+    steps.push({
+        content: "Ensure Product is second row",
+        trigger: 'tbody tr:nth-child(2) .o_field_product_label_section_and_note_cell:contains(Test Product)',
+    });
+    return steps
+}

--- a/addons/account/static/tests/tours/account_product_catalog_tests.js
+++ b/addons/account/static/tests/tours/account_product_catalog_tests.js
@@ -1,3 +1,4 @@
+import { addSectionFromProductCatalog } from "@account/js/tours/tour_utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_use_product_catalog_on_invoice", {
@@ -26,4 +27,8 @@ registry.category("web_tour.tours").add("test_use_product_catalog_on_invoice", {
             trigger: ".o_field_product_label_section_and_note_cell:contains(Test Product)",
         },
     ],
+});
+
+registry.category("web_tour.tours").add('test_add_section_from_product_catalog_on_invoice', {
+    steps: () => addSectionFromProductCatalog()
 });

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -1,8 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
-
 from odoo import Command
+
 from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
 
 
@@ -107,3 +107,12 @@ class TestUi(AccountTestInvoicingHttpCommon):
         move.action_post()
         self.assertTrue(self.env.user.has_group('account.group_partial_purchase_deductibility'))
         self.start_tour("/odoo/vendor-bills/new", 'deductible_amount_column', login=self.env.user.login)
+
+    def _test_add_section_from_product_catalog_on_invoice_tour(self):
+        # TODO SHRM fix tour and uncomment
+        self.product.write({'is_favorite': True})
+        self.start_tour(
+            '/odoo/customer-invoices/new',
+            'test_add_section_from_product_catalog_on_invoice',
+            login='admin',
+        )

--- a/addons/mrp/static/src/product_catalog/search_panel.js
+++ b/addons/mrp/static/src/product_catalog/search_panel.js
@@ -1,0 +1,11 @@
+import { ProductCatalogSearchPanel } from "@product/product_catalog/search/search_panel";
+import { patch } from "@web/core/utils/patch";
+
+patch(ProductCatalogSearchPanel.prototype, {
+    get showSections() {
+        return (
+            super.showSections
+            && this.env.model.config.context.product_catalog_order_model !== 'mrp.production'
+        );
+    }
+});

--- a/addons/product/controllers/catalog.py
+++ b/addons/product/controllers/catalog.py
@@ -46,3 +46,62 @@ class ProductCatalogController(Controller):
         return order.with_company(order.company_id)._update_order_line_info(
             product_id, quantity, **kwargs,
         )
+
+    @route('/product/catalog/get_sections', auth='user', type='jsonrpc', readonly=True)
+    def product_catalog_order_get_sections(self, res_model, order_id, child_field, **kwargs):
+        """ Returns the sections which are in given order to be shown in the product catalog.
+
+        :param string res_model: The order model.
+        :param int order_id: The order id.
+        :param string child_field: The field name of the lines in the order model.
+        :rtype: list
+        :return: A list of dictionaries containing section information with following structure:
+            [
+                {
+                    'id': int,
+                    'name': string,
+                    'sequence': int,
+                    'line_count': int,
+                },
+            ]
+        """
+        order = request.env[res_model].browse(order_id)
+        return order.with_company(order.company_id)._get_order_sections(child_field, **kwargs)
+
+    @route('/product/catalog/create_section', auth='user', type='jsonrpc')
+    def product_catalog_order_create_section(
+        self, res_model, order_id, child_field, name, position, **kwargs,
+    ):
+        """ Create a new section on the given order.
+
+        :param string res_model: The order model.
+        :param int order_id: The order id.
+        :param string child_field: The field name of the lines in the order model.
+        :param string name: The name of the section to create.
+        :param str position: The position of the section where it should be created, either 'top'
+                             or 'bottom'.
+        :return: A dictionary with newly created section's 'id' and 'sequence'.
+        :rtype: dict
+        """
+        order = request.env[res_model].browse(order_id)
+        return order.with_company(order.company_id)._create_order_section(
+            child_field, name, position, **kwargs,
+        )
+
+    @route('/product/catalog/resequence_sections', auth='user', type='jsonrpc')
+    def product_catalog_order_resequence_sections(
+        self, res_model, order_id, sections, child_field, **kwargs,
+    ):
+        """ Reorder the sections of a given order.
+
+        param string res_model: The order model.
+        :param int order_id: The order id.
+        :param list sections:  A list of section dictionaries with their sequence.
+        :param string child_field: The field name of the lines in the order model.
+        :return: A dictionary with new sequences of the sections.
+        :rtype: dict
+        """
+        order = request.env[res_model].browse(order_id)
+        return order.with_company(order.company_id)._resequence_order_sections(
+            sections, child_field, **kwargs,
+        )

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -149,3 +149,177 @@ class ProductCatalogMixin(models.AbstractModel):
         :rtype: float
         """
         return 0
+
+    def _create_order_section(self, child_field, name, position, **kwargs):
+        """ Create a new section in order.
+
+        :param str child_field: Field name of the order's lines (e.g., 'order_line').
+        :param str name: The name of the section to create.
+        :param str position: The position of the section where it should be created, either 'top'
+                              or 'bottom'.
+        :param dict kwargs: Additional values given for inherited models.
+        :return: A dictionary with newly created section's 'id' and 'sequence'.
+        :rtype: dict
+        """
+        line_model, parent_field = self._get_section_model_info()
+
+        if not (line_model and parent_field):
+            return {}
+
+        lines = self[child_field]
+        sequence = 10
+        if lines:
+            sequence = (
+                lines[0].sequence - 1 if position == 'top'
+                else lines[-1].sequence + 1
+            )
+
+        section = self.env[line_model].create({
+            parent_field: self.id,
+            'name': name,
+            'display_type': 'line_section',
+            'sequence': sequence,
+            **kwargs,
+        })
+
+        return {
+            'id': section.id,
+            'sequence': section.sequence,
+        }
+
+    def _get_new_line_sequence(self, child_field, selected_section_id):
+        """ Compute the sequence number for inserting a new line into the order.
+
+        :param str child_field: Field name of the order's lines (e.g., 'order_line').
+        :param int selected_section_id: ID of the section line to insert after.
+        :return: Computed sequence number.
+        :rtype: int
+        """
+        lines = self[child_field]
+        section_lines = lines.filtered_domain([
+            ('display_type', '=', 'line_section'),
+        ]).sorted('sequence')
+
+        if selected_section_id:
+            # Insert after the selected section line
+            sequence = section_lines.filtered_domain([
+                ('id', '=', selected_section_id),
+            ]).sequence + 1
+        elif section_lines:
+            # Insert before the first section (top of the order)
+            sequence = section_lines[0].sequence
+        else:
+            # No sections exist, insert at the end
+            sequence = (lines and lines[-1].sequence + 1) or 10
+
+        for line in lines.filtered_domain([('sequence', '>=', sequence)]):
+            line.sequence += 1
+
+        return sequence
+
+    def _get_order_sections(self, child_field, **kwargs):
+        """ Return section data for the product catalog display.
+
+        :param str child_field: Field name of the order's lines (e.g., 'order_line').
+        :param dict kwargs: Additional values given for inherited models.
+        :return: List of section dicts with 'id', 'name', 'sequence', and 'line_count'.
+        :rtype: list
+        """
+        if not child_field:
+            return []
+        sections = {}
+        no_section_count = 0
+        lines = self[child_field]
+        for line in lines:
+            if line.display_type == 'line_section':
+                sections[line.id] = {
+                    'id': line.id,
+                    'name': line.name,
+                    'sequence': line.sequence,
+                    'line_count': 0,
+                }
+            elif self._is_line_valid_for_section_line_count(line):
+                sec_id = line.section_line_id.id
+                if sec_id and sec_id in sections:
+                    sections[sec_id]['line_count'] += 1
+                else:
+                    no_section_count += 1
+
+        if no_section_count > 0 or not lines:
+            sections[False] = {
+                'id': False,
+                'name': self.env._("No Section"),
+                'sequence': lines[0].sequence - 1 if lines else 0,
+                'line_count': no_section_count,
+            }
+
+        return sorted(sections.values(), key=lambda x: x['sequence'])
+
+    def _get_section_model_info(self):
+        """ Return the model name and parent field for the order lines.
+
+        :return: line_model, parent_field
+        """
+        return False, False
+
+    def _is_line_valid_for_section_line_count(self, line):
+        """ Check if a line is valid for inclusion in the section's line count.
+
+        :param recordset line: A record of an order line.
+        :return: True if this line is a valid, else False.
+        :rtype: bool
+        """
+        return (
+            not line.display_type
+            and line.product_type != 'combo'
+            and line.product_uom_qty > 0
+        )
+
+    def _resequence_order_sections(self, sections, child_field, **kwargs):
+        """ Resequence the sections of the order based on the provided move and target sections.
+        The sections are reordered by updating their sequence numbers.
+
+        :param list sections: A list of dictionaries containing move and target sections.
+        :param str child_field: Field name of the order's lines (e.g., 'order_line').
+        :param dict kwargs: Additional values given for inherited models.
+        :return: A dictonary containing the new sequences of all the sections of order.
+        :rtype: dict
+        """
+        if not child_field:
+            return {}
+        lines = self[child_field].sorted('sequence')
+        move_section, target_section = sections
+
+        move_block = lines.filtered_domain([
+            '|',
+            ('id', '=', move_section['id']),
+            ('section_line_id', '=', move_section['id']),
+        ])
+
+        target_block = lines.filtered_domain([
+            '|',
+            ('id', '=', target_section['id']),
+            ('section_line_id', '=', target_section['id']),
+        ])
+
+        remaining_lines = lines - move_block
+        insert_after = move_section['sequence'] < target_section['sequence']
+        insert_index = len(remaining_lines)
+        for idx, line in enumerate(remaining_lines):
+            if line.id == (target_block[-1].id if insert_after else target_section['id']):
+                insert_index = idx + 1 if insert_after else idx
+                break
+
+        reordered_lines = (
+            remaining_lines[:insert_index] +
+            move_block +
+            remaining_lines[insert_index:]
+        )
+
+        sections = {}
+        for sequence, line in enumerate(reordered_lines, start=1):
+            line.sequence = sequence
+            if line.display_type == 'line_section':
+                sections[line.id] = sequence
+
+        return sections

--- a/addons/product/static/src/product_catalog/kanban_model.js
+++ b/addons/product/static/src/product_catalog/kanban_model.js
@@ -19,7 +19,18 @@ export class ProductCatalogKanbanModel extends RelationalModel {
     async _loadData(params) {
         // if orm have isSample field and its value set to be true then we have sample data as there is no product found for selected vendor, show sample data
         const isSample = this.orm.isSample !== undefined ? this.orm.isSample : false;
-        const result = await super._loadData(...arguments);
+        const selectedSection = this.env.searchModel.selectedSection;
+        if (selectedSection.filtered) {
+            params = {
+                ...params,
+                domain: [...(params.domain || []), ['is_in_selected_section_of_order', '=', true]],
+                context: {
+                    ...params.context,
+                    selected_section_id: selectedSection.sectionId,
+                },
+            };
+        }
+        const result = await super._loadData(params);
         if (!params.isMonoRecord) {
             let records;
             if (params.groupBy?.length) {
@@ -57,7 +68,8 @@ export class ProductCatalogKanbanModel extends RelationalModel {
             order_id: params.context.order_id,
             product_ids: productIds,
             res_model: params.context.product_catalog_order_model,
-            child_field: params.context?.child_field,
+            child_field: params.context.child_field,
+            selected_section_id: this.env.searchModel.selectedSection.sectionId,
         }
     }
 

--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -30,7 +30,8 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             increaseQuantity: this.increaseQuantity.bind(this),
             setQuantity: this.setQuantity.bind(this),
             decreaseQuantity: this.decreaseQuantity.bind(this),
-            childField: this.props.record.context?.child_field
+            childField: this.props.record.context.child_field,
+            selectedSectionId: this.env.searchModel.selectedSection.sectionId,
         });
     }
 
@@ -74,6 +75,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             quantity: this.productCatalogData.quantity,
             res_model: this.env.orderResModel,
             child_field: this.env.childField,
+            selected_section_id: this.env.selectedSectionId,
         }
     }
 
@@ -84,6 +86,10 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
     updateQuantity(quantity) {
         if (this.productCatalogData.readOnly) {
             return;
+        }
+        const lineCountChange = (quantity > 0) - (this.productCatalogData.quantity > 0);
+        if (lineCountChange !== 0) {
+            this.notifyLineCountChange(lineCountChange);
         }
         this.productCatalogData.quantity = quantity || 0;
         this.debouncedUpdateQuantity();
@@ -124,5 +130,12 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
      */
     decreaseQuantity() {
         this.updateQuantity(parseFloat(this.productCatalogData.quantity - 1));
+    }
+
+    notifyLineCountChange(lineCountChange) {
+        this.env.searchModel.trigger('section-line-count-change', {
+            sectionId: this.env.selectedSectionId,
+            lineCountChange: lineCountChange,
+        });
     }
 }

--- a/addons/product/static/src/product_catalog/kanban_view.js
+++ b/addons/product/static/src/product_catalog/kanban_view.js
@@ -4,6 +4,7 @@ import { registry } from "@web/core/registry";
 import { ProductCatalogKanbanController } from "./kanban_controller";
 import { ProductCatalogKanbanModel } from "./kanban_model";
 import { ProductCatalogKanbanRenderer } from "./kanban_renderer";
+import { ProductCatalogSearchModel } from "./search/search_model";
 import { ProductCatalogSearchPanel} from "./search/search_panel";
 
 
@@ -12,6 +13,7 @@ export const productCatalogKanbanView = {
     Controller: ProductCatalogKanbanController,
     Model: ProductCatalogKanbanModel,
     Renderer: ProductCatalogKanbanRenderer,
+    SearchModel: ProductCatalogSearchModel,
     SearchPanel: ProductCatalogSearchPanel,
 };
 

--- a/addons/product/static/src/product_catalog/search/search_model.js
+++ b/addons/product/static/src/product_catalog/search/search_model.js
@@ -1,0 +1,13 @@
+import { SearchModel } from "@web/search/search_model";
+
+export class ProductCatalogSearchModel extends SearchModel {
+    setup() {
+        super.setup(...arguments);
+        this.selectedSection = {sectionId: null, filtered: false};
+    }
+
+    setSelectedSection(sectionId, filtered) {
+        this.selectedSection = {sectionId, filtered};
+        this._notify();
+    }
+}

--- a/addons/product/static/src/product_catalog/search/search_panel.js
+++ b/addons/product/static/src/product_catalog/search/search_panel.js
@@ -1,54 +1,169 @@
-import { SearchPanel } from "@web/search/search_panel/search_panel";
-import { useState } from "@odoo/owl";
+import { onWillStart, useState } from '@odoo/owl';
+import { getActiveHotkey } from '@web/core/hotkeys/hotkey_service';
+import { rpc } from '@web/core/network/rpc';
+import { useBus } from '@web/core/utils/hooks';
+import { SearchPanel } from '@web/search/search_panel/search_panel';
 
 
 export class ProductCatalogSearchPanel extends SearchPanel {
-    static subTemplates = {
-        ...SearchPanel.subTemplates,
-        filtersGroup: "ProductCatalogSearchPanel.FiltersGroup",
-    };
+    static template = 'product.SearchPanel';
 
     setup() {
         super.setup();
 
         this.state = useState({
             ...this.state,
-            sectionOfAttributes: {},
+            sectionOfSections: new Map(),
+            isAddingSection: '',
+            newSectionName: "",
         });
+
+        useBus(this.env.searchModel, 'section-line-count-change', this.updateSectionLineCount);
+
+        onWillStart(async () =>  await this.loadSections());
     }
 
-    updateActiveValues() {
-        super.updateActiveValues();
-        this.state.sectionOfAttributes = this.buildSection();
+    get showSections() {
+        return this.env.model.config.context.product_catalog_order_id;
     }
 
-    buildSection() {
-        const values = this.env.searchModel.filters[0].values;
-        let sections = new Map();
+    get selectedSection() {
+        return this.env.searchModel.selectedSection;
+    }
 
-        values.forEach(element => {
-            const name = element.display_name;
-            const id = element.id;
-            const count = element.__count;
+    onDragStart(sectionId, ev) {
+        ev.dataTransfer.setData('section_id', sectionId);
+    }
 
-            if (sections.has(name)) {
-                let currentAttr = sections.get(name);
-                currentAttr.get('ids').push(id);
-                currentAttr.set('count', currentAttr.get('count') + count);
-            } else if (count > 0) {
-                let newAttr = new Map();
-                newAttr.set('ids', [id]);
-                newAttr.set('count', count);
-                sections.set(name, newAttr);
+    onDragOver(ev) {
+        ev.preventDefault();
+    }
+
+    onDrop(targetSecId, ev) {
+        ev.preventDefault();
+        const moveSecId = ev.dataTransfer.getData('section_id');
+        if (moveSecId !== targetSecId) this.reorderSections(moveSecId, targetSecId);
+    }
+
+    enableSectionInput(isAddingSection) {
+        this.state.isAddingSection = isAddingSection;
+        setTimeout(() => document.querySelector('.o_section_input')?.focus(), 100);
+    }
+
+    onSectionInputKeydown(ev) {
+        const hotkey = getActiveHotkey(ev);
+        if (hotkey === 'enter') {
+            this.createSection();
+        } else if (hotkey === 'escape') {
+            Object.assign(this.state, {
+                isAddingSection: '',
+                newSectionName: "",
+            });
+        }
+    }
+
+    setSelectedSection(sectionId=null, filtered=false) {
+        this.env.searchModel.setSelectedSection(sectionId, filtered);
+    }
+
+    async createSection() {
+        const sectionName = this.state.newSectionName.trim();
+        if (!sectionName) return this.state.isAddingSection = '';
+
+        const sections = this.state.sectionOfSections;
+
+        const extraParams = {
+            name: sectionName,
+            position: this.state.isAddingSection,
+        };
+        let newLineCount = 0;
+
+        const section = await rpc('/product/catalog/create_section',
+            this._getSectionInfoParams(extraParams)
+        );
+
+        if (section) {
+            if (extraParams.position === 'top') {
+                newLineCount = sections.get(false).line_count;
+                sections.delete(false);
             }
+            sections.set(section.id, {
+                name: this.state.newSectionName,
+                sequence: section.sequence,
+                line_count: newLineCount,
+            });
+            this._sortSectionsBySequence(sections);
+            this.setSelectedSection(section.id);
+        }
+        Object.assign(this.state, {
+            isAddingSection: '',
+            newSectionName: "",
         });
-
-        return sections;
     }
 
-    toggleSectionFilterValue(filterId, attrIds, { currentTarget }) {
-        attrIds.forEach(id => {
-            this.toggleFilterValue(filterId, id, { currentTarget });
-        })
+    async loadSections() {
+        if (!this.showSections) return;
+        const sections = await rpc('/product/catalog/get_sections', this._getSectionInfoParams());
+
+        const sectionMap = new Map();
+        for (const {id, name, sequence, line_count} of sections) {
+            sectionMap.set(id, {name, sequence, line_count});
+        }
+        this.state.sectionOfSections = sectionMap;
+        this.setSelectedSection(sectionMap.size > 0 ? [...sectionMap.keys()][0] : null);
+    }
+
+    async reorderSections(moveId, targetId) {
+        [moveId, targetId] = [parseInt(moveId), parseInt(targetId)];
+        const sections = this.state.sectionOfSections;
+        const moveSection = sections.get(moveId);
+        const targetSection = sections.get(targetId);
+
+        if (!moveSection || !targetSection) return;
+
+        const updatedSequences = await rpc('/product/catalog/resequence_sections',
+            this._getSectionInfoParams({
+                sections: [
+                    { id: moveId, sequence: moveSection.sequence },
+                    { id: targetId, sequence: targetSection.sequence },
+                ],
+            })
+        );
+        for (const [id, sequence] of Object.entries(updatedSequences)) {
+            const section = sections.get(parseInt(id));
+            section && (section.sequence = sequence);
+        }
+        const noSection = sections.get(false);
+        noSection && (noSection.sequence = 0); // Reset the sequence of the "No Section"
+        this._sortSectionsBySequence(sections);
+    }
+
+    updateSectionLineCount({detail: {sectionId, lineCountChange}}) {
+        const sections = this.state.sectionOfSections;
+        const section = sections.get(sectionId);
+        if (!section) return;
+
+        section.line_count = Math.max(0, section.line_count + lineCountChange);
+
+        if (section.line_count === 0 && sectionId === false && sections.size > 1) {
+            sections.delete(sectionId);
+            this.setSelectedSection(sections.size > 0 ? [...sections.keys()][0] : null);
+        }
+    }
+
+    _getSectionInfoParams(extra = {}) {
+        const ctx = this.env.model.config.context;
+        return {
+            res_model: ctx.product_catalog_order_model,
+            order_id: ctx.order_id,
+            child_field: ctx.child_field,
+            ...extra,
+        };
+    }
+
+    _sortSectionsBySequence(sections) {
+        this.state.sectionOfSections = new Map(
+            [...sections].sort((a, b) => a[1].sequence - b[1].sequence)
+        );
     }
 }

--- a/addons/product/static/src/product_catalog/search/search_panel.scss
+++ b/addons/product/static/src/product_catalog/search/search_panel.scss
@@ -1,0 +1,14 @@
+.o_section_input {
+    border: none;
+    outline: none;
+    background: transparent;
+    border-bottom: 2px solid var(--primary);
+}
+
+.o_selected_section {
+    background-color: var(--list-group-active-bg);
+
+    .o_section_name {
+        font-weight: bold;
+    }
+}

--- a/addons/product/static/src/product_catalog/search/search_panel.xml
+++ b/addons/product/static/src/product_catalog/search/search_panel.xml
@@ -1,28 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <templates id="template" xml:space="preserve">
-    <t t-name="ProductCatalogSearchPanel.FiltersGroup" t-inherit="web.SearchPanel.FiltersGroup" t-inherit-mode="primary">
-        <li t-foreach="[...values.keys()]" position="replace">
-            <li t-foreach="[...this.state.sectionOfAttributes.keys()]" t-as="attrName" t-key="attrName"
-                class="o_search_panel_filter_value list-group-item p-0 mb-1 border-0 o_cursor_pointer"
-                t-att-class="{ 'ps-2' : isChildList }">
-                <t t-set="attrCount" t-value="this.state.sectionOfAttributes.get(attrName).get('count')"/>
-                <t t-set="attrIds" t-value="this.state.sectionOfAttributes.get(attrName).get('ids')"/>
-                <div class="form-check w-100">
-                    <input type="checkbox"
-                           t-attf-id="{{ section.id }}_input_{{ attrName }}"
-                           class="form-check-input"
-                           t-on-click="ev => this.toggleSectionFilterValue(section.id, attrIds, ev)"/>
-                    <label class="o_search_panel_label form-check-label d-flex align-items-center justify-content-between w-100 o_cursor_pointer"
-                           t-attf-for="{{ section.id }}_input_{{ attrName }}"
-                           t-att-title="(group and group.tooltip) or false">
-                        <span class="o_search_panel_label_title text-truncate" t-esc="attrName"/>
-                        <span t-if="section.enableCounters and attrCount gt 0"
-                              class="o_search_panel_counter text-muted mx-2 small"
-                              t-esc="attrCount"/>
-                    </label>
-                </div>
-            </li>
-        </li>
+    <t
+        t-name="product.SearchPanelContent"
+        t-inherit="web.SearchPanelContent"
+        t-inherit-mode="primary"
+    >
+        <section position="before">
+            <section t-if="showSections" class="o_search_panel_sections mt-5">
+                <header class="d-flex align-items-center cursor-default gap-2 mb-3">
+                    <i class="fa fa-filter"/>
+                    <span class="text-uppercase fw-bold">Sections</span>
+                    <div class="d-flex align-items-center ms-auto">
+                        <span class="me-2">Filter</span>
+                        <div class="form-check form-switch mb-0">
+                            <input
+                                class="form-check-input"
+                                type="checkbox"
+                                role="switch"
+                                t-att-checked="selectedSection.filtered ? true : false"
+                                t-on-click="() => this.setSelectedSection(
+                                    selectedSection.sectionId, !selectedSection.filtered
+                                )"
+                            />
+                        </div>
+                    </div>
+                </header>
+                <ul class="list-group d-block">
+                    <li
+                        draggable="true"
+                        t-foreach="this.state.sectionOfSections.keys()"
+                        t-as="secId"
+                        t-key="secId"
+                        t-att-class="'list-group-item p-0 mb-1 border-0 cursor-pointer ' + (
+                            selectedSection.sectionId == secId ? 'o_selected_section' : ''
+                        )"
+                        t-on-dragstart="(e) => onDragStart(secId, e)"
+                        t-on-dragover="(e) => onDragOver(e)"
+                        t-on-drop="(e) => this.onDrop(secId, e)"
+                    >
+                        <div class="d-flex align-items-center">
+                            <t t-set="section" t-value="this.state.sectionOfSections.get(secId)"/>
+                            <span
+                                t-if="secId"
+                                class="o_row_handle oi oi-draggable ui-sortable-handle"
+                            />
+                            <i
+                                t-else=""
+                                class="fa fa-pencil"
+                                t-on-click="() => this.enableSectionInput('top')"
+                            />
+                            <input
+                                t-if="secId === false and this.state.isAddingSection === 'top'"
+                                class="ms-2 o_section_input"
+                                type="text"
+                                t-model="this.state.newSectionName"
+                                t-on-keydown="onSectionInputKeydown"
+                                t-on-blur="createSection"
+                            />
+                            <div
+                                t-else=""
+                                class="w-100 ms-2 d-flex align-items-center justify-content-between overflow-hidden"
+                                t-on-click="() => this.setSelectedSection(
+                                    secId, selectedSection.filtered
+                                )"
+                                t-att-title="section.name"
+                            >
+                                <span class="o_section_name text-truncate" t-out="section.name"/>
+                                <span class="mx-2 text-muted" t-out="section.line_count"/>
+                            </div>
+                        </div>
+                    </li>
+                </ul>
+                <input
+                    t-if="this.state.isAddingSection === 'bottom'"
+                    class="o_section_input py-1"
+                    type="text"
+                    placeholder="Enter a description"
+                    t-model="this.state.newSectionName"
+                    t-on-keydown="onSectionInputKeydown"
+                    t-on-blur="createSection"
+                />
+                <button
+                    t-else=""
+                    class="btn btn-link px-0 py-1"
+                    type="button"
+                    t-on-click="() => this.enableSectionInput('bottom')"
+                >
+                    + Add Section
+                </button>
+            </section>
+        </section>
+    </t>
+
+    <t t-name="product.SearchPanel" t-inherit="web.SearchPanel" t-inherit-mode="primary">
+        <t t-call="web.SearchPanel.Regular" position="attributes">
+            <attribute name="t-call">product.SearchPanelContent</attribute>
+        </t>
     </t>
 </templates>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -730,12 +730,11 @@ action = {
                 <!-- searchpanel -->
                 <searchpanel>
                     <field name="categ_id"
-                           string="Product Category"
+                           string="Categories"
                            icon="fa-th-list"/>
-                    <field name="product_template_attribute_value_ids"
-                           string="Attributes"
+                    <field name="product_tag_ids"
+                           string="Tags"
                            icon="fa-th-list"
-                           domain="[('ptav_active', '=', True), ('product_tmpl_id.active', '=', True)]"
                            enable_counters="1"
                            select="multi"/>
                 </searchpanel>

--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -52,6 +52,9 @@
         'web.assets_frontend': [
             'purchase/static/src/interactions/**/*',
         ],
+        'web.assets_tests': [
+            'purchase/static/tests/tours/**/*',
+        ],
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/purchase/static/tests/tours/purchase_catalog.js
+++ b/addons/purchase/static/tests/tours/purchase_catalog.js
@@ -1,0 +1,49 @@
+import { addSectionFromProductCatalog } from "@account/js/tours/tour_utils";
+import { registry } from "@web/core/registry";
+
+const openSearchPanelStep = {
+    content: "Open Search Panel if it is closed",
+    trigger: '.o_search_panel_sidebar',
+    run: 'click',
+};
+
+registry.category("web_tour.tours").add('test_add_section_from_product_catalog_on_purchase_order', {
+    steps: () => {
+        const steps = [
+            {
+                content: "Create a new PO",
+                trigger: '.o_list_button_add',
+                run: 'click',
+            },
+            {
+                content: "Select the customer field",
+                trigger: '.o_field_res_partner_many2one input.o_input',
+                run: 'click',
+            },
+            {
+                content: "Wait for the field to be active",
+                trigger: '.o_field_res_partner_many2one input[aria-expanded=true]',
+            },
+            {
+                trigger: ".o_field_res_partner_many2one[name='partner_id'] input",
+                content: "Search a vendor name",
+                tooltipPosition: "bottom",
+                async run(actions) {
+                    const input = this.anchor.querySelector("input");
+                    await actions.edit("Test Vendor", input || this.anchor);
+                },
+            },
+            {
+                isActive: ["auto"],
+                trigger: '.ui-menu-item > a:contains("Test Vendor")',
+                run: 'click',
+            },
+        ];
+
+        const catalogSteps = addSectionFromProductCatalog();
+        catalogSteps.splice(1, 0, openSearchPanelStep);
+        catalogSteps.splice(5, 0, openSearchPanelStep);
+
+        return [...steps, ...catalogSteps];
+    },
+});

--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -3,6 +3,7 @@
 
 from . import test_purchase
 from . import test_purchase_downpayment
+from . import test_purchase_order_product_catalog
 from . import test_purchase_order_report
 from . import test_purchase_invoice
 from . import test_access_rights

--- a/addons/purchase/tests/test_purchase_order_product_catalog.py
+++ b/addons/purchase/tests/test_purchase_order_product_catalog.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestPurchaseOrderProductCatalog(HttpCase):
+
+    def test_add_section_from_product_catalog_on_purchase_order_tour(self):
+        vendor = self.env['res.partner'].create({'name': 'Test Vendor'})
+        self.env['product.template'].create({
+            'name': "Test Product",
+            'seller_ids': [(0, 0, {
+                'partner_id': vendor.id,
+                'min_qty': 1.0,
+                'price': 1.0,
+            })],
+        })
+        self.start_tour(
+            '/web#action=purchase.purchase_rfq',
+            'test_add_section_from_product_catalog_on_purchase_order',
+            login='admin',
+        )

--- a/addons/sale/static/tests/tours/sale_catalog.js
+++ b/addons/sale/static/tests/tours/sale_catalog.js
@@ -1,3 +1,4 @@
+import { addSectionFromProductCatalog } from "@account/js/tours/tour_utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('sale_catalog', {
@@ -68,5 +69,30 @@ registry.category("web_tour.tours").add('sale_catalog', {
             trigger: '.o-kanban-button-back',
             run: 'click',
         },
+    ]
+});
+
+registry.category("web_tour.tours").add('test_add_section_from_product_catalog_on_sale_order', {
+    steps: () => [
+        {
+            content: "Create a new SO",
+            trigger: '.o_list_button_add',
+            run: 'click',
+        },
+        {
+            content: "Select the customer field",
+            trigger: '.o_field_res_partner_many2one input.o_input',
+            run: 'click',
+        },
+        {
+            content: "Wait for the field to be active",
+            trigger: '.o_field_res_partner_many2one input[aria-expanded=true]',
+        },
+        {
+            content: "Select a customer from the dropdown",
+            trigger: '.o_field_res_partner_many2one .dropdown-item:not([id$="_loading"]):first',
+            run: 'click',
+        },
+        ...addSectionFromProductCatalog(),
     ]
 });

--- a/addons/sale/tests/test_sale_order_product_catalog.py
+++ b/addons/sale/tests/test_sale_order_product_catalog.py
@@ -31,3 +31,11 @@ class TestSaleOrderProductCatalog(HttpCase):
             'sale_catalog',
             login="admin",
         )
+
+    def test_add_section_from_product_catalog_on_sale_order_tour(self):
+        self.env['product.template'].create({'name': "Test Product", 'is_favorite': True})
+        self.start_tour(
+            '/web#action=sale.action_quotations',
+            'test_add_section_from_product_catalog_on_sale_order',
+            login='admin',
+        )


### PR DESCRIPTION
Before this commit:
- It was not possible to add products to specific sections from the catalog.
- Reordering entire sections within the order was not supported.
- Attribute filter in the product catalog were often ineffective for
  product search

After this commit:
- Sections from the order are now visible in the product catalog’s search panel.
- Products can be added directly into specific sections from the catalog
- When a section is selected, only products belonging to that section are
  highlighted.
- 'Selected Products' toggle allows users to filter out products that belong to
  a specific section.
- Entire sections within a order can be reordered directly from the catalog.
- New sections can be created in the order through the catalog.
- Attribute filter have been replaced with tags filter.

See also:
- https://github.com/odoo/enterprise/pull/84404

task-4593041

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
