### PR TITLE
[FIX] html_editor: prevent infinite loop in link tools

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -345,7 +345,7 @@ export class LinkPlugin extends Plugin {
      * @param {HTMLElement} [linkElement]
      */
     openLinkTools(linkElement, type) {
-        this.closeLinkTools();
+        this.overlay.close();
         if (!this.isLinkAllowedOnSelection()) {
             return this.services.notification.add(
                 _t("Unable to create a link on the current selection."),


### PR DESCRIPTION
**Problem**:
Calling `closeLinkTools` on `link.isConnected` sets the selection, which triggers `selectionchange`, leading to `openLinkTools`, which then calls `closeLinkTools`, causing an infinite loop.

**Solution**:
In `openLinkTools`, use `this.overlay.close();` to close the link popover without changing the selection.

**Steps to reproduce**:
1. Create a new task.
2. Select and copy the task's URL.
3. Paste the URL in the description.
4. Press Enter.
5. Paste the URL again.
6. Click quickly between the two URLs.
   - **Issue**: Sometimes, the link preview appears blank.

**opw-4669353**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
