### PR TITLE
[FIX] crm, sale_subscription: fix dashboards.

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -62,7 +62,7 @@ class AccountBankStatement(models.Model):
 
     currency_id = fields.Many2one(
         comodel_name='res.currency',
-        compute='_compute_currency_id',
+        compute='_compute_currency_id', store=True,
     )
 
     journal_id = fields.Many2one(
@@ -166,7 +166,7 @@ class AccountBankStatement(models.Model):
         for stmt in self:
             stmt.balance_end_real = stmt.balance_end
 
-    @api.depends('journal_id')
+    @api.depends('journal_id.currency_id', 'company_id.currency_id')
     def _compute_currency_id(self):
         for statement in self:
             statement.currency_id = statement.journal_id.currency_id or statement.company_id.currency_id

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -96,7 +96,7 @@ class PosConfig(models.Model):
         domain=[('type', '=', 'sale')],
         help="Accounting journal used to create invoices.",
         default=_default_invoice_journal)
-    currency_id = fields.Many2one('res.currency', compute='_compute_currency', compute_sudo=True, string="Currency")
+    currency_id = fields.Many2one('res.currency', compute='_compute_currency', store=True, compute_sudo=True, string="Currency")
     iface_cashdrawer = fields.Boolean(string='Cashdrawer', help="Automatically open the cashdrawer.")
     iface_electronic_scale = fields.Boolean(string='Electronic Scale', help="Enables Electronic Scale integration.")
     iface_print_via_proxy = fields.Boolean(string='Print via Proxy', help="Bypass browser printing and prints via the hardware proxy.")


### PR DESCRIPTION
#### [FIX] crm: fix kanban/dashboard

Since https://github.com/odoo/odoo/pull/199958, monetary fields can now
only be aggregated (from the web client) if the currency field is also
aggregated. There are many monetary fields in `crm.lead` that can no
longer be aggregated because the corresponding currency field is a
compute no store field. However, since these fields are used in the
kanban column header and in some dashboards, it is important to make
them aggregable.

Add an `_read_group_select` override to manage the
`company_currency:array_agg_distinct` aggregates.

#### [FIX] point_of_sale: fix dashboard

Since https://github.com/odoo/odoo/pull/199958, monetary fields can now
only be aggregated (from the web client) if the currency field is also
aggregated. The point of sale dashboard explicitly explicitly uses some
monetaries aggregates on pos.order where the currency is a related to
"config_id.currency_id". Unfortunately,  'pos.config.currency_id' isn't
stored and then doesn't have a valid SQL representation for the
array_agg_distinct.

Store the `pos.config.currency_id` to make the `pos.order.currency_id`
aggregable.

#### [FIX] account: store account.bank.statement.currency_id

Since https://github.com/odoo/odoo/pull/199958, monetary fields can now
only be aggregated (from the web client) if the currency field is also
aggregated. There are many monetary fields in `account.bank.statement` that can no
longer be aggregated because the corresponding currency field is a
compute no store field.

Store the currency field and update its depends to be recompute as expected.

https://github.com/odoo/enterprise/pull/82415
https://github.com/odoo/upgrade/pull/7471