### PR TITLE
[IMP] mail:  move open in discuss to the top of actions

### DIFF
--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -34,6 +34,6 @@ threadActionsRegistry.add("expand-discuss", {
             }
         );
     },
-    sequence: 40,
-    sequenceGroup: 20,
+    sequence: 10,
+    sequenceGroup: 5,
 });

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -187,6 +187,7 @@ test("chat window: basic rendering", async () => {
     await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
     await contains(".o-mail-ChatWindow-command", { count: 15 });
+    await contains(".o-dropdown-item", { text: "Open in Discuss" });
     await contains(".o-dropdown-item", { text: "Attachments" });
     await contains(".o-dropdown-item", { text: "Pinned Messages" });
     await contains(".o-dropdown-item", { text: "Members" });
@@ -194,7 +195,6 @@ test("chat window: basic rendering", async () => {
     await contains(".o-dropdown-item", { text: "Invite People" });
     await contains(".o-dropdown-item", { text: "Search Messages" });
     await contains(".o-dropdown-item", { text: "Rename Thread" });
-    await contains(".o-dropdown-item", { text: "Open in Discuss" });
     await contains(".o-dropdown-item", { text: "Notification Settings" });
     await contains(".o-dropdown-item", { text: "Call Settings" });
 });


### PR DESCRIPTION
**Specifications:**
- Move Open in Discuss to the top of the actions category for better visibility and accessibility.

**Purpose:**
- Previously, Open in Discuss was positioned at the bottom of the actions category, making it harder to find.
- Enhances user experience by making this frequently used action easily discoverable and accessible at the top.

task-4606985

Before
<img width="575" alt="Screenshot 2025-04-07 at 10 47 03" src="https://github.com/user-attachments/assets/e5502ec0-b742-427d-9fd4-f6dc0aea8f10" />

After
<img width="568" alt="Screenshot 2025-04-07 at 10 46 48" src="https://github.com/user-attachments/assets/da6250b6-ae66-48e9-8c41-f8160cdf2bd8" />

