### PR TITLE
[FIX] product: make sure `product_uom_id` is set on vendor pricelist

### DIFF
--- a/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
+++ b/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
@@ -9,7 +9,7 @@ class ReportMrpReport_Bom_Structure(models.AbstractModel):
     _inherit = 'report.mrp.report_bom_structure'
 
     def _get_subcontracting_line(self, bom, seller, level, bom_quantity):
-        ratio_uom_seller = seller.product_uom_id.factor / bom.product_uom_id.factor
+        ratio_uom_seller = (seller.product_uom_id or seller.product_tmpl_id.uom_id).factor / bom.product_uom_id.factor
         price = seller.currency_id._convert(seller.price, self.env.company.currency_id, (bom.company_id or self.env.company), fields.Date.today())
         return {
             'name': seller.partner_id.display_name,
@@ -86,7 +86,7 @@ class ReportMrpReport_Bom_Structure(models.AbstractModel):
             # for subcontracting, we can't decide the lead time without component's resupply availability
             # we only return necessary info and calculate the lead time late when we have component's data
             if supplier:
-                qty_supplier_uom = product.uom_id._compute_quantity(quantity, supplier.product_uom_id)
+                qty_supplier_uom = product.uom_id._compute_quantity(quantity, supplier.product_uom_id or supplier.product_tmpl_id.uom_id)
                 return {
                     'route_type': 'subcontract',
                     'route_name': subcontract_rules[0].route_id.display_name,

--- a/addons/mrp_subcontracting_account/models/product_product.py
+++ b/addons/mrp_subcontracting_account/models/product_product.py
@@ -15,5 +15,5 @@ class ProductProduct(models.Model):
             seller = self._select_seller(quantity=bom.product_qty, uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
             if seller:
                 seller_price = seller.currency_id._convert(seller.price, self.env.company.currency_id, (bom.company_id or self.env.company), fields.Date.today())
-                price += seller.product_uom_id._compute_price(seller_price, self.uom_id)
+                price += (seller.product_uom_id or seller.product_tmpl_id.uom_id)._compute_price(seller_price, self.uom_id)
         return price

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -712,8 +712,8 @@ class ProductProduct(models.Model):
         for seller in sellers_filtered:
             # Set quantity in UoM of seller
             quantity_uom_seller = quantity
-            if quantity_uom_seller and uom_id and uom_id != seller.product_uom_id:
-                quantity_uom_seller = uom_id._compute_quantity(quantity_uom_seller, seller.product_uom_id)
+            if quantity_uom_seller and uom_id and uom_id != (seller.product_uom_id or seller.product_tmpl_id.uom_id):
+                quantity_uom_seller = uom_id._compute_quantity(quantity_uom_seller, seller.product_uom_id or seller.product_tmpl_id.uom_id)
 
             if seller.date_start and seller.date_start > date:
                 continue

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -355,7 +355,7 @@ class PurchaseOrderLine(models.Model):
                 price_unit = line.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.taxes_id, line.company_id) if seller else 0.0
                 price_unit = seller.currency_id._convert(price_unit, line.currency_id, line.company_id, line.date_order or fields.Date.context_today(line), False)
                 price_unit = float_round(price_unit, precision_digits=max(line.currency_id.decimal_places, self.env['decimal.precision'].precision_get('Product Price')))
-                line.price_unit = seller.product_uom_id._compute_price(price_unit, line.product_uom_id)
+                line.price_unit = (seller.product_uom_id or seller.product_tmpl_id.uom_id)._compute_price(price_unit, line.product_uom_id)
                 line.discount = seller.discount or 0.0
 
             # record product names to avoid resetting custom descriptions
@@ -539,13 +539,13 @@ class PurchaseOrderLine(models.Model):
             quantity=uom_po_qty,
             date=po.date_order and max(po.date_order.date(), today) or today,
             uom_id=product_id.uom_id)
-        if seller and seller.product_uom_id != product_uom:
-            uom_po_qty = product_id.uom_id._compute_quantity(uom_po_qty, seller.product_uom_id, rounding_method='HALF-UP')
+        if seller and (seller.product_uom_id or seller.product_tmpl_id.uom_id) != product_uom:
+            uom_po_qty = product_id.uom_id._compute_quantity(uom_po_qty, seller.product_uom_id or seller.product_tmpl_id.uom_id, rounding_method='HALF-UP')
 
         product_taxes = product_id.supplier_taxes_id.filtered(lambda x: x.company_id in company_id.parent_ids)
         taxes = po.fiscal_position_id.map_tax(product_taxes)
 
-        price_unit = (seller.product_uom_id._compute_price(seller.price, product_uom) if product_uom else seller.price) if seller else product_id.standard_price
+        price_unit = ((seller.product_uom_id or seller.product_tmpl_id.uom_id)._compute_price(seller.price, product_uom) if product_uom else seller.price) if seller else product_id.standard_price
         price_unit = self.env['account.tax']._fix_tax_included_price_company(
             price_unit, product_taxes, taxes, company_id)
         if price_unit and seller and po.currency_id and seller.currency_id != po.currency_id:

--- a/addons/purchase_mrp/report/mrp_report_bom_structure.py
+++ b/addons/purchase_mrp/report/mrp_report_bom_structure.py
@@ -20,7 +20,7 @@ class ReportMrpReport_Bom_Structure(models.AbstractModel):
             parent_bom = self.env.context.get('parent_bom')
             purchase_lead = parent_bom.company_id.days_to_purchase + parent_bom.company_id.po_lead if parent_bom and parent_bom.company_id else 0
             if supplier:
-                qty_supplier_uom = product.uom_id._compute_quantity(quantity, supplier.product_uom_id)
+                qty_supplier_uom = product.uom_id._compute_quantity(quantity, supplier.product_uom_id or supplier.product_tmpl_id.uom_id)
                 return {
                     'route_type': 'buy',
                     'route_name': buy_rules[0].route_id.display_name,

--- a/addons/purchase_mrp/report/mrp_report_mo_overview.py
+++ b/addons/purchase_mrp/report/mrp_report_mo_overview.py
@@ -68,7 +68,7 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
             if supplier:
                 return {
                     'delay': supplier.delay + rules_delay,
-                    'cost': supplier.price * uom_id._compute_quantity(quantity, supplier.product_uom_id),
+                    'cost': supplier.price * uom_id._compute_quantity(quantity, supplier.product_uom_id or supplier.product_tmpl_id.uom_id),
                     'currency': supplier.currency_id,
                 }
         return res

--- a/addons/purchase_requisition_stock/tests/test_purchase_requisition_stock.py
+++ b/addons/purchase_requisition_stock/tests/test_purchase_requisition_stock.py
@@ -109,22 +109,22 @@ class TestPurchaseRequisitionStock(TestPurchaseRequisitionCommon):
         route_buy = self.ref('purchase_stock.route_warehouse0_buy')
         route_mto = warehouse1.mto_pull_id.route_id.id
         vendor1 = self.env['res.partner'].create({'name': 'AAA', 'email': 'from.test@example.com'})
-        supplier_info1 = self.env['product.supplierinfo'].create({
+        supplier_info_vals = {
             'partner_id': vendor1.id,
             'price': 50,
-        })
+        }
         product_1 = self.env['product.product'].create({
             'name': 'product1',
             'is_storable': True,
             'uom_id': unit,
-            'seller_ids': [(6, 0, [supplier_info1.id])],
+            'seller_ids': [Command.create(supplier_info_vals)],
             'route_ids': [(6, 0, [route_buy, route_mto])]
         })
         product_2 = self.env['product.product'].create({
             'name': 'product2',
             'is_storable': True,
             'uom_id': unit,
-            'seller_ids': [(6, 0, [supplier_info1.id])],
+            'seller_ids': [Command.create(supplier_info_vals)],
             'route_ids': [(6, 0, [route_buy, route_mto])]
         })
         # Blanket orders creation

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -76,8 +76,8 @@
                     <field name="move_lines_count" column_invisible="True"/>
                     <field name="is_locked" column_invisible="True"/>
                     <field name="product_id" required="1" readonly="(state != 'draft' and not additional) or move_lines_count &gt; 0"/>
-                    <field name="packaging_uom_qty" optional="hide"/>
-                    <field name="packaging_uom_id" optional="hide"/>
+                    <field name="packaging_uom_qty" optional="hide" groups="uom.group_uom"/>
+                    <field name="packaging_uom_id" optional="hide" groups="uom.group_uom"/>
                     <field name="is_initial_demand_editable" column_invisible="True"/>
                     <field name="is_quantity_done_editable" column_invisible="True"/>
                     <field name="product_uom_qty" string="Demand" readonly="not is_initial_demand_editable"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -270,8 +270,8 @@
                                     <field name="is_storable" column_invisible="True"/>
                                     <field name="has_tracking" column_invisible="True"/>
                                     <field name="product_id" context="{'default_is_storable': True}" required="1" readonly="(state != 'draft' and not additional) or move_lines_count &gt; 0" force_save="1"/>
-                                    <field name="packaging_uom_qty" optional="hide"/>
-                                    <field name="packaging_uom_id" optional="hide"/>
+                                    <field name="packaging_uom_qty" optional="hide" groups="uom.group_uom"/>
+                                    <field name="packaging_uom_id" optional="hide" groups="uom.group_uom"/>
                                     <field name="location_final_id" optional="hide" groups="stock.group_stock_multi_locations"/>
                                     <field name="description_picking" string="Description" optional="hide"/>
                                     <field name="date" optional="hide"/>


### PR DESCRIPTION
This commit makes sure that `product_uom_id` field is set on `product_supplierinfo` model, since the field is needed in most operations dealing with pricelists.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
