### PR TITLE
[FIX] mrp_subcontacting_dropshipping: remove backorder_ids from tests

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
@@ -532,6 +532,6 @@ class TestSubcontractingDropshippingPortal(TestSubcontractingPortal):
         }])
         # Check that the initial MO has been splitted in 2
         self.assertTrue("-001" in mo.name)
-        self.assertRecordValues(mo.backorder_ids - mo, [{
+        self.assertRecordValues(mo.procurement_group_id.mrp_production_ids - mo, [{
             'qty_producing': 1.0, 'lot_producing_id': False, 'state': 'to_close',
         }])


### PR DESCRIPTION
### Issue:

The community runs of the test:
`test_portal_subcontractor_record_production_with_dropship` fail since the field `backorder_ids` of the mrp.production model is part of the `stock_barcode_mrp` module (part of the entreprise repo).

runbot-build-error-159951
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
