### PR TITLE
[REF] web_tour: remove initial delay

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -14,7 +14,6 @@ const macroSchema = {
             type: Object,
             shape: {
                 action: { type: [Function, String], optional: true },
-                initialDelay: { type: Function, optional: true },
                 timeout: { type: Number, optional: true },
                 trigger: { type: [Function, String], optional: true },
                 value: { type: [String, Number], optional: true },
@@ -94,10 +93,6 @@ export class Macro {
         if (!this.stepHasStarted[this.currentIndex]) {
             delay = this.currentIndex === 0 ? 0 : 50;
             this.stepHasStarted[this.currentIndex] = true;
-            if (this.currentStep?.initialDelay) {
-                const initialDelay = parseFloat(this.currentStep.initialDelay());
-                delay = initialDelay >= 0 ? initialDelay : delay;
-            }
         }
         return delay;
     }

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -53,7 +53,6 @@ export class TourAutomatic {
                     },
                 },
                 {
-                    initialDelay: () => (this.previousStepIsJustACheck ? 0 : null),
                     trigger: step.trigger ? () => step.findTrigger() : null,
                     timeout:
                         step.pause && this.debugMode
@@ -63,7 +62,6 @@ export class TourAutomatic {
                         if (delayToCheckUndeterminisms > 0) {
                             await step.checkForUndeterminisms(trigger, delayToCheckUndeterminisms);
                         }
-                        this.previousStepIsJustACheck = !step.hasAction;
                         const result = await step.doAction();
                         if (this.debugMode) {
                             console.log(trigger);


### PR DESCRIPTION
In this commit, we're removing the initial delay from macro.js. This parameter was introduced to try to optimize macro execution times. However, in practice, it doesn't change much. The debounceDelay is only used if there's a trigger in a step.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
