### PR TITLE
[FIX] website_sale_loyalty: edit validation error message

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -160,5 +160,8 @@ class PaymentPortal(main.PaymentPortal):
             order_sudo.validate_taxes_on_sales_order()  # re-applies taxcloud taxes if necessary
             if order_sudo.currency_id.compare_amounts(initial_amount, order_sudo.amount_total):
                 raise ValidationError(
-                    _("Cannot process payment: applied reward was changed or has expired.")
+                    _(
+                        "Cannot process payment: applied reward was changed or has expired.\n"
+                        "Please refresh the page and try again."
+                    )
                 )

--- a/addons/website_sale_loyalty/i18n/website_sale_loyalty.pot
+++ b/addons/website_sale_loyalty/i18n/website_sale_loyalty.pot
@@ -53,7 +53,9 @@ msgstr ""
 #. odoo-python
 #: code:addons/website_sale_loyalty/controllers/main.py:0
 #, python-format
-msgid "Cannot process payment: applied reward was changed or has expired."
+msgid ""
+"Cannot process payment: applied reward was changed or has expired.\n"
+"Please refresh the page and try again."
 msgstr ""
 
 #. module: website_sale_loyalty


### PR DESCRIPTION
Commit 2afc30a introduced reward validation before payment, due to this if promotion expired during payment step during checkout, error informing that promotion was expired was thrown, but user was not able to do anything about. Info about refreshing page has been added.

opw-4573640

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
