### PR TITLE
[IMP] mail: remove unnecessary background color from chat bubble button

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -14,8 +14,8 @@
                 </t>
             </ImStatus>
             <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border'"/>
-            <button class="o-mail-ChatHub-bubbleBtn btn bg-view shadow">
-                <img class="o-mail-ChatBubble-avatar rounded-circle o_object_fit_cover" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
+            <button class="o-mail-ChatHub-bubbleBtn btn shadow">
+                <img class="o-mail-ChatBubble-avatar bg-view rounded-circle o_object_fit_cover" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>
         </div>
     </t>


### PR DESCRIPTION
**Current behavior before PR:**

- `bg-view` on the chat bubble button causes an unintended white outline around
avatars, affecting UI consistency.

**Desired behavior after PR:**

- Removed `bg-view` from the button and applied background color directly to the
image to handle transparency.
- Ensures the chat bubble renders cleanly as a filled circle without visual
artifacts.

task-[4630768](https://www.odoo.com/odoo/project/1519/tasks/4630768)

-----
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)