### PR TITLE
[FIX] account: accrued orders several currencies

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -150,6 +150,8 @@ class AccruedExpenseRevenue(models.TransientModel):
 
         if orders.filtered(lambda o: o.company_id != self.company_id):
             raise UserError(_('Entries can only be created for a single company at a time.'))
+        if len({order.currency_id or order.company_id.currency_id for order in orders}) != 1:
+            raise UserError(_('Cannot create an accrual entry with orders in different currencies.'))
 
         orders_with_entries = []
         fnames = []
@@ -252,9 +254,6 @@ class AccruedExpenseRevenue(models.TransientModel):
 
         if self.reversal_date <= self.date:
             raise UserError(_('Reversal date must be posterior to date.'))
-        orders = self.env[self._context['active_model']].with_company(self.company_id).browse(self._context['active_ids'])
-        if len({order.currency_id or order.company_id.currency_id for order in orders}) != 1:
-            raise UserError(_('Cannot create an accrual entry with orders in different currencies.'))
 
         move_vals, orders_with_entries = self._compute_move_vals()
         move = self.env['account.move'].create(move_vals)


### PR DESCRIPTION
Create 2 Sales Order in different currencies.
Multi-select them and Click on Accrued Revenue Entry
=> Traceback

The UserError is raised too late.
It should be raised when the wizard is opened.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
