### PR TITLE
[FIX] partner_autocomplete: can unset partner many2one field

### DIFF
--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -45,6 +45,7 @@
                 autoSelect="true"
                 sources="sources"
                 onSelect.bind="onSelect"
+                onChange.bind="onChange"
                 input="inputRef"
                 placeholder="placeholder || ''"
             />

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -353,6 +353,30 @@ QUnit.module('partner_autocomplete', {
         assert.strictEqual(input.value, "");
     });
 
+    QUnit.test("Can unset the partner many2one field", async function (assert) {
+        assert.expect(5);
+        const record = { id: 1, name: "Some partner", parent_id: 1 };
+        makeViewParams.serverData.models["res.partner"].records.push(record);
+        makeViewParams.resId = 1;
+        const mockRPC = makeViewParams.mockRPC;
+        makeViewParams.mockRPC = function(route, { args, method }) {
+            if (method === "web_save") {
+                assert.step("web_save");
+                assert.deepEqual(args[1].parent_id, false);
+            }
+            return mockRPC(...arguments);
+        }
+        await makeView(makeViewParams);
+        assert.strictEqual(target.querySelector("[name=parent_id] input").value, "Some partner");
+        const input = target.querySelector("[name=parent_id] input.o-autocomplete--input.o_input");
+        await triggerEvent(input, null, "focus");
+        await click(input);
+        await editInput(target.querySelector("[name=parent_id] input.o-autocomplete--input.o_input"), null, "");
+        assert.isVisible(target, ".o_form_button_save");
+        await click(target.querySelector(".o_form_button_save"));
+        assert.verifySteps(["web_save"]);
+    });
+
     QUnit.test("Hide auto complete suggestion for no create", async function (assert) {
         const partnerMakeViewParams = {
             ...makeViewParams,


### PR DESCRIPTION
In a form view with a many2one field using the res_partner_many2one widget (e.g. in the "Contacts" form view) where this field is set, remove the value. Before this commit, this didn't trigger a change in the model. As a matter of fact, the "save" button in the control panel (the small cloud) wasn't displayed. As a consequence, such a change couldn't be saved.

This commit fixes the issue.

OPW-4669817

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
