### PR TITLE
[FIX] project: traceback on point drag event in calendar day and week mode

### DIFF
--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_common/project_task_calendar_common_renderer.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_common/project_task_calendar_common_renderer.js
@@ -7,10 +7,12 @@ export function patchCommonRenderer(CommonRenderer) {
             const classesToAdd = super.eventClassNames(info);
             const { event } = info;
             const record = this.props.model.records[event.id];
-            const { state, is_closed } = record.rawRecord;
-            const isTaskClosed = is_closed !== undefined ? is_closed : ['1_done', '1_canceled'].includes(state);
-            if (isTaskClosed) {
-                classesToAdd.push("o_past_event");
+            if (record) {
+                const { state, is_closed } = record.rawRecord;
+                const isTaskClosed = is_closed !== undefined ? is_closed : ['1_done', '1_canceled'].includes(state);
+                if (isTaskClosed) {
+                    classesToAdd.push("o_past_event");
+                }
             }
             return classesToAdd;
         },


### PR DESCRIPTION
Steps to produce:

- Install project.
- Open calendar view.
- Switch to day/week mode.
- Create a task using drag motion.

Issue:

- A traceback appears.

Reason:

- Usually the call to create new record in FullCalendar when dragging is done at every event (mousedown, mousemove, moveup) of drag sequence.
- In Month/Year mode it uses something called Element Dragging where we just collect co-ordinates of movement and call to create is done on mouseup.

Solution:

- Make logic concrete even to work in those conditions.

task-4672805