### PR TITLE
[FIX] website: removed duplicate backround image classes

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -689,17 +689,6 @@ font[class*='bg-'] {
 
 // Background Images
 .oe_img_bg {
-    background-size: cover;
-    background-repeat: no-repeat;
-
-    &.o_bg_img_opt_repeat {
-        background-size: auto;
-        background-repeat: repeat;
-    }
-    &.o_bg_img_center {
-        background-position: center;
-    }
-
     // Compatibility <= 13.0, TODO remove?
     // -----------------------------------
     &.o_bg_img_opt_contain {


### PR DESCRIPTION
Duplicate classes concerning backround images have been removed from website and kept in web_editor
