### PR TITLE
[FIX] web: control panel displayed even when scrolling on small screen.

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -176,11 +176,11 @@ export class ControlPanel extends Component {
         if (scrollTop > this.initialScrollTop) {
             // Beneath initial position => sticky display
             this.root.el.classList.add(STICKY_CLASS);
-            if (delta < 0) {
-                // Going up
+            if (delta <= 0) {
+                // Going up | not moving
                 this.lastScrollTop = Math.min(0, this.lastScrollTop - delta);
             } else {
-                // Going down | not moving
+                // Going down
                 this.lastScrollTop = Math.max(
                     -this.root.el.offsetHeight,
                     -this.root.el.offsetTop - delta


### PR DESCRIPTION
Step to reproduce:

- Open the Sales application on a small screen such as a mobile phone.
- Remove "My Quotations" to show all quotations.
- Scroll down to hide the control panel.
- Scroll up to show the control panel => Bug The control panel is shown but immediately "hidden" when we stop scrolling and the user has to scroll up to the top screen to see it.

task-4466063

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
