### PR TITLE
[IMP] calendar: show attendee information

### DIFF
--- a/addons/calendar/static/src/views/avatar_partner_card/avatar_partner_card.js
+++ b/addons/calendar/static/src/views/avatar_partner_card/avatar_partner_card.js
@@ -1,0 +1,64 @@
+import { useService } from "@web/core/utils/hooks";
+import { Component, onWillStart } from "@odoo/owl";
+import { useOpenChat } from "@mail/core/web/open_chat_hook";
+
+export class AvatarPartnerCardPopover extends Component {
+    static template = "calendar.AvatarPartnerCardPopover";
+
+    static props = {
+        id: { type: Number, required: true },
+        close: { type: Function, required: true },
+    };
+
+    setup() {
+        this.actionService = useService("action");
+        this.orm = useService("orm");
+        this.openChat = useOpenChat("res.partner");
+        onWillStart(async () => {
+            [this.partner] = await this.orm.read("res.partner", [this.props.id], this.fieldNames);
+        });
+    }
+
+    get fieldNames() {
+        return ["name", "email", "phone", "im_status"];
+    }
+
+    get email() {
+        return this.partner.email;
+    }
+
+    get phone() {
+        return this.partner.phone;
+    }
+
+    get showViewProfileBtn() {
+        return true;
+    }
+
+    get hasFooter() {
+        return false;
+    }
+
+    async getProfileAction() {
+        return {
+            res_id: this.partner.id,
+            res_model: "res.partner",
+            type: "ir.actions.act_window",
+            views: [[false, "form"]],
+        };
+    }
+
+    get partnerId() {
+        return this.partner.id;
+    }
+
+    onSendClick() {
+        this.openChat(this.partner.id);
+        this.props.close();
+    }
+
+    async onClickViewProfile(newWindow) {
+        const action = await this.getProfileAction();
+        this.actionService.doAction(action, { newWindow });
+    }
+}

--- a/addons/calendar/static/src/views/avatar_partner_card/avatar_partner_card.js
+++ b/addons/calendar/static/src/views/avatar_partner_card/avatar_partner_card.js
@@ -1,21 +1,17 @@
+import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
 import { useService } from "@web/core/utils/hooks";
-import { Component, onWillStart } from "@odoo/owl";
 import { useOpenChat } from "@mail/core/web/open_chat_hook";
+import { onWillStart } from "@odoo/owl";
 
-export class AvatarPartnerCardPopover extends Component {
+export class AvatarPartnerCardPopover extends AvatarCardPopover {
     static template = "calendar.AvatarPartnerCardPopover";
-
-    static props = {
-        id: { type: Number, required: true },
-        close: { type: Function, required: true },
-    };
 
     setup() {
         this.actionService = useService("action");
         this.orm = useService("orm");
         this.openChat = useOpenChat("res.partner");
         onWillStart(async () => {
-            [this.partner] = await this.orm.read("res.partner", [this.props.id], this.fieldNames);
+            [this.user] = await this.orm.read("res.partner", [this.props.id], this.fieldNames);
         });
     }
 
@@ -23,42 +19,12 @@ export class AvatarPartnerCardPopover extends Component {
         return ["name", "email", "phone", "im_status"];
     }
 
-    get email() {
-        return this.partner.email;
-    }
-
-    get phone() {
-        return this.partner.phone;
-    }
-
-    get showViewProfileBtn() {
-        return true;
-    }
-
-    get hasFooter() {
-        return false;
-    }
-
     async getProfileAction() {
         return {
-            res_id: this.partner.id,
+            res_id: this.user.id,
             res_model: "res.partner",
             type: "ir.actions.act_window",
             views: [[false, "form"]],
         };
-    }
-
-    get partnerId() {
-        return this.partner.id;
-    }
-
-    onSendClick() {
-        this.openChat(this.partner.id);
-        this.props.close();
-    }
-
-    async onClickViewProfile(newWindow) {
-        const action = await this.getProfileAction();
-        this.actionService.doAction(action, { newWindow });
     }
 }

--- a/addons/calendar/static/src/views/avatar_partner_card/avatar_partner_card.xml
+++ b/addons/calendar/static/src/views/avatar_partner_card/avatar_partner_card.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="calendar.AvatarPartnerCardPopover">
+        <div class="o_avatar_card card border-0 rounded">
+            <div class="card-body bg-inherit rounded">
+                <div class="d-flex align-items-start gap-2 bg-inherit">
+                    <span class="o_avatar pt-1 position-relative o_card_avatar bg-inherit">
+                        <img
+                            t-if="props.id"
+                            t-attf-src="/web/image/res.partner/{{props.id}}/avatar_128"
+                            class="rounded"
+                        />
+                        <span 
+                            t-if="partner.im_status"
+                            name="icon"
+                            class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center bg-inherit"
+                        >
+                            <i
+                                t-if="partner.im_status === 'online'"
+                                class="fa fa-fw fa-circle text-success"
+                                title="Online"
+                                role="img"
+                                aria-label="partner is online"
+                            />
+                            <i
+                                t-elif="partner.im_status === 'away'"
+                                class="fa fa-fw fa-circle text-warning"
+                                title="Idle"
+                                role="img"
+                                aria-label="partner is idle"
+                            />
+                            <i
+                                t-elif="partner.im_status === 'offline'"
+                                class="fa fa-fw fa-circle-o text-700"
+                                title="Offline"
+                                role="img"
+                                aria-label="partner is offline"
+                            />
+                            <i
+                                t-elif="partner.im_status === 'bot'"
+                                class="fa fa-fw fa-heart text-success"
+                                title="Bot"
+                                role="img"
+                                aria-label="partner is a bot"
+                            />
+                            <i
+                                t-elif="!partner.im_status"
+                                class="fa fa-fw fa-question-circle"
+                                title="No IM status available"
+                            />
+                        </span>
+                    </span>
+                    <div class="d-flex flex-column o_card_partner_infos overflow-hidden">
+                        <span class="fw-bold" t-esc="partner.name"/>
+                        <a t-if="email" t-att-href="'mailto:'+email" t-att-title="email" class="text-truncate">
+                            <i class="fa fa-fw fa-envelope me-1"/><t t-esc="email"/>
+                        </a>
+                        <a t-if="phone" class="o-mail-avatar-card-tel text-truncate" t-att-title="phone" t-att-href="'tel:'+phone">
+                            <i class="fa fa-fw fa-phone me-1"/><t t-esc="phone"/>
+                        </a>
+                        <div class="o_avatar_card_buttons d-flex gap-2 mt-2">
+                            <button
+                                t-if="!partner.share"
+                                class="btn btn-secondary btn-sm"
+                                t-on-click.stop="onSendClick">
+                                Send message
+                            </button>
+                            <button
+                                t-if="showViewProfileBtn"
+                                class="btn btn-secondary btn-sm"
+                                t-custom-click.stop="(ev, isMiddleClick) => this.onClickViewProfile(isMiddleClick)"
+                                t-ref="viewProfileBtn">
+                                View Profile
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div t-if="hasFooter" class="o_avatar_card_details card-footer d-flex flex-column gap-3 rounded-bottom bg-100"/>
+        </div>
+    </t>
+</templates>

--- a/addons/calendar/static/src/views/avatar_partner_card/avatar_partner_card.xml
+++ b/addons/calendar/static/src/views/avatar_partner_card/avatar_partner_card.xml
@@ -1,82 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="calendar.AvatarPartnerCardPopover">
-        <div class="o_avatar_card card border-0 rounded">
-            <div class="card-body bg-inherit rounded">
-                <div class="d-flex align-items-start gap-2 bg-inherit">
-                    <span class="o_avatar pt-1 position-relative o_card_avatar bg-inherit">
-                        <img
-                            t-if="props.id"
-                            t-attf-src="/web/image/res.partner/{{props.id}}/avatar_128"
-                            class="rounded"
-                        />
-                        <span 
-                            t-if="partner.im_status"
-                            name="icon"
-                            class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center bg-inherit"
-                        >
-                            <i
-                                t-if="partner.im_status === 'online'"
-                                class="fa fa-fw fa-circle text-success"
-                                title="Online"
-                                role="img"
-                                aria-label="partner is online"
-                            />
-                            <i
-                                t-elif="partner.im_status === 'away'"
-                                class="fa fa-fw fa-circle text-warning"
-                                title="Idle"
-                                role="img"
-                                aria-label="partner is idle"
-                            />
-                            <i
-                                t-elif="partner.im_status === 'offline'"
-                                class="fa fa-fw fa-circle-o text-700"
-                                title="Offline"
-                                role="img"
-                                aria-label="partner is offline"
-                            />
-                            <i
-                                t-elif="partner.im_status === 'bot'"
-                                class="fa fa-fw fa-heart text-success"
-                                title="Bot"
-                                role="img"
-                                aria-label="partner is a bot"
-                            />
-                            <i
-                                t-elif="!partner.im_status"
-                                class="fa fa-fw fa-question-circle"
-                                title="No IM status available"
-                            />
-                        </span>
-                    </span>
-                    <div class="d-flex flex-column o_card_partner_infos overflow-hidden">
-                        <span class="fw-bold" t-esc="partner.name"/>
-                        <a t-if="email" t-att-href="'mailto:'+email" t-att-title="email" class="text-truncate">
-                            <i class="fa fa-fw fa-envelope me-1"/><t t-esc="email"/>
-                        </a>
-                        <a t-if="phone" class="o-mail-avatar-card-tel text-truncate" t-att-title="phone" t-att-href="'tel:'+phone">
-                            <i class="fa fa-fw fa-phone me-1"/><t t-esc="phone"/>
-                        </a>
-                        <div class="o_avatar_card_buttons d-flex gap-2 mt-2">
-                            <button
-                                t-if="!partner.share"
-                                class="btn btn-secondary btn-sm"
-                                t-on-click.stop="onSendClick">
-                                Send message
-                            </button>
-                            <button
-                                t-if="showViewProfileBtn"
-                                class="btn btn-secondary btn-sm"
-                                t-custom-click.stop="(ev, isMiddleClick) => this.onClickViewProfile(isMiddleClick)"
-                                t-ref="viewProfileBtn">
-                                View Profile
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div t-if="hasFooter" class="o_avatar_card_details card-footer d-flex flex-column gap-3 rounded-bottom bg-100"/>
-        </div>
+    <t t-name="calendar.AvatarPartnerCardPopover" t-inherit="mail.AvatarCardPopover" t-inherit-mode="primary">
+        <xpath expr="//span[hasclass('o_avatar')]/img" position="attributes">
+            <attribute name="t-attf-src" t-if="displayAvatar">/web/image/res.partner/{{props.id}}/avatar_128</attribute>
+        </xpath>
     </t>
 </templates>

--- a/addons/calendar/static/src/views/fields/attendee_tags_list.xml
+++ b/addons/calendar/static/src/views/fields/attendee_tags_list.xml
@@ -10,6 +10,7 @@
                 <img t-if="tag.img"
                     t-att-src="tag.img"
                     class="o_avatar o_m2m_avatar position-relative rounded"
+                    t-on-click.stop.prevent="tag.onImageClicked"
                     t-att-class="tag.imageClass"/>
                 <div t-if="tag.status &amp;&amp; tag.statusIcon" t-attf-class="attendee_tag_status o_attendee_status_{{tag.status}} fa fa-fw {{tag.statusIcon}} rounded-circle"/>
             </div>

--- a/addons/calendar/static/src/views/fields/many2many_attendee.js
+++ b/addons/calendar/static/src/views/fields/many2many_attendee.js
@@ -5,6 +5,8 @@ import {
 } from "@web/views/fields/many2many_tags_avatar/many2many_tags_avatar_field";
 import { useSpecialData } from "@web/views/fields/relational_utils";
 import { AttendeeTagsList } from "@calendar/views/fields/attendee_tags_list";
+import { AvatarPartnerCardPopover } from "@calendar/views/avatar_partner_card/avatar_partner_card";
+import { usePopover } from "@web/core/popover/popover_hook";
 
 const ICON_BY_STATUS = {
     accepted: "fa-check",
@@ -19,6 +21,7 @@ export class Many2ManyAttendee extends Many2ManyTagsAvatarField {
     };
     setup() {
         super.setup();
+        this.avatarCard = usePopover(AvatarPartnerCardPopover);
         this.specialData = useSpecialData((orm, props) => {
             const { context, name, record } = props;
             return orm.call(
@@ -30,6 +33,35 @@ export class Many2ManyAttendee extends Many2ManyTagsAvatarField {
                 }
             );
         });
+    }
+
+    displayAvatarCard(record) {
+        return !this.env.isSmall && this.relation === "res.partner";
+    }
+
+    getAvatarCardProps(record) {
+        return {
+            id: record.resId,
+        };
+    }
+
+    getTagProps(record) {
+        return {
+            ...super.getTagProps(...arguments),
+            onImageClicked: (ev) => {
+                if (!this.displayAvatarCard(record)) {
+                    return;
+                }
+                const target = ev.currentTarget;
+                if (
+                    !this.avatarCard.isOpen ||
+                    (this.lastOpenedId && record.resId !== this.lastOpenedId)
+                ) {
+                    this.avatarCard.open(target, this.getAvatarCardProps(record));
+                    this.lastOpenedId = record.resId;
+                }
+            },
+        };
     }
 
     get tags() {

--- a/addons/calendar/static/src/views/open_partner_chat_hook.js
+++ b/addons/calendar/static/src/views/open_partner_chat_hook.js
@@ -1,0 +1,15 @@
+import { helpers } from "@mail/core/web/open_chat_hook";
+import { patch } from "@web/core/utils/patch";
+
+patch(helpers, {
+    SUPPORTED_M2X_AVATAR_MODELS: [
+        ...helpers.SUPPORTED_M2X_AVATAR_MODELS,
+        "res.partner",
+    ],
+    buildOpenChatParams(resModel, id) {
+        if ("res.partner".includes(resModel)) {
+            return { partnerId: id };
+        }
+        return super.buildOpenChatParams(...arguments);
+    }
+});


### PR DESCRIPTION
Before this commit, it was difficult to view details about event attendees.

With this change, clicking on an attendee will open a small info box showing their details. This reuses the same widget used in the chatter.

Task-4664620

