### PR TITLE
[IMP] html_editor: mouse middle click on link

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -248,6 +248,15 @@ export class LinkPlugin extends Plugin {
         this.addDomListener(this.editable, "keydown", () => {
             delete this._isNavigatingByMouse;
         });
+        this.addDomListener(this.editable, "auxclick", (ev) => {
+            if (ev.button === 1) {
+                const link = closestElement(ev.target, "a");
+                if (link?.href) {
+                    window.open(link.href, "_blank");
+                    ev.preventDefault();
+                }
+            }
+        });
         // link creation is added to the command service because of a shortcut conflict,
         // as ctrl+k is used for invoking the command palette
         this.unregisterLinkCommandCallback = this.services.command.add(


### PR DESCRIPTION
**Current behavior before PR:**

- The middle mouse button functioned as a paste action.

**Desired behavior after PR is merged:**

- Middle clicking on a link opens it in a new tab instead of pasting copied content but still retains the paste functionality when not clicking on a link.

task:3143963