### PR TITLE
[IMP] web_editor: add toggle button for vertical video

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -27,6 +27,7 @@ export class VideoSelector extends Component {
     static mediaSpecificStyles = [];
     static mediaExtraClasses = [];
     static tagNames = ["IFRAME", "DIV"];
+    static isVertical = false;
     static template = "html_editor.VideoSelector";
     static components = {
         VideoIframe,
@@ -106,6 +107,7 @@ export class VideoSelector extends Component {
             platform: null,
             vimeoPreviews: [],
             errorMessage: "",
+            isVertical: false,
         });
         this.urlInputRef = useRef("url-input");
 
@@ -117,10 +119,12 @@ export class VideoSelector extends Component {
                     (this.props.media.tagName === "IFRAME" &&
                         this.props.media.getAttribute("src")) ||
                     "";
+                VideoSelector.isVertical = this.props.media.dataset.isVertical || false;
                 if (src) {
                     this.state.urlInput = src;
                     await this.updateVideo();
 
+                    this.state.isVertical = VideoSelector.isVertical;
                     this.state.options = this.state.options.map((option) => {
                         const { urlParameter } = this.OPTIONS[option.id];
                         return { ...option, value: src.indexOf(urlParameter) >= 0 };
@@ -152,6 +156,12 @@ export class VideoSelector extends Component {
             }
             return option;
         });
+        await this.updateVideo();
+    }
+
+    async onChangeIsVertical() {
+        this.state.isVertical = !this.state.isVertical;
+        VideoSelector.isVertical = this.state.isVertical;
         await this.updateVideo();
     }
 
@@ -251,11 +261,20 @@ export class VideoSelector extends Component {
         return selectedMedia.map((video) => {
             const div = document.createElement("div");
             div.dataset.oeExpression = video.src;
-            div.innerHTML =
-                '<div class="css_editable_mode_display"></div>' +
-                '<div class="media_iframe_video_size" contenteditable="false"></div>' +
-                '<iframe frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>';
-
+            div.dataset.isVertical = VideoSelector.isVertical;
+            if (VideoSelector.isVertical) {
+                div.innerHTML = `
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size_for_shorts" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>
+            `;
+            } else {
+                div.innerHTML = `
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>
+            `;
+            }
             div.querySelector("iframe").src = video.src;
             return div;
         });

--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.xml
@@ -39,6 +39,18 @@
                     label="option.label"
                     description="option.description"/>
             </div>
+            <t t-if="state.platform === 'youtube' and !props.isForBgVideo">
+                <div class="mb-1">
+                    <label class="d-flex align-items-start gap-2 cursor-pointer" t-on-change="this.onChangeIsVertical">
+                        <div class="o_switch flex-shrink-0">
+                            <input type="checkbox" t-att-checked="state.isVertical"/>
+                            <span/>
+                        </div>
+                        <span>Vertical</span>
+                        <span class="text-muted">Turn on for vertical content</span>
+                    </label>
+                </div>
+            </t>
             <t t-if="state.vimeoPreviews.length">
                 <span class="fw-bold">Suggestions</span>
                 <div id="video-suggestion" class="mt-4 d-flex flex-wrap mh-75 overflow-auto">
@@ -54,7 +66,12 @@
             <div class="o_video_preview position-relative border-0 p-3">
                 <div t-if="this.state.src and !this.state.errorMessage" class="o_video_dialog_preview_text mb-2">Preview</div>
                 <div class="media_iframe_video">
-                    <div class="media_iframe_video_size"/>
+                    <t t-if="this.state.isVertical">
+                        <div class="media_iframe_video_size_for_shorts"/>
+                    </t>
+                    <t t-else="">
+                        <div class="media_iframe_video_size"/>
+                    </t>
                     <VideoIframe
                         t-if="this.state.src and !this.state.errorMessage"
                         src="this.state.src"/>

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -3115,9 +3115,13 @@ describe("youtube video", () => {
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
             await tick();
-            expect(getContent(el)).toBe(
-                `<p>ab</p><div data-oe-expression="${videoUrl}" class="media_iframe_video" contenteditable="false"><div class="css_editable_mode_display"></div><div class="media_iframe_video_size" contenteditable="false"></div><iframe frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="${videoUrl}"></iframe></div><p>[]cd</p>`
-            );
+
+            const expected = `<p>ab</p><div data-oe-expression="${videoUrl}" data-is-vertical="false" class="media_iframe_video" contenteditable="false">
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="${videoUrl}"></iframe>
+            </div><p>[]cd</p>`;
+            expect(getContent(el)).toBe(expected);
         });
 
         test("should paste and transform a youtube URL in a span (1)", async () => {
@@ -3129,9 +3133,13 @@ describe("youtube video", () => {
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
             await tick();
-            expect(getContent(el)).toBe(
-                '<p>a<span class="a">b</span></p><div data-oe-expression="https://youtu.be/dQw4w9WgXcQ" class="media_iframe_video" contenteditable="false"><div class="css_editable_mode_display"></div><div class="media_iframe_video_size" contenteditable="false"></div><iframe frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="https://youtu.be/dQw4w9WgXcQ"></iframe></div><p><span class="a">[]c</span>d</p>'
-            );
+
+            const expected = `<p>a<span class="a">b</span></p><div data-oe-expression="https://youtu.be/dQw4w9WgXcQ" data-is-vertical="false" class="media_iframe_video" contenteditable="false">
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="https://youtu.be/dQw4w9WgXcQ"></iframe>
+            </div><p><span class="a">[]c</span>d</p>`;
+            expect(getContent(el)).toBe(expected);
         });
 
         test("should paste and not transform a youtube URL in a existing link", async () => {
@@ -3193,9 +3201,13 @@ describe("youtube video", () => {
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
             await tick();
-            expect(getContent(el)).toBe(
-                '<p>ab</p><div data-oe-expression="https://youtu.be/dQw4w9WgXcQ" class="media_iframe_video" contenteditable="false"><div class="css_editable_mode_display"></div><div class="media_iframe_video_size" contenteditable="false"></div><iframe frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="https://youtu.be/dQw4w9WgXcQ"></iframe></div><p>[]cd</p>'
-            );
+
+            const expected = `<p>ab</p><div data-oe-expression="https://youtu.be/dQw4w9WgXcQ" data-is-vertical="false" class="media_iframe_video" contenteditable="false">
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="https://youtu.be/dQw4w9WgXcQ"></iframe>
+            </div><p>[]cd</p>`;
+            expect(getContent(el)).toBe(expected);
         });
 
         test("should paste and transform a youtube URL in a span (2)", async () => {
@@ -3209,9 +3221,13 @@ describe("youtube video", () => {
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
             await tick();
-            expect(getContent(el)).toBe(
-                `<p>a<span class="a">b</span></p><div data-oe-expression="${videoUrl}" class="media_iframe_video" contenteditable="false"><div class="css_editable_mode_display"></div><div class="media_iframe_video_size" contenteditable="false"></div><iframe frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="${videoUrl}"></iframe></div><p><span class="a">[]c</span>d</p>`
-            );
+
+            const expected = `<p>a<span class="a">b</span></p><div data-oe-expression="${videoUrl}" data-is-vertical="false" class="media_iframe_video" contenteditable="false">
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="${videoUrl}"></iframe>
+            </div><p><span class="a">[]c</span>d</p>`;
+            expect(getContent(el)).toBe(expected);
         });
 
         test("should paste and not transform a youtube URL in a existing link", async () => {

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -27,6 +27,7 @@ export class VideoSelector extends Component {
     static mediaSpecificStyles = [];
     static mediaExtraClasses = [];
     static tagNames = ["IFRAME", "DIV"];
+    static isVertical = false;
     static template = "web_editor.VideoSelector";
     static components = {
         VideoIframe,
@@ -97,16 +98,19 @@ export class VideoSelector extends Component {
             platform: null,
             vimeoPreviews: [],
             errorMessage: '',
+            isVertical: false,
         });
         this.urlInputRef = useRef('url-input');
 
         onWillStart(async () => {
             if (this.props.media) {
                 const src = this.props.media.dataset.oeExpression || this.props.media.dataset.src || (this.props.media.tagName === 'IFRAME' && this.props.media.getAttribute('src')) || '';
+                VideoSelector.isVertical = this.props.media.dataset.isVertical || false;
                 if (src) {
                     this.state.urlInput = "https:" + src;
                     await this.updateVideo();
 
+                    this.state.isVertical = VideoSelector.isVertical;
                     this.state.options = this.state.options.map((option) => {
                         const { urlParameter } = this.OPTIONS[option.id];
                         return { ...option, value: src.indexOf(urlParameter) >= 0 };
@@ -136,6 +140,12 @@ export class VideoSelector extends Component {
             }
             return option;
         });
+        await this.updateVideo();
+    }
+
+    async onChangeIsVertical() {
+        this.state.isVertical = !this.state.isVertical;
+        VideoSelector.isVertical = this.state.isVertical;
         await this.updateVideo();
     }
 
@@ -236,11 +246,20 @@ export class VideoSelector extends Component {
         return selectedMedia.map(video => {
             const div = document.createElement('div');
             div.dataset.oeExpression = video.src;
-            div.innerHTML = `
+            div.dataset.isVertical = VideoSelector.isVertical;
+            if (VideoSelector.isVertical) {
+                div.innerHTML = `
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size_for_shorts" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>
+            `;
+            } else {
+                div.innerHTML = `
                 <div class="css_editable_mode_display"></div>
                 <div class="media_iframe_video_size" contenteditable="false"></div>
                 <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen"></iframe>
             `;
+            }
             div.querySelector('iframe').src = video.src;
             return div;
         });

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.xml
@@ -40,6 +40,18 @@
                     label="option.label"
                     description="option.description"/>
             </div>
+            <t t-if="state.platform === 'youtube' and !props.isForBgVideo">
+                <div class="mb-1">
+                    <label class="d-flex align-items-start gap-2 cursor-pointer" t-on-change="this.onChangeIsVertical">
+                        <div class="o_switch flex-shrink-0">
+                            <input type="checkbox" t-att-checked="state.isVertical"/>
+                            <span/>
+                        </div>
+                        <span>Vertical</span>
+                        <span class="text-muted">Turn on for vertical content</span>
+                    </label>
+                </div>
+            </t>
             <t t-if="state.vimeoPreviews.length">
                 <span class="fw-bold">Suggestions</span>
                 <div id="video-suggestion" class="mt-4 d-flex flex-wrap mh-75 overflow-auto">
@@ -55,7 +67,12 @@
             <div class="o_video_preview position-relative border-0 p-3">
                 <div t-if="this.state.src and !this.state.errorMessage" class="o_video_dialog_preview_text mb-2">Preview</div>
                 <div class="media_iframe_video">
-                    <div class="media_iframe_video_size"/>
+                    <t t-if="this.state.isVertical">
+                        <div class="media_iframe_video_size_for_shorts"/>
+                    </t>
+                    <t t-else="">
+                        <div class="media_iframe_video_size"/>
+                    </t>
                     <VideoIframe
                         t-if="this.state.src and !this.state.errorMessage"
                         src="this.state.src"/>

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -331,6 +331,13 @@ div.media_iframe_video {
         height: 0;
     }
 
+    .media_iframe_video_size_for_shorts {
+        padding-bottom: 177.78%;
+        position: relative;
+        width: 100%;
+        height: 0;
+    }
+
     .css_editable_mode_display {
         @include o-position-absolute(0,0,0,0);
         width: 100%;


### PR DESCRIPTION
*=html, web

Specification:
- Introduced a "Vertical" toggle button in the media dialog to switch
between YouTube and YouTube Shorts.

After this commit:
- The media dialog includes a "Vertical" toggle button for switching
video types.
- When the "Vertical" toggle is ON, the YouTube Shorts video selector
is displayed.
- When the "Vertical" toggle is OFF, the regular YouTube video selector
is shown.
- The "Vertical" toggle is hidden when the media dialog is opened for
selecting a background video.
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
