### PR TITLE
[FIX] point_of_sale: Fix test cash move list popup

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
@@ -24,7 +24,7 @@
                                     </td>
                                     
                                     <td class="align-middle">
-                                        <div class="fw-bolder"><t t-esc="getAmount(cm)"></t></div>
+                                        <div class="cash-move-amount fw-bolder"><t t-esc="getAmount(cm)"></t></div>
                                     </td>
                                     
                                     <td class="text-end delete-row">
@@ -52,7 +52,7 @@
                                 <div t-attf-class="col-1 align-self-center fs-6 px-0 badge rounded text-bg-{{status === 'In' ? 'success' : 'danger'}}">
                                     <t t-esc="status"></t>
                                 </div>
-                                <div class="col-4 align-self-center fw-bolder"><t t-esc="getAmount(cm)"></t></div>
+                                <div class="cash-move-amount col-4 align-self-center fw-bolder"><t t-esc="getAmount(cm)"></t></div>
                                 <div class="col-2 align-self-center delete-row">
                                     <div class="d-flex align-items-center justify-content-center h-100" name="delete" t-on-click.stop="callbacks[cm.id].call">
                                         <div class="btn btn-danger btn-lg">

--- a/addons/point_of_sale/static/tests/pos/tours/utils/cash_move_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/cash_move_list_util.js
@@ -3,7 +3,7 @@ import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 export function checkCashMoveShown(amount) {
     return {
         content: `Check has cash move with amount ${amount}`,
-        trigger: `.cash-move-list .cash-move-row:contains(${amount})`,
+        trigger: `.cash-move-list .cash-move-row .cash-move-amount:contains(${amount})`,
     };
 }
 export function deleteCashMove(amount) {


### PR DESCRIPTION
A previous PR add a test where we check if a row does not contain a certain amount. The problem was that it was not checking the particular field so it was failing when another field was containing the same value like the hour.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
