### PR TITLE
[FIX] core: avoid sending invalid json-rpc responses

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1923,7 +1923,7 @@ class JsonRPCDispatcher(Dispatcher):
         response = {'jsonrpc': '2.0', 'id': self.request_id}
         if error is not None:
             response['error'] = error
-        if result is not None:
+        else:
             response['result'] = result
 
         return self.request.make_json_response(response)


### PR DESCRIPTION
Before this change, if a jsonrpc handler was successful but returned the value `None` the dispatcher would return a response object containing just the `jsonrpc` and `id` keys.

This is an invalid response according to [JSON-RPC 2.0 Specification section 5 "Response Object"][jsonrpc-response]:

> Either the result member or error member MUST be included [...]

[jsonrpc-response]: https://www.jsonrpc.org/specification#response_object
