### PR TITLE
[FIX] account: skip if no rep lines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1822,6 +1822,9 @@ class AccountTax(models.Model):
                 total_tax_rep_amounts['tax_amount_currency'] += tax_rep_data['tax_amount_currency']
                 total_tax_rep_amounts['tax_amount'] += tax_rep_data['tax_amount']
                 tax_reps_data.append(tax_rep_data)
+            
+            if not tax_reps_data:
+                continue
 
             # Distribute the delta on the repartition lines.
             sorted_tax_reps_data = sorted(


### PR DESCRIPTION
When there are no repartition_lines  we should skip updating them because it will cause IndexError: list index out of range.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
