### PR TITLE
[IMP] stock: redirect to reverted move lines after inventory adjustment

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -1123,12 +1123,11 @@ class StockMoveLine(models.Model):
         moves = self.env['stock.move'].create(move_vals)
         moves._action_done()
         return {
-            'type': 'ir.actions.client',
-            'tag': 'display_notification',
-            'params': {
-                'type': 'success',
-                'message': _("The inventory adjustments have been reverted."),
-            }
+            'name': _('Reverted Moves'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'stock.move.line',
+            'view_mode': 'list',
+            'domain': [('id', 'in', moves.move_line_ids.ids + self.ids)]
         }
 
     def _get_linkable_moves(self):


### PR DESCRIPTION
When reverting an inventory adjustment, only a toast notification appeared for confirmation, but the reverted move line was not immediately visible. Users had to manually refresh the screen to see the changes.

With this update, the system now directly opens the list view of the reverted move lines after reverting an inventory adjustment, ensuring better visibility and a smoother user experience.

Task - [4594967](https://www.odoo.com/odoo/my-tasks/4594967)
