### PR TITLE
[FIX] mail: notification for followers edit of single record

### DIFF
--- a/addons/mail/wizard/mail_followers_edit.py
+++ b/addons/mail/wizard/mail_followers_edit.py
@@ -44,7 +44,10 @@ class MailFollowersEdit(models.TransientModel):
                     model_name = self.env["ir.model"]._get(wizard.res_model).display_name
                     message_values = wizard._prepare_message_values(documents, model_name)
                     message_values["partner_ids"] = wizard.partner_ids.ids
-                    self.env[wizard.res_model].message_notify(**message_values)
+                    if len(documents) == 1:
+                        documents.message_notify(**message_values)
+                    else:
+                        self.env[wizard.res_model].message_notify(**message_values)
         return {
             "type": "ir.actions.client",
             "tag": "display_notification",

--- a/addons/test_mail/tests/test_invite.py
+++ b/addons/test_mail/tests/test_invite.py
@@ -31,6 +31,7 @@ class TestInvite(MailCommon):
                          test_partner | self.user_admin.partner_id)
         self.assertEqual(len(self._new_msgs), 1)
         self.assertEqual(len(self._mails), 1)
+        self.assertEqual(self._new_msgs.res_id, test_record.id)
         self.assertSentEmail(self.partner_employee, [test_partner])
         self.assertNotSentEmail([self.partner_admin])
         self.assertNotified(


### PR DESCRIPTION
**Steps to reproduce the issue**
- From Projects app, go on a task.
- Add a follower with portal access.
- Chose to "Notify recipients".
Issue: the mail sent no longer contains the "View task" button
like in previous versions.

![notif](https://github.com/user-attachments/assets/f45a6fbf-aeb7-4c47-b2df-1fcb5504232d)

**Cause**
Commit https://github.com/odoo/odoo/commit/284d7c6ecc9d631a119af3cf4f7205d2ee6b3fe8 introduced a way
to mass edit subscriptions and since `message_notify` can only
be called on either an empty recordset or a single record, it is
now called on an empty recordset if multiple records are selected.
However, this introduces functional changes when the wizard is used
on a single record, e.g. on the form view.

In the case of a task, the "View task" button will not appear because
`has_button_access` is False by default for portal users
https://github.com/odoo/odoo/blob/c088d5423e98ad99f1d7bfdc2e42bfac6eb418de/addons/mail/models/mail_thread.py#L3447
And we return early in `_notify_get_recipients_groups` of `ProjectTask`,
which previously allowed `has_button_access` to be set to True.

**Solution**
When the wizard is used on a single record, call `message_notify`
on that record.

opw-4661374