### PR TITLE
[FIX] tools: do not search for image name in base64

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -430,7 +430,10 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
         if src:
             i += 1
             img.tag = 'span'
-            img_name = re.search(r'[^/]+(?=\.[a-zA-Z]+(?:\?|$))', src)
+            if src.startswith('data:'):
+                img_name = None   # base64 image
+            else:
+                img_name = re.search(r'[^/]+(?=\.[a-zA-Z]+(?:\?|$))', src)
             img.text = '%s [%s]' % (img_name.group(0) if img_name else 'Image', i)
             url_index.append(src)
 


### PR DESCRIPTION
Steps to reproduce:
 1. Create a new storable product
 2. In the product's description, insert a base64 image
    - Pasting a (big) image from the clipboard insert it as base64 in <16.3
    - Or do it manually by modifying the HTML
 3. Create a Sale Order with the product
 4. Validate the sale order

### Before this commit:
During the Stock Picking creation, the picking's description is taken from the product's description and converted into plaintext. It replaces the images by some text, but the Regex searching for a name in the src attribute, has a terrible backtracking (due to the lookahead).

### After this commit:
Searching for the filename does not make sense when dealing with base64; therefore, this commit skips this feature to prevent intensive CPU usage.

opw-4674295