### PR TITLE
[FIX] resource, hr_holidays: testing removing fallback which sets company calendar for fully flexible

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -552,15 +552,17 @@ class HolidaysType(models.Model):
                                                                         )
                 if closest_expiration_date:
                     closest_allocation_expire = format_date(self.env, closest_expiration_date)
-                    calendar = employee.resource_calendar_id\
-                                or self.env.company.resource_calendar_id
-                    # closest_allocation_duration corresponds to the time remaining before the allocation expires
-                    calendar_attendance = calendar._work_intervals_batch(
-                        datetime.combine(target_date, time.min).replace(tzinfo=pytz.UTC),
-                        datetime.combine(closest_expiration_date, time.max).replace(tzinfo=pytz.UTC),
-                        resources=employee.resource_id
-                    )
-                    closest_allocation_dict = calendar._get_attendance_intervals_days_data(calendar_attendance[employee.resource_id.id])
+                    calendar = employee.resource_calendar_id
+                    start_datetime = datetime.combine(target_date, time.min).replace(tzinfo=pytz.UTC)
+                    end_datetime = datetime.combine(closest_expiration_date, time.max).replace(tzinfo=pytz.UTC)
+                    closest_allocation_dict = {}
+                    if not calendar:
+                        closest_allocation_dict['hours'] = float_round((end_datetime - start_datetime).total_seconds() / 3600, precision_rounding=0.001)
+                        closest_allocation_dict['days'] = (end_datetime - start_datetime).days + 1
+                    else:
+                        # closest_allocation_duration corresponds to the time remaining before the allocation expires
+                        calendar_attendance = calendar._work_intervals_batch(start_datetime, end_datetime, resources=employee.resource_id)
+                        closest_allocation_dict = calendar._get_attendance_intervals_days_data(calendar_attendance[employee.resource_id.id])
                     if leave_type.request_unit in ['hour']:
                         closest_allocation_duration = closest_allocation_dict['hours']
                     else:

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -369,7 +369,10 @@ class ResourceCalendar(models.Model):
             for resource in resources:
                 if resource and resource._is_flexible():
                 # If the resource is flexible, return the whole period from start_dt to end_dt with a dummy attendance
-                    dummy_attendance = self.env['resource.calendar.attendance']
+                    dummy_attendance = self.env['resource.calendar.attendance'].new({
+                        'duration_hours': (end - start).total_seconds() / 3600,
+                        'duration_days': (end - start).days + 1,
+                    })
                     result_per_resource_id[resource.id] = WorkIntervals([(start, end, dummy_attendance)])
                 elif resource in per_resource_result:
                     resource_specific_result = [(max(bounds_per_tz[tz][0], tz.localize(val[0])), min(bounds_per_tz[tz][1], tz.localize(val[1])), val[2])


### PR DESCRIPTION
… flexible

This commit aims to resolve critical error in time off when the user is
fully flexible.

- get_allocation_data is updated to handle the case when the employee is fully flexible.
- Set duration_hours and duration_days in the dummy attendance to handle
  flexible time off requests and to avoid unintended zero division error in _get_attendance_intervals_days_data.
  P.S: Currently Fully Flexible resources do not support fully time offs,
  so this allows a fallback that prevents error while still setting a valid
  duration of a time off request.

Steps to reproduce:
1. Install hr_holidays
2. Go to Mitchel Admin's employee profile > work information
3. Delete the working calendar > so that the employee is fully flexible
4. Try to open time off module
   -> Prior to this commit, it would raise a zero division error

ticket-id: 4677726


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
