### PR TITLE
[IMP] l10n_bh: no need to have a Non-Bahrain country group

### DIFF
--- a/addons/l10n_bh/__manifest__.py
+++ b/addons/l10n_bh/__manifest__.py
@@ -23,7 +23,6 @@ Activates:
         'data/tax_report_full.xml',
         'data/tax_report_simplified.xml',
         'data/res.country.state.csv',
-        'data/res_country_data.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_bh/data/res_country_data.xml
+++ b/addons/l10n_bh/data/res_country_data.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <data noupdate="1">
-        <record id="gulf_cooperation_council_without_bh" model="res.country.group">
-            <field name="name">Gulf Cooperation Council (GCC) without bh</field>
-            <field name="country_ids" eval="[(6,0, [ref('base.sa'), ref('base.ae'), ref('base.om'), ref('base.qa'), ref('base.kw')])]"/>
-        </record>
-    </data>
-</odoo>

--- a/addons/l10n_bh/data/template/account.fiscal.position-bh.csv
+++ b/addons/l10n_bh/data/template/account.fiscal.position-bh.csv
@@ -1,6 +1,6 @@
 "id","sequence","name","auto_apply","vat_required","country_id","country_group_id","tax_ids/tax_src_id","tax_ids/tax_dest_id","name@ar"
 "fiscal_position_template_dom","1","Bahrain","1","","base.bh","","","","البحرين"
-"fiscal_position_non_bahrain_gcc","2","Non-Bahrain (GCC)","1","","","l10n_bh.gulf_cooperation_council_without_bh","l10n_bh_purchase_vat_10","l10n_bh_purchase_vat_10_ex","غير البحرين (دول مجلس التعاون الخليجي)"
+"fiscal_position_non_bahrain_gcc","2","Non-Bahrain (GCC)","1","","","base.gulf_cooperation_council","l10n_bh_purchase_vat_10","l10n_bh_purchase_vat_10_ex","غير البحرين (دول مجلس التعاون الخليجي)"
 "","","","","","","","l10n_bh_sale_vat_10","l10n_bh_sale_vat_0_gcc",""
 "fiscal_position_non_bahrain","3","Non-Bahrain","1","","","","l10n_bh_purchase_vat_10","l10n_bh_purchase_vat_10_ex","غير البحرين"
 "","","","","","","","l10n_bh_sale_vat_10","l10n_bh_sale_0_ex",""


### PR DESCRIPTION
As the fiscal positions will take Bahrain first
there is no need to define a GCC without Bahrain.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
