### PR TITLE
[FIX] sale(_management): multi-company issues

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -87,7 +87,8 @@ class SaleOrderLine(models.Model):
         comodel_name='product.product',
         string="Product",
         change_default=True, ondelete='restrict', index='btree_not_null',
-        domain="[('sale_ok', '=', True)]")
+        domain=lambda self: self._domain_product_id(),
+        check_company=True)
     product_template_id = fields.Many2one(
         string="Product Template",
         comodel_name='product.template',
@@ -97,7 +98,11 @@ class SaleOrderLine(models.Model):
         # previously related='product_id.product_tmpl_id'
         # not anymore since the field must be considered editable for product configurator logic
         # without modifying the related product_id when updated.
-        domain=[('sale_ok', '=', True)])
+
+        # magic way to make sure the domain integrates the check_company _domain_product_id logics
+        # despite not being a check_company=True field
+        domain=lambda self: self._fields['product_id']._description_domain(self.env),
+    )
 
     product_template_attribute_value_ids = fields.Many2many(
         related='product_id.product_template_attribute_value_ids',
@@ -161,7 +166,9 @@ class SaleOrderLine(models.Model):
         compute='_compute_tax_ids',
         store=True, readonly=False, precompute=True,
         context={'active_test': False},
-        check_company=True)
+        check_company=True,
+        domain="[('type_tax_use', '=', 'sale'), ('country_id', '=', tax_country_id)]",
+    )
 
     # Tech field caching pricelist rule used for price & discount computation
     pricelist_item_id = fields.Many2one(
@@ -309,6 +316,9 @@ class SaleOrderLine(models.Model):
             if additional_name:
                 name = f'{name} {additional_name}'
             so_line.display_name = name
+
+    def _domain_product_id(self):
+        return [('sale_ok', '=', True)]
 
     @api.depends('product_id')
     def _compute_product_template_id(self):

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -514,7 +514,6 @@
                                                 invisible="state not in ['draft', 'sent'] or not is_product_archived"
                                             />
                                             <field name="product_id"
-                                                domain="[('sale_ok', '=', True)]"
                                                 context="{'default_uom_id': product_uom_id}"
                                                 readonly="not product_updatable"
                                                 required="not display_type and not is_downpayment"
@@ -549,7 +548,6 @@
                                             widget="many2many_tax_tags"
                                             options="{'no_create': True}"
                                             context="{'search_view_ref': 'account.account_tax_view_search'}"
-                                            domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                             readonly="qty_invoiced &gt; 0"/>
                                         <t groups="sale.group_discount_per_so_line">
                                             <label for="discount"/>
@@ -628,7 +626,6 @@
                                         'default_uom_id': product_uom_id,
                                     }"
                                     optional="hide"
-                                    domain="[('sale_ok', '=', True)]"
                                     widget="sol_product_many2one"/>
                                 <field name="product_template_id"
                                     string="Product"
@@ -639,7 +636,6 @@
                                         'default_uom_id': product_uom_id,
                                     }"
                                     optional="show"
-                                    domain="[('sale_ok', '=', True)]"
                                     widget="sol_product_many2one"
                                     placeholder="Type to find a product..."/>
                                 <field name="name" widget="sol_text" optional="show"/>
@@ -694,7 +690,6 @@
                                     name="tax_ids"
                                     widget="many2many_tax_tags"
                                     options="{'no_create': True}"
-                                    domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                     context="{'active_test': True}"
                                     readonly="qty_invoiced &gt; 0 or is_downpayment"
                                     optional="show"/>

--- a/addons/sale_management/models/sale_order_option.py
+++ b/addons/sale_management/models/sale_order_option.py
@@ -8,15 +8,18 @@ class SaleOrderOption(models.Model):
     _name = 'sale.order.option'
     _description = "Sale Options"
     _order = 'sequence, id'
+    _check_company_auto = True
 
     # FIXME ANVFE wtf is it not required ???
-    # TODO related to order.company_id and restrict product choice based on company
     order_id = fields.Many2one('sale.order', 'Sales Order Reference', ondelete='cascade', index=True)
+    company_id = fields.Many2one(related='order_id.company_id', depends=['order_id'])
 
     product_id = fields.Many2one(
         comodel_name='product.product',
         required=True,
-        domain=lambda self: self._product_id_domain())
+        domain=lambda self: self._domain_product_id(),
+        check_company=True,
+    )
     line_id = fields.Many2one(
         comodel_name='sale.order.line', ondelete='set null', copy=False, index='btree_not_null')
     sequence = fields.Integer(
@@ -136,7 +139,7 @@ class SaleOrderOption(models.Model):
         return [('line_id', operator, [False])]
 
     @api.model
-    def _product_id_domain(self):
+    def _domain_product_id(self):
         """ Returns the domain of the products that can be added as a sale order option. """
         return [('sale_ok', '=', True)]
 

--- a/addons/sale_management/views/sale_order_views.xml
+++ b/addons/sale_management/views/sale_order_views.xml
@@ -13,14 +13,14 @@
                     <field name="sale_order_option_ids" mode="list,kanban" readonly="state in ['cancel', 'sale']">
                         <form string="Optional Products">
                             <group>
-                                <field name="product_id"
-                                    domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
+                                <field name="product_id"/>
                                 <field name="name"/>
                                 <field name="quantity"/>
                                 <field name="uom_id" widget="many2one_uom" groups="uom.group_uom"/>
                                 <field name="price_unit"/>
                                 <field name="discount" groups="sale.group_discount_per_so_line"/>
                                 <field name="is_present" />
+                                <field name="company_id" invisible="1"/>
                             </group>
                         </form>
                         <kanban class="o_kanban_mobile">
@@ -54,8 +54,7 @@
                                 <create name="add_product_control" string="Add a product"/>
                             </control>
                             <field name="sequence" widget="handle"/>
-                            <field name="product_id"
-                                domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
+                            <field name="product_id"/>
                             <field name="name" optional="show"/>
                             <field name="quantity"/>
                             <field name="uom_id" widget="many2one_uom" groups="uom.group_uom" optional="show"/>


### PR DESCRIPTION
Commit b0f0fd2ee3dcc3bbb24a123d4a1b38d17d0ce8c9 removed the multi-company check from SOL products, but this makes all products available (if in the env companies, or subsidiaries), even when they are not compatible with the SO company (and triggers an error when saving the SO).

Furthermore, some inherited views (rental) were not handled correctly nor the same way.

This commit make sure the right domain is applied to the product variant, product template and tax fields of the SOlines, by always handling the domain through the python field definition (not through the xml anymore).

Also fully delegates the multi-company checks to the orm, to rely on the valid generic behavior, reducing maintenance costs, incoherences, and issues.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
