### PR TITLE
[IMP] mail: improve file upload UI on mobile

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -38,3 +38,14 @@
 .o-viewable {
     cursor: zoom-in;
 }
+
+.o-mail-AttachmentCard-CancelUpload {
+    .fa-times {
+        z-index: 2;
+        font-size: 1.2rem;
+    }
+
+    .fa-circle-o-notch {
+        font-size: 2rem;
+    }
+}

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -62,13 +62,19 @@
                     </t>
                     <div class="flex-grow-1"/>
                     <div class="o-mail-AttachmentCard-aside position-relative rounded-end overflow-hidden d-flex" t-att-class="{ 'o-hasMultipleActions d-flex flex-column': showDelete and !env.inComposer }">
-                        <div t-if="attachment.uploading" class="d-flex justify-content-center align-items-center w-100 h-100" title="Uploading">
+                        <div t-if="!isMobileOS() and attachment.uploading" class="d-flex justify-content-center align-items-center w-100 h-100" title="Uploading">
                             <i class="fa fa-circle-o-notch fa-spin"/>
+                        </div>
+                        <div t-if="isMobileOS() and attachment.uploading" class="d-flex justify-content-center align-items-center w-100 h-100" title="Uploading">
+                            <button class="o-mail-AttachmentCard-CancelUpload position-relative btn border-0 bg-transparent p-0 d-flex align-items-center justify-content-center text-black-50" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Cancel Upload">
+                                <i class="fa fa-times position-absolute" aria-hidden="true"/>
+                                <i class="fa fa-circle-o-notch fa-spin position-absolute"/>
+                            </button>
                         </div>
                         <div t-if="!attachment.uploading and env.inComposer" class="d-flex justify-content-center me-2 align-items-center w-100 h-100 text-primary" title="Uploaded">
                             <i class="fa fa-check"/>
                         </div>
-                        <button t-if="showDelete"
+                        <button t-if="!(isMobileOS() and attachment.uploading) and showDelete"
                                 class="o-mail-AttachmentCard-unlink btn top-0 align-items-center justify-content-center d-flex w-100 h-100 rounded-0 border-0"
                                 t-attf-class="{{ env.inComposer ? 'o-inComposer position-absolute btn-primary transition-base justify-content-center' : 'bg-300' }}"
                                 t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove"

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -10,6 +10,17 @@
         grid-template-columns: $o-mail-Message-sidebarWidth 1fr;
     }
 
+    &:not(.o-hasSelfAvatar) {
+        .o-mail-Composer-coreHeader {
+            grid-column: 2/3;
+        }
+
+        .o-mail-Composer-footer,
+        .o-mail-Composer-coreMain {
+            grid-column: 1/3;
+        }
+    }
+
     .o-mail-Composer-sidebarMain {
         padding-top: 0.125rem; // avatar centered with composer text input: 38px (avatar) + 2*2px (this value) = 20px + 2 * { 10px (padding) + 1px (border) }
         width: $o-mail-Message-sidebarWidth;


### PR DESCRIPTION
Before this PR:
- When uploading a file in the message composer on mobile, only the trash icon
  was displayed, regardless of whether the file was uploading or already
  uploaded.

After this PR:
- A spinning icon around a cross (`X`) is displayed during file upload,
  indicating progress and allowing users to cancel the upload.
- Once the upload is complete, the spinning icon is replaced with a trash icon,
  indicating that the uploaded file can be removed.

Task-4661534