### PR TITLE
[FIX] point_of_sale: infinite loading screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -345,11 +345,14 @@ export class ProductScreen extends Component {
         if (limit_categories) {
             const productIds = new Set([]);
             for (const categ of iface_available_categ_ids) {
-                for (const p of this.pos.models["product.product"].getBy(
+                const category_products = this.pos.models["product.product"].getBy(
                     "pos_categ_ids",
                     categ.id
-                )) {
-                    productIds.add(p.id);
+                );
+                if (category_products) {
+                    for (const p of category_products) {
+                        productIds.add(p.id);
+                    }
                 }
             }
             return this.pos.models["product.product"].filter((p) => productIds.has(p.id));


### PR DESCRIPTION
This commit fixes an issue where we'd experience an infinite loading screen when trying to open a POS instance. This happened when the configuration included a POS product category with no products associated with it.

Now, we'll check to make sure that there are products to be looped over before trying to loop over something undefined.

opw-4678381