### PR TITLE
[REM] orm: domains remove _value_to_ids

### DIFF
--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -541,12 +541,12 @@ class TestDomainOptimize(TransactionCase):
             Domain('discussion', 'not in', OrderedSet([False])),
             "Matching anything in relation",
         )
-        query = model.discussion._search([('display_name', 'like', 'ok')])
-        domain = Domain('discussion', 'like', 'ok').optimize(model, full=True)
+        domain = Domain('discussion', 'like', 'ok').optimize(model)
         self.assertEqual(domain.operator, 'any')
-        self.assertEqual(domain.value.select().code, query.select().code)
+        self.assertIsInstance(domain.value, Domain)
+        self.assertEqual(domain.value.field_expr, 'display_name')
 
-        domain = Domain('discussion', 'not like', 'ok').optimize(model, full=True)
+        domain = Domain('discussion', 'not like', 'ok').optimize(model)
         self.assertEqual(
             domain.operator, 'not any',
             f"Always use positive operator when searching on display_name; in {domain}"


### PR DESCRIPTION
The semantic used is `('some_id', 'like', "str")` means `('some_id', 'any', [('display_name', 'like', "str")])`.

That optimization to rewrite the domain can be done on the basic level.

The function `_value_to_ids` is very generic and used only twice. The needed parts can be inlined in the functions making them simpler to read.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
