### PR TITLE
[IMP] *: default focus on customer/ref in move form

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -995,6 +995,7 @@
                                             'show_address': 1, 'default_is_company': True, 'show_vat': True}"
                                            domain="[('company_id', 'in', (False, company_id))]"
                                            options='{"no_quick_create": True}'
+                                           default_focus="1"
                                            invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')"
                                            placeholder="Search a name or Tax ID..."
                                            readonly="state != 'draft'"/>
@@ -1015,8 +1016,8 @@
                                        readonly="state != 'draft'"/>
                                 <label for="ref" string="Bill Reference"
                                        invisible="move_type not in ('in_invoice', 'in_receipt', 'in_refund')" />
-                                <field name="ref" nolabel="1" invisible="move_type not in ('in_invoice', 'in_receipt', 'in_refund')" />
-                                <field name="ref" invisible="move_type in ('in_invoice', 'in_receipt', 'in_refund', 'out_invoice', 'out_refund')"/>
+                                <field name="ref" default_focus="1" nolabel="1" invisible="move_type not in ('in_invoice', 'in_receipt', 'in_refund')"/>
+                                <field name="ref" default_focus="1" invisible="move_type in ('in_invoice', 'in_receipt', 'in_refund', 'out_invoice', 'out_refund')"/>
                                 <field name="tax_cash_basis_origin_move_id" invisible="not tax_cash_basis_origin_move_id"/>
                                 <label name="invoice_vendor_bill_id_label" for="invoice_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
                                        invisible="state != 'draft' or move_type != 'in_invoice'"/>

--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -55,6 +55,7 @@
                 input="inputRef"
                 placeholder="placeholder || ''"
                 slots="props.slots"
+                id="this.props.id"
             />
         </xpath>
     </t>

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -618,17 +618,22 @@ export class X2ManyFieldDialog extends Component {
             this.archInfo.arch = this.archInfo.xmlDoc.outerHTML;
         }
 
-        const { autofocusFieldId, disableAutofocus } = this.archInfo;
+        const { autofocusFieldIds, disableAutofocus } = this.archInfo;
         if (!disableAutofocus) {
             // to simplify
             useEffect(
                 (isInEdition) => {
                     let elementToFocus;
                     if (isInEdition) {
-                        elementToFocus =
-                            (autofocusFieldId &&
-                                this.modalRef.el.querySelector(`#${autofocusFieldId}`)) ||
-                            this.modalRef.el.querySelector(".o_field_widget input");
+                        for (const id of autofocusFieldIds) {
+                            elementToFocus = this.modalRef.el.querySelector(`#${id}`);
+                            if (elementToFocus) {
+                                break;
+                            };
+                        };
+                        elementToFocus = elementToFocus || this.modalRef.el.querySelector(
+                            ".o_field_widget input"
+                        );
                     } else {
                         elementToFocus = this.modalRef.el.querySelector("button.btn-primary");
                     }

--- a/addons/web/static/src/views/form/form_arch_parser.js
+++ b/addons/web/static/src/views/form/form_arch_parser.js
@@ -13,7 +13,7 @@ export class FormArchParser {
         const widgetNodes = {};
         let widgetNextId = 0;
         const fieldNextIds = {};
-        let autofocusFieldId = null;
+        const autofocusFieldIds = [];
         visitXML(xmlDoc, (node) => {
             if (node.tagName === "field") {
                 const fieldInfo = Field.parseFieldNode(node, models, modelName, "form", jsClass);
@@ -24,7 +24,7 @@ export class FormArchParser {
                 fieldNodes[fieldId] = fieldInfo;
                 node.setAttribute("field_id", fieldId);
                 if (exprToBoolean(node.getAttribute("default_focus") || "")) {
-                    autofocusFieldId = fieldId;
+                    autofocusFieldIds.push(fieldId);
                 }
                 if (fieldInfo.type === "properties") {
                     activeActions.addPropertyFieldValue = true;
@@ -39,7 +39,7 @@ export class FormArchParser {
         });
         return {
             activeActions,
-            autofocusFieldId,
+            autofocusFieldIds,
             disableAutofocus,
             fieldNodes,
             widgetNodes,

--- a/addons/web/static/src/views/form/form_renderer.js
+++ b/addons/web/static/src/views/form/form_renderer.js
@@ -71,7 +71,7 @@ export class FormRenderer extends Component {
         onMounted(() => browser.addEventListener("resize", this.onResize));
         onWillUnmount(() => browser.removeEventListener("resize", this.onResize));
 
-        const { autofocusFieldId } = archInfo;
+        const { autofocusFieldIds } = archInfo;
         const rootRef = useRef("compiled_view_root");
         if (this.shouldAutoFocus) {
             useEffect(
@@ -86,13 +86,17 @@ export class FormRenderer extends Component {
                             "textarea",
                             "[contenteditable]",
                         ];
-                        elementToFocus =
-                            (autofocusFieldId && rootEl.querySelector(`#${autofocusFieldId}`)) ||
-                            rootEl.querySelector(
-                                focusableSelectors
-                                    .map((sel) => `.o_content .o_field_widget ${sel}`)
-                                    .join(", ")
-                            );
+                        for (const id of autofocusFieldIds) {
+                            elementToFocus = rootEl.querySelector(`#${id}`);
+                            if (elementToFocus) {
+                                break;
+                            };
+                        };
+                        elementToFocus = elementToFocus || rootEl.querySelector(
+                            focusableSelectors
+                                .map((sel) => `.o_content .o_field_widget ${sel}`)
+                                .join(", ")
+                        );
                     }
                     if (elementToFocus) {
                         elementToFocus.focus();

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -7635,6 +7635,26 @@ test(`in create mode, autofocus fields are focused`, async () => {
 });
 
 test.tags("desktop");
+test(`in create mode, if two fields have default focus, the first gets the focus`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="int_field" default_focus="1"/><field name="foo" default_focus="1"/></form>`,
+    });
+    expect(`.o_field_widget[name="int_field"] input`).toBeFocused();
+});
+
+test.tags("desktop");
+test(`in create mode, if two fields have default focus but the first is invisible, the second gets the focus`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="int_field" default_focus="1" invisible="1"/><field name="foo" default_focus="1"/></form>`,
+    });
+    expect(`.o_field_widget[name="foo"] input`).toBeFocused();
+});
+
+test.tags("desktop");
 test(`autofocus first visible field`, async () => {
     await mountView({
         resModel: "partner",


### PR DESCRIPTION
*: account, partner_autocomplete, web

---

This PR contains three commits with all separate purposes in the main objective of making the invoice form view focus on the customer field per default or on the reference field if the first is invisible.

Here's more detail about each of them:

1. This commit allows to define multiple fields as default_focus="1" on a view, the resulting focused field is the first found on the view. If the first is invisible but not the second for example, the focus is going to be on the second.
2. This commit makes sure the field_id attributed by the XML Parser to each field's input tag in a view is passed to the PartnerAutoComplete component in the partner_autocomplete.PartnerAutoCompleteMany2XField template.
3. This commit sets the default_focus="1" on the desired fields in the invoice form view.

---

task-4558713

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
