### PR TITLE
[IMP] point_of_sale: allow multiple selections per combo

### DIFF
--- a/addons/point_of_sale/models/product_combo.py
+++ b/addons/point_of_sale/models/product_combo.py
@@ -1,11 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import _, api, models, fields
+from odoo.exceptions import ValidationError
 
 
 class ProductCombo(models.Model):
     _name = 'product.combo'
     _inherit = ['product.combo', 'pos.load.mixin']
+
+    qty_max = fields.Integer(string="Maximum quantity", default=1, help="Maximum number of items to select in the combo.")
+    qty_free = fields.Integer(string="Free quantity", default=1, help="Number of free items included in the combo.")
 
     @api.model
     def _load_pos_data_domain(self, data):
@@ -13,4 +17,19 @@ class ProductCombo(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'name', 'combo_item_ids', 'base_price']
+        return ['id', 'name', 'combo_item_ids', 'base_price', 'qty_free', 'qty_max']
+
+    @api.constrains('qty_max')
+    def _check_qty_max(self):
+        if any(combo.qty_max < 1 for combo in self):
+            raise ValidationError(_("The maximum quantity of a combo must be greater or equal to 1."))
+
+    @api.constrains('qty_free')
+    def _check_qty_free(self):
+        if any(combo.qty_free < 0 for combo in self):
+            raise ValidationError(_("The free quantity of a combo must be greater or equal to 0."))
+
+    @api.constrains('qty_max', 'qty_free')
+    def _check_qty_max_greater_than_qty_free(self):
+        if any(combo.qty_free > combo.qty_max for combo in self):
+            raise ValidationError(_("The free quantity must be smaller or equal to the maximum quantity."))

--- a/addons/point_of_sale/static/src/app/components/buttons/quantity_buttons/quantity_buttons.js
+++ b/addons/point_of_sale/static/src/app/components/buttons/quantity_buttons/quantity_buttons.js
@@ -1,0 +1,23 @@
+import { Component } from "@odoo/owl";
+
+export class QuantityButtons extends Component {
+    static template = "point_of_sale.QuantityButtons";
+    static props = {
+        quantity: Number,
+        setQuantity: Function,
+        isPlusButtonDisabled: { type: Boolean, optional: true },
+        btnClasses: { type: String, optional: true },
+    };
+
+    changeQuantity(increment) {
+        const isDisabled = increment == 1 && this.props.isPlusButtonDisabled;
+        if (!isDisabled) {
+            this.props.setQuantity(this.props.quantity + increment);
+        }
+    }
+
+    setQuantity(event) {
+        const quantity = parseFloat(event.target.value);
+        this.props.setQuantity(isNaN(quantity) ? 0 : quantity);
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/buttons/quantity_buttons/quantity_buttons.scss
+++ b/addons/point_of_sale/static/src/app/components/buttons/quantity_buttons/quantity_buttons.scss
@@ -1,0 +1,27 @@
+input[name="pos_quantity"] {
+    padding: 0;
+
+    @include media-breakpoint-down(md) {
+        max-width: 3rem;
+    }
+
+    @include media-breakpoint-up(md) {
+        max-width: 4rem;
+    }
+
+    // removing input field=number arrows as their size might
+    // change depending on browser default styling and shift input's position
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+    &[type=number] {
+        -moz-appearance: textfield;
+    }
+}
+
+.px-2-5 {
+  padding-right: 0.75rem !important;
+  padding-left: 0.75rem !important;
+}

--- a/addons/point_of_sale/static/src/app/components/buttons/quantity_buttons/quantity_buttons.xml
+++ b/addons/point_of_sale/static/src/app/components/buttons/quantity_buttons/quantity_buttons.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="point_of_sale.QuantityButtons">
+        <div name="quantity_buttons_wrapper" class="input-group justify-content-end justify-content-md-center p-1 pt-0">
+            <button
+                t-attf-class="px-2-5 btn btn-secondary btn-sm {{ props.btnClasses or 'd-md-inline-block' }}"
+                name="pos_quantity_button_minus"
+                aria-label="Remove one"
+                t-on-click.stop="() => this.changeQuantity(-1)">
+                <i class="fa fa-minus"/>
+            </button>
+            <input
+                class="form-control quantity text-center"
+                name="pos_quantity"
+                type="number"
+                t-att-value="props.quantity"
+                t-on-click.stop=""
+                t-on-change="setQuantity"/>
+            <button
+                t-attf-class="px-2-5 btn btn-secondary btn-sm {{ props.btnClasses or 'd-md-inline-block' }}"
+                name="pos_quantity_button_plus"
+                aria-label="Add one"
+                t-att-disabled="props.isPlusButtonDisabled"
+                t-on-click.stop="() => this.changeQuantity(1)">
+                <i class="fa fa-plus"/>
+            </button>
+        </div>
+    </t>
+</templates>

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -2,14 +2,14 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.Orderline">
         <li t-if="line.order_id" class="orderline position-relative d-flex align-items-center lh-sm cursor-pointer"
-            t-attf-class="{{ line.combo_parent_id?.getFullProductName() ? 'orderline-combo fst-italic ms-4 border-start' : '' }}"
+            t-attf-class="{{ line.combo_parent_id ? 'orderline-combo fst-italic ms-4 border-start' : '' }}"
             t-att-class="{'selected' : line.isSelected() and this.props.mode === 'display', ...line.getDisplayClasses(), ...(props.class || [])}">
             <div class="product-order"></div>
             <div t-if="props.showImage and line.product_id.getImageUrl()" class="o_line_container d-flex align-items-center justify-content-center">
                 <img t-attf-style="border-radius: 1rem;" t-att-src="line.product_id.getImageUrl()"/>
             </div>
             <div class="d-flex flex-column w-100"
-                 t-attf-class="{{ line.combo_parent_id?.getFullProductName() ? 'px-2 py-1' : 'p-2' }}">
+                 t-attf-class="{{ line.combo_parent_id ? 'px-2 py-1' : 'p-2' }}">
                 <div class="line-details d-flex justify-content-between align-items-center">
                     <div class="product-name d-flex flex-grow-1 align-items-center pe-2 text-truncate">
                         <span class="qty d-inline-block px-1 fw-bolder">
@@ -34,7 +34,7 @@
                             <i class="fa fa-tag pe-1"/><em><t t-esc="discount" />% </em> discount off on <t t-esc="env.utils.formatCurrency(line.allPrices.priceWithTaxBeforeDiscount)"/>
                         </t>
                     </li>
-                    <li class="price-per-unit" t-if="!props.basic_receipt and (props.mode == 'receipt' || line.price_type !== 'original')">
+                    <li class="price-per-unit" t-if="!props.basic_receipt and (props.mode == 'receipt' || (line.price_type !== 'original' and !line.combo_parent_id))">
                         <t t-if="line.price !== 0">
                             <i class="fa fa-money center pe-1"/>
                             <t t-esc="formatCurrency(line.unitDisplayPrice)" />

--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.js
@@ -2,10 +2,12 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { Component, useState, onMounted } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { ProductCard } from "@point_of_sale/app/components/product_card/product_card";
+import { QuantityButtons } from "@point_of_sale/app/components/buttons/quantity_buttons/quantity_buttons";
+import { useService } from "@web/core/utils/hooks";
 
 export class ComboConfiguratorPopup extends Component {
     static template = "point_of_sale.ComboConfiguratorPopup";
-    static components = { ProductCard, Dialog };
+    static components = { ProductCard, Dialog, QuantityButtons };
     static props = {
         productTemplate: Object,
         getPayload: Function,
@@ -14,12 +16,16 @@ export class ComboConfiguratorPopup extends Component {
 
     setup() {
         this.pos = usePos();
+        this.ui = useService("ui");
         this.state = useState({
-            combo: Object.fromEntries(
-                this.props.productTemplate.combo_ids.map((combo) => [combo.id, 0])
-            ),
             // configuration: id of combo_item -> ProductConfiguratorPopup payload
             configuration: {},
+            qty: Object.fromEntries(
+                this.props.productTemplate.combo_ids.map((combo) => [
+                    combo.id,
+                    Object.fromEntries(combo.combo_item_ids.map((item) => [item.id, 0])),
+                ])
+            ),
         });
 
         onMounted(() => {
@@ -43,7 +49,7 @@ export class ComboConfiguratorPopup extends Component {
                 combo.combo_item_ids.length === 1 &&
                 !combo.combo_item_ids[0].product_id.isConfigurable()
             ) {
-                this.state.combo[combo.id] = combo.combo_item_ids[0].id;
+                this.state.qty[combo.id][combo.combo_item_ids[0].id] = 1;
             }
         });
     }
@@ -52,45 +58,100 @@ export class ComboConfiguratorPopup extends Component {
         return this.props.productTemplate.combo_ids.some((combo) => this.shouldShowCombo(combo));
     }
 
-    areAllCombosSelected() {
-        return Object.values(this.state.combo).every((x) => Boolean(x));
+    isConfirmButtonEnabled() {
+        return Object.keys(this.state.qty).every((comboId) => {
+            const combo = this.pos.models["product.combo"].get(comboId);
+            return combo.qty_free == 0 || this.totalQuantityForCombo(comboId) >= combo.qty_free;
+        });
     }
 
     formattedComboPrice(comboItem) {
-        const extra_price = comboItem.extra_price;
-        if (this.pos.currency.isZero(extra_price)) {
-            return "";
-        } else {
-            const product = comboItem.product_id;
-            const price = this.pos.getProductPrice(product, extra_price);
-            return this.env.utils.formatCurrency(price);
-        }
+        return this.pos.currency.isZero(comboItem.extra_price)
+            ? ""
+            : this.env.utils.formatCurrency(comboItem.extra_price);
     }
 
     getSelectedComboItems() {
-        return Object.values(this.state.combo)
-            .filter((x) => x) // we only keep the non-zero values
-            .map((x) => {
-                const combo_item_id = this.pos.models["product.combo.item"].get(x);
-                return {
-                    combo_item_id: combo_item_id,
-                    configuration: this.state.configuration[combo_item_id.id],
-                };
-            });
+        const itemsIncluded = [];
+        const itemsExtra = [];
+        const comboFreeQtyTracker = {};
+        Object.values(this.state.qty).forEach((comboItems) => {
+            Object.entries(comboItems)
+                .filter(([, qty]) => qty > 0)
+                .forEach(([itemId, qty]) => {
+                    const comboItemId = this.pos.models["product.combo.item"].get(itemId);
+                    const comboId = comboItemId.combo_id.id;
+                    const comboFreeQty = comboItemId.combo_id.qty_free;
+
+                    if (!comboFreeQtyTracker[comboId]) {
+                        comboFreeQtyTracker[comboId] = 0;
+                    }
+
+                    const remainingFreeQty = comboFreeQty - comboFreeQtyTracker[comboId];
+                    if (remainingFreeQty > 0) {
+                        const includedQty = Math.min(qty, remainingFreeQty);
+                        itemsIncluded.push({
+                            combo_item_id: comboItemId,
+                            configuration: this.state.configuration[comboItemId.id],
+                            qty: includedQty,
+                        });
+                        comboFreeQtyTracker[comboId] += includedQty;
+                        qty -= includedQty;
+                    }
+
+                    if (qty > 0) {
+                        itemsExtra.push({
+                            combo_item_id: comboItemId,
+                            configuration: this.state.configuration[comboItemId.id],
+                            qty: qty,
+                        });
+                    }
+                });
+        });
+
+        return [itemsIncluded, itemsExtra];
     }
 
-    async onClickProduct({ product, combo_item }, ev) {
+    async onClickProduct(product, combo_item) {
         const productTmpl = product.product_tmpl_id;
+        const combo = combo_item.combo_id;
         if (
             productTmpl.isConfigurable() &&
             product.product_template_variant_value_ids.length === 0
         ) {
-            const payload = await this.pos.openConfigurator(product.product_tmpl_id);
-            if (payload) {
-                this.state.configuration[combo_item.id] = payload;
+            this.onClickConfigurableProduct(product, combo_item, combo);
+        } else {
+            this.onClickSimpleProduct(combo_item, combo);
+        }
+    }
+
+    resetComboQuantities(comboId) {
+        for (const itemId in this.state.qty[comboId]) {
+            this.state.qty[comboId][itemId] = 0;
+        }
+    }
+
+    async onClickSimpleProduct(combo_item, combo) {
+        if (combo.qty_max === 1) {
+            this.resetComboQuantities(combo.id);
+        }
+        if (this.totalQuantityForCombo(combo.id) < combo.qty_max) {
+            this.state.qty[combo.id][combo_item.id] += 1;
+        }
+    }
+
+    async onClickConfigurableProduct(product, combo_item, combo) {
+        const isSingleQtyChoice = combo.qty_max === 1;
+        if (this.totalQuantityForCombo(combo.id) < combo.qty_max || isSingleQtyChoice) {
+            if (this.state.qty[combo.id][combo_item.id] > 0 && !isSingleQtyChoice) {
+                this.state.qty[combo.id][combo_item.id] += 1;
             } else {
-                // Do not select the product if configuration popup is cancelled.
-                this.state.combo[combo_item.combo_id.id] = 0;
+                const payload = await this.pos.openConfigurator(product.product_tmpl_id);
+                if (payload) {
+                    this.resetComboQuantities(combo.id);
+                    this.state.configuration[combo_item.id] = payload;
+                    this.state.qty[combo.id][combo_item.id] = 1;
+                }
             }
         }
     }
@@ -98,5 +159,53 @@ export class ComboConfiguratorPopup extends Component {
     confirm() {
         this.props.getPayload(this.getSelectedComboItems());
         this.props.close();
+    }
+
+    showQuantityButtons(combo_item) {
+        return (
+            this.state.qty[combo_item.combo_id.id][combo_item.id] && combo_item.combo_id.qty_max > 1
+        );
+    }
+
+    setQuantity(combo_item, quantity) {
+        //Make sure quantity is within the bounds [0, combo_id.qty_max]
+        const combo_id = combo_item.combo_id;
+        const maxQtyAvailable =
+            combo_id.qty_max -
+            this.totalQuantityForCombo(combo_id.id) +
+            this.state.qty[combo_id.id][combo_item.id];
+        quantity = Math.max(0, Math.min(quantity, maxQtyAvailable));
+        this.state.qty[combo_id.id][combo_item.id] = quantity;
+    }
+
+    totalQuantityForCombo(comboId) {
+        return Object.values(this.state.qty[comboId]).reduce((total, qty) => total + qty, 0);
+    }
+
+    computeComboExtraPrice(combo) {
+        const extraQty = this.totalQuantityForCombo(combo.id) - combo.qty_free;
+        const extraQtyPrice = extraQty > 0 ? extraQty * combo.base_price : 0;
+
+        const comboChoicesExtraPrices = combo.combo_item_ids.reduce((acc, comboItem) => {
+            const qty = this.state.qty[combo.id][comboItem.id];
+            const extraPrice = comboItem.extra_price;
+            return acc + qty * extraPrice;
+        }, 0);
+        return extraQtyPrice + comboChoicesExtraPrices;
+    }
+
+    formatTotalPrice(productTemplate) {
+        const basePrice = productTemplate.list_price;
+        const extraPrice = productTemplate.combo_ids.reduce(
+            (acc, combo) => acc + this.computeComboExtraPrice(combo),
+            0
+        );
+        return this.env.utils.formatCurrency(basePrice + extraPrice);
+    }
+
+    getSelectedComboItemsText(combo) {
+        return combo.qty_free > 1
+            ? `${Math.min(this.totalQuantityForCombo(combo.id), combo.qty_free)}/${combo.qty_free}`
+            : "1";
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.scss
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.scss
@@ -1,9 +1,3 @@
-.combo-configurator-popup input{
-    -webkit-appearance:none;
-       -moz-appearance:none;
-            appearance:none;
-}
-
-.combo-configurator-popup input.selected + label {
+.combo-configurator-popup label.selected {
     box-shadow: 0 0 0 ($border-width * 2) $o-action;
 }

--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
@@ -4,35 +4,55 @@
         <Dialog title="props.productTemplate.display_name" contentClass="'combo-configurator-popup'">
             <div t-foreach="props.productTemplate.combo_ids" t-as="combo" t-key="combo.id" class="d-flex flex-column m-3 mb-4">
                 <t t-if="shouldShowCombo(combo)">
-                    <h3 class="me-auto mb-3" t-esc="combo.name"/>
+                    <div class="d-flex align-items-center mb-3">
+                        <h3 class="mb-0" t-esc="combo.name"></h3>
+                        <t t-if="combo.qty_free > 0">
+                            <h5 class="text-muted ms-2 mb-0">
+                                <t t-esc="this.getSelectedComboItemsText(combo)"/>
+                                <span class="fst-italic"> free</span>
+                            </h5>
+                        </t>
+                    </div>
                     <div class="product-list d-grid gap-1 gap-lg-2">
                         <div t-foreach="combo.combo_item_ids" t-as="combo_item" t-key="combo_item.id" t-if="combo_item.product_id">
                             <t t-set="product" t-value="combo_item.product_id"/>
-                            <input type="radio"
-                                t-attf-name="combo-{{combo.id}}"
-                                t-attf-id="combo-{{combo.id}}-combo_item-{{combo_item.id}}"
-                                t-attf-value="{{combo_item.id}}"
-                                t-model="state.combo[combo.id]"
-                                t-att-class="{ 'selected': state.combo[combo.id] == combo_item.id }" />
-                            <label t-attf-for="combo-{{combo.id}}-combo_item-{{combo_item.id}}" class="combo-item h-100 w-100 rounded cursor-pointer transition-base">
+                            <label class="combo-item h-100 w-100 rounded cursor-pointer transition-base"
+                                t-att-class="{ 'selected': state.qty[combo.id][combo_item.id] and combo.qty_max == 1 }"
+                                t-attf-for="combo-{{combo.id}}-combo_item-{{combo_item.id}}">
                                 <ProductCard name="product.display_name"
                                     class="'flex-column h-100 border'"
+                                    isComboPopup="true"
                                     productId="product.id"
                                     product="product"
                                     comboExtraPrice="formattedComboPrice(combo_item)"
                                     imageUrl="product.getImageUrl()"
-                                    onClick="(ev) => this.onClickProduct({ product, combo_item }, ev)" />
+                                    onClick="() => this.onClickProduct(product, combo_item)">
+                                    <t t-if="this.showQuantityButtons(combo_item)" t-set-slot="quantityButtons">
+                                        <QuantityButtons
+                                            quantity="state.qty[combo.id][combo_item.id]"
+                                            setQuantity="quantity => this.setQuantity(combo_item, quantity)"
+                                            isPlusButtonDisabled="this.totalQuantityForCombo(combo.id) == combo.qty_max"
+                                            btnClasses="'d-inline-block w-auto'"
+                                        />
+                                    </t>
+                                </ProductCard>
                             </label>
                         </div>
                     </div>
                 </t>
             </div>
             <t t-set-slot="footer">
-                <div class="d-flex flex-column flex-lg-row-reverse align-items-center gap-2 w-100">
-                    <button class="confirm btn btn-primary btn-lg lh-lg w-100 w-lg-25 me-lg-auto"
-                        t-att-disabled="!areAllCombosSelected()" t-on-click="confirm">
+                <div class="d-flex flex-column flex-lg-row align-items-center gap-2 w-100">
+                    <t t-if="this.ui.isSmall">
+                        <div class="h3 ms-lg-auto mb-0 fw-bold">Total: <t t-esc="this.formatTotalPrice(props.productTemplate)"/></div>
+                    </t>
+                    <button class="confirm btn btn-primary btn-lg lh-lg w-100 w-lg-25"
+                        t-att-disabled="!this.isConfirmButtonEnabled()" t-on-click="confirm">
                         Add to order
                     </button>
+                    <t t-if="!this.ui.isSmall">
+                        <div class="h3 ms-lg-auto mb-0 fw-bold">Total: <t t-esc="this.formatTotalPrice(props.productTemplate)"/></div>
+                    </t>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.js
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.js
@@ -13,11 +13,14 @@ export class ProductCard extends Component {
         onClick: { type: Function, optional: true },
         showWarning: { type: Boolean, optional: true },
         productCartQty: { type: [Number, undefined], optional: true },
+        slots: { type: Object, optional: true },
+        isComboPopup: { type: Boolean, optional: true },
     };
     static defaultProps = {
         onClick: () => {},
         class: "",
         showWarning: false,
+        isComboPopup: false,
     };
 
     get productQty() {

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -11,20 +11,23 @@
             <div t-if="props.imageUrl" class="product-img ratio ratio-4x3 rounded-top rounded-3">
                 <img class="w-100 o_object_fit_cover bg-200" t-att-src="props.imageUrl" t-att-alt="props.name" />
             </div>
-            <div class="product-content d-flex h-100 my-1 px-2 rounded-bottom-3 flex-shrink-1" t-att-class="{'h-100' : !props.imageUrl}">
+            <div class="product-content h-100 px-2 rounded-bottom-3 flex-shrink-1"
+                t-att-class="{'d-flex' : !props.isComboPopup, 'my-1': !(props.isComboPopup and !props.imageUrl)}">
                 <div class="overflow-hidden lh-sm product-name"
-                    t-att-class="{'no-image d-flex justify-content-center align-items-center text-center': !props.imageUrl}"
+                    t-att-class="{
+                        'no-image d-flex justify-content-center align-items-center text-center': !props.imageUrl,
+                        'mt-1': props.isComboPopup and !props.imageUrl
+                    }"
                     t-attf-id="article_product_{{props.productId}}"
                     t-esc="props.name" />
                 <span t-if="props.productCartQty"
                     t-out="this.productQty"
                     class="product-cart-qty position-absolute bottom-0 end-0 m-1 px-2 rounded bg-black text-white fs-5 fw-bolder"/>
             </div>
-            <div t-if="props.comboExtraPrice" class="d-flex px-2 pb-1">
-                <span class="price-extra px-2 py-0 rounded-pill text-bg-info">
-                    + <t t-esc="props.comboExtraPrice"/>
-                </span>
-            </div>
+            <span t-if="props.comboExtraPrice" style="font-size: 0.75rem;" class="price-extra px-2 py-0 rounded-pill text-bg-info position-absolute top-0 end-0 mt-1 me-1">
+                <t t-esc="props.comboExtraPrice"/>
+            </span>
+            <t t-slot="quantityButtons" />
         </article>
     </t>
 </templates>

--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -3,14 +3,20 @@ export const computeComboItems = (
     childLineConf,
     pricelist,
     decimalPrecision,
-    productTemplateAttributeValueById
+    productTemplateAttributeValueById,
+    childLineExtra = []
 ) => {
     const comboItems = [];
     const parentLstPrice = parentProduct.getPrice(pricelist, 1, 0, false, parentProduct);
     const originalTotal = childLineConf.reduce((acc, conf) => {
-        const originalPrice = conf.combo_item_id.combo_id.base_price;
+        const originalPrice = conf.combo_item_id.combo_id.base_price * conf.qty;
         return acc + originalPrice;
     }, 0);
+
+    const getAttributesPriceExtra = (attributeValueIds) =>
+        (attributeValueIds ?? [])
+            .map((attr) => attr?.price_extra || 0)
+            .reduce((acc, price) => acc + price, 0);
 
     let remainingTotal = parentLstPrice;
     const ProductPrice = decimalPrecision.find((dp) => dp.name === "Product Price");
@@ -18,22 +24,42 @@ export const computeComboItems = (
         const comboItem = conf.combo_item_id;
         const combo = comboItem.combo_id;
         let priceUnit = ProductPrice.round((combo.base_price * parentLstPrice) / originalTotal);
-        remainingTotal -= priceUnit;
+        remainingTotal -= priceUnit * conf.qty;
+
         if (comboItem.id == childLineConf[childLineConf.length - 1].combo_item_id.id) {
             priceUnit += remainingTotal;
         }
         const attribute_value_ids = conf.configuration?.attribute_value_ids.map(
             (id) => productTemplateAttributeValueById[id]
         );
-        const attributesPriceExtra = (attribute_value_ids ?? [])
-            .map((attr) => attr?.price_extra || 0)
-            .reduce((acc, price) => acc + price, 0);
-        const totalPriceExtra = priceUnit + attributesPriceExtra + comboItem.extra_price;
+
+        const totalPriceExtra =
+            priceUnit + getAttributesPriceExtra(attribute_value_ids) + comboItem.extra_price;
         comboItems.push({
             combo_item_id: comboItem,
             price_unit: totalPriceExtra,
             attribute_value_ids,
             attribute_custom_values: conf.configuration?.attribute_custom_values || {},
+            qty: conf.qty,
+        });
+    }
+
+    // Process extra child lines using combo 'base_price'
+    for (const extra of childLineExtra) {
+        const comboItem = extra.combo_item_id;
+        const priceUnit = ProductPrice.round(comboItem.combo_id.base_price);
+        const attribute_value_ids = extra.configuration?.attribute_value_ids.map(
+            (id) => productTemplateAttributeValueById[id]
+        );
+
+        const totalPriceExtra =
+            priceUnit + getAttributesPriceExtra(attribute_value_ids) + comboItem.extra_price;
+        comboItems.push({
+            combo_item_id: comboItem,
+            price_unit: totalPriceExtra,
+            attribute_value_ids,
+            attribute_custom_values: extra.configuration?.attribute_custom_values || {},
+            qty: extra.qty,
         });
     }
 

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -776,12 +776,14 @@ export class PosStore extends WithLazyGetterTrap {
             }
 
             // Product template of combo should not have more than 1 variant.
+            const [childLineConf, comboExtraLines] = payload;
             const comboPrices = computeComboItems(
                 values.product_tmpl_id.product_variant_ids[0],
-                payload,
+                childLineConf,
                 order.pricelist_id,
                 this.data.models["decimal.precision"].getAll(),
-                this.data.models["product.template.attribute.value"].getAllBy("id")
+                this.data.models["product.template.attribute.value"].getAllBy("id"),
+                comboExtraLines
             );
 
             values.combo_line_ids = comboPrices.map((comboItem) => [
@@ -796,7 +798,7 @@ export class PosStore extends WithLazyGetterTrap {
                     price_unit: comboItem.price_unit,
                     price_type: "manual",
                     order_id: order,
-                    qty: values.qty,
+                    qty: comboItem.qty,
                     attribute_value_ids: comboItem.attribute_value_ids?.map((attr) => [
                         "link",
                         attr,

--- a/addons/point_of_sale/static/src/app/utils/use_idle_timer.js
+++ b/addons/point_of_sale/static/src/app/utils/use_idle_timer.js
@@ -1,13 +1,13 @@
-import { useExternalListener, useState } from "@odoo/owl";
+import { useExternalListener } from "@odoo/owl";
 
 const UserPresenceEvents = ["mousemove", "mousedown", "touchmove", "click", "scroll", "keypress"];
 
 export function useIdleTimer(steps, onAlive) {
-    const state = useState({
+    const state = {
         timeout: new Set(steps.map((s) => s.timeout)),
         idle: false,
         time: 0,
-    });
+    };
 
     const checkSteps = () => {
         for (const step of steps) {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/combo_popup_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/combo_popup_util.js
@@ -1,14 +1,15 @@
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
 const productTrigger = (productName) =>
-    `label.combo-item article.product:has(.product-name:contains("${productName}"))`;
-const isComboSelectedTrigger = (productName) => `input:checked ~ ${productTrigger(productName)}`;
+    `article.product:has(.product-name:contains("${productName}"))`;
+const isComboSelectedTrigger = (productName) =>
+    `label.combo-item.selected ${productTrigger(productName)}`;
 const confirmationButtonTrigger = `footer button.confirm`;
 
 export function select(productName) {
     return {
         content: `Select combo item ${productName}`,
-        trigger: `.modal ${productTrigger(productName)}`,
+        trigger: `.modal label.combo-item ${productTrigger(productName)}`,
         run: "click",
     };
 }
@@ -30,5 +31,42 @@ export function isConfirmationButtonDisabled() {
     return {
         content: "try to click `confirm` without having made all the selections",
         trigger: `.modal ${confirmationButtonTrigger}[disabled]`,
+    };
+}
+export function checkTotal(expectedAmount) {
+    return {
+        content: `Check that combo total amount is $${expectedAmount}`,
+        trigger: `.modal div.h3:contains("Total: $ ${expectedAmount}")`,
+    };
+}
+export function clickQtyBtnAdd(productName) {
+    return {
+        content: `Click the add quantity button for ${productName}`,
+        trigger: `.modal article:has(.product-name:contains("${productName}")) button[name="pos_quantity_button_plus"]`,
+        run: "click",
+    };
+}
+export function clickQtyBtnMinus(productName) {
+    return {
+        content: `Click the minus quantity button for ${productName}`,
+        trigger: `.modal article:has(.product-name:contains("${productName}")) button[name="pos_quantity_button_minus"]`,
+        run: "click",
+    };
+}
+export function checkProductQty(productName, expectedQty) {
+    return {
+        content: `Check that product ${productName} has quantity ${expectedQty}`,
+        trigger: `.modal article:has(.product-name:contains("${productName}")):has(input[name="pos_quantity"])`,
+        run: () => {
+            const article = [...document.querySelectorAll(".modal article")].find((el) =>
+                el.textContent.includes(productName)
+            );
+            const input = article.querySelector('input[name="pos_quantity"]');
+            if (input.value != expectedQty) {
+                throw new Error(
+                    `Expected ${expectedQty}, but got ${input.value} for "${productName}".`
+                );
+            }
+        },
     };
 }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1016,6 +1016,20 @@ class TestUi(TestPointOfSaleHttpCommon):
         #   - the combo lines are correctly stored in and restored from local storage
         #   - the combo lines are correctly shared between the pos configs ( in cross ordering )
 
+    def test_07_product_combo_max_free_qty(self):
+        """ Test the max free quantity of a product combo."""
+        setup_product_combo_items(self)
+        self.office_combo.combo_ids[0].write({
+            'qty_free': 2,
+            'qty_max': 2,
+        })
+        self.office_combo.combo_ids[1].write({
+            'qty_free': 2,
+            'qty_max': 5,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('ProductComboMaxFreeQtyTour')
+
     def test_07_pos_barcodes_scan(self):
         barcode_rule = self.env.ref("point_of_sale.barcode_rule_client")
         barcode_rule.pattern = barcode_rule.pattern + "|234"

--- a/addons/point_of_sale/views/product_combo_views.xml
+++ b/addons/point_of_sale/views/product_combo_views.xml
@@ -8,6 +8,31 @@
             <field name="product_id" position="attributes">
                 <attribute name="context">{'default_available_in_pos': True}</attribute>
             </field>
+
+            <xpath expr="//field[@name='company_id']" position="replace">
+                <group>
+                    <span class="o_form_label oe_inline fw-bolder">Maximum</span>
+                    <div>
+                        <field name="qty_max" class="text-center" style="width:50px;"/>
+                        <label for="qty_max" string="items" class="fw-bolder ps-3" />
+                    </div>
+                    <span class="o_form_label oe_inline fw-bolder">Includes</span>
+                    <div>
+                        <field name="qty_free" class="text-center" style="width:50px;"/>
+                        <label for="qty_free" string="free" class="fw-bolder ps-3" />
+                    </div>
+                </group>
+                <group>
+                    <field name="base_price" widget="monetary" options="{'field_digits': True}"/>
+                    <field
+                        name="company_id"
+                        placeholder="Visible to all"
+                        groups="base.group_multi_company"
+                        options="{'no_create': True}"
+                        class="oe_inline"
+                    />
+                </group>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -141,7 +141,10 @@ export class ComboPage extends Component {
             "",
             {},
             {},
-            this.state.selectedCombos
+            this.state.selectedCombos.map((combo) => ({
+                ...combo,
+                qty: 1,
+            }))
         );
         this.router.back();
     }


### PR DESCRIPTION
- Add `qty_max` and `qty_free` fields to `product.product_combo` model to allow selection of multiple quantity per combo. As the defaults values for these fields is `1`, the default behavior does not change.
- User can select up to `qty_max` items for a combo choice, and `qty_free` items are included in the combo price. If user select more than `qty_free` items, each extra items will cost an extra `combo.base_price`.
- Updated PoS UI to support multiple combo selection.
- Add `base_price` to product combo form (it was only visible inside list view before).

task-id: 4642341




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
