### PR TITLE
[FIX] portal: properly return markup in portal_message_format

### DIFF
--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -95,6 +95,7 @@ class MailMessage(models.Model):
 
         note_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note')
         for message, values in zip(self, vals_list):
+            values["body"] = ["markup", values["body"]]
             if message_to_attachments:
                 values['attachment_ids'] = message_to_attachments.get(message.id, {})
             if 'author_avatar_url' in properties_names:


### PR DESCRIPTION
Follow up of https://github.com/odoo/odoo/pull/199262

The result of `portal_message_format` is given to store insert in JS but the method currently does not use Store in python, leading to markup (and potentially other fields) being returned with the wrong format.

Converting the full method to Store is not necessary as it will be removed in https://github.com/odoo/odoo/pull/182334.

In the meantime, manually fixing the format is sufficient.

task-4678115