### PR TITLE
[FIX] base: Prevent concurrent module operations

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -22622,6 +22622,14 @@ msgstr ""
 
 #. module: base
 #. odoo-python
+#: code:addons/base/models/ir_module.py:0
+msgid ""
+"Odoo is currently processing another module operation.\n"
+"Please try again later or contact your system administrator."
+msgstr ""
+
+#. module: base
+#. odoo-python
 #: code:addons/base/models/ir_actions_report.py:0
 #, python-format
 msgid ""

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -587,6 +587,18 @@ class Module(models.Model):
                 "is best to write it as a standalone script, and ask the runbot/metastorm team "
                 "for help."
             )
+
+        # raise error if database is updating for module operations
+        if self.search_count([('state', 'in', ('to install', 'to upgrade', 'to remove'))], limit=1):
+            raise UserError(_("Odoo is currently processing another module operation.\n"
+                               "Please try again later or contact your system administrator."))
+        try:
+            # raise error if another transaction is trying to schedule module operations concurrently
+            self.env.cr.execute("LOCK ir_module_module IN EXCLUSIVE MODE NOWAIT")
+        except psycopg2.OperationalError:
+            raise UserError(_("Odoo is currently processing another module operation.\n"
+                               "Please try again later or contact your system administrator."))
+
         try:
             # This is done because the installation/uninstallation/upgrade can modify a currently
             # running cron job and prevent it from finishing, and since the ir_cron table is locked


### PR DESCRIPTION
Before this commit, a user could start a module installation, abandon the loading page due to impatience, and attempt to start another installation. This could lead to various errors, such as `SERIALIZATION_FAILURE`, "Failed to load registry," or even a broken database.

Module operations (install/upgrade/uninstall) are executed in multiple transactions:
1. Dependency Check & State Update:
   - A transaction checks module dependencies, determines which modules need updating, and marks them as 'to install', 'to upgrade', or 'to remove'.
2. Registry Reload & Module Update:
   - The registry is reloaded, and modules are updated one by one in their own transactions, changing their states to 'installed' or 'uninstalled'.

This commit introduces two additional checks in step (1):
a) If any module is already in an updating state, raise a `UserError` to prevent concurrent module operations in step (2).
b) If the transaction fails to acquire a `SELECT ... FOR UPDATE` lock on all `ir_module_module` records, raise a `UserError`, as this indicates another concurrent operation of step (1) has either acquired the lock or already modified some module states and committed.

These checks ensure proper concurrency control, preventing concurrent module operations

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
