### PR TITLE
[IMP] mail, im_livechat: add call statistics to live chat report

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -7,11 +7,14 @@
             <field name="model">im_livechat.report.channel</field>
             <field name="arch" type="xml">
                 <pivot string="Livechat Support Statistics" sample="1">
+                    <field name="has_call" type="measure" invisible="1"/>
+                    <field name="call_duration_hour" type="measure" widget="float_time"/>
                     <field name="partner_id" type="row"/>
+                    <field name="percentage_of_calls" type="measure" widget="percentage"/>
                     <field name="nbr_channel" type="measure"/>
                     <field name="time_to_answer" type="measure"/>
                     <field name="duration" type="measure"/>
-                    <field name="rating" type="measure"/>
+                    <field name="rating" string="Rating (%)" type="measure" widget="im_livechat.rating_percentage"/>
                 </pivot>
             </field>
         </record>
@@ -50,6 +53,9 @@
             <field name="model">im_livechat.report.channel</field>
             <field name="arch" type="xml">
                 <graph string="Livechat Support Statistics" stacked="1" sample="1">
+                    <field name="call_duration_hour" type="measure" widget="float_time"/>
+                    <field name="has_call" invisible="1"/>
+                    <field name="percentage_of_calls" type="measure" widget="percentage"/>
                     <field name="start_date" interval="day"/>
                     <field name="rating_text"/>
                 </graph>

--- a/addons/im_livechat/security/im_livechat_channel_security.xml
+++ b/addons/im_livechat/security/im_livechat_channel_security.xml
@@ -42,5 +42,15 @@
             <field name="perm_write" eval="False"/>
             <field name="perm_unlink" eval="False"/>
         </record>
+
+        <record id="ir_rule_discuss_call_history_im_livechat_group_user" model="ir.rule">
+            <field name="name">discuss.call.history: livechat users can access all call histories</field>
+            <field name="model_id" ref="mail.model_discuss_call_history"/>
+            <field name="groups" eval="[(4, ref('im_livechat_group_user'))]"/>
+            <field name="domain_force">[('channel_id.channel_type', '=', 'livechat')]</field>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -120,6 +120,8 @@ For more specific needs, you may also assign custom-defined actions
         'views/res_partner_views.xml',
         'views/mail_blacklist_views.xml',
         'views/mail_menus.xml',
+        'views/discuss/discuss_menus.xml',
+        'views/discuss/discuss_call_history_views.xml',
         'views/res_company_views.xml',
         "views/mail_scheduled_message_views.xml",
         "data/mail_canned_response_data.xml",

--- a/addons/mail/models/discuss/__init__.py
+++ b/addons/mail/models/discuss/__init__.py
@@ -4,6 +4,7 @@
 from . import mail_message
 
 # discuss
+from . import discuss_call_history
 from . import discuss_channel_member
 from . import discuss_channel_rtc_session
 from . import discuss_channel

--- a/addons/mail/models/discuss/discuss_call_history.py
+++ b/addons/mail/models/discuss/discuss_call_history.py
@@ -1,0 +1,32 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, fields
+
+
+class DiscussCallHistory(models.Model):
+    _name = "discuss.call.history"
+    _order = "start_dt DESC, id DESC"
+    _description = "Keep the call history"
+
+    channel_id = fields.Many2one("discuss.channel", index=True, required=True, ondelete="cascade")
+    duration_hour = fields.Float(compute="_compute_duration_hour")
+    start_dt = fields.Datetime(index=True, required=True)
+    end_dt = fields.Datetime()
+    start_call_message_id = fields.Many2one("mail.message")
+
+    _channel_id_not_null_constraint = models.Constraint(
+        "CHECK (channel_id IS NOT NULL)", "Call history must have a channel"
+    )
+    _start_dt_is_not_null_constraint = models.Constraint(
+        "CHECK (start_dt IS NOT NULL)", "Call history must have a start date"
+    )
+    _message_id_unique_constraint = models.Constraint(
+        "UNIQUE (start_call_message_id)", "Messages can only be linked to one call history"
+    )
+    _channel_id_end_dt_idx = models.Index("(channel_id, end_dt) WHERE end_dt IS NULL")
+
+    @api.depends("start_dt", "end_dt")
+    def _compute_duration_hour(self):
+        for record in self:
+            end_dt = record.end_dt or fields.Datetime.now()
+            record.duration_hour = (end_dt - record.start_dt).total_seconds() / 3600

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -68,7 +68,7 @@ class DiscussChannel(models.Model):
     sfu_channel_uuid = fields.Char(groups="base.group_system")
     sfu_server_url = fields.Char(groups="base.group_system")
     rtc_session_ids = fields.One2many('discuss.channel.rtc.session', 'channel_id', groups="base.group_system")
-    last_call_message_id = fields.Many2one("mail.message", string="Message of last call start")
+    call_history_ids = fields.One2many("discuss.call.history", "channel_id")
     is_member = fields.Boolean("Is Member", compute="_compute_is_member", search="_search_is_member", compute_sudo=True)
     # sudo: discuss.channel - sudo for performance, self member can be accessed on accessible channel
     self_member_id = fields.Many2one("discuss.channel.member", compute="_compute_self_member_id", compute_sudo=True)

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -3,8 +3,8 @@
 import logging
 import requests
 import uuid
-from markupsafe import Markup
 from datetime import timedelta
+from markupsafe import Markup
 
 from odoo import api, fields, models, _
 from odoo.addons.mail.tools.discuss import Store
@@ -319,9 +319,6 @@ class DiscussChannelMember(models.Model):
                 },
             )
         if len(self.channel_id.rtc_session_ids) == 1:
-            body = Markup('<div data-oe-type="call" class="o_mail_notification"></div>')
-            message = self.channel_id.message_post(body=body, message_type="notification")
-            self.channel_id.last_call_message_id = message
             if self.channel_id.channel_type != "channel":
                 self._rtc_invite_members()
 
@@ -388,13 +385,6 @@ class DiscussChannelMember(models.Model):
             self.rtc_session_ids.unlink()
         else:
             self.channel_id._rtc_cancel_invitations(member_ids=self.ids)
-        if not self.channel_id.rtc_session_ids and self.channel_id.last_call_message_id:
-            # deducing information about the end of call through write_date
-            self.channel_id._message_update_content(
-                self.channel_id.last_call_message_id,
-                self.channel_id.last_call_message_id.body,
-                strict=False
-            )
 
     def _rtc_sync_sessions(self, check_rtc_session_ids=None):
         """Synchronize the RTC sessions for self channel member.

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -5,6 +5,7 @@ import requests
 
 from collections import defaultdict
 from dateutil.relativedelta import relativedelta
+from markupsafe import Markup
 
 from odoo import api, fields, models
 from odoo.addons.mail.tools import discuss, jwt
@@ -44,21 +45,32 @@ class DiscussChannelRtcSession(models.Model):
             rtc_sessions_by_channel[rtc_session.channel_id] += rtc_session
         for channel, rtc_sessions in rtc_sessions_by_channel.items():
             channel._bus_send_store(channel, {"rtc_session_ids": Store.Many(rtc_sessions, mode="ADD")})
+        for channel in rtc_sessions.channel_id.filtered(lambda c: len(c.rtc_session_ids) == 1):
+            body = Markup('<div data-oe-type="call" class="o_mail_notification"></div>')
+            message = channel.message_post(body=body, message_type="notification")
+            # sudo - discuss.call.history: can create call history when call is created.
+            self.env["discuss.call.history"].sudo().create(
+                {
+                    "channel_id": channel.id,
+                    "start_dt": fields.Datetime.now(),
+                    "start_call_message_id": message.id,
+                },
+            )
+            channel._bus_send_store(message, [Store.Many("call_history_ids", [])])
         return rtc_sessions
 
     def unlink(self):
-        channels = self.channel_id
-        for channel in channels:
-            if channel.rtc_session_ids and len(channel.rtc_session_ids - self) == 0:
-                # If there is no member left in the RTC call, all invitations are cancelled.
-                # Note: invitation depends on field `rtc_inviting_session_id` so the cancel must be
-                # done before the delete to be able to know who was invited.
-                channel._rtc_cancel_invitations()
-                # If there is no member left in the RTC call, we remove the SFU channel uuid as the SFU
-                # server will timeout the channel. It is better to obtain a new channel from the SFU server
-                # than to attempt recycling a possibly stale channel uuid.
-                channel.sfu_channel_uuid = False
-                channel.sfu_server_url = False
+        call_ended_channels = self.channel_id.filtered(lambda c: not (c.rtc_session_ids - self))
+        for channel in call_ended_channels:
+            # If there is no member left in the RTC call, all invitations are cancelled.
+            # Note: invitation depends on field `rtc_inviting_session_id` so the cancel must be
+            # done before the delete to be able to know who was invited.
+            channel._rtc_cancel_invitations()
+            # If there is no member left in the RTC call, we remove the SFU channel uuid as the SFU
+            # server will timeout the channel. It is better to obtain a new channel from the SFU server
+            # than to attempt recycling a possibly stale channel uuid.
+            channel.sfu_channel_uuid = False
+            channel.sfu_server_url = False
         rtc_sessions_by_channel = defaultdict(lambda: self.env["discuss.channel.rtc.session"])
         for rtc_session in self:
             rtc_sessions_by_channel[rtc_session.channel_id] += rtc_session
@@ -70,6 +82,15 @@ class DiscussChannelRtcSession(models.Model):
             rtc_session._bus_send(
                 "discuss.channel.rtc.session/ended", {"sessionId": rtc_session.id}
             )
+        # sudo - dicuss.rtc.call.history: setting the end date of the call
+        # after it ends is allowed.
+        for history in (
+            self.env["discuss.call.history"]
+            .sudo()
+            .search([("channel_id", "in", call_ended_channels.ids), ("end_dt", "=", False)])
+        ):
+            history.end_dt = fields.Datetime.now()
+            history.channel_id._bus_send_store(history, ["duration_hour", "end_dt"])
         return super().unlink()
 
     def _bus_channel(self):

--- a/addons/mail/models/discuss/mail_message.py
+++ b/addons/mail/models/discuss/mail_message.py
@@ -1,11 +1,22 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import models, fields
 from odoo.addons.mail.tools.discuss import Store
 
 
 class MailMessage(models.Model):
     _inherit = "mail.message"
+
+    call_history_ids = fields.One2many("discuss.call.history", "start_call_message_id")
+
+    def _to_store_defaults(self):
+        return super()._to_store_defaults() + [
+            Store.Many(
+                "call_history_ids",
+                ["duration_hour", "end_dt"],
+                predicate=lambda m: 'data-oe-type="call"' in m.body,
+            ),
+        ]
 
     def _extras_to_store(self, store: Store, format_reply):
         super()._extras_to_store(store, format_reply=format_reply)

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -18,6 +18,9 @@ access_discuss_channel_member_public,discuss.channel.member.public,model_discuss
 access_discuss_channel_member_portal,discuss.channel.member.portal,model_discuss_channel_member,base.group_portal,1,1,1,1
 access_discuss_channel_member_user,discuss.channel.member.user,model_discuss_channel_member,base.group_user,1,1,1,1
 access_discuss_channel_rtc_session_system,discuss.channel.rtc.session.system,model_discuss_channel_rtc_session,base.group_system,1,1,1,1
+access_discuss_call_history_user,discuss.call.history.user,model_discuss_call_history,base.group_user,1,0,0,0
+access_discuss_call_history_public,discuss.call.history.public,model_discuss_call_history,base.group_public,1,0,0,0
+access_discuss_call_history_portal,discuss.call.history.portal,model_discuss_call_history,base.group_portal,1,0,0,0
 access_res_role_user,res.role.user,model_res_role,base.group_user,1,0,0,0
 access_res_role_admin,res.role.admin,model_res_role,base.group_erp_manager,1,1,1,1
 access_mail_alias_user,mail.alias.user,model_mail_alias,base.group_user,1,0,0,0

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -162,6 +162,36 @@
             <field name="perm_unlink" eval="False"/>
         </record>
 
+        <record id="ir_rule_discuss_call_history_read_all" model="ir.rule">
+            <field name="name">discuss.call.history: read call history of accessible channels</field>
+            <field name="model_id" ref="mail.model_discuss_call_history"/>
+            <field name="groups"
+                eval="[
+                    Command.link(ref('base.group_user')),
+                    Command.link(ref('base.group_portal')),
+                    Command.link(ref('base.group_public')),
+                ]"
+            />
+            <field name="domain_force">
+                [
+                    "|",
+                        "&amp;",
+                            ("channel_id.channel_type", "!=", "channel"),
+                            "|",
+                                ("channel_id.is_member", "=", True),
+                                ("channel_id.parent_channel_id.is_member", "=", True),
+                        "&amp;",
+                            ("channel_id.channel_type", "=", "channel"),
+                            "|",
+                                ("channel_id.group_public_id", "=", False),
+                                ("channel_id.group_public_id", "in", user.all_group_ids.ids),
+                ]
+            </field>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+
         <record id="ir_rule_discuss_channel_member_group_system" model="ir.rule">
             <field name="name">discuss.channel.member: admin can manipulate all entries</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>

--- a/addons/mail/static/src/core/common/discuss_call_history_model.js
+++ b/addons/mail/static/src/core/common/discuss_call_history_model.js
@@ -1,0 +1,13 @@
+import { fields, Record } from "@mail/core/common/record";
+
+export class DiscussCallHistory extends Record {
+    static id = "id";
+    static _name = "discuss.call.history";
+
+    /** @type {number} */
+    id;
+    end_dt = fields.Datetime();
+    /** @type {number|undefined} */
+    duration_hour;
+}
+DiscussCallHistory.register();

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -34,6 +34,7 @@ export class Message extends Record {
     attachment_ids = fields.Many("ir.attachment", { inverse: "message" });
     author = fields.One("Persona");
     body = fields.Html("");
+    call_history_ids = fields.Many("discuss.call.history");
     richBody = fields.Html("", {
         compute() {
             if (!this.store.emojiLoader.loaded) {

--- a/addons/mail/static/src/core/common/notification_message.js
+++ b/addons/mail/static/src/core/common/notification_message.js
@@ -51,14 +51,13 @@ export class NotificationMessage extends Component {
     }
 
     get callInformation() {
-        if (this.message.create_date.equals(this.message.write_date)) {
+        const history = this.message.call_history_ids[0];
+        if (history?.duration_hour === undefined || !history?.end_dt) {
             return _t("%(author)s started a call.", { author: this.message.author.name });
         }
-        let duration = this.message.write_date.diff(this.message.create_date, [
-            "hours",
-            "minutes",
-            "seconds",
-        ]);
+        let duration = luxon.Duration.fromObject({
+            seconds: Math.max(1, Math.round(history.duration_hour * 3600)),
+        }).shiftTo("hours", "minutes", "seconds");
         if (duration.hours || duration.minutes) {
             duration = duration.set({ seconds: 0 });
         }

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -24,17 +24,21 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                # update sessions
+                # delete of old sessions
                 (self.cr.dbname, "discuss.channel", channel.id),
-                # end of previous session
+                # end of old sessions
                 (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-
+                # update history with duration of previous session
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # insert new session
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # message unread counter (message post)
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                # update members is_pinned (message post)
+                (self.cr.dbname, "discuss.channel", channel.id, "members"),
                 # start call notification message post
                 (self.cr.dbname, "discuss.channel", channel.id),
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                (self.cr.dbname, "discuss.channel", channel.id, "members"),
-
-                # update sessions
+                # new call history (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
@@ -190,6 +194,8 @@ class TestChannelRTC(MailCommon):
                 (self.cr.dbname, "discuss.channel", channel.id, "members"),
                 # update of last interest (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id),
+                # update call history (not asserted below)
+                (self.cr.dbname, "discuss.channel", channel.id),
                 # incoming invitation
                 (self.cr.dbname, "res.partner", test_user.partner_id.id),
                 # update list of invitations
@@ -305,6 +311,8 @@ class TestChannelRTC(MailCommon):
                 # update of pin state (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id, "members"),
                 # update of last interest (not asserted below)
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # update call history (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id),
                 # incoming invitation
                 (self.cr.dbname, "res.partner", test_user.partner_id.id),
@@ -829,7 +837,7 @@ class TestChannelRTC(MailCommon):
                 (self.cr.dbname, "discuss.channel", channel.id),
                 # end session
                 (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                # update status call message
+                # update call history (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
@@ -922,25 +930,6 @@ class TestChannelRTC(MailCommon):
                             {
                                 "id": channel.id,
                                 "rtc_session_ids": [("DELETE", [channel_member.rtc_session_ids.id])],
-                            },
-                        ],
-                    },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "mail.message": [
-                            {
-                                "attachment_ids": [],
-                                "body": [
-                                    "markup",
-                                    '<div data-oe-type="call" class="o_mail_notification"></div><span class="o-mail-Message-edited"></span>',
-                                ],
-                                "id": channel.last_call_message_id.id,
-                                "pinned_at": False,
-                                "recipients": [],
-                                "translationValue": False,
-                                "write_date": channel.last_call_message_id.write_date,
                             },
                         ],
                     },
@@ -1168,7 +1157,7 @@ class TestChannelRTC(MailCommon):
                 (self.cr.dbname, "discuss.channel", channel.id),
                 # end session
                 (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                # update status call message
+                # update call history (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
@@ -1183,25 +1172,6 @@ class TestChannelRTC(MailCommon):
                             {
                                 "id": channel.id,
                                 "rtc_session_ids": [("DELETE", [channel_member.rtc_session_ids.id])],
-                            },
-                        ],
-                    },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "mail.message": [
-                            {
-                                "attachment_ids": [],
-                                "body": [
-                                    "markup",
-                                    '<div data-oe-type="call" class="o_mail_notification"></div><span class="o-mail-Message-edited"></span>',
-                                ],
-                                "id": channel.last_call_message_id.id,
-                                "pinned_at": False,
-                                "recipients": [],
-                                "translationValue": False,
-                                "write_date": channel.last_call_message_id.write_date,
                             },
                         ],
                     },
@@ -1228,6 +1198,8 @@ class TestChannelRTC(MailCommon):
                 (self.cr.dbname, "discuss.channel", channel.id),
                 # session ended
                 (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                # update call history duration
+                (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
                 {
@@ -1263,6 +1235,8 @@ class TestChannelRTC(MailCommon):
                 (self.cr.dbname, "discuss.channel", channel.id),
                 # session ended
                 (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                # update call history duration
+                (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
                 {

--- a/addons/mail/views/discuss/discuss_call_history_views.xml
+++ b/addons/mail/views/discuss/discuss_call_history_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="discuss_call_history_view_tree" model="ir.ui.view">
+            <field name="name">discuss.call.history.view.list</field>
+            <field name="model">discuss.call.history</field>
+            <field name="arch" type="xml">
+                <list string="Call History" sample="1">
+                    <field name="channel_id"/>
+                    <field name="start_dt"/>
+                    <field name="end_dt"/>
+                    <field name="duration_hour" widget="float_time" options="{'displaySeconds': True}"/>
+                </list>
+            </field>
+        </record>
+        <record id="discuss_call_history_view_form" model="ir.ui.view">
+            <field name="name">discuss.call.history.view.form</field>
+            <field name="model">discuss.call.history</field>
+            <field name="arch" type="xml">
+                <form string="Call History">
+                    <group class="oe_form_field">
+                        <field name="channel_id"/>
+                        <field name="start_dt"/>
+                        <field name="end_dt"/>
+                        <field name="duration_hour" widget="float_time" options="{'displaySeconds': True}"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+        <record id="discuss_call_history_action" model="ir.actions.act_window">
+            <field name="name">Call History</field>
+            <field name="res_model">discuss.call.history</field>
+            <field name="view_mode">list,form</field>
+            <field name="context">{"create": False}</field>
+        </record>
+        <menuitem
+            action="discuss_call_history_action"
+            id="discuss_call_history_menu"
+            name="Call History"
+            parent="discuss_technical"
+            sequence="15"
+        />
+    </data>
+</odoo>

--- a/addons/mail/views/discuss/discuss_menus.xml
+++ b/addons/mail/views/discuss/discuss_menus.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <menuitem
+            id="discuss_technical"
+            name="Technical"
+            parent="mail.menu_root_discuss"
+            groups="base.group_no_one"
+            sequence="10"
+        />
+    </data>
+</odoo>


### PR DESCRIPTION
This PR introduces statistics about calls in the live chat
report, specifically:
- Call duration.
- Number of calls.
- Percentage of sessions having calls.

task-4614125