### PR TITLE
[REV] stock: no modify state in move create

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -663,10 +663,6 @@ Please change the quantity done or the rounding precision of your unit of measur
                 picking = self.env['stock.picking'].browse(vals['picking_id'])
                 if picking.group_id:
                     vals['group_id'] = picking.group_id.id
-            if vals.get('picking_id') and vals.get('state'):
-                picking = self.env['stock.picking'].browse(vals['picking_id'])
-                if picking.state == 'done' and vals['state'] != 'done':
-                    vals['state'] = 'done'
         res = super().create(vals_list)
         res._update_orderpoints()
         return res

--- a/addons/stock/tests/test_robustness.py
+++ b/addons/stock/tests/test_robustness.py
@@ -10,7 +10,6 @@ class TestRobustness(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestRobustness, cls).setUpClass()
-        cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')
         cls.stock_location = cls.env.ref('stock.stock_location_stock')
         cls.customer_location = cls.env.ref('stock.stock_location_customers')
         cls.uom_unit = cls.env.ref('uom.product_uom_unit')
@@ -314,49 +313,3 @@ class TestRobustness(TransactionCase):
         self.assertEqual(move.reserved_availability, 0)
         self.assertEqual(move.state, 'confirmed')
         self.assertEqual(quant.reserved_quantity, 0)
-
-    def test_new_move_done_picking(self):
-        """ Ensure that adding a Draft move to a Done picking doesn't change the picking state
-        """
-        categ_id = self.env.ref('product.product_category_all').id
-        product1 = self.env['product.product'].create({'name': 'P1', 'type': 'product', 'categ_id': categ_id})
-        product2 = self.env['product.product'].create({'name': 'P2', 'type': 'product', 'categ_id': categ_id})
-
-        receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location.id,
-            'location_dest_id': self.stock_location.id,
-            'picking_type_id': self.env.ref('stock.picking_type_in').id,
-        })
-        move1 = self.env['stock.move'].create({
-            'name': 'P1',
-            'location_id': receipt.location_id.id,
-            'location_dest_id': receipt.location_dest_id.id,
-            'picking_id': receipt.id,
-            'product_id': product1.id,
-            'product_uom': self.uom_unit.id,
-            'product_uom_qty': 1.0,
-        })
-        receipt.action_confirm()
-        receipt.action_assign()
-        move1.move_line_ids.qty_done = 1
-
-        receipt.button_validate()
-
-        self.assertEqual(receipt.state, 'done')
-        self.assertEqual(move1.state, 'done')
-
-        move2 = self.env['stock.move'].create({
-            'name': 'P2',
-            'location_id': receipt.location_id.id,
-            'location_dest_id': receipt.location_dest_id.id,
-            'picking_id': receipt.id,
-            'state': 'draft',
-            'product_id': product2.id,
-            'product_uom': self.uom_unit.id,
-            'product_uom_qty': 1.0,
-            'quantity_done': 1.0,
-        })
-
-        self.assertEqual(receipt.state, 'done')
-        self.assertEqual(move1.state, 'done')
-        self.assertEqual(move2.state, 'done')

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -4338,3 +4338,35 @@ class TestStockValuation(TransactionCase):
 
         self.assertEqual(move.quantity_done, 24)
         self.assertRecordValues(move.stock_valuation_layer_ids, [{'quantity': 12}, {'quantity': 12}])
+
+    def test_scrap_reception_valuation(self):
+        product = self.product1
+        product.categ_id.property_cost_method = 'fifo'
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.ref('stock.picking_type_in'),
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'move_ids': [Command.create({
+                'name': f'in {product.name}',
+                'product_id': product.id,
+                'product_uom_qty': 10,
+                'quantity_done': 10,
+                'price_unit': 15,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
+            })],
+        })
+        receipt.button_validate()
+        scrap_form = Form(self.env['stock.scrap'].with_context(default_picking_id=receipt.id))
+        scrap_form.product_id = product
+        scrap_form.scrap_qty = 2
+        scrap = scrap_form.save()
+        scrap.action_validate()
+        svls = product.stock_valuation_layer_ids
+        self.assertRecordValues(
+            svls,
+            [
+                {'quantity': 10.0, 'remaining_qty': 8.0, 'value': 150.0, 'remaining_value': 120.0},
+                {'quantity': -2.0, 'remaining_qty': 0.0, 'value': -30.0, 'remaining_value': 0.0},
+            ]
+        )


### PR DESCRIPTION
Commit f494e9d addressed an issue with an edge case of move/picking state conflicts.

But in v16 this has the adverse effect of breaking valuation for scrap actions by generating additional corrective SVLs during the confirmation of a stock scrap.

We should revert the change for v16, as the original use-case is very non-critical and the more changes made in this version, the higher chances of inadvertently breaking other things.

opw-4574728