### PR TITLE
[FIX] l10n_it_edi: reduce batch limit to prevent timeout

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -968,7 +968,7 @@ class AccountEdiFormat(models.Model):
             return {
                 'post': self._post_fattura_pa,
                 'post_batching': lambda move: (move.move_type, bool(move.l10n_it_edi_transaction)),
-                'batching_limit': 50,
+                'batching_limit': 20,
             }
 
     def _l10n_it_edi_export_invoice_as_xml(self, invoice):


### PR DESCRIPTION
This fix lowers the batch size to prevent timeouts, as the IAP server may take longer than the 30-second limit set in the proxy client to respond.

Steps to reproduce:
- Create 50 invoices in draft.
- Validate them all at once.

If the IAP server exceeds 30s to respond, all invoices will show an error banner: "The URL that this service requested returned an error.". However, the invoices were actually sent successfully.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4557948)
opw-4557948
