### PR TITLE
[FIX] payment: sync access token generation parameters

### DIFF
--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -55,7 +55,9 @@ class PaymentLinkWizard(models.TransientModel):
     def _get_access_token(self):
         self.ensure_one()
         return payment_utils.generate_access_token(
-            self.partner_id.id, self.amount, self.currency_id.id
+            self.partner_id.id,
+            float(float_repr(self.amount, self.currency_id.decimal_places)),
+            self.currency_id.id,
         )
 
     @api.depends('amount', 'currency_id', 'partner_id', 'company_id')
@@ -64,7 +66,7 @@ class PaymentLinkWizard(models.TransientModel):
             related_document = self.env[payment_link.res_model].browse(payment_link.res_id)
             base_url = related_document.get_base_url()  # Don't generate links for the wrong website
             url_params = {
-                'amount': float_repr(self.amount, self.currency_id.decimal_places),
+                'amount': float(float_repr(self.amount, self.currency_id.decimal_places)),
                 'access_token': self._get_access_token(),
                 **self._get_additional_link_values(),
             }

--- a/addons/sale/tests/test_payment_flow.py
+++ b/addons/sale/tests/test_payment_flow.py
@@ -26,6 +26,10 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
 
     def test_11_so_payment_link(self):
         # test customized /payment/pay route with sale_order_id param
+        sol1, sol2 = self.sale_order.order_line
+        sol1.write({'product_uom_qty': 1, 'price_unit': 100})
+        sol2.write({'product_uom_qty': 1, 'price_unit': 186.9})
+        self.assertEqual(self.sale_order.amount_total, self.currency.round(286.9))
         self.amount = self.sale_order.amount_total
         route_values = self._prepare_pay_values()
         route_values['sale_order_id'] = self.sale_order.id
@@ -39,7 +43,7 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
 
         self.assertEqual(tx_context['currency_id'], self.sale_order.currency_id.id)
         self.assertEqual(tx_context['partner_id'], self.sale_order.partner_invoice_id.id)
-        self.assertEqual(tx_context['amount'], self.sale_order.amount_total)
+        self.assertAlmostEqual(tx_context['amount'], self.sale_order.amount_total)
 
         # /my/orders/<id>/transaction/
         tx_route_values = {
@@ -59,7 +63,7 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
         tx_sudo = self._get_tx(processing_values['reference'])
 
         self.assertEqual(tx_sudo.sale_order_ids, self.sale_order)
-        self.assertEqual(tx_sudo.amount, self.amount)
+        self.assertAlmostEqual(tx_sudo.amount, self.amount)
         self.assertEqual(tx_sudo.partner_id, self.sale_order.partner_invoice_id)
         self.assertEqual(tx_sudo.company_id, self.sale_order.company_id)
         self.assertEqual(tx_sudo.currency_id, self.sale_order.currency_id)


### PR DESCRIPTION
Versions
--------
- 17.0

Doesn't occur in later versions due to improved rounding utils.

Steps
-----
1. Set up a sales order with a total of $286.90;
2. generate a payment link;
3. open payment link in private window.

Issue
-----
Error: The provided parameters are invalid.

Cause
-----
Commit c59a47da7400 added a `float_repr` to round the amount used in the url parameters. Issue occurs because this number can be different from the value used to generate the token (286.90 vs 286.90000000000003), making their hashes different.

Solution
--------
Use `float_repr` when generating a token, and in both instances, convert the string back into a float so they don't have mismatching zeroes at the end.

opw-4669839