### PR TITLE
[FIX] */tests: missing groups when ran without demo data

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -260,6 +260,53 @@ class AccountTestInvoicingCommon(ProductCommon):
     @classmethod
     def get_default_groups(cls):
         groups = super().get_default_groups()
+        groups |= cls.env['res.groups'].browse(
+            cls.env['ir.model.data'].search([
+                ('model', '=', 'res.groups'),
+                ('name', 'in', (
+                    # TODO: Progressively remove groups from this list, hopefully no groups share the same name.
+                    # This is a consequence of moving groups from data to demo data: https://github.com/odoo/odoo/pull/198078
+                    'group_account_manager', # account
+                    'group_event_manager', # event
+                    'fleet_group_manager', # fleet
+                    'group_hr_manager', # hr
+                    'group_hr_attendance_manager', # hr_attendance
+                    'group_hr_contract_manager', # hr_contract
+                    'group_hr_expense_manager', # hr_expense
+                    'group_hr_holidays_manager', # hr_holidays
+                    'group_hr_recruitment_manager', # hr_recruitment
+                    'group_timesheet_manager', # hr_timesheet
+                    'im_livechat_group_manager', # im_livechat
+                    'group_lunch_manager', # lunch
+                    'group_mass_mailing_user', # mass_mailing
+                    'group_mrp_manager', # mrp
+                    'group_pos_manager', # point_of_sale
+                    'group_product_manager', # product
+                    'group_project_manager', # project
+                    'group_purchase_manager', # purchase
+                    'group_sale_manager', # sales_team
+                    'group_stock_manager', # stock
+                    'group_survey_user', # survey
+                    'group_website_designer', # website
+                    'group_website_slides_manager', # website_slides
+                    # enterprise groups
+                    'group_appointment_manager', # appointment
+                    'group_approval_manager', # approval
+                    'group_documents_manager', # documents
+                    'frontdesk_group_administrator', # frontdesk
+                    'group_helpdesk_manager', # helpdesk
+                    'group_hr_appraisal_manager', # hr_appraisal
+                    'group_hr_payroll_manager', # hr_payroll
+                    'group_hr_recruitment_manager', # hr_referral -> duplicate from hr_recruitment /!\
+                    'group_fsm_manager', # industry_fsm
+                    'group_marketing_automation_user', # marketing_automation
+                    'group_plm_manager', # mrp_plm
+                    'group_planning_manager', # planning
+                    'group_sign_manager', # sign
+                    'group_social_manager', # social
+                ))
+            ]).mapped('res_id')
+        )
         return groups | cls.env.ref('account.group_account_manager') | cls.env.ref('account.group_account_user')
 
     @classmethod

--- a/addons/im_livechat/security/im_livechat_channel_security.xml
+++ b/addons/im_livechat/security/im_livechat_channel_security.xml
@@ -10,6 +10,7 @@
             <field name="sequence">10</field>
             <field name="category_id" ref="base.module_category_website_live_chat"/>
             <field name="comment">The user will be able to join support channels.</field>
+            <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         </record>
 
         <record id="im_livechat_group_manager" model="res.groups">

--- a/addons/im_livechat/tests/common.py
+++ b/addons/im_livechat/tests/common.py
@@ -15,8 +15,7 @@ class TestImLivechatCommon(HttpCase):
             'password': cls.password,
             'livechat_username': "Michel Operator",
             'email': 'michel@example.com',
-            # TODO: im_livechat should imply group_user ?
-            'group_ids': cls.env.ref('im_livechat.im_livechat_group_user') | cls.env.ref('base.group_user'),
+            'group_ids': cls.env.ref('im_livechat.im_livechat_group_user'),
         }, {
             'name': 'Paul',
             'login': 'paul'

--- a/addons/im_livechat/tests/common.py
+++ b/addons/im_livechat/tests/common.py
@@ -15,6 +15,8 @@ class TestImLivechatCommon(HttpCase):
             'password': cls.password,
             'livechat_username': "Michel Operator",
             'email': 'michel@example.com',
+            # TODO: im_livechat should imply group_user ?
+            'group_ids': cls.env.ref('im_livechat.im_livechat_group_user') | cls.env.ref('base.group_user'),
         }, {
             'name': 'Paul',
             'login': 'paul'

--- a/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
@@ -409,6 +409,7 @@ class TestTimesheetGlobalTimeOff(common.TransactionCase):
         test_user = self.env['res.users'].with_company(self.test_company).create({
             'name': 'Jonathan Doe',
             'login': 'jdoe@example.com',
+            'group_ids': self.env.ref('hr_timesheet.group_hr_timesheet_user'),
         })
         test_user.with_company(self.test_company).action_create_employee()
         test_user.employee_id.write({

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -365,6 +365,10 @@ class TestSalePrices(SaleCommon):
             'company_ids': [Command.set([other_company.id])],
             'name': 'E.T',
             'login': 'hohoho',
+            'group_ids': (
+                self.env.ref('sales_team.group_sale_salesman') |
+                self.env.ref('product.group_product_manager')
+            ),
         })
         with mute_logger('odoo.models.unlink'):
             self.env['res.currency.rate'].search([]).unlink()

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -133,7 +133,7 @@ class SaleOrder(models.Model):
 
         # If the order has exactly one project and that project comes from a template, set the company of the template
         # on the project.
-        for order in self:
+        for order in self.sudo(): # Salesman may not have access to projects
             if len(order.project_ids) == 1:
                 project = order.project_ids[0]
                 for sol in order.order_line:

--- a/addons/sale_purchase_stock/tests/test_lead_time.py
+++ b/addons/sale_purchase_stock/tests/test_lead_time.py
@@ -23,6 +23,7 @@ class TestLeadTime(TestCommonSalePurchaseNoChart):
             'name': 'Le Grand Horus',
             'login': 'grand.horus',
             'email': 'grand.horus@chansonbelge.dz',
+            'group_ids': cls.env.ref('sales_team.group_sale_salesman'),
         })
 
     def test_supplier_lead_time(self):

--- a/addons/sale_timesheet/tests/test_performance.py
+++ b/addons/sale_timesheet/tests/test_performance.py
@@ -19,7 +19,7 @@ class TestPerformanceTimesheet(TestSaleTimesheet):
         })
         self.assertFalse(project.task_ids.sale_line_id)
         self.env.invalidate_all()
-        with self.assertQueryCount(83):
+        with self.assertQueryCount(85):
             project.write({
                 'allow_billable': True,
                 'partner_id': self.partner_b.id,

--- a/addons/stock_delivery/tests/test_carrier_propagation.py
+++ b/addons/stock_delivery/tests/test_carrier_propagation.py
@@ -225,6 +225,7 @@ class TestCarrierPropagation(TransactionCase):
             'login': 'Mars Man',
             'name': 'Spleton',
             'email': 'alien@mars.com',
+            'group_ids': self.env.ref('stock.group_stock_user'),
         })
         super_product_2 = self.ProductProduct.create({
             'name': 'Super Product 2',


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/198078, default groups have been moved from regular data to demo data.

Due to many test's reliance on those groups, a big chunk of tests stopped working when ran without demo data; as we want to change the behaviour of odoo to install without demo data by default, we require the test suite to run without it as well.

This PR adds those missing groups explicitly to restore the behaviour prior to the PR mentioned above for tests inheriting from `odoo/addons/base/tests/common.py:BaseCommon`, other instances of missing groups have also been adapted.
Those changes are made with the hope that individual teams will go through the necessity of such groups and remove them/adapt the code as appropriate.