### PR TITLE
[FIX] website_sale: ensure sale order retrieval before updating cart

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -223,6 +223,8 @@ class Cart(PaymentPortal):
         :params dict kwargs: additional parameters given to _cart_update_line_quantity calls.
         """
         order_sudo = request.cart
+        if not order_sudo:
+            return {}
 
         # This method must be only called from the cart page BUT in some advanced logic
         # eg. website_sale_loyalty, a cart line could be a temporary record without id.


### PR DESCRIPTION
This error occurs when users update the cart item after the order is confirmed.

Steps to Reproduce:
 - Install the module `website_sale`.
 - Add a product to the cart.
 - Proceed to checkout and complete the payment.
 - After the order is confirmed, go back to the checkout page by clicking the `back arrow` of the browser.
 - `Update` the cart product.

ValueError: Expected singleton: sale.order()

This error occurred because the system failed to retrieve the `Sale Order ID` due to current changes in the cart, causing `sale.order` to be empty.

This commit ensures the Sale Order is correctly retrieved before updating the cart.

Sentry-5682671428

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
