### PR TITLE
[FIX] point_of_sale: fix category without products

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -345,10 +345,9 @@ export class ProductScreen extends Component {
         if (limit_categories) {
             const productIds = new Set([]);
             for (const categ of iface_available_categ_ids) {
-                for (const p of this.pos.models["product.product"].getBy(
-                    "pos_categ_ids",
-                    categ.id
-                )) {
+                const categoryProducts =
+                    this.pos.models["product.product"].getBy("pos_categ_ids", categ.id) || [];
+                for (const p of categoryProducts) {
                     productIds.add(p.id);
                 }
             }

--- a/addons/point_of_sale/static/tests/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_tour.js
@@ -6,7 +6,7 @@ import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as Utils from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
-import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
+import { inLeftSide, negateStep } from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("ChromeTour", {
     checkDelay: 50,
@@ -186,5 +186,23 @@ registry.category("web_tour.tours").add("test_zero_decimal_places_currency", {
             PaymentScreen.clickValidate(),
             ReceiptScreen.receiptIsThere(),
             ReceiptScreen.totalAmountContains("100"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_limited_categories", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickSubcategory("Parent"),
+            ProductScreen.productIsDisplayed("Product 1"),
+            ProductScreen.productIsDisplayed("Product 2"),
+            ProductScreen.clickSubcategory("Child 1"),
+            ProductScreen.productIsDisplayed("Product 1"),
+            ProductScreen.productIsDisplayed("Product 2").map(negateStep),
+            ProductScreen.clickSubcategory("Child 2"),
+            ProductScreen.productIsDisplayed("Product 1").map(negateStep),
+            ProductScreen.productIsDisplayed("Product 2"),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1725,6 +1725,41 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_zero_decimal_places_currency', login="pos_user")
 
+    def test_limited_categories(self):
+        parent_category = self.env['pos.category'].create({
+            'name': 'Parent',
+        })
+        child_category_1 = self.env['pos.category'].create({
+            'name': 'Child 1',
+            'parent_id': parent_category.id,
+        })
+        child_category_2 = self.env['pos.category'].create({
+            'name': 'Child 2',
+            'parent_id': parent_category.id,
+        })
+        self.env['product.product'].create({
+            'name': 'Product 1',
+            'available_in_pos': True,
+            'list_price': 1.20,
+            'taxes_id': False,
+            'pos_categ_ids': [(4, child_category_1.id)],
+        })
+        self.env['product.product'].create({
+            'name': 'Product 2',
+            'available_in_pos': True,
+            'list_price': 2.30,
+            'taxes_id': False,
+            'pos_categ_ids': [(4, child_category_2.id)],
+        })
+        self.main_pos_config.write({
+            'limit_categories': True,
+            'iface_available_categ_ids': [(6, 0, [parent_category.id, child_category_1.id, child_category_2.id])],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_limited_categories', login="pos_user")
+
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Before this commit, get products in product screen was trying to get products in available categories, but if a category has no products like a parent category without products, the method would raise a traceback and the product screen would not display anything (white screen). This commit solves it by checking the return of the getBy and assinging an empty list if the category has no products.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
