### PR TITLE
[FIX] html_editor: traceback when cropping image

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -43,7 +43,7 @@ export class ImageCrop extends Component {
         this.elRef = useRef("el");
         this.cropperWrapper = useRef("cropperWrapper");
         this.imageRef = useRef("imageRef");
-        this.cropperOpen = false;
+        this.isCropperActive = false;
 
         // We use capture so that the handler is called before other editor handlers
         // like save, such that we can restore the src before a save.
@@ -66,19 +66,18 @@ export class ImageCrop extends Component {
     }
 
     closeCropper() {
-        if (!this.cropperOpen) {
-            return;
-        }
-        this.cropper?.destroy?.();
-        this.media.setAttribute("src", this.initialSrc);
-        if (
-            this.hasModifiedImageClass &&
-            !this.media.classList.contains("o_modified_image_to_save")
-        ) {
-            this.media.classList.add("o_modified_image_to_save");
+        if (this.isCropperActive) {
+            this.cropper?.destroy?.();
+            this.media.setAttribute("src", this.initialSrc);
+            if (
+                this.hasModifiedImageClass &&
+                !this.media.classList.contains("o_modified_image_to_save")
+            ) {
+                this.media.classList.add("o_modified_image_to_save");
+            }
         }
         this.props?.onClose?.();
-        this.cropperOpen = false;
+        this.isCropperActive = false;
     }
 
     /**
@@ -96,7 +95,7 @@ export class ImageCrop extends Component {
     }
 
     async show() {
-        if (this.cropperOpen) {
+        if (this.isCropperActive) {
             return;
         }
         // key: ratio identifier, label: displayed to user, value: used by cropper lib
@@ -183,13 +182,16 @@ export class ImageCrop extends Component {
         this.cropperWrapper.el.style.top = `${offset.top}px`;
 
         await loadImage(this.originalSrc, cropperImage);
+        if (status(this) !== "mounted") {
+            return;
+        }
 
         this.cropper = await activateCropper(
             cropperImage,
             this.aspectRatios[this.aspectRatio].value,
             this.media.dataset
         );
-        this.cropperOpen = true;
+        this.isCropperActive = true;
     }
     /**
      * Updates the DOM image with cropped data and associates required

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -123,3 +123,23 @@ describe("Powerbox search keywords", () => {
         }
     });
 });
+
+test("cropper should not open for external image", async () => {
+    onRpc("/html_editor/get_image_info", () => {
+        return {
+            original: false,
+        };
+    });
+
+    await setupEditor(
+        `<p>[<img src="https://download.odoocdn.com/icons/website/static/description/icon.png">]</p>`
+    );
+    await waitFor('div[name="image_transform"]');
+
+    await click('div[name="image_transform"] > .btn');
+    await animationFrame();
+
+    await click('.btn[name="image_crop"]');
+    await waitFor(".o_notification_manager .o_notification");
+    expect("img.o_we_cropper_img").toHaveCount(0);
+});

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -842,7 +842,7 @@ test("close the toolbar if the selection contains any nodes (traverseNode = [], 
 });
 
 test.tags("desktop");
-test("should not close image cropper while loading media", async () => {
+test("should be able to close image cropper while loading the media", async () => {
     onRpc("/html_editor/get_image_info", () => ({
         original: {
             image_src: "#",
@@ -866,24 +866,8 @@ test("should not close image cropper while loading media", async () => {
     await click('.btn[title="Discard"]');
     await animationFrame();
 
-    // cropper should not close as the cropper still loading the image.
-    expect('.btn[title="Discard"]').toHaveCount(1);
-
-    // once the image loaded we should be able to close
-    await waitFor('img[src^="blob:"]', { timeout: 2000 });
-    await click('.btn[title="Discard"]');
-    await waitForNone('.btn[title="Discard"]', { timeout: 1000 });
-
-    await click("img");
-    await waitFor(".o-we-toolbar", { timeout: 1000 });
-
-    await click('div[name="image_transform"] > .btn');
-    await animationFrame();
-
-    await waitFor('.btn[name="image_crop"]', { timeout: 1000 });
-    await click('.btn[name="image_crop"]');
-    await waitFor('.btn[title="Discard"]', { timeout: 1000 });
-    expect('.btn[title="Discard"]').toHaveCount(1);
+    // Cropper should get closed while the cropper still loading the image.
+    expect('.btn[title="Discard"]').toHaveCount(0);
 });
 
 describe.tags("desktop");


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce the issue:

- Upload an external image.
- Click on it to open the toolbar.
- Try to open image cropper.
- Clicking on "Apply" button leads to traceback.

This issue happens because after merging this commit [1] `closeCropper` method closes the cropper only if `cropperOpen`
flag is true. In case of external image, cropper should be closed before it gets fully mounted as such images are uncroppable. In this case `cropperOpen` flag is false and `closeCropper` fails to close cropper which results in traceback later.

**Desired behavior after PR is merged:**

Cropper gets closed in case of external image and there is a toaster notification at the top-right showing "This type of
image is not supported for cropping".

[1]: https://github.com/odoo/odoo/commit/df64afb4e9504413f966a153772c568b625a5e13

task-4677287



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
