### PR TITLE
[FIX] pos_restaurant: fix transferring orders between floors

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -467,20 +467,21 @@ patch(PosStore.prototype, {
         const orderUuid = this.getOrder().uuid;
         this.getOrder().setBooked(true);
         this.showScreen("FloorScreen");
-        document.addEventListener(
-            "click",
-            async (ev) => {
-                this.isOrderTransferMode = false;
-                const tableElement = ev.target.closest(".table");
-                if (!tableElement) {
-                    return;
-                }
-                const table = this.getTableFromElement(tableElement);
-                await this.transferOrder(orderUuid, table);
-                this.setTableFromUi(table);
-            },
-            { once: true }
-        );
+        const onClickWhileTransfer = async (ev) => {
+            if (ev.target.closest(".button-floor")) {
+                return;
+            }
+            this.isOrderTransferMode = false;
+            const tableElement = ev.target.closest(".table");
+            if (!tableElement) {
+                return;
+            }
+            const table = this.getTableFromElement(tableElement);
+            await this.transferOrder(orderUuid, table);
+            this.setTableFromUi(table);
+            document.removeEventListener("click", onClickWhileTransfer);
+        };
+        document.addEventListener("click", onClickWhileTransfer);
     },
     prepareOrderTransfer(order, destinationTable) {
         const originalTable = order.table_id;

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -98,5 +98,13 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             Dialog.confirm(),
             Order.doesNotHaveLine(),
             FloorScreen.isShown(),
+
+            // Test moving order to a table on a different floor
+            FloorScreen.clickTable("5"),
+            ProductScreen.addOrderline("Water", "5", "2", "10.0"),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickFloor("Second Floor"),
+            FloorScreen.clickTable("1"),
+            Order.hasLine({ productName: "Water", quantity: "5" }),
         ].flat(),
 });


### PR DESCRIPTION
Transferring an order to a table on a different floor was not working, so a fix has been made for it in 18.0 by the commit 29d06d76889c8231190e563688fa698a551c3672. However, later refactors overrode the fix of the previous commit for versions 18.1 and up.

This commit restores the previous fix in
29d06d76889c8231190e563688fa698a551c3672 and adds an appropriate test.

opw-4645820