### PR TITLE
[FIX] project_mrp: give MO's project to BOM

### DIFF
--- a/addons/project_mrp/models/mrp_production.py
+++ b/addons/project_mrp/models/mrp_production.py
@@ -13,3 +13,8 @@ class MrpProduction(models.Model):
         if not self.env.context.get('from_project_action'):
             for production in self:
                 production.project_id = production.bom_id.project_id
+
+    def action_generate_bom(self):
+        action = super().action_generate_bom()
+        action['context']['default_project_id'] = self.project_id.id
+        return action

--- a/addons/project_mrp/views/mrp_production_views.xml
+++ b/addons/project_mrp/views/mrp_production_views.xml
@@ -16,6 +16,12 @@
         <field name="model">mrp.production</field>
         <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
         <field name="arch" type="xml">
+            <field name="bom_id" position="attributes">
+                <attribute name="context">{
+                    'default_product_tmpl_id': product_tmpl_id,
+                    'default_project_id': project_id,
+                }</attribute>
+            </field>
             <xpath expr="//page[@name='miscellaneous']//field[@name='date_deadline']" position="after">
                 <t groups="stock.group_stock_manager">
                     <field name="project_id" groups="project.group_project_user"/>


### PR DESCRIPTION
Backport of this commit: https://github.com/odoo/odoo/commit/eaf2ea619644c29c9fbccd5410db77053b82d64d

Steps to reproduce the bug:
- Create a storable product “P1”
- Create a MO:
    - Product to produce: P1
    - Project: set any project
    - Save

- Click on the “Generate BoM” button or try to create a BoM directly from the BoM field
- Open the BoM

Problem:
The project field is not inherited from the MO.


opw-4669529
