### PR TITLE
[IMP] stock: improve titles for inventory adjustments

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -414,7 +414,7 @@ class StockQuant(models.Model):
             ctx['search_default_my_count'] = True
         view_id = self.env.ref('stock.view_stock_quant_tree_inventory_editable').id
         action = {
-            'name': _('Inventory Adjustments'),
+            'name': _('Physical Inventory'),
             'view_mode': 'list',
             'res_model': 'stock.quant',
             'type': 'ir.actions.act_window',

--- a/addons/stock/wizard/stock_inventory_adjustment_name.xml
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.xml
@@ -19,7 +19,7 @@
         </field>
     </record>
     <record id="action_stock_inventory_adjustement_name" model="ir.actions.act_window">
-        <field name="name">Inventory Adjustment</field>
+        <field name="name">Physical Inventory</field>
         <field name="res_model">stock.inventory.adjustment.name</field>
         <field name="view_mode">form</field>
         <field name="view_id" ref="stock_inventory_adjustment_name_form_view"/>


### PR DESCRIPTION
- Renamed the action title from ‘Inventory Adjustments’ to ‘Physical Inventory’.

- Renamed the wizard title from ‘Inventory Adjustments’ to ‘Physical Inventory’
  shown when the user clicks the apply button to change the product inventory.

These changes help users better understand the purpose and improve the
overall consistency.

TaskId - 4526266
