### PR TITLE
[FIX] account: Fix UI/UX of credit journal

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -99,7 +99,7 @@
                                     </group>
                                     <group name="bank_source" string="Credit Card Setup" invisible="type != 'credit'">
                                         <label for="bank_statements_source" string="Transaction Feeds" invisible="type != 'credit'" groups="account.group_account_readonly"/>
-                                        <field name="bank_statements_source" nolabel="1" widget="radio" required="type != 'credit'" groups="account.group_account_basic"/>
+                                        <field name="bank_statements_source" nolabel="1" widget="radio" required="type == 'credit'" groups="account.group_account_basic"/>
                                     </group>
                                 </group>
                             </page>


### PR DESCRIPTION
In odoo/odoo/pull/175315, we added a new journal type: 'credit'. The `bank_statements_source` was meant to be required for credit journal the same way it is for bank journals.

no-opw
no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
