### PR TITLE
[FIX] purchase_stock: hide forecast icon for non-storable products

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -29,6 +29,7 @@ class PurchaseOrderLine(models.Model):
     product_description_variants = fields.Char('Custom Description')
     propagate_cancel = fields.Boolean('Propagate cancellation', default=True)
     forecasted_issue = fields.Boolean(compute='_compute_forecasted_issue')
+    is_storable = fields.Boolean(related='product_id.is_storable')
     location_final_id = fields.Many2one('stock.location', 'Location from procurement')
 
     def _compute_qty_received_method(self):

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -31,8 +31,8 @@
             </xpath>
             <xpath expr="//page/field[@name='order_line']/tree/field[@name='product_qty']" position="after">
                 <field name="forecasted_issue" column_invisible="True"/>
-                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or not forecasted_issue or not product_id.is_storable" class="text-danger"/>
-                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or forecasted_issue or not product_id.is_storable"/>
+                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or not forecasted_issue or not is_storable" class="text-danger"/>
+                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or forecasted_issue or not is_storable"/>
             </xpath>
             <xpath expr="//div[@name='date_planned_div']" position="inside">
                 <div>


### PR DESCRIPTION
Steps to reproduce:
- Create a non-storable product (e.g. a service)
- Create a new RFQ
- Add that product to a PO line

Issue:
The forecast icon is visible, even though the product is non-storable and the forecast doesn't make any sense.

73170f0 was a bit too optimistic on the invisible condition, as it needs a field directly on the model to be able to check these clauses. So we add a related as it's done for other.

opw-4672513

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
