### PR TITLE
[IMP] orm: domain optimize microseconds

### DIFF
--- a/addons/account/tests/test_account_lock_exception.py
+++ b/addons/account/tests/test_account_lock_exception.py
@@ -236,7 +236,7 @@ class TestAccountLockException(AccountTestInvoicingCommon):
                     'user_id': self.env.user.id,
                     lock_date_field: fields.Date.to_date('2010-01-01'),
                     'create_date': self.fakenow - timedelta(hours=24),
-                    'end_datetime': self.fakenow - timedelta(milliseconds=1),
+                    'end_datetime': self.fakenow - timedelta(seconds=1),
                     'reason': 'test_expired_exception',
                 })
                 with self.assertRaises(UserError):

--- a/addons/point_of_sale/models/product_pricelist.py
+++ b/addons/point_of_sale/models/product_pricelist.py
@@ -26,13 +26,13 @@ class ProductPricelistItem(models.Model):
         product_tmpl_ids = [p['product_tmpl_id'] for p in data['product.product']]
         product_ids = [p['id'] for p in data['product.product']]
         pricelist_ids = [p['id'] for p in data['product.pricelist']]
-        today = fields.Date.today()
+        now = fields.Datetime.now()
         return [
             ('pricelist_id', 'in', pricelist_ids),
             '|', ('product_tmpl_id', '=', False), ('product_tmpl_id', 'in', product_tmpl_ids),
             '|', ('product_id', '=', False), ('product_id', 'in', product_ids),
-            '|', ('date_start', '=', False), ('date_start', '<=', today),
-            '|', ('date_end', '=', False), ('date_end', '>=', today)
+            '|', ('date_start', '=', False), ('date_start', '<=', now),
+            '|', ('date_end', '=', False), ('date_end', '>=', now)
         ]
 
     @api.model

--- a/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
@@ -185,7 +185,7 @@ export default class DevicesSynchronisation {
                 domains.push(
                     new Domain([
                         ["id", "=", record.id],
-                        ["write_date", ">", recordDateTimeString],
+                        ["write_date", ">=", recordDateTimeString],
                     ])
                 );
             }

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1285,22 +1285,30 @@ def _optimize_type_date(condition, _):
 
 
 def _value_to_datetime(value):
+    """Convert a value(s) to datetime.
+
+    :returns: A tuple containing the converted value and a boolean indicating
+              that all input values were dates.
+              These are handled differently during rewrites.
+    """
     if isinstance(value, datetime):
         if value.tzinfo:
             # cast to a naive datetime
             warnings.warn("Use naive datetimes in domains")
             value = value.astimezone(timezone.utc).replace(tzinfo=None)
         return value, False
-    if isinstance(value, SQL) or value is False:
-        return value, False
+    if value is False:
+        return False, True
     if isinstance(value, str):
         dt, _ = _value_to_datetime(datetime.fromisoformat(value))
         return dt, len(value) == 10
     if isinstance(value, date):
         return datetime.combine(value, time.min), True
     if isinstance(value, COLLECTION_TYPES):
-        value, is_day = zip(*(_value_to_datetime(v) for v in value))
-        return OrderedSet(value), any(is_day)
+        value, is_date = zip(*(_value_to_datetime(v) for v in value))
+        return OrderedSet(value), all(is_date)
+    if isinstance(value, SQL):
+        return value, False
     raise ValueError(f'Failed to cast {value!r} into a datetime')
 
 
@@ -1309,32 +1317,53 @@ def _optimize_type_datetime(condition, _):
     """Make sure we have a datetime type in the value"""
     if condition.operator.endswith('like') or "." in condition.field_expr:
         return condition
+    field_expr = condition.field_expr
     operator = condition.operator
-    value, is_day = _value_to_datetime(condition.value)
-    if value is False and operator[0] in ('<', '>'):
-        # comparison to False results in an empty domain
-        return _FALSE_DOMAIN
-    if value == condition.value:
-        assert not is_day
-        return condition
+    value, is_date = _value_to_datetime(condition.value)
 
-    # if we get a day we may need to add 1 depending on the operator
-    if is_day and operator == '>':
-        try:
-            value += timedelta(1)
-        except OverflowError:
-            # higher than max, not possible
+    # Handle inequality
+    if operator[0] in ('<', '>'):
+        if value is False:
             return _FALSE_DOMAIN
-        operator = '>='
-    elif is_day and operator == '<=':
-        try:
-            value += timedelta(1)
-        except OverflowError:
-            # lower than max, just check if field is set
-            return DomainCondition(condition.field_expr, '!=', False)
-        operator = '<'
+        if not isinstance(value, datetime):
+            return condition
+        if value.microsecond:
+            assert not is_date, "date don't have microseconds"
+            value = value.replace(microsecond=0)
+        delta = timedelta(days=1) if is_date else timedelta(seconds=1)
+        if operator == '>':
+            try:
+                value += delta
+            except OverflowError:
+                # higher than max, not possible
+                return _FALSE_DOMAIN
+            operator = '>='
+        elif operator == '<=':
+            try:
+                value += delta
+            except OverflowError:
+                # lower than max, just check if field is set
+                return DomainCondition(field_expr, '!=', False)
+            operator = '<'
 
-    return DomainCondition(condition.field_expr, operator, value)
+    # Handle equality: compare to the whole second
+    if (
+        operator in ('in', 'not in')
+        and isinstance(value, COLLECTION_TYPES)
+        and any(isinstance(v, datetime) for v in value)
+    ):
+        delta = timedelta(seconds=1)
+        domain = DomainOr.apply(
+            DomainCondition(field_expr, '>=', v.replace(microsecond=0))
+            & DomainCondition(field_expr, '<', v.replace(microsecond=0) + delta)
+            if isinstance(v, datetime) else DomainCondition(field_expr, '=', v)
+            for v in value
+        )
+        if operator == 'not in':
+            domain = ~domain
+        return domain
+
+    return DomainCondition(field_expr, operator, value)
 
 
 @field_type_optimization(['binary'])


### PR DESCRIPTION
Odoo manipulates datetimes as whole seconds, however, values saves in the database may have microseconds. Conditions should have that case and compare whole seconds.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
