### PR TITLE
[FIX] point_of_sale: default syst param product load limit

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -12,6 +12,8 @@ from odoo.exceptions import AccessError, ValidationError, UserError
 from odoo.tools import convert, SQL
 from odoo.osv import expression
 
+DEFAULT_LIMIT_LOAD_PRODUCT = 5000
+DEFAULT_LIMIT_LOAD_PARTNER = 100
 
 class PosConfig(models.Model):
     _name = 'pos.config'
@@ -742,20 +744,18 @@ class PosConfig(models.Model):
         }).id
 
     def get_limited_product_count(self):
-        default_limit = 5000
-        config_param = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.limited_product_count', default_limit)
+        config_param = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.limited_product_count', DEFAULT_LIMIT_LOAD_PRODUCT)
         try:
             return int(config_param)
         except (TypeError, ValueError, OverflowError):
-            return default_limit
+            return DEFAULT_LIMIT_LOAD_PRODUCT
 
     def _get_limited_partner_count(self):
-        default_limit = 100
-        config_param = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.limited_customer_count', default_limit)
+        config_param = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.limited_customer_count', DEFAULT_LIMIT_LOAD_PARTNER)
         try:
             return int(config_param)
         except (TypeError, ValueError, OverflowError):
-            return default_limit
+            return DEFAULT_LIMIT_LOAD_PARTNER
 
     def get_limited_partners_loading(self, offset=0):
         return self.env.execute_query(SQL("""
@@ -1038,7 +1038,7 @@ class PosConfig(models.Model):
     def _set_default_pos_load_limit(self):
         param_model = self.env["ir.config_parameter"]
         if not param_model.get_param("point_of_sale.limited_product_count"):
-            param_model.set_param("point_of_sale.limited_product_count", 20000)
+            param_model.set_param("point_of_sale.limited_product_count", DEFAULT_LIMIT_LOAD_PRODUCT)
 
         if not param_model.get_param("point_of_sale.limited_customer_count"):
-            param_model.set_param("point_of_sale.limited_customer_count", 100)
+            param_model.set_param("point_of_sale.limited_customer_count", DEFAULT_LIMIT_LOAD_PARTNER)


### PR DESCRIPTION
- In this PR (https://github.com/odoo/odoo/pull/199923) we set a default system parameter to define the number limit of partner to load in PoS by default (set to 20000).
- But since this PR (https://github.com/odoo/odoo/pull/184417) the default value was was changes from 20000 to 5000.
- To avoid making new similar issues, these defaults values are now extracted as constant class.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
