### PR TITLE
[FIX] point_of_sale: display searched partner by mobile number with spaces

### DIFF
--- a/addons/point_of_sale/static/src/app/models/res_partner.js
+++ b/addons/point_of_sale/static/src/app/models/res_partner.js
@@ -18,7 +18,7 @@ export class ResPartner extends Base {
         return fields
             .map((field) => {
                 if ((field === "phone" || field === "mobile") && this[field]) {
-                    return this[field].split(" ").join("");
+                    return this[field].replace(/[+\s()-]/g, "");
                 }
                 return this[field] || "";
             })

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -81,10 +81,12 @@ export class PartnerList extends Component {
         if (exactMatches.length > 0) {
             return exactMatches;
         }
+        const numberString = searchWord.replace(/[+\s()-]/g, "");
+        const isSearchWordNumber = /^[0-9]+$/.test(numberString);
 
         const availablePartners = searchWord
             ? partners.filter((p) =>
-                  unaccent(p.searchString, false).toLowerCase().includes(searchWord)
+                  unaccent(p.searchString).includes(isSearchWordNumber ? numberString : searchWord)
               )
             : partners
                   .slice(0, 1000)


### PR DESCRIPTION
Issue:
========
When searching for a partner using a mobile number with spaces (e.g., `+91 123456789`), the expected partner is not displayed.

Cause:
========
The code removes spaces from stored phone numbers but does not modify the search input, leading to a mismatch:
- Stored: `+91123456789`
- Search input: `+91 123456789`

Fix:
======
Added a regex to standardize mobile numbers on the frontend by removing `+, -,
(), and spaces`. The same transformation is applied during search
to ensure correct matches.
Task-4675406


