### PR TITLE
[FIX] auth_signup: logged on change password no traceback


### DIFF
--- a/addons/auth_signup/static/src/interactions/signup.js
+++ b/addons/auth_signup/static/src/interactions/signup.js
@@ -11,7 +11,7 @@ export class Signup extends Interaction {
 
     onSubmit() {
         const submitEl = this.el.querySelector('.oe_login_buttons > button[type="submit"]');
-        if (!submitEl.disabled) {
+        if (submitEl && !submitEl.disabled) {
             const removeLoadingEffect = addLoadingEffect(submitEl);
             this.registerCleanup(removeLoadingEffect);
         }


### PR DESCRIPTION
Scenario: log in > My Account > Connection & Security > change your
password

Result:

The page is reloaded and the password is changed, but before that, there
is a traceback with:

TypeError: Cannot read properties of null (reading 'disabled')
  at Signup.onSubmit (/auth_signup/static/src/interactions/signup.js:14)

Issue: the signup interaction is also being run on the logged-in
password change form (portal.portal_my_security) when it should only be
run on login (web.login) or logged-out password reset
(auth_signup.reset_password).

opw-4671226

**PR note:** with this commit, there is no spinning wheel for the logged in password change. Another possibility could be to also have it (but before 22e777c046521f3f89b62caa5876680beb7f5aba it seems that the SignUpForm was just on the signup form).