### PR TITLE
[FIX] crm_livechat: error when creating lead

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -175,7 +175,8 @@ class DiscussChannel(models.Model):
             :1
         ].script_step_id.chatbot_script_id.operator_partner_id
         last_msg_from_chatbot = False
-        for message in (self.message_ids - self.message_ids._filter_empty()).sorted("id"):
+        # sudo - mail.message: getting empty messages to exclude them is allowed.
+        for message in (self.message_ids - self.message_ids.sudo()._filter_empty()).sorted("id"):
             if message.author_id == chatbot_op and not last_msg_from_chatbot:
                 parts.append(Markup("<br/>"))
             if message.author_id == chatbot_op:


### PR DESCRIPTION
Since [1], creating a lead using the `/lead` command would sometimes fail. This occurs when the chat contains an empty message. Specifically, a call to `_filter_empty` is made when creating the lead description in order to exclude empty messages. This call tries to access `tracking_value_ids` which is limited to `base.group_system` hence the access error. This PR fixes this issue.

task-4669481

[1]: https://github.com/odoo/odoo/pull/191813

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
