### PR TITLE
[FIX] account: subscription_discount should be ignored too

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -165,9 +165,9 @@ class AccountAccruedOrdersWizard(models.TransientModel):
                     o.order_line.with_context(accrual_entry_date=self.date)._compute_untaxed_amount_invoiced()
                     o.order_line.with_context(accrual_entry_date=self.date)._compute_qty_to_invoice()
                 lines = o.order_line.filtered(
-                    # We only want lines that are not sections or notes and include all lines
+                    # We only want non-comment lines (no sections, notes, ...) and include all lines
                     # for purchase orders but exclude downpayment lines for sales orders.
-                    lambda l: l.display_type not in ['line_section', 'line_note'] and (is_purchase or not l.is_downpayment) and
+                    lambda l: not l.display_type and (is_purchase or not l.is_downpayment) and
                     fields.Float.compare(
                         l.qty_to_invoice,
                         0,


### PR DESCRIPTION
Create a subscription
Create an upsell
On the SO of the upsell, create an accrued entry
=> Traceback

The subscription_discount is like a line_note, and so should be ignored.
For order lines, only these types of lines have a display type as the only
possibilities are line_note and line_section (and subscription_discount now).
So we can filter them by the presence of the display_type.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
