### PR TITLE
[FIX] stock: Prevent ValidationError on _set_quantity_done

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -389,7 +389,7 @@ class StockMoveLine(models.Model):
                 reservation = not move._should_bypass_reservation()
             else:
                 reservation = product.type == 'product' and not location.should_bypass_reservation()
-            if move_line.quantity and reservation:
+            if move_line.quantity_product_uom and reservation:
                 self.env['stock.quant']._update_reserved_quantity(
                     product, location, move_line.quantity_product_uom, lot_id=move_line.lot_id, package_id=move_line.package_id, owner_id=move_line.owner_id)
 

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6841,3 +6841,43 @@ class StockMove(TransactionCase):
         })
         receipt.action_confirm()
         self.assertNotEqual(old_reference, receipt.move_ids.reference)
+
+    def test_set_quantity_done_with_rounding_issues(self):
+        """Imperial UoM can sometime create a discrepancy between the demand and the actual quantity moved,
+        this is mostly expected.
+        However, when the user force set the quantity manually, a ValidationError could be raised because
+        Odoo tried to create a new stock.move.line with the difference and then reserved the 0 quantity.
+        This test ensure that a move line with a product uom quantity of 0 does not impact the Quants reserved quantity.
+        """
+        gram_uom = self.env.ref('uom.product_uom_gram')
+        oz_uom = self.env.ref('uom.product_uom_oz')
+
+        self.product.write({'uom_id': oz_uom.id})
+        self.env['stock.quant']._update_available_quantity(self.product, self.stock_location, 10)
+
+        delivery = self.env['stock.picking'].create({
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+            'move_ids': [(0, 0, {
+                'name': self.product.name,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
+                'product_id': self.product.id,
+                'product_uom': gram_uom.id,
+                'product_uom_qty': 150.0,
+            })],
+        })
+        delivery.action_confirm()
+        delivery.action_assign()
+
+        self.assertEqual(delivery.move_ids.quantity, 149.97)  # 150 g -> 5.29109 oz -> 5.29 oz -> 149.97 g
+        delivery.move_ids.write({'quantity': 150})
+
+        self.assertEqual(delivery.move_ids.quantity, 150)
+        delivery.button_validate()
+        self.assertEqual(delivery.state, 'done')
+        self.assertRecordValues(delivery.move_line_ids, [
+            {'quantity': 149.97, 'quantity_product_uom': 5.29},
+            {'quantity': 0.03, 'quantity_product_uom': 0},
+        ])


### PR DESCRIPTION
Imperial UoM can sometime create a discrepancy in between the demand and the actual quantity move, this is mostly expected. However, when the user force set the quantity manually, a ValidationError could be raised because Odoo tried to create a new stock.move.line with the difference.

This test ensure that a move line with a product uom quantity of 0 does not impact the Quants reserved quantity.

https://github.com/user-attachments/assets/661c23e2-2de1-4328-aad8-b4e6d80e0500


# HOW TO REPRODUCE
- Create Product P, with oz uom
- Set available quantity to 10 oz
- Create delivery transfer for 150g of P > Confirm > Assign
- -> Reserved quantity is 149.97 g (expected) which is 5.29 oz
- Set Quantity to 150 g
- => ValidationError: "Quantity or Reserved Quantity should be set."
- Unreserve > Set Quantity to 150g == No problem ...
OPW-4659565


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
