### PR TITLE
[FIX] mrp: prevent duplicate MO names in 3-step manufacturing

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -184,7 +184,7 @@ class StockRule(models.Model):
         }
         # Use the procurement group created in _run_pull mrp override
         # Preserve the origin from the original stock move, if available
-        if location_dest_id.warehouse_id.manufacture_steps == 'pbm_sam' and values.get('move_dest_ids') and values.get('group_id') and values['move_dest_ids'][0].origin != values['group_id'].name:
+        if location_dest_id.warehouse_id.manufacture_steps == 'pbm_sam' and values.get('move_dest_ids') and values.get('group_id') and not values['move_dest_ids'][0].origin.startswith(values['group_id'].name):
             origin = values['move_dest_ids'][0].origin
             mo_values.update({
                 'name': values['group_id'].name,

--- a/addons/sale_mrp/tests/test_multistep_manufacturing.py
+++ b/addons/sale_mrp/tests/test_multistep_manufacturing.py
@@ -157,3 +157,32 @@ class TestMultistepManufacturing(TestMrpCommon):
 
         self.assertEqual(self.sale_order.action_view_mrp_production()['res_id'], mo.id)
         self.assertEqual(mo.action_view_sale_orders()['res_id'], self.sale_order.id)
+
+    def test_sales_order_with_mto_manufacturing(self):
+        self.env.ref('stock.route_warehouse0_mto').active = True
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.manufacture_steps = 'pbm_sam'
+        prod1 = self.env['product.product'].create({
+            'name': 'elct1',
+            'type': 'consu',
+            'route_ids': [(6, 0, [
+                warehouse.manufacture_pull_id.route_id.id,
+                warehouse.mto_pull_id.route_id.id
+            ])],
+        })
+        prod2 = self.env['product.product'].create({
+            'name': 'elct2',
+            'type': 'consu',
+            'route_ids': [(6, 0, [
+                warehouse.manufacture_pull_id.route_id.id,
+                warehouse.mto_pull_id.route_id.id
+            ])],
+        })
+        partner = self.env['res.partner'].create({'name': 'Steve Buscemi'})
+        so = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'order_line': [(0, 0, {'product_id': prod1.id, 'product_uom_qty': 1}),
+                           (0, 0, {'product_id': prod2.id, 'product_uom_qty': 1})],
+            'client_order_ref': 'Test Reference'
+        })
+        so.action_confirm()


### PR DESCRIPTION
When the warehouse is set to pbm_sam, MOs are assigned the procurement group name if the move origin differs from the group_id. This causes a validation error when confirming a sales order with a client_order_ref, as MO references must be unique per company.

For example, if an SO has a reference S00011 - test_client_order_ref, it differs from S00011, leading to an MO name conflict. This fix ensures that MO names are always generated using the picking type sequence instead of inheriting the procurement group name, preventing duplicate references or incorrectly setting the MO name as the SO name.

Current behavior before PR:
If there is more than one sale order line with MTO products:
We get a duplicate name error

If there is one sale order line with an MTO product:
We get a MO.name == SO.name

Desired behavior after PR is merged:
Both cases are resolved and the MO(s) are successfully created with the appropriate name

Steps to reproduce:
1.) Install sales; inventory; manufacturing
2.) Enable multi-step routes
3.) Unarchive MTO
4.) Set warehouse manufacture steps to:
Pick components, manufacture, then store products (3 steps)
(manufacture_steps == 'pbm_sam')
5.) Unarchive MTO
6.) Create two storable products (enable manufacture and mto routes)
7.) Create an SO with both products
8.) Add any text to the Customer Reference on the sales order (client_order_ref)
9.) Try to confirm the SO

Validation Error
The operation cannot be completed: Reference must be unique per Company!

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr