### PR TITLE
[4602920][FIX] l10n_eg_edi, l10n_in_edi, l10n_in_edi_ewaybill, l10n_ke_edi_tre…

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -301,7 +301,7 @@ class AccountEdiFormat(models.Model):
             discount_amount = self._l10n_eg_edi_round(price_subtotal_before_discount - abs(line.balance))
             item_code = line.product_id.l10n_eg_eta_code or line.product_id.barcode
             lines.append({
-                'description': line.product_id.display_name or line.name,
+                'description': line.name,
                 'itemType': item_code.startswith('EG') and 'EGS' or 'GS1',
                 'itemCode': item_code,
                 'unitType': line.product_uom_id.l10n_eg_unit_code_id.code,

--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -356,10 +356,9 @@ class AccountEdiFormat(models.Model):
             # government does not accept negative in qty or unit price
             unit_price_in_inr = unit_price_in_inr * -1
             quantity = quantity * -1
-        PrdDesc = line.product_id.display_name or line.name
         return {
             "SlNo": str(index),
-            "PrdDesc": PrdDesc.replace("\n", ""),
+            "PrdDesc": line.name.replace("\n", ""),
             "IsServc": line.product_id.type == "service" and "Y" or "N",
             "HsnCd": self._l10n_in_edi_extract_digits(line.l10n_in_hsn_code),
             "Qty": self._l10n_in_round_value(quantity or 0.0, 3),

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -508,9 +508,9 @@ class AccountEdiFormat(models.Model):
         extract_digits = self._l10n_in_edi_extract_digits
         tax_details_by_code = self._get_l10n_in_tax_details_by_line_code(line_tax_details.get("tax_details", {}))
         line_details = {
-            "productName": line.product_id.name or line.name,
+            "productName": line.product_id.name,
             "hsnCode": extract_digits(line.l10n_in_hsn_code),
-            "productDesc": line.product_id.display_name,
+            "productDesc": line.name,
             "quantity": line.quantity,
             "qtyUnit": line.product_id.uom_id.l10n_in_code and line.product_id.uom_id.l10n_in_code.split("-")[0] or "OTH",
             "taxableAmount": self._l10n_in_round_value(line.balance * sign),

--- a/addons/l10n_ke_edi_tremol/models/account_move.py
+++ b/addons/l10n_ke_edi_tremol/models/account_move.py
@@ -205,7 +205,7 @@ class AccountMove(models.Model):
             uom = line.product_uom_id and line.product_uom_id.name or ''
 
             line_data = b';'.join([
-                self._l10n_ke_fmt(line.product_id.display_name or line.name, 36),                       # 36 symbols for the article's name
+                self._l10n_ke_fmt(line.name, 36),                       # 36 symbols for the article's name
                 self._l10n_ke_fmt(item_code.tax_rate or 'A', 1),        # 1 symbol for article's vat class ('A', 'B', 'C', 'D', or 'E')
                 price[:15].encode('cp1251'),                    # 1 to 15 symbols for article's price with up to 5 digits after decimal point
                 self._l10n_ke_fmt(uom, 3),                              # 3 symbols for unit of measure


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
modified labels are not sent to the ETA
Current behavior before PR:
-> change an invoice line label
-> post the invoice
-> send to ETA
-> only product name is sent to the ETA
Desired behavior after PR is merged:
-> change an invoice line label
-> post the invoice
-> send to ETA
-> line label is sent to the ETA

this is based on this pr: https://github.com/odoo/odoo/pull/200907

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
