### PR TITLE
[IMP] mail: store.destroy() and store.reset()

### DIFF
--- a/addons/hr_holidays/static/src/im_status_patch.xml
+++ b/addons/hr_holidays/static/src/im_status_patch.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ImStatus" t-inherit-mode="extension">
         <xpath expr="//*[@name='icon']" position="replace">
-            <i t-if="persona.im_status === 'leave_online'" class="fa fa-plane text-success" title="On Leave (Online)" role="img" aria-label="User is on leave and online"/>
-            <i t-elif="persona.im_status === 'leave_away'" class="fa fa-plane o-away" title="On Leave (Idle)" role="img" aria-label="User is on leave and idle"/>
-            <i t-elif="persona.im_status === 'leave_offline'" class="fa fa-plane text-500" title="On Leave" role="img" aria-label="User is on leave"/>
+            <i t-if="persona?.im_status === 'leave_online'" class="fa fa-plane text-success" title="On Leave (Online)" role="img" aria-label="User is on leave and online"/>
+            <i t-elif="persona?.im_status === 'leave_away'" class="fa fa-plane o-away" title="On Leave (Idle)" role="img" aria-label="User is on leave and idle"/>
+            <i t-elif="persona?.im_status === 'leave_offline'" class="fa fa-plane text-500" title="On Leave" role="img" aria-label="User is on leave"/>
             <t t-else="">$0</t>
         </xpath>
     </t>

--- a/addons/hr_homeworking/static/src/im_status_patch.xml
+++ b/addons/hr_homeworking/static/src/im_status_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ImStatus" t-inherit-mode="extension">
         <xpath expr="//*[@name='icon']" position="replace">
-            <t t-if="persona.im_status">
+            <t t-if="persona?.im_status">
                 <t t-if="persona.im_status.split('_').length == 2">
                     <t t-set="location" t-value="persona.im_status.split('_')[0]"/>
                     <t t-if="location == 'home' || location == 'office' || location == 'other'">
@@ -23,7 +23,7 @@
 
     <t t-inherit="mail.ThreadIcon" t-inherit-mode="extension">
         <xpath expr="//*[@name='chat_static']" position="replace">
-            <t t-if="correspondent.persona.im_status">
+            <t t-if="correspondent.persona?.im_status">
                 <t t-if="correspondent.persona.im_status.split('_').length >= 2">
                     <t t-set="location" t-value="correspondent.persona.im_status.split('_')[0]"/>
                     <t t-if="location == 'home' || location == 'office' || location == 'other'">

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -175,6 +175,7 @@ Help your customers with this chat, and analyse their feedback.
             "web/static/tests/legacy/helpers/cleanup.js",
             "web/static/tests/legacy/helpers/utils.js",
             "web/static/tests/legacy/utils.js",
+            'mail/static/tests/tours/discuss_store_reset_tour.js',
             "im_livechat/static/tests/tours/support/*",
         ],
         'im_livechat.embed_assets_unit_tests': [

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -165,6 +165,7 @@ Help your customers with this chat, and analyse their feedback.
             'rating/static/tests/mock_server/**/*',
             'im_livechat/static/tests/mock_server/**/*',
             'bus/static/tests/mock_websocket.js',
+            'bus/static/src/outdated_page_watcher_service.js',
         ],
         "im_livechat.assets_livechat_support_tours": [
             "web_tour/static/src/tour_pointer/**/*",

--- a/addons/im_livechat/static/src/core/public_web/discuss_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_patch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.Discuss" t-inherit-mode="extension">
+    <t t-inherit="mail.Discuss.main" t-inherit-mode="extension">
         <xpath expr="//Composer" position="replace">
             <span t-if="thread?.composerDisabled" class="bg-200 py-1 text-center fst-italic fw-bold text-muted" t-esc="thread.composerDisabledText"/>
             <t t-else="">$0</t>

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -19,6 +19,10 @@ const storePatch = {
             this.livechatChannels.fetch();
         }
     },
+    async onReset() {
+        this.livechatChannels.status = "not_fetched";
+        await super.onReset();
+    },
     /** @returns {boolean} Whether the livechat thread changed. */
     goToOldestUnreadLivechatThread() {
         const [oldestUnreadThread] = this.discuss.livechats

--- a/addons/im_livechat/static/src/embed/common/chat_hub_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/chat_hub_patch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.ChatHub" t-inherit-mode="extension">
+    <t t-inherit="mail.ChatHub.main" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-ChatHub')]" position="attributes">
             <attribute name="part">ChatHub</attribute>
         </xpath>

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -39,14 +39,6 @@ export class LivechatService {
         this.store = services["mail.store"];
     }
 
-    async initialize() {
-        this.store.fetchStoreData("init_livechat", this.options.channel_id, { readonly: false });
-        if (this.options.chatbot_test_store) {
-            await this.store.chatHub.initPromise;
-            this.store.insert(this.options.chatbot_test_store);
-        }
-    }
-
     /**
      * Open a new live chat thread.
      *
@@ -146,11 +138,7 @@ export class LivechatService {
 export const livechatService = {
     dependencies: ["mail.store", "notification"],
     start(env, services) {
-        const livechat = reactive(new LivechatService(env, services));
-        if (livechat.store.livechat_available) {
-            livechat.initialize();
-        }
-        return livechat;
+        return reactive(new LivechatService(env, services));
     },
 };
 registry.category("services").add("im_livechat.livechat", livechatService);

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -33,5 +33,17 @@ const StorePatch = {
         /** @type {boolean} */
         this.livechat_available = session.livechatData?.isAvailable;
     },
+    onStarted() {
+        super.onStarted();
+        if (this.livechat_available) {
+            const { options } = session.livechatData;
+            this.fetchStoreData("init_livechat", options.channel_id, { readonly: false });
+            if (options.chatbot_test_store) {
+                this.chatHub.initPromise.then(() => {
+                    this.insert(options.chatbot_test_store);
+                });
+            }
+        }
+    },
 };
 patch(Store.prototype, StorePatch);

--- a/addons/im_livechat/static/src/embed/common/thread_actions.js
+++ b/addons/im_livechat/static/src/embed/common/thread_actions.js
@@ -22,7 +22,7 @@ const callSettingsAction = threadActionsRegistry.get("settings");
 patch(callSettingsAction, {
     condition(component) {
         return component.thread?.channel_type === "livechat"
-            ? component.env.services["discuss.rtc"].state.channel?.eq(component.thread)
+            ? component.env.services["mail.store"].rtc.state.channel?.eq(component.thread)
             : super.condition(...arguments);
     },
 });

--- a/addons/im_livechat/static/src/embed/external/boot.js
+++ b/addons/im_livechat/static/src/embed/external/boot.js
@@ -22,11 +22,12 @@ odoo.livechatReady = new Deferred();
     await startServices(env);
     odoo.isReady = true;
     const target = await makeShadow(makeRoot(document.body));
-    await mount(MainComponentsContainer, target, {
+    const root = await mount(MainComponentsContainer, target, {
         env,
         getTemplate,
         translateFn: _t,
         dev: env.debug,
     });
     odoo.livechatReady.resolve();
+    odoo.__WOWL_DEBUG__ = { root };
 })();

--- a/addons/im_livechat/static/tests/tours/support/discuss_store_reset_tour.js
+++ b/addons/im_livechat/static/tests/tours/support/discuss_store_reset_tour.js
@@ -1,0 +1,17 @@
+import {
+    getAfterResetSteps,
+    getSendFirstMessageAndResetSteps,
+} from "@mail/../tests/tours/discuss_store_reset_tour";
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("im_livechat.store_reset_in_embed_livechat", {
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        ...getSendFirstMessageAndResetSteps(".o-livechat-root:shadow"),
+        ...getAfterResetSteps(".o-livechat-root:shadow"),
+    ],
+});

--- a/addons/im_livechat/tests/test_im_livechat_support_page.py
+++ b/addons/im_livechat/tests/test_im_livechat_support_page.py
@@ -23,3 +23,13 @@ class TestImLivechatSupportPage(TestGetOperatorCommon):
         )
         with patch.object(LivechatController, "_is_cors_request", return_value=True):
             self.start_tour(f"/im_livechat/support/{livechat_channel.id}", "im_livechat.basic_tour")
+
+    def test_store_reset_in_embed_livechat(self):
+        operator = self._create_operator()
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {"name": "Support Channel", "user_ids": [operator.id]}
+        )
+        self.start_tour(
+            f"/im_livechat/support/{livechat_channel.id}",
+            "im_livechat.store_reset_in_embed_livechat",
+        )

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -188,6 +188,7 @@ For more specific needs, you may also assign custom-defined actions
             'web/static/tests/legacy/helpers/cleanup.js',
             'web/static/tests/legacy/helpers/utils.js',
             'web/static/tests/legacy/utils.js',
+            'mail/static/tests/tours/discuss_store_reset_tour.js',
             'mail/static/tests/tours/discuss_channel_public_tour.js',
             'mail/static/tests/tours/discuss_channel_as_guest_tour.js',
             'mail/static/tests/tours/discuss_channel_call_action.js',

--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Chatter">
-    <div t-if="state.thread" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex flex-column bg-inherit" t-att-class="{ 'overflow-auto': props.isChatterAside, 'o-chatter-disabled': props.threadId === false }" t-on-scroll="onScrollDebounced" t-ref="root">
+    <div t-if="state.thread?.exists()" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex flex-column bg-inherit" t-att-class="{ 'overflow-auto': props.isChatterAside, 'o-chatter-disabled': props.threadId === false }" t-on-scroll="onScrollDebounced" t-ref="root">
         <div class="o-mail-Chatter-top d-print-none position-sticky top-0" t-att-class="{ 'shadow-sm': state.isTopStickyPinned }" t-ref="top">
             <div class="o-mail-Chatter-topbar d-flex flex-shrink-0 flex-grow-0 overflow-x-auto">
                 <div t-if="state.isSearchOpen" class="flex-grow-1">

--- a/addons/mail/static/src/chatter/web/form_controller.js
+++ b/addons/mail/static/src/chatter/web/form_controller.js
@@ -1,6 +1,6 @@
 import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
-import { useSubEnv } from "@odoo/owl";
+import { useEffect, useSubEnv } from "@odoo/owl";
 
 import { x2ManyCommands } from "@web/core/orm_service";
 import { useService } from "@web/core/utils/hooks";
@@ -12,6 +12,17 @@ patch(FormController.prototype, {
         super.setup(...arguments);
         if (this.env.services["mail.store"]) {
             this.mailStore = useService("mail.store");
+            useEffect(
+                () => {
+                    if (this.mailStore.resetCount) {
+                        this.env.chatter.fetchThreadData = true;
+                        this.env.chatter.fetchMessages = true;
+                        const { resModel, resId } = this.model.root;
+                        this.env.bus.trigger("MAIL:RELOAD-THREAD", { model: resModel, id: resId });
+                    }
+                },
+                () => [this.mailStore.resetCount]
+            );
         }
         useSubEnv({
             chatter: {

--- a/addons/mail/static/src/chatter/web/form_renderer.js
+++ b/addons/mail/static/src/chatter/web/form_renderer.js
@@ -47,9 +47,12 @@ patch(FormRenderer.prototype, {
         return this.messagingState.thread.attachmentsInWebClientView.length > 0;
     },
     mailLayout(hasAttachmentContainer) {
+        const hasChatter = !!this.mailStore;
+        if (!hasChatter || !this.mailStore.exists()) {
+            return "NONE";
+        }
         const xxl = this.uiService.size >= SIZES.XXL;
         const hasFile = this.hasFile();
-        const hasChatter = !!this.mailStore;
         const hasExternalWindow = !!this.mailPopoutService.externalWindow;
         if (hasExternalWindow && hasFile && hasAttachmentContainer) {
             if (xxl) {

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -6,6 +6,7 @@ import {
     onMounted,
     onWillUpdateProps,
     useChildSubEnv,
+    useEffect,
     useRef,
     useState,
 } from "@odoo/owl";
@@ -51,6 +52,16 @@ export class Chatter extends Component {
                 this.load(this.state.thread, this.requestList);
             }
         });
+        useEffect(
+            () => {
+                if (this.store.resetCount) {
+                    const { model, id } = this.state.thread;
+                    this.state.thread = this.store.Thread.insert({ model, id });
+                    this.load(this.state.thread, this.requestList);
+                }
+            },
+            () => [this.store.resetCount]
+        );
     }
 
     get afterPostRequestList() {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -2,6 +2,10 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatHub">
+    <t t-if="chatHub" t-call="mail.ChatHub.main"/>
+</t>
+
+<t t-name="mail.ChatHub.main">
     <div class="o-mail-ChatHub d-print-none">
 
         <t t-set="visibleChatWindows" t-value="chatHub.compact ? chatHub.opened.filter(({ bypassCompact }) => bypassCompact) : chatHub.opened "/>

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -626,6 +626,7 @@ export class Store extends BaseStore {
     }
     async onReset() {
         await super.onReset();
+        this.cannedReponses.status = "not_fetched";
         this.insert(session.storeData);
         /**
          * Add defaults for `self` and `settings` because in livechat there could be no user and no

--- a/addons/mail/static/src/core/public_web/chat_hub_patch.js
+++ b/addons/mail/static/src/core/public_web/chat_hub_patch.js
@@ -3,6 +3,6 @@ import { ChatHub } from "@mail/core/common/chat_hub";
 
 patch(ChatHub.prototype, {
     get isShown() {
-        return super.isShown && !this.store.discuss.isActive;
+        return super.isShown && !this.store.discuss?.isActive;
     },
 });

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -105,7 +105,7 @@ export class Discuss extends Component {
     }
 
     get thread() {
-        return this.props.thread || this.store.discuss.thread;
+        return this.props.thread || this.store?.discuss?.thread;
     }
 
     async onFileUploaded(file) {

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -2,10 +2,14 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Discuss">
+    <t t-if="store?.exists()" t-call="mail.Discuss.main"/>
+</t>
+
+<t t-name="mail.Discuss.main">
     <t t-set="partitionedActions" t-value="threadActions.partition"/>
     <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center': ui.isSmall }" t-ref="root">
         <DiscussSidebar t-if="!ui.isSmall and props.hasSidebar"/>
-        <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
+        <div t-if="!(ui.isSmall and store.discuss?.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
             <div class="o-mail-Discuss-header px-2 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mx-2 my-1 bg-inherit">
@@ -100,7 +104,7 @@
                                 <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>
                             </div>
                         </t>
-                        <div t-elif="(!ui.isSmall or store.discuss.activeTab === 'main') and store.discuss.hasRestoredThread" class="d-flex flex-grow-1 align-items-center justify-content-center w-100 bg-view">
+                        <div t-elif="(!ui.isSmall or store.discuss?.activeTab === 'main') and store.discuss?.hasRestoredThread" class="d-flex flex-grow-1 align-items-center justify-content-center w-100 bg-view">
                             <h4 class="text-muted"><b><i>No conversation selected.</i></b></h4>
                         </div>
                     </t>
@@ -120,7 +124,7 @@
 <t t-name="mail.MobileMailbox">
     <button class="btn btn-secondary flex-grow-1 p-2"
         t-att-class="{
-            'active o-active shadow-none': mailbox.eq(store.discuss.thread),
+            'active o-active shadow-none': mailbox.eq(store.discuss?.thread),
         }" t-on-click="mailbox.setAsDiscussThread" t-esc="mailbox.display_name"
     />
 </t>

--- a/addons/mail/static/src/core/public_web/discuss_client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_client_action.js
@@ -1,6 +1,13 @@
 import { Discuss } from "@mail/core/public_web/discuss";
 
-import { Component, onMounted, onWillStart, onWillUnmount, onWillUpdateProps } from "@odoo/owl";
+import {
+    Component,
+    onMounted,
+    onWillStart,
+    onWillUnmount,
+    onWillUpdateProps,
+    useEffect,
+} from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
@@ -30,8 +37,19 @@ export class DiscussClientAction extends Component {
             // bracket to avoid blocking rendering with restore promise
             this.restoreDiscussThread(nextProps);
         });
+        useEffect(
+            () => {
+                this.restoreDiscussThread(this.props);
+                this.store.discuss.isActive = true;
+            },
+            () => [this.store.resetCount]
+        );
         onMounted(() => (this.store.discuss.isActive = true));
-        onWillUnmount(() => (this.store.discuss.isActive = false));
+        onWillUnmount(() => {
+            if (this.store.exists() && this.store.discuss) {
+                this.store.discuss.isActive = false;
+            }
+        });
     }
 
     getActiveId(props) {

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor gap-1" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor gap-1" t-att-class="{ 'o-compact': store.discuss?.isSidebarCompact }">
             <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 mt-1 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
-                <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss.isSidebarCompact }">
+                <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss?.isSidebarCompact }">
                     <t name="options-btn">
                         <Dropdown position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary px-0 py-1 mx-2 my-0 min-w-0 shadow-sm'">
-                            <button class="o-mail-DiscussSidebar-optionsBtn btn btn-light p-0 align-items-center justify-content-center smaller border border-dark rounded-circle opacity-25 opacity-100-hover" title="Options" t-att-class="{ 'ms-auto': !store.discuss.isSidebarCompact, 'position-absolute': !store.discuss.isSidebarCompact and !store.inPublicPage, 'o-compact': store.discuss.isSidebarCompact }"><i class="oi oi-ellipsis-h oi-fw align-text-top" style="font-size: 15px;"/></button>
+                            <button class="o-mail-DiscussSidebar-optionsBtn btn btn-light p-0 align-items-center justify-content-center smaller border border-dark rounded-circle opacity-25 opacity-100-hover" title="Options" t-att-class="{ 'ms-auto': !store.discuss?.isSidebarCompact, 'position-absolute': !store.discuss?.isSidebarCompact and !store.inPublicPage, 'o-compact': store.discuss?.isSidebarCompact }"><i class="oi oi-ellipsis-h oi-fw align-text-top" style="font-size: 15px;"/></button>
                             <t t-set-slot="content">
                                 <div>
-                                    <DropdownItem class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="() => this.store.discuss.isSidebarCompact = !this.store.discuss.isSidebarCompact">
-                                         <i class="fa fa-fw" t-att-class="{ 'fa-expand': store.discuss.isSidebarCompact, 'fa-compress': !store.discuss.isSidebarCompact }"/>
+                                    <DropdownItem class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="() => this.store.discuss.isSidebarCompact = !this.store.discuss?.isSidebarCompact">
+                                         <i class="fa fa-fw" t-att-class="{ 'fa-expand': store.discuss?.isSidebarCompact, 'fa-compress': !store.discuss?.isSidebarCompact }"/>
                                          <span class="mx-2">
-                                             <t t-if="store.discuss.isSidebarCompact">Expand panel</t>
+                                             <t t-if="store.discuss?.isSidebarCompact">Expand panel</t>
                                              <t t-else="">Collapse panel</t>
                                          </span>
                                      </DropdownItem>

--- a/addons/mail/static/src/core/public_web/mail_core_public_web_service.js
+++ b/addons/mail/static/src/core/public_web/mail_core_public_web_service.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+
+export const mailCorePublicWebService = {
+    dependencies: ["mail.store", "bus.outdated_page_watcher"],
+    /**
+     * @param {import("@web/env").OdooEnv}
+     * @param {Partial<import("services").Services>} services
+     */
+    start(env, { "mail.store": store, "bus.outdated_page_watcher": watcher }) {
+        watcher.subscribe(() => store.reset());
+    },
+};
+
+registry.category("services").add("mail_core_public_web", mailCorePublicWebService);

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -3,7 +3,7 @@ import { ImStatus } from "@mail/core/common/im_status";
 import { NotificationItem } from "@mail/core/public_web/notification_item";
 import { useDiscussSystray } from "@mail/utils/common/hooks";
 
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, useEffect, useExternalListener, useRef, useState } from "@odoo/owl";
 
 import { hasTouch, isDisplayStandalone, isIOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
@@ -31,7 +31,14 @@ export class MessagingMenu extends Component {
         });
         this.dropdown = useDropdownState();
         this.notificationList = useRef("notification-list");
-
+        useEffect(
+            () => {
+                if (this.dropdown.isOpen && this.store.channels?.status === "not_fetched") {
+                    this.store.channels.fetch();
+                }
+            },
+            () => [this.store.resetCount]
+        );
         useExternalListener(window, "keydown", this.onKeydown, true);
     }
 
@@ -125,15 +132,15 @@ export class MessagingMenu extends Component {
     get tabs() {
         return [
             {
-                counter: this.store.getDiscussSidebarCategoryCounter(this.store.discuss.chats.id),
+                counter: this.store.getDiscussSidebarCategoryCounter(this.store.discuss?.chats.id),
                 icon: "fa fa-user",
                 id: "chat",
                 label: _t("Chat"),
             },
             {
-                channelHasUnread: Boolean(this.store.discuss.unreadChannels.length),
+                channelHasUnread: Boolean(this.store.discuss?.unreadChannels.length),
                 counter: this.store.getDiscussSidebarCategoryCounter(
-                    this.store.discuss.channels.id
+                    this.store.discuss?.channels.id
                 ),
                 icon: "fa fa-users",
                 id: "channel",

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -2,12 +2,16 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.MessagingMenu">
+    <t t-if="store?.exists()" t-call="mail.MessagingMenu.main"/>
+</t>
+
+<t t-name="mail.MessagingMenu.main">
     <t t-if="env.inDiscussApp" t-call="mail.MessagingMenu.content"/>
 </t>
 
 <t t-name="mail.MessagingMenu.content">
-    <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu ${ui.isSmall ? 'o-small' : ''}`">
-        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush px-2 py-1 gap-1" t-ref="notification-list">
+    <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss?.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu ${ui.isSmall ? 'o-small' : ''}`">
+        <div t-if="!env.inDiscussApp or store.discuss?.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush px-2 py-1 gap-1" t-ref="notification-list">
             <t t-foreach="threads" name="threads" t-as="thread" t-key="thread.localId">
                 <t t-set="message" t-value="thread.isChatChannel or (thread.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentOfAllMessage : thread.needactionMessages.at(-1)"/>
                 <NotificationItem
@@ -57,12 +61,12 @@
     </div>
     <div t-if="ui.isSmall" class="o-mail-MessagingMenu-navbar d-flex bg-view shadow-lg w-100 btn-group">
         <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 rounded-0 bg-transparent position-relative" t-att-class="{
-            'text-primary fw-bold o-active': store.discuss.activeTab === tab.id,
+            'text-primary fw-bold o-active': store.discuss?.activeTab === tab.id,
             'pb-4': isIosPwa,
             'pb-2': !isIosPwa,
         }" t-on-click="() => this.onClickNavTab(tab.id)">
-            <i t-attf-class="p-1 fs-2 {{ tab.icon }}" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id }"/>
-            <span class="smaller" t-esc="tab.label" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id }"/>
+            <i t-attf-class="p-1 fs-2 {{ tab.icon }}" t-att-class="{ 'text-primary': store.discuss?.activeTab === tab.id }"/>
+            <span class="smaller" t-esc="tab.label" t-att-class="{ 'text-primary': store.discuss?.activeTab === tab.id }"/>
             <span t-if="tab.counter" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabCounter overflow-visible d-inline-block" t-esc="tab.counter"/>
             <span t-elif="tab.channelHasUnread" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabUnread overflow-visible d-inline-block ms-2"><i class="fa fa-circle"/></span>
         </button>

--- a/addons/mail/static/src/core/web/discuss_patch.js
+++ b/addons/mail/static/src/core/web/discuss_patch.js
@@ -25,8 +25,8 @@ patch(Discuss.prototype, {
             () => {
                 if (
                     this.thread?.id === "inbox" &&
-                    this.prevInboxCounter !== this.store.inbox.counter &&
-                    this.store.inbox.counter === 0
+                    this.prevInboxCounter !== this.store.inbox?.counter &&
+                    (this.store.inbox?.counter ?? 0) === 0
                 ) {
                     this.effect.add({
                         message: _t("Congratulations, your inbox is empty!"),
@@ -34,9 +34,9 @@ patch(Discuss.prototype, {
                         fadeout: "fast",
                     });
                 }
-                this.prevInboxCounter = this.store.inbox.counter;
+                this.prevInboxCounter = this.store.inbox?.counter;
             },
-            () => [this.store.inbox.counter]
+            () => [this.store.inbox?.counter]
         );
     },
 });

--- a/addons/mail/static/src/core/web/discuss_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_patch.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.Discuss" t-inherit-mode="extension">
+    <t t-inherit="mail.Discuss.main" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='content']" position="before">
-            <div t-if="ui.isSmall and store.discuss.activeTab === 'main'" class="w-100 border-bottom" t-call="mail.Discuss.mobileTopbar" t-ref="mobileTopbar"/>
+            <div t-if="ui.isSmall and store.discuss?.activeTab === 'main'" class="w-100 border-bottom" t-call="mail.Discuss.mobileTopbar" t-ref="mobileTopbar"/>
         </xpath>
         <xpath expr="//*[@t-ref='root']" position="replace">
             <div class="h-100 d-flex flex-column">
@@ -22,13 +22,13 @@
     </t>
     <t t-name="mail.Discuss.mobileTopbar">
         <div class="btn-group d-flex w-100 p-1">
-            <t t-call="mail.MobileMailbox" >
+            <t t-if="store.inbox" t-call="mail.MobileMailbox" >
                 <t t-set="mailbox" t-value="store.inbox"/>
             </t>
-            <t t-call="mail.MobileMailbox">
+            <t t-if="store.starred" t-call="mail.MobileMailbox">
                 <t t-set="mailbox" t-value="store.starred"/>
             </t>
-            <t t-call="mail.MobileMailbox">
+            <t t-if="store.history" t-call="mail.MobileMailbox">
                 <t t-set="mailbox" t-value="store.history"/>
             </t>
         </div>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -3,14 +3,14 @@
 
     <t t-name="mail.DiscussSidebarMailboxes">
         <div class="d-flex flex-column flex-grow-0 o-gap-0_5 mt-1 bg-inherit">
-            <Mailbox mailbox="store.inbox"/>
-            <Mailbox mailbox="store.starred"/>
-            <Mailbox mailbox="store.history"/>
+            <Mailbox t-if="store.inbox" mailbox="store.inbox"/>
+            <Mailbox t-if="store.starred" mailbox="store.starred"/>
+            <Mailbox t-if="store.history" mailbox="store.history"/>
         </div>
     </t>
 
     <t t-name="mail.Mailbox">
-        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-2 min-w-0 shadow-sm'" manual="true">
+        <Dropdown t-if="store.discuss?.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-2 min-w-0 shadow-sm'" manual="true">
             <t t-call="mail.Mailbox.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden" t-ref="floating">
@@ -25,10 +25,10 @@
         <button
             class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-baseline px-0 mx-2 border-0 rounded-3 fw-normal text-reset"
             t-att-class="{
-                'bg-inherit': mailbox.notEq(store.discuss.thread),
-                'o-active': mailbox.eq(store.discuss.thread),
-                'justify-content-center position-relative o-compact': store.discuss.isSidebarCompact,
-                'o-py-0_5': !store.discuss.isSidebarCompact,
+                'bg-inherit': mailbox.notEq(store.discuss?.thread),
+                'o-active': mailbox.eq(store.discuss?.thread),
+                'justify-content-center position-relative o-compact': store.discuss?.isSidebarCompact,
+                'o-py-0_5': !store.discuss?.isSidebarCompact,
                 'o-unread': mailbox.counter,
             }"
             style="line-height: 1.65;"
@@ -36,16 +36,16 @@
             t-on-click="(ev) => this.openThread(ev)"
             t-ref="root"
         >
-            <ThreadIcon className="'bg-inherit opacity-75 ' + (store.discuss.isSidebarCompact ? '' : 'mx-2 pt-1')" thread="mailbox" size="store.discuss.isSidebarCompact ? 'large' : 'medium'"/>
-            <t t-if="!store.discuss.isSidebarCompact">
+            <ThreadIcon className="'bg-inherit opacity-75 ' + (store.discuss?.isSidebarCompact ? '' : 'mx-2 pt-1')" thread="mailbox" size="store.discuss?.isSidebarCompact ? 'large' : 'medium'"/>
+            <t t-if="!store.discuss?.isSidebarCompact">
                 <div class="me-2 text-truncate text-muted small" t-esc="mailbox.display_name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>
             </t>
             <t t-if="mailbox.counter > 0" t-call="mail.discuss_badge">
                 <t t-set="counter" t-value="mailbox.counter"/>
-                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebar-badge ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'mx-1')"/>
+                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebar-badge ' + (store.discuss?.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'mx-1')"/>
                 <t t-set="counterClass" t-value="(mailbox.id === 'starred' ? 'o-muted' : '')"/>
-                <t t-set="floating" t-value="store.discuss.isSidebarCompact"/>
+                <t t-set="floating" t-value="store.discuss?.isSidebarCompact"/>
             </t>
         </button>
     </t>

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussSidebar" t-inherit-mode="extension">
         <xpath expr="//*[@name='options-btn']" position="after">
-            <Dropdown t-if="store.discuss.isSidebarCompact" state="meetingFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
+            <Dropdown t-if="store.discuss?.isSidebarCompact" state="meetingFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
                 <t t-call="mail.DiscussSidebar.startMeetingButton"/>
                 <t t-set-slot="content">
                     <div t-ref="meeting-floating">
@@ -15,6 +15,6 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.startMeetingButton">
-        <button class="btn btn-primary rounded-3 d-flex align-items-center gap-1" t-att-class="{ 'px-1 py-2': store.discuss.isSidebarCompact, 'btn-sm mx-5': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75" t-att-class="{ 'fa-lg': store.discuss.isSidebarCompact }"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
+        <button class="btn btn-primary rounded-3 d-flex align-items-center gap-1" t-att-class="{ 'px-1 py-2': store.discuss?.isSidebarCompact, 'btn-sm mx-5': !store.discuss?.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75" t-att-class="{ 'fa-lg': store.discuss?.isSidebarCompact }"/><span t-if="!store.discuss?.isSidebarCompact" t-esc="startMeetingText"/></button>
     </t>
 </templates>

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -23,10 +23,18 @@ export class MailCoreWeb {
             }
         });
         this.env.bus.addEventListener("mail.message/delete", ({ detail: { message, notifId } }) => {
-            if (message.needaction && notifId > this.store.inbox.counter_bus_id) {
+            if (
+                this.store.inbox &&
+                message.needaction &&
+                notifId > this.store.inbox.counter_bus_id
+            ) {
                 this.store.inbox.counter--;
             }
-            if (message.starred && notifId > this.store.starred.counter_bus_id) {
+            if (
+                this.store.starred &&
+                message.starred &&
+                notifId > this.store.starred.counter_bus_id
+            ) {
                 this.store.starred.counter--;
             }
         });

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -23,18 +23,18 @@ patch(MessagingMenu.prototype, {
         useEffect(
             () => {
                 if (
-                    this.store.discuss.searchTerm &&
+                    this.store.discuss?.searchTerm &&
                     this.lastSearchTerm !== this.store.discuss.searchTerm &&
                     this.state.activeIndex
                 ) {
                     this.state.activeIndex = 0;
                 }
-                if (!this.store.discuss.searchTerm) {
+                if (!this.store.discuss?.searchTerm) {
                     this.state.activeIndex = null;
                 }
-                this.lastSearchTerm = this.store.discuss.searchTerm;
+                this.lastSearchTerm = this.store.discuss?.searchTerm;
             },
-            () => [this.store.discuss.searchTerm]
+            () => [this.store.discuss?.searchTerm]
         );
         useEffect(
             () => {
@@ -52,6 +52,7 @@ patch(MessagingMenu.prototype, {
             if (
                 !this.store.inbox.isLoaded &&
                 this.store.inbox.status !== "loading" &&
+                this.store.inbox &&
                 this.store.inbox.counter !== this.store.inbox.messages.length
             ) {
                 this.store.inbox.fetchNewMessages();
@@ -65,13 +66,13 @@ patch(MessagingMenu.prototype, {
         return (
             this.threads.length > 0 ||
             (this.store.failures.length > 0 &&
-                this.store.discuss.activeTab === "main" &&
+                this.store.discuss?.activeTab === "main" &&
                 !this.env.inDiscussApp) ||
             (this.shouldAskPushPermission &&
-                this.store.discuss.activeTab === "main" &&
+                this.store.discuss?.activeTab === "main" &&
                 !this.env.inDiscussApp) ||
             (this.canPromptToInstall &&
-                this.store.discuss.activeTab === "main" &&
+                this.store.discuss?.activeTab === "main" &&
                 !this.env.inDiscussApp)
         );
     },
@@ -84,7 +85,7 @@ patch(MessagingMenu.prototype, {
             },
             iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
-            isShown: this.store.discuss.activeTab === "main" && this.canPromptToInstall,
+            isShown: this.store.discuss?.activeTab === "main" && this.canPromptToInstall,
         };
     },
     get notificationRequest() {
@@ -93,13 +94,13 @@ patch(MessagingMenu.prototype, {
             displayName: _t("Turn on notifications"),
             iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
-            isShown: this.store.discuss.activeTab === "main" && this.shouldAskPushPermission,
+            isShown: this.store.discuss?.activeTab === "main" && this.shouldAskPushPermission,
         };
     },
     get tabs() {
         return [
             {
-                counter: this.env.inDiscussApp ? this.store.inbox.counter : undefined,
+                counter: this.env.inDiscussApp ? this.store.inbox?.counter : undefined,
                 icon: this.env.inDiscussApp ? "fa fa-inbox" : "fa fa-envelope",
                 id: "main",
                 label: this.env.inDiscussApp ? _t("Mailboxes") : _t("All"),
@@ -166,6 +167,9 @@ patch(MessagingMenu.prototype, {
         this.state.searchOpen = !this.state.searchOpen;
     },
     get counter() {
+        if (!this.store.exists() || !this.store.inbox) {
+            return 0;
+        }
         let value =
             this.store.inbox.counter +
             this.store.failures.reduce((acc, f) => acc + parseInt(f.notifications.length), 0);

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.MessagingMenu" t-inherit-mode="extension">
-        <xpath expr="//*[@t-name='mail.MessagingMenu']" position="inside">
+    <t t-inherit="mail.MessagingMenu.main" t-inherit-mode="extension">
+        <xpath expr="//*[@t-name='mail.MessagingMenu.main']" position="inside">
             <div t-if="!env.inDiscussApp" t-att-class="discussSystray.class">
                 <Dropdown state="dropdown" beforeOpen.bind="beforeOpen" position="'bottom-end'" menuClass="discussSystray.menuClass">
                     <button>
                         <i class="fa fa-lg fa-comments" role="img" aria-label="Messages" t-on-click="() => store.discuss.activeTab = ui.isSmall and store.discuss.activeTab === 'main' ? 'main' : store.discuss.activeTab"></i>
-                        <span t-if="!store.settings.mute_until_dt and counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>
+                        <span t-if="!store.settings?.mute_until_dt and counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>
                     </button>
                     <t t-set-slot="content">
                         <t t-call="mail.MessagingMenu.content"/>
@@ -22,9 +22,9 @@
                 <t t-if="!ui.isSmall">
                     <MessagingMenuQuickSearch t-if="state.searchOpen" onClose.bind="toggleSearch"/>
                     <t t-else="">
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss?.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss?.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss?.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
                         <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
                         <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                     </t>
@@ -35,11 +35,11 @@
             <div t-if="store.channels.status !== 'fetching' and !hasPreviews" class="d-flex justify-content-center py-4 px-2 text-muted">
                 No conversation yet...
             </div>
-            <div t-if="store.discuss.searchTerm and !threads.length" class="d-flex justify-content-center py-4 px-2 text-muted">
+            <div t-if="store.discuss?.searchTerm and !threads.length" class="d-flex justify-content-center py-4 px-2 text-muted">
                 No thread found.
             </div>
             <t t-set="itemIndex" t-value="0"/>
-            <t t-if="installationRequest.isShown and !store.discuss.searchTerm">
+            <t t-if="installationRequest.isShown and !store.discuss?.searchTerm">
                 <NotificationItem
                     isActive="state.activeIndex === itemIndex"
                     iconSrc="installationRequest.iconSrc"
@@ -61,7 +61,7 @@
                 </NotificationItem>
                 <t t-set="itemIndex" t-value="itemIndex + 1"/>
             </t>
-            <t t-if="notificationRequest.isShown and !store.discuss.searchTerm">
+            <t t-if="notificationRequest.isShown and !store.discuss?.searchTerm">
                 <NotificationItem
                     isActive="state.activeIndex === itemIndex"
                     iconSrc="notificationRequest.iconSrc"
@@ -82,7 +82,7 @@
                 </NotificationItem>
                 <t t-set="itemIndex" t-value="itemIndex + 1"/>
             </t>
-            <t t-if="store.discuss.activeTab === 'main' and !env.inDiscussApp and !store.discuss.searchTerm">
+            <t t-if="store.discuss?.activeTab === 'main' and !env.inDiscussApp and !store.discuss?.searchTerm">
                 <t t-foreach="store.failures" t-as="failure" t-key="failure.id">
                     <NotificationItem
                         isActive="state.activeIndex === itemIndex"

--- a/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
@@ -1,6 +1,6 @@
 <t t-name="mail.MessagingMenuQuickSearch">
-    <div class="position-relative w-50 m-1" t-ref="search" t-on-keydown="onKeydownInput">
-        <input t-model="store.discuss.searchTerm" t-ref="autofocus" class="form-control px-1 py-0" placeholder="Quick search…" type="text" />
+    <div t-if="store?.exists()" class="position-relative w-50 m-1" t-ref="search" t-on-keydown="onKeydownInput">
+        <input t-if="store.discuss" t-model="store.discuss.searchTerm" t-ref="autofocus" class="form-control px-1 py-0" placeholder="Quick search…" type="text" />
         <button class="btn btn-link text-muted p-1 position-absolute top-50 end-0 translate-middle-y" title="Close search" t-on-click="props.onClose"><i class="oi oi-close"/></button>
     </div>
 </t>

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -23,7 +23,7 @@ const threadPatch = {
         return this.recipientsCount === this.recipients.length;
     },
     computeIsDisplayed() {
-        if (this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
+        if (this.store.discuss?.isActive && !this.store.env.services.ui.isSmall) {
             return this.eq(this.store.discuss.thread);
         }
         return super.computeIsDisplayed();
@@ -84,6 +84,6 @@ const threadPatch = {
             partner_ids: [this.store.self.id],
         });
         this.store.insert(data);
-    }
+    },
 };
 patch(Thread.prototype, threadPatch);

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -45,7 +45,6 @@ export class Call extends Component {
         super.setup();
         this.grid = useRef("grid");
         this.notification = useService("notification");
-        this.rtc = useService("discuss.rtc");
         this.isMobileOs = isMobileOS();
         this.ui = useService("ui");
         this.state = useState({
@@ -72,6 +71,10 @@ export class Call extends Component {
         useExternalListener(browser, "fullscreenchange", this.onFullScreenChange);
         useHotkey("shift+d", () => this.rtc.toggleDeafen());
         useHotkey("shift+m", () => this.rtc.toggleMicrophone());
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 
     get isActiveCall() {

--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -20,12 +20,15 @@ export class CallActionList extends Component {
         super.setup();
         this.CALL_PROMOTE_FULLSCREEN = CALL_PROMOTE_FULLSCREEN;
         this.store = useService("mail.store");
-        this.rtc = useService("discuss.rtc");
         this.callActions = useCallActions();
         this.more = useRef("more");
         this.popover = usePopover(Tooltip, {
             position: "top-middle",
         });
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 
     get MORE() {

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.js
@@ -18,7 +18,6 @@ export class CallContextMenu extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.rtc = useService("discuss.rtc");
         this.state = useState({
             downloadStats: {},
             uploadStats: {},
@@ -34,6 +33,10 @@ export class CallContextMenu extends Component {
             this.updateStatsTimeout = browser.setInterval(() => this.updateStats(), 3000);
         });
         onWillUnmount(() => browser.clearInterval(this.updateStatsTimeout));
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 
     get isSelf() {

--- a/addons/mail/static/src/discuss/call/common/call_invitation.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.js
@@ -8,7 +8,7 @@ export class CallInvitation extends Component {
 
     setup() {
         super.setup();
-        this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
         this.ui = useService("ui");
         this.state = useState({ videoStream: null });
         this.videoRef = useRef("video");
@@ -18,6 +18,10 @@ export class CallInvitation extends Component {
             }
             this.stopTracksOnMediaStream(this.state.videoStream);
         });
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 
     async onClickAccept(ev, { camera = false } = {}) {

--- a/addons/mail/static/src/discuss/call/common/call_invitations.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitations.js
@@ -12,8 +12,11 @@ export class CallInvitations extends Component {
 
     setup() {
         super.setup();
-        this.rtc = useService("discuss.rtc");
         this.store = useService("mail.store");
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 }
 

--- a/addons/mail/static/src/discuss/call/common/call_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_menu.js
@@ -9,14 +9,19 @@ export class CallMenu extends Component {
     static template = "discuss.CallMenu";
     setup() {
         super.setup();
-        this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
         this.callActions = useCallActions();
         this.isEnterprise = odoo.info && odoo.info.isEnterprise;
     }
 
+    get rtc() {
+        return this.store.rtc;
+    }
+
     get icon() {
         return (
-            callActionsRegistry.get(this.rtc.lastSelfCallAction, undefined)?.icon ?? "fa-microphone"
+            callActionsRegistry.get(this.rtc?.lastSelfCallAction, undefined)?.icon ??
+            "fa-microphone"
         );
     }
 }

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.CallMenu">
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
-            <button t-if="rtc.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
+            <button t-if="rtc?.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
                 <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center o-gap-0_5 rounded-3 opacity-75 opacity-100-hover px-1" t-att-class="{ 'o-is-talking': rtc.selfSession?.isActuallyTalking, 'o-isOdooCommunity': !isEnterprise }">
                     <span class="position-relative small bg-transparent">
                         <i class="me-2 fa fa-fw" t-att-class="icon" />

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -34,7 +34,6 @@ export class CallParticipantCard extends Component {
             arrow: false,
             popoverClass: "border-secondary",
         });
-        this.rtc = useService("discuss.rtc");
         this.store = useService("mail.store");
         this.ui = useService("ui");
         this.rootHover = useHover("root");
@@ -46,7 +45,7 @@ export class CallParticipantCard extends Component {
             if (!this.rtcSession) {
                 return;
             }
-            this.rtc.updateVideoDownload(this.rtcSession, {
+            this.rtc?.updateVideoDownload(this.rtcSession, {
                 viewCountIncrement: 1,
             });
         });
@@ -54,11 +53,15 @@ export class CallParticipantCard extends Component {
             if (!this.rtcSession) {
                 return;
             }
-            this.rtc.updateVideoDownload(this.rtcSession, {
+            this.rtc?.updateVideoDownload(this.rtcSession, {
                 viewCountIncrement: -1,
             });
         });
         useExternalListener(browser, "fullscreenchange", this.onFullScreenChange);
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 
     get isContextMenuAvailable() {

--- a/addons/mail/static/src/discuss/call/common/call_participant_video.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_video.js
@@ -12,13 +12,17 @@ export class CallParticipantVideo extends Component {
 
     setup() {
         super.setup();
-        this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
         this.root = useRef("root");
         onMounted(() => this._update());
         onPatched(() => this._update());
         useExternalListener(this.env.bus, "RTC-SERVICE:PLAY_MEDIA", async () => {
             await this.play();
         });
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 
     _update() {

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -20,7 +20,6 @@ export class CallSettings extends Component {
         super.setup();
         this.notification = useService("notification");
         this.store = useService("mail.store");
-        this.rtc = useService("discuss.rtc");
         this.microphoneVolume = useMicrophoneVolume();
         this.state = useState({
             userDevices: [],
@@ -52,6 +51,10 @@ export class CallSettings extends Component {
             }
             this.state.userDevices = await browser.navigator.mediaDevices.enumerateDevices();
         });
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 
     get stopText() {

--- a/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
@@ -6,6 +6,7 @@ import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 
 export const pttExtensionHookService = {
+    dependencies: ["discuss.rtc"],
     start(env) {
         const INITIAL_RELEASE_TIMEOUT = 500;
         const COMMON_RELEASE_TIMEOUT = 200;
@@ -42,7 +43,7 @@ export const pttExtensionHookService = {
         });
 
         browser.addEventListener("message", ({ data, origin, source }) => {
-            const rtc = env.services["discuss.rtc"];
+            const rtc = env.services["mail.store"].rtc;
             if (
                 source !== window ||
                 origin !== location.origin ||

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -9,7 +9,9 @@ import { useService } from "@web/core/utils/hooks";
 threadActionsRegistry
     .add("call", {
         condition(component) {
-            return component.thread?.allowCalls && !component.thread?.eq(component.rtc.channel);
+            return (
+                component.thread?.allowCalls && !component.thread?.eq(component.store.rtc.channel)
+            );
         },
         icon: "fa fa-fw fa-phone",
         iconLarge: "fa fa-fw fa-lg fa-phone",
@@ -20,18 +22,20 @@ threadActionsRegistry
             return _t("Start a Call");
         },
         open(component) {
-            component.rtc.toggleCall(component.thread);
+            component.store.rtc.toggleCall(component.thread);
         },
         sequence: 10,
         sequenceQuick: 30,
         setup() {
             const component = useComponent();
-            component.rtc = useService("discuss.rtc");
+            component.store = useService("mail.store");
         },
     })
     .add("camera-call", {
         condition(component) {
-            return component.thread?.allowCalls && !component.thread?.eq(component.rtc.channel);
+            return (
+                component.thread?.allowCalls && !component.thread?.eq(component.store.rtc.channel)
+            );
         },
         icon: "fa fa-fw fa-video-camera",
         iconLarge: "fa fa-fw fa-lg fa-video-camera",
@@ -42,13 +46,13 @@ threadActionsRegistry
             return _t("Start a Video Call");
         },
         open(component) {
-            component.rtc.toggleCall(component.thread, { camera: true });
+            component.store.rtc.toggleCall(component.thread, { camera: true });
         },
         sequence: 5,
         sequenceQuick: (component) => (component.env.inDiscussApp ? 25 : 35),
         setup() {
             const component = useComponent();
-            component.rtc = useService("discuss.rtc");
+            component.store = useService("mail.store");
         },
     })
     .add("settings", {
@@ -69,7 +73,7 @@ threadActionsRegistry
         sequenceGroup: 30,
         setup() {
             const component = useComponent();
-            component.rtc = useService("discuss.rtc");
+            component.store = useService("mail.store");
         },
         toggle: true,
     });

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -36,7 +36,7 @@ const ThreadPatch = {
                 this.rtc_session_ids.add(r);
                 this.store.ringingThreads.add(this);
                 this.cancelRtcInvitationTimeout = browser.setTimeout(() => {
-                    this.store.env.services["discuss.rtc"].leaveCall(this);
+                    this.store.env.services["mail.store"].rtc.leaveCall(this);
                 }, 30000);
             },
             /** @this {import("models").Thread} */
@@ -48,7 +48,7 @@ const ThreadPatch = {
         this.rtc_session_ids = fields.Many("discuss.channel.rtc.session", {
             /** @this {import("models").Thread} */
             onDelete(r) {
-                this.store.env.services["discuss.rtc"].deleteSession(r.id);
+                this.store.env.services["mail.store"].rtc?.deleteSession(r.id);
             },
             /** @this {import("models").Thread} */
             onUpdate() {

--- a/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
@@ -8,10 +8,13 @@ import { patch } from "@web/core/utils/patch";
 patch(DiscussClientAction.prototype, {
     setup() {
         super.setup(...arguments);
-        this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
+    },
+    get rtc() {
+        return this.store.rtc;
     },
     async joinCallWithWelcomeSettings() {
-        if (this.store.discuss_public_thread.default_display_mode !== "video_full_screen") {
+        if (this.store.discuss_public_thread?.default_display_mode !== "video_full_screen") {
             return;
         }
         const mute = browser.localStorage.getItem("discuss_call_preview_join_mute") === "true";

--- a/addons/mail/static/src/discuss/call/public_web/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_client_action_patch.js
@@ -6,7 +6,10 @@ import { patch } from "@web/core/utils/patch";
 patch(DiscussClientAction.prototype, {
     setup() {
         super.setup(...arguments);
-        this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
+    },
+    get rtc() {
+        return this.store.rtc;
     },
     /**
      * Checks if we are in a client action and if we have a query parameter requesting to join a call,

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.js
@@ -17,7 +17,10 @@ export class DiscussSidebarCallIndicator extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.rtc = useService("discuss.rtc");
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 }
 

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
@@ -4,7 +4,7 @@
         <div t-if="props.thread.rtc_session_ids.length > 0" title="Ongoing call" class="o-mail-DiscussSidebarCallIndicator fa-fw rounded-circle fa fa-volume-up" style="padding-top: 1px; padding-bottom: 1px;" t-att-class="{
             'o-discuss-inCallIconColor': props.thread.eq(rtc.channel),
             'opacity-50': !props.thread.eq(rtc.channel),
-            'me-2': !store.discuss.isSidebarCompact and props.thread.importantCounter === 0,
+            'me-2': !store.discuss?.isSidebarCompact and props.thread.importantCounter === 0,
         }"/>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -21,7 +21,6 @@ export class DiscussSidebarCallParticipants extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.rtc = useService("discuss.rtc");
         this.hover = useHover(["root", "floating*"], {
             onHover: () => (this.floating.isOpen = true),
             onAway: () => (this.floating.isOpen = false),
@@ -41,6 +40,10 @@ export class DiscussSidebarCallParticipants extends Component {
         );
     }
 
+    get rtc() {
+        return this.store.rtc;
+    }
+
     get callActionsRegistry() {
         return callActionsRegistry;
     }
@@ -49,7 +52,7 @@ export class DiscussSidebarCallParticipants extends Component {
         if (typeof this.props.compact === "boolean") {
             return this.props.compact;
         }
-        return this.store.discuss.isSidebarCompact;
+        return this.store.discuss?.isSidebarCompact;
     }
 
     get lastActiveSession() {

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -25,7 +25,6 @@ export class ChannelInvitation extends Component {
         super.setup();
         this.orm = useService("orm");
         this.store = useService("mail.store");
-        this.rtc = useService("discuss.rtc");
         this.notification = useService("notification");
         this.suggestionService = useService("mail.suggestion");
         this.ui = useService("ui");
@@ -37,7 +36,10 @@ export class ChannelInvitation extends Component {
             searchResultCount: 0,
             searchStr: "",
         });
-        this.debouncedFetchPartnersToInvite = useDebounced(this.fetchPartnersToInvite.bind(this), 250);
+        this.debouncedFetchPartnersToInvite = useDebounced(
+            this.fetchPartnersToInvite.bind(this),
+            250
+        );
         onWillStart(() => {
             if (this.store.self.type === "partner") {
                 this.fetchPartnersToInvite();
@@ -56,6 +58,10 @@ export class ChannelInvitation extends Component {
             },
             () => [this.props.autofocus]
         );
+    }
+
+    get rtc() {
+        return this.store.rtc;
     }
 
     get selectablePartners() {

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -2,10 +2,12 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelInvitation">
-        <ActionPanel t-if="props.thread" title.translate="Invite people" resizable="false" icon="'fa fa-user-plus'">
-            <t t-call="discuss.ChannelInvitation.main"/>
-        </ActionPanel>
-        <t t-else="" t-call="discuss.ChannelInvitation.main"/>
+        <t t-if="store?.exists()">
+            <ActionPanel t-if="props.thread" title.translate="Invite people" resizable="false" icon="'fa fa-user-plus'">
+                <t t-call="discuss.ChannelInvitation.main"/>
+            </ActionPanel>
+            <t t-else="" t-call="discuss.ChannelInvitation.main"/>
+        </t>
     </t>
 
     <t t-name="discuss.ChannelInvitation.main">

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.js
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.js
@@ -12,6 +12,7 @@ class MessageSeenIndicatorDialog extends Component {
     setup() {
         super.setup();
         this.contentRef = useRef("content");
+        this.store = useService("mail.store");
         useExternalListener(
             browser,
             "click",
@@ -37,6 +38,7 @@ export class MessageSeenIndicator extends Component {
 
     setup() {
         super.setup();
+        this.store = useService("mail.store");
         this.dialog = useService("dialog");
     }
 

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageSeenIndicator">
+        <t t-if="store?.exists()" t-call="mail.MessageSeenIndicator.main"/>
+    </t>
+
+    <t t-name="mail.MessageSeenIndicator.main">
         <span class="o-mail-MessageSeenIndicator position-relative" t-att-class="{ 'opacity-50': !props.message.hasEveryoneSeen, 'text-primary opacity-75': props.message.hasEveryoneSeen, 'cursor-pointer': props.message.channelMemberHaveSeen.length }" t-att-title="summary" t-attf-class="{{ props.className }}" t-on-click="openDialog">
             <t t-if="!props.message.isMessagePreviousToLastSelfMessageSeenByEveryone">
                 <i t-if="props.message.hasSomeoneFetched or props.message.hasSomeoneSeen" class="fa fa-check ps-1"/>
@@ -20,7 +24,7 @@
     </t>
 
     <t t-name="mail.MessageSeenIndicatorDialog">
-        <Dialog size="'sm'" title.translate="Seen by:" footer="false" withBodyPadding="false">
+        <Dialog t-if="store?.exists()" size="'sm'" title.translate="Seen by:" footer="false" withBodyPadding="false">
             <ul class="list-group list-group-flush list-unstyled py-1" t-ref="content">
                 <li class="list-group-item py-2" t-foreach="props.message.channelMemberHaveSeen" t-as="member" t-key="member.id">
                     <t t-call="mail.MessageSeenIndicatorPopover.card"/>

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -2,6 +2,10 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.NotificationSettings">
+        <t t-if="store?.exists()" t-call="discuss.NotificationSettings.main"/>
+    </t>
+
+    <t t-name="discuss.NotificationSettings.main">
         <ActionPanel title.translate="Notification Settings" resizable="false" icon="'fa fa-bell'">
             <div class="o-discuss-NotificationSettings">
                 <div t-if="store.settings.mute_until_dt" class="d-flex flex-column alert alert-warning">

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -245,7 +245,9 @@ const threadPatch = {
     },
     /** @returns {import("models").ChannelMember[]} */
     get correspondents() {
-        return this.channel_member_ids.filter(({ persona }) => persona.notEq(this.store.self));
+        return this.channel_member_ids.filter(
+            ({ persona }) => persona && persona.notEq(this.store.self)
+        );
     },
     get displayName() {
         if (this.channel_type === "chat" && this.correspondent) {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
@@ -14,7 +14,6 @@ export class DiscussCorePublicWeb {
         this.store = services["mail.store"];
         this.busService = services.bus_service;
         this.notificationService = services.notification;
-        this.rtcService = services["discuss.rtc"];
         try {
             this.sidebarCategoriesBroadcast = new browser.BroadcastChannel(
                 "discuss_core_public_web.sidebar_categories"
@@ -74,6 +73,10 @@ export class DiscussCorePublicWeb {
                 }
             }
         );
+    }
+
+    get rtcService() {
+        return this.store.rtc;
     }
 
     /**

--- a/addons/mail/static/src/discuss/core/public_web/discuss_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_patch.js
@@ -1,14 +1,12 @@
 import { Discuss } from "@mail/core/public_web/discuss";
 import { Call } from "@mail/discuss/call/common/call";
-import { useService } from "@web/core/utils/hooks";
 
 import { patch } from "@web/core/utils/patch";
 
 Object.assign(Discuss.components, { Call });
 
 patch(Discuss.prototype, {
-    setup() {
-        super.setup(...arguments);
-        this.rtc = useService("discuss.rtc");
+    get rtc() {
+        return this.store.rtc;
     },
 });

--- a/addons/mail/static/src/discuss/core/public_web/discuss_patch.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_patch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.Discuss" t-inherit-mode="extension">
+    <t t-inherit="mail.Discuss.main" t-inherit-mode="extension">
         <xpath expr="//Thread" position="before">
             <Call t-if="thread.rtc_session_ids.length > 0" thread="thread"/>
         </xpath>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -79,27 +79,27 @@ export class DiscussSidebarChannel extends Component {
 
     get attClass() {
         return {
-            "bg-inherit": this.thread.notEq(this.store.discuss.thread),
-            "o-active": this.thread.eq(this.store.discuss.thread),
+            "bg-inherit": this.thread.notEq(this.store.discuss?.thread),
+            "o-active": this.thread.eq(this.store.discuss?.thread),
             "o-unread": this.thread.selfMember?.message_unread_counter > 0 && !this.thread.isMuted,
             "border-bottom-0 rounded-bottom-0": this.bordered,
             "opacity-50": this.thread.isMuted,
             "position-relative justify-content-center o-compact mt-0 p-1":
-                this.store.discuss.isSidebarCompact,
-            "px-0": !this.store.discuss.isSidebarCompact,
+                this.store.discuss?.isSidebarCompact,
+            "px-0": !this.store.discuss?.isSidebarCompact,
         };
     }
 
     get attClassContainer() {
         return {
             "border border-dark rounded-3 o-bordered": this.bordered,
-            "o-compact": this.store.discuss.isSidebarCompact,
+            "o-compact": this.store.discuss?.isSidebarCompact,
         };
     }
 
     get bordered() {
         return (
-            this.store.discuss.isSidebarCompact &&
+            this.store.discuss?.isSidebarCompact &&
             Boolean(this.env.filteredThreads?.(this.thread.sub_channel_ids)?.length)
         );
     }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
-        <Dropdown t-if="store.discuss.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm'" manual="true">
+        <Dropdown t-if="store.discuss?.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm'" manual="true">
             <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75 bg-transparent" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-lg fa-fw fa-search"/></button>
             <t t-set-slot="content">
                 <div class="p-2" t-ref="search-floating">
@@ -13,7 +13,7 @@
             <input class="form-control rounded-3 border-0 bg-inherit" t-att-class="{ 'lh-1': !ui.isSmall }" disabled="true" placeholder="Find or start a conversation" tabindex="0"/>
             <div class="o-mail-DiscussSidebarCategories-searchClickable position-absolute z-1 opacity-0 cursor-pointer w-100 h-100"/>
         </div>
-        <t t-foreach="store.discuss.allCategories" t-as="cat" t-key="cat.id">
+        <t t-foreach="store.discuss?.allCategories ?? []" t-as="cat" t-key="cat.id">
             <t t-if="cat.isVisible" t-call="mail.DiscussSidebarCategories.category">
                 <t t-set="category" t-value="cat"/>
             </t>
@@ -25,12 +25,12 @@
         <t t-if="category.open">
             <DiscussSidebarChannel t-foreach="filteredThreads(category.threads)" t-as="thread" t-key="thread.localId" thread="thread"/>
         </t>
-        <DiscussSidebarChannel t-elif="store.discuss.thread?.in(category.threads)" thread="store.discuss.thread"/>
-        <DiscussSidebarChannel t-elif="store.discuss.thread?.parent_channel_id?.in(category.threads)" thread="store.discuss.thread.parent_channel_id" />
+        <DiscussSidebarChannel t-elif="store.discuss?.thread?.in(category.threads)" thread="store.discuss.thread"/>
+        <DiscussSidebarChannel t-elif="store.discuss?.thread?.parent_channel_id?.in(category.threads)" thread="store.discuss.thread.parent_channel_id" />
     </t>
 
     <t t-name="mail.DiscussSidebarCategory">
-        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
+        <Dropdown t-if="store.discuss?.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm'" manual="true">
             <t t-call="mail.DiscussSidebarCategory.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden" t-ref="floating">
@@ -43,9 +43,9 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory.main">
-        <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'm-2 position-relative': store.discuss.isSidebarCompact, 'mt-1 ms-1 me-2 pe-1': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
-            <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start opacity-100-hover" t-att-class="{ 'align-items-baseline opacity-75 o-gap-0_5': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact opacity-50 gap-1': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
-                <t t-if="store.discuss.isSidebarCompact">
+        <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'm-2 position-relative': store.discuss?.isSidebarCompact, 'mt-1 ms-1 me-2 pe-1': !store.discuss?.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
+            <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start opacity-100-hover" t-att-class="{ 'align-items-baseline opacity-75 o-gap-0_5': !store.discuss?.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact opacity-50 gap-1': store.discuss?.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
+                <t t-if="store.discuss?.isSidebarCompact">
                     <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xxsmaller" t-att-class="{
                         'oi oi-chevron-down opacity-75': category.open,
                         'oi oi-chevron-right opacity-50': !category.open,

--- a/addons/mail/static/src/discuss/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/store_service_patch.js
@@ -11,12 +11,16 @@ const StorePatch = {
         this.channels = this.makeCachedFetchData("channels_as_member");
         this.fetchSsearchConversationsSequential = useSequential();
     },
+    async onReset() {
+        this.channels.status = "not_fetched";
+        await super.onReset();
+    },
     /**
      * @param {string} categoryId
      * @returns {number}
      * */
     getDiscussSidebarCategoryCounter(categoryId) {
-        return this.DiscussAppCategory.get({ id: categoryId }).threads.reduce((acc, channel) => {
+        return this.DiscussAppCategory.get({ id: categoryId })?.threads.reduce((acc, channel) => {
             if (categoryId === "channels") {
                 return channel.message_needaction_counter > 0 ? acc + 1 : acc;
             } else {

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.SubChannelList">
+        <t t-if="store?.exists()" t-call="mail.SubChannelList.main"/>
+    </t>
+
+    <t t-name="mail.SubChannelList.main">
         <ActionPanel title.translate="Threads" resizable="false" icon="'fa fa-comments-o'">
             <t t-set-slot="header">
                 <div class="d-flex align-items-center my-0">

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
@@ -7,7 +7,7 @@
                 New Message
             </button>
             <t t-if="ui.isSmall">
-                <t t-if="store.discuss.activeTab !== 'main' or !env.inDiscussApp">
+                <t t-if="store.discuss?.activeTab !== 'main' or !env.inDiscussApp">
                     <button name="startMeetingButton" class="w-50 m-1 me-0 btn btn-primary" t-on-click.stop="onClickStartMeeting">
                         <i class="fa fa-users"/> Start a meeting
                     </button>

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="discuss.GifPicker">
+        <t t-if="store?.exists()" t-call="discuss.GifPicker.main"/>
+    </t>
+
+    <t t-name="discuss.GifPicker.main">
         <div class="o-discuss-GifPicker d-flex flex-column" t-attf-class="{{ props.className }}" t-att-class="{ 'h-100': props.mobile }">
             <div t-if="!store.hasGifPickerFeature and store.self.isAdmin" class="d-flex flex-column align-items-center justify-content-center m-3 h-100">
                 <span class="o-discuss-GifPicker-bigEmoji">🧑‍🍳🌶️</span>

--- a/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
+++ b/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
@@ -14,19 +14,21 @@ patch(DiscussCoreCommon.prototype, {
             }
         }
         this.store.starred.messages = filteredStarredMessages;
-        if (notifId > this.store.starred.counter_bus_id) {
+        if (this.store.starred && notifId > this.store.starred.counter_bus_id) {
             this.store.starred.counter -= starredCounter;
         }
         this.store.inbox.messages = this.store.inbox.messages.filter(
             (msg) => !msg.thread?.eq(thread)
         );
-        if (notifId > this.store.inbox.counter_bus_id) {
+        if (this.store.inbox && notifId > this.store.inbox.counter_bus_id) {
             this.store.inbox.counter -= thread.message_needaction_counter;
         }
-        this.store.history.messages = this.store.history.messages.filter(
-            (msg) => !msg.thread?.eq(thread)
-        );
-        if (thread.eq(this.store.discuss.thread)) {
+        if (this.store.history) {
+            this.store.history.messages = this.store.history.messages.filter(
+                (msg) => !msg.thread?.eq(thread)
+            );
+        }
+        if (thread.eq(this.store.discuss?.thread)) {
             this.store.inbox.setAsDiscussThread();
         }
         super._handleNotificationChannelDelete(thread, metadata);

--- a/addons/mail/static/src/js/tooling/types/services.d.ts
+++ b/addons/mail/static/src/js/tooling/types/services.d.ts
@@ -26,6 +26,7 @@ declare module "services" {
         "discuss.core.web": typeof discussCoreWeb;
         "discuss.p2p": typeof discussP2P;
         "discuss.ptt_extension": typeof pttExtensionHookService;
+        /** @deprecated */
         "discuss.rtc": typeof rtcService;
         "discuss.voice_message": typeof voiceMessageService;
         "mail.attachment_upload": typeof attachmentUploadService;

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -19,12 +19,53 @@ export class Store extends Record {
     /** @type {Map<string, Record>} */
     recordByLocalId;
     storeReady = false;
+    resetCount = 0;
     /**
      * @param {string} localId
      * @returns {Record}
      */
     get(localId) {
         return this.recordByLocalId.get(localId);
+    }
+
+    /**
+     * Reset the store to its initial state. To customize the reset behavior, override
+     * the `onReset` method.
+     */
+    async reset() {
+        this.storeReady = false;
+        await this.onReset();
+        this.resetCount++;
+        this.storeReady = true;
+    }
+
+    async onReset() {
+        this.MAKE_UPDATE(() => {
+            for (const [localId, record] of this.recordByLocalId.entries()) {
+                if (this.localId !== localId && record.exists()) {
+                    record.delete();
+                }
+            }
+        });
+        const rawStore = toRaw(this)._raw;
+        this.MAKE_UPDATE(() => {
+            for (const fieldName of rawStore.Model._.fields.keys()) {
+                rawStore._.requestCompute?.(rawStore, fieldName);
+                rawStore._.requestSort?.(rawStore, fieldName);
+            }
+        });
+    }
+
+    destroy() {
+        this.MAKE_UPDATE(() => {
+            for (const [localId, record] of this.recordByLocalId.entries()) {
+                if (this.localId !== localId && record.exists()) {
+                    record.delete();
+                }
+            }
+        });
+        this.delete();
+        this._[IS_DELETED_SYM] = true;
     }
 
     handleError(err) {
@@ -126,6 +167,9 @@ export class Store extends Record {
                     /** @type {[Record, Map<string, true>]} */
                     const [record, map] = FU_QUEUE.entries().next().value;
                     FU_QUEUE.delete(record);
+                    if (RHD_QUEUE.has(record) || RD_QUEUE.has(record)) {
+                        continue;
+                    }
                     for (const fieldName of map.keys()) {
                         record._.onUpdate(record, fieldName);
                     }
@@ -171,6 +215,11 @@ export class Store extends Record {
                     record._[IS_DELETED_SYM] = true;
                     delete record.Model.records[record.localId];
                     this.recordByLocalId.delete(record.localId);
+                    const stopFns = toRaw(record)._raw._.reactiveStopFns;
+                    while (stopFns.length) {
+                        const fn = stopFns.pop();
+                        fn();
+                    }
                 }
             }
             this._.UPDATE--;
@@ -264,7 +313,17 @@ export class Store extends Record {
      */
     _onChange(record, key, callback) {
         let proxy;
+        let ready = true;
+        const ON_CHANGE_SYM = Symbol("onChange");
+        const stopFn = () => {
+            ready = false;
+            if (proxy) {
+                proxy[ON_CHANGE_SYM] = 1; // force trigger callback to "clear" reactive
+            }
+        };
+        toRaw(record)._raw._.reactiveStopFns.push(stopFn);
         function _observe() {
+            void proxy[ON_CHANGE_SYM];
             // access proxy[key] only once to avoid triggering reactive get() many times
             const val = proxy[key];
             if (typeof val === "object" && val !== null) {
@@ -276,21 +335,16 @@ export class Store extends Record {
             }
         }
         if (Array.isArray(key)) {
-            for (const k of key) {
-                this._onChange(record, k, callback);
-            }
-            return;
+            const stopFns = key.map((k) => this._onChange(record, k, callback));
+            return () => stopFns.forEach((fn) => fn());
         }
-        let ready = true;
         proxy = reactive(record, () => {
             if (ready) {
                 callback(_observe);
             }
         });
         _observe();
-        return () => {
-            ready = false;
-        };
+        return stopFn;
     }
     _cleanupData(data) {
         super._cleanupData(data);

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -353,6 +353,7 @@ export async function start(options) {
     env.testEnv = true;
     await mountWithCleanup(WebClient, { env, target });
     await loadEmoji();
+    after(() => env.services["mail.store"].destroy());
     return Object.assign(env, { ...options?.env, target });
 }
 

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1381,9 +1381,12 @@ test("Can remove files of message individually", async () => {
     await contains(
         ":nth-child(1 of .o-mail-Message) :nth-child(2 of .o-mail-AttachmentContainer) [title='Remove']"
     );
-    await contains(":nth-child(2 of .o-mail-Message) .o-mail-AttachmentContainer [title='Remove']", {
-        count: 0,
-    });
+    await contains(
+        ":nth-child(2 of .o-mail-Message) .o-mail-AttachmentContainer [title='Remove']",
+        {
+            count: 0,
+        }
+    );
     await contains(":nth-child(3 of .o-mail-Message) .o-mail-AttachmentContainer [title='Remove']");
 });
 

--- a/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
@@ -7,7 +7,7 @@ registry.category("web_tour.tours").add("discuss_channel_call_public_tour.js", {
             trigger: ".o-mail-WelcomePage",
             async run() {
                 await new Promise((r) => setTimeout(r, 250));
-                const rtcService = odoo.__WOWL_DEBUG__.root.env.services["discuss.rtc"];
+                const rtcService = odoo.__WOWL_DEBUG__.root.env.services["mail.store"].rtc;
                 if (rtcService?.selfSession || rtcService?.state.hasPendingRequest) {
                     console.error("The call should not have started.");
                 }

--- a/addons/mail/static/tests/tours/discuss_store_reset_tour.js
+++ b/addons/mail/static/tests/tours/discuss_store_reset_tour.js
@@ -1,0 +1,103 @@
+import { registry } from "@web/core/registry";
+
+export function getSendFirstMessageAndResetSteps(containerSelector) {
+    return [
+        {
+            trigger: `${containerSelector} .o-mail-Composer-input`,
+            run: "edit Hello!",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Composer-input`,
+            run: "press Enter",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Message-body:contains("Hello!")`,
+            async run() {
+                await odoo.__WOWL_DEBUG__.root.env.services["mail.store"].reset();
+            },
+        },
+    ];
+}
+
+export function getAfterResetSteps(containerSelector) {
+    // Execute basic actions after store reset to ensure that the basic functionalities
+    // are still working as expected: Send/Edit message, Add/Remove reactio
+    return [
+        {
+            trigger: `${containerSelector} .o-mail-Composer-input`,
+            run: "click",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Composer-input`,
+            run: "edit Hello again!",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Composer-input`,
+            run: "press Enter",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Message-textContent:contains(Hello again!):not(:has(.o-mail-Message-pendingProgress))`,
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Message:contains(Hello again!) [title='Expand']:not(:visible)`,
+            run: "click",
+        },
+        {
+            trigger: `[title='Edit'], ${containerSelector} [title='Edit']`,
+            run: "click",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Composer-input`,
+            run: "edit Goodbye!",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Composer-input`,
+            run: "press Enter",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Message-textContent:contains(Hello!)`,
+            run: `hover && click .o-mail-Message [title='Add a Reaction'], ${containerSelector} .o-mail-Message [title='Add a Reaction']`,
+        },
+        {
+            trigger: `.o-mail-QuickReactionMenu-emojiPicker, ${containerSelector} .o-mail-QuickReactionMenu-emojiPicker`,
+            run: "click",
+        },
+        {
+            trigger: `.o-EmojiPicker .o-Emoji:contains('🙂'), ${containerSelector} .o-EmojiPicker .o-Emoji:contains('🙂')`,
+            run: "click",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-MessageReaction:contains('🙂')`,
+            run: "click",
+        },
+        {
+            trigger: `${containerSelector} .o-mail-Message:not(:has(.o-mail-MessageReaction))`,
+        },
+    ];
+}
+
+registry.category("web_tour.tours").add("discuss.store_reset_in_discuss", {
+    steps: () => [
+        ...getSendFirstMessageAndResetSteps(
+            ".o-mail-Discuss-content:has(.o-mail-Discuss-threadName[title='MyChannel'])"
+        ),
+        ...getAfterResetSteps(
+            ".o-mail-Discuss-content:has(.o-mail-Discuss-threadName[title='MyChannel'])"
+        ),
+    ],
+});
+
+registry.category("web_tour.tours").add("discuss.store_reset_with_chat_windows", {
+    steps: () => [
+        {
+            trigger: ".o-mail-DiscussSystray-class .fa-comments",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-NotificationItem:contains('MyChannel')",
+            run: "click",
+        },
+        ...getSendFirstMessageAndResetSteps(".o-mail-ChatWindow:contains('MyChannel')"),
+        ...getAfterResetSteps(".o-mail-ChatWindow:contains('MyChannel')"),
+    ],
+});

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -15,6 +15,7 @@ from . import test_discuss_res_role
 from . import test_discuss_sub_channels
 from . import test_discuss_thread_controller
 from . import test_message_controller
+from . import test_store_reset
 from . import test_guest_feature
 from . import test_toggle_upload
 from . import test_load_messages

--- a/addons/mail/tests/discuss/test_store_reset.py
+++ b/addons/mail/tests/discuss/test_store_reset.py
@@ -1,0 +1,34 @@
+from odoo.tests import tagged
+from odoo.addons.base.tests.common import HttpCase
+
+
+@tagged("-at_install", "post_install")
+class TestStoreReset(HttpCase):
+    def test_store_reset_in_discuss(self):
+        channel = self.env["discuss.channel"].create({"name": "MyChannel"})
+        channel._add_members(users=self.env.ref("base.user_admin"))
+        self.start_tour(
+            f"/odoo/discuss?active_id=discuss.channel_{channel.id}",
+            "discuss.store_reset_in_discuss",
+            login="admin",
+        )
+
+    def test_store_reset_with_chat_windows(self):
+        channel = self.env["discuss.channel"].create({"name": "MyChannel"})
+        channel._add_members(users=self.env.ref("base.user_admin"))
+        self.start_tour("/odoo/apps", "discuss.store_reset_with_chat_windows", login="admin")
+
+    def test_store_reset_in_public_page(self):
+        channel = self.env["discuss.channel"].create({"name": "MyChannel"})
+        channel._add_members(users=self.env.ref("base.user_admin"))
+        self.start_tour(channel.invitation_url, "discuss.store_reset_in_discuss", login="admin")
+
+    def test_store_reset_in_public_page_as_guest(self):
+        channel = self.env["discuss.channel"].create({"name": "MyChannel", "group_public_id": None})
+        guest = self.env["mail.guest"].create({"name": "Guest"})
+        channel._add_members(guests=guest)
+        self.start_tour(
+            channel.invitation_url,
+            "discuss.store_reset_in_discuss",
+            cookies={guest._cookie_name: guest._format_auth_cookie()},
+        )

--- a/addons/portal/static/src/chatter/core/portal_chatter.xml
+++ b/addons/portal/static/src/chatter/core/portal_chatter.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="portal.Chatter">
-    <div t-if="state.thread" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex pt-2" t-att-class="{ 'row':props.twoColumns, 'flex-column':!props.twoColumns }" t-on-scroll="onScrollDebounced" t-ref="root">
+    <div t-if="state.thread?.exists()" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex pt-2" t-att-class="{ 'row':props.twoColumns, 'flex-column':!props.twoColumns }" t-on-scroll="onScrollDebounced" t-ref="root">
         <div t-if="props.composer" class="o-mail-Chatter-top position-sticky top-0" t-att-class="{ 'col-lg-6':props.twoColumns, 'bg-view':env.inFrontendPortalChatter }" t-att-style="(!props.twoColumns and env.inFrontendPortalChatter and !env.projectSharingId) and 'top: -1px !important; margin-top:-15px; padding-top: 20px'" t-ref="top">
             <Composer composer="state.thread.composer" autofocus="env.inFrontendPortalChatter ? false : true" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" t-key="props.threadId"/>
         </div>


### PR DESCRIPTION
This commit adds `store.destroy()` to cleanly destroy the store, including ongoing reactive observers. This is useful to make sure no side-effect store among HOOT tests

This commit adds `store.reset()`, to make the store fresh as at page load. This is in preparation to make store reset in case we miss notifications for a long time.

https://github.com/odoo/enterprise/pull/85474