### PR TITLE
[FIX] project: fix small typo in description of Tasks menu in `/my`

### DIFF
--- a/addons/project/views/project_portal_project_project_templates.xml
+++ b/addons/project/views/project_portal_project_project_templates.xml
@@ -54,7 +54,7 @@
                 <t t-set="icon" t-value="'/project/static/src/img/tasks.svg'"/>
                 <t t-set="title">Tasks</t>
                 <t t-set="url" t-value="'/my/tasks'"/>
-                <t t-set="text">Follow and comments tasks of your projects</t>
+                <t t-set="text">Follow and comment on tasks in your projects</t>
                 <t t-set="placeholder_count" t-value="'task_count'"/>
             </t>
         </div>


### PR DESCRIPTION
This commit fixes a small in the description of `Tasks` menu in `/my` (portal view).
