### PR TITLE
[IMP] mail: sort chatter messages by date

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -61,7 +61,7 @@ class ThreadController(http.Controller):
     @http.route("/mail/thread/messages", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_messages(self, thread_model, thread_id, fetch_params=None):
         thread = self._get_thread_with_access(thread_model, thread_id, mode="read")
-        res = request.env["mail.message"]._message_fetch(domain=None, thread=thread, **(fetch_params or {}))
+        res = request.env["mail.message"].with_context(is_chatter_view=True)._message_fetch(domain=None, thread=thread, **(fetch_params or {}))
         messages = res.pop("messages")
         if not request.env.user._is_public():
             messages.set_message_done()

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -945,17 +945,45 @@ class MailMessage(models.Model):
                 message_domain |= Domain("id", "in", accessible_tracking_value_ids.mail_message_id.ids)
             domain &= message_domain
             res["count"] = self.search_count(domain)
-        if around is not None:
-            messages_before = self.search(domain & Domain('id', '<=', around), limit=limit // 2, order="id DESC")
-            messages_after = self.search(domain & Domain('id', '>', around), limit=limit // 2, order='id ASC')
-            return {**res, "messages": (messages_after + messages_before).sorted('id', reverse=True)}
-        if before:
-            domain &= Domain('id', '<', before)
+
+        is_chatter_view = self.env.context.get('is_chatter_view', False)
+
+        if is_chatter_view:
+            if around is not None:
+                around_message = self.browse(around)
+                messages_before = self.search(domain & Domain('date', '<=', around_message.date), limit=limit // 2, order="date DESC, id DESC")
+                messages_after = self.search(domain & Domain('date', '>', around_message.date), limit=limit // 2, order='date ASC, id ASC')
+                return {**res, "messages": (messages_after + messages_before).sorted(lambda m: (m.date, m.id), reverse=True)}
+            if before:
+                before_message = self.browse(before)
+                domain &= Domain.OR([
+                    [('date', '<', before_message.date)],
+                    [('date', '=', before_message.date), ('id', '<', before)]
+                ])
+            if after:
+                after_message = self.browse(after)
+                domain &= Domain.OR([
+                    [('date', '>', after_message.date)],
+                    [('date', '=', after_message.date), ('id', '>', after)]
+                ])
+            order = 'date ASC, id ASC' if after else 'date DESC, id DESC'
+        else:
+            if around is not None:
+                messages_before = self.search(domain & Domain('id', '<=', around), limit=limit // 2, order="id DESC")
+                messages_after = self.search(domain & Domain('id', '>', around), limit=limit // 2, order='id ASC')
+                return {**res, "messages": (messages_after + messages_before).sorted('id', reverse=True)}
+            if before:
+                domain &= Domain('id', '<', before)
+            if after:
+                domain &= Domain('id', '>', after)
+            order = 'id ASC' if after else 'id DESC'
+
+        res["messages"] = self.search(domain, limit=limit, order=order)
         if after:
-            domain &= Domain('id', '>', after)
-        res["messages"] = self.search(domain, limit=limit, order='id ASC' if after else 'id DESC')
-        if after:
-            res["messages"] = res["messages"].sorted('id', reverse=True)
+            if is_chatter_view:
+                res["messages"] = res["messages"].sorted(lambda m: (m.date, m.id), reverse=True)
+            else:
+                res["messages"] = res["messages"].sorted('id', reverse=True)
         return res
 
     def _get_tracking_values_domain(self, search_term):


### PR DESCRIPTION
Before this PR:
Chatter messages were not always ordered correctly by date.

After this PR:
Chatter messages are now consistently displayed in chronological order.

Task-4354648