### PR TITLE
[FIX] web: reuse same image url if the related field on same model

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -58,7 +58,8 @@ export class ImageField extends Component {
                 "ImageField: previewImage must be provided when set on a many2one field"
             );
         }
-        if (this.props.record.fields[this.props.name].related) {
+        const field = this.props.record.fields[this.props.name];
+        if (field.related?.includes(".")) {
             this.lastUpdate = DateTime.now();
             let key = this.props.value;
             onWillRender(() => {
@@ -89,10 +90,7 @@ export class ImageField extends Component {
     }
 
     get rawCacheKey() {
-        if (this.props.record.fields[this.props.name].related) {
-            return this.lastUpdate;
-        }
-        return this.props.record.data.write_date;
+        return this.lastUpdate || this.props.record.data.write_date;
     }
 
     get sizeStyle() {


### PR DESCRIPTION
Steps to reproduce
==================

- Go to the products kanban view
- Open a record
- Go back to the kanban view => Every product image is downloaded again

Cause of the issue
==================

There is a unique query param in the url as the browser doesn't fetch twice the same image from the same url in the same session.

For non related fields, we use the last record update as a unique timestamp.

For related fields, since we don't have the information about the last update, we generate a unique timestamp when instanciating an ImageField component.

It can happen that a related field points to the same model.

This is the case here where the product kanban view uses the "image_128" field.

```py
image_1920 = fields.Image("Image", max_width=1920, max_height=1920)
image_128 = fields.Image("Image 128", related="image_1920", max_width=128, max_height=128, store=True)
```

Solution
========

When a field is related but the relation points to the same model, we can still use the last record update

We can try to detect this by checking if there is a dot in the related path.