### PR TITLE
[IMP] web: export performance for grouped export using `export_data`

### DIFF
--- a/addons/test_import_export/models/models_export.py
+++ b/addons/test_import_export/models/models_export.py
@@ -16,6 +16,7 @@ class ExportAggregator(models.Model):
     bool_or = fields.Boolean(aggregator='bool_or')
     many2one = fields.Many2one('export.integer')
     one2many = fields.One2many('export.aggregator.one2many', 'parent_id')
+    many2many = fields.Many2many(comodel_name='res.partner')
     active = fields.Boolean(default=True)
 
 


### PR DESCRIPTION
During an export in Excell format not import compatible with a group by applied
`export_data` was called once per group, recursively in `insert_leaf`, while this is possible to get the the whole data using `export_data` on all records at once,
hence providing better performances:
- less calls to `export_data`,
- less queries
