### PR TITLE
[IMP] html_editor: link popover readability

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -361,6 +361,7 @@ export class DomPlugin extends Plugin {
             currentNode = nodeToInsert;
         }
         allInsertedNodes.push(...lastInsertedNodes);
+        this.getResource("after_insert_handlers").forEach((handler) => handler(allInsertedNodes));
         let insertedNodesParents = getConnectedParents(allInsertedNodes);
         for (const parent of insertedNodesParents) {
             if (

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -18,6 +18,7 @@ export class LinkPopover extends Component {
         getExternalMetaData: Function,
         getAttachmentMetadata: Function,
         isImage: Boolean,
+        showReplaceTitleBanner: Boolean,
         type: String,
         recordInfo: Object,
         canEdit: { type: Boolean, optional: true },
@@ -66,6 +67,7 @@ export class LinkPopover extends Component {
                     ?.pop() ||
                 "",
             isImage: this.props.isImage,
+            showReplaceTitleBanner: this.props.showReplaceTitleBanner,
         });
 
         this.editingWrapper = useRef("editing-wrapper");

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -62,6 +62,13 @@
                                     <t t-esc="state.urlTitle"/>
                                 </a>
                                 <div class="flex-grow-1 d-flex justify-content-end">
+                                    <a href="#" class="mx-1 o_we_replace_title_btn text-dark"
+                                        t-if="!state.isImage and state.urlTitle and state.label === '' and !state.showReplaceTitleBanner"
+                                        t-on-click="onClickReplaceTitle"
+                                        title="Replace URL with its title"
+                                    >
+                                        <i class="fa fa-magic"></i>
+                                    </a>
                                     <a href="#" class="mx-1 o_we_copy_link text-dark" t-on-click="onClickCopy" title="Copy Link">
                                         <i class="fa fa-clipboard"></i>
                                     </a>
@@ -95,7 +102,7 @@
                         </span>
                     </div>
                 </div>
-                <div t-if="!state.isImage and state.urlTitle and state.label === ''" class="d-flex align-items-baseline" style="background-color: var(--primary);">
+                <div t-if="!state.isImage and state.urlTitle and state.label === '' and state.showReplaceTitleBanner" class="d-flex align-items-baseline" style="background-color: var(--primary);">
                     <i class="fa fa-magic fa-fw m-1" style="color: var(--o-cc1-btn-primary-text);"></i>
                     <span class="me-2 flex-grow-1" style="color: var(--o-cc1-btn-primary-text);font-size: smaller;">Replace URL with its title?</span>
                     <button class=" btn btn-sm btn-primary o_we_replace_title_btn" style="margin: 1px;font-size: smaller;" t-on-click="onClickReplaceTitle">Yes</button>

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -971,6 +971,41 @@ describe("link preview", () => {
         await waitFor(".o-we-linkpopover");
         expect.verifySteps([]);
     });
+    test("should change replace URL button to magic wand icon after selection change", async () => {
+        onRpc("/html_editor/link_preview_external", () => ({
+            og_description:
+                "From ERP to CRM, eCommerce and CMS. Download Odoo or use it in the cloud. Grow Your Business.",
+            og_image: "https://www.odoo.com/web/image/41207129-1abe7a15/homepage-seo.png",
+            og_title: "Open Source ERP and CRM | Odoo",
+            og_type: "website",
+            og_site_name: "Odoo",
+            source_url: "http://odoo.com/",
+        }));
+        const { editor } = await setupEditor(`<p>abc</p><p>[]</p>`);
+        await insertText(editor, "/link");
+        await animationFrame();
+        await click(".o-we-command-name:first");
+        await contains(".o-we-linkpopover input.o_we_href_input_link").fill("http://odoo.com/");
+        await animationFrame();
+        expect("button.o_we_replace_title_btn").toHaveCount(1);
+        expect("a.o_we_replace_title_btn").toHaveCount(0);
+        const pNode = document.querySelector("p");
+        setSelection({
+            anchorNode: pNode,
+            anchorOffset: 0,
+        });
+        await waitForNone(".o-we-linkpopover", { timeout: 1500 });
+        expect(".o-we-linkpopover").toHaveCount(0);
+        const link = document.querySelector("a");
+        setSelection({
+            anchorNode: link,
+            anchorOffset: 0,
+        });
+        await waitFor(".o_we_replace_title_btn");
+        expect(".o-we-linkpopover").toHaveCount(1);
+        expect("a.o_we_replace_title_btn").toHaveCount(1);
+        expect("button.o_we_replace_title_btn").toHaveCount(0);
+    });
 });
 
 describe("link in templates", () => {


### PR DESCRIPTION
Purpose:

When the link popover is opened for the first time on internal links, the `Replace URL with its title` option should be visible in the popover. After this first occurrence, the option should be replaced by a wand icon, positioned before the copy button, with `Replace URL with its title` as its tooltip.

task:4630525
