### PR TITLE
[FIX] sale_timesheet: Access Error in My timesheets list view

### DIFF
--- a/addons/sale_timesheet/__init__.py
+++ b/addons/sale_timesheet/__init__.py
@@ -11,6 +11,7 @@ def uninstall_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
 
     env.ref("account.account_analytic_line_rule_billing_user").write({'domain_force': "[(1, '=', 1)]"})
+    env.ref("account.account_analytic_line_rule_readonly_user").write({'domain_force': "[(1, '=', 1)]"})
 
 def _sale_timesheet_post_init(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})

--- a/addons/sale_timesheet/security/sale_timesheet_security.xml
+++ b/addons/sale_timesheet/security/sale_timesheet_security.xml
@@ -8,6 +8,9 @@
             Therefore, we need to override this rule to change the domain, and then the
             rules for the account.analytic.line defined in timesheet will be apply.
          -->
+        <record id="account.account_analytic_line_rule_readonly_user" model="ir.rule">
+            <field name="domain_force">[('project_id', '=', False)]</field>
+        </record>
         <record id="account.account_analytic_line_rule_billing_user" model="ir.rule">
             <field name="domain_force">[('project_id', '=', False)]</field>
         </record>


### PR DESCRIPTION
Steps to reproduce:
  - Access with the demo user
  - Open Timesheet dashboard
  - Switch to list view

Issue: Access error will raise

Since commit https://github.com/odoo/odoo/commit/0258a627addf678d2c9b66bd8ee6752905fbac8f
Readonly account users have now read access to analytic account lines.
However, when sale_timesheet is installed, in the lowest access right it
is possible to see only the own timesheets, so the rule needed to be
limited as it occurs with Billing users.