### PR TITLE
[FIX] mail: improve references computation in case of logs

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2814,20 +2814,24 @@ class MailThread(models.AbstractModel):
         # have a fallback in case replies mess with Messsage-Id in the In-Reply-To (e.g. amazon
         # SES SMTP may replace Message-Id and In-Reply-To refers an internal ID not stored in Odoo)
         message_sudo = message.sudo()
-        outgoing_types = ('comment', 'auto_comment', 'email', 'email_outgoing')
-        note_type = self.env.ref('mail.mt_note')
         ancestors = self.env['mail.message'].sudo().search(
             [
                 ('model', '=', message_sudo.model), ('res_id', '=', message_sudo.res_id),
-                ('message_type', 'in', outgoing_types),
                 ('id', '!=', message_sudo.id),
-                ('subtype_id', '!=', note_type.id),  # filters out notes, using subtype which is indexed
-            ], limit=16, order='id DESC',
+                ('subtype_id', '!=', False),  # filters out logs
+            ], limit=32, order='id DESC',  # take 32 last, hoping to find public discussions in it
         )
-        # filter out internal messages that are not notes, manually because of indexes
-        ancestors = ancestors.filtered(lambda m: not m.is_internal and m.subtype_id and not m.subtype_id.internal)[:3]
-        # order frrom oldest to newest
-        references = ' '.join(m.message_id for m in (ancestors[::-1] + message_sudo))
+
+        # filter out internal messages, to fetch 'public discussion' first
+        outgoing_types = ('comment', 'auto_comment', 'email', 'email_outgoing')
+        history_ancestors = ancestors.sorted(lambda m: (
+            not m.is_internal and not m.subtype_id.internal,
+            m.message_type in outgoing_types,
+            m.message_type != 'user_notification',  # user notif -> avoid if possible
+        ), reverse=True)  # False before True unless reverse
+        # order from oldest to newest
+        ancestors = history_ancestors[:3].sorted('id')
+        references = ' '.join(m.message_id for m in (ancestors + message_sudo))
         # prepare notification mail values
         base_mail_values = {
             'mail_message_id': message.id,

--- a/addons/test_mail/data/subtype_data.xml
+++ b/addons/test_mail/data/subtype_data.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <!-- mail.test.simple -->
     <record id="st_mail_test_simple_external" model="mail.message.subtype">
         <field name="name">External subtype</field>
         <field name="description">External subtype</field>
@@ -9,6 +10,7 @@
         <field name="internal" eval="False"/>
     </record>
 
+    <!-- mail.test.ticket -->
     <record id="st_mail_test_ticket_container_upd" model="mail.message.subtype">
         <field name="name">Container Changed Subtype</field>
         <field name="description">Container Changed</field>
@@ -17,6 +19,7 @@
         <field name="internal" eval="False"/>
     </record>
 
+    <!-- mail.test.container -->
     <record id="st_mail_test_container_default" model="mail.message.subtype">
         <field name="name">Container Default Subtype</field>
         <field name="res_model">mail.test.container</field>
@@ -32,4 +35,21 @@
         <field name="default" eval="False"/>
         <field name="internal" eval="False"/>
     </record>
+
+    <!-- mail.test.ticket.mc -->
+    <record id="st_mail_test_ticket_container_mc_upd" model="mail.message.subtype">
+        <field name="name">Container MC Changed Subtype</field>
+        <field name="description">Container Changed</field>
+        <field name="res_model">mail.test.ticket.mc</field>
+        <field name="default" eval="True"/>
+        <field name="internal" eval="False"/>
+    </record>
+    <record id="st_mail_test_ticket_internal" model="mail.message.subtype">
+        <field name="name">Ticket MC Internal</field>
+        <field name="description">Ticket MC Internal</field>
+        <field name="res_model">mail.test.ticket.mc</field>
+        <field name="default" eval="False"/>
+        <field name="internal" eval="True"/>
+    </record>
+
 </odoo>

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -220,6 +220,17 @@ class MailTestTicketMC(models.Model):
     company_id = fields.Many2one('res.company', 'Company', default=lambda self: self.env.company)
     container_id = fields.Many2one('mail.test.container.mc', tracking=True)
 
+    def _creation_subtype(self):
+        if self.container_id:
+            return self.env.ref('test_mail.st_mail_test_ticket_container_mc_upd')
+        return super()._creation_subtype()
+
+    def _track_subtype(self, init_values):
+        self.ensure_one()
+        if 'container_id' in init_values and self.container_id:
+            return self.env.ref('test_mail.st_mail_test_ticket_container_mc_upd')
+        return super()._track_subtype(init_values)
+
 
 class MailTestContainer(models.Model):
     """ This model can be used in tests when container records like projects

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -2208,14 +2208,14 @@ class TestMailGatewayReplies(MailGatewayCommon):
                 partner_ids=self.partner_1.ids,
                 subtype_id=self.env.ref('mail.mt_comment').id,
             )
-        reply, _log, email = gateway_record.message_ids
+        reply, log, email = gateway_record.message_ids
         self.assertMailNotifications(
             reply,
             [{
                 'content': 'Odoo Reply',
                 'email_values': {
                     'message_id': reply.message_id,
-                    'references': f'{email.message_id} {reply.message_id}',  # should contain reference to OdooExternal message
+                    'references': f'{email.message_id} {log.message_id} {reply.message_id}',  # should contain reference to OdooExternal message, logs to fill up history
                 },
                 'fields_values': {
                     'notified_partner_ids': self.partner_1,
@@ -2278,7 +2278,7 @@ class TestMailGatewayReplies(MailGatewayCommon):
                 'content': 'Odoo Reply',
                 'email_values': {
                     'message_id': reply.message_id,
-                    'references': f'{odooext_msg.message_id} {reply.message_id}',  # should contain reference to OdooExternal message
+                    'references': f'{log.message_id} {odooext_msg.message_id} {reply.message_id}',  # should contain reference to OdooExternal message
                 },
                 'fields_values': {
                     'notified_partner_ids': self.partner_1 + self.partner_admin,
@@ -2313,7 +2313,7 @@ class TestMailGatewayReplies(MailGatewayCommon):
                 'email_values': {
                     'email_from': self.email_from,
                     'message_id': reply_2.message_id,
-                    'references': f'{odooext_msg.message_id} {reply.message_id} {reply_2.message_id}',  # should contain reference to OdooExternal message
+                    'references': f'{log.message_id} {odooext_msg.message_id} {reply.message_id} {reply_2.message_id}',  # should contain reference to OdooExternal message
                 },
                 'fields_values': {
                     'author_id': self.env['res.partner'],

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -359,8 +359,8 @@ class TestMailMessageAccess(MessageAccessCommon):
             ('mail_message_id', '=', new_msg.id),
         ])
         self.assertEqual(
-            new_mail.references, new_msg.message_id,
-            'References should not include message parent message_id, as it is a note hence internal')
+            new_mail.references, f'{message.message_id} {new_msg.message_id}',
+            'References should not include message parent message_id, even if internal note, to help thread formation')
         self.assertTrue(new_mail)
         self.assertEqual(new_msg.parent_id, message)
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -968,7 +968,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=43, employee=43):
+        with self.assertQueryCount(admin=44, employee=44):
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message


### PR DESCRIPTION
Improve references computation, notably when message history consists
mainly in note-like messages (tracking with subtypes, ...). After odoo/odoo#197127
threads are split in email readers are references are missing.

Task-4677717