### PR TITLE
[FIX] website: ensure top menu creation when missing

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -11511,6 +11511,7 @@ msgstr ""
 #. module: website
 #. odoo-python
 #: code:addons/website/models/website.py:0
+#: code:addons/website/models/website_menu.py:0
 #, python-format
 msgid "Top Menu for Website %s"
 msgstr ""

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -292,6 +292,14 @@ class Menu(models.Model):
                         menu_id.page_id = None
                     except werkzeug.exceptions.NotFound:
                         menu_id.page_id.write({'url': menu['url']})
+            if menu.get('parent_id') is False:
+                # If no parent_id is defined, create the default top menu
+                top_menu = self.env['website.menu'].create({
+                    'name': _('Top Menu for Website %s', website_id),
+                    'url': '/default-main-menu',
+                    'website_id': website_id,
+                })
+                menu['parent_id'] = top_menu.id
             menu_id.write(menu)
 
         return True


### PR DESCRIPTION
In `saas-18.2`, an error produced due to [this](https://github.com/odoo/odoo/commit/bbc425bca963b0db36563f267e7265588ba9745b) commit, which attempts to access `parent_id`, leading to a **KeyError** when no parent menu exists.

**Steps to reproduce (in saas-18.2):**
- Install the `website_event` module without demo data.
- Navigate to `Website > Configuration > Menus` .
- Delete the `Top Menu for Website 1` record.
- Add a new **Menu Item**  using the **Menu Editor**.
- Observe the error.

**Error:**
`KeyError - False`

**Previous Behavior:**
If a user deleted all menus, including the default **Top Menu**, and then attempted to create a new menu using the **Menu Editor**, the new menu would not appear in the website's navigation bar. This occurred because the newly created menu does not have a parent menu.

This commit ensures that when `parent_id` is `False`, a **Top Menu** is created for the respective website menus.

Sentry - 6433136359