### PR TITLE
[PERF] account: speedup bank_statement_line creation

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -415,20 +415,21 @@ class AccountBankStatementLine(models.Model):
             'name': False,
             **vals,
         } for vals in vals_list])
-
+        to_create_lines_vals = []
         for i, (st_line, vals) in enumerate(zip(st_lines, vals_list)):
-            counterpart_account_id = counterpart_account_ids[i]
-
-            to_write = {'statement_line_id': st_line.id, 'narration': st_line.narration, 'name': False}
             if 'line_ids' not in vals_list[i]:
-                to_write['line_ids'] = [(0, 0, line_vals) for line_vals in st_line._prepare_move_line_default_vals(
-                    counterpart_account_id=counterpart_account_id)]
+                to_create_lines_vals.extend(
+                    line_vals
+                    for line_vals in st_line._prepare_move_line_default_vals(counterpart_account_ids[i])
+                )
+            to_write = {'statement_line_id': st_line.id, 'narration': st_line.narration, 'name': False}
             with self.env.protecting(self.env['account.move']._get_protected_vals(vals, st_line)):
                 st_line.move_id.write(to_write)
-            self.env.add_to_compute(self.env['account.move']._fields['name'], st_line.move_id)
+        self.env['account.move.line'].create(to_create_lines_vals)
+        self.env.add_to_compute(self.env['account.move']._fields['name'], st_lines.move_id)
 
-            # Otherwise field narration will be recomputed silently (at next flush) when writing on partner_id
-            self.env.remove_to_compute(st_line.move_id._fields['narration'], st_line.move_id)
+        # Otherwise field narration will be recomputed silently (at next flush) when writing on partner_id
+        self.env.remove_to_compute(self.env['account.move']._fields['narration'], st_lines.move_id)
 
         # No need for the user to manage their status (from 'Draft' to 'Posted')
         st_lines.move_id.action_post()


### PR DESCRIPTION
When importing statements the creation of the `account_move_lines` in `account_bank_statement_line.create` takes a lot of time. One of the reasons for that is that the amls are created for each st_line via the one2many field assignation.

This commit speeds up this process by creating all the amls at once after looping through `st_lines`. Batching the amls creation like that leads to a noticeable speedup when importing a lot of statements.

speedup

Importing bank_statement file in Odoo 18.0.

| Number of lines_to_create | Before PR  | After PR |
|:-------------------------:|:----------:|:--------:|
|           100             |    5.24s   |  2.78s   |
|           500             |    22.72s  |  11.47s  |
|           1000            |    44.66s  |  21.73s  |
|           3000            |    2min15s |  1min05s |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
