### PR TITLE
[IMP] web: whitelist `documents_document` for the eslint rules

### DIFF
--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -113,6 +113,10 @@ web_map/static/tests/legacy/**/*
 !addons/purchase
 !addons/purchase/**/*
 
+# Whitelist documents_document
+!documents
+!documents/**/*
+
 # Whitelist documents_spreadsheet
 !documents_spreadsheet
 !documents_spreadsheet/**/*


### PR DESCRIPTION
Purpose
=======
We want to enforce the web style in the Documents app, therefor we enable the eslint configuration for the application.