### PR TITLE
[IMP] website{,_sale}: display e-commerce specific blocks on homepage

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -673,7 +673,19 @@ class IrModuleModule(models.Model):
         # Configurator
         # ------------------------------------------------------------
 
-        configurator_snippets = manifest.get('configurator_snippets', {})
+        configurator_snippets = dict(manifest.get('configurator_snippets', {}))
+        addons = manifest.get('configurator_snippets_addons', {})
+        installed_modules = self.env['ir.module.module']._installed()
+
+        # Add addon snippets to the main snippet list for batch generation
+        for module_name, pages in addons.items():
+            # generate snippet only if the module is installed
+            if module_name not in installed_modules and module_name != self.name:
+                continue
+            for page, snippets_to_insert in pages.items():
+                snippets = configurator_snippets.setdefault(page, [])
+                dynamic_snippets = [snippet for snippet, *_ in snippets_to_insert]
+                configurator_snippets[page] = list(dict.fromkeys(snippets + dynamic_snippets))
 
         # Generate general configurator snippet templates
         create_values = []

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -73,6 +73,7 @@
         'views/snippets/s_mega_menu/multi_menus.xml',
         'views/snippets/s_mega_menu/odoo_menu.xml',
         'views/snippets/s_mega_menu/thumbnails.xml',
+        'views/generate_primary_template.xml',
     ],
     'demo': [
         'data/demo.xml',

--- a/addons/website_sale/const.py
+++ b/addons/website_sale/const.py
@@ -306,6 +306,48 @@ GMC_SUPPORTED_UOM = {
     'sqm',
 }
 
+SNIPPET_DEFAULTS = {
+    'website_sale.s_dynamic_snippet_products': {
+        'filter_xmlid': 'website_sale.dynamic_filter_newest_products',
+        'template_key': 'website_sale.dynamic_filter_template_product_product_products_item',
+        'data_attributes': {
+            'snippet': 's_dynamic_snippet_products',
+            'carousel-interval': '5000',
+            'product-category-id': 'all',
+            'number-of-elements': '4',
+            'number-of-elements-small-devices': '2',
+            'show-variants': 'true',
+        },
+        'add_classes': [
+            'o_wsale_products_opt_design_cards',
+            'o_wsale_products_opt_rounded_2',
+            'o_wsale_products_opt_has_comparison',
+            {
+                's_dynamic_snippet_title': 's_dynamic_snippet_title_aside col-lg-3 flex-lg-column justify-content-lg-start',
+            },
+        ],
+        'remove_classes': [
+            'o_wsale_products_opt_design_thumbs',
+            'o_wsale_products_opt_has_description',
+        ],
+    },
+    'website_sale.s_dynamic_snippet_category_list': {
+        'filter_xmlid': 'website_sale.dynamic_filter_category_list',
+        'template_key': (
+            'website_sale.dynamic_filter_template_product_public_category_clickable_items'
+        ),
+        'data_attributes': {
+            'snippet': 's_dynamic_snippet_category_list',
+            'show-parent': 'true',
+            'columns': '4',
+            'rounded': '2',
+            'gap': '2',
+            'size': 'medium',
+            'alignment': 'center',
+        },
+    },
+}
+
 GMC_BASE_MEASURE = re.compile(r'(?P<base_count>\d+)?\s*(?P<base_unit>[a-z]+)')
 
 SHOP_PATH = '/shop'

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -3,21 +3,19 @@
 import base64
 import json
 import logging
-from lxml import etree
 
+from lxml import etree
 from werkzeug import urls
 from werkzeug.exceptions import NotFound
 
 from odoo import SUPERUSER_ID, api, fields, models
 from odoo.exceptions import AccessError
-
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools import file_open, ormcache
 from odoo.tools.translate import LazyTranslate, _
 
 from odoo.addons.website_sale import const
-
 
 logger = logging.getLogger(__name__)
 _lt = LazyTranslate(__name__)
@@ -1007,3 +1005,6 @@ class Website(models.Model):
             path_parts.pop(2)
             canonical_url = canonical_url.replace(path='/'.join(path_parts))
         return canonical_url.to_url()
+
+    def _get_snippet_defaults(self, snippet):
+        return super()._get_snippet_defaults(snippet) | const.SNIPPET_DEFAULTS.get(snippet, {})

--- a/addons/website_sale/views/generate_primary_template.xml
+++ b/addons/website_sale/views/generate_primary_template.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<!--
+Non-website snippets need to be generated in the same way as other snippets, following the format 
+module_name.configurator_{snippet_name} or module_name.configurator_{page}_{snippet_name}. 
+Since these snippets are module-specific (e.g. website_sale) and do not exist in the website module
+itself, their parent_id cannot be resolved during generation until the respective module
+is installed.
+
+To handle this, configurator snippet addons are declared inside their own module manifest.
+This makes the generation process independent, generic, and consistent with how themes also declare
+their configurator snippets. As a result, snippet templates are only generated when the
+corresponding module is installed, ensuring that dynamic snippets are correctly created and linked
+at the right time.
+-->
+<function model="ir.module.module" name="_generate_primary_snippet_templates">
+    <value eval="[ref('base.module_website_sale')]"/>
+</function>
+
+</odoo>

--- a/odoo/addons/base/tests/test_module.py
+++ b/odoo/addons/base/tests/test_module.py
@@ -43,6 +43,7 @@ class TestModuleManifest(BaseCase):
             'category': 'Uncategorized',
             'cloc_exclude': [],
             'configurator_snippets': {},
+            'configurator_snippets_addons': {},
             'countries': [],
             'data': [],
             'demo': [],

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -66,6 +66,7 @@ _DEFAULT_MANIFEST = {
     'category': 'Uncategorized',
     'cloc_exclude': [],
     'configurator_snippets': {},  # website themes
+    'configurator_snippets_addons': {},  # website themes
     'countries': [],
     'data': [],
     'demo': [],


### PR DESCRIPTION
Previous Behaviour:
- Snippets existing in the website module could only be added to pages of a website when generated via website  configurator.
- Manifest of all themes have their own `configurator_snippets` that defines what snippets will be rendered on the pages.

Expected Behaviour after the PR is merged:
- Snippets existing in other modules such as `website_sale`, etc. can now add their snippets to the pages via website configurator.
- Previously these snippets could only be used via drag & drop method from the editor after the website is already generated.

For adding non-website snippets into the pages of website:
- For website snippets, names can be given directly like `s_text_image`, etc. but for non-website snippets, the module prefix is required. (e.g., `website_sale.s_dynamic_snippet_products`).
- Module specific snippets can be defined in their own module's manifest(for default theme) and in the theme's manifest as addons to `configurator_snippets` like:

```
  'configurator_snippets_addons': {
        'website_sale': {
            'homepage': [
                ('website_sale.s_dynamic_snippet_products', 'after', 's_cover'),
            ],
        },
    },
```
  - `s_cover` is the reference snippet existing in the above `configurator_snippets` and `'after'` is the position, hence the `s_dynamic_snippet_products` will be rendered on the homepage after the `s_cover` snippet.
  - If `'after'` is replaced with `''` then the snippet will be appended before the reference snippet.

For default configuration:
- Dynamic snippets need some default values such as filter-id, template-key, etc. to load completely.
- All required default values for a snippet to render should be defined in the const file existing in the module where snippet exists under `SNIPPET_DEFAULTS` - like:

```
SNIPPET_DEFAULTS = {
    'website_sale.s_dynamic_snippet_products': {
        'filter_xmlid': 'website_sale.dynamic_filter_newest_products',
        'template_key':
            ('website_sale.dynamic_filter_template_product_product_products_item'),
        'data_attributes': {
            'snippet': 's_dynamic_snippet_products',
            'carousel-interval': '5000',
            'product-category-id': 'all',
            'number-of-elements': '4',
            'number-of-elements-small-devices': '2',
            'show-variants': 'true',
        },
    },
}
```
For theme-level snippet customization:
- Snippets in themes may require customizations to match with theme standards, for that we can define them in theme's manifest like:

```
'theme_customizations': {
    'website_sale.s_dynamic_snippet_products': {
        'data_attributes': {
            'number-of-records': '7',
            'carousel-interval': '3000',
        },
        'background': {
            'color': 'o_cc3',
            'shape': {
                'data-oe-shape-data': '{"shape":"web_editor/Wavy/07","flip":["x"]}',
                'element': """<div class="o_we_shape o_web_editor_Airy_07_001">""",
            },
        },
    },
}
```

task-4502087

Co-authored-by: Bojabza Soukéina (sobo) <sobo@odoo.com>