### PR TITLE
[IMP] website: add description input field in map snippet

### DIFF
--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_api_key_dialog.xml
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_api_key_dialog.xml
@@ -17,7 +17,7 @@
                 <div class="small form-text text-muted">
                     Hint: How to use Google Map on your website (Contact Us page and as a snippet)
                     <br/>
-                    <a target="_blank" href="https://console.developers.google.com/flows/enableapi?apiid=maps_backend,static_maps_backend&amp;keyType=CLIENT_SIDE&amp;reusekey=true">
+                    <a target="_blank" href="https://console.developers.google.com/flows/enableapi?apiid=maps-backend.googleapis.com,static-maps-backend.googleapis.com,places-backend.googleapis.com&amp;keyType=CLIENT_SIDE&amp;reusekey=true">
                         <i class="oi oi-arrow-right"/>
                         Create a Google Project and Get a Key
                     </a>

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.xml
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="website.GoogleMapsDescription">
-    <div class="description">
-        <font>Visit us:</font>
-        <span>Our office is located in the northeast of Brussels. TEL (555) 432 2365</span>
-    </div>
-</t>
-
 <t t-name="website.GoogleMapsOption">
     <BuilderRow label.translate="Address" preview="false">
         <input
@@ -70,7 +63,10 @@
         <BuilderNumberInput dataAttributeAction="'mapZoom'" default="12" step="1" min="0" max="22"/>
     </BuilderRow>
     <BuilderRow label.translate="Description" preview="false">
-        <BuilderCheckbox action="'showDescription'"/>
+        <BuilderCheckbox id="'google_maps_description'" action="'mapDescription'"/>
+    </BuilderRow>
+    <BuilderRow label.translate="Description Text" level="1" t-if="isActiveItem('google_maps_description')">
+        <BuilderTextInput action="'mapDescriptionTextValue'"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.xml
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.xml
@@ -62,12 +62,7 @@
     <BuilderRow label.translate="Zoom" preview="false">
         <BuilderNumberInput dataAttributeAction="'mapZoom'" default="12" step="1" min="0" max="22"/>
     </BuilderRow>
-    <BuilderRow label.translate="Description" preview="false">
-        <BuilderCheckbox id="'google_maps_description'" action="'mapDescription'"/>
-    </BuilderRow>
-    <BuilderRow label.translate="Description Text" level="1" t-if="isActiveItem('google_maps_description')">
-        <BuilderTextInput action="'mapDescriptionTextValue'"/>
-    </BuilderRow>
+    <t t-call="website.MapDescriptionOption"/>
 </t>
 
 </templates>

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
-import { renderToElement } from "@web/core/utils/render";
 import { Plugin } from "@html_editor/plugin";
 import { GoogleMapsApiKeyDialog } from "./google_maps_api_key_dialog";
 import { GoogleMapsOption } from "./google_maps_option";
@@ -53,7 +52,6 @@ export class GoogleMapsOptionPlugin extends Plugin {
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         builder_actions: {
             ResetMapColorAction,
-            ShowDescriptionAction,
         },
         // TODO remove when the snippet will have a "Height" option.
         keep_overlay_options: (el) => el.matches(".s_google_map"),
@@ -70,6 +68,18 @@ export class GoogleMapsOptionPlugin extends Plugin {
 
         /** @type {Map<HTMLElement, Deferred} */
         this.recentlyDroppedSnippetDeferredInit = new Map();
+        this.upgradeSnippets();
+    }
+
+    // TODO: Remove this method when data-vxml is reintroduced.
+    upgradeSnippets() {
+        // This is for pages which already existed before the plugin was created.
+        this.document
+            .querySelectorAll(".s_google_map")
+            .forEach((mapSnippetEl) => {
+                mapSnippetEl.classList.add("o_not_editable");
+                mapSnippetEl.dataset.vxml = "001";
+            });
     }
 
     async onSnippetDropped({ snippetEl }) {
@@ -291,18 +301,6 @@ export class ResetMapColorAction extends BuilderAction {
     static id = "resetMapColor";
     apply({ editingElement }) {
         editingElement.dataset.mapColor = "";
-    }
-}
-export class ShowDescriptionAction extends BuilderAction {
-    static id = "showDescription";
-    isApplied({ editingElement }) {
-        return !!editingElement.querySelector(".description");
-    }
-    apply({ editingElement }) {
-        editingElement.append(renderToElement("html_builder.GoogleMapsDescription"));
-    }
-    clean({ editingElement }) {
-        editingElement.querySelector(".description").remove();
     }
 }
 

--- a/addons/website/static/src/builder/plugins/options/map_option.xml
+++ b/addons/website/static/src/builder/plugins/options/map_option.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
+
+<t t-name="website.MapsDescription">
+    <div class="description">
+        Visit us: Our office is located in the northeast of Brussels. TEL (555) 432 2365
+    </div>
+</t>
+
 <t t-name="website.mapOption">
     <BuilderRow label.translate="Address" action="'mapUpdateSrc'" preview="false">
         <BuilderTextInput
@@ -63,7 +70,10 @@
         />
     </BuilderRow>
     <BuilderRow label.translate="Description">
-        <BuilderCheckbox action="'mapDescription'"/>
+        <BuilderCheckbox id="'map_description'" action="'mapDescription'"/>
+    </BuilderRow>
+    <BuilderRow label.translate="Description Text" level="1" t-if="isActiveItem('map_description')">
+        <BuilderTextInput action="'mapDescriptionTextValue'"/>
     </BuilderRow>
 </t>
 </templates>

--- a/addons/website/static/src/builder/plugins/options/map_option.xml
+++ b/addons/website/static/src/builder/plugins/options/map_option.xml
@@ -69,11 +69,25 @@
             max="5"
         />
     </BuilderRow>
+    <t t-call="website.MapDescriptionOption"/>
+</t>
+
+<t t-name="website.MapDescriptionOption">
     <BuilderRow label.translate="Description">
         <BuilderCheckbox id="'map_description'" action="'mapDescription'"/>
     </BuilderRow>
-    <BuilderRow label.translate="Description Text" level="1" t-if="isActiveItem('map_description')">
-        <BuilderTextInput action="'mapDescriptionTextValue'"/>
-    </BuilderRow>
+    <t t-if="isActiveItem('map_description')">
+        <BuilderRow label.translate="Description Text" level="1">
+            <BuilderTextInput action="'mapDescriptionTextValue'"/>
+        </BuilderRow>
+        <BuilderContext applyTo="'.description'">
+            <BuilderRow label.translate="Text Color" level="1">
+                <BuilderColorPicker enabledTabs="['custom']" styleAction="'color'"/>
+            </BuilderRow>
+            <BuilderRow label.translate="Background Color" level="1">
+                <BuilderColorPicker enabledTabs="['custom', 'gradient']" styleAction="'background-color'"/>
+            </BuilderRow>
+        </BuilderContext>
+    </t>
 </t>
 </templates>

--- a/addons/website/static/src/builder/plugins/options/map_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/map_option_plugin.js
@@ -1,8 +1,8 @@
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { Plugin } from "@html_editor/plugin";
-import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { generateGMapLink } from "@website/js/utils";
+import { renderToElement } from "@web/core/utils/render";
 
 class MapOptionPlugin extends Plugin {
     static id = "mapOption";
@@ -17,10 +17,27 @@ class MapOptionPlugin extends Plugin {
         builder_actions: {
             MapUpdateSrcAction,
             MapDescriptionAction,
+            MapDescriptionTextAction,
         },
         // TODO remove when the snippet will have a "Height" option.
         keep_overlay_options: (el) => el.matches(".s_map"),
     };
+
+    setup() {
+        this.upgradeSnippets();
+    }
+
+    // TODO: Remove this method when data-vxml is reintroduced.
+    upgradeSnippets() {
+        // Ensure that all map snippets have the correct editable/not-editable classes
+        // This is for pages which already existed before the plugin was created.
+        const mapSnippetEls = this.document.querySelectorAll(".s_map");
+        mapSnippetEls.forEach((mapSnippetEl) => {
+            mapSnippetEl.classList.add("o_not_editable");
+            mapSnippetEl.dataset.vxml = "001";
+            mapSnippetEl.querySelector(".map_container").classList.remove("o_not_editable");
+        });
+    }
 }
 
 export class MapUpdateSrcAction extends BuilderAction {
@@ -45,20 +62,25 @@ export class MapUpdateSrcAction extends BuilderAction {
 export class MapDescriptionAction extends BuilderAction {
     static id = "mapDescription";
     isApplied({ editingElement }) {
-        return editingElement.querySelector(".description") !== null;
+        return !!editingElement.querySelector(".description");
     }
     apply({ editingElement }) {
-        editingElement.appendChild(
-            document.createRange().createContextualFragment(
-                `<div class="description">
-                    <strong>${_t("Visit us:")}</strong>
-                    ${_t("Our office is open Monday – Friday 8:30 a.m. – 4:00 p.m.")}
-                </div>`
-            )
-        );
+        editingElement.append(renderToElement("website.MapsDescription"));
     }
     clean({ editingElement }) {
         editingElement.querySelector(".description").remove();
+    }
+}
+class MapDescriptionTextAction extends BuilderAction {
+    static id = "mapDescriptionTextValue";
+    getValue({ editingElement }) {
+        return editingElement
+            .querySelector(".description")
+            ?.textContent.trim()
+            .replace(/\s+/g, " ") || "";
+    }
+    apply({ editingElement, value }) {
+        return editingElement.querySelector(".description").textContent = value;
     }
 }
 

--- a/addons/website/static/src/snippets/s_google_map/000.scss
+++ b/addons/website/static/src/snippets/s_google_map/000.scss
@@ -1,8 +1,6 @@
 
 $s-google-map-desc-bg: map-get($theme-colors, 'primary') !default;
 $s-google-map-desc-alpha: 0.80 !default;
-$s-google-map-desc-hover-bg: map-get($theme-colors, 'primary') !default;
-$s-google-map-desc-hover-alpha: 0.55 !default;
 
 .s_google_map {
     position: relative;
@@ -17,7 +15,6 @@ $s-google-map-desc-hover-alpha: 0.55 !default;
         padding: 0 1em;
         background: rgba($s-google-map-desc-bg, $s-google-map-desc-alpha);
         color: color-contrast(rgba($s-google-map-desc-bg, $s-google-map-desc-alpha));
-        transition: background-color 250ms ease;
 
         font {
             float: left;
@@ -33,10 +30,5 @@ $s-google-map-desc-hover-alpha: 0.55 !default;
             margin-top: 20px;
             margin-left: 10px;
         }
-    }
-    &:hover .description {
-        background: $s-google-map-desc-hover-bg;
-        background: rgba($s-google-map-desc-hover-bg, $s-google-map-desc-hover-alpha);
-        color: color-contrast(rgba($s-google-map-desc-hover-bg, $s-google-map-desc-hover-alpha));
     }
 }

--- a/addons/website/static/src/snippets/s_map/000.scss
+++ b/addons/website/static/src/snippets/s_map/000.scss
@@ -1,8 +1,6 @@
 
 $s-map-desc-bg: map-get($theme-colors, 'primary') !default;
 $s-map-desc-alpha: 0.80 !default;
-$s-map-desc-hover-bg: map-get($theme-colors, 'primary') !default;
-$s-map-desc-hover-alpha: 0.55 !default;
 
 .s_map {
     position: relative;
@@ -21,7 +19,6 @@ $s-map-desc-hover-alpha: 0.55 !default;
         padding: 0 1em;
         background: rgba($s-map-desc-bg, $s-map-desc-alpha);
         color: color-contrast(rgba($s-map-desc-bg, $s-map-desc-alpha));
-        transition: background-color 250ms ease;
 
         font {
             float: left;
@@ -37,11 +34,6 @@ $s-map-desc-hover-alpha: 0.55 !default;
             margin-top: 20px;
             margin-left: 10px;
         }
-    }
-    &:hover .description {
-        background: $s-map-desc-hover-bg;
-        background: rgba($s-map-desc-hover-bg, $s-map-desc-hover-alpha);
-        color: color-contrast(rgba($s-map-desc-hover-bg, $s-map-desc-hover-alpha));
     }
     .s_map_color_filter {
         @include o-position-absolute(0, 0, 0, 0);

--- a/addons/website/static/tests/builder/website_builder/map_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/map_option.test.js
@@ -1,0 +1,35 @@
+import { expect, test } from "@odoo/hoot";
+import { contains } from "@web/../tests/web_test_helpers";
+import { defineWebsiteModels, setupWebsiteBuilderWithSnippet } from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("test description option", async () => {
+    await setupWebsiteBuilderWithSnippet("s_map");
+    await contains(":iframe .s_map").click();
+
+    // toggle description
+    await contains("[data-action-id='mapDescription'] input").click();
+    expect(":iframe .s_map .description").toBeVisible();
+
+    // Change Description Text
+    await contains("[data-action-id='mapDescriptionTextValue'] input").edit("New description");
+    expect(":iframe .s_map .description").toHaveText("New description");
+
+    // Check Gradient tab background color
+    await contains("div[data-label='Background Color'] .o_we_color_preview").click();
+    await contains(".o_popover .o_font_color_selector .btn-tab:contains('Gradient')").click();
+    await contains(".o_colorpicker_sections .o_color_button[data-color='linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%)']").click();
+    expect(":iframe .s_map .description").toHaveStyle({ "background-image": "linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%)" });
+
+    // Check Custom tab background color
+    await contains("div[data-label='Background Color'] .o_we_color_preview").click();
+    await contains(".o_popover .o_font_color_selector .btn-tab:contains('Custom')").click();
+    await contains(".o_popover .o_colorpicker_widget .o_hex_input").edit("#E4F641");
+    expect(":iframe .s_map .description").toHaveStyle({ "background-color": "rgb(228, 246, 65)" });
+
+    // Check text color
+    await contains("div[data-label='Text Color'] .o_we_color_preview").click();
+    await contains(".o_popover .o_colorpicker_widget .o_hex_input").edit("#EB28EB");
+    expect(":iframe .s_map .description").toHaveStyle({ "color": "rgb(235, 40, 235)" });
+});

--- a/addons/website/views/snippets/s_google_map.xml
+++ b/addons/website/views/snippets/s_google_map.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template name="Google Map" id="s_google_map">
-    <section class="s_google_map pt256 pb256" data-map-type="ROADMAP" data-map-color="" data-map-zoom="12" data-map-gps="(50.854975,4.3753899)" data-pin-style="flat">
+    <section class="s_google_map pt256 pb256 o_not_editable" data-map-type="ROADMAP" data-map-color="" data-map-zoom="12" data-map-gps="(50.854975,4.3753899)" data-pin-style="flat" data-vxml="001">
         <div class="map_container"/>
     </section>
 </template>

--- a/addons/website/views/snippets/s_map.xml
+++ b/addons/website/views/snippets/s_map.xml
@@ -2,8 +2,8 @@
 <odoo>
 
 <template name="Map" id="s_map">
-    <section class="s_map pb56 pt56 rounded-3" data-map-type="m" data-map-zoom="12" t-att-data-map-address="' '.join(filter(None, (user_id.company_id.street, user_id.company_id.city, user_id.company_id.state_id.display_name, user_id.company_id.country_id.display_name)))">
-        <div class="map_container o_not_editable">
+    <section class="s_map pb56 pt56 rounded-3 o_not_editable" data-map-type="m" data-map-zoom="12" t-att-data-map-address="' '.join(filter(None, (user_id.company_id.street, user_id.company_id.city, user_id.company_id.state_id.display_name, user_id.company_id.country_id.display_name)))" data-vxml="001">
+        <div class="map_container">
             <div class="css_non_editable_mode_hidden">
                 <div class="missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none">
                     An address must be specified for a map to be embedded


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Issue 1:
Users are unable to edit the description immediately after adding a map snippet. They must first click elsewhere and then return to the description field to make changes.

Issue 2:
Reproduced by navigating to Website > Edit > Theme Tab > Custom Key (Google Map) > 'Create a Google Project and Get a Key', leading to an error on console.cloud.google.com.

 ̶I̶s̶s̶u̶e̶ ̶3̶:̶
̶T̶h̶e̶ ̶d̶y̶n̶a̶m̶i̶c̶ ̶p̶a̶d̶d̶i̶n̶g̶ ̶o̶p̶t̶i̶o̶n̶s̶ ̶f̶o̶r̶ ̶t̶h̶e̶ ̶m̶a̶p̶ ̶s̶n̶i̶p̶p̶e̶t̶ ̶d̶u̶r̶i̶n̶g̶ ̶e̶d̶i̶t̶ ̶m̶o̶d̶e̶ ̶a̶r̶e̶ ̶s̶e̶t̶ ̶w̶i̶t̶h̶i̶n̶ ̶t̶h̶e̶ ̶s̶n̶i̶p̶p̶e̶t̶ ̶r̶a̶t̶h̶e̶r̶ ̶t̶h̶a̶n̶ ̶e̶x̶t̶e̶r̶n̶a̶l̶l̶y̶.̶ ̶A̶d̶d̶i̶n̶g̶ ̶p̶a̶d̶d̶i̶n̶g̶ ̶d̶o̶e̶s̶ ̶n̶o̶t̶ ̶a̶p̶p̶l̶y̶ ̶t̶h̶e̶ ̶i̶n̶t̶e̶n̶d̶e̶d̶ ̶e̶f̶f̶e̶c̶t̶;̶ ̶i̶n̶s̶t̶e̶a̶d̶,̶ ̶i̶t̶ ̶a̶d̶j̶u̶s̶t̶s̶ ̶t̶h̶e̶ ̶h̶e̶i̶g̶h̶t̶ ̶o̶f̶ ̶t̶h̶e̶ ̶b̶l̶o̶c̶k̶.̶

Issue 4: 
There was no option to customise the background or text color of the attached description.

Desired behaviour after PR is merged:

1. Add an input field in the options of the map snippet.
This input field is visible when the description checkbox is true. Any Update in the field will update the description of the snippet.
2. Fix the issue generated at console.cloud.google.com after clicking 'Create a Google Project and Get a Key'.
3. R̶e̶s̶o̶l̶v̶e̶s̶ ̶t̶h̶e̶ ̶p̶a̶d̶d̶i̶n̶g̶ ̶i̶s̶s̶u̶e̶ ̶b̶y̶ ̶e̶n̶s̶u̶r̶i̶n̶g̶ ̶t̶h̶a̶t̶ ̶w̶h̶e̶n̶ ̶p̶a̶d̶d̶i̶n̶g̶ ̶i̶s̶ ̶a̶d̶d̶e̶d̶,̶ ̶i̶t̶ ̶c̶o̶r̶r̶e̶c̶t̶l̶y̶ ̶s̶e̶t̶s̶ ̶t̶h̶e̶ ̶b̶l̶o̶c̶k̶’̶s̶ ̶p̶a̶d̶d̶i̶n̶g̶.̶
4. Introduces customisation options for both text and background colors in the map snippet description. 


task-4604018