### PR TITLE
[FIX] point_of_sale: fix error on Arabic language setting

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -62,7 +62,9 @@ export default class IndexedDB {
                     }
 
                     if (!alreadyExists || JSON.stringify(alreadyExists) !== JSON.stringify(data)) {
-                        arrData[idx].write_date = DateTime.now().toFormat("yyyy-MM-dd HH:mm:ss");
+                        arrData[idx].write_date = DateTime.now().toFormat("yyyy-MM-dd HH:mm:ss", {
+                            numberingSystem: "latn",
+                        });
                     } else {
                         delete arrData[idx];
                     }


### PR DESCRIPTION
When the Arabic language was selected, an error occurred due to the write date being formatted with Arabic numerals. This commit ensures that Latin digits are used in the date format, preventing the error and ensuring compatibility.

opw-4654484

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
