### PR TITLE
[FIX] discuss: prevent traceback when missing channel in call

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -127,7 +127,7 @@ export class CallParticipantCard extends Component {
     }
 
     get isActiveRtcSession() {
-        return this.rtcSession && this.rtcSession.eq(this.rtcSession.channel.activeRtcSession);
+        return this.rtcSession && this.rtcSession.eq(this.rtcSession.channel?.activeRtcSession);
     }
 
     async onClick(ev) {


### PR DESCRIPTION
Before this commit, a a race condition could lead to a missing channel for a rtcSession (for example if the channel is removed and that knowledge is obtained before the removal of the session).


