### PR TITLE
[IMP] auth_signup: check for existing unactive user

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -64,7 +64,9 @@ class AuthSignupHome(Home):
             except UserError as e:
                 qcontext['error'] = e.args[0]
             except (SignupError, AssertionError) as e:
-                if request.env["res.users"].sudo().search_count([("login", "=", qcontext.get("login"))], limit=1):
+                User = request.env['res.users']
+                if User.sudo().with_context(active_test=False).\
+                        search_count(User._get_login_domain(qcontext.get('login')), limit=1):
                     qcontext["error"] = _("Another user is already registered using this email address.")
                 else:
                     _logger.warning("%s", e)


### PR DESCRIPTION
If one try to create an account for an existing but archived user, it will fail with an error:
```
Could not create a new account.
duplicate key value violates unique constraint "res_users_login_key_unique2"
DETAIL: Key (login, website_id)=(<login>, null) already exists.
```
which is not very user-friendly.

There are a few deactivated users (public, `__system__`, default) or when somebody leaves an organisation, his account is usually deactivated.

Follow-up of 5425316eff19e7ae71
