### PR TITLE
[REF] *: remove optionTemplate from AutoComplete

### DIFF
--- a/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
+++ b/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
@@ -79,7 +79,7 @@ export class AddressAutoComplete extends CharField {
                         return [];
                     }
                 },
-                optionTemplate: "google_address_autocomplete.CharFieldDropdownOption",
+                optionSlot: "option",
                 placeholder: _t("Searching for addresses..."),
             },
         ];

--- a/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.xml
+++ b/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.xml
@@ -10,9 +10,10 @@
             searchOnInputClick="false"
             inputDebounceDelay="350"
             input="input"
-         />
-    </t>
-    <t t-name="google_address_autocomplete.CharFieldDropdownOption">
-        <strong t-esc="option.formatted_address or '&#160;'"/>
+        >
+            <t t-set-slot="option" t-slot-scope="optionScope">
+                <strong t-esc="optionScope.option.formatted_address or '&#160;'"/>
+            </t>
+        </AutoComplete>
     </t>
 </templates>

--- a/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.js
+++ b/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.js
@@ -83,7 +83,7 @@ export class L10nInHsnAutoComplete extends CharField {
                         return [];
                     }
                 },
-                optionTemplate: "hsn_autocomplete.DropdownOption",
+                optionSlot: "option",
                 placeholder: _t("Searching..."),
             },
         ];

--- a/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.xml
+++ b/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.xml
@@ -7,13 +7,13 @@
             onSelect.bind="onSelect"
             input="inputRef"
             placeholder="props.placeholder || ''"
-        />
-    </t>
-
-    <t t-name="hsn_autocomplete.DropdownOption">
-        <div class="text-wrap">
-            <strong t-out="option.label"/>
-            <div t-out="option.description"/>
-        </div>
+        >
+            <t t-set-slot="option" t-slot-scope="optionScope">
+                <div class="text-wrap">
+                    <strong t-out="optionScope.option.label"/>
+                    <div t-out="optionScope.option.description"/>
+                </div>
+            </t>
+        </AutoComplete>
     </t>
 </templates>

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -46,7 +46,7 @@ export class PartnerAutoCompleteCharField extends CharField {
                         return [];
                     }
                 },
-                optionTemplate: "partner_autocomplete.DropdownOption",
+                optionSlot: "partnerOption",
                 placeholder: _t('Searching Autocomplete...'),
             },
         ];

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -65,7 +65,7 @@ class PartnerAutoCompleteMany2one extends Component {
                         return [];
                     }
                 },
-                optionTemplate: "partner_autocomplete.DropdownOption",
+                optionSlot: "partnerOption",
                 placeholder: _t("Searching Autocomplete..."),
             },
         ];

--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -33,7 +33,13 @@
                     onSelect.bind="onSelect"
                     input="inputRef"
                     placeholder="placeholder || ''"
-                />
+                >
+                    <t t-set-slot="partnerOption" t-slot-scope="partnerOptionScope">
+                        <t t-call="partner_autocomplete.DropdownOption">
+                            <t t-set="option" t-value="partnerOptionScope.option"/>
+                        </t>
+                    </t>
+                </PartnerAutoComplete>
             </t>
         </xpath>
     </t>
@@ -47,6 +53,7 @@
                 onSelect.bind="onSelect"
                 input="inputRef"
                 placeholder="placeholder || ''"
+                slots="props.slots"
             />
         </xpath>
     </t>
@@ -74,7 +81,13 @@
     </t>
 
     <t t-name="partner_autocomplete.PartnerAutoCompleteMany2one">
-        <Many2One t-props="m2oProps"/>
+        <Many2One t-props="m2oProps">
+            <t t-set-slot="partnerOption" t-slot-scope="partnerOptionScope">
+                <t t-call="partner_autocomplete.DropdownOption">
+                    <t t-set="option" t-value="partnerOptionScope.option"/>
+                </t>
+            </t>
+        </Many2One>
     </t>
 
 </templates>

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -10,20 +10,13 @@ import {
     listMany2ManyTagsAvatarUserField,
     many2ManyTagsAvatarUserField,
 } from "@mail/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field";
-import { AvatarMany2XAutocomplete } from "@web/views/fields/relational_utils";
+import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { AvatarCardResourcePopover } from "@resource_mail/components/avatar_card_resource/avatar_card_resource_popover";
 import { Domain } from "@web/core/domain";
 import { KanbanMany2ManyTagsAvatarFieldTagsList } from "@web/views/fields/many2many_tags_avatar/many2many_tags_avatar_field";
 
 
-export class AvatarResourceMany2XAutocomplete extends AvatarMany2XAutocomplete {
-    get optionsSource() {
-        return {
-            ...super.optionsSource,
-            optionTemplate: "resource_mail.AvatarResourceMany2XAutocomplete",
-        };
-    }
-
+export class AvatarResourceMany2XAutocomplete extends Many2XAutocomplete {
     /**
      * @override
      */
@@ -80,6 +73,7 @@ const WithResourceFieldMixin = (T) => class ResourceFieldMixin extends T {
         Many2XAutocomplete: AvatarResourceMany2XAutocomplete,
         TagsList: Many2ManyAvatarResourceTagsList,
     };
+    static optionTemplate = "resource_mail.Many2ManyAvatarResourceField.option";
 
     displayAvatarCard(record) {
         return !this.env.isSmall && this.relation === "resource.resource" && record.data.resource_type === "user";

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-name="resource_mail.AvatarResourceMany2XAutocomplete" t-inherit="web.AvatarMany2XAutocomplete">
+    <t t-name="resource_mail.Many2ManyAvatarResourceField.option" t-inherit="web.Many2ManyTagsAvatarField.option">
         <xpath expr="//span[hasclass('o_avatar_many2x_autocomplete')]/img" position="before">
-            <i t-if="option.resourceType === 'material'" class="o_material_resource fa fa-wrench rounded text-center me-2
-            d-flex align-items-center justify-content-center" t-attf-class="o_colorlist_item_color_{{ option.color }}"/>
+            <i t-if="autoCompleteItemScope.resourceType === 'material'" class="o_material_resource fa fa-wrench rounded text-center me-2
+            d-flex align-items-center justify-content-center" t-attf-class="o_colorlist_item_color_{{ autoCompleteItemScope.color }}"/>
         </xpath>
         <xpath expr="//span[hasclass('o_avatar_many2x_autocomplete')]/img" position="attributes">
-            <attribute name="t-if" add="&amp;&amp; option.resourceType !== 'material'" separator=" "/>
+            <attribute name="t-if" add="&amp;&amp; autoCompleteItemScope.resourceType !== 'material'" separator=" "/>
         </xpath>
     </t>
 

--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -18,7 +18,6 @@ export class AutoComplete extends Component {
                 type: Object,
                 shape: {
                     placeholder: { type: String, optional: true },
-                    optionTemplate: { type: String, optional: true },
                     options: [Array, Function],
                     optionSlot: { type: String, optional: true },
                 },
@@ -235,7 +234,6 @@ export class AutoComplete extends Component {
             options: [],
             isLoading: false,
             placeholder: source.placeholder,
-            optionTemplate: source.optionTemplate,
             optionSlot: source.optionSlot,
         };
     }

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -66,12 +66,7 @@
                                         t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
                                     >
                                         <t t-slot="{{ source.optionSlot }}" option="Object.getPrototypeOf(option)">
-                                            <t t-if="source.optionTemplate">
-                                                <t t-call="{{ source.optionTemplate }}"/>
-                                            </t>
-                                            <t t-else="">
-                                                <t t-esc="option.label"/>
-                                            </t>
+                                            <t t-esc="option.label"/>
                                         </t>
                                     </t>
                                 </li>

--- a/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.js
+++ b/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.js
@@ -40,7 +40,7 @@ export class CalendarFilterSection extends Component {
                 {
                     placeholder: _t("Loading..."),
                     options: (request) => this.loadSource(request),
-                    optionTemplate: "web.CalendarFilterPanel.autocomplete.options",
+                    optionSlot: "option",
                 },
             ],
             onSelect: (option, params = {}) => {
@@ -108,8 +108,6 @@ export class CalendarFilterSection extends Component {
         const options = records.map((result) => ({
             value: result[0],
             label: result[1],
-            model: resModel,
-            avatarField: this.section.avatar.field,
         }));
 
         if (records.length > 7) {

--- a/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
+++ b/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
@@ -40,7 +40,14 @@
                         <t t-call="{{ constructor.subTemplates.filter }}"/>
                     </t>
                 </div>
-                <AutoComplete t-if="section.canAddFilter" t-props="autoCompleteProps"/>
+                <AutoComplete t-if="section.canAddFilter" t-props="autoCompleteProps">
+                    <t t-set-slot="option" t-slot-scope="optionScope">
+                        <t t-if="optionScope.option.value and section.avatar.field">
+                            <img class="rounded me-1 o_avatar" t-attf-src="/web/image/{{ section.avatar.model }}/{{ optionScope.option.value }}/{{ section.avatar.field }}"/>
+                        </t>
+                        <t t-esc="optionScope.option.label" />
+                    </t>
+                </AutoComplete>
             </t>
         </div>
     </t>
@@ -91,11 +98,4 @@
         </div>
     </t>
 
-    <t t-name="web.CalendarFilterPanel.autocomplete.options">
-        <img t-if='option.value and option.avatarField'
-            t-attf-src="/web/image/{{option.model}}/{{option.value}}/{{option.avatarField}}"
-            class="rounded me-1 o_avatar"
-        />
-        <t t-esc="option.label" />
-    </t>
 </templates>

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -6,15 +6,11 @@ import {
     Many2ManyTagsField,
 } from "@web/views/fields/many2many_tags/many2many_tags_field";
 import { TagsList } from "@web/core/tags_list/tags_list";
-import { AvatarMany2XAutocomplete } from "@web/views/fields/relational_utils";
 import { imageUrl } from "@web/core/utils/urls";
 
 export class Many2ManyTagsAvatarField extends Many2ManyTagsField {
     static template = "web.Many2ManyTagsAvatarField";
-    static components = {
-        Many2XAutocomplete: AvatarMany2XAutocomplete,
-        TagsList,
-    };
+    static optionTemplate = "web.Many2ManyTagsAvatarField.option";
     static props = {
         ...Many2ManyTagsField.props,
         withCommand: { type: Boolean, optional: true },

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -22,9 +22,21 @@
                     getDomain.bind="getDomain"
                     isToMany="true"
                     getOptionClassnames.bind="getOptionClassnames"
-                />
+                >
+                    <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                        <t t-call="{{ constructor.optionTemplate }}"/>
+                    </t>
+                </Many2XAutocomplete>
             </div>
         </div>
+    </t>
+
+    <t t-name="web.Many2ManyTagsAvatarField.option">
+        <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
+            <img t-if="autoCompleteItemScope.value" class="rounded me-1"
+                t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.value}}/avatar_128"/>
+            <t t-esc="autoCompleteItemScope.label"/>
+        </span>
     </t>
 
     <t t-name="web.KanbanMany2ManyTagsAvatarFieldTagsList" t-inherit="web.TagsList" t-inherit-mode="primary">

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -497,21 +497,6 @@ export class Many2XAutocomplete extends Component {
     }
 }
 
-export class AvatarMany2XAutocomplete extends Many2XAutocomplete {
-    mapRecordToOption(result) {
-        return {
-            ...super.mapRecordToOption(result),
-            resModel: this.props.resModel,
-        };
-    }
-    get optionsSource() {
-        return {
-            ...super.optionsSource,
-            optionTemplate: "web.AvatarMany2XAutocomplete",
-        };
-    }
-}
-
 export function useOpenMany2XRecord({
     resModel,
     onRecordSaved,

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -46,14 +46,6 @@
     </div>
 </t>
 
-<t t-name="web.AvatarMany2XAutocomplete">
-    <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-        <img t-if="option.value" class="rounded me-1"
-             t-attf-src="/web/image/{{option.resModel}}/{{option.value}}/avatar_128" />
-        <t t-esc="option.label" />
-    </span>
-</t>
-
 <t t-name="web.X2ManyFieldDialogDefaultButtons">
     <t t-if="record.isInEdition">
         <t t-if="canCreate">

--- a/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.js
+++ b/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.js
@@ -37,7 +37,7 @@ export class UrlAutoComplete extends Component {
     get sources() {
         return [
             {
-                optionTemplate: "website.AutoCompleteWithPagesItem",
+                optionSlot: "option",
                 options: async (term) => {
                     if (term[0] === "#") {
                         const anchors = await this.props.loadAnchors(

--- a/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.xml
+++ b/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.xml
@@ -7,17 +7,18 @@
             dropdownClass="dropdownClass"
             dropdownOptions="dropdownOptions"
             sources="sources"
-            targetDropdown="props.targetDropdown"/>
-    </t>
-
-    <t t-name="website.AutoCompleteWithPagesItem">
-        <div t-att-class="{
-            'fw-bold text-capitalize p-2': option.separator,
-        }">
-            <t t-if="option.icon and option.icon.length">
-                <img t-att-src="option.icon" width="24px" height="24px" class="me-2 rounded"/>
+            targetDropdown="props.targetDropdown"
+        >
+            <t t-set-slot="option" t-slot-scope="optionScope">
+                <div t-att-class="{
+                    'fw-bold text-capitalize p-2': optionScope.option.separator,
+                }">
+                    <t t-if="optionScope.option.icon and optionScope.option.icon.length">
+                        <img t-att-src="optionScope.option.icon" width="24px" height="24px" class="me-2 rounded"/>
+                    </t>
+                    <t t-out="optionScope.option.label"/>
+                </div>
             </t>
-            <t t-out="option.label"/>
-        </div>
+        </AutoCompleteWithPages>
     </t>
 </templates>


### PR DESCRIPTION
\* google_address_autocomplete, l10n_in, partner_autocomplete, resource_mail, web, website

This commit removes the props `optionTemplate` from `AutoComplete` and replaces all occurence by `optionSlot`. Slots give more power than templates. If we want to use a template, we can still `t-call` it in the slot.

task-4660366