### PR TITLE
[FIX] point_of_sale: ensure instant reflection of product edits from frontend

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1788,6 +1788,9 @@ export class PosStore extends WithLazyGetterTrap {
                     resId: product?.id,
                     onSave: (record) => {
                         this.data.read("product.template", [record.evalContext.id]);
+                        this.data.searchRead("product.product", [
+                            ["product_tmpl_id", "=", record.evalContext.id],
+                        ]);
                         this.action.doAction({
                             type: "ir.actions.act_window_close",
                         });

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -595,3 +595,56 @@ registry.category("web_tour.tours").add("AddMultipleSerialsAtOnce", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_product_create_update_from_frontend", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Chrome.clickMenuOption("Create Product"),
+
+            // Verify that the "New Product" dialog is displayed.
+            Dialog.is({ title: "New Product" }),
+
+            // Create a new product from frontend.
+            ProductScreen.createProductFromFrontend(
+                "Test Frontend Product",
+                "710535977349",
+                "20.0",
+                "Chairs"
+            ),
+            Dialog.confirm(),
+
+            // Click on the category button for "Chairs" to verify the product's addition.
+            ProductScreen.clickSubcategory("Chairs"),
+            ProductScreen.clickDisplayedProduct("Test Frontend Product"),
+            inLeftSide([
+                ...ProductScreen.selectedOrderlineHasDirect("Test Frontend Product", "1", "20.0"),
+            ]),
+
+            // Open the product's information popup.
+            ProductScreen.clickInfoProduct("Test Frontend Product"),
+            Dialog.confirm("Edit", ".btn-secondary"),
+
+            // Verify that the "Edit Product" dialog is displayed.
+            Dialog.is({ title: "Edit Product" }),
+
+            // Edit the product with new details.
+            ProductScreen.editProductFromFrontend(
+                "Test Frontend Product Edited",
+                "710535977348",
+                "50.0"
+            ),
+            Dialog.confirm(),
+            ProductScreen.clickSubcategory("Chairs"),
+            ProductScreen.clickDisplayedProduct("Test Frontend Product Edited"),
+            inLeftSide([
+                ...ProductScreen.selectedOrderlineHasDirect(
+                    "Test Frontend Product Edited",
+                    "1",
+                    "50.0"
+                ),
+            ]),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -773,3 +773,55 @@ export function setTimeZone(testTimeZone) {
         },
     };
 }
+
+function productInputSteps(name, barcode, list_price) {
+    return [
+        {
+            content: "Enter product name.",
+            trigger: 'div[name="name"] input',
+            run: `edit ${name}`,
+        },
+        {
+            content: "Enter barcode to fetch product data using barcodelookup.",
+            trigger: 'div[name="barcode"] input',
+            run: `edit ${barcode}`,
+        },
+        {
+            content: "Enter list_price.",
+            trigger: 'div[name="list_price"] input',
+            run: `edit ${list_price}`,
+        },
+    ];
+}
+
+export function createProductFromFrontend(name, barcode, list_price, category) {
+    return [
+        ...productInputSteps(name, barcode, list_price),
+        {
+            content: "Remove default tax 15%.",
+            trigger: 'div[name="taxes_id"] .o_delete',
+            run: "click",
+        },
+        {
+            content: "Open category selector.",
+            trigger: 'div[name="pos_categ_ids"] input',
+            run: "click",
+        },
+        {
+            isActive: ["desktop"],
+            content: "Select category.",
+            trigger: `.o_input_dropdown .o-autocomplete--dropdown-menu li:contains(${category})`,
+            run: "click",
+        },
+        {
+            isActive: ["mobile"],
+            content: "Select category.",
+            trigger: `.o_kanban_renderer .o_kanban_record span:contains(${category})`,
+            run: "click",
+        },
+    ];
+}
+
+export function editProductFromFrontend(name, barcode, list_price) {
+    return productInputSteps(name, barcode, list_price);
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1828,6 +1828,28 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_zero_decimal_places_currency', login="pos_user")
 
+    def test_product_create_update_from_frontend(self):
+        ''' This test verifies product creation and updates product details from the POS frontend. '''
+        self.pos_admin.write({
+            'groups_id': [Command.link(self.env.ref('base.group_system').id)],
+        })
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour('/pos/ui?config_id=%d' % self.main_pos_config.id, 'test_product_create_update_from_frontend', login='pos_admin')
+
+        # In the frontend, a product was created during the tour with the following details:
+        # - Product name: Test Frontend Product
+        # - Barcode: 710535977349
+        # - List price: 20.0
+
+        #  Ensure that the original product created in the frontend ('Test Frontend Product') has been edited to ('Test Frontend Product Edited').
+        frontend_created_product = self.env['product.product'].search_count([('name', '=', 'Test Frontend Product')])
+        frontend_created_product_edited = self.env['product.product'].search([('name', '=', 'Test Frontend Product Edited')])
+
+        self.assertEqual(frontend_created_product, 0)
+        self.assertEqual(frontend_created_product_edited.name, 'Test Frontend Product Edited')
+        self.assertEqual(frontend_created_product_edited.barcode, '710535977348')
+        self.assertEqual(frontend_created_product_edited.list_price, 50.0)
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Before this commit:
====================
Product price edits from the POS frontend were not immediately reflected on the product screen.

After this commit:
====================
Product edits now instantly update and reflect on the product screen.

Task-4431596
