### PR TITLE
[FIX] product: fix singleton constraint on product_supplierinfo

### DIFF
--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -70,7 +70,8 @@ class ProductSupplierinfo(models.Model):
     @api.depends('discount', 'price')
     def _compute_price_discounted(self):
         for rec in self:
-            rec.price_discounted = rec.product_uom_id._compute_price(rec.price, rec.product_id.uom_id) * (1 - rec.discount / 100)
+            if rec.product_uom_id:
+                rec.price_discounted = rec.product_uom_id._compute_price(rec.price, rec.product_id.uom_id) * (1 - rec.discount / 100)
 
     @api.depends('product_id', 'product_tmpl_id', 'product_variant_count')
     def _compute_product_id(self):


### PR DESCRIPTION
Ensure product_uom_id is set before calling _compute_price to avoid a singleton constraint error.
The issue occurs when product_uom_id is not assigned on newly created vendor pricelists, leading to ensure_one() failing.

This fix safeguards against the issue by adding a conditional check before computing the price.

Exact steps list to reproduce the issue happens when product_uom_id is not set on all new vendor pricelists so it throws an error due to ensure_one() being called :

1- Go to Inventory → Operations → Replenishment

2- Create a new vendor pricelist without setting product_uom_id

3- Error occurs due to ensure_one() being called on an empty recordset

another linked PR that ensures product_uom_id is set on all new vendor pricelists : #203751

Traceback (most recent call last):
File "/home/odoo/src/odoo/saas-18.1/odoo/orm/models.py", line 6107, in ensure_one
_id, = self._ids
^^^^

ValueError: not enough values to unpack (expected 1, got 0)

opw-4665300 (related to ticket)
