### PR TITLE
[REV] web: reduce empty stars opacity of priority field

### DIFF
--- a/addons/web/static/src/views/fields/priority/priority_field.scss
+++ b/addons/web/static/src/views/fields/priority/priority_field.scss
@@ -19,14 +19,10 @@
 
             &.fa-star-o {
                 color: $o-main-color-muted;
-                opacity: 0.1;
             }
             &.fa-star {
                 color: $o-main-favorite-color;
             }
-        }
-        &:hover .fa-star-o {
-            opacity: 1;
         }
     }
 }


### PR DESCRIPTION
This reverts commit https://github.com/odoo/odoo/commit/93d9a5d9bb0bb871e2baa521c12fe70bfe749ebf because the field could become very hard to even notice on the screen when no stars were set (especially with screen color filters).
