### PR TITLE
[FIX] hr_expense: restore search filter

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -423,10 +423,10 @@
             <field name="arch" type="xml">
                 <search string="Expense">
                     <!-- Search -->
-                    <field name="name" filter_domain="[('name', '=like', self)]" string="Expense"/>
-                    <field name="department_id" filter_domain="[('department_id.name', '=like', self)]"/>
-                    <field name="company_id" filter_domain="[('company_id.name', '=like', self)]" groups="base.group_multi_company"/>
-                    <field name="employee_id" filter_domain="[('employee_id.name', '=like', self)]"/>
+                    <field name="name" filter_domain="[('name', 'ilike', self)]" string="Expense"/>
+                    <field name="department_id" filter_domain="[('department_id.name', 'ilike', self)]"/>
+                    <field name="company_id" filter_domain="[('company_id.name', 'ilike', self)]" groups="base.group_multi_company"/>
+                    <field name="employee_id" filter_domain="[('employee_id.name', 'ilike', self)]"/>
 
                     <!-- Filters -->
                     <filter string="My Expenses" name="my_open_expenses" domain="[('employee_id.user_id', '=', uid)]"/>


### PR DESCRIPTION
The search filter was broken since the refactoring of expense reports. This was due to a wrong operator.

task-4669889


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
