### PR TITLE
[FIX] website: fix kanban view if only one website

### DIFF
--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -133,7 +133,7 @@
                             title="Home page of the current website"/>
                         <field name="name" />
                     </div>
-                    <div t-if="record.website_id.value" class="text-truncate fw-bold text-muted">
+                    <div t-if="record.website_id.value" class="text-truncate fw-bold text-muted" groups="website.group_multi_website">
                         <i class="fa fa-globe me-1" title="Website"/>
                         <field name="website_id" groups="website.group_multi_website"/>
                     </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Kanban view of the website pages not working
 
(opw-4651572)

Current behavior before PR:
The kanban view was not working if the database only contains one website because of the group multi-website not set on the users so the t-if="record.website_id.value" cannot be evaluated.

Desired behavior after PR is merged:
The group attribute is now set correctly on the parent div so the if statement is working properly



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
