### PR TITLE
[IMP] im_livechat: introduce member history

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -33,6 +33,7 @@ Help your customers with this chat, and analyse their feedback.
         "views/im_livechat_channel_templates.xml",
         "views/im_livechat_chatbot_templates.xml",
         "views/im_livechat_expertise_views.xml",
+        "views/im_livechat_channel_member_history_views.xml",
         "views/res_users_views.xml",
         "views/digest_views.xml",
         "views/webclient_templates.xml",

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -154,6 +154,7 @@ class LivechatController(http.Controller):
                     guest_name=self._get_guest_name(),
                     country_code=request.geoip.country_code,
                     timezone=request.env['mail.guest']._get_timezone_from_request(request),
+                    create_member_params={"livechat_member_type": "visitor"},
                     post_joined_message=False
                 )
             channel = channel.with_context(guest=guest)  # a new guest was possibly created

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
@@ -13,6 +13,7 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_1"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_1_guest" model="mail.guest">
             <field name="name">Visitor #234</field>
@@ -20,6 +21,7 @@
         <record id="im_livechat.livechat_channel_session_1_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_1_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_1"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_1_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
@@ -15,6 +15,7 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_10"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_10_guest" model="mail.guest">
             <field name="name">Visitor</field>
@@ -22,6 +23,7 @@
         <record id="im_livechat.livechat_channel_session_10_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_10_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_10"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_10_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
@@ -13,6 +13,7 @@
         <record id="im_livechat.livechat_channel_session_11_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_11"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_11_guest" model="mail.guest">
             <field name="name">Visitor</field>
@@ -20,6 +21,7 @@
         <record id="im_livechat.livechat_channel_session_11_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_11_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_11"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_11_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
@@ -13,6 +13,7 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_2"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_2_guest" model="mail.guest">
             <field name="name">Visitor #323</field>
@@ -20,6 +21,7 @@
         <record id="im_livechat.livechat_channel_session_2_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_2_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_2"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_2_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
@@ -13,10 +13,12 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_3"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_3_member_portal" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo_portal"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_3"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_3_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
@@ -13,10 +13,12 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_4"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_4_member_portal" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo_portal"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_4"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_4_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -13,6 +13,7 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_5"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_5_guest" model="mail.guest">
             <field name="name">Visitor #532</field>
@@ -20,6 +21,7 @@
         <record id="im_livechat.livechat_channel_session_5_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_5_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_5"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_5_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -13,6 +13,7 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_6"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_6_guest" model="mail.guest">
             <field name="name">Visitor #649</field>
@@ -20,6 +21,7 @@
         <record id="im_livechat.livechat_channel_session_6_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_6_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_6"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_6_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
@@ -13,10 +13,12 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_7"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_7_member_portal" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo_portal"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_7"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_7_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -13,6 +13,7 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_8"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_8_guest" model="mail.guest">
             <field name="name">Visitor #722</field>
@@ -20,6 +21,7 @@
         <record id="im_livechat.livechat_channel_session_8_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_8_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_8"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_8_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
@@ -14,6 +14,7 @@
             <field name="channel_id" ref="im_livechat.livechat_channel_session_9"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_9_guest" model="mail.guest">
             <field name="name">Visitor</field>
@@ -21,6 +22,7 @@
         <record id="im_livechat.livechat_channel_session_9_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_9_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_9"/>
+            <field name="livechat_member_type">visitor</field>
         </record>
 
         <record id="livechat_channel_session_9_message_1" model="mail.message">

--- a/addons/im_livechat/models/__init__.py
+++ b/addons/im_livechat/models/__init__.py
@@ -10,6 +10,7 @@ from . import im_livechat_channel
 from . import im_livechat_expertise
 from . import discuss_channel
 from . import discuss_channel_member
+from . import im_livechat_channel_member_history
 from . import mail_message
 from . import res_users_settings
 from . import rating_rating

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -378,12 +378,14 @@ class ChatbotScriptStep(models.Model):
                 posted_message = discuss_channel._chatbot_post_message(self.chatbot_script_id, plaintext2html(self.message))
 
             # next, add the human_operator to the channel and post a "Operator joined the channel" notification
-            discuss_channel.with_user(human_operator).sudo()._add_members(users=human_operator)
+            discuss_channel.with_user(human_operator).sudo()._add_members(
+                users=human_operator, create_member_params={"livechat_member_type": "agent"}
+            )
             # sudo - discuss.channel: let the chat bot proceed to the forward step (change channel operator, add human operator
             # as member, remove bot from channel, rename channel and finally broadcast the channel to the new operator).
             channel_sudo = discuss_channel.sudo()
             if bot_member := channel_sudo.channel_member_ids.filtered(
-                lambda m: m.partner_id == self.chatbot_script_id.operator_partner_id
+                lambda m: m.livechat_member_type == "bot"
             ):
                 channel_sudo._action_unfollow(partner=bot_member.partner_id, post_leave_message=False)
             # finally, rename the channel to include the operator's name

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -22,6 +22,7 @@ class DiscussChannel(models.Model):
     livechat_active = fields.Boolean('Is livechat ongoing?', help='Livechat session is active until visitor or operator leaves the conversation.')
     livechat_channel_id = fields.Many2one('im_livechat.channel', 'Channel', index='btree_not_null')
     livechat_operator_id = fields.Many2one('res.partner', string='Operator', index='btree_not_null')
+    channel_member_history_ids = fields.One2many('im_livechat.channel.member.history', 'channel_id')
     chatbot_current_step_id = fields.Many2one('chatbot.script.step', string='Chatbot Current Step')
     chatbot_message_ids = fields.One2many('chatbot.message', 'discuss_channel_id', string='Chatbot Messages')
     country_id = fields.Many2one('res.country', string="Country", help="Country of the visitor of the channel")
@@ -299,6 +300,9 @@ class DiscussChannel(models.Model):
             chatbot_script,
             Markup('<div class="o_mail_notification">%s</div>') % _('Restarting conversation...'),
         )
+
+    def _get_allowed_channel_member_create_params(self):
+        return super()._get_allowed_channel_member_create_params() + ["livechat_member_type"]
 
     def _types_allowing_seen_infos(self):
         return super()._types_allowing_seen_infos() + ["livechat"]

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -223,13 +223,19 @@ class Im_LivechatChannel(models.Model):
         # partner to add to the discuss.channel
         operator_partner_id = user_operator.partner_id.id if user_operator else chatbot_script.operator_partner_id.id
         members_to_add = [
-            Command.create({"partner_id": operator_partner_id, "unpin_dt": fields.Datetime.now()})
+            Command.create(
+                {
+                    "livechat_member_type": "agent" if user_operator else "bot",
+                    "partner_id": operator_partner_id,
+                    "unpin_dt": fields.Datetime.now(),
+                }
+            )
         ]
         visitor_user = False
         if user_id:
             visitor_user = self.env['res.users'].browse(user_id)
             if visitor_user and visitor_user.active and user_operator and visitor_user != user_operator:  # valid session user (not public)
-                members_to_add.append(Command.create({'partner_id': visitor_user.partner_id.id}))
+                members_to_add.append(Command.create({"livechat_member_type": "visitor", 'partner_id': visitor_user.partner_id.id}))
 
         if chatbot_script:
             name = chatbot_script.title

--- a/addons/im_livechat/models/im_livechat_channel_member_history.py
+++ b/addons/im_livechat/models/im_livechat_channel_member_history.py
@@ -1,0 +1,55 @@
+from odoo import api, models, fields
+from odoo.exceptions import ValidationError
+
+
+class ImLivechatChannelMemberHistory(models.Model):
+    _name = "im_livechat.channel.member.history"
+    _description = "Keep the channel member history"
+
+    member_id = fields.Many2one("discuss.channel.member", index="btree_not_null")
+    livechat_member_type = fields.Selection(
+        [("agent", "Agent"), ("visitor", "Visitor"), ("bot", "Chatbot")],
+        compute="_compute_member_fields",
+        store=True,
+    )
+    channel_id = fields.Many2one(
+        "discuss.channel",
+        compute="_compute_member_fields",
+        index=True,
+        ondelete="cascade",
+        store=True,
+    )
+    guest_id = fields.Many2one(
+        "mail.guest", compute="_compute_member_fields", index="btree_not_null", store=True
+    )
+    partner_id = fields.Many2one(
+        "res.partner", compute="_compute_member_fields", index="btree_not_null", store=True
+    )
+
+    _member_id_unique = models.Constraint(
+        "UNIQUE(member_id)", "Members can only be linked to one history"
+    )
+
+    @api.constrains("channel_id")
+    def _constraint_channel_id(self):
+        # sudo: im_livechat.channel.member.history - skipping ACL for
+        # constraint, more performant and no sensitive information is leaked.
+        if failing_histories := self.sudo().filtered(
+            lambda h: h.channel_id.channel_type != "livechat"
+        ):
+            raise ValidationError(
+                self.env._(
+                    "Cannot create history as it is only available for live chats: %(histories)s.",
+                    histories=failing_histories.member_id.mapped("display_name")
+                )
+            )
+
+    @api.depends("member_id")
+    def _compute_member_fields(self):
+        for history in self:
+            history.channel_id = history.channel_id or history.member_id.channel_id
+            history.guest_id = history.guest_id or history.member_id.guest_id
+            history.partner_id = history.partner_id or history.member_id.partner_id
+            history.livechat_member_type = (
+                history.livechat_member_type or history.member_id.livechat_member_type
+            )

--- a/addons/im_livechat/security/ir.model.access.csv
+++ b/addons/im_livechat/security/ir.model.access.csv
@@ -18,3 +18,4 @@ access_chatbot_script_step_user,chatbot.script.step.user,model_chatbot_script_st
 access_chatbot_script_answer,chatbot.script.answer,model_chatbot_script_answer,,0,0,0,0
 access_chatbot_script_answer_user,chatbot.script.answer.user,model_chatbot_script_answer,im_livechat_group_manager,1,1,1,1
 access_chatbot_message_user,chatbot.script.user,model_chatbot_message,im_livechat_group_manager,1,1,1,1
+access_im_livechat_channel_member_history_user,im_livechat.channel.member.history,model_im_livechat_channel_member_history,im_livechat_group_user,1,0,0,0

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -13,6 +13,7 @@ from . import test_im_livechat_channel
 from . import test_im_livechat_report
 from . import test_im_livechat_support_page
 from . import test_js
+from . import test_member_history
 from . import test_message
 from . import test_upload_attachment
 from . import test_res_users

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -447,6 +447,12 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             )
         self.assertEqual(discuss_channel.name, "OdooBot Ernest Employee")
         self.assertEqual(discuss_channel.livechat_operator_id, self.partner_employee)
+        self.assertTrue(
+            discuss_channel.channel_member_ids.filtered(
+                lambda m: m.partner_id == self.partner_employee
+                and m.livechat_member_type == "agent"
+            )
+        )
 
     def test_chatbot_multiple_rules_on_same_url(self):
         bob_user = new_test_user(

--- a/addons/im_livechat/tests/test_member_history.py
+++ b/addons/im_livechat/tests/test_member_history.py
@@ -1,0 +1,132 @@
+from odoo.addons.im_livechat.tests import chatbot_common
+from odoo.exceptions import ValidationError
+from odoo.tests.common import tagged, new_test_user
+from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
+
+
+@tagged("post_install", "-at_install")
+class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCase):
+    def test_get_session_create_history(self):
+        john = self._create_operator("fr_FR")
+        bob = self._create_operator("fr_FR")
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {
+                "name": "Livechat Channel",
+                "user_ids": [bob.id],
+            },
+        )
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Visitor",
+                "channel_id": livechat_channel.id,
+            },
+        )
+        channel = self.env["discuss.channel"].browse(data["channel_id"])
+        self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 2)
+        self.assertEqual(
+            channel.channel_member_ids.livechat_member_history_ids.filtered(
+                lambda m: m.partner_id == bob.partner_id
+            ).livechat_member_type,
+            "agent",
+        )
+        self.assertEqual(
+            channel.channel_member_ids.livechat_member_history_ids.filtered(
+                lambda m: m.partner_id != bob.partner_id
+            ).livechat_member_type,
+            "visitor",
+        )
+        channel.add_members(partner_ids=john.partner_id.ids)
+        self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 3)
+        self.assertEqual(
+            channel.channel_member_ids.livechat_member_history_ids.filtered(
+                lambda m: m.partner_id == john.partner_id
+            ).livechat_member_type,
+            "agent",
+        )
+
+    def test_get_session_create_history_with_bot(self):
+        john = self._create_operator("fr_FR")
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Test Visitor",
+                "chatbot_script_id": self.chatbot_script.id,
+                "channel_id": self.livechat_channel.id,
+            },
+        )
+        channel = self.env["discuss.channel"].browse(data["channel_id"])
+        self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 2)
+        self.assertEqual(
+            channel.channel_member_ids.livechat_member_history_ids.filtered(
+                lambda m: m.partner_id == self.chatbot_script.operator_partner_id
+            ).livechat_member_type,
+            "bot",
+        )
+        self.assertEqual(
+            channel.channel_member_ids.livechat_member_history_ids.filtered(
+                lambda m: m.partner_id != self.chatbot_script.operator_partner_id
+            ).livechat_member_type,
+            "visitor",
+        )
+        channel.add_members(partner_ids=john.partner_id.ids)
+        self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 3)
+        self.assertEqual(
+            channel.channel_member_ids.livechat_member_history_ids.filtered(
+                lambda m: m.partner_id == john.partner_id
+            ).livechat_member_type,
+            "agent",
+        )
+
+    def test_marked_as_visitor_when_joining_after_log_in(self):
+        self.authenticate(None, None)
+        john = self._create_operator("fr_FR")
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {
+                "name": "Livechat Channel",
+                "user_ids": [john.id],
+            },
+        )
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Visitor",
+                "channel_id": livechat_channel.id,
+            },
+        )
+        channel = self.env["discuss.channel"].browse(data["channel_id"])
+        self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 2)
+        self.assertEqual(
+            channel.channel_member_ids.livechat_member_history_ids.filtered(
+                lambda m: m.partner_id == john.partner_id,
+            ).livechat_member_type,
+            "agent",
+        )
+        guest_visitor_history = channel.channel_member_ids.livechat_member_history_ids.filtered(
+            lambda m: m.guest_id
+        )
+        self.assertEqual(guest_visitor_history.livechat_member_type, "visitor")
+        visitor_user = new_test_user(
+            self.env, login="visitor_user", groups="im_livechat.im_livechat_group_manager"
+        )
+        self.authenticate("visitor_user", "visitor_user")
+        data = self.make_jsonrpc_request(
+            "/discuss/channel/notify_typing",
+            {"channel_id": channel.id, "is_typing": True},
+            cookies={
+                guest_visitor_history.guest_id._cookie_name: guest_visitor_history.guest_id._format_auth_cookie()
+            },
+        )
+        self.assertEqual(
+            channel.channel_member_ids.livechat_member_history_ids.filtered(
+                lambda m: m.partner_id == visitor_user.partner_id,
+            ).livechat_member_type,
+            "visitor",
+        )
+
+    def test_can_only_create_history_for_livechats(self):
+        john = self._create_operator("fr_FR")
+        channel = self.env["discuss.channel"]._create_channel(name="General", group_id=None)
+        member = channel.add_members(partner_ids=john.partner_id.ids)
+        with self.assertRaises(ValidationError):
+            self.env["im_livechat.channel.member.history"].create({"member_id": member.id}).channel_id

--- a/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="im_livechat_channel_member_history_view_search" model="ir.ui.view">
+            <field name="name">im_livechat.channel.member.history.view.search</field>
+            <field name="model">im_livechat.channel.member.history</field>
+            <field name="arch" type="xml">
+                <search string="Search History">
+                    <field name="channel_id"/>
+                    <field name="partner_id"/>
+                    <field name="guest_id"/>
+                    <field name="livechat_member_type" string="Member Type"/>
+                </search>
+            </field>
+        </record>
+        <record id="im_livechat_channel_member_history_view_tree" model="ir.ui.view">
+            <field name="name">im_livechat.channel.member.history.view.list</field>
+            <field name="model">im_livechat.channel.member.history</field>
+            <field name="arch" type="xml">
+                <list default_order="create_date desc" string="Member History" sample="1">
+                    <field name="create_date"/>
+                    <field name="channel_id"/>
+                    <field name="partner_id"/>
+                    <field name="guest_id"/>
+                    <field name="livechat_member_type" string="Member Type"/>
+                </list>
+            </field>
+        </record>
+        <record id="im_livechat_channel_member_history_action" model="ir.actions.act_window">
+            <field name="name">Member History</field>
+            <field name="res_model">im_livechat.channel.member.history</field>
+            <field name="search_view_id" ref="im_livechat_channel_member_history_view_search"/>
+            <field name="view_mode">list,form</field>
+            <field name="context">{"create": False}</field>
+        </record>
+        <menuitem
+            action="im_livechat_channel_member_history_action"
+            id="im_livechat.menu_member_history"
+            name="Member History"
+            parent="im_livechat.livechat_technical"
+            sequence="15"
+        />
+    </data>
+</odoo>

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -295,6 +295,13 @@
             sequence="55"/>
 
         <menuitem
+            id="livechat_technical"
+            name="Technical"
+            parent="menu_livechat_root"
+            groups="base.group_no_one"
+            sequence="75"/>
+
+        <menuitem
             id="canned_responses"
             name="Canned Responses"
             parent="livechat_config"


### PR DESCRIPTION
This commit aims to track the status of livechat participants (bot, operator or visitor).
This takes the form of an history since it's hard to track `discuss.channel.member` as they are deleted when leaving the channel.

The goal is to make it easier to build statistics around operators and bots.

part of task-4589964