### PR TITLE
[FIX] product, mrp: avoid traceback when creating a pricelist

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -183,6 +183,7 @@
                     <field name="code" optional="show"/>
                     <field name="type"/>
                     <field name="product_id" groups="product.group_product_variant" optional="hide"/>
+                    <field name="product_id" groups="!product.group_product_variant" column_invisible="1"/>
                     <field name="company_id" groups="base.group_multi_company" optional="show"/>
                     <field name="product_qty" optional="hide"/>
                     <field name="product_uom_id" groups="uom.group_uom" optional="hide" widget="many2one_uom"/>

--- a/addons/product/views/product_supplierinfo_views.xml
+++ b/addons/product/views/product_supplierinfo_views.xml
@@ -21,6 +21,7 @@
                         <group string="Pricelist">
                             <field name="product_tmpl_id" string="Product" invisible="context.get('visible_product_tmpl_id', True)"/>
                             <field name="product_id" groups="product.group_product_variant" options="{'no_create': True}"/>
+                            <field name="product_id" groups="!product.group_product_variant" invisible="1"/>
                             <label for="min_qty"/>
                             <div class="o_row">
                                 <field name="min_qty"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Start a new database without demo data (make sure the product variant option is disabled).
- Install the purchase module
- Enable the UoM option in the Purchase settings
- Go to Purchase → Configuration → Vendor Pricelist
- Create a new one

Problem:
A traceback is triggered:
“Caused by: TypeError: Cannot read properties of undefined (reading '0') at Many2OneUomField.template”

This issue occurs because, in the pricelist form view, the field “product_uom_id” is using the widget “many2one_uom”:

https://github.com/odoo/odoo/blob/b6732a405362373f6ad92a8557e9cef79357d055/addons/product/views/product_supplierinfo_views.xml#L27

However, this widget requires the “product_id” field to work properly: https://github.com/odoo-dev/odoo/blob/682f49c72c8fcb9c81e07b084de9333f14815058/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.xml#L13

But the “product_id” field is restricted to users with the “group_product_variant”, meaning it cannot be accessed by the widget. As a result, the widget tries to read an undefined element, causing the error:
https://github.com/odoo/odoo/blob/b6732a405362373f6ad92a8557e9cef79357d055/addons/product/views/product_supplierinfo_views.xml#L23

2:/ The same issue can occur with the BoM list:

- Create a BoM:
    - Product: P1
    - save
- Go to the BoM list:
    - Select the created BoM
    - Try to update its UoM directly from the list view

Problem:
The same error occurs.
Opw-4666641
Opw-4672104
Opw-4673028
Opw-4670980
Opw-4655011