### PR TITLE
[IMP] im_livechat: remove new button in session

### DIFF
--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -44,7 +44,7 @@
             <field name="name">discuss.channel.kanban</field>
             <field name="model">discuss.channel</field>
             <field name="arch" type="xml">
-                <kanban js_class="im_livechat.discuss_channel_kanban" class="o_kanban_mobile" sample="1" quick_create="false" default_order="create_date desc">
+                <kanban js_class="im_livechat.discuss_channel_kanban" class="o_kanban_mobile" sample="1" quick_create="false" create="False" default_order="create_date desc">
                     <templates>
                         <t t-name="card">
                             <div class="d-flex">


### PR DESCRIPTION
Purpose:
Sessions should only be created through live chat. 
Since the list view doesn’t allow session creation, 
the same rule should apply to the kanban view.

task-[4668382](https://www.odoo.com/odoo/project/1519/tasks/4668382)