### PR TITLE
[FIX] web: dialog and file viewer overlapping

### DIFF
--- a/addons/web/static/src/core/file_viewer/file_viewer.xml
+++ b/addons/web/static/src/core/file_viewer/file_viewer.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.FileViewer">
-        <div class="d-flex justify-content-center" t-att-class="{ 'modal fixed-top bottom-0': props.modal }">
+        <div class="d-flex justify-content-center" t-att-class="{ 'modal modal-fullscreen': props.modal }">
             <div class="o-FileViewer flex-column align-items-center d-flex w-100 h-100" tabindex="0" t-ref="autofocus" t-on-keydown.stop="(ev) => this.onKeydown(ev)">
                 <div class="o-FileViewer-header position-absolute top-0 d-flex w-100" t-on-click.stop="">
                     <div t-if="isViewable" class="d-flex align-items-center ms-4 me-2">


### PR DESCRIPTION
This commit fixes the overlapping between the dialog and file viewer due to a combination of the z-index value set by the .modal class and the .fixed-top utility class.

Steps to reproduce:
- Open Marketing Card app
- Open the form view for one of the campaign
- Click "Send" button
- A dialog opens and display the preview of the mail to send
- Double-click an image in the Mail Body tab (or add one first, if none are present) => the file viewer appears behind the dialog and is not usable.

task-4387904
