### PR TITLE
[FIX] sale_loyalty: preserve custom discount line description on SO Confirmation

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -599,6 +599,8 @@ class SaleOrder(models.Model):
         self.ensure_one()
         command_list = []
         for vals, line in zip(reward_vals, old_lines):
+            if vals['product_id'] == line.product_id.id:
+                vals['name'] = line.name  # Preserve custom description
             command_list.append((Command.UPDATE, line.id, vals))
         if len(reward_vals) > len(old_lines):
             command_list.extend((Command.CREATE, 0, vals) for vals in reward_vals[len(old_lines):])


### PR DESCRIPTION
Steps to reproduce:
- Create a quotation in the Sales app.
- Apply a coupon with any discount.
- Modify the description of the discount SO line.
- Confirm the sale order.
- The discount line's description is reset.

Root Cause:
- `_get_reward_values_discount` recomputes discount line values, resetting the description.

Fix:
- Preserve the manually set name field to prevent unintended recomputation.

Affected version-17.0
opw-4653070
