### PR TITLE
[FIX] mail: notify recipients with active records of model

### DIFF
--- a/addons/account/tests/test_mail_tracking_value.py
+++ b/addons/account/tests/test_mail_tracking_value.py
@@ -5,7 +5,7 @@
 from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.mail.tests.common import MailCommon
-from odoo.tests import Form
+from odoo.tests import Form, users
 from odoo.tests.common import tagged
 
 
@@ -45,3 +45,45 @@ class TestTracking(AccountTestInvoicingCommon, MailCommon):
         self.assertTrue(tracking_value.field_id)
         field = self.env[tracking_value.field_id.model]._fields[tracking_value.field_id.name]
         self.assertFalse(field.groups, "There is no group on account.move.line.account_id")
+
+    @users('admin')
+    def test_invite_follower_account_moves(self):
+        """ Test that the mail_followers_edit wizard works on both single and multiple account.move records """
+        multiple_account_moves = [
+            {
+                'description': 'Single account.move',
+                'account_moves': [{'name': 'Test Single', 'partner_id': self.partner_a.id}],
+                'expected_partners': self.partner_a | self.user_admin.partner_id,
+            },
+            {
+                'description': 'Multiple account.moves',
+                'account_moves': [
+                    {'name': 'Move 1', 'partner_id': self.partner_a.id},
+                    {'name': 'Move 2', 'partner_id': self.partner_b.id},
+                ],
+                'expected_partners': self.partner_a | self.user_admin.partner_id,
+            },
+        ]
+        for move in multiple_account_moves:
+            with self.subTest(move['description']):
+                account_moves = self.env['account.move'].with_context(self._test_context).create(move['account_moves'])
+                mail_invite = self.env['mail.followers.edit'].with_context({
+                    'default_res_model': 'account.move',
+                    'default_res_ids': account_moves.ids,
+                }).with_user(self.user_admin).create({
+                    'partner_ids': [(4, self.partner_a.id), (4, self.user_admin.partner_id.id)],
+                    'notify': True,
+                })
+                with self.mock_mail_app(), self.mock_mail_gateway():
+                    mail_invite.edit_followers()
+
+                for account_move in account_moves:
+                    self.assertEqual(account_move.message_partner_ids, move['expected_partners'])
+
+                self.assertEqual(len(self._new_msgs), 1)
+                self.assertEqual(len(self._mails), 1)
+                self.assertNotSentEmail([self.partner_admin])
+                self.assertNotified(
+                    self._new_msgs[0],
+                    [{'partner': self.partner_admin, 'type': 'inbox', 'is_read': False}]
+                )

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -6786,6 +6786,12 @@ msgid "No conversation yet..."
 msgstr ""
 
 #. module: mail
+#. odoo-python
+#: code:addons/mail/wizard/mail_followers_edit.py:0
+msgid "No documents found for the selected records."
+msgstr ""
+
+#. module: mail
 #. odoo-javascript
 #: code:addons/mail/static/src/core/web/thread_patch.xml:0
 msgid "No history messages"

--- a/addons/mail/wizard/mail_followers_edit.py
+++ b/addons/mail/wizard/mail_followers_edit.py
@@ -30,6 +30,8 @@ class MailFollowersEdit(models.TransientModel):
         for wizard in self:
             res_ids = parse_res_ids(wizard.res_ids, self.env)
             documents = self.env[wizard.res_model].browse(res_ids)
+            if not documents:
+                raise UserError(self.env._("No documents found for the selected records."))
             if wizard.operation == "remove":
                 documents.message_unsubscribe(partner_ids=wizard.partner_ids.ids)
             else:
@@ -44,7 +46,7 @@ class MailFollowersEdit(models.TransientModel):
                     model_name = self.env["ir.model"]._get(wizard.res_model).display_name
                     message_values = wizard._prepare_message_values(documents, model_name)
                     message_values["partner_ids"] = wizard.partner_ids.ids
-                    self.env[wizard.res_model].message_notify(**message_values)
+                    documents[0].message_notify(**message_values)
         return {
             "type": "ir.actions.client",
             "tag": "display_notification",


### PR DESCRIPTION
This error occurs when users select Add Follower in Invoice and enable `Notify Recipients.`

Steps to Reproduce:

- Install the `Account module`
- Open Invoices > In Chatter `Add Follower`
- Activate `Notify Recipients`
- Click on Add Followers

`ValueError: Expected singleton: account.move()`

This error occurred when the system failed to retrieve the account move ID due to 
current changes at [1], causing account.move to be empty.

This commit ensures the records are correctly retrieved from the wizard context
before sending notifications.

Link [1] : https://github.com/odoo/odoo/pull/167045

Sentry - 6489398559, 6451557597

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
