### PR TITLE
[FIX] html_builder, html_editor: background filters have round corners

### DIFF
--- a/addons/html_builder/static/src/core/border_radius_style_plugin.js
+++ b/addons/html_builder/static/src/core/border_radius_style_plugin.js
@@ -1,0 +1,40 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { applyNeededCss } from "@html_builder/utils/utils_css";
+
+class BorderRadiusStylePlugin extends Plugin {
+    static id = "borderRadiusStyle";
+    resources = {
+        builder_style_actions: this.getStyleActions(),
+        step_added_handlers: () => {
+            this.document.querySelectorAll(".o_grid_item").forEach((gridEl) => {
+                this.calculateAndSetRadius(gridEl);
+            });
+        },
+    };
+
+    getStyleActions() {
+        return {
+            "border-radius": {
+                getValue: (el, styleName) => window.getComputedStyle(el)[styleName],
+                apply: (el, styleValue) => {
+                    applyNeededCss(el, "border-radius", styleValue);
+                    this.calculateAndSetRadius(el);
+                },
+            },
+        };
+    }
+
+    calculateAndSetRadius(parentElement) {
+        const backgroundEls = parentElement.querySelectorAll(":scope > [class*='_bg']");
+        backgroundEls.forEach((backgroundEl) => {
+            backgroundEl.style.borderRadius =
+                Math.max(
+                    0,
+                    (parseInt(parentElement.style.borderRadius) || 0) -
+                        (parseInt(parentElement.style.borderWidth) || 0)
+                ) + "px";
+        });
+    }
+}
+registry.category("website-plugins").add(BorderRadiusStylePlugin.id, BorderRadiusStylePlugin);


### PR DESCRIPTION
Before the change a filter (color filter or parallax or anything that adds a _bg children element) applied to a block would not cover it properly if the block had rounded corners.

Steps to reproduce:

- Add a masonry block and select any of its components
- Set a background image
- Add a color filter
- Add a border
- Add round corners => The color filter does not cover the image properly

After the change the filters properly respects the rounding of the border corners.

task-3358501