### PR TITLE
[FIX] core: fix werkzeug OrderedMultiDict deprecation

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1071,7 +1071,7 @@ class HTTPRequest:
     def __init__(self, environ):
         httprequest = werkzeug.wrappers.Request(environ)
         httprequest.user_agent_class = UserAgent  # use vendored userAgent since it will be removed in 2.1
-        httprequest.parameter_storage_class = werkzeug.datastructures.ImmutableOrderedMultiDict
+        httprequest.parameter_storage_class = werkzeug.datastructures.ImmutableMultiDict
         httprequest.max_form_memory_size = 10 * 1024 * 1024  # 10 MB
 
         self.__wrapped = httprequest


### PR DESCRIPTION
ImmutableOrderedMultiDict was deprecated in Werkzeug 3.1.0. As the upcoming Debian Trixie provides Werkzeug 3.1.3 we need to fix that in Odoo supoprted versions.

See:
  - https://packages.debian.org/trixie/python3-werkzeug
  - pallets/werkzeug#2968
  - pallets/werkzeug#2975

A less intrusive way would be to ignore the deprecation warning 🤔 