### PR TITLE
[IMP] tests: avoid extensions when running Chrome

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1010,6 +1010,7 @@ class ChromeBrowser:
             '--no-default-browser-check': '',
             '--no-first-run': '',
             '--disable-extensions': '',
+            '--disable-component-extensions-with-background-pages': '',
             '--disable-background-networking' : '',
             '--disable-background-timer-throttling' : '',
             '--disable-backgrounding-occluded-windows': '',


### PR DESCRIPTION
This commits adds a new argument
`--disable-component-extensions-with-background-pages` into the run command of Chrome.

This argument disable some built-in extensions that aren't affected by `--disable-extensions`.

Ref:
https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md https://docs.google.com/spreadsheets/d/1n-vw_PCPS45jX3Jt9jQaAhFqBY6Ge1vWF_Pa0k7dCk4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
