### PR TITLE
[FIX] portal: 'Follow' fully visible in project sharing page

### DIFF
--- a/addons/portal/static/src/chatter/core/portal_chatter.xml
+++ b/addons/portal/static/src/chatter/core/portal_chatter.xml
@@ -3,7 +3,7 @@
 
 <t t-name="portal.Chatter">
     <div t-if="state.thread" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex pt-2" t-att-class="{ 'row':props.twoColumns, 'flex-column':!props.twoColumns }" t-on-scroll="onScrollDebounced" t-ref="root">
-        <div t-if="props.composer" class="o-mail-Chatter-top position-sticky top-0" t-att-class="{ 'col-lg-6':props.twoColumns, 'bg-view':env.inFrontendPortalChatter }" t-att-style="(!props.twoColumns and env.inFrontendPortalChatter) and 'top: -1px !important; margin-top:-15px; padding-top: 20px'" t-ref="top">
+        <div t-if="props.composer" class="o-mail-Chatter-top position-sticky top-0" t-att-class="{ 'col-lg-6':props.twoColumns, 'bg-view':env.inFrontendPortalChatter }" t-att-style="(!props.twoColumns and env.inFrontendPortalChatter and !env.projectSharingId) and 'top: -1px !important; margin-top:-15px; padding-top: 20px'" t-ref="top">
             <Composer composer="state.thread.composer" autofocus="env.inFrontendPortalChatter ? false : true" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" t-key="props.threadId"/>
         </div>
         <div class="o-mail-Chatter-content" t-att-class="{ 'col-lg-6':props.twoColumns }">

--- a/addons/portal_rating/static/src/chatter/frontend/message_patch.xml
+++ b/addons/portal_rating/static/src/chatter/frontend/message_patch.xml
@@ -20,7 +20,7 @@
                     <i class="fa fa-comment text-muted me-1"/>Comment
                 </button>
                 <div t-if="state.editRating" class="mt-2">
-                    <Composer autofocus="true" composer="message.composer" messageComponent="constructor" onDiscardCallback.bind="exitEditCommentMode" onPostCallback.bind="exitEditCommentMode" mode="'compact'"/>
+                    <Composer autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditCommentMode" onPostCallback.bind="exitEditCommentMode" mode="'compact'"/>
                 </div>
                 <div t-if="message.rating.publisher_comment and !state.editRating" class="o_wrating_publisher_comment mt-2 mb-2">
                     <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">


### PR DESCRIPTION
Before this commit, when accessing public project sharing page with "edit" access rights, opening a task showed the chatter and "Follow" button above but it was partially cut.

This comes from the following causes:

- portal composer has special margin/padding at the top to compensate with website header, so that scrolling on website keeps the composer at the top
- portal composers should not autofocus on mount compared to backend views.

The portal sharing page was mistakenly not considered a portal composer at some point and was fixed by [1].

However had regression to include the margin/padding top compensation, thus it cut the 'Follow' button.

The margin/padding top is not pretty but it works fine for website. Here for project we want to ignore them. This commit fixes the issue by ignoring project sharing for the padding/margin top compensation, using variable `env.projectSharingId`.

opw-4509372

[1]: https://github.com/odoo/odoo/pull/189568

Before
![before](https://github.com/user-attachments/assets/1ad66b75-bad6-4fc2-b6e2-a7840acb60ee)

After
![after](https://github.com/user-attachments/assets/0d0e4166-a977-4e48-a8e6-0a5bf936d364)

