### PR TITLE
[FIX] base: cron auto-vacuum race

### DIFF
--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -253,8 +253,7 @@ class TestEventNotifications(TransactionCase, MailCase, MockEmail, CronMixinCase
                 self.env['calendar.alarm_manager']._send_reminder()
                 self.assertEqual(len(capt.records), 1)
 
-            with freeze_time('2022-04-28 10:00+0000'):
-                self.env['ir.cron.trigger']._gc_cron_triggers()
+            self.env['ir.cron.trigger'].search([('cron_id', '=', cron.id)]).unlink()
 
             with freeze_time('2022-05-16 10:00+0000'):
                 self.env['calendar.alarm_manager']._send_reminder()
@@ -319,9 +318,7 @@ class TestEventNotifications(TransactionCase, MailCase, MockEmail, CronMixinCase
                 self.assertEqual(len(capt.records), 1, "Only one trigger must be created for the entire recurrence.")
                 self.assertEqual(capt.records.mapped('call_at'), [datetime(2024, 4, 16, 11, 0)], "Alarm must be one hour before the first event.")
 
-            # Garbage-collect the previous trigger from the cron.
-            with freeze_time('2024-05-10 11:00+0000'):
-                self.env['ir.cron.trigger']._gc_cron_triggers()
+            self.env['ir.cron.trigger'].search([('cron_id', '=', cron.id)]).unlink()
 
             with freeze_time('2024-04-22 10:00+0000'):
                 # The next alarm will be set through the next_date selection for the next event.

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -797,7 +797,11 @@ class IrCronTrigger(models.Model):
 
     @api.autovacuum
     def _gc_cron_triggers(self):
-        domain = [('call_at', '<', datetime.now() + relativedelta(weeks=-1))]
+        # active cron jobs are cleared by `_clear_schedule` when the job starts
+        domain = [
+            ('call_at', '<', datetime.now() + relativedelta(weeks=-1)),
+            ('cron_id.active', '=', False),
+        ]
         records = self.search(domain, limit=GC_UNLINK_LIMIT)
         if len(records) >= GC_UNLINK_LIMIT:
             self.env.ref('base.autovacuum_job')._trigger()


### PR DESCRIPTION
When a cron is starting, it removes all triggers that are in the past and the autovacuum job on triggers removes all triggers older than a week. When the autovacuum tries to run, there is a high probability that a cron is already running and rows are being deleted/locked.

We change the autovacuum so that it only removes the records for inactive cron jobs because the active ones will already be removed when that job will start.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
