### PR TITLE
[FIX] pos_self_order: reordered the orderlines in create_order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -167,8 +167,10 @@ class PosOrder(models.Model):
         line_by_uuid = {line.uuid: line for line in  self.lines.filtered_domain([("uuid", "in", [line['uuid'] for line in lines])])}
 
         for line in lines:
-            if line.get('combo_parent_id'):
-                line_by_uuid[line['uuid']].combo_parent_id = line_by_uuid[uuid_by_cid[line['combo_parent_id']]]
+            if not line.get('combo_parent_id'):
+                continue
+            idx = line['combo_parent_id'] if isinstance(line['combo_parent_id'], str) else uuid_by_cid[line['combo_parent_id']]
+            line_by_uuid[line['uuid']].combo_parent_id = line_by_uuid[idx].id
 
     def _process_saved_order(self, draft):
         self.ensure_one()

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import uuid
+from functools import partial
 from datetime import timedelta
 from odoo import http, fields, _
 from odoo.http import request
@@ -60,36 +61,26 @@ class PosSelfOrderController(http.Controller):
         posted_order_id = pos_config.env['pos.order'].with_context(from_self=True).create_from_ui([order], draft=True)[0].get('id')
 
         # Process the lines and get their prices computed
-        lines = self._process_lines(lines, pos_config, posted_order_id, is_take_away)
+        processed_lines = self._process_lines(lines, pos_config, posted_order_id, is_take_away)
 
         # Compute the order prices
-        amount_total, amount_untaxed = self._get_order_prices(lines)
+        amount_total, amount_untaxed = self._get_order_prices(processed_lines)
 
         # Update the order with the computed prices and lines
-        order = pos_config.env["pos.order"].browse(posted_order_id)
+        saved_order = pos_config.env["pos.order"].browse(posted_order_id)
+        saved_lines = pos_config.env['pos.order.line'].with_user(pos_config.self_ordering_default_user_id).create(processed_lines)
 
-        classic_lines = []
-        combo_lines = []
-        for line in lines:
-            if line["combo_parent_uuid"]:
-                combo_lines.append(line)
-            else:
-                classic_lines.append(line)
-
-        # combo lines must be created after classic_line, as they need the classic line identifier
-        # use user admin to avoid access rights issues
-        lines = pos_config.env['pos.order.line'].with_user(pos_config.self_ordering_default_user_id).create(classic_lines)
-        lines += pos_config.env['pos.order.line'].with_user(pos_config.self_ordering_default_user_id).create(combo_lines)
-
-        order.write({
-            'lines': lines,
+        saved_order.write({
+            'lines': saved_lines,
             'state': 'paid' if amount_total == 0 else 'draft',
             'amount_tax': amount_total - amount_untaxed,
             'amount_total': amount_total,
         })
 
-        order.send_table_count_notification(order.table_id)
-        return order._export_for_self_order()
+        order['data']['lines'] = lines
+        self._process_combo_items(saved_order, order['data'])
+        saved_order.send_table_count_notification(saved_order.table_id)
+        return saved_order._export_for_self_order()
 
     @http.route('/pos-self-order/get-orders-taxes', auth='public', type='json', website=True)
     def get_order_taxes(self, order, access_token):
@@ -150,8 +141,30 @@ class PosSelfOrderController(http.Controller):
             'table_stand_number': order.get('table_stand_number'),
         })
 
+        self._process_combo_items(pos_order, order)
         pos_order.send_table_count_notification(pos_order.table_id)
         return pos_order._export_for_self_order()
+
+    def _process_combo_items(self, order, order_values):
+        """
+            Here we need to process original order dict to add
+            combo_line_ids and combo_parent_id to the lines
+            and then call the _link_combo_items method to link
+            the combo lines together.
+        """
+        combo_lines = []
+        lines = order_values.get('lines')
+        for line in lines:
+            if line.get('child_lines'):
+                line['combo_line_ids'] = [child_line['uuid'] for child_line in line['child_lines']]
+            elif line.get('combo_parent_uuid'):
+                line['combo_parent_id'] = line.get('combo_parent_uuid')
+
+            if line.get('combo_line_ids') or line.get('combo_parent_id'):
+                combo_lines.append([0, 0, line])
+
+        order_values['lines'] = combo_lines
+        order._link_combo_items(order_values)
 
     @http.route('/pos-self-order/remove-order', auth='public', type='json', website=True)
     def remove_order(self, access_token, order_id, order_access_token):
@@ -221,6 +234,7 @@ class PosSelfOrderController(http.Controller):
         newLines = []
         pricelist = pos_config.pricelist_id
         sale_price_digits = pos_config.env['decimal.precision'].precision_get('Product Price')
+        process_line = partial(pos_config.env['pos.order.line']._order_line_fields, session_id=pos_config.current_session_id.id)
 
         combo_line_ids = [line['combo_line_id'] for line in lines if line.get('combo_line_id')]
         combo_lines = pos_config.env['pos.combo.line'].search([('id', 'in', combo_line_ids)])
@@ -246,6 +260,7 @@ class PosSelfOrderController(http.Controller):
             children = [l for l in lines if l.get('combo_parent_uuid') == line.get('uuid')]
             pos_combo_lines = combo_lines.browse([child.get('combo_line_id') for child in children])
 
+            newLines.append({})
             if len(children) > 0:
                 original_total = sum(pos_combo_lines.mapped("combo_id.base_price"))
                 remaining_total = lst_price
@@ -293,7 +308,7 @@ class PosSelfOrderController(http.Controller):
             taxes_after_fp = fiscal_pos.map_tax(product.taxes_id) if fiscal_pos else product.taxes_id
             pdetails = taxes_after_fp.compute_all(price_unit_fp, pos_config.currency_id, line_qty, product)
 
-            newLines.append({
+            newLine = {
                 'price_unit': price_unit_fp,
                 'price_subtotal': pdetails.get('total_excluded'),
                 'price_subtotal_incl': pdetails.get('total_included'),
@@ -310,10 +325,12 @@ class PosSelfOrderController(http.Controller):
                 'combo_parent_uuid': line.get('combo_parent_uuid'),
                 'combo_id': line.get('combo_id'),
                 'price_extra': price_extra
-            })
+            }
+            newLines[len(newLines) - 1 - len(children)] = newLine
             appended_uuid.append(line.get('uuid'))
 
-        return newLines
+        sanatized_lines = [process_line([0, 0, line])[2] for line in newLines]
+        return sanatized_lines
 
     def _get_order_prices(self, lines):
         amount_untaxed = sum([line.get('price_subtotal') for line in lines])

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -13,17 +13,6 @@ class PosOrderLine(models.Model):
     combo_line_ids = fields.One2many('pos.order.line', 'combo_parent_id', string='Combo Lines')
     combo_id = fields.Many2one('pos.combo', string='Combo line reference')
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            if (vals.get('combo_parent_uuid')):
-                vals.update([
-                    ('combo_parent_id', self.search([('uuid', '=', vals.get('combo_parent_uuid'))]).id)
-                ])
-            if 'combo_parent_uuid' in vals:
-                del vals['combo_parent_uuid']
-        return super().create(vals_list)
-
     def write(self, vals):
         if (vals.get('combo_parent_uuid')):
             vals.update([

--- a/addons/pos_self_order/static/tests/tours/test_self_order_combo.js
+++ b/addons/pos_self_order/static/tests/tours/test_self_order_combo.js
@@ -50,3 +50,44 @@ registry.category("web_tour.tours").add("self_combo_selector", {
         Utils.checkIsNoBtn("Order Now"),
     ],
 });
+
+registry.category("web_tour.tours").add("test_self_order_combo_correct_order", {
+    steps: () =>
+        [
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Office Combo"),
+            ...ProductPage.setupCombo([
+                {
+                    product: "Combo Product 1",
+                    attributes: [],
+                },
+                {
+                    product: "Combo Product 5",
+                    attributes: [],
+                },
+                {
+                    product: "Combo Product 8",
+                    attributes: [],
+                },
+            ]),
+            ProductPage.clickProduct("Office Combo"),
+            ...ProductPage.setupCombo([
+                {
+                    product: "Combo Product 2",
+                    attributes: [],
+                },
+                {
+                    product: "Combo Product 5",
+                    attributes: [],
+                },
+                {
+                    product: "Combo Product 8",
+                    attributes: [],
+                },
+            ]),
+            Utils.clickBtn("Order"),
+            Utils.clickBtn("Pay"),
+            Utils.clickBtn("Ok"),
+            Utils.checkIsNoBtn("Order Now"),
+        ].flat(),
+});

--- a/addons/pos_self_order/tests/test_self_order_combo.py
+++ b/addons/pos_self_order/tests/test_self_order_combo.py
@@ -29,3 +29,24 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
         self_route = self.pos_config._get_self_order_route()
 
         self.start_tour(self_route, "self_combo_selector")
+
+    def test_self_order_combo_correct_order(self):
+        setup_pos_combo_items(self)
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_self_order_combo_correct_order")
+
+        pos_order = self.env['pos.order'].search([], order="id desc", limit=1)
+        order_lines = pos_order._export_for_ui(pos_order)['lines']
+
+        def check_combo_products_order(lines):
+            combo_header_id = None
+            for line in lines:
+                if len(line[2]['combo_line_ids']):
+                    combo_header_id = line[2]['id']
+                else:
+                    if line[2]['combo_parent_id'] != combo_header_id:
+                        return False
+            return True
+
+        self.assertTrue(check_combo_products_order(order_lines))


### PR DESCRIPTION
Steps to reproduce:
- Install pos_resturant
- Activate self order to the restaurant you have
- Go to the mobile menu and order at least 2 combos
- Go to the restaurant orders and select the created order

Issue:
Combo headers are displayed first, then combo children. Although they are linked correctly, the UI renders them in the order they are read from the database. Headers are created first, then children, as the child must be linked to the header.

Now, lines are created in the order received from the frontend, and linkage is done after creation instead of on the fly in the create call.

opw-4601833

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
