### PR TITLE
[FIX] point_of_sale: prevent numpad from hiding on small screens

### DIFF
--- a/addons/point_of_sale/static/src/app/components/numpad/numpad.xml
+++ b/addons/point_of_sale/static/src/app/components/numpad/numpad.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
   <t t-name="point_of_sale.Numpad">
-    <div t-attf-class="d-grid numpad numpad-{{buttons.length / 4}}-cols {{props.class}} overflow-hidden">
+    <div t-attf-class="d-grid numpad numpad-{{buttons.length / 4}}-cols {{props.class}}">
       <t t-foreach="buttons.map((b) => typeof b === 'object' ? b : { value: b })"  t-as="button" t-key="button.value">
         <span t-if="Object.keys(button).length === 0"/>
         <button 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -29,7 +29,7 @@
         <t t-else="">
             <div class="payment-screen screen d-flex flex-column h-100 ">
                 <div class="main-content d-flex gap-2 h-100 bg-100 overflow-auto">
-                    <div class="left-content d-flex flex-column col-md-4 p-2 border-end bg-white">
+                    <div class="left-content d-flex flex-column col-md-4 p-2 border-end bg-white overflow-y-auto">
                         <t t-call="point_of_sale.PaymentScreenMethods" />
                         <t t-call="point_of_sale.PaymentScreenButtons" />
                         <Numpad class="'my-2'"  buttons="getNumpadButtons()"/>


### PR DESCRIPTION
Before this commit, when the screen size was small and there were a high number of payment methods, the numpad would become invisible, making it impossible to edit the payment amount.

opw-4666090

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
