### PR TITLE
[FIX] account: unable to open bill cash rounding tax that is with no taxes

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2236,9 +2236,9 @@ class AccountTax(models.Model):
                 rounding_method=cash_rounding_method,
             )
             cash_rounding_base_amount_currency = expected_total_amount_currency - total_amount_currency
+            rate = abs(total_amount_currency / total_amount) if total_amount else 0.0
+            cash_rounding_base_amount = company.currency_id.round(cash_rounding_base_amount_currency / rate) if rate else 0.0
             if not currency.is_zero(cash_rounding_base_amount_currency):
-                rate = abs(total_amount_currency / total_amount) if total_amount else 0.0
-                cash_rounding_base_amount = company.currency_id.round(cash_rounding_base_amount_currency / rate) if rate else 0.0
                 if strategy == 'add_invoice_line':
                     tax_totals_summary['cash_rounding_base_amount_currency'] = cash_rounding_base_amount_currency
                     tax_totals_summary['cash_rounding_base_amount'] = cash_rounding_base_amount
@@ -2247,20 +2247,27 @@ class AccountTax(models.Model):
                     subtotals[untaxed_amount_subtotal_label]['base_amount_currency'] += cash_rounding_base_amount_currency
                     subtotals[untaxed_amount_subtotal_label]['base_amount'] += cash_rounding_base_amount
                 elif strategy == 'biggest_tax':
-                    max_subtotal, max_tax_group = max(
-                        [
-                            (subtotal, tax_group)
-                            for subtotal in tax_totals_summary['subtotals']
-                            for tax_group in subtotal['tax_groups']
-                        ],
-                        key=lambda item: item[1]['tax_amount_currency'],
-                    )
-                    max_tax_group['tax_amount_currency'] += cash_rounding_base_amount_currency
-                    max_tax_group['tax_amount'] += cash_rounding_base_amount
-                    max_subtotal['tax_amount_currency'] += cash_rounding_base_amount_currency
-                    max_subtotal['tax_amount'] += cash_rounding_base_amount
-                    tax_totals_summary['tax_amount_currency'] += cash_rounding_base_amount_currency
-                    tax_totals_summary['tax_amount'] += cash_rounding_base_amount
+                    all_subtotal_tax_group = [
+                        (subtotal, tax_group)
+                        for subtotal in tax_totals_summary['subtotals']
+                        for tax_group in subtotal['tax_groups']
+                    ]
+
+                    if all_subtotal_tax_group:
+                        max_subtotal, max_tax_group = max(
+                            all_subtotal_tax_group,
+                            key=lambda item: item[1]['tax_amount_currency'],
+                        )
+                        max_tax_group['tax_amount_currency'] += cash_rounding_base_amount_currency
+                        max_tax_group['tax_amount'] += cash_rounding_base_amount
+                        max_subtotal['tax_amount_currency'] += cash_rounding_base_amount_currency
+                        max_subtotal['tax_amount'] += cash_rounding_base_amount 
+                        tax_totals_summary['tax_amount_currency'] += cash_rounding_base_amount_currency
+                        tax_totals_summary['tax_amount'] += cash_rounding_base_amount
+                    else:
+                        # Failed to apply the cash rounding since there is no tax.
+                        cash_rounding_base_amount_currency = 0.0
+                        cash_rounding_base_amount = 0.0
 
         # Subtract the cash rounding from the untaxed amounts.
         cash_rounding_base_amount_currency = tax_totals_summary.get('cash_rounding_base_amount_currency', 0.0)

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -1011,10 +1011,10 @@ export const accountTaxHelpers = {
             const total_amount_currency = tax_totals_summary.base_amount_currency + tax_totals_summary.tax_amount_currency;
             const total_amount = tax_totals_summary.base_amount + tax_totals_summary.tax_amount;
             const expected_total_amount_currency = roundPrecision(total_amount_currency, cash_rounding_pd, cash_rounding_method);
-            const cash_rounding_base_amount_currency = expected_total_amount_currency - total_amount_currency;
+            let cash_rounding_base_amount_currency = expected_total_amount_currency - total_amount_currency;
+            const rate = total_amount ? Math.abs(total_amount_currency / total_amount) : 0.0;
+            let cash_rounding_base_amount = rate ? roundPrecision(cash_rounding_base_amount_currency / rate, company_pd) : 0.0;
             if (!floatIsZero(cash_rounding_base_amount_currency, currency.decimal_places)) {
-                const rate = total_amount ? Math.abs(total_amount_currency / total_amount) : 0.0;
-                const cash_rounding_base_amount = rate ? roundPrecision(cash_rounding_base_amount_currency / rate, company_pd) : 0.0;
                 if (strategy === 'add_invoice_line') {
                     tax_totals_summary.cash_rounding_base_amount_currency = cash_rounding_base_amount_currency;
                     tax_totals_summary.cash_rounding_base_amount = cash_rounding_base_amount;
@@ -1023,16 +1023,24 @@ export const accountTaxHelpers = {
                     subtotals[untaxed_amount_subtotal_label].base_amount_currency += cash_rounding_base_amount_currency;
                     subtotals[untaxed_amount_subtotal_label].base_amount += cash_rounding_base_amount;
                 } else if (strategy === 'biggest_tax') {
-                    const [max_subtotal, max_tax_group] = tax_totals_summary.subtotals
-                        .flatMap(subtotal => subtotal.tax_groups.map(tax_group => [subtotal, tax_group]))
-                        .reduce((a, b) => (b[1].tax_amount_currency > a[1].tax_amount_currency ? b : a));
+                    const all_subtotal_tax_group = tax_totals_summary.subtotals
+                        .flatMap(subtotal => subtotal.tax_groups.map(tax_group => [subtotal, tax_group]));
 
-                    max_tax_group.tax_amount_currency += cash_rounding_base_amount_currency;
-                    max_tax_group.tax_amount += cash_rounding_base_amount;
-                    max_subtotal.tax_amount_currency += cash_rounding_base_amount_currency;
-                    max_subtotal.tax_amount += cash_rounding_base_amount;
-                    tax_totals_summary.tax_amount_currency += cash_rounding_base_amount_currency;
-                    tax_totals_summary.tax_amount += cash_rounding_base_amount;
+                    if (all_subtotal_tax_group.length) {
+                        const [max_subtotal, max_tax_group] = all_subtotal_tax_group
+                            .reduce((a, b) => (b[1].tax_amount_currency > a[1].tax_amount_currency ? b : a));
+
+                        max_tax_group.tax_amount_currency += cash_rounding_base_amount_currency;
+                        max_tax_group.tax_amount += cash_rounding_base_amount;
+                        max_subtotal.tax_amount_currency += cash_rounding_base_amount_currency;
+                        max_subtotal.tax_amount += cash_rounding_base_amount;
+                        tax_totals_summary.tax_amount_currency += cash_rounding_base_amount_currency;
+                        tax_totals_summary.tax_amount += cash_rounding_base_amount;
+                    } else {
+                        // Failed to apply the cash rounding since there is no tax.
+                        cash_rounding_base_amount_currency = 0.0
+                        cash_rounding_base_amount = 0.0
+                    }
                 }
             }
         }

--- a/addons/account/tests/test_taxes_tax_totals_summary.py
+++ b/addons/account/tests/test_taxes_tax_totals_summary.py
@@ -1728,6 +1728,27 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
             }
             yield 2, self.populate_document(document_params), expected_values
 
+            document_params = self.init_document(
+                lines=[{'price_unit': 50.01}],
+                cash_rounding=cash_rounding,
+            )
+            expected_values = {
+                'same_tax_base': True,
+                'currency_id': self.currency.id,
+                'base_amount_currency': 50.01,
+                'tax_amount_currency': 0.0,
+                'total_amount_currency': 50.01,
+                'subtotals': [
+                    {
+                        'name': "Untaxed Amount",
+                        'base_amount_currency': 50.01,
+                        'tax_amount_currency': 0.0,
+                        'tax_groups': [],
+                    },
+                ],
+            }
+            yield 3, self.populate_document(document_params), expected_values
+
     def test_cash_rounding_generic_helpers(self):
         for test_index, document, expected_values in self._test_cash_rounding():
             with self.subTest(test_index=test_index):


### PR DESCRIPTION

The Error is reproducible in the runbot here is an attached video with the steps: https://drive.google.com/file/d/1W1ZJG7aYueFa8Y24LSZlsil0caZB9mE5/view?usp=sharing

This happens because of :

1- cash rounding is enabled in the settings of accounting 2 - cash rounding by tax is chosen 3 - opening a vendor bill
4 - putting a decimal price and removing taxes
5- then choosing cash rounding by tax

The Error :
File "/home/odoo/odoo/odoo/addons/account/models/account_move.py", line 1570, in _compute_tax_totals move.tax_totals = self.env['account.tax']._get_tax_totals_summary( File "/home/odoo/odoo/odoo/addons/account/models/account_tax.py", line 2090, in _get_tax_totals_summary max_subtotal, max_tax_group = max(
ValueError: max() arg is an empty sequence

opw-4558251 (related to ticket)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


