### PR TITLE
[FIX] im_livechat: chats displayed under wrong side bar category

### DIFF
--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.DiscussSidebarCategories">
         <hr class="my-2 w-100 opacity-0 flex-shrink-0"/>
         <input t-if="hasQuickSearch" class="form-control mx-4 mb-2 rounded-3 w-auto" placeholder="Quick search..." t-model="state.quickSearchVal"/>
-        <t t-foreach="store.discuss.allCategories" t-as="cat" t-key="cat_index">
+        <t t-foreach="store.discuss.allCategories" t-as="cat" t-key="cat.id">
             <t t-if="cat.isVisible" t-call="mail.DiscussSidebarCategory">
                 <t t-set="category" t-value="cat"/>
             </t>


### PR DESCRIPTION
Before this PR, live chats were sometimes displayed under the wrong category.

Steps to reproduce:
- Ensure you have one live chat pinned in the sidebar.
- Go to the inbox, fold the live chat category.
- Reload the page.
- Open the live chat category.
- The chat is displayed under the wrong category.

Since [1], the t-key used in the side bar template is the index of the category which is not reliable. Change it to the id field which is also unique but more reliable.

[1]: https://github.com/odoo/odoo/pull/203150

![chrome-capture-2025-3-24](https://github.com/user-attachments/assets/13fe7c25-4c6c-4bd7-ba25-16eaf6b9a1cd)

