### PR TITLE
[FIX] html_editor: link popover in chatter

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { Component, useState, onMounted, useRef } from "@odoo/owl";
-import { useAutofocus, useService } from "@web/core/utils/hooks";
+import { useService } from "@web/core/utils/hooks";
 import { browser } from "@web/core/browser/browser";
 import { cleanZWChars, deduceURLfromText } from "./utils";
 
@@ -79,13 +79,12 @@ export class LinkPopover extends Component {
         });
 
         this.editingWrapper = useRef("editing-wrapper");
-        useAutofocus({
-            refName: this.state.isImage || this.state.label !== "" ? "url" : "label",
-            mobile: true,
-        });
+        const ref = useRef(this.state.isImage || this.state.label !== "" ? "url" : "label");
         onMounted(() => {
             if (!this.state.editing) {
                 this.loadAsyncLinkPreview();
+            } else {
+                ref.el.focus();
             }
         });
     }


### PR DESCRIPTION
**Current behavior before PR:**

- When creating a link using the powerbox command in Chatter, the link popover would immediately close upon opening, making it impossible to create a link.

**Desired behavior after PR is merged:**

- The link popover now remains open when creating a link using the powerbox command in Chatter, allowing the link to be created successfully.

task:4669462
