### PR TITLE
[FIX] core: don't send Date header twice

### DIFF
--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -407,6 +407,14 @@ class TestHttpStatic(TestHttpStaticCommon):
                     raise AssertionError(e) from exc
                 self.assertEqual(res.content, self.gizeh_data)
 
+    def test_static24_only_one_date_header(self):
+        res = self.assertDownloadPlaceholder('/web/image')
+        # requests merge multiple headers with a same key together, it
+        # concatenates the values, hence .count(' GMT')
+        self.assertEqual(res.headers['Date'].count(' GMT'), 1,
+            "There must be only 1 Date header, not 2")
+
+
 @tagged('post_install', '-at_install')
 class TestHttpStaticLogo(TestHttpStaticCommon):
     @staticmethod

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -120,6 +120,11 @@ class BaseWSGIServerNoBind(LoggingBaseWSGIServerMixIn, werkzeug.serving.BaseWSGI
 
 
 class RequestHandler(werkzeug.serving.WSGIRequestHandler):
+    def __init__(self, *args, **kwargs):
+        self._sent_date_header = None
+        self._sent_server_header = None
+        super().__init__(*args, **kwargs)
+
     def setup(self):
         # timeout to avoid chrome headless preconnect during tests
         if config['test_enable'] or config['test_file']:
@@ -148,6 +153,27 @@ class RequestHandler(werkzeug.serving.WSGIRequestHandler):
             # Do not keep processing requests.
             self.close_connection = True
             return
+
+        if keyword.casefold() == 'date':
+            if self._sent_date_header is None:
+                self._sent_date_header = value
+            elif self._sent_date_header == value:
+                return  # don't send the same header twice
+            else:
+                _logger.warning(
+                    "sending two different Date response headers: %r vs %r",
+                    self._sent_date_header, value)
+
+        if keyword.casefold() == 'server':
+            if self._sent_server_header is None:
+                self._sent_server_header = value
+            elif self._sent_server_header == value:
+                return  # don't send the same header twice
+            else:
+                _logger.warning(
+                    "sending two different Server response headers: %r vs %r",
+                    self._sent_server_header, value)
+
         super().send_header(keyword, value)
 
     def end_headers(self, *a, **kw):


### PR DESCRIPTION
Werkzeug historically prevented sending the same header twice[^1] but a refactor done with Werkzeug 2.0.0 removed that code[^2]. Additionnally `http.server.BaseHTTPRequestHandler.send_response`[^3] always send both the `Server` and `Date` header, no matter if those headers are actually present in the response already. The Werkzeug team is aware (issue 2500) of this issue but they considere **rightfuly** that (1) we shouldn't be using their builtin http server, and (2) that it is a problem to be solved upstream in CPython.

We usually don't send those two headers, and let werkzeug/http.server send them for us. But when using `Response.make_conditional`, Werkzeug is gonna force a Date header with the response. This is desirable because the Date is very when doing conditional requests, as the resource might have been created in the past but be still fresh.

The result is that when using `Response.make_conditional`, there are 2 Date headers in the response. This is not a problem when the two Date headers have the same value, but nginx is still sending warnings. The operational team here at Odoo wants to get rid of those silly warnings.

In this work we silently discard the second Date/Server header in case it has the same value as the first one. And we emit a warning may those two values be different.

Note that the header that is discard is the one from the response, and not the one that http.server always send with `send_response`. Ideally we should do the contrary: discard the one of `send_response` and keep the one from the response, but that's more complicated, and we don't need it at the moment.

[^1]: pallets/werkzeug:37b3fcc
[^2]: pallets/werkzeug:d062807
[^3]: https://github.com/python/cpython/blob/f1967e72498209e42f7cf5eeff0cd84d1ec10d18/Lib/http/server.py#L499-L510

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
