### PR TITLE
[IMP] account: allow user to link a default invoice template to a journal

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6257,6 +6257,22 @@ class AccountMove(models.Model):
             return self.company_id.account_discount_income_allocation_id
         return None
 
+    def _get_available_invoice_template_pdf_report_ids(self):
+        """
+        Helper to get available invoice template pdf reports
+        """
+        moves = self
+
+        for move_type in ['out_invoice', 'out_refund', 'out_receipt']:
+            moves += self.new({'move_type': move_type})
+
+        available_reports = moves._get_available_action_reports()
+
+        if not available_reports:
+            raise UserError(_("There is no template that applies to invoices."))
+
+        return available_reports
+
     # -------------------------------------------------------------------------
     # TOOLING
     # -------------------------------------------------------------------------

--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -45,6 +45,9 @@ class AccountMoveSend(models.AbstractModel):
         if partner_default_template := move.partner_id.with_company(move.company_id).invoice_template_pdf_report_id:
             return partner_default_template
 
+        if journal_default_template := move.journal_id.with_company(move.company_id).invoice_template_pdf_report_id:
+            return journal_default_template
+
         action_report = self.env.ref('account.account_invoices')
 
         if move._is_action_report_available(action_report):

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -480,17 +480,8 @@ class ResPartner(models.Model):
             partner.days_sales_outstanding = ((partner.credit / total_invoiced_tax_included) * days_since_oldest_invoice) if total_invoiced_tax_included else 0
 
     def _compute_available_invoice_template_pdf_report_ids(self):
-        moves = self.env['account.move']
-
-        for move_type in ['out_invoice', 'out_refund', 'out_receipt']:
-            moves += self.env['account.move'].new({'move_type': move_type})
-
-        available_reports = moves._get_available_action_reports()
-
-        if not available_reports:
-            raise UserError(_("There is no template that applies to invoices."))
-
-        self.available_invoice_template_pdf_report_ids = available_reports
+        for partner in self:
+            partner.available_invoice_template_pdf_report_ids = self.env['account.move']._get_available_invoice_template_pdf_report_ids()
 
     def _get_company_currency(self):
         for partner in self:

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -100,6 +100,9 @@
                                         <field name="loss_account_id" invisible="type not in ('cash', 'bank')" groups="account.group_account_readonly"/>
                                         <field name="refund_sequence" invisible="type not in ['sale', 'purchase']"/>
                                         <field name="payment_sequence" invisible="type not in ('bank', 'cash', 'credit')"/>
+                                        <field name="invoice_template_pdf_report_id"
+                                               invisible="not display_invoice_template_pdf_report_id"
+                                               options="{'no_create': True, 'no_edit': True}"/>
                                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                     </group>
                                     <group name="bank_account_number" invisible="type != 'bank'">


### PR DESCRIPTION
Before this commit, we can set a default invoice template by customer.
We add here the same functionality to the journals. The order to decide
which invoice template will be used to prefill the 'Invoice report'
field in the move send wizard is the following :
1. The partner's default invoice template
2. The journal's default invoice template
3. The first one we find

Task-4663942
Runbot: https://runbot.odoo.com/runbot/bundle/master-invoice-report-custom-by-journal-roto-358149


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
