### PR TITLE
[FIX] web: Allows users to download file from pdf_viewer widget

### DIFF
--- a/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.js
+++ b/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.js
@@ -19,6 +19,7 @@ export class PdfViewerField extends Component {
 
     setup() {
         this.notification = useService("notification");
+        this.action = useService("action");
         this.state = useState({
             isValid: true,
             objectUrl: "",
@@ -42,19 +43,23 @@ export class PdfViewerField extends Component {
         );
     }
 
+    get urlFile() {
+        return (
+            this.state.objectUrl ||
+            url("/web/content", {
+                model: this.props.record.resModel,
+                field: this.props.name,
+                id: this.props.record.resId,
+            })
+        );
+    }
+
     get url() {
         if (!this.state.isValid || !this.props.record.data[this.props.name]) {
             return null;
         }
         const page = this.props.record.data[`${this.props.name}_page`] || 1;
-        const file = encodeURIComponent(
-            this.state.objectUrl ||
-                url("/web/content", {
-                    model: this.props.record.resModel,
-                    field: this.props.name,
-                    id: this.props.record.resId,
-                })
-        );
+        const file = encodeURIComponent(this.urlFile);
         return `/web/static/lib/pdfjs/web/viewer.html?file=${file}#page=${page}`;
     }
 
@@ -66,6 +71,14 @@ export class PdfViewerField extends Component {
     onFileRemove() {
         this.state.isValid = true;
         this.update({});
+    }
+
+    onFileDownload() {
+        this.action.doAction({
+            type: "ir.actions.act_url",
+            url: this.urlFile,
+            target: "new",
+        });
     }
 
     onFileUploaded({ data, objectUrl }) {

--- a/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.xml
+++ b/addons/web/static/src/views/fields/pdf_viewer/pdf_viewer_field.xml
@@ -16,6 +16,12 @@
                                 aria-label="Edit"
                             />
                         </t>
+                            <button
+                                class="btn btn-secondary fa fa-download"
+                                data-tooltip="Download"
+                                aria-label="Download"
+                                t-on-click="onFileDownload"
+                            />
                         <button
                             class="btn btn-secondary fa fa-trash o_clear_file_button"
                             data-tooltip="Clear"


### PR DESCRIPTION
Example of steps:
- Install `web_studio`
- Add a file field anywhere in a view form via Studio
- Use pdf_viewer widget on this file field
- Close Studio
- Create a new record
- Upload a pdf
- Save
- You have no way to download the pdf

Since https://github.com/odoo/odoo/commit/8a755d58330218b550efc0fea2f98800151c09a5

This commit allow users to do it by adding a new download button between the existing edit and remove button.

Since
opw-4630186