### PR TITLE
[FIX] account: Account tab is not opening on the contact

### DIFF
--- a/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
+++ b/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
@@ -5,6 +5,7 @@ import {
 import { registry } from "@web/core/registry";
 import { TagsList } from "@web/core/tags_list/tags_list";
 import { _t } from "@web/core/l10n/translation";
+import { onMounted } from "@odoo/owl";
 
 export class FieldMany2ManyTagsBanksTagsList extends TagsList {
     static template = "FieldMany2ManyTagsBanksTagsList";
@@ -20,7 +21,9 @@ export class FieldMany2ManyTagsBanks extends Many2ManyTagsFieldColorEditable {
         super.setup();
         // Needed when you create a partner (from a move for example), we want the partner to be saved to be able
         // to have it as account holder
-        this.props.record.model.root.save();
+        onMounted(()=>{
+            this.props.record.model.root.save();
+        })
     }
 
     getTagProps(record) {


### PR DESCRIPTION
### Steps to Reproduce:
- Go to the Contacts app and create a new contact with an associated account.
- Reload or reopen the same contact's Accounting tab.

### Cause:
- It seems that the many2many_tags_bank.js file is re-rendering multiple times, causing it to get stuck in the setup() call.

### Fix:
- To resolve this, we will call the save() method while mounting the component.

task: 4674029

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
