### PR TITLE
[FIX] html_editor: prevent portal users from editing banners

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -76,6 +76,7 @@ export class BannerPlugin extends Plugin {
         ],
         power_buttons_visibility_predicates: ({ anchorNode }) =>
             !closestElement(anchorNode, ".o_editor_banner"),
+        clean_for_save_handlers: this.cleanForSave.bind(this),
     };
 
     setup() {
@@ -127,5 +128,11 @@ export class BannerPlugin extends Plugin {
 
     normalize(root) {
         this.dependencies.sanitize.restoreSanitizedContentEditable(root);
+    }
+
+    cleanForSave({ root }) {
+        root.querySelectorAll(".o_editor_banner [contenteditable='true']").forEach((el) => {
+            el.removeAttribute("contenteditable");
+        });
     }
 }

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -34,6 +34,7 @@ export class FilePlugin extends Plugin {
             },
         }),
         selectors_for_feff_providers: () => ".o_file_box",
+        clean_for_save_handlers: this.cleanForSave.bind(this),
     };
 
     get recordInfo() {
@@ -77,5 +78,11 @@ export class FilePlugin extends Plugin {
         });
         const { name: filename, mimetype } = attachment;
         return renderStaticFileBox(filename, mimetype, url);
+    }
+
+    cleanForSave({ root }) {
+        root.querySelectorAll(".o_file_box [contenteditable='true']").forEach((el) => {
+            el.removeAttribute("contenteditable");
+        });
     }
 }

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -2193,3 +2193,35 @@ describe("translatable", () => {
         expect(".o_field_html .btn.o_field_translate").not.toBeVisible();
     });
 });
+
+test('should remove `contenteditable="true"` from banner on save', async () => {
+    onRpc("partner", "web_save", ({ args }) => {
+        expect.step("web_save");
+        expect(args[1].txt).toBe(
+            `<div contenteditable="false" class="o_editor_banner"><a href="#">link</a></div><div><br></div>`
+        );
+    });
+    Partner._records = [
+        {
+            id: 1,
+            txt: ``,
+        },
+    ];
+    await mountView({
+        type: "form",
+        resId: 1,
+        resIds: [1, 2],
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+
+    pasteOdooEditorHtml(
+        htmlEditor,
+        `<div class="o_editor_banner" contenteditable="false"><a href="#" contenteditable="true">link</a></div>`
+    );
+    await clickSave();
+    expect.verifySteps(["web_save"]);
+});


### PR DESCRIPTION
**Problem**:
Banners and file boxes contain elements with `contenteditable=true`. Once saved, portal users can edit them even when the editor is disabled.

**Solution**:
Remove `contenteditable=true` from elements inside banners and file boxes.

**Steps to reproduce**:
1. Navigate to **Sales > Product**.
2. Open any product.
3. In the **Sales** tab, add a **banner** to "Ecommerce Description".
4. Save and click **Go to Website**.
   - **Issue**: The banner remains editable, even when the editor is disabled.

**opw-4597744**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
