### PR TITLE
[FIX] stock: remove labelary call

### DIFF
--- a/addons/stock/wizard/product_label_layout.py
+++ b/addons/stock/wizard/product_label_layout.py
@@ -39,23 +39,6 @@ class ProductLabelLayout(models.TransientModel):
     ], string="ZPL Template", default='normal', required=True)
     zpl_preview = fields.Image('ZPL Preview', readonly=True, default=_get_zpl_label_placeholder)
 
-    @api.onchange('print_format', 'zpl_template')
-    def _compute_zpl_preview(self):
-        if 'zpl' not in self.print_format:
-            return
-
-        xml_id, data = self._prepare_report_data()
-        zpl = self.env.ref(xml_id)._render_qweb_text(xml_id, None, data=data)[0].decode('utf-8')
-        width, height = ZPL_FORMAT_SIZE[self.zpl_template]
-        url = f"https://api.labelary.com/v1/printers/8dpmm/labels/{width}x{height}/0/"
-        try:
-            response = requests.post(url, files={'file': zpl}, stream=True, timeout=5)
-            if response.status_code == 200:
-                response.raw.decode_content = True
-                self.zpl_preview = base64.b64encode(response.content).decode('utf-8')
-        except Exception:
-            self.zpl_preview = self._get_zpl_label_placeholder()
-
     def _prepare_report_data(self):
         xml_id, data = super()._prepare_report_data()
 


### PR DESCRIPTION
In `07df9a2` a preview for the zpl labels of products was added in `stock`.

In order to generate this preview the `labelary` api was used.

The fact the server calls an external API with enterprise data (pricing information associated with product) automatically is in breach of our privacy policies.

In this commit we remove the api call. The user will now see the default placeholder image instead of the rendered label.

The plan is to later find a way to render the label locally.

Task 4555651





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
