### PR TITLE
[IMP] hw_drivers: remove print_confirmation check

### DIFF
--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -57,7 +57,7 @@ def on_message(ws, messages):
             else:
                 # likely intended as IoT share the same channel
                 _logger.debug("message ignored due to different iot mac: %s", iot_mac)
-        elif message_type != 'print_confirmation':  # intended to be ignored
+        else:
             _logger.warning("message type not supported: %s", message_type)
 
 


### PR DESCRIPTION
See Enterprise PR: https://github.com/odoo/enterprise/pull/82179

In the enterprise PR, we are switching to using a separate websocket channel for DB -> client messages. This means that the IoT will no longer receive useless `print_confirmation` messages, so there is no need to ignore them anymore.

task-4075545

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
