### PR TITLE
[FIX] html_editor: preserve list types when pasting

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -700,11 +700,11 @@ export class ListPlugin extends Plugin {
             return nodeToInsert;
         }
         const mode = container && this.getListMode(listEl);
-        if (
-            (isListItemElement(nodeToInsert) && nodeToInsert.classList.contains("oe-nested")) ||
-            isListElement(nodeToInsert)
-        ) {
+        if (isListItemElement(nodeToInsert) && nodeToInsert.classList.contains("oe-nested")) {
             return this.convertList(nodeToInsert, mode);
+        }
+        if (isListElement(nodeToInsert)) {
+            return this.convertList(nodeToInsert, this.getListMode(nodeToInsert));
         }
         return nodeToInsert;
     }

--- a/addons/html_editor/static/tests/list/checklist.test.js
+++ b/addons/html_editor/static/tests/list/checklist.test.js
@@ -1,7 +1,7 @@
 import { test } from "@odoo/hoot";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
-import { clickCheckbox } from "../_helpers/user_actions";
+import { clickCheckbox, pasteHtml } from "../_helpers/user_actions";
 import { click } from "@odoo/hoot-dom";
 
 test("should do nothing if do not click on the checkbox", async () => {
@@ -425,5 +425,20 @@ test("should uncheck all nested checklist items and update wrapper title", async
                     </ul>
                 </li>
             </ul>`),
+    });
+});
+
+test("should preserve list type on paste", async () => {
+    await testEditor({
+        contentBefore: unformat(`<div></div>`),
+        stepFunction: async (editor) => {
+            pasteHtml(
+                editor,
+                `<ul><li>a</li></ul><ul class="o_checklist"><li>b</li><li>c</li><li>d</li></ul>`
+            );
+        },
+        contentAfter: unformat(
+            `<ul><li>a</li></ul><ul class="o_checklist"><li>b</li><li>c</li><li>d[]</li></ul><div><br></div>`
+        ),
     });
 });


### PR DESCRIPTION
**Problem**:
When pasting lists of different types (`UL` and `CL`), a new list is created with all `li` elements matching the type of the first list.

**Solution**:
If `nodeToInsert` is a list element, use its `mode` to create the list instead of using the `mode` of
the container.

**Steps to reproduce**:
1. Copy two lists: ```html <ul><li>1</li></ul> <ul class="o_checklist"><li>1</li><li>2</li><li>3</li></ul> ```
2. Paste into the editor.
    Issue: The second list is pasted using the same
    type as the first list.

opw-4670379

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
