### PR TITLE
[IMP] web_tour: edit on autocomplete alternative validation

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -340,6 +340,49 @@ export class TourInteractive {
                     name: "input",
                     target: element,
                 });
+                if (element.classList.contains("o-autocomplete--input")) {
+                    consumeEvents.push({
+                        name: "keydown",
+                        target: element,
+                        conditional: (ev) => {
+                            if (
+                                ["Tab", "Enter"].includes(ev.key) &&
+                                ev.target.parentElement.querySelector(
+                                    ".o-autocomplete--dropdown-item .ui-state-active"
+                                )
+                            ) {
+                                const nextStep = this.actions.at(this.currentActionIndex + 1);
+                                if (
+                                    this.findTriggers(nextStep.anchor)
+                                        .at(0)
+                                        ?.closest(".o-autocomplete--dropdown-item")
+                                ) {
+                                    // Skip the next step if the next one is a click on a dropdown item
+                                    this.currentActionIndex++;
+                                }
+                                return true;
+                            }
+                        },
+                    });
+                    consumeEvents.push({
+                        name: "click",
+                        target: element.ownerDocument,
+                        conditional: (ev) => {
+                            if (ev.target.closest(".o-autocomplete--dropdown-item")) {
+                                const nextStep = this.actions.at(this.currentActionIndex + 1);
+                                if (
+                                    this.findTriggers(nextStep.anchor)
+                                        .at(0)
+                                        ?.closest(".o-autocomplete--dropdown-item")
+                                ) {
+                                    // Skip the next step if the next one is a click on a dropdown item
+                                    this.currentActionIndex++;
+                                }
+                                return true;
+                            }
+                        },
+                    });
+                }
             }
         }
 

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { click, hover, leave, queryFirst, waitFor } from "@odoo/hoot-dom";
+import { click, hover, leave, queryFirst, waitFor, press } from "@odoo/hoot-dom";
 import { advanceTime, animationFrame, disableAnimations, runAllTimers } from "@odoo/hoot-mock";
 import { Component, useState, xml } from "@odoo/owl";
 import {
@@ -10,13 +10,40 @@ import {
     mountWithCleanup,
     onRpc,
     patchWithCleanup,
+    models,
+    fields,
+    defineModels,
 } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 import { Dialog } from "@web/core/dialog/dialog";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
+import { WebClient } from "../../../web/static/src/webclient/webclient";
 
 describe.current.tags("desktop");
+
+class Partner extends models.Model {
+    _name = "partner";
+
+    m2o = fields.Many2one({ relation: "product" });
+
+    _views = {
+        search: `<search/>`,
+        form: `<form>
+            <field name="m2o"/>
+        </form>`,
+    };
+}
+
+class Product extends models.Model {
+    _name = "product";
+
+    name = fields.Char();
+
+    _records = [{ name: "A" }, { name: "B" }];
+}
+
+defineModels([Partner, Product]);
 
 class Counter extends Component {
     static props = ["*"];
@@ -945,5 +972,112 @@ test("check alternative trigger that appear after the initial trigger", async ()
     otherButton.classList.add("button1");
     queryFirst(".add_button").appendChild(otherButton);
     await contains(".button1").click();
+    expect(".o_tour_pointer").toHaveCount(0);
+});
+
+test("validating edit step on autocomplete by selecting autocomplete item", async () => {
+    registry.category("web_tour.tours").add("rainbow_tour", {
+        steps: () => [
+            {
+                trigger: ".o-autocomplete--input",
+                run: "edit A",
+            },
+            {
+                trigger: ".o_form_button_save",
+                run: "click",
+            },
+        ],
+    });
+
+    await mountWithCleanup(WebClient);
+
+    await getService("action").doAction({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+    });
+    getService("tour_service").startTour("rainbow_tour", { mode: "manual" });
+    await animationFrame();
+
+    expect(".o_tour_pointer").toHaveCount(1);
+    await contains(".o-autocomplete--input").click();
+    await contains(".o-autocomplete--dropdown-item:first-child").click();
+    expect(".o_tour_pointer").toHaveCount(1);
+    await contains(".o_form_button_save").click();
+    expect(".o_tour_pointer").toHaveCount(0);
+});
+
+test("validating edit step on autocomplete by selecting autocomplete item (validate automatically autocomplete item step)", async () => {
+    registry.category("web_tour.tours").add("rainbow_tour", {
+        steps: () => [
+            {
+                trigger: ".o-autocomplete--input",
+                run: "edit A",
+            },
+            {
+                trigger: ".o-autocomplete--dropdown-item:first-child",
+                run: "click",
+            },
+            {
+                trigger: ".o_form_button_save",
+                run: "click",
+            },
+        ],
+    });
+
+    await mountWithCleanup(WebClient);
+
+    await getService("action").doAction({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+    });
+    getService("tour_service").startTour("rainbow_tour", { mode: "manual" });
+    await animationFrame();
+
+    expect(".o_tour_pointer").toHaveCount(1);
+    await contains(".o-autocomplete--input").click();
+    await contains(".o-autocomplete--dropdown-item:first-child").click();
+    expect(".o_tour_pointer").toHaveCount(1);
+    await contains(".o_form_button_save").click();
+    expect(".o_tour_pointer").toHaveCount(0);
+});
+
+test("validating click on autocomplete item by pressing Enter", async () => {
+    registry.category("web_tour.tours").add("rainbow_tour", {
+        steps: () => [
+            {
+                trigger: ".o-autocomplete--input",
+                run: "click",
+            },
+            {
+                trigger: ".o-autocomplete--dropdown-item:first-child",
+                run: "click",
+            },
+            {
+                trigger: ".o_form_button_save",
+                run: "click",
+            },
+        ],
+    });
+
+    await mountWithCleanup(WebClient);
+
+    await getService("action").doAction({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+    });
+    getService("tour_service").startTour("rainbow_tour", { mode: "manual" });
+    await animationFrame();
+
+    expect(".o_tour_pointer").toHaveCount(1);
+    await contains(".o-autocomplete--input").click();
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(1);
+    await press("Enter");
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(1);
+    await contains(".o_form_button_save").click();
     expect(".o_tour_pointer").toHaveCount(0);
 });


### PR DESCRIPTION
When a step in an onboarding tour ask for an edit on an autocomplete input, selecting a dropdown item valid the step. And if the next step was a click on a dropdown item, this step is also validated.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
