### PR TITLE
[FIX] hr_holidays: fix RPC error when changing leave type at leave creation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -256,16 +256,14 @@ class HrLeaveType(models.Model):
         return [('id', 'in', valid_leaves)]
 
     def _search_virtual_remaining_leaves(self, operator, value):
+        def is_valid(leave_type):
+            return leave_type.requires_allocation != "yes" or op(leave_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented
         if operator != 'in':
             value = float(value)
         leave_types = self.env['hr.leave.type'].search([])
-
-        def is_valid(leave_type):
-            return leave_type.requires_allocation != "yes" or op(leave_type.virtual_remaining_leaves)
-
         return [('id', 'in', leave_types.filtered(is_valid).ids)]
 
     @api.depends_context('employee_id', 'default_employee_id', 'leave_date_from', 'default_date_from')


### PR DESCRIPTION
Steps:
- Try to create a time off and select a leave type.

Issue:
- Fixed a TypeError caused by a missing value in a comparison call.
- The operation expected two values but was given only one.

Fix:
- Updated the condition to include the missing value in the call.
- This resolves the RPC_ERROR that occurred when changing leave types.

Task - 4677315

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
