### PR TITLE
[IMP] hw_drivers: auto checkout on monday as Odoo

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -113,6 +113,7 @@ class Manager(Thread):
         # Set scheduled actions
         schedule and schedule.every().day.at("00:00").do(helpers.get_certificate_status)
         schedule and schedule.every().day.at("00:00").do(helpers.reset_log_level)
+        schedule and platform.system() == 'Linux' and schedule.every().monday.at("00:00").do(helpers.check_git_branch, force_checkout=True)
 
         # Set up the websocket connection
         ws_client = WebsocketClient(self.ws_channel)

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -182,10 +182,11 @@ def check_certificate():
 
 @toggleable
 @require_db
-def check_git_branch(server_url=None):
+def check_git_branch(force_checkout=False, server_url=None):
     """Check if the local branch is the same as the connected Odoo DB and
     checkout to match it if needed.
 
+    :param force_checkout: Force the checkout to the db branch even if it's the same as the local one.
     :param server_url: The URL of the connected Odoo database (provided by decorator).
     """
     try:
@@ -215,7 +216,7 @@ def check_git_branch(server_url=None):
             db_branch,
         )
 
-        if db_branch != local_branch:
+        if db_branch != local_branch or force_checkout:
             try:
                 with writable():
                     subprocess.run(git + ['branch', '-m', db_branch], check=True)

--- a/addons/iot_box_image/overwrite_after_init/etc/rc.local
+++ b/addons/iot_box_image/overwrite_after_init/etc/rc.local
@@ -26,4 +26,10 @@ if [ -f $start_wifi ]; then
   $start_wifi &
 fi
 
+update_odoo=/home/pi/odoo/addons/iot_box_image/configuration/checkout.sh
+if [ -f $update_odoo ]; then
+  printf "Updating Odoo service...\n"
+  $update_odoo &
+fi
+
 exit 0


### PR DESCRIPTION
Currently, the Odoo code on the IoT Box is almost only updated when the client upgrades his db.

The only way for us to provide new code to the user if he doesn't change his db version, is to release a new image (users can also update manually from the IoT Box homepage, but it nearly never happens).

IoT Boxes will now checkout on every Monday, allowing us to deploy updates more regularly. Additionally, it will checkout on every boot to allow hot fixing, as clients will only have to reboot their IoT Box if we fix an issue in the middle of a week.

Task: 4306247

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
