### PR TITLE
[IMP] web: log time of test suites

### DIFF
--- a/addons/web/static/lib/hoot/core/logger.js
+++ b/addons/web/static/lib/hoot/core/logger.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-import { formatTime, stringify } from "../hoot_utils";
+import { stringify } from "../hoot_utils";
 import { urlParams } from "./url";
 
 //-----------------------------------------------------------------------------
@@ -160,7 +160,7 @@ export const logger = {
             ...styledArguments([
                 `Test ${stringify(fullName)} passed`,
                 lastResults.counts.assertion || 0,
-                `assertions (time: ${formatTime(lastResults.duration)})`,
+                `assertions (time: ${lastResults.duration})`,
             ])
         );
     },
@@ -183,6 +183,8 @@ export const logger = {
             withArgs.push(suite.reporting.skipped, "skipped");
         }
         if (withArgs.length) {
+            const totalDuration = suite.jobs.reduce((acc, job) => acc + (job.duration || 0), 0);
+            withArgs.push(`ms: ${totalDuration}`);
             args.push("(", ...withArgs, ")");
         }
         $log(...styledArguments(args));


### PR DESCRIPTION
The aim of this commit is double:
- Log the time of each test suites (in ms) This change will help us to identify slow suites.
- Change the format of the log the time of each test cases (from hh:mm:ss to ms) As many of our test cases are faster than 100ms, they appear as "00:00:00" in the logs, with is not very useful.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
