### PR TITLE
[FIX] point_of_sale: display products with no restricted categories

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -126,7 +126,7 @@ export class ProductScreen extends Component {
     getCategoriesAndSub() {
         const { limit_categories, iface_available_categ_ids } = this.pos.config;
         let rootCategories = this.pos.models["pos.category"].getAll();
-        if (limit_categories) {
+        if (limit_categories && iface_available_categ_ids.length > 0) {
             rootCategories = iface_available_categ_ids;
         }
         rootCategories = rootCategories.filter((category) => !category.parent_id);
@@ -342,7 +342,7 @@ export class ProductScreen extends Component {
 
     get products() {
         const { limit_categories, iface_available_categ_ids } = this.pos.config;
-        if (limit_categories) {
+        if (limit_categories && iface_available_categ_ids.length > 0) {
             const productIds = new Set([]);
             for (const categ of iface_available_categ_ids) {
                 const categoryProducts =

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1759,6 +1759,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_limited_categories', login="pos_user")
 
+        self.main_pos_config.current_session_id.close_session_from_ui()
+
+        # when no category is selected, all products should be displayed
+        self.main_pos_config.write({
+            'iface_available_categ_ids': [(6, 0, [])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_limited_categories', login="pos_user")
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Before this commit, when restricted categories were enabled but no category was added to the allowed list, all products were loaded but none were displayed due to a recent code change.

opw-4680158

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
