### PR TITLE
[FIX] mail: message_partner_ids search for portal users

### DIFF
--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -62,6 +62,8 @@ class BaseFollowersTest(MailCommon):
         followed_after = self.env['mail.test.simple'].search([('message_partner_ids', 'in', partner.ids)])
         self.assertTrue(partner in test_record.message_partner_ids)
         self.assertEqual(followed_before + test_record, followed_after)
+        with self.assertRaisesRegex(AccessError, 'Portal users can only filter threads'):
+            self.env['mail.test.simple'].with_user(self.user_portal).search([('message_partner_ids', 'in', partner.ids)])
 
     def test_field_followers(self):
         test_record = self.test_record.with_user(self.user_employee)


### PR DESCRIPTION
When searching `message_partner_ids`, we have a search method that will replace the domain, so `_condition_to_sql` will not be called for that field.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
