### PR TITLE
[IMP] l10n_jo_edi: Auto install module

### DIFF
--- a/addons/l10n_jo_edi/__manifest__.py
+++ b/addons/l10n_jo_edi/__manifest__.py
@@ -17,5 +17,6 @@
         'wizard/account_move_send_views.xml',
     ],
     'installable': True,
+    'auto_install': ['l10n_jo'],
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
The E-invoicing is mandatory in Jordan, and most of the users need it. So, it's simpler if they have it already installed when they install the base module.

task-4669464




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
