### PR TITLE
[IMP] orm: deprecate expression.distribute_not

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -997,20 +997,14 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
     def test_40_negating_long_expression(self):
         source = ['!', '&', ('user_id', '=', 4), ('partner_id', 'in', [1, 2])]
         expect = ['|', ('user_id', '!=', 4), ('partner_id', 'not in', [1, 2])]
-        self.assertEqual(expression.distribute_not(source), expect,
+        self.assertEqual(Domain(source), Domain(expect),
             "distribute_not on expression applied wrongly")
 
         pos_leaves = [[('a', 'in', [])], [('d', '!=', 3)]]
         neg_leaves = [[('a', 'not in', [])], [('d', '=', 3)]]
-
-        source = expression.OR([expression.AND(pos_leaves)] * 1000)
-        expect = source
-        self.assertEqual(expression.distribute_not(source), expect,
-            "distribute_not on long expression without negation operator should not alter it")
-
-        source = ['!'] + source
-        expect = expression.AND([expression.OR(neg_leaves)] * 1000)
-        self.assertEqual(expression.distribute_not(source), expect,
+        source = ~Domain.OR([Domain.AND(pos_leaves)] * 1000)
+        expect = Domain.AND([Domain.OR(neg_leaves)] * 1000)
+        self.assertEqual(source, expect,
             "distribute_not on long expression applied wrongly")
 
     def test_40_negating_traversal(self):

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -257,7 +257,7 @@ def distribute_not(domain):
          ['|',('user_id','!=',4),('partner_id','not in',[1,2])]
 
     """
-    # TODO warnings.warn("Use Domain() instead of distribute_not()", DeprecationWarning)
+    warnings.warn("Since 19.0, use Domain() instead of distribute_not()", DeprecationWarning)
     return list(orm_domains.Domain(domain))
 
 


### PR DESCRIPTION
Remove the function that is no longer used.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
