### PR TITLE
[FIX] point_of_sale: Prevent double sync of the same order

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -444,7 +444,7 @@ patch(PosStore.prototype, {
             this.removeOrder(order);
         } else if (order) {
             if (!this.isOrderTransferMode) {
-                this.syncAllOrders({ orders: [order] });
+                this.syncAllOrders();
             } else if (order && this.previousScreen !== "ReceiptScreen") {
                 await this.syncAllOrders({ orders: [order] });
             }


### PR DESCRIPTION
When the order is sent to the preparation tools, synchronization is performed twice.

This is because synchronization is done in the preparation tool method and in the unsetTable method.

Add last synchronization date to order states. If it has been synchronized within 2 seconds, the second call is not made.

taskId: 4664549

