### PR TITLE
[IMP] point_of_sale: update order line removal logic and enhance test utilities

### DIFF
--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -65,13 +65,13 @@ registry.category("web_tour.tours").add("l10n_es_pos_settle_account_due", {
             PartnerList.clickPartnerOptions("Partner Test 1"),
             {
                 isActive: ["auto"],
-                trigger: "div.o_popover :contains('Settle Due Accounts')",
+                trigger: "div.o_popover :contains('Settle invoices')",
                 content: "Check the popover opened",
                 run: "click",
             },
             {
-                trigger: "tr.o_data_row td[name='name']:contains('Shop/0001')",
-                content: "Check the settle due account line is present",
+                trigger: "tr.o_data_row td[name='name']:contains('TSJ/2025/00001')",
+                content: "Check the settle invoice line is present",
                 run: "click",
             },
             ProductScreen.clickPayButton(),
@@ -79,5 +79,8 @@ registry.category("web_tour.tours").add("l10n_es_pos_settle_account_due", {
             PaymentScreen.clickValidate(),
             Chrome.confirmPopup(),
             ReceiptScreen.isShown(),
+            ReceiptScreen.paymentLineContains("Bank", "10.00"),
+            ReceiptScreen.paymentLineContains("Customer Account", "-10.00"),
+            Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -708,6 +708,9 @@ export class PosOrderline extends Base {
     isSelected() {
         return this.order_id?.uiState?.selected_orderline_uuid === this.uuid;
     }
+    get canBeRemoved() {
+        return this.product_id.uom_id.isZero(this.qty);
+    }
 }
 
 registry.category("pos_available_models").add(PosOrderline.pythonModel, PosOrderline);

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -292,9 +292,7 @@ export class PaymentScreen extends Component {
         if (!this.checkCashRoundingHasBeenWellApplied()) {
             return;
         }
-        const linesToRemove = this.currentOrder.lines.filter((line) =>
-            line.product_id.uom_id.isZero(line.qty)
-        );
+        const linesToRemove = this.currentOrder.lines.filter((line) => line.canBeRemoved);
         for (const line of linesToRemove) {
             this.currentOrder.removeOrderline(line);
         }

--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -96,6 +96,14 @@ export function receiptRoundingAmountIs(value) {
         },
     ];
 }
+export function paymentLineContains(paymentMethodName, amount) {
+    return [
+        {
+            content: `Check if payment line contains ${paymentMethodName} with amount ${amount}`,
+            trigger: `.receipt-screen .paymentlines:contains("${paymentMethodName}"):has(.pos-receipt-right-align:contains("${amount}"))`,
+        },
+    ];
+}
 export function receiptRoundingAmountIsNotThere() {
     return [
         {
@@ -208,6 +216,15 @@ export function cashierNameExists(name) {
         {
             content: `Cashier ${name} exists on the receipt`,
             trigger: `.pos-receipt-contact .cashier:contains(Served by):contains(${name})`,
+        },
+    ];
+}
+
+export function containsOrderLine(name, quantity, price_unit, line_price) {
+    return [
+        {
+            content: `Order line with name: ${name}, quantity: ${quantity}, price per unit: ${price_unit}, and line price: ${line_price} exists`,
+            trigger: `.pos-receipt .orderline:has(.product-name:contains('${name}') .qty:contains('${quantity}')):has(.product-price:contains('${line_price}')):has(.price-per-unit:contains('${price_unit}'))`,
         },
     ];
 }


### PR DESCRIPTION
- Added `canBeRemoved` getter to `PosOrderline` model for cleaner zero-qty checks
- Updated `PaymentScreen` to use `canBeRemoved` for order line filtering
- Added `paymentLineContains` utility in receipt test suite for better validation

enterprise PR: https://github.com/odoo/enterprise/pull/80267

task-id: 4501448



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
