### PR TITLE
[FIX] point_of_sale: internal note appearance in kitchen ticket

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1618,6 +1618,14 @@ export class PosStore extends WithLazyGetterTrap {
         await this.sendOrderInPreparation(o, { cancelled });
     }
 
+    getStrNotes(note) {
+        return note && typeof note === "string"
+            ? JSON.parse(note)
+                  .map((n) => n.text)
+                  .join(", ")
+            : "";
+    }
+
     generateOrderChange(order, orderChange, categories, reprint = false) {
         const isPartOfCombo = (line) =>
             line.isCombo || this.models["product.product"].get(line.product_id).type == "combo";
@@ -1643,7 +1651,7 @@ export class PosStore extends WithLazyGetterTrap {
             preset_name: order.preset_id?.name || "",
             preset_time: order.presetDateTime,
             employee_name: order.employee_id?.name || order.user_id?.name,
-            internal_note: order.internal_note,
+            internal_note: this.getStrNotes(order.internal_note),
             general_customer_note: order.general_customer_note,
             changes: {
                 title: "",
@@ -1652,6 +1660,9 @@ export class PosStore extends WithLazyGetterTrap {
         };
 
         const changes = this.filterChangeByCategories(categories, orderChange);
+        for (const changeItem of [...changes.new, ...changes.cancelled, ...changes.noteUpdate]) {
+            changeItem.note = this.getStrNotes(changeItem.note || "[]");
+        }
         return { orderData, changes };
     }
 

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -49,13 +49,13 @@
                     <div class="pos-receipt-title text-center w-100">
                         <strong>INTERNAL NOTE</strong>
                     </div>
-                    <div class="text-center" style="font-size: 109%;" t-esc="data.internal_note.split('\n').join(', ')" />
+                    <div class="text-center" style="font-size: 109%;" t-esc="data.internal_note" />
                 </div>
                 <div t-if="data.general_customer_note and !hasDataChanges" class="new-changes w-100">
                     <div class="pos-receipt-title text-center w-100">
                         <strong>CUSTOMER NOTE</strong>
                     </div>
-                    <div class="text-center" style="font-size: 109%;" t-esc="data.general_customer_note.split('\n').join(', ')" />
+                    <div class="text-center" style="font-size: 109%;" t-esc="data.general_customer_note" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
In this commit:
-------------------
- We have adapted the new structure of internal note of having a string containing array of objects so now restructured to show only the text needed correctly on ui.

task-4674444
