### PR TITLE
[IMP] l10n_ro_efactura: add B2C endpoint for CIUS-RO

### DIFF
--- a/addons/l10n_ro_efactura/models/account_move.py
+++ b/addons/l10n_ro_efactura/models/account_move.py
@@ -184,7 +184,9 @@ class AccountMove(models.Model):
             return
 
         self.env['res.company']._with_locked_records(self)
-        result = self.env['l10n_ro_edi.document']._request_ciusro_send_invoice(
+        result = self.env['l10n_ro_edi.document']\
+                     .with_context(is_b2b=self.partner_id.commercial_partner_id.is_company)\
+                     ._request_ciusro_send_invoice(
             company=self.company_id,
             xml_data=xml_data,
             move_type=self.move_type,

--- a/addons/l10n_ro_efactura/models/ciusro_document.py
+++ b/addons/l10n_ro_efactura/models/ciusro_document.py
@@ -86,7 +86,7 @@ class L10nRoEdiDocument(models.Model):
         result = make_efactura_request(
             session=requests,
             company=company,
-            endpoint='upload',
+            endpoint='upload' if self.env.context.get('is_b2b') else 'uploadb2c',  # TODO: change the context value into a method parameter in master 
             method='POST',
             params={'standard': 'UBL' if move_type == 'out_invoice' else 'CN',
                     'cif': company.vat.replace('RO', '')},


### PR DESCRIPTION
There has been a recent change to the specs where they changed the endpoint to send B2C invoices: `uploadb2c`. So now,
- if an invoice is made to a commercial partner that is of type company, we keep sending it to the old endpoint (no change);
- if it is made to a non-company customer, then we send to the new endpoint.

task-4645442

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
