### PR TITLE
[FIX] l10n_in: fix fiscal position computation dependencies

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -72,7 +72,7 @@ class AccountMove(models.Model):
             else:
                 move.l10n_in_state_id = False
 
-    @api.depends('l10n_in_state_id')
+    @api.depends('l10n_in_state_id', 'l10n_in_gst_treatment')
     def _compute_fiscal_position_id(self):
 
         def _get_fiscal_state(move, foreign_state):


### PR DESCRIPTION
**Before this commit:** The fiscal position computation method did not depend on `gst_treatment`, causing issues where changes to `gst_treatment` were not detected. As a result, the computation did not trigger as expected, leading to incorrect fiscal position determination.

**After this commit:** The computation method now depends on `gst_treatment`, ensuring that any changes to it trigger a recalculation. This guarantees accurate fiscal position computation as required.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
