### PR TITLE
[FIX] mrp: don't create dummy move lines in MOs made with barcodes

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -796,7 +796,7 @@ class MrpProduction(models.Model):
 
     @api.onchange('qty_producing', 'lot_producing_id')
     def _onchange_producing(self):
-        productions_bypass_qty_producting = self.filtered(lambda p: p.lot_producing_id and p.product_tracking == 'lot' and p._origin and p._origin.qty_producing == p.qty_producing)
+        productions_bypass_qty_producting = self.filtered(lambda p: p.lot_producing_id and p.product_tracking == 'lot')
         (self - productions_bypass_qty_producting)._set_qty_producing()
 
     @api.onchange('lot_producing_id')


### PR DESCRIPTION
If the user creates a manufacturing order for a product tracked by lots, then enters a quantity to be produced through the digipad, move lines of 0 quantity get created for each component the product has in its bill of materials.

This is because `qty_producing` is updated more than once when entering the value, which triggers an onchange each time. This happens in two ways:
  1. The user inputs a value by pressing individual numbers on the numpad. The field is updated each time a number is entered. (eg entering '3333' updates the field 4 times.) As the numpad was removed from the digipad in 18.0 onwards, this is only an issue in 17.0, where the bug was originally reported.
  2. The user inputs a value by editing the input box, then shifts the focus out of the input box. Each time the focus shifts from the input box, the field gets updated. This is how the bug persists in 18.0 onwards.

The onchange is supposed to ignore the intermediate updates until the user presses confirm by filtering them out before passing the manufacturing orders to `_set_qty_producing()`. The filter checks whether the field has changed before the onchange was called, which always fails with the intermediate updates.

opw-4623527