### PR TITLE
[IMP] web: Show avatars in custom filters

### DIFF
--- a/addons/web/static/src/core/record_selectors/multi_record_selector.js
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.js
@@ -4,6 +4,7 @@ import { useService } from "@web/core/utils/hooks";
 import { RecordAutocomplete } from "./record_autocomplete";
 import { _t } from "@web/core/l10n/translation";
 import { useTagNavigation } from "./tag_navigation_hook";
+import { imageUrl } from "@web/core/utils/urls";
 
 export class MultiRecordSelector extends Component {
     static props = {
@@ -23,6 +24,13 @@ export class MultiRecordSelector extends Component {
         this.onTagKeydown = useTagNavigation("multiRecordSelector", this.deleteTag.bind(this));
         onWillStart(() => this.computeDerivedParams());
         onWillUpdateProps((nextProps) => this.computeDerivedParams(nextProps));
+    }
+
+    get isAvatarModel() {
+        // bof
+        return ["res.partner", "res.users", "hr.employee", "hr.employee.public"].includes(
+            this.props.resModel
+        );
     }
 
     async computeDerivedParams(props = this.props) {
@@ -60,6 +68,7 @@ export class MultiRecordSelector extends Component {
                     this.deleteTag(index);
                 },
                 onKeydown: this.onTagKeydown,
+                img: this.isAvatarModel && imageUrl(this.props.resModel, id, "avatar_128"),
             };
         });
     }

--- a/addons/web/static/src/core/record_selectors/multi_record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.xml
@@ -15,7 +15,15 @@
                 multiSelect="true"
                 getIds.bind="getIds"
                 update.bind="update"
-            />
+            >
+                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                    <span t-if="isAvatarModel" class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
+                        <img class="rounded me-1" t-attf-src="/web/image/{{props.resModel}}/{{autoCompleteItemScope.value}}/avatar_128"/>
+                        <t t-esc="autoCompleteItemScope.label"/>
+                    </span>
+                    <t t-else="" t-esc="autoCompleteItemScope.label"/>
+                </t>
+            </RecordAutocomplete>
         </div>
     </t>
 

--- a/addons/web/static/src/core/record_selectors/record_autocomplete.js
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.js
@@ -20,6 +20,7 @@ export class RecordAutocomplete extends Component {
         className: { type: String, optional: true },
         fieldString: { type: String, optional: true },
         placeholder: { type: String, optional: true },
+        slots: { optional: true },
     };
     static components = { AutoComplete };
     static template = "web.RecordAutocomplete";
@@ -32,6 +33,7 @@ export class RecordAutocomplete extends Component {
             {
                 placeholder: _t("Loading..."),
                 options: this.loadOptionsSource.bind(this),
+                optionSlot: this.props.slots?.autoCompleteItem ? "option" : undefined,
             },
         ];
     }
@@ -50,9 +52,12 @@ export class RecordAutocomplete extends Component {
             this.lastProm.abort(false);
         }
         this.lastProm = this.search(name, SEARCH_LIMIT + 1);
-        const nameGets = (await this.lastProm).map(([id, label]) => ([id, label ? label.split("\n")[0] : _t("Unnamed")]));
+        const nameGets = (await this.lastProm).map(([id, label]) => [
+            id,
+            label ? label.split("\n")[0] : _t("Unnamed"),
+        ]);
         this.addNames(nameGets);
-        const options = nameGets.map(([value, label]) => ({value, label}));
+        const options = nameGets.map(([value, label]) => ({ value, label, record: true }));
         if (SEARCH_LIMIT < nameGets.length) {
             options.push({
                 label: _t("Search More..."),

--- a/addons/web/static/src/core/record_selectors/record_autocomplete.xml
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.xml
@@ -11,7 +11,16 @@
             sources="sources"
             onSelect.bind="onSelect"
             onChange.bind="onChange"
-        />
+        >
+            <t t-set-slot="option" t-slot-scope="optionScope">
+                <t t-if="optionScope.option.record">
+                    <t t-slot="autoCompleteItem" t-props="optionScope.option"/>
+                </t>
+                <t t-else="">
+                    <t t-esc="optionScope.option.label"/>
+                </t>
+            </t>
+        </AutoComplete>
     </t>
 
 </templates>

--- a/addons/web/static/src/core/record_selectors/record_selector.js
+++ b/addons/web/static/src/core/record_selectors/record_selector.js
@@ -22,6 +22,13 @@ export class RecordSelector extends Component {
         onWillUpdateProps((nextProps) => this.computeDerivedParams(nextProps));
     }
 
+    get isAvatarModel() {
+        // bof
+        return ["res.partner", "res.users", "hr.employee", "hr.employee.public"].includes(
+            this.props.resModel
+        );
+    }
+
     async computeDerivedParams(props = this.props) {
         const displayNames = await this.getDisplayNames(props);
         this.displayName = this.getDisplayName(props, displayNames);

--- a/addons/web/static/src/core/record_selectors/record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/record_selector.xml
@@ -3,6 +3,9 @@
 
     <t t-name="web.RecordSelector" >
         <div class="o_input d-flex flex-wrap gap-1 o_record_selector">
+            <span t-if="isAvatarModel and props.resId" class="o_avatar o_m2o_avatar">
+                <img class="rounded" t-attf-src="/web/image/{{props.resModel}}/{{props.resId}}/avatar_128"/>
+            </span>
             <RecordAutocomplete
                 resModel="props.resModel"
                 value="displayName"
@@ -14,7 +17,15 @@
                 multiSelect="false"
                 getIds="() => []"
                 update.bind="update"
-            />
+            >
+                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                    <span t-if="isAvatarModel" class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
+                        <img class="rounded me-1" t-attf-src="/web/image/{{props.resModel}}/{{autoCompleteItemScope.value}}/avatar_128"/>
+                        <t t-esc="autoCompleteItemScope.label"/>
+                    </span>
+                    <t t-else="" t-esc="autoCompleteItemScope.label"/>
+                </t>
+            </RecordAutocomplete>
             <span class="o_dropdown_button"/>
         </div>
     </t>

--- a/addons/web/static/src/core/tree_editor/tree_editor_autocomplete.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_autocomplete.js
@@ -3,6 +3,7 @@ import { _t } from "@web/core/l10n/translation";
 import { formatAST, toPyValue } from "@web/core/py_js/py_utils";
 import { Expression } from "@web/core/tree_editor/condition_tree";
 import { RecordSelector } from "@web/core/record_selectors/record_selector";
+import { imageUrl } from "@web/core/utils/urls";
 
 export const isId = (val) => Number.isInteger(val) && val >= 1;
 
@@ -47,6 +48,7 @@ export class DomainSelectorAutocomplete extends MultiRecordSelector {
                         ...this.props.resIds.slice(index + 1),
                     ]);
                 },
+                img: this.isAvatarModel && imageUrl(this.props.resModel, val, "avatar_128"),
             };
         });
     }

--- a/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
@@ -107,6 +107,35 @@ test("Can be updated from autocomplete", async () => {
     expect(".o_tag").toHaveText("Bob");
 });
 
+test("Can display avatars with the right model", async () => {
+    Partner._name = "res.partner";
+    await mountMultiRecordSelector({
+        resModel: "res.partner",
+        resIds: [],
+    });
+
+    expect(".o_multi_record_selector input").toHaveValue("");
+    expect(".o_tag").toHaveCount(0);
+    expect(".o-autocomplete--dropdown-menu").toHaveCount(0);
+    await click(".o_multi_record_selector input");
+    await animationFrame();
+    expect(".o-autocomplete--dropdown-menu").toHaveCount(1);
+    expect("span.o_avatar img").toHaveCount(3);
+    expect("span.o_avatar img:eq(1)").toHaveAttribute(
+        "data-src",
+        "/web/image/res.partner/2/avatar_128"
+    );
+    await click("li.o-autocomplete--dropdown-item:eq(1)");
+    await animationFrame();
+    expect(".o_tag").toHaveCount(1);
+    expect(".o_tag").toHaveText("Bob");
+    expect(".o_tag img.o_m2m_avatar").toHaveCount(1);
+    expect(".o_tag img.o_m2m_avatar").toHaveAttribute(
+        "data-src",
+        "https://www.hoot.test/web/image/res.partner/2/avatar_128"
+    );
+});
+
 test("Display name is correctly fetched", async () => {
     expect.assertions(4);
     onRpc("partner", "web_search_read", ({ kwargs }) => {

--- a/addons/web/static/tests/core/record_selectors/record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/record_selector.test.js
@@ -12,7 +12,7 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { click } from "@odoo/hoot-dom";
 
 class Partner extends models.Model {
-    _name = "partner";
+    _name = "res.partner";
 
     name = fields.Char();
 
@@ -52,7 +52,7 @@ async function mountRecordSelector(props) {
 
 test("Can be renderer with no values", async () => {
     await mountRecordSelector({
-        resModel: "partner",
+        resModel: "res.partner",
         resId: false,
     });
 
@@ -62,7 +62,7 @@ test("Can be renderer with no values", async () => {
 
 test("Can be renderer with a value", async () => {
     await mountRecordSelector({
-        resModel: "partner",
+        resModel: "res.partner",
         resId: 1,
     });
 
@@ -71,7 +71,7 @@ test("Can be renderer with a value", async () => {
 
 test("Can be updated from autocomplete", async () => {
     await mountRecordSelector({
-        resModel: "partner",
+        resModel: "res.partner",
         resId: 1,
     });
 
@@ -85,14 +85,40 @@ test("Can be updated from autocomplete", async () => {
     expect(".o_record_selector input").toHaveValue("Bob");
 });
 
+test("Can display avatars with the right model", async () => {
+    await mountRecordSelector({
+        resModel: "res.partner",
+        resId: 1,
+    });
+
+    expect(".o_record_selector input").toHaveValue("Alice");
+    expect(".o-autocomplete--dropdown-menu").toHaveCount(0);
+    await click(".o_record_selector input");
+    await animationFrame();
+    expect(".o-autocomplete--dropdown-menu").toHaveCount(1);
+    expect(".o-autocomplete--dropdown-menu span.o_avatar img").toHaveCount(3);
+    expect(".o-autocomplete--dropdown-menu span.o_avatar img:eq(1)").toHaveAttribute(
+        "data-src",
+        "/web/image/res.partner/2/avatar_128"
+    );
+    await click("li.o-autocomplete--dropdown-item:eq(1)");
+    await animationFrame();
+    expect(".o_record_selector input").toHaveValue("Bob");
+    expect(".o_record_selector .o_m2o_avatar").toHaveCount(1);
+    expect(".o_record_selector .o_m2o_avatar img").toHaveAttribute(
+        "data-src",
+        "/web/image/res.partner/2/avatar_128"
+    );
+});
+
 test("Display name is correctly fetched", async () => {
     expect.assertions(3);
-    onRpc("partner", "web_search_read", ({ kwargs }) => {
+    onRpc("res.partner", "web_search_read", ({ kwargs }) => {
         expect.step("web_search_read");
         expect(kwargs.domain).toEqual([["id", "in", [1]]]);
     });
     await mountRecordSelector({
-        resModel: "partner",
+        resModel: "res.partner",
         resId: 1,
     });
 
@@ -102,13 +128,13 @@ test("Display name is correctly fetched", async () => {
 
 test("Can give domain and context props for the name search", async () => {
     expect.assertions(5);
-    onRpc("partner", "name_search", ({ kwargs }) => {
+    onRpc("res.partner", "name_search", ({ kwargs }) => {
         expect.step("name_search");
         expect(kwargs.domain).toEqual(["&", ["display_name", "=", "Bob"], "!", ["id", "in", []]]);
         expect(kwargs.context.blip).toBe("blop");
     });
     await mountRecordSelector({
-        resModel: "partner",
+        resModel: "res.partner",
         resId: 1,
         domain: [["display_name", "=", "Bob"]],
         context: { blip: "blop" },
@@ -123,7 +149,7 @@ test("Can give domain and context props for the name search", async () => {
 
 test("Support placeholder", async () => {
     await mountRecordSelector({
-        resModel: "partner",
+        resModel: "res.partner",
         resId: false,
         placeholder: "Select a partner",
     });


### PR DESCRIPTION
This commit enables record_selector and multi_record_selector to display avatars when the model supports them.

task-4613150
