### PR TITLE
[FIX] website{,_mass_mailing}: add to x2m uses field config


### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -473,6 +473,11 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
             this.trigger_up('activate_snippet', {
                 $snippet: $(fieldEl),
             });
+        } else if (name === 'get_form_fields') {
+            const formKey = this.activeForm && this.activeForm.website_form_key;
+            if (formKey) {
+                data.onSuccess(FormEditorRegistry.get(formKey).formFields || []);
+            }
         }
     },
 
@@ -899,6 +904,22 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
             this.fields = _.each(fields, function (field, fieldName) {
                 field.name = fieldName;
                 field.domain = field.domain || [];
+            });
+            // Copy field attributes from the form
+            this.trigger_up('option_update', {
+                optionName: 'WebsiteFormEditor',
+                name: 'get_form_fields',
+                data: {
+                    onSuccess: formFields => formFields.forEach(formField => {
+                        const field = this.fields[formField.name];
+                        if (formField.fieldName) {
+                            field.fieldName = formField.fieldName;
+                        }
+                        if (formField.domain) {
+                            field.domain = formField.domain
+                        }
+                    }),
+                },
             });
             // Create the buttons for the type we-select
             return Object.keys(fields).map(key => {

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -709,6 +709,63 @@ odoo.define('website.tour.form_editor', function (require) {
         },
     ]));
 
+    wTourUtils.registerWebsitePreviewTour('website_form_m2m_field', {
+        url: '/contactus',
+        edition: true,
+        test: true,
+    }, [
+        {
+            content: "Modify form to have many2many field",
+            trigger: 'iframe section.s_website_form',
+            run: function () {
+                const FormEditorRegistry = odoo.__DEBUG__.services['website.form_editor_registry'];
+                FormEditorRegistry.map['send_mail'].formFields = [{
+                    name: 'recipient_ids',
+                    relation: 'res.partner',
+                    domain: [['name', '=', 'testuserA']],
+                    modelRequired: true,
+                    string: 'recipients',
+                    type: 'many2many',
+                    fieldName: "email",
+                }];
+            },
+        },
+        {
+            content: "Select the contact us form by clicking on an input field",
+            trigger: 'iframe .s_website_form input',
+            extra_trigger: '#oe_snippets .oe_snippet_thumbnail',
+            run: 'click',
+        },
+        {
+            content: "Open action selector",
+            trigger: '[class="snippet-option-WebsiteFormEditor"] we-toggler',
+            run: 'click',
+        },
+        {
+            content: "Reset form action",
+            trigger: '[class="snippet-option-WebsiteFormEditor"] we-button[data-select-action].active div',
+            run: 'click',
+        },
+        {
+            content: "Check that the domain and fieldName is applied to the form",
+            trigger: 'iframe div[data-name="recipient_ids"] div.checkbox:last-child:first-child label:containsExact(testA@example.com)',
+        },
+        {
+            content: "Activate one2many field",
+            trigger: 'iframe div[data-name="recipient_ids"]',
+            run: 'click',
+        },
+        {
+            content: "Open 'add new checkbox' list",
+            trigger: '[class="snippet-option-WebsiteFieldEditor"] we-select.o_we_add_list_item',
+            run: 'click',
+        },
+        {
+            content: "Check that the domain and fieldName is applied to 'add new checkbox' list",
+            trigger: 'we-selection-items we-button.o_we_list_add_existing:last-child:first-child div:containsExact(testA@example.com)',
+        },
+    ]);
+
     wTourUtils.registerWebsitePreviewTour('website_form_conditional_required_checkboxes', {
         test: true,
         url: '/',

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -57,6 +57,17 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
     def test_website_form_editable_content(self):
         self.start_tour('/', 'website_form_editable_content', login="admin")
 
+    def test_website_form_m2m_field(self):
+        self.env['res.partner'].create({
+            'name': 'testuserA',
+            'email': 'testA@example.com',
+        })
+        self.env['res.partner'].create({
+            'name': 'testuserB',
+            'email': 'testB@example.com',
+        })
+        self.start_tour('/', 'website_form_m2m_field', login="admin")
+
     def test_website_form_special_characters(self):
         self.start_tour('/', 'website_form_special_characters', login='admin')
         mail = self.env['mail.mail'].search([], order='id desc', limit=1)

--- a/addons/website_mass_mailing/static/src/js/mass_mailing_form_editor.js
+++ b/addons/website_mass_mailing/static/src/js/mass_mailing_form_editor.js
@@ -21,6 +21,7 @@ FormEditorRegistry.add('create_mailing_contact', {
     }, {
         name: 'list_ids',
         relation: 'mailing.list',
+        domain: [['is_public', '=', true]],
         modelRequired: true,
         string: _lt('Subscribe to'),
         type: 'many2many',


### PR DESCRIPTION
Scenario:
- add a form in website
- change it to "Subscribe to Newsletter"
- edit the mailing list field and do "Add new Checkbox"

Result: the proposition from the checkbox includes the number of
recipient, that were remove when initiating the form thanks to the
"formField" attribute that allow us to select another field.

side note: this PR also adds a domain for the list (that is already
present in newsletter snippet) and make the domain also transferred to
the "Add new Checkbox" feature.

note: followup to https://github.com/odoo/odoo/commit/8fbf6655502ef1753c6d9205ae03f45e8d4fe0d7 that fixed
the issue when the field is added, but not in the case that a checkbox
is added afterwards.

note: without the fix, the added tour only failed at the last tour step
with several possible tags and the display name instead of the email
that is set as fieldName.

opw-4658964

__PR note:__ the odoo.define needs to be defined outside of the tour, so the tour itself doesn't get `website.test_website_form_m2m_field` as dependency (which will not be met because the tour is loaded in non-editor mode where the wysiwyg is not available).