### PR TITLE
[IMP] hw_drivers: adapt to new ssl certificate

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -312,14 +312,14 @@ def load_certificate():
     """
     db_uuid = read_file_first_line('odoo-db-uuid.conf')
     enterprise_code = read_file_first_line('odoo-enterprise-code.conf')
-    if not (db_uuid and enterprise_code):
+    if not db_uuid:
         return "ERR_IOT_HTTPS_LOAD_NO_CREDENTIAL"
 
     url = 'https://www.odoo.com/odoo-enterprise/iot/x509'
     data = {
         'params': {
             'db_uuid': db_uuid,
-            'enterprise_code': enterprise_code
+            'enterprise_code': enterprise_code or ''
         }
     }
     urllib3.disable_warnings()
@@ -338,6 +338,10 @@ def load_certificate():
     if response.status != 200:
         return "ERR_IOT_HTTPS_LOAD_REQUEST_STATUS %s\n\n%s" % (response.status, response.reason)
 
+    response = json.loads(response.data.decode('utf8'))
+    error = response.get('error')
+    if error:
+        _logger.warning("An error received from odoo.com while trying to get the certificate: %s", error)
     result = json.loads(response.data.decode('utf8'))['result']
     if not result:
         return "ERR_IOT_HTTPS_LOAD_REQUEST_NO_RESULT"


### PR DESCRIPTION
Currently ssl certificates are only generated on odoo.com based on db_uuid and enterprise_code. Since we won't be needing enterprise_code anymore we adapt our code to still recover the ssl certificate and be able to recover and log the new 'error' values sent by odoo.com

task-4585446

Related PR: https://github.com/odoo/internal/pull/3425
