### PR TITLE
[IMP] website: allow users to review and update their cookie preferences

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -3361,6 +3361,7 @@ msgstr ""
 
 #. module: website
 #. odoo-javascript
+#: code:addons/website/static/src/snippets/s_popup/000.js:0
 #: code:addons/website/static/src/xml/website.cookies_bar.xml:0
 #: code:addons/website/static/src/xml/website.cookies_bar.xml:0
 #: model_terms:ir.ui.view,arch_db:website.cookie_policy

--- a/addons/website/static/tests/tours/cookies_consent.js
+++ b/addons/website/static/tests/tours/cookies_consent.js
@@ -1,0 +1,81 @@
+/** @odoo-module **/
+
+import { cookie } from "@web/core/browser/cookie";
+import { registry } from "@web/core/registry";
+
+/**
+ * Assert that the cookie preference matches the expected state.
+ *
+ * @param {boolean} expectedOptional - Whether optional cookies should be
+ *                                     accepted
+ */
+function assertOptionalCookies(expectedOptional) {
+    const cookiePreference = JSON.parse(cookie.get("website_cookies_bar"));
+    if (cookiePreference.optional !== expectedOptional) {
+        console.error(`Optional cookies should be ${expectedOptional ? "accepted" : "rejected"}.`);
+    }
+}
+
+/**
+ * Assert that all consent values in `dataLayer` match the expected state.
+ *
+ * @param {string} expectedState - "granted" or "denied"
+ */
+function assertConsentInDataLayer(expectedState) {
+    const lastDataLayerEntry = window.dataLayer?.at(-1);
+
+    if (!lastDataLayerEntry || lastDataLayerEntry[0] !== "consent") {
+        console.error("Cookie preference change must push a consent update to dataLayer");
+        return;
+    }
+
+    const allConsentValues = Object.values(lastDataLayerEntry[2]);
+    const allValuesMatch = allConsentValues.every((value) => value === expectedState);
+
+    if (!allValuesMatch) {
+        console.error(`All consent values should be '${expectedState}'`);
+    }
+}
+
+registry.category("web_tour.tours").add("cookies_consent", {
+    test: true,
+    url: "/",
+    steps: () => [
+        {
+            content: "Accept all cookies",
+            trigger: "a#cookies-consent-all",
+            run: "click",
+        },
+        {
+            content: "Confirm if optional cookies are also accepted",
+            trigger: "body",
+            run: function () {
+                assertOptionalCookies(true);
+                assertConsentInDataLayer("granted");
+            },
+        },
+        {
+            content: "Goto Cookie Policy page",
+            trigger: "footer a[href='/cookie-policy']",
+            run: "click",
+        },
+        {
+            content: "Toggle the cookie bar",
+            trigger: "button.o_cookies_bar_toggle",
+            run: "click",
+        },
+        {
+            content: "Update the preference to only accept essential cookies",
+            trigger: "a#cookies-consent-essential",
+            run: "click",
+        },
+        {
+            content: "Confirm if only the required cookies are accepted",
+            trigger: "body",
+            run: function () {
+                assertOptionalCookies(false);
+                assertConsentInDataLayer("denied");
+            },
+        },
+    ],
+});

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -147,3 +147,9 @@ class TestSnippets(HttpCase):
 
     def test_tabs_snippet(self):
         self.start_tour(self.env["website"].get_client_action_url("/"), "snippet_tabs", login="admin")
+
+    def test_cookies_consent(self):
+        website = self.env.ref('website.default_website')
+        website.google_analytics_key = 'G-XXXXXXXXXXX'
+        website.cookies_bar = True
+        self.start_tour(website.get_client_action_url('/'), 'cookies_consent')


### PR DESCRIPTION
This improvement enhances user control over cookie preferences by making
the Cookie Policy page (/cookie-policy) more accessible and allowing
users to modify their consent at any time.

**Issue:**

- Previously, the only way to access the Cookie Policy page was through
  the link in the cookie consent popup. However, once users accepted
  cookies, the popup was no longer displayed, making it impossible to
  navigate to the policy page later.

- Additionally, the Cookie Policy page had a button to reopen the cookie
  consent popup, but it was only visible if cookies were not accepted.
  Once cookies were accepted, the button was hidden, preventing users
  from changing their preferences.

**Improvements:**

- Added a permanent link to the Cookie Policy page in the copyright
  footer, ensuring it remains accessible at all times.

- The cookie consent toggle button now remains visible even after a user
  has accepted cookies, allowing them to update their preferences at any
  time.

task-[4502416](https://www.odoo.com/odoo/project/974/tasks/4502416)