### PR TITLE
[IMP] point_of_sale: added color field in edit product form view

### DIFF
--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -198,6 +198,7 @@
                                 <field name="tax_string"/>
                             </div>
                             <field name="pos_categ_ids" string="POS Category" class="oe_inline" widget="many2many_tags"/>
+                            <field name="color" widget="color_picker" string="Color" />
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
Following this commit:
- Color field is been added in the edit form view

Related PR- https://github.com/odoo/odoo/pull/202656/files
task-4423837
