### PR TITLE
[IMP] l10n_in_edi: Log Message in chatter for Invalid Optional Fields

### DIFF
--- a/addons/l10n_in_edi/i18n/l10n_in_edi.pot
+++ b/addons/l10n_in_edi/i18n/l10n_in_edi.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~18.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-20 10:17+0000\n"
-"PO-Revision-Date: 2025-03-20 10:17+0000\n"
+"POT-Creation-Date: 2025-05-12 05:50+0000\n"
+"PO-Revision-Date: 2025-05-12 05:50+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,14 +23,14 @@ msgstr ""
 
 #. module: l10n_in_edi
 #. odoo-python
-#: code:addons/l10n_in_edi/models/res_partner.py:0
-msgid "- Email address should be valid and not more then 100 characters"
+#: code:addons/l10n_in_edi/models/account_move.py:0
+msgid "- Email: invalid or longer than 100 characters."
 msgstr ""
 
 #. module: l10n_in_edi
 #. odoo-python
-#: code:addons/l10n_in_edi/models/res_partner.py:0
-msgid "- Mobile number should be minimum 10 or maximum 12 digits"
+#: code:addons/l10n_in_edi/models/account_move.py:0
+msgid "- Phone number: must be 10–12 digits."
 msgstr ""
 
 #. module: l10n_in_edi
@@ -47,8 +47,8 @@ msgstr ""
 
 #. module: l10n_in_edi
 #. odoo-python
-#: code:addons/l10n_in_edi/models/res_partner.py:0
-msgid "- Street2 should be min 3 and max 100 characters"
+#: code:addons/l10n_in_edi/models/account_move.py:0
+msgid "- Street2: must be 3–100 characters."
 msgstr ""
 
 #. module: l10n_in_edi
@@ -291,6 +291,12 @@ msgid "Error when sending the invoice to government:"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/account_move.py:0
+msgid "Following:"
+msgstr ""
+
+#. module: l10n_in_edi
 #: model_terms:ir.ui.view,arch_db:l10n_in_edi.invoice_form_inherit_l10n_in_edi
 msgid "Force Cancel"
 msgstr ""
@@ -519,7 +525,14 @@ msgstr ""
 #. module: l10n_in_edi
 #. odoo-python
 #: code:addons/l10n_in_edi/models/res_company.py:0
-msgid "View Company/ies"
+#: code:addons/l10n_in_edi/models/res_partner.py:0
+msgid "View %s"
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/res_company.py:0
+msgid "View Companies"
 msgstr ""
 
 #. module: l10n_in_edi

--- a/addons/l10n_in_edi/models/res_company.py
+++ b/addons/l10n_in_edi/models/res_company.py
@@ -89,7 +89,10 @@ class ResCompany(models.Model):
         return {
             f"l10n_in_edi_{key}": {
                 'message': check['message'],
-                'action_text': _("View Company/ies"),
+                'action_text': (
+                    _("View Companies") if len(invalid_records) > 1
+                    else _("View %s", invalid_records.name)
+                ),
                 'action': invalid_records._get_records_action(name=_("Check Company Data")),
             }
             for key, check in checks.items()

--- a/addons/l10n_in_edi/models/res_partner.py
+++ b/addons/l10n_in_edi/models/res_partner.py
@@ -18,23 +18,12 @@ class ResPartner(models.Model):
         message = []
         if not re.match("^.{3,100}$", self.street or ""):
             message.append(_("- Street required min 3 and max 100 characters"))
-        if self.street2 and not re.match("^.{3,100}$", self.street2):
-            message.append(_("- Street2 should be min 3 and max 100 characters"))
         if not re.match("^.{3,100}$", self.city or ""):
             message.append(_("- City required min 3 and max 100 characters"))
         if self.country_id.code == "IN" and not re.match("^.{3,50}$", self.state_id.name or ""):
             message.append(_("- State required min 3 and max 50 characters"))
         if self.country_id.code == "IN" and not re.match("^([1-9][0-9]{5})$", self.zip or ""):
             message.append(_("- ZIP code required 6 digits ranging from 100000 to 999999"))
-        if self.phone and not re.match("^[0-9]{10,12}$",
-            self.env['account.move']._l10n_in_extract_digits(self.phone)
-        ):
-            message.append(_("- Mobile number should be minimum 10 or maximum 12 digits"))
-        if self.email and (
-            not re.match(r"^[a-zA-Z0-9+_.-]+@[a-zA-Z0-9.-]+$", self.email)
-            or not re.match("^.{6,100}$", self.email)
-        ):
-            message.append(_("- Email address should be valid and not more then 100 characters"))
         if message:
             message.insert(0, self.display_name)
         return message
@@ -44,15 +33,17 @@ class ResPartner(models.Model):
             'partner_address_missing': {
                 'fields': ('street', 'zip', 'city', 'state_id', 'country_id',),
                 'message': _(
-                    "Partners should have a complete address, verify their Street, City, State, "
-                    "Country and Zip code."
+                    "Partners should have a complete address, verify their Street, City, State, Country and Zip code."
                 ),
             },
         }
         return {
             f"l10n_in_edi_{key}": {
                 'message': check['message'],
-                'action_text': _("View Partners"),
+                'action_text': (
+                    _("View Partners") if len(invalid_records) > 1
+                    else _("View %s", invalid_records.name)
+                ),
                 'action': invalid_records._get_records_action(name=_("Check Partner Data")),
             }
             for key, check in checks.items()


### PR DESCRIPTION
Previously, all available data was sent to the E-Invoice system,
even if some fields contained incorrect values.
However, certain fields (e.g., email) have validation but are not required.

**After this commit:**
- Before generating the final JSON, only correctly validated
  fields are included.
- Ensured that incorrect or improperly formatted data does not get sent.
- Invalid optional fields are now logged  in the chatter with error message.

![image](https://github.com/user-attachments/assets/5dd00fa3-aac4-4e75-8b7d-9a7c92879eda)


task-4594234

