### PR TITLE
[IMP] website: show warning on 301/302 redirects for existing pages

### DIFF
--- a/addons/website/static/src/components/fields/fields.js
+++ b/addons/website/static/src/components/fields/fields.js
@@ -4,6 +4,7 @@ import { UrlField, urlField } from "@web/views/fields/url/url_field";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { Component, useEffect, useRef } from "@odoo/owl";
+import { charField, CharField } from "@web/views/fields/char/char_field";
 
 /**
  * Displays website page dependencies and URL redirect options when the page URL
@@ -111,3 +112,30 @@ export const imageRadioField = {
 };
 
 registry.category("fields").add("image_radio", imageRadioField);
+
+/**
+ * A Char field that updates its value on input.
+ */
+export class UrlWarningBannerVisibilityCharField extends CharField {
+    static template = "website.UrlWarningBannerVisibilityCharField";
+
+    onFocus(ev) {
+        if (this.props.record.data.is_url_from_exist) {
+            this.props.record.update({ is_url_from_exist: false });
+        }
+    }
+
+    onBlur() {
+        this.props.record.update({ [this.props.name]: this.input.el.value });
+        super.onBlur();
+    }
+}
+
+export const urlWarningBannerVisibilityCharField = {
+    ...charField,
+    component: UrlWarningBannerVisibilityCharField,
+};
+
+registry
+    .category("fields")
+    .add("url_warning_banner_visibility", urlWarningBannerVisibilityCharField);

--- a/addons/website/static/src/components/fields/fields.xml
+++ b/addons/website/static/src/components/fields/fields.xml
@@ -27,4 +27,10 @@
     </fieldset>
 </t>
 
+<t t-name="website.UrlWarningBannerVisibilityCharField" t-inherit="web.CharField" t-inherit-mode="primary">
+    <xpath expr="//input" position="attributes">
+        <attribute name="t-on-focus">onFocus</attribute>
+    </xpath>
+</t>
+
 </templates>

--- a/addons/website/views/website_rewrite.xml
+++ b/addons/website/views/website_rewrite.xml
@@ -11,11 +11,14 @@
                                 invisible="redirect_type != '308'"/>
                     </header>
                     <sheet>
+                        <div class="alert alert-warning" role="alert" invisible="not is_url_from_exist">
+                            This redirection will not have any effect since the URL '<field name="url_from" readonly="1"/>' is already in use.
+                        </div>
                         <group>
                             <group>
                                 <field name="name"/>
                                 <field name="redirect_type"/>
-                                <field name="url_from" invisible="redirect_type == '308'"/>
+                                <field name="url_from" invisible="redirect_type == '308'" widget="url_warning_banner_visibility"/>
                                 <field name="route_id" string="URL from" options="{'no_create': True, 'no_open': True}" invisible="redirect_type != '308'"/>
                                 <field name="url_to" invisible="redirect_type == '404'"/>
                             </group>
@@ -34,7 +37,7 @@
             <field name="name">website.rewrite.list</field>
             <field name="model">website.rewrite</field>
             <field name="arch" type="xml">
-                <list string="Website rewrites">
+                <list string="Website rewrites" decoration-warning="is_url_from_exist">
                     <field name="sequence" widget="handle" />
                     <field name="redirect_type"/>
                     <field name="name"/>
@@ -62,8 +65,7 @@
             id="menu_website_rewrite"
             action="action_website_rewrite_list"
             parent="menu_website_global_configuration"
-            sequence="30"
-            groups="base.group_no_one"/>
+            sequence="30"/>
 
         <record id="view_rewrite_search" model="ir.ui.view">
             <field name="name">website.rewrite.search</field>


### PR DESCRIPTION
This commit aims to: 
- Add a warning message when saving 301 & 302 redirects in website pages.  
- Ensure both dynamic and static pages trigger a user alert before saving.  
- If you try saving pages that are already defined on either website pages or 
from controllers,

task-3861555
