### PR TITLE
[FIX] account: Fix wrong required condition on eInvoice notification

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -180,7 +180,9 @@
                                     </group>
                                     <group string="Incoming E-Invoice Notifications" invisible="type != 'purchase'">
                                         <field name="notify_on_incoming_einvoice"/>
-                                        <field name="incoming_einvoice_notification_email" invisible="not notify_on_incoming_einvoice" required="True"/>
+                                        <field name="incoming_einvoice_notification_email"
+                                               invisible="not notify_on_incoming_einvoice"
+                                               required="notify_on_incoming_einvoice and type == 'purchase'"/>
                                     </group>
                                 </group>
                             </page>


### PR DESCRIPTION
The required should not always be true, it should be only when the journal is a purchase journal, and when the notification feature is enabled.

task-no
