### PR TITLE
[IMP] account,point_of_sale: restore excluding invoices from follow-ups

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -334,6 +334,13 @@ class AccountMove(models.Model):
         ],
         string='Audit Trail Messages',
     )
+    no_followup = fields.Boolean(
+        string="No Follow-Up",
+        compute='_compute_no_followup',
+        inverse='_inverse_no_followup',
+        readonly=False,
+        help="Exclude this journal entry from follow-up reports."
+    )
 
     # === Hash Fields === #
     restrict_mode_hash_table = fields.Boolean(related='journal_id.restrict_mode_hash_table')
@@ -2204,6 +2211,23 @@ class AccountMove(models.Model):
     def _compute_checked(self):
         for move in self:
             move.checked = move.state == 'posted' and (move.journal_id.type == 'general' or move._is_user_able_to_review())
+
+    @api.depends('line_ids.no_followup')
+    def _compute_no_followup(self):
+        for move in self:
+            if move.is_invoice():
+                move.no_followup = move.line_ids.filtered(
+                    lambda line: line.account_type in ('asset_receivable', 'liability_payable'),
+                )[0].no_followup
+            else:
+                move.no_followup = True
+
+    def _inverse_no_followup(self):
+        for move in self:
+            if move.is_invoice():
+                move.line_ids.filtered(
+                    lambda line: line.account_type in ('asset_receivable', 'liability_payable'),
+                ).no_followup = move.no_followup
 
     # -------------------------------------------------------------------------
     # ALERTS

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4767,3 +4767,61 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             with Form(invoice) as move_form:
                 move_form.invoice_currency_rate = -420
         self.assertEqual(invoice.invoice_currency_rate, 2.0)
+
+    def test_invoice_no_followup(self):
+        """Make sure that excluding an invoice from follow-up excludes all its receivable lines."""
+        installments_payment_term = self.env['account.payment.term'].create({
+            'name': "3 installments",
+            'line_ids': [
+                Command.create({'value_amount': 40, 'value': 'percent', 'nb_days': 0}),
+                Command.create({'value_amount': 30, 'value': 'percent', 'nb_days': 30}),
+                Command.create({'value_amount': 30, 'value': 'percent', 'nb_days': 60}),
+            ],
+        })
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'invoice_date': fields.Date.from_string('2024-08-01'),
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({'quantity': 1, 'price_unit': 1000})],
+            'invoice_payment_term_id': installments_payment_term.id,
+        })
+        invoice_terms = invoice.line_ids.filtered(lambda line: line.display_type == 'payment_term')
+        self.assertFalse(invoice.no_followup)
+        self.assertEqual(invoice_terms.mapped('no_followup'), [False, False, False])
+
+        invoice.no_followup = True
+        self.assertTrue(invoice.no_followup)
+        self.assertEqual(invoice_terms.mapped('no_followup'), [True, True, True])
+
+        invoice.no_followup = False
+        self.assertFalse(invoice.no_followup)
+        self.assertEqual(invoice_terms.mapped('no_followup'), [False, False, False])
+
+    def test_invoice_line_no_followup(self):
+        """Make sure that excluding one receivable line from an invoice excludes all the others."""
+        installments_payment_term = self.env['account.payment.term'].create({
+            'name': "3 installments",
+            'line_ids': [
+                Command.create({'value_amount': 40, 'value': 'percent', 'nb_days': 0}),
+                Command.create({'value_amount': 30, 'value': 'percent', 'nb_days': 30}),
+                Command.create({'value_amount': 30, 'value': 'percent', 'nb_days': 60}),
+            ],
+        })
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'invoice_date': fields.Date.from_string('2024-08-01'),
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({'quantity': 1, 'price_unit': 1000})],
+            'invoice_payment_term_id': installments_payment_term.id,
+        })
+        invoice_terms = invoice.line_ids.filtered(lambda line: line.display_type == 'payment_term')
+        self.assertFalse(invoice.no_followup)
+        self.assertEqual(invoice_terms.mapped('no_followup'), [False, False, False])
+
+        invoice_terms[0].no_followup = True
+        self.assertTrue(invoice.no_followup)
+        self.assertEqual(invoice_terms.mapped('no_followup'), [True, True, True])
+
+        invoice_terms[1].no_followup = False
+        self.assertFalse(invoice.no_followup)
+        self.assertEqual(invoice_terms.mapped('no_followup'), [False, False, False])

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -891,6 +891,7 @@ class PosOrder(models.Model):
             'amount_currency': amount_currency,
             'balance': balance,
             'tax_tag_invert': not base_line_vals['is_refund'],
+            'no_followup': False,
         }
 
     def _prepare_aml_values_list_per_nature(self):

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -100,6 +100,7 @@ class PosPayment(models.Model):
                 'account_id': accounting_partner.with_company(order.company_id).property_account_receivable_id.id,  # The field being company dependant, we need to make sure the right value is received.
                 'partner_id': accounting_partner.id,
                 'move_id': payment_move.id,
+                'no_followup': False,
             }, amounts['amount'], amounts['amount_converted'])
             is_split_transaction = payment.payment_method_id.split_transactions
             if is_split_transaction and is_reverse:
@@ -112,6 +113,7 @@ class PosPayment(models.Model):
                 'account_id': reversed_move_receivable_account_id,
                 'move_id': payment_move.id,
                 'partner_id': accounting_partner.id if is_split_transaction and is_reverse else False,
+                'no_followup': False,
             }, amounts['amount'], amounts['amount_converted'])
             self.env['account.move.line'].create([credit_line_vals, debit_line_vals])
             payment_move._post()

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1090,6 +1090,9 @@ class PosSession(models.Model):
             vals.append(self._get_combine_receivable_vals(payment_method, amounts['amount'], amounts['amount_converted']))
         for payment, amounts in split_receivables_pay_later.items():
             vals.append(self._get_split_receivable_vals(payment, amounts['amount'], amounts['amount_converted']))
+        for val in vals:
+            # Entries related to a `pay_later` payment method should not be excluded from follow-ups.
+            val['no_followup'] = False
         data['pay_later_move_lines'] = MoveLine.create(vals)
         return data
 
@@ -1680,7 +1683,7 @@ class PosSession(models.Model):
             'domain': self._get_captured_payments_domain(),
             'context': {'search_default_group_by_payment_method': 1}
         }
-    
+
     def _get_captured_payments_domain(self):
         return [('session_id', 'in', self.ids), ('pos_order_id.state', 'in', ['paid', 'invoiced', 'done'])]
 


### PR DESCRIPTION
During the [rework of the follow-up report][1], we removed the "No Follow-Up" field from journal items, making it impossible to exclude individual journal items from triggering a follow-up.

In this commit, we re-introduce a field for that, since it is a common requirement to be able to exclude individual items from the follow-up reports.

The field is stored on the journal item, but can also be toggled from the journal entry. In case of multiple installments on the invoice, toggling the field on one installment will toggle it for all installments.

[1]: https://github.com/odoo/odoo/commit/67dc71588751c9f115e09959d774686c2207a1f9

[task-4632300](https://www.odoo.com/odoo/project.task/4632300)

Related to https://github.com/odoo/enterprise/pull/82105