### PR TITLE
[FIX] account_peppol: search only for Peppol EDI users

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -65,11 +65,11 @@ class AccountEdiProxyClientUser(models.Model):
     # -------------------------------------------------------------------------
 
     def _cron_peppol_get_new_documents(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', '=', 'active')])
+        edi_users = self.search([('company_id.account_peppol_proxy_state', '=', 'active'), ('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_new_documents()
 
     def _cron_peppol_get_message_status(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', '=', 'active')])
+        edi_users = self.search([('company_id.account_peppol_proxy_state', '=', 'active'), ('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_message_status()
 
     # -------------------------------------------------------------------------

--- a/addons/account_peppol/models/account_journal.py
+++ b/addons/account_peppol/models/account_journal.py
@@ -13,6 +13,7 @@ class AccountJournal(models.Model):
         edi_users = self.env['account_edi_proxy_client.user'].search([
             ('company_id.account_peppol_proxy_state', '=', 'active'),
             ('company_id', 'in', self.company_id.ids),
+            ('proxy_type', '=', 'peppol')
         ])
         edi_users._peppol_get_new_documents()
 
@@ -20,6 +21,7 @@ class AccountJournal(models.Model):
         edi_users = self.env['account_edi_proxy_client.user'].search([
             ('company_id.account_peppol_proxy_state', '=', 'active'),
             ('company_id', 'in', self.company_id.ids),
+            ('proxy_type', '=', 'peppol')
         ])
         edi_users._peppol_get_message_status()
 


### PR DESCRIPTION
Ensure only Peppol-type proxies are retrieved when performing Peppol operations.

Steps to reproduce:
- Install Peppol and IT EDI
- Register Peppol and IT EDI users
- In Accounting, on the Vendor Bill journal, click "Fetch from Peppol"

Odoo will attempt requests for all users, including an invalid call  
to 'False/api/peppol/1/get_all_documents'. This is not an issue in V17  
but causes problems in V18.  

This fix makes sense in both versions as it prevents unnecessary  
requests and avoids error messages in the logs.  

opw-4624633
