### PR TITLE
[FIX] purchase_stock: prevent error on confirming sale order

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -78,7 +78,7 @@ class StockRule(models.Model):
                 errors.append((procurement, msg))
             elif not supplier:
                 # If the supplier is not set, we cannot create a PO.
-                moves = procurement.values.get('move_dest_ids', self.env['stock.move'])
+                moves = procurement.values.get('move_dest_ids') or self.env['stock.move']
                 if moves.propagate_cancel:
                     moves._action_cancel()
                 moves.procure_method = 'make_to_stock'

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -270,7 +270,7 @@ class TestSalePurchaseStockFlow(TransactionCase):
             {'product_id': self.mto_product.id, 'product_uom_qty': 1.0},
         ])
 
-def test_two_step_delivery_forecast_after_first_picking(self):
+    def test_two_step_delivery_forecast_after_first_picking(self):
         """ When a product is moved with 2-step delivery, the first of the two pickings associated
         with that delivery (upon completion) should have the actual physical location to which the
         product was delivered as its destination in `report.stock.quantity`: prior, irrespective of
@@ -306,14 +306,14 @@ def test_two_step_delivery_forecast_after_first_picking(self):
         pick_picking.move_ids.quantity = 2
         pick_picking.button_validate()
 
-        forecasted_qty = self.env['report.stock.quantity'].with_context(fill_temporal=False).read_group(
+        forecasted_qty = self.env['report.stock.quantity'].with_context(fill_temporal=False)._read_group(
             domain=[
                 ('state', '=', 'forecast'),
                 ('warehouse_id', '=', wh.id),
                 ('product_tmpl_id', '=', product.product_tmpl_id.id),
                 ('date', '=', fields.Date.today() - timedelta(days=20)),
             ],
-            fields=['__count', 'product_qty:sum'],
+            aggregates=['product_qty:sum'],
             groupby=['date:day', 'product_id'],
         )
-        self.assertEqual(forecasted_qty[0]['product_qty'], 0)
+        self.assertEqual(forecasted_qty[0][2], 0)


### PR DESCRIPTION
This error occurs when attempting to confirm the SO.

Steps to reproduce:
---
- Install the `purchase_stock` and `sale_management` modules
- Enable `Multi-Step Routes` in Configuration
- Go to routes and unarchive `Replenish on Order (MTO)` > Open rule and change `Supply Method`(`Take From Stock, if unavailable, Trigger Another Rule`)
- Create new Product(eg: Test) and in Inventory set Routes (Replenish on Order (MTO) and Buy)
- Create new SO with product created(Test) and `Confirm`

Traceback:
---
``AttributeError: 'bool' object has no attribute 'propagate_cancel'``

At [1], this error occurs because the value of `move_dest_ids` in `procurement.values` is set to `False`. This happens because when calling `_action_confirm`, the method `_prepare_procurement_values` is triggered, and within this method, at [2], `move_dest_ids` is explicitly assigned as `False`.

[1]- https://github.com/odoo/odoo/blob/571161f0b28e85521c519f57c28ce1c19a4b4a33/addons/purchase_stock/models/stock_rule.py#L81-L83

[2]- https://github.com/odoo/odoo/blob/571161f0b28e85521c519f57c28ce1c19a4b4a33/addons/stock/models/stock_move.py#L1567-L1569

This commit resolves the error by returning a default value if the key does not exist. In this case, the default value is an empty recordset of the `stock.move` model.

sentry-6451186204

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
