### PR TITLE
[IMP] *: namespace webclient translations

### DIFF
--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
@@ -3,7 +3,7 @@ import { CardLayout } from "@hr_attendance/components/card_layout/card_layout";
 import { KioskManualSelection } from "@hr_attendance/components/manual_selection/manual_selection";
 import { makeEnv, startServices } from "@web/env";
 import { getTemplate } from "@web/core/templates";
-import { _t } from "@web/core/l10n/translation";
+import { _t, appTranslateFn } from "@web/core/l10n/translation";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { rpc } from "@web/core/network/rpc";
 import { useService, useBus } from "@web/core/utils/hooks";
@@ -233,7 +233,7 @@ export async function createPublicKioskAttendance(document, kiosk_backend_info) 
                 fromTrialMode: kiosk_backend_info.from_trial_mode,
             },
         dev: env.debug,
-        translateFn: _t,
+        translateFn: appTranslateFn,
         translatableAttributes: ["data-tooltip"],
     });
     return app.mount(document.body);

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1144,7 +1144,9 @@ test("toolbar buttons should have title attribute with translated text", async (
     editor.destroy();
 
     // Patch translations to return "Translated" for these terms
-    patchTranslations(Object.fromEntries(descriptions.map((title) => [title, "Translated"])));
+    patchTranslations({
+        html_editor: Object.fromEntries(descriptions.map((title) => [title, "Translated"])),
+    });
 
     // Instantiate a new editor.
     const { plugins: postPatchPlugins } = await setupEditor("<p>[abc]</p>");

--- a/addons/im_livechat/static/src/embed/external/boot.js
+++ b/addons/im_livechat/static/src/embed/external/boot.js
@@ -4,7 +4,7 @@ import { canLoadLivechat } from "@im_livechat/embed/common/misc";
 import { mount, whenReady } from "@odoo/owl";
 
 import { loadBundle } from "@web/core/assets";
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { getTemplate } from "@web/core/templates";
 import { makeEnv, startServices } from "@web/env";
@@ -26,7 +26,7 @@ import { session } from "@web/session";
     await mount(MainComponentsContainer, target, {
         env,
         getTemplate,
-        translateFn: _t,
+        translateFn: appTranslateFn,
         dev: env.debug,
     });
 })();

--- a/addons/im_livechat/static/src/embed/frontend/boot_service.js
+++ b/addons/im_livechat/static/src/embed/frontend/boot_service.js
@@ -2,7 +2,7 @@ import { makeRoot, makeShadow } from "@im_livechat/embed/common/boot_helpers";
 import { canLoadLivechat } from "@im_livechat/embed/common/misc";
 import { LivechatRoot } from "@im_livechat/embed/frontend/livechat_root";
 import { App } from "@odoo/owl";
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 
 import { registry } from "@web/core/registry";
 import { getTemplate } from "@web/core/templates";
@@ -28,7 +28,7 @@ export const livechatBootService = {
                 env,
                 getTemplate,
                 translatableAttributes: ["data-tooltip"],
-                translateFn: _t,
+                translateFn: appTranslateFn,
                 dev: env.debug,
             }).mount(shadow);
         });

--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -1,4 +1,4 @@
-import { patchTranslations, preloadBundle, serverState } from "@web/../tests/web_test_helpers";
+import { defineParams, preloadBundle, serverState } from "@web/../tests/web_test_helpers";
 
 import {
     click,
@@ -20,8 +20,10 @@ defineMailModels();
 preloadBundle("web.assets_emoji");
 
 test("emoji picker works well with translation with double quotes", async () => {
-    patchTranslations({
-        "Japanese “here” button": `Bouton "ici" japonais`,
+    defineParams({
+        translations: {
+            "Japanese “here” button": `Bouton "ici" japonais`,
+        },
     });
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "" });

--- a/addons/point_of_sale/static/src/app/main.js
+++ b/addons/point_of_sale/static/src/app/main.js
@@ -1,7 +1,7 @@
 import { Loader } from "@point_of_sale/app/components/loader/loader";
 import { getTemplate } from "@web/core/templates";
 import { mount, reactive, whenReady } from "@odoo/owl";
-import { _t } from "@web/core/l10n/translation";
+import { _t, appTranslateFn } from "@web/core/l10n/translation";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { localization } from "@web/core/l10n/localization";
 import { user } from "@web/core/user";
@@ -13,7 +13,7 @@ const loader = reactive({ isShown: true });
 whenReady(() => {
     // Show loader as soon as the page is ready, do not wait for services to be started
     // as some services load data over RPC and this is why we want to show a loader.
-    mount(Loader, document.body, { getTemplate, translateFn: _t, props: { loader } });
+    mount(Loader, document.body, { getTemplate, translateFn: appTranslateFn, props: { loader } });
 });
 // The following is mostly a copy of startWebclient but without any of the legacy stuff
 (async function startPosApp() {

--- a/addons/point_of_sale/static/tests/unit/services/render_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/render_service.test.js
@@ -2,7 +2,7 @@ import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { mockFetch } from "@odoo/hoot-mock";
 import { Component, xml } from "@odoo/owl";
 import { registry } from "@web/core/registry";
-import { clearRegistry, mountWithCleanup, patchTranslations } from "@web/../tests/web_test_helpers";
+import { clearRegistry, mountWithCleanup, allowTranslations } from "@web/../tests/web_test_helpers";
 import { renderService, htmlToCanvas } from "@point_of_sale/app/services/render_service";
 
 describe("RenderService", () => {
@@ -17,7 +17,7 @@ describe("RenderService", () => {
         clearRegistry(registry.category("main_components"));
         registry.category("services").add("render", renderService);
 
-        patchTranslations(); // this is needed because we are not loading the localization service
+        allowTranslations(); // this is needed because we are not loading the localization service
         const comp = await mountWithCleanup("none");
         const renderedComp = await comp.env.services.render.toHtml(ComponentToBeRendered, {
             name: "Mario",

--- a/addons/point_of_sale/static/tests/unit/tools/lazy_getter.test.js
+++ b/addons/point_of_sale/static/tests/unit/tools/lazy_getter.test.js
@@ -3,7 +3,7 @@ import { animationFrame } from "@odoo/hoot-dom";
 import { Component, onWillRender, reactive, useState, xml } from "@odoo/owl";
 import {
     mountWithCleanup,
-    patchTranslations,
+    allowTranslations,
     patchWithCleanup,
 } from "@web/../tests/web_test_helpers";
 
@@ -44,7 +44,7 @@ function verifyUnorderedSteps(expectedSteps, stepOrders = []) {
 
 let unorderedSteps = [];
 
-patchTranslations();
+allowTranslations();
 afterEach(clearGettersCache);
 
 class AppStore extends WithLazyGetterTrap {

--- a/addons/portal/static/src/chatter/frontend/portal_chatter_service.js
+++ b/addons/portal/static/src/chatter/frontend/portal_chatter_service.js
@@ -4,7 +4,7 @@ import { AssetsLoadingError, getBundle } from "@web/core/assets";
 import { registry } from "@web/core/registry";
 import { rpc } from "@web/core/network/rpc";
 import { session } from "@web/session";
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 import { getTemplate } from "@web/core/templates";
 
 export class PortalChatterService {
@@ -70,7 +70,7 @@ export class PortalChatterService {
                 getTemplate,
                 props,
                 translatableAttributes: ["data-tooltip"],
-                translateFn: _t,
+                translateFn: appTranslateFn,
                 dev: env.debug,
             }).mount(shadow);
         });

--- a/addons/spreadsheet/static/src/public_readonly_app/main.js
+++ b/addons/spreadsheet/static/src/public_readonly_app/main.js
@@ -3,7 +3,7 @@ import { PublicReadonlySpreadsheet } from "./public_readonly";
 import { getTemplate } from "@web/core/templates";
 import { makeEnv, startServices } from "@web/env";
 import { session } from "@web/session";
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 
 (async function boot() {
     odoo.info = {
@@ -20,7 +20,7 @@ import { _t } from "@web/core/l10n/translation";
         env,
         props: session.spreadsheet_public_props,
         getTemplate,
-        translateFn: _t,
+        translateFn: appTranslateFn,
         dev: env.debug,
         warnIfNoStaticProps: env.debug,
         translatableAttributes: ["data-tooltip"],

--- a/addons/spreadsheet/static/tests/global_filters/global_filter_helper.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filter_helper.test.js
@@ -14,7 +14,7 @@ import {
     getDateDomainDurationInDays,
     assertDateDomainEqual,
 } from "@spreadsheet/../tests/helpers/date_domain";
-import { makeMockEnv, patchTranslations } from "@web/../tests/web_test_helpers";
+import { makeMockEnv, allowTranslations } from "@web/../tests/web_test_helpers";
 import { getOperatorLabel } from "@web/core/tree_editor/tree_editor_operator_editor";
 
 import { defineSpreadsheetModels } from "../helpers/data";
@@ -28,7 +28,7 @@ const LAZY_TRANSLATED_NOT_SET = getOperatorLabel("not_set");
 const LAZY_TRANSLATED_CONTAINS = getOperatorLabel("ilike");
 
 beforeEach(() => {
-    patchTranslations();
+    allowTranslations();
 });
 
 function getRelativeDateDomain(now, offset, period, fieldName, fieldType) {

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -8,7 +8,7 @@ import {
 import {
     makeServerError,
     onRpc,
-    patchTranslations,
+    allowTranslations,
     patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
@@ -1710,7 +1710,7 @@ test("Cannot duplicate unknown pivot", async () => {
 });
 
 test("Spreadsheet pivot table ignored by global fiter plugin", () => {
-    patchTranslations();
+    allowTranslations();
 
     const model = new Model();
     model.selection.selectZone({ cell: { col: 0, row: 0 }, zone: toZone("A1:A4") });

--- a/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test } from "@odoo/hoot";
 
 import { getFirstListFunction, getNumberOfListFormulas } from "@spreadsheet/list/list_helpers";
 import { constants, tokenize, helpers } from "@odoo/o-spreadsheet";
-import { patchTranslations } from "@web/../tests/web_test_helpers";
+import { allowTranslations } from "@web/../tests/web_test_helpers";
 const {
     getFirstPivotFunction,
     getNumberOfPivotFunctions,
@@ -22,7 +22,7 @@ function stringArg(value, tokenIndex) {
 }
 
 beforeEach(() => {
-    patchTranslations();
+    allowTranslations();
 });
 
 describe.current.tags("headless");

--- a/addons/web/static/src/core/emoji_picker/emoji_data.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_data.js
@@ -53,10 +53,10 @@
 // Since JSON grammar is way simpler than JavaScript's grammar, it is actually
 // faster to parse the data as a JSON object than as a JavaScript object.
 
-import { _t as realT } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 
 // replace all double quotes with escaped double quotes
-const _t = (str) => realT(str).replace(/"/g, '\\"')
+const _t = (str) =>  appTranslateFn(str, "web").replace(/"/g, '\\"');
 
 const _getCategories = () => `[
     {

--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -47,12 +47,12 @@ export const localizationService = {
         };
 
         const updateTranslations = (result) => {
-            // FIXME We flatten the result of the python route.
             // Eventually, we want a new python route to return directly the good result.
             const terms = {};
             for (const addon of Object.keys(result.modules)) {
+                terms[addon] ??= {};
                 for (const message of result.modules[addon].messages) {
-                    terms[message.id] = message.string;
+                    terms[addon][message.id] = message.string;
                 }
             }
             Object.assign(translatedTerms, terms);

--- a/addons/web/static/src/core/l10n/setup_jquery_timeago.js
+++ b/addons/web/static/src/core/l10n/setup_jquery_timeago.js
@@ -1,0 +1,20 @@
+import { _t } from "./translation";
+
+/*
+ * Setup jQuery timeago:
+ * Strings in timeago are "composed" with prefixes, words and suffixes. This
+ * makes their detection by our translating system impossible. Use all literal
+ * strings we're using with a translation mark here so the extractor can do its
+ * job.
+ */
+_t("less than a minute ago");
+_t("about a minute ago");
+_t("%d minutes ago");
+_t("about an hour ago");
+_t("%d hours ago");
+_t("a day ago");
+_t("%d days ago");
+_t("about a month ago");
+_t("%d months ago");
+_t("about a year ago");
+_t("%d years ago");

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -44,6 +44,12 @@ const Markup = markup().constructor;
  */
 export function _t(term, ...values) {
     if (translatedTerms[translationLoaded]) {
+        if (!odoo.translationContext) {
+            throw new Error("No translation context found");
+        }
+        if (!(odoo.translationContext in translatedTerms)) {
+            throw new Error(`Invalid translation context found: ${odoo.translationContext}`);
+        }
         const translation = translatedTerms[odoo.translationContext]?.[term] ?? term;
         if (values.length === 0) {
             return translation;
@@ -57,12 +63,18 @@ export function _t(term, ...values) {
 class LazyTranslatedString extends String {
     constructor(term, values) {
         super(term);
+        if (!odoo.translationContext) {
+            throw new Error("No translation context found");
+        }
         this.translationContext = odoo.translationContext;
         this.values = values;
     }
     valueOf() {
         const term = super.valueOf();
         if (translatedTerms[translationLoaded]) {
+            if (!(this.translationContext in translatedTerms)) {
+                throw new Error(`Invalid translation context found: ${this.translationContext}`);
+            }
             const translation = translatedTerms[this.translationContext]?.[term] ?? term;
             if (this.values.length === 0) {
                 return translation;

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -44,7 +44,7 @@ const Markup = markup().constructor;
  */
 export function _t(term, ...values) {
     if (translatedTerms[translationLoaded]) {
-        const translation = translatedTerms[term] ?? term;
+        const translation = translatedTerms[odoo.translationContext]?.[term] ?? term;
         if (values.length === 0) {
             return translation;
         }
@@ -57,12 +57,13 @@ export function _t(term, ...values) {
 class LazyTranslatedString extends String {
     constructor(term, values) {
         super(term);
+        this.translationContext = odoo.translationContext;
         this.values = values;
     }
     valueOf() {
         const term = super.valueOf();
         if (translatedTerms[translationLoaded]) {
-            const translation = translatedTerms[term] ?? term;
+            const translation = translatedTerms[this.translationContext]?.[term] ?? term;
             if (this.values.length === 0) {
                 return translation;
             }
@@ -140,4 +141,24 @@ function _safeFormatAndSprintf(str, ...values) {
         return htmlSprintf(str, ...values);
     }
     return sprintf(str, ...values);
+}
+
+/**
+ * This is a wrapper for _t that the transpiler injects in its place
+ * to provide the knowledge of the module from which it was called.
+ *
+ * Providing the context of the module is useful to avoid conflicting
+ * translations, e.g. "table" has a different meaning depending on the module:
+ * the table of a restaurant (POS module) vs. a spreadsheet table.
+ *
+ * @param {string} str The term to translate
+ * @param {string} moduleName The name of the module, used as a context key to
+ * retrieve the translation.
+ * @param  {...any} args The other arguments passed to _t.
+ */
+export function appTranslateFn(str, moduleName, ...args) {
+    odoo.translationContext = moduleName;
+    const translatedTerms = _t(str, ...args);
+    odoo.translationContext = null;
+    return translatedTerms;
 }

--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -89,25 +89,6 @@ class LazyTranslatedString extends String {
     }
 }
 
-/*
- * Setup jQuery timeago:
- * Strings in timeago are "composed" with prefixes, words and suffixes. This
- * makes their detection by our translating system impossible. Use all literal
- * strings we're using with a translation mark here so the extractor can do its
- * job.
- */
-_t("less than a minute ago");
-_t("about a minute ago");
-_t("%d minutes ago");
-_t("about an hour ago");
-_t("%d hours ago");
-_t("a day ago");
-_t("%d days ago");
-_t("about a month ago");
-_t("%d months ago");
-_t("about a year ago");
-_t("%d years ago");
-
 /**
  * Load the installed languages long names and code
  *

--- a/addons/web/static/src/core/template_inheritance.js
+++ b/addons/web/static/src/core/template_inheritance.js
@@ -1,4 +1,54 @@
 const RSTRIP_REGEXP = /(?=\n[ \t]*$)/;
+
+let translationContext = null;
+
+const TCTX = "t-translation-context";
+function getTranslationContext(node) {
+    if (node.hasAttribute(TCTX)) {
+        return node.getAttribute(TCTX);
+    }
+    return getTranslationContext(node.parentElement);
+}
+
+const contextByTextNode = new Map();
+function setTranslationContext(node) {
+    switch (node.nodeType) {
+        case Node.TEXT_NODE:
+            if (node.nodeValue.trim() != "") {
+                contextByTextNode.set(node, translationContext);
+            }
+            break;
+        case Node.ELEMENT_NODE:
+            node.setAttribute(TCTX, translationContext);
+            break;
+    }
+}
+
+export function applyContextToTextNode() {
+    for (const [textNode, context] of contextByTextNode) {
+        const wrapper = document.createElement("t");
+        wrapper.setAttribute(TCTX, context);
+        textNode.before(wrapper);
+        wrapper.appendChild(textNode);
+    }
+    contextByTextNode.clear();
+}
+
+export function deepClone(node) {
+    const clone = node.cloneNode();
+    if (node.nodeType === Node.TEXT_NODE) {
+        if (contextByTextNode.has(node)) {
+            contextByTextNode.set(clone, contextByTextNode.get(node));
+        }
+    }
+    if (node.childNodes?.length) {
+        for (const childNode of [...node.childNodes]) {
+            clone.append(deepClone(childNode));
+        }
+    }
+    return clone;
+}
+
 /**
  * The child nodes of operation represent new content to create before target or
  * or other elements to move before target from the target tree (tree from which target is part of).
@@ -17,14 +67,11 @@ function addBefore(target, operation) {
     if (previousSibling?.nodeType === Node.TEXT_NODE) {
         const [text1, text2] = previousSibling.data.split(RSTRIP_REGEXP);
         previousSibling.data = text1.trimEnd();
-        if (nodes[0].nodeType === Node.TEXT_NODE) {
-            mergeTextNodes(previousSibling, nodes[0]);
-        }
         if (text2 && nodes.some((n) => n.nodeType !== Node.TEXT_NODE)) {
             const textNode = document.createTextNode(text2);
             target.before(textNode);
             if (textNode.previousSibling.nodeType === Node.TEXT_NODE) {
-                mergeTextNodes(textNode.previousSibling, textNode);
+                textNode.previousSibling.data = textNode.previousSibling.data.trimEnd();
             }
         }
     }
@@ -58,19 +105,19 @@ function getXpath(operation) {
             const templateName = parent.getAttribute("t-name") || parent.getAttribute("t-inherit");
             console.warn(
                 `Error-prone use of @class in template "${templateName}" (or one of its inheritors).` +
-                " Use the hasclass(*classes) function to filter elements by their classes"
+                    " Use the hasclass(*classes) function to filter elements by their classes"
             );
         }
     }
     // hasclass does not exist in XPath 1.0 but is a custom function defined server side (see _hasclass) usable in lxml.
     // Here we have to replace it by a complex condition (which is not nice).
     // Note: we assume that classes do not contain the 2 chars , and )
-    return xpath.replaceAll(HASCLASS_REGEXP, (_, capturedGroup) => {
-        return capturedGroup
+    return xpath.replaceAll(HASCLASS_REGEXP, (_, capturedGroup) =>
+        capturedGroup
             .split(",")
             .map((c) => `contains(concat(' ', @class, ' '), ' ${c.trim().slice(1, -1)} ')`)
-            .join(" and ");
-    });
+            .join(" and ")
+    );
 }
 
 /**
@@ -87,9 +134,10 @@ function getNode(element, operation) {
         const result = doc.evaluate(xpath, root, null, XPathResult.FIRST_ORDERED_NODE_TYPE);
         return result.singleNodeValue;
     }
+    const attributes = [...operation.attributes].filter((attr) => !attr.name.startsWith(TCTX));
     for (const elem of root.querySelectorAll(operation.tagName)) {
         if (
-            [...operation.attributes].every(
+            attributes.every(
                 ({ name, value }) => name === "position" || elem.getAttribute(name) === value
             )
         ) {
@@ -125,23 +173,15 @@ function getNodes(element, operation) {
     for (const childNode of operation.childNodes) {
         if (childNode.tagName === "xpath" && childNode.getAttribute?.("position") === "move") {
             const node = getElement(element, childNode);
+            node.setAttribute(TCTX, getTranslationContext(node));
             removeNode(node);
             nodes.push(node);
         } else {
+            setTranslationContext(childNode);
             nodes.push(childNode);
         }
     }
     return nodes;
-}
-
-/**
- * @param {Text} first
- * @param {Text} second
- * @param {boolean} [trimEnd=true]
- */
-function mergeTextNodes(first, second, trimEnd = true) {
-    first.data = (trimEnd ? first.data.trimEnd() : first.data) + second.data;
-    second.remove();
 }
 
 function splitAndTrim(str, separator) {
@@ -178,6 +218,9 @@ function modifyAttributes(target, operation) {
 
         if (value) {
             target.setAttribute(attributeName, value);
+            if (!(add || remove)) {
+                target.setAttribute(`t-translation-context-${attributeName}`, translationContext);
+            }
         } else {
             target.removeAttribute(attributeName);
         }
@@ -192,12 +235,12 @@ function modifyAttributes(target, operation) {
 function removeNode(node) {
     const { nextSibling, previousSibling } = node;
     node.remove();
-    if (nextSibling?.nodeType === Node.TEXT_NODE && previousSibling?.nodeType === Node.TEXT_NODE) {
-        mergeTextNodes(
-            previousSibling,
-            nextSibling,
-            previousSibling.parentElement.firstChild === previousSibling
-        );
+    if (
+        nextSibling?.nodeType === Node.TEXT_NODE &&
+        previousSibling?.nodeType === Node.TEXT_NODE &&
+        previousSibling.parentElement.firstChild === previousSibling
+    ) {
+        previousSibling.data = previousSibling.data.trimEnd();
     }
 }
 
@@ -216,9 +259,10 @@ function replace(root, target, operation) {
                 null,
                 XPathResult.ORDERED_NODE_SNAPSHOT_TYPE
             );
+            target.setAttribute(TCTX, getTranslationContext(target));
             for (let i = 0; i < result.snapshotLength; i++) {
                 const loc = result.snapshotItem(i);
-                loc.firstChild.replaceWith(target.cloneNode(true));
+                loc.firstChild.replaceWith(deepClone(target));
             }
             if (target.parentElement) {
                 const nodes = getNodes(target, operation);
@@ -228,6 +272,7 @@ function replace(root, target, operation) {
                 let comment = null;
                 for (const child of operation.childNodes) {
                     if (child.nodeType === Node.ELEMENT_NODE) {
+                        setTranslationContext(child);
                         operationContent = child;
                         break;
                     }
@@ -235,7 +280,7 @@ function replace(root, target, operation) {
                         comment = child;
                     }
                 }
-                root = operationContent.cloneNode(true);
+                root = deepClone(operationContent);
                 if (target.hasAttribute("t-name")) {
                     root.setAttribute("t-name", target.getAttribute("t-name"));
                 }
@@ -249,7 +294,10 @@ function replace(root, target, operation) {
             while (target.firstChild) {
                 target.removeChild(target.lastChild);
             }
-            target.append(...operation.childNodes);
+            for (const node of [...operation.childNodes]) {
+                setTranslationContext(node);
+                target.append(node);
+            }
             break;
         default:
             throw new Error(`Invalid mode attribute: '${mode}'`);
@@ -264,6 +312,7 @@ function replace(root, target, operation) {
  * @returns {Element} root modified (in place) by the operations
  */
 export function applyInheritance(root, operations, url = "") {
+    translationContext = url.split("/")[1] ?? ""; // use addon name as context
     for (const operation of operations.children) {
         const target = getElement(root, operation);
         const position = operation.getAttribute("position") || "inside";
@@ -314,5 +363,6 @@ export function applyInheritance(root, operations, url = "") {
                 throw new Error(`Invalid position attribute: '${position}'`);
         }
     }
+    translationContext = null;
     return root;
 }

--- a/addons/web/static/src/core/ui/block_ui.js
+++ b/addons/web/static/src/core/ui/block_ui.js
@@ -1,33 +1,14 @@
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
 
-import { EventBus, Component, useState, xml } from "@odoo/owl";
+import { EventBus, Component, useState } from "@odoo/owl";
 
 export class BlockUI extends Component {
     static props = {
         bus: EventBus,
     };
 
-    static template = xml`
-        <t t-if="state.blockState === BLOCK_STATES.UNBLOCKED">
-            <div/>
-        </t>
-        <t t-else="">
-            <t t-set="visiblyBlocked" t-value="state.blockState === BLOCK_STATES.VISIBLY_BLOCKED"/>
-            <div class="o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100"
-                 t-att-class="visiblyBlocked ? '' : 'o_blockUI_invisible'">
-                <t t-if="visiblyBlocked">
-                    <div class="o_spinner mb-4">
-                        <img src="/web/static/img/spin.svg" alt="Loading..."/>
-                    </div>
-                    <div class="o_message text-center px-4">
-                        <t t-esc="state.line1"/><br/>
-                        <t t-esc="state.line2"/>
-                    </div>
-                </t>
-            </div>
-        </t>
-    `;
+    static template = "web.BlockUI";
 
     setup() {
         this.messagesByDuration = [

--- a/addons/web/static/src/core/ui/block_ui.xml
+++ b/addons/web/static/src/core/ui/block_ui.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+       
+    <t t-name="web.BlockUI">
+        <t t-if="state.blockState === BLOCK_STATES.UNBLOCKED">
+            <div/>
+        </t>
+        <t t-else="">
+            <t t-set="visiblyBlocked" t-value="state.blockState === BLOCK_STATES.VISIBLY_BLOCKED"/>
+            <div class="o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100"
+                 t-att-class="visiblyBlocked ? '' : 'o_blockUI_invisible'">
+                <t t-if="visiblyBlocked">
+                    <div class="o_spinner mb-4">
+                        <img src="/web/static/img/spin.svg" alt="Loading..."/>
+                    </div>
+                    <div class="o_message text-center px-4">
+                        <t t-esc="state.line1"/><br/>
+                        <t t-esc="state.line2"/>
+                    </div>
+                </t>
+            </div>
+        </t>
+    </t>
+
+</templates>

--- a/addons/web/static/src/core/utils/render.js
+++ b/addons/web/static/src/core/utils/render.js
@@ -1,6 +1,6 @@
 import { App, blockDom, Component, markup } from "@odoo/owl";
 import { getTemplate } from "@web/core/templates";
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 
 export function renderToElement(template, context = {}) {
     const el = render(template, context).firstElementChild;
@@ -41,7 +41,7 @@ Object.defineProperty(renderToString, "app", {
                 name: "renderToString",
                 getTemplate,
                 translatableAttributes: ["data-tooltip"],
-                translateFn: _t,
+                translateFn: appTranslateFn,
             });
         }
         return app;

--- a/addons/web/static/src/env.js
+++ b/addons/web/static/src/env.js
@@ -2,7 +2,7 @@ import { App, EventBus } from "@odoo/owl";
 import { SERVICES_METADATA } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { getTemplate } from "@web/core/templates";
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 import { session } from "@web/session";
 import { isMacOS } from "@web/core/browser/feature_detection";
 
@@ -15,7 +15,6 @@ import { isMacOS } from "@web/core/browser/feature_detection";
  * @property {import("services").Services} services
  * @property {EventBus} bus
  * @property {string} debug
- * @property {(str: string) => string} _t
  * @property {boolean} [isSmall]
  */
 
@@ -237,7 +236,7 @@ export async function mountComponent(component, target, appConfig = {}) {
         warnIfNoStaticProps: !session.test_mode,
         name: component.constructor.name,
         translatableAttributes: ["data-tooltip"],
-        translateFn: _t,
+        translateFn: appTranslateFn,
         customDirectives,
         globalValues,
         ...appConfig,

--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -7,7 +7,7 @@ import { makeEnv, startServices } from "@web/env";
 import { getTemplate } from '@web/core/templates';
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { browser } from '@web/core/browser/browser';
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 import { jsToPyLocale, pyToJsLocale } from "@web/core/l10n/utils";
 import { App, Component, whenReady } from "@odoo/owl";
 import { RPCError } from '@web/core/network/rpc';
@@ -381,7 +381,7 @@ export async function createPublicRoot(RootWidget) {
         getTemplate,
         env,
         dev: env.debug,
-        translateFn: _t,
+        translateFn: appTranslateFn,
         translatableAttributes: ["data-tooltip"],
     });
     const locale = pyToJsLocale(lang) || browser.navigator.language;

--- a/addons/web/static/src/public/interaction_service.js
+++ b/addons/web/static/src/public/interaction_service.js
@@ -1,5 +1,5 @@
 import { registry } from "@web/core/registry";
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 import { Interaction } from "./interaction";
 import { getTemplate } from "@web/core/templates";
 import { PairSet } from "./utils";
@@ -65,7 +65,7 @@ class InteractionService {
                 getTemplate,
                 env: this.env,
                 dev: this.env.debug,
-                translateFn: _t,
+                translateFn: appTranslateFn,
                 warnIfNoStaticProps: this.env.debug,
                 translatableAttributes: ["data-tooltip"],
             };

--- a/addons/web/static/tests/_framework/component_test_helpers.js
+++ b/addons/web/static/tests/_framework/component_test_helpers.js
@@ -1,7 +1,7 @@
 import { after, destroy, getFixture } from "@odoo/hoot";
 import { queryFirst, queryOne } from "@odoo/hoot-dom";
 import { App, Component, xml } from "@odoo/owl";
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { getPopoverForTarget } from "@web/core/popover/popover";
 import { getTemplate as defaultGetTemplate } from "@web/core/templates";
@@ -126,7 +126,7 @@ export async function mountWithCleanup(ComponentClass, options) {
         target,
         templates,
         translatableAttributes,
-        translateFn = _t,
+        translateFn = appTranslateFn,
     } = options || {};
 
     // Common component configuration

--- a/addons/web/static/tests/_framework/translation_test_helpers.js
+++ b/addons/web/static/tests/_framework/translation_test_helpers.js
@@ -14,13 +14,22 @@ export function installLanguages(languages) {
     });
 }
 
-/**
- * @param {Record<string, string>} [terms]
- */
-export function patchTranslations(terms = {}) {
+export function allowTranslations() {
     translatedTerms[translationLoaded] = true;
     after(() => {
         translatedTerms[translationLoaded] = false;
     });
-    patchWithCleanup(translatedTerms, terms);
+}
+
+/**
+ * @param {Record<string, Record<string, string>>} [terms]
+ */
+export function patchTranslations(terms = {}) {
+    allowTranslations();
+    for (const addonName in terms) {
+        if (!(addonName in translatedTerms)) {
+            patchWithCleanup(translatedTerms, { [addonName]: {} });
+        }
+        patchWithCleanup(translatedTerms[addonName], terms[addonName]);
+    }
 }

--- a/addons/web/static/tests/core/checkbox.test.js
+++ b/addons/web/static/tests/core/checkbox.test.js
@@ -18,7 +18,7 @@ test("has a slot for translatable text", async () => {
     class Parent extends Component {
         static components = { CheckBox };
         static props = {};
-        static template = xml`<CheckBox>ragabadabadaba</CheckBox>`;
+        static template = xml`<div t-translation-context="web"><CheckBox>ragabadabadaba</CheckBox></div>`;
     }
 
     await mountWithCleanup(Parent);

--- a/addons/web/static/tests/core/l10n/dates.test.js
+++ b/addons/web/static/tests/core/l10n/dates.test.js
@@ -3,7 +3,7 @@ import { mockDate, mockTimeZone } from "@odoo/hoot-mock";
 import {
     defineParams,
     makeMockEnv,
-    patchTranslations,
+    allowTranslations,
     patchWithCleanup,
 } from "@web/../tests/web_test_helpers";
 
@@ -30,7 +30,7 @@ const dateFormat = strftimeToLuxonFormat(formats.date);
 const timeFormat = strftimeToLuxonFormat(formats.time);
 
 beforeEach(() => {
-    patchTranslations();
+    allowTranslations();
 });
 
 test("formatDate/formatDateTime specs", async () => {

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -9,13 +9,20 @@ import {
     patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
-import { _t, translatedTerms, translationLoaded } from "@web/core/l10n/translation";
+import { _t as basic_t, translatedTerms, translationLoaded } from "@web/core/l10n/translation";
 import { session } from "@web/session";
 import { IndexedDB } from "@web/core/utils/indexed_db";
 import { animationFrame, Deferred } from "@odoo/hoot-mock";
 
 import { Component, markup, xml } from "@odoo/owl";
 const { DateTime } = luxon;
+
+function _t() {
+    odoo.translationContext = "web";
+    const translatedTerms = basic_t(...arguments);
+    odoo.translationContext = null;
+    return translatedTerms;
+}
 
 let id = 0;
 
@@ -84,7 +91,7 @@ test("url is given by the session", async () => {
 });
 
 test("can translate a text node", async () => {
-    TestComponent._template = `<div id="main">Hello</div>`;
+    TestComponent._template = `<div id="main" t-translation-context="web">Hello</div>`;
     defineParams({
         translations: frenchTerms,
     });
@@ -103,7 +110,7 @@ test("[cache] write into the cache", async () => {
     onRpc("/web/webclient/translations", (request) => {
         expect.step(`hash: ${new URL(request.url).searchParams.get("hash")}`);
     });
-    TestComponent._template = `<div id="main">Hello</div>`;
+    TestComponent._template = `<div id="main" t-translation-context="web">Hello</div>`;
     defineParams({
         translations: frenchTerms,
     });
@@ -159,7 +166,7 @@ test("[cache] read from cache, and don't wait to render", async () => {
         await def;
         expect.step(`hash: ${new URL(request.url).searchParams.get("hash")}`);
     });
-    TestComponent._template = `<div id="main">Hello</div>`;
+    TestComponent._template = `<div id="main" t-translation-context="web">Hello</div>`;
     defineParams({
         translations: frenchTerms,
     });
@@ -201,7 +208,7 @@ test("[cache] update the cache if hash are different - template", async () => {
         await def;
         expect.step(`hash: ${new URL(request.url).searchParams.get("hash")}`);
     });
-    TestComponent._template = `<div id="main">Hello</div>`;
+    TestComponent._template = `<div id="main" t-translation-context="web">Hello</div>`;
     defineParams({
         translations: frenchTerms,
     });
@@ -275,7 +282,7 @@ test("[cache] update the cache if hash are different - js", async () => {
         expect.step(`hash: ${new URL(request.url).searchParams.get("hash")}`);
     });
     class MyTestComponent extends Component {
-        static template = xml`<div id="main"><t t-esc="otherText"/></div>`;
+        static template = xml`<div id="main" t-translation-context="web"><t t-esc="otherText"/></div>`;
         static props = ["*"];
 
         get otherText() {
@@ -328,7 +335,7 @@ test("[cache] update the cache if hash are different - js", async () => {
 test("can lazy translate", async () => {
     // Can't use patchWithCleanup cause it doesn't support Symbol
     translatedTerms[translationLoaded] = false;
-    TestComponent._template = `<div id="main"><t t-esc="constructor.someLazyText" /></div>`;
+    TestComponent._template = `<div id="main" t-translation-context="web"><t t-esc="constructor.someLazyText" /></div>`;
     TestComponent.someLazyText = _t("Hello");
     expect(() => TestComponent.someLazyText.toString()).toThrow();
     expect(() => TestComponent.someLazyText.valueOf()).toThrow();
@@ -391,18 +398,23 @@ test("tamil has the correct numbering system", async () => {
 
 test("_t fills the format specifiers in translated terms with its extra arguments", async () => {
     patchTranslations({
-        "Due in %s days": "Échéance dans %s jours",
+        web: {
+            "Due in %s days": "Échéance dans %s jours",
+        },
     });
     const translatedStr = _t("Due in %s days", 513);
     expect(translatedStr).toBe("Échéance dans 513 jours");
 });
 
 test("_t fills the format specifiers in translated terms with formatted lists", async () => {
-    patchTranslations({
-        "Due in %s days": "Échéance dans %s jours",
-        "Due in %(due_dates)s days for %(user)s": "Échéance dans %(due_dates)s jours pour %(user)s",
-    });
     await mockLang("fr_FR");
+    patchTranslations({
+        web: {
+            "Due in %s days": "Échéance dans %s jours",
+            "Due in %(due_dates)s days for %(user)s":
+                "Échéance dans %(due_dates)s jours pour %(user)s",
+        },
+    });
     const translatedStr1 = _t("Due in %s days", ["30", "60", "90"]);
     const translatedStr2 = _t("Due in %(due_dates)s days for %(user)s", {
         due_dates: ["30", "60", "90"],
@@ -416,7 +428,9 @@ test("_t fills the format specifiers in lazy translated terms with its extra arg
     translatedTerms[translationLoaded] = false;
     const translatedStr = _t("Due in %s days", 513);
     patchTranslations({
-        "Due in %s days": "Échéance dans %s jours",
+        web: {
+            "Due in %s days": "Échéance dans %s jours",
+        },
     });
     expect(translatedStr.toString()).toBe("Échéance dans 513 jours");
 });
@@ -441,7 +455,11 @@ describe("_t with markups", () => {
     test("translations are escaped", () => {
         translatedTerms[translationLoaded] = true;
         const maliciousTranslation = "<script>document.write('pizza hawai')</script> %s";
-        patchTranslations({ "I love %s": maliciousTranslation });
+        patchTranslations({
+            web: {
+                "I love %s": maliciousTranslation,
+            },
+        });
         const translatedStr = _t("I love %s", markup`<blink>Mario Kart</blink>`);
         expect(translatedStr.valueOf()).toBe(
             "&lt;script&gt;document.write(&#x27;pizza hawai&#x27;)&lt;/script&gt; <blink>Mario Kart</blink>"

--- a/addons/web/static/tests/core/network/download.test.js
+++ b/addons/web/static/tests/core/network/download.test.js
@@ -1,6 +1,6 @@
 import { after, describe, expect, test } from "@odoo/hoot";
 import { Deferred, mockFetch } from "@odoo/hoot-mock";
-import { patchTranslations } from "@web/../tests/web_test_helpers";
+import { allowTranslations } from "@web/../tests/web_test_helpers";
 
 import { download } from "@web/core/network/download";
 import { ConnectionLostError, RPCError } from "@web/core/network/rpc";
@@ -68,7 +68,7 @@ test("handles arbitrary error", async () => {
 });
 
 test("handles success download", async () => {
-    patchTranslations();
+    allowTranslations();
     // This test relies on a implementation detail of the lowest layer of download
     // That is, a link will be created with the download attribute
 

--- a/addons/web/static/tests/core/template.test.js
+++ b/addons/web/static/tests/core/template.test.js
@@ -1,0 +1,472 @@
+import { after, expect, test } from "@odoo/hoot";
+import { Component, useRef, xml } from "@odoo/owl";
+import { mountWithCleanup, patchTranslations } from "@web/../tests/web_test_helpers";
+import { registerTemplate, registerTemplateExtension, setUrlFilters } from "@web/core/templates";
+
+function makeTemplate({ name, content, inheritFrom }) {
+    return `<t t-name="${name}" ${inheritFrom ? `t-inherit="${inheritFrom}"` : ``}>${content}</t>`;
+}
+
+function makeTemplateExtension({ content, inheritFrom }) {
+    return `<t t-inherit="${inheritFrom}" t-inherit-mode="extension">${content}</t>`;
+}
+
+function visit(node, addon, terms) {
+    for (const { value } of node.attributes) {
+        terms[value] = `${value} (${addon})`;
+    }
+    for (const childNode of node.childNodes) {
+        if (childNode.nodeType === Node.TEXT_NODE) {
+            const text = childNode.data.trim();
+            terms[text] = `${text} (${addon})`;
+        } else {
+            visit(childNode, addon, terms);
+        }
+    }
+}
+
+const parser = new DOMParser();
+function extractTranslations(template, addon) {
+    const doc = parser.parseFromString(template, "text/xml");
+    const root = doc.firstChild;
+    const terms = {};
+    visit(root, addon, terms);
+    return terms;
+}
+
+function registerTemplates(...templates) {
+    const translations = {};
+
+    for (const { name, content, inheritFrom, inheritMode } of templates) {
+        // we should avoid do twice makeTemplate/makeTemplateExtension
+        const template =
+            inheritMode === "extension"
+                ? makeTemplateExtension({ content, inheritFrom })
+                : makeTemplate({ name, content, inheritFrom });
+        const addon = `addon_${name}`;
+        const terms = extractTranslations(template, addon);
+        translations[addon] = terms;
+        after(
+            inheritMode === "extension"
+                ? registerTemplateExtension(inheritFrom, `/${addon}`, template)
+                : registerTemplate(name, `/${addon}`, template)
+        );
+    }
+    patchTranslations(translations);
+}
+
+async function mountTestComponentWithTemplate(name) {
+    class TestComponent extends Component {
+        static props = ["*"];
+        static template = xml`<div t-ref="root"><t t-call="${name}"/></div>`;
+        setup() {
+            this.rootRef = useRef("root");
+        }
+    }
+    const component = await mountWithCleanup(TestComponent);
+    return component.rootRef.el;
+}
+
+test("translation-context: single template", async () => {
+    registerTemplates({
+        name: "A",
+        content: `
+            <div class="o_test_component" title="title">
+                text
+            </div>
+        `,
+    });
+    const el = await mountTestComponentWithTemplate("A");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component" title="title (addon_A)">
+            text (addon_A)
+        </div>
+    `);
+});
+
+test("translation-context: xpath position replace (outer)", async () => {
+    registerTemplates(
+        { name: "A", content: `<div class="o_test_component" title="title"> text </div>` },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div" position="replace">
+                    <div class="o_test_component" title="title"> text </div>
+                </xpath>
+            `,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("B");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component" title="title (addon_B)">
+            text (addon_B)
+        </div>
+    `);
+});
+
+test("translation-context: xpath position replace (outer) with $0", async () => {
+    registerTemplates(
+        { name: "A", content: `<div class="o_test_component" title="title"> text </div>` },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div" position="replace">
+                    <div class="o_test_component" title="title">
+                        text
+                        <div title="title2">$0</div>
+                    </div>
+                </xpath>
+            `,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("B");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component" title="title (addon_B)">
+            text (addon_B)
+            <div title="title2 (addon_B)">
+                <div class="o_test_component" title="title (addon_A)">
+                    text (addon_A)
+                </div>
+            </div>
+        </div>
+    `);
+});
+
+test("translation-context: xpath position replace (inner)", async () => {
+    registerTemplates(
+        {
+            name: "A",
+            content: `
+                <div class="o_test_component" title="title">
+                    text
+                    <span> text </span>
+                </div>
+            `,
+        },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div" position="replace" mode="inner">
+                    <span>
+                        text
+                        <div title="title"> text </div>
+                    </span>
+                </xpath>
+            `,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("B");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component" title="title (addon_A)">
+            <span>
+                text (addon_B)
+                <div title="title (addon_B)">
+                    text (addon_B)
+                </div>
+            </span>
+        </div>
+    `);
+});
+
+test("translation-context: xpath position attributes", async () => {
+    registerTemplates(
+        { name: "A", content: `<div class="o_test_component" title="title"> text </div>` },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div" position="attributes">
+                    <attribute name="title">title</attribute>
+                    <attribute name="label">label</attribute>
+                </xpath>
+            `,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("B");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component" title="title (addon_B)" label="label (addon_B)">
+            text (addon_A)
+        </div>
+    `);
+});
+
+test("translation-context: xpath position inside", async () => {
+    registerTemplates(
+        { name: "A", content: `<div class="o_test_component" title="title"> text </div>` },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div" position="inside">
+                    text
+                    <span title="title"> text </span>
+                    text
+                </xpath>
+            `,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("B");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component" title="title (addon_A)">
+            text (addon_A) text (addon_B)
+            <span title="title (addon_B)">
+                text (addon_B)
+            </span>
+            text (addon_B)
+        </div>
+    `);
+});
+
+test("translation-context: xpath position inside: moved element", async () => {
+    registerTemplates(
+        {
+            name: "A",
+            content: `
+                <div class="o_test_component">
+                    <span>Hello</span>
+                    <span>World</span>
+                </div>
+            `,
+        },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div/span" position="before">
+                    <xpath expr="div/span[2]" position="move"/>
+                </xpath>`,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("B");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component">
+            <span>World (addon_A)</span>
+            <span>Hello (addon_A)</span>
+        </div>
+    `);
+});
+
+test("translation-context: xpath position after with some text", async () => {
+    registerTemplates(
+        {
+            name: "A",
+            content: `
+                <div class="o_test_component" title="title">
+                    <span>text1</span>
+                    <span>text2</span>
+                </div>
+            `,
+        },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div/span" position="after">
+                    <div title="title">
+                        text1
+                    </div>
+                    text2
+                </xpath>
+            `,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("B");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component" title="title (addon_A)">
+            <span>
+                text1 (addon_A)
+            </span>
+            <div title="title (addon_B)">
+                text1 (addon_B)
+            </div>
+            text2 (addon_B)
+            <span>
+                text2 (addon_A)
+            </span>
+        </div>
+    `);
+});
+
+test("translation-context: xpath position before with some text", async () => {
+    registerTemplates(
+        {
+            name: "A",
+            content: `
+                <div class="o_test_component" title="title">
+                    <span>text1</span>
+                    <span>text2</span>
+                </div>
+            `,
+        },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div/span" position="before">
+                    <div title="title">
+                        text1
+                    </div>
+                    text2
+                </xpath>
+            `,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("B");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component" title="title (addon_A)">
+            <div title="title (addon_B)">
+                text1 (addon_B)
+            </div>
+            text2 (addon_B)
+            <span>
+                text1 (addon_A)
+            </span>
+            <span>
+                text2 (addon_A)
+            </span>
+        </div>
+    `);
+});
+
+test("translation-context: wrappers texts in t tags", async () => {
+    registerTemplates(
+        {
+            name: "A",
+            content: `
+                <div class="o_test_component">
+                    Hello
+                </div>
+            `,
+        },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div" position="inside">
+                    World
+                </xpath>`,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("B");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component">
+            Hello (addon_A) World (addon_B)
+        </div>
+    `);
+});
+
+test("translation-context: wrappers texts in t tags (2)", async () => {
+    after(setUrlFilters([]));
+    registerTemplates(
+        {
+            name: "A",
+            content: `
+                <div class="o_test_component">
+                    Hello
+                </div>
+            `,
+        },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div" position="inside">
+                    World
+                </xpath>`,
+            inheritFrom: "A",
+            inheritMode: "extension",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("A");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component">
+            Hello (addon_A) World (addon_B)
+        </div>
+    `);
+});
+
+test("translation-context: wrappers texts in t tags (3)", async () => {
+    after(setUrlFilters([]));
+    registerTemplates(
+        {
+            name: "A",
+            content: `
+                <div class="o_test_component" title="title">
+                    text
+                </div>
+            `,
+        },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div" position="inside">
+                    text
+                </xpath>`,
+            inheritFrom: "A",
+            inheritMode: "extension",
+        },
+        {
+            name: "C",
+            content: `
+                <xpath expr="div" position="replace">
+                    <div class="o_test_component" title="title">
+                        text
+                        <div title="title2">$0</div>
+                    </div>
+                </xpath>
+            `,
+            inheritFrom: "A",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("C");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component" title="title (addon_C)">
+            text (addon_C)
+            <div title="title2 (addon_C)">
+                <div class="o_test_component" title="title (addon_A)">
+                    text (addon_A) text (addon_B)
+                </div>
+            </div>
+        </div>
+    `);
+});
+
+test("translation-context: wrappers around texts do not affect xpaths (1)", async () => {
+    registerTemplates(
+        {
+            name: "A",
+            content: `
+                <div class="o_test_component">
+                    Hello
+                    <t t-if="true">
+                        Janet
+                    </t>
+                </div>
+            `,
+        },
+        {
+            name: "B",
+            content: `
+                <xpath expr="div/t" position="before">
+                    World
+                </xpath>`,
+            inheritFrom: "A",
+        },
+        {
+            name: "C",
+            content: `
+                <xpath expr="div/t" position="replace" mode="inner">
+                    Jamie
+                </xpath>`,
+            inheritFrom: "B",
+        }
+    );
+    const el = await mountTestComponentWithTemplate("C");
+    expect(el).toHaveInnerHTML(`
+        <div class="o_test_component">
+            Hello (addon_A) World (addon_B)  Jamie (addon_C)
+        </div>
+    `);
+});

--- a/addons/web/static/tests/core/template_inheritance.test.js
+++ b/addons/web/static/tests/core/template_inheritance.test.js
@@ -5,9 +5,10 @@ import { patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
 const parser = new DOMParser();
 const serializer = new XMLSerializer();
 
-function _applyInheritance(arch, inherits, url = "test/url") {
+function _applyInheritance(arch, inherits, url = "test/from_op") {
     const archXmlDoc = parser.parseFromString(arch, "text/xml");
     const inheritsDoc = parser.parseFromString(inherits, "text/xml");
+    archXmlDoc.documentElement.setAttribute("t-translation-context", "from_target");
     const modifiedTemplate = applyInheritance(
         archXmlDoc.documentElement,
         inheritsDoc.documentElement,
@@ -26,8 +27,8 @@ test("warn when contains(@class, ...)", async () => {
     const arch = `<t t-name="web.A"><div class="my-class" /></t>`;
     const operations = `
     <t t-inherit="web.A"><xpath expr="*[contains(@class, 'my-class')]" position="inside"><span/></xpath></t>`;
-    expect(_applyInheritance(arch, operations, false)).toBe(
-        `<t t-name="web.A"><div class="my-class"><span/></div></t>`
+    expect(_applyInheritance(arch, operations, "")).toBe(
+        `<t t-name="web.A" t-translation-context="from_target"><div class="my-class"><span t-translation-context=""/></div></t>`
     );
     expect.verifySteps([
         `Error-prone use of @class in template "web.A" (or one of its inheritors). Use the hasclass(*classes) function to filter elements by their classes`,
@@ -35,7 +36,7 @@ test("warn when contains(@class, ...)", async () => {
 });
 
 test("no operation", async () => {
-    const arch = `<t t-name="web.A"> <div><h2>Title</h2>text</div> </t>`;
+    const arch = `<t t-name="web.A" t-translation-context="from_target"> <div><h2>Title</h2>text</div> </t>`;
     const operations = `<t/>`;
     expect(_applyInheritance(arch, operations)).toBe(arch);
 });
@@ -48,7 +49,7 @@ test("single operation: replace", async () => {
                 <t>
                     <xpath expr="./div/h2" position="replace"><h3>Other title</h3></xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div><h3>Other title</h3>text</div> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div><h3 t-translation-context="from_op">Other title</h3>text</div> </t>`,
             // TODO check if text should be there? (I think there is a bug in python code)
         },
     ];
@@ -66,7 +67,7 @@ test("single operation: replace (debug mode)", async () => {
                 <t>
                     <xpath expr="./div/h2" position="replace"><h3>Other title</h3></xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div><!-- From file: test/url ; expr="./div/h2" ; position="replace" --><h3>Other title</h3>text</div> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div><!-- From file: test/from_op ; expr="./div/h2" ; position="replace" --><h3 t-translation-context="from_op">Other title</h3>text</div> </t>`,
         },
     ];
     for (const { arch, operations, result } of toTest) {
@@ -82,7 +83,7 @@ test("single operation: replace root (and use a $0)", async () => {
                 <t>
                     <xpath expr="." position="replace"><div>At first I was afraid</div>$0</xpath>
                 </t>`,
-            result: `<div t-name="web.A">At first I was afraid</div>`,
+            result: `<div t-translation-context="from_op" t-name="web.A">At first I was afraid</div>`,
             // in outer mode with no parent only first child of operation is kept
         },
         {
@@ -91,7 +92,7 @@ test("single operation: replace root (and use a $0)", async () => {
                 <t>
                     <xpath expr="." position="replace"> <div>$0</div><div>At first I was afraid</div> </xpath>
                 </t>`,
-            result: `<div t-name="web.A"><t t-name="web.A"> <div>I was petrified</div> </t></div>`,
+            result: `<div t-translation-context="from_op" t-name="web.A"><t t-name="web.A" t-translation-context="from_target"> <div>I was petrified</div> </t></div>`,
         },
         {
             arch: `<t t-name="web.A"> <div>I was petrified</div> </t>`,
@@ -99,7 +100,7 @@ test("single operation: replace root (and use a $0)", async () => {
                 <t>
                     <xpath expr="." position="replace"> <t><t t-if="cond"><div>At first I was afraid</div></t><t t-else="">$0</t></t> </xpath>
                 </t>`,
-            result: `<t t-name="web.A"><t t-if="cond"><div>At first I was afraid</div></t><t t-else=""><t t-name="web.A"> <div>I was petrified</div> </t></t></t>`,
+            result: `<t t-translation-context="from_op" t-name="web.A"><t t-if="cond"><div>At first I was afraid</div></t><t t-else=""><t t-name="web.A" t-translation-context="from_target"> <div>I was petrified</div> </t></t></t>`,
         },
         {
             arch: `<form t-name="template_1_1" random-attr="gloria"> <div>At first I was afraid</div> <form>Inner Form</form> </form>`,
@@ -109,7 +110,7 @@ test("single operation: replace root (and use a $0)", async () => {
                         <div> Form replacer </div>
                     </xpath>
                 </t>`,
-            result: `<div t-name="template_1_1"> Form replacer </div>`,
+            result: `<div t-translation-context="from_op" t-name="template_1_1"> Form replacer </div>`,
         },
         {
             arch: `<form t-name="template_1_1" random-attr="gloria"> <div>At first I was afraid</div> </form>`,
@@ -120,7 +121,7 @@ test("single operation: replace root (and use a $0)", async () => {
                     </xpath>
                 </t>
             `,
-            result: `<div overriden-attr="overriden" t-name="template_1_1">And I grew strong</div>`,
+            result: `<div overriden-attr="overriden" t-translation-context="from_op" t-name="template_1_1">And I grew strong</div>`,
         },
     ];
     for (const { arch, operations, result } of toTest) {
@@ -136,7 +137,7 @@ test("single operation: replace (mode inner)", async () => {
                 <t>
                     <xpath expr="./div" position="replace" mode="inner"> E <div/> F <span attr1="12"/> </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div> E <div/> F <span attr1="12"/> </div> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div> E <div t-translation-context="from_op"/> F <span attr1="12" t-translation-context="from_op"/> </div> </t>`,
         },
     ];
     for (const { arch, operations, result } of toTest) {
@@ -153,11 +154,11 @@ test("single operation: replace (mode inner) (debug mode)", async () => {
                 <t>
                     <xpath expr="./div" position="replace" mode="inner"> E <div/> F <span attr1="12"/> </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div><!-- From file: test/url ; expr="./div" ; position="replace" ; mode="inner" --> E <div/> F <span attr1="12"/> </div> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div><!-- From file: test/from_op ; expr="./div" ; position="replace" ; mode="inner" --> E <div t-translation-context="from_op"/> F <span attr1="12" t-translation-context="from_op"/> </div> </t>`,
         },
     ];
     for (const { arch, operations, result } of toTest) {
-        expect(_applyInheritance(arch, operations, "test/url")).toBe(result);
+        expect(_applyInheritance(arch, operations)).toBe(result);
     }
 });
 
@@ -169,7 +170,7 @@ test("single operation: before", async () => {
                 <t>
                     <xpath expr="./div/h2" position="before"> <h3>Other title</h3>Yooplahoo!<h4>Yet another title</h4> </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div>AAB is the best <h3>Other title</h3>Yooplahoo!<h4>Yet another title</h4> <h2>Title</h2>text</div> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div>AAB is the best <h3 t-translation-context="from_op">Other title</h3>Yooplahoo!<h4 t-translation-context="from_op">Yet another title</h4> <h2>Title</h2>text</div> </t>`,
         },
         {
             arch: `<t t-name="web.A"> <div>AAB is the best<h2>Title</h2><div><span>Ola</span></div></div> </t>`,
@@ -177,7 +178,7 @@ test("single operation: before", async () => {
                 <t>
                     <xpath expr="./div/h2" position="before"> <xpath expr="./div/div/span" position="move" /> </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div>AAB is the best <span>Ola</span> <h2>Title</h2><div/></div> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div>AAB is the best <span t-translation-context="from_target">Ola</span> <h2>Title</h2><div/></div> </t>`,
         },
         {
             arch: `<t t-name="web.A"> a <div/> </t>`,
@@ -185,7 +186,7 @@ test("single operation: before", async () => {
                 <t>
                     <xpath expr="./div" position="before"> 4 </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> a 4 <div/> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> a 4 <div/> </t>`,
         },
     ];
     for (const { arch, operations, result } of toTest) {
@@ -196,12 +197,12 @@ test("single operation: before", async () => {
 test("single operation: inside", async () => {
     const toTest = [
         {
-            arch: `<t t-name="web.A"> <div>AAB is the best <h2>Title</h2> <div/> </div> </t>`,
+            arch: `<t t-name="web.A" t-translation-context="from_target"> <div>AAB is the best <h2>Title</h2> <div/> </div> </t>`,
             operations: `
                 <t>
                     <xpath expr="./div/div" position="inside"> Hop! <xpath expr="./div/h2" position="move" /> <span>Yellow</span> </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div>AAB is the best <div> Hop! <h2>Title</h2> <span>Yellow</span> </div> </div> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div>AAB is the best <div> Hop! <h2 t-translation-context="from_target">Title</h2> <span t-translation-context="from_op">Yellow</span> </div> </div> </t>`,
         },
         {
             arch: `<t><div/></t>`,
@@ -209,7 +210,7 @@ test("single operation: inside", async () => {
                 <t>
                     <xpath expr="./div" position="inside">4</xpath>
                 </t>`,
-            result: `<t><div>4</div></t>`,
+            result: `<t t-translation-context="from_target"><div>4</div></t>`,
         },
         {
             arch: `<t><div>\na \n </div></t>`,
@@ -217,7 +218,7 @@ test("single operation: inside", async () => {
                 <t>
                     <xpath expr="./div" position="inside">4</xpath>
                 </t>`,
-            result: `<t><div>\na4</div></t>`,
+            result: `<t t-translation-context="from_target"><div>\na4</div></t>`,
         },
         {
             arch: `<t>a<div></div><span/></t>`,
@@ -225,7 +226,7 @@ test("single operation: inside", async () => {
                 <t>
                     <xpath expr="./div" position="inside"><span/></xpath>
                 </t>`,
-            result: `<t>a<div><span/></div><span/></t>`,
+            result: `<t t-translation-context="from_target">a<div><span t-translation-context="from_op"/></div><span/></t>`,
         },
     ];
     for (const { arch, operations, result } of toTest) {
@@ -236,20 +237,20 @@ test("single operation: inside", async () => {
 test("single operation: after", async () => {
     const toTest = [
         {
-            arch: `<t t-name="web.A"> <div> AAB is the best <h2>Title</h2> <div id="1"/> <div id="2"/> </div> </t>`,
+            arch: `<t t-name="web.A" t-translation-context="from_target"> <div> AAB is the best <h2>Title</h2> <div id="1"/> <div id="2"/> </div> </t>`,
             operations: `
                 <t>
-                    <xpath expr="./div/h2" position="after"> Hop! <xpath expr="./div/div[2]" position="move" /> <span>Yellow</span> </xpath>
+                    <xpath expr="./div/h2" position="after"> Hop! <xpath expr="./div/div[@id=2]" position="move" /> <span>Yellow</span> </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div> AAB is the best <h2>Title</h2> Hop! <div id="2"/> <span>Yellow</span>  <div id="1"/>  </div> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div> AAB is the best <h2>Title</h2> Hop! <div id="2" t-translation-context="from_target"/> <span t-translation-context="from_op">Yellow</span>  <div id="1"/>  </div> </t>`,
         },
         {
-            arch: `<t t-name="web.A"> <div/>a </t>`,
+            arch: `<t t-name="web.A" t-translation-context="from_target"> <div/>a </t>`,
             operations: `
                 <t>
                     <xpath expr="./div" position="after">4</xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div/>4a </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div/>4a </t>`,
         },
     ];
     for (const { arch, operations, result } of toTest) {
@@ -271,7 +272,7 @@ test("single operation: attributes", async (assert) => {
                         <attribute name="attr4">new</attribute>
                     </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div attr1="45" attr2="b c" attr4="new"/> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div attr1="45" attr2="b c" t-translation-context-attr1="from_op" attr4="new" t-translation-context-attr4="from_op"/> </t>`,
         },
         {
             arch: `<t t-name="web.A"> <div><a href="1"/><div><a href="2"/></div></div> </t>`,
@@ -281,7 +282,7 @@ test("single operation: attributes", async (assert) => {
                         <attribute name="found">1</attribute>
                     </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <div><a href="1"/><div><a href="2" found="1"/></div></div> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <div><a href="1"/><div><a href="2" found="1" t-translation-context-found="from_op"/></div></div> </t>`,
         },
     ];
     for (const { arch, operations, result } of toTest) {
@@ -304,7 +305,7 @@ test("single operation: attributes (debug mode)", async () => {
                         <attribute name="attr4">new</attribute>
                     </xpath>
                 </t>`,
-            result: `<t t-name="web.A"> <!-- From file: test/url ; expr="./div" ; position="attributes" --><div attr1="45" attr2="b c" attr4="new"/> </t>`,
+            result: `<t t-name="web.A" t-translation-context="from_target"> <!-- From file: test/from_op ; expr="./div" ; position="attributes" --><div attr1="45" attr2="b c" t-translation-context-attr1="from_op" attr4="new" t-translation-context-attr4="from_op"/> </t>`,
         },
     ];
     for (const { arch, operations, result } of toTest) {
@@ -317,52 +318,52 @@ test("xpath with hasclass", async () => {
         {
             arch: `<t><div class="abc"/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc')]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class="abc "/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc')]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class=" abc"/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc')]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class=" abc "/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc')]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class="d abc e"/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc')]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class="d abc"/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc')]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class="abc d"/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc')]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class="abcd e abc"/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc')]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class="abcd e abc"/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc', 'abcd' )]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class="abcd e abc"/></t>`,
             operations: `<t><xpath expr="./div[hasclass('abc') and hasclass('abcd')]" position="replace"></xpath></t>`,
-            result: `<t/>`,
+            result: `<t t-translation-context="from_target"/>`,
         },
         {
             arch: `<t><div class="abcd"/></t>`,

--- a/addons/web/static/tests/core/utils/binary.test.js
+++ b/addons/web/static/tests/core/utils/binary.test.js
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { patchTranslations } from "@web/../tests/web_test_helpers";
+import { allowTranslations } from "@web/../tests/web_test_helpers";
 
 import { humanSize } from "@web/core/utils/binary";
 
 describe.current.tags("headless");
 
 test("humanSize", () => {
-    patchTranslations();
+    allowTranslations();
     expect(humanSize(0)).toBe("0.00 Bytes");
     expect(humanSize(3)).toBe("3.00 Bytes");
     expect(humanSize(2048)).toBe("2.00 Kb");

--- a/addons/web/static/tests/core/utils/numbers.test.js
+++ b/addons/web/static/tests/core/utils/numbers.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { patchTranslations, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { allowTranslations, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { localization } from "@web/core/l10n/localization";
 import {
@@ -289,7 +289,7 @@ describe("formatFloat", () => {
     });
 
     test("humanReadable", () => {
-        patchTranslations();
+        allowTranslations();
         patchWithCleanup(localization, {
             decimalPoint: ".",
             grouping: [3, 0],

--- a/addons/web/static/tests/core/utils/render.test.js
+++ b/addons/web/static/tests/core/utils/render.test.js
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { expectMarkup, patchTranslations } from "@web/../tests/web_test_helpers";
+import { expectMarkup, allowTranslations } from "@web/../tests/web_test_helpers";
 
 import { renderToElement, renderToString } from "@web/core/utils/render";
 
 describe.current.tags("headless");
 
 test("renderToElement always returns an element", () => {
-    patchTranslations();
+    allowTranslations();
     renderToString.app.addTemplate(
         "test.render.template.1",
         `<t t-if="False">

--- a/addons/web/static/tests/core/utils/strings.test.js
+++ b/addons/web/static/tests/core/utils/strings.test.js
@@ -10,7 +10,14 @@ import {
     isNumeric,
     sprintf,
 } from "@web/core/utils/strings";
-import { _t } from "@web/core/l10n/translation";
+import { _t as basic_t } from "@web/core/l10n/translation";
+
+function _t() {
+    odoo.translationContext = "web";
+    const translatedTerms = basic_t(...arguments);
+    odoo.translationContext = null;
+    return translatedTerms;
+}
 
 describe.current.tags("headless");
 
@@ -94,7 +101,7 @@ describe("sprintf", () => {
     });
 
     test("supports lazy translated string", () => {
-        patchTranslations({ one: "en", two: "två" });
+        patchTranslations({ web: { one: "en", two: "två" } });
         expect(sprintf("Hello %s", _t("one"))).toBe("Hello en");
         expect(sprintf("Hello %s %s", _t("one"), _t("two"))).toBe("Hello en två");
 

--- a/addons/web/static/tests/env.test.js
+++ b/addons/web/static/tests/env.test.js
@@ -1,7 +1,7 @@
 import { after, beforeEach, describe, expect, getFixture, test } from "@odoo/hoot";
 import { Deferred, tick } from "@odoo/hoot-mock";
 import { Component, xml } from "@odoo/owl";
-import { clearRegistry, makeMockEnv, patchTranslations } from "@web/../tests/web_test_helpers";
+import { clearRegistry, makeMockEnv, allowTranslations } from "@web/../tests/web_test_helpers";
 
 import { registry } from "@web/core/registry";
 import { makeEnv, mountComponent, startServices } from "@web/env";
@@ -180,7 +180,7 @@ test(`startServices: waits for all synchronous code before attempting to start s
 });
 
 test(`mountComponent creates an env and sets the application as root when no env is provided`, async () => {
-    patchTranslations();
+    allowTranslations();
     registerService("my_service", [], () => "a");
 
     class Root extends Component {
@@ -198,7 +198,7 @@ test(`mountComponent creates an env and sets the application as root when no env
 });
 
 test(`mountComponent uses the env when provided and doesn't start the services`, async () => {
-    patchTranslations();
+    allowTranslations();
     registerService("my_service", [], () => {
         expect.step("starting myService");
         return "a";

--- a/addons/web/static/tests/search/search_utils.test.js
+++ b/addons/web/static/tests/search/search_utils.test.js
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { mockDate, mockTimeZone } from "@odoo/hoot-mock";
-import { patchTranslations, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import {
+    allowTranslations,
+    patchTranslations,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
 
 import { Domain } from "@web/core/domain";
 import { localization } from "@web/core/l10n/localization";
@@ -28,7 +32,7 @@ const dateTimeSearchItem = {
 beforeEach(() => {
     mockTimeZone(0);
     patchWithCleanup(localization, { direction: "ltr" });
-    patchTranslations();
+    allowTranslations();
 });
 
 test("construct simple domain based on date field (no comparisonOptionId)", () => {
@@ -262,7 +266,7 @@ test("construct domain based on datetime field (no comparisonOptionId)", () => {
 test("Quarter option: custom translation", async () => {
     mockDate("2020-06-01T13:00:00");
     const referenceMoment = luxon.DateTime.local().setLocale("en");
-    patchTranslations({ Q2: "Deuxième trimestre de l'an de grâce" });
+    patchTranslations({ web: { Q2: "Deuxième trimestre de l'an de grâce" } });
 
     const domain = constructDateDomain(referenceMoment, dateSearchItem, ["second_quarter", "year"]);
     expect(domain).toEqual({
@@ -291,7 +295,7 @@ test("Quarter option: custom translation and right to left", async () => {
     mockDate("2020-06-01T13:00:00");
     const referenceMoment = luxon.DateTime.local().setLocale("en");
     patchWithCleanup(localization, { direction: "rtl" });
-    patchTranslations({ Q2: "2e Trimestre" });
+    patchTranslations({ web: { Q2: "2e Trimestre" } });
 
     const domain = constructDateDomain(referenceMoment, dateSearchItem, ["second_quarter", "year"]);
     expect(domain).toEqual({

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { patchTranslations, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { allowTranslations, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { markup } from "@odoo/owl";
 import { currencies } from "@web/core/currency";
@@ -22,7 +22,7 @@ import {
 describe.current.tags("headless");
 
 beforeEach(() => {
-    patchTranslations();
+    allowTranslations();
     patchWithCleanup(localization, {
         decimalPoint: ".",
         thousandsSep: ",",

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -25,7 +25,6 @@ import {
     toggleSaveFavorite,
     toggleSearchBarMenu,
 } from "@web/../tests/web_test_helpers";
-import { _t } from "@web/core/l10n/translation";
 import { download } from "@web/core/network/download";
 import { PivotController } from "@web/views/pivot/pivot_controller";
 import { WebClient } from "@web/webclient/webclient";
@@ -216,7 +215,7 @@ test('pivot view without "string" attribute', async () => {
 
     const model = findComponent(view, (c) => c instanceof PivotController).model;
     // this is important for export functionality.
-    expect(model.metaData.title.toString()).toBe(_t("Untitled"));
+    expect(model.metaData.title.toString()).toBe("Untitled");
 });
 
 test('pivot view with "class" attribute', async () => {

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -132,7 +132,11 @@ export {
     validateSearch,
 } from "./_framework/search_test_helpers";
 export { swipeLeft, swipeRight } from "./_framework/touch_helpers";
-export { installLanguages, patchTranslations } from "./_framework/translation_test_helpers";
+export {
+    installLanguages,
+    patchTranslations,
+    allowTranslations,
+} from "./_framework/translation_test_helpers";
 export {
     clickButton,
     clickCancel,

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -25,9 +25,16 @@ import { WebClient } from "@web/webclient/webclient";
 import { router, routerBus, startRouter } from "@web/core/browser/router";
 import { redirect } from "@web/core/utils/urls";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
-import { _t } from "@web/core/l10n/translation";
+import { _t as basic_t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 import { queryAllAttributes, queryAllTexts, queryFirst } from "@odoo/hoot-dom";
+
+function _t() {
+    odoo.translationContext = "web";
+    const translatedTerms = basic_t(...arguments);
+    odoo.translationContext = null;
+    return translatedTerms;
+}
 
 describe.current.tags("desktop");
 

--- a/addons/web_editor/static/src/js/core/owl_utils.js
+++ b/addons/web_editor/static/src/js/core/owl_utils.js
@@ -1,6 +1,6 @@
 import { App, Component, useState, xml } from "@odoo/owl";
 import { getTemplate } from "@web/core/templates";
-import { _t } from "@web/core/l10n/translation";
+import { appTranslateFn } from "@web/core/l10n/translation";
 
 const rootTemplate = xml`<SubComp t-props="state"/>`;
 export async function attachComponent(parent, element, componentClass, props = {}) {
@@ -17,7 +17,7 @@ export async function attachComponent(parent, element, componentClass, props = {
         getTemplate,
         dev: env.debug,
         translatableAttributes: ["data-tooltip"],
-        translateFn: _t,
+        translateFn: appTranslateFn,
     });
 
     if (parent.__parentedMixin) {

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -1,5 +1,5 @@
 import { intersection } from "@web/core/utils/arrays";
-import { _t } from "@web/core/l10n/translation";
+import { _t, appTranslateFn } from "@web/core/l10n/translation";
 import { renderToElement } from "@web/core/utils/render";
 import { App, Component } from "@odoo/owl";
 import { getTemplate } from "@web/core/templates";
@@ -72,7 +72,7 @@ function autocompleteWithPages(input, options= {}, env = undefined) {
             targetDropdown: input,
         },
         translatableAttributes: ["data-tooltip"],
-        translateFn: _t,
+        translateFn: appTranslateFn,
     });
 
     const container = document.createElement("div");

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -4,7 +4,6 @@ import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_he
 import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
 import { patch } from "@web/core/utils/patch";
 import { IrModel } from "@web/../tests/_framework/mock_server/mock_models/ir_model";
-import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { animationFrame } from "@odoo/hoot-dom";
 
@@ -49,15 +48,15 @@ test("change action of form changes available options", async () => {
         .category("website.form_editor_actions")
         .add("apply_job", {
             formFields: [
-                { type: "char", name: "partner_name", fillWith: "name", string: _t("Your Name") },
+                { type: "char", name: "partner_name", fillWith: "name", string: "Your Name" },
             ],
             fields: [
-                { name: "job_id", type: "many2one", relation: "hr.job", string: _t("Applied Job") },
+                { name: "job_id", type: "many2one", relation: "hr.job", string: "Applied Job" },
             ],
             successPage: "/job-thank-you",
         })
         .add("create_customer", {
-            formFields: [{ type: "char", name: "name", fillWith: "name", string: _t("Your Name") }],
+            formFields: [{ type: "char", name: "name", fillWith: "name", string: "Your Name" }],
         });
 
     await setupWebsiteBuilder(

--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -12,12 +12,10 @@ the original source need to be supported by the browsers.
 """
 
 import re
-import logging
 from functools import partial
 
 from odoo.tools.misc import OrderedSet
 
-_logger = logging.getLogger(__name__)
 
 def transpile_javascript(url, content):
     """
@@ -50,6 +48,7 @@ def transpile_javascript(url, content):
         convert_default_export,
         partial(wrap_with_qunit_module, url),
         partial(wrap_with_odoo_define, module_path, dependencies),
+        partial(convert_t, url)
     ]
     for s in steps:
         content = s(content)
@@ -228,6 +227,46 @@ def convert_export_class_default(content):
     """
     repl = r"""\g<space>const \g<identifier> = __exports[Symbol.for("default")] = \g<type> \g<identifier>"""
     return EXPORT_CLASS_DEFAULT_RE.sub(repl, content)
+
+
+GETTEXT_RE = re.compile(r"""
+    ^
+    \s*const\s*{
+    (?:\s*\w*\s*,)*
+    \s*(_t)\s*
+    (?:,\s*\w*\s*)*,?\s*
+    }\s*=\s*require\("@web/core/l10n/translation"\);$
+""", re.MULTILINE | re.VERBOSE)
+
+
+T_FN_RE = re.compile(r"""
+    ^
+    \s*const\s*{
+    (?:\s*\w*\s*,)*
+    \s*(appTranslateFn)\s*
+    (?:,\s*\w*\s*)*,?\s*
+    }\s*=\s*require\("@web/core/l10n/translation"\);$
+""", re.MULTILINE | re.VERBOSE)
+
+
+def convert_t(url, content):
+    if url.endswith(".test.js"):
+        return content
+
+    module_name = URL_RE.match(url)["module"]
+
+    has_import_of_appTranslateFn = bool(T_FN_RE.search(content))
+
+    def rename_gettext(match_):
+        if has_import_of_appTranslateFn:
+            match_ = match_.group(0).replace("_t", "__not_defined__")
+        else:
+            match_ = match_.group(0).replace("_t", "appTranslateFn")
+        match_ += f"""const _t = (str, ...args) => appTranslateFn(str, "{module_name}", ...args);"""
+        return match_
+
+    return GETTEXT_RE.sub(rename_gettext, content)
+
 
 EXPORT_VAR_RE = re.compile(r"""
     ^


### PR DESCRIPTION
Before this commit:
===================
Client-side translations are loaded into a big dictionary in RAM, where
the key is the source term and the value is the translation.

This design is problematic because it doesn't allow a same term to have
different translations in different modules: since there is only one
entry per term, they would overwrite each other.

Practical example: "Bar" in the context of pos_restaurant is a place
where you serve drinks, while "Bar" in the context of spreadsheets is a
completely different thing. In French, they should be translated
differently: "Bar" for the former, "Barre" for the latter.

After this commit:
==================
An additional level of depth is added at the top of the translation
dictionary, corresponding to the name of the module it comes from, so
that translations are now retrieved like this:
translations[module][terms].

This allows the same term to be translated differently in different
modules.

Note that:
- Providing multiple translations for the same term WITHIN the same
  module is still not possible.
- Since translation no longer leaks between modules, if a translation is
  undefined in module A but defined in module B, module A won't benefit
  from the translation of module B.

Task-4457503
opw-4407750
opw-4300506
opw-4455322
opw-4017059

Co-authored-by: Louis Wicket <wil@odoo.com>
Co-authored-by: Mathieu Duckerts-Antoine <dam@odoo.com>