### PR TITLE
[FIX] account: sequence prefix with concurrency

### DIFF
--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -930,6 +930,8 @@ class TestSequenceMixinConcurrency(TransactionCase):
         # check the values
         moves = env0['account.move'].browse(self.data['move_ids'])
         self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', 'CT/2016/01/0002', 'CT/2016/01/0003'])
+        self.assertEqual(moves.mapped('sequence_prefix'), ['CT/2016/01/', 'CT/2016/01/', 'CT/2016/01/'])
+        self.assertEqual(moves.mapped('sequence_number'), [1, 2, 3])
 
     def test_sequence_concurency_no_useless_lock(self):
         """Do not lock needlessly when the sequence is not computed"""


### PR DESCRIPTION
When looping inside of the `while True` loop because of concurrency, the `sequence_prefix` was not correctly set.
This was breaking the behavior of `sequence.mixin` because we were not able to get the last number.

Partial revert of 10565c6968a5d0f285f93c4bdc610350999a88e3