### PR TITLE
[IMP] point_of_sale: exclude combo choice quantity from product card count

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -105,9 +105,10 @@ export class ProductScreen extends Component {
         useEffect(
             () => {
                 this.state.quantityByProductTmplId = this.currentOrder?.lines?.reduce((acc, ol) => {
-                    acc[ol.product_id.product_tmpl_id.id]
-                        ? (acc[ol.product_id.product_tmpl_id.id] += ol.qty)
-                        : (acc[ol.product_id.product_tmpl_id.id] = ol.qty);
+                    if (!ol.combo_parent_id) {
+                        const productTmplId = ol.product_id.product_tmpl_id.id;
+                        acc[productTmplId] = (acc[productTmplId] || 0) + ol.qty;
+                    }
                     return acc;
                 }, {});
             },

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -81,6 +81,11 @@ registry.category("web_tour.tours").add("ProductComboPriceTaxIncludedTour", {
             combo.select("Combo Product 4"),
             combo.select("Combo Product 6"),
             Dialog.confirm(),
+            {
+                content: "The 'Combo Product 6' card should not display a quantity.",
+                trigger:
+                    "article.product .product-content:has(.product-name:contains('Combo Product 6')):not(:has(.product-cart-qty))",
+            },
             ...ProductScreen.totalAmountIs("59.17"),
             ...inLeftSide(Order.hasTax("10.56")),
             // the split screen is tested in `pos_restaurant`


### PR DESCRIPTION
In this commit:
=======
Ensures that combo choice quantities are not included when calculating the product card quantity count.

Task: 4676110
