### PR TITLE
[FIX] point_of_sale: prevent crash when a category has no products

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -345,11 +345,14 @@ export class ProductScreen extends Component {
         if (limit_categories) {
             const productIds = new Set([]);
             for (const categ of iface_available_categ_ids) {
-                for (const p of this.pos.models["product.product"].getBy(
+                const products = this.pos.models["product.product"].getBy(
                     "pos_categ_ids",
                     categ.id
-                )) {
-                    productIds.add(p.id);
+                );
+                if (products) {
+                    for (const p of products) {
+                        productIds.add(p.id);
+                    }
                 }
             }
             return this.pos.models["product.product"].filter((p) => productIds.has(p.id));


### PR DESCRIPTION
Before this commit, enabling category restriction could cause a crash if one of the selected categories did not contain any products.

opw-4677964

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
