### PR TITLE
[FIX] point_of_sale: fix total discount sum

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -687,7 +687,10 @@ export class PosOrder extends Base {
                     sum +=
                         orderLine.getAllPrices().priceWithTaxBeforeDiscount -
                         orderLine.getAllPrices().priceWithTax;
-                    if (orderLine.displayDiscountPolicy() === "without_discount") {
+                    if (
+                        orderLine.displayDiscountPolicy() === "without_discount" &&
+                        !(orderLine.price_type === "manual")
+                    ) {
                         sum +=
                             (orderLine.getTaxedlstUnitPrice() -
                                 orderLine.getUnitDisplayPriceBeforeDiscount()) *


### PR DESCRIPTION
This [commit](https://github.com/odoo/odoo/pull/201578) removes a fix that was made in the computation of the total discount sum in the POS (https://github.com/odoo/odoo/commit/b2e2927db2bd23310deefea17edec18e7683d278). We put it back in this commit.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
