### PR TITLE
[FIX] account: dashboard to_check wrongly displayed

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -518,18 +518,9 @@ class account_journal(models.Model):
             for journal in sale_journals:
                 late_query_results[journal.id] = late_bills_query_results[journal.id]
 
-        to_check_vals = {
-            journal.id: (amount_total_signed_sum, count)
-            for journal, amount_total_signed_sum, count in self.env['account.move']._read_group(
-                domain=[
-                    *self.env['account.move']._check_company_domain(self.env.companies),
-                    ('journal_id', 'in', sale_purchase_journals.ids),
-                    ('to_check', '=', True),
-                ],
-                groupby=['journal_id'],
-                aggregates=['amount_total_signed:sum', '__count'],
-            )
-        }
+        query, params = sale_purchase_journals._get_to_check_payment_query().select(*bills_field_list)
+        self.env.cr.execute(query, params)
+        to_check_vals = group_by_journal(self.env.cr.dictfetchall())
 
         self.env.cr.execute(SQL("""
             SELECT id, moves_exists
@@ -554,10 +545,10 @@ class account_journal(models.Model):
             (number_waiting, sum_waiting) = self._count_results_and_sum_amounts(query_results_to_pay[journal.id], currency)
             (number_draft, sum_draft) = self._count_results_and_sum_amounts(query_results_drafts[journal.id], currency)
             (number_late, sum_late) = self._count_results_and_sum_amounts(late_query_results[journal.id], currency)
-            amount_total_signed_sum, count = to_check_vals.get(journal.id, (0, 0))
+            (number_to_check, sum_to_check) = self._count_results_and_sum_amounts(to_check_vals[journal.id], currency)
             dashboard_data[journal.id].update({
-                'number_to_check': count,
-                'to_check_balance': currency.format(amount_total_signed_sum),
+                'number_to_check': number_to_check,
+                'to_check_balance': currency.format(sum_to_check),
                 'title': _('Bills to pay') if journal.type == 'purchase' else _('Invoices owed to you'),
                 'number_draft': number_draft,
                 'number_waiting': number_waiting,
@@ -645,6 +636,14 @@ class account_journal(models.Model):
             ('amount_residual', '<', 0),
             ('parent_state', '=', 'posted'),
             ('journal_id.type', '=', 'purchase'),
+        ])
+
+    def _get_to_check_payment_query(self):
+        # todo in master: use this hook function in _fill_general_dashboard_data as it's the same domain
+        return self.env['account.move']._where_calc([
+            *self.env['account.move']._check_company_domain(self.env.companies),
+            ('journal_id', 'in', self.ids),
+            ('to_check', '=', True),
         ])
 
     def _count_results_and_sum_amounts(self, results_dict, target_currency):

--- a/addons/account/tests/test_account_journal_dashboard.py
+++ b/addons/account/tests/test_account_journal_dashboard.py
@@ -361,3 +361,49 @@ class TestAccountJournalDashboard(TestAccountJournalDashboardCommon):
 
         self.assertEqual(dashboard_data.get('misc_operations_balance', 0), None)
         self.assertEqual(dashboard_data.get('misc_class', ''), 'text-warning')
+
+    def test_to_check_amount_different_currency(self):
+        """
+        We want the to_check amount to be displayed in the journal currency
+        Company currency = $
+        Journal's currency = €
+        Inv01 of 100 EUR; rate: 2€/1$
+        Inv02 of 100 CHF; rate: 4CHF/1$
+
+        => to check = 150 €
+        """
+        self.env['res.currency.rate'].create({
+            'currency_id': self.env.ref('base.EUR').id,
+            'name': '2024-12-01',
+            'rate': 2.0,
+        })
+        self.env['res.currency.rate'].create({
+            'currency_id': self.env.ref('base.CHF').id,
+            'name': '2024-12-01',
+            'rate': 4.0,
+        })
+        journal = self.env['account.journal'].create({
+            'name': 'Test Foreign Currency Journal',
+            'type': 'sale',
+            'code': 'TEST',
+            'currency_id': self.env.ref('base.EUR').id,
+            'company_id': self.env.company.id,
+        })
+        self.env['account.move'].create([{
+            'move_type': 'out_invoice',
+            'journal_id': journal.id,
+            'partner_id': self.partner_a.id,
+            'currency_id': currency.id,
+            'to_check': True,
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'tax_ids': [],
+                })
+            ]
+        } for currency in (self.env.ref('base.EUR'), self.env.ref('base.CHF'))])
+
+        dashboard_data = journal._get_journal_dashboard_data_batched()[journal.id]
+        self.assertEqual(dashboard_data['to_check_balance'], journal.currency_id.format(150))


### PR DESCRIPTION
Steps to reproduce:
- create a new journal with foreign currency
- create an invoice (amount:100)  with this journal and set it "to check"
- Go to dashboard

Issue:
check balance is in company currency amount but the symbol is the one from the currency of the journal

Solution:
Chkl: <strike>Misc and Sales/Purchase Journals should display all amounts in company currency</strike>
Eventually, we decided that it would be better for the stable versions to keep the currency displayed as the one from the journals.
We therefore use the same logic as for the bill/invoices

opw-4349684