### PR TITLE
[FIX] hw_drivers: missing subprocess import

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import screeninfo
+import subprocess
 
 from odoo.addons.hw_drivers.interface import Interface
 from odoo.addons.hw_drivers.tools import helpers


### PR DESCRIPTION
The PR to add wayland support (#202722) relied on `subprocess` being
imported in `DisplayInterface_L`, however in saas-18.2 onwards this was
not the case. This commit adds the missing import.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
