### PR TITLE
[FIX] html_editor: properly parse self-closing spans

### DIFF
--- a/addons/html_editor/static/src/utils/sanitize.js
+++ b/addons/html_editor/static/src/utils/sanitize.js
@@ -30,7 +30,7 @@ export function fixInvalidHTML(content) {
     }
     // TODO: improve the regex to support nodes with data-attributes containing
     // `/` and `>` characters.
-    const regex = /<\s*(a|strong|t)[^<]*?\/\s*>/g;
+    const regex = /<\s*(a|strong|t|span)[^<]*?\/\s*>/g;
     return content.replace(regex, (match, g0) => match.replace(/\/\s*>/, `></${g0}>`));
 }
 


### PR DESCRIPTION
**Problem**:
Some email templates (e.g., "Mail: Install Request") contain self-closing `<span>` elements, which are
not parsed correctly in the editor. This leads to
broken styles upon saving changes.

**Solution**:
Convert self-closing `<span>` elements into properly opened and closed `<span>` tags.

**Steps to reproduce**:
1. Open the email template **"Mail: Install Request"**.
2. Apply any change and save.
   - **Issue**: Styles are completely broken.

**opw-4633229**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
