### PR TITLE
[FIX] account: avoid computed account which is not allowed in journal

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -592,6 +592,7 @@ class AccountMoveLine(models.Model):
                     company_id=line.company_id.id,
                     partner_id=line.partner_id.id,
                     move_type=line.move_id.move_type,
+                    journal_id=line.journal_id.id,
                 )
         for line in self:
             if not line.account_id and line.display_type not in ('line_section', 'line_note'):


### PR DESCRIPTION
We predict the account to use in an invoice/purchase entries based on product configuration and frequent account used for partner but we do not verify if those accounts are allowed on the specified journal. This can be problematic if the entry is generated from a external file (ex: using Peppol), Odoo should retrieve an account allowed in the journal.

Steps to reproduce:
1. Have two purchase journal A and B on the same company
2. Set an expense account that is allowed on one of those journal (A) and not the other (B)
3. Create multiple bills with this account on the journal A for partner X
4. Upload a XML bill of partner X in journal B -> The expense account is used based on the bills in journal A -> Error because journal B is not allowed for this account

opw-4607733
