### PR TITLE
[IMP] purchase_stock: improve receipt status decoration

### DIFF
--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -96,10 +96,13 @@
             <field name="invoice_status" position="before">
                 <field name="effective_date" column_invisible="True"/>
                 <field name="receipt_status" optional="hide" widget="badge"
-                decoration-success="date_planned and (date_planned &gt; datetime.datetime.combine(datetime.date.today(), datetime.time(23,59,59)).to_utc().strftime('%Y-%m-%d %H:%M:%S') or receipt_status=='full' and effective_date &lt;= date_planned)"
+                decoration-success="receipt_status=='full'"
                 decoration-danger="date_planned and (date_planned &lt; effective_date or date_planned &lt; datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)).to_utc().strftime('%Y-%m-%d %H:%M:%S') and receipt_status!='full' and effective_date &lt;= date_planned)"
                 decoration-warning="date_planned and date_planned &gt;= datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)).to_utc().strftime('%Y-%m-%d %H:%M:%S') and date_planned &lt;= datetime.datetime.combine(datetime.date.today(), datetime.time(23,59,59)).to_utc().strftime('%Y-%m-%d %H:%M:%S') and receipt_status!='full'"/>
             </field>
+            <xpath expr="//field[@name='date_planned']" position="attributes">
+                <attribute name="decoration-danger">date_planned and (date_planned &lt; effective_date or date_planned &lt; datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)).to_utc().strftime('%Y-%m-%d %H:%M:%S') and receipt_status!='full' and effective_date &lt;= date_planned)</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Previously, the receipt status remained red even when the order was fully received, which made the user confused.

Now, for fully received orders, the receipt status is shown in green, and the expected arrival date is highlighted in red if the order is late. This improves clarity and prevents user confusion.

Task - [4633641](https://www.odoo.com/odoo/my-tasks/4633641)

