### PR TITLE
[FIX] core: socket timeout as INFO during test

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -160,6 +160,12 @@ class RequestHandler(werkzeug.serving.WSGIRequestHandler):
             self.rfile = BytesIO()
             self.wfile = BytesIO()
 
+    def log_error(self, format, *args):
+        if format == "Request timed out: %r" and config['test_enable']:
+            _logger.info(format, *args)
+        else:
+            super().log_error(format, *args)
+
 class ThreadedWSGIServerReloadable(LoggingBaseWSGIServerMixIn, werkzeug.serving.ThreadedWSGIServer):
     """ werkzeug Threaded WSGI Server patched to allow reusing a listen socket
     given by the environment, this is used by autoreload to keep the listen


### PR DESCRIPTION
During post-install tests, run the following code in a python terminal:

    import socket, time
    with socket.create_connection(('127.0.0.1', 8069)):
        time.sleep(6)

It opens a socket and connect to the running odoo server, but does nothing. After 5 seconds the odoo server closes the socket with a timeout.

The timeout is only set during tests in ``RequestHandler.setup``, and it set to a hardcoded value of 5 seconds. Since Werkzeug 2.1.0[^1], it logs an error in the logs. We want to get rid of that error log.

Those errors can occur when the test chrome browser is killed while it was performing http requests. Chrome doesn't TCP RST the sockets and just let those sockets die.

The socket timeout error actually cannot occurs in production, as all traffic is routed via nginx, and nginx will only proxy the connection to Odoo once nginx has all the requests headers.

That error log is silly, it is now ignored.

[^1]: pallets/werkzeug:d062807

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
