### PR TITLE
[FIX] account: save record only if dirty

### DIFF
--- a/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
+++ b/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
@@ -5,6 +5,7 @@ import {
 import { registry } from "@web/core/registry";
 import { TagsList } from "@web/core/tags_list/tags_list";
 import { _t } from "@web/core/l10n/translation";
+import { onMounted } from "@odoo/owl";
 
 export class FieldMany2ManyTagsBanksTagsList extends TagsList {
     static template = "FieldMany2ManyTagsBanksTagsList";
@@ -18,9 +19,14 @@ export class FieldMany2ManyTagsBanks extends Many2ManyTagsFieldColorEditable {
 
     setup() {
         super.setup();
-        // Needed when you create a partner (from a move for example), we want the partner to be saved to be able
-        // to have it as account holder
-        this.props.record.model.root.save();
+        onMounted(async () => {
+            // Needed when you create a partner (from a move for example), we want the partner to be saved to be able
+            // to have it as account holder
+            const isDirty = await this.props.record.model.root.isDirty();
+            if (isDirty) {
+                this.props.record.model.root.save();
+            }
+        });
     }
 
     getTagProps(record) {


### PR DESCRIPTION
- Open a Contact;
- Click on the Accounting tab;

Before this commit, a recursion occurred which blocked the interface. This issue arises due to the FieldMany2ManyTagsBanks component always saving the record on its setup. Additionally, since [1], a saved record without changes will be updated with the initial values. This will generate a re-rendering and the FieldMany2ManyTagsBanks will force the record to be saved again, and this will create a recursion.

Now, the FieldMany2ManyTagsBanks will only save dirty records.

opw-4675973
opw-4676949
opw-4677092
opw-4677086
opw-4677856
opw-4678211

[1] : https://github.com/odoo/odoo/commit/43fb8a45ac629c1883ca9521a8879cf19ca7538b
