### PR TITLE
[FIX] website_customer: Fix website tag list class

### DIFF
--- a/addons/website_customer/views/website_customer_templates.xml
+++ b/addons/website_customer/views/website_customer_templates.xml
@@ -233,7 +233,7 @@
 
 <template id="opt_tag_list" inherit_id="website_customer.index" name="Filter on Tags" priority="40">
     <xpath expr="//div[hasclass('o_wcrm_filters_top')]" position="after">
-        <div class="d-flex align-items-center gap-2 my-4" t-if="len(tags)">
+        <div class="d-flex flex-wrap align-items-center gap-2 my-4" t-if="len(tags)">
             <a class="badge text-bg-light" t-attf-href="/customers/#{ current_industry_id and 'industry/%s/' % slug(current_industry) or '' }#{ current_country_id and 'country/%s' % slug(current_country) or '' }">
                 <span class="fa fa-1x fa-tags"/> All 
             </a>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

**Description:**
> - When we open the 'Customers' menu on the website, the 'tags' are displayed in a single line

**Steps:**

> - Install the "website_customer" module.
> - Create a "Website Tag" from the Contacts app-> Configurations.
> - Add the tag to any partner's "Website Tags" field (inside the "Sales & Purchase" page).
> - Go to the website and open the "Customers" menu(from url).

Current behavior before PR:

    Before Fix:
![Our-References-My-Website](https://github.com/user-attachments/assets/9d5bc1ac-d407-4225-abd0-5f5edf5d6fa8)

    After Fix:
![Our-References-My-Website(1)](https://github.com/user-attachments/assets/d9876e8a-ef52-44d0-8204-34b3325c1f36)

Desired behavior after PR is merged:

    - All Tags are appropriately shown after my fix
    - The issue comes in version 17.0, 18.0, saas~18.1, and saas~18.2

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
