### PR TITLE
[FIX] html_editor: fix autofocus issue in modal for `LinkPopover`

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
-import { Component, useState, onMounted, useRef } from "@odoo/owl";
-import { useAutofocus, useService } from "@web/core/utils/hooks";
+import { Component, useState, onMounted, useRef, useEffect } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
 import { browser } from "@web/core/browser/browser";
 import { cleanZWChars, deduceURLfromText } from "./utils";
 
@@ -79,10 +79,15 @@ export class LinkPopover extends Component {
         });
 
         this.editingWrapper = useRef("editing-wrapper");
-        useAutofocus({
-            refName: this.state.isImage || this.state.label !== "" ? "url" : "label",
-            mobile: true,
-        });
+        this.inputRef = useRef(this.state.isImage || this.state.label !== "" ? "url" : "label");
+        useEffect(
+            (el) => {
+                if (el) {
+                    el.focus();
+                }
+            },
+            () => [this.inputRef.el]
+        );
         onMounted(() => {
             if (!this.state.editing) {
                 this.loadAsyncLinkPreview();


### PR DESCRIPTION
**Problem**:
When inside a modal (Full Composer), the autofocus hook in the setup of `LinkPopover` does not work as expected.

- The active element is set to the modal `<div role="dialog" ...>`, while the input inside the `LinkPopover` is not within the dialog.
- As a result, `uiService.activeElement.contains(el)` in `hooks.js:51` returns `false`.
- Without a modal, it returns `true` since `activeElement` is `document`.

**Solution**:
To bypass this issue, manually focus the input without relying on the autofocus hook.

**Steps to Reproduce**:
1. Open a **Sale Order**.
2. Click on **Send by Email** to open the **Full Composer**.
3. Add some text.
4. Select the text and click **Link** in the toolbar.
   - **Issue**: The `LinkPopover` opens and closes immediately because the input was not focused.

**opw-4656387**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
