### PR TITLE
[IMP] mail: no email notification for internal users in channels

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -759,7 +759,6 @@ class DiscussChannel(models.Model):
                        partner.name,
                        partner.partner_share,
                        users.id as uid,
-                       COALESCE(users.notification_type, 'email') as notif,
                        COALESCE(users.share, FALSE) as ushare
                   FROM res_partner partner
              LEFT JOIN res_users users on partner.id = users.partner_id
@@ -772,7 +771,7 @@ class DiscussChannel(models.Model):
                 author_id=author_id or 0,
             )
             self.env.cr.execute(sql_query)
-            for partner_id, email_normalized, lang, name, partner_share, uid, notif, ushare in self.env.cr.fetchall():
+            for partner_id, email_normalized, lang, name, partner_share, uid, ushare in self.env.cr.fetchall():
                 # ocn_client: will add partners to recipient recipient_data. more ocn notifications. We neeed to filter them maybe
                 recipients_data.append({
                     'active': True,
@@ -782,9 +781,9 @@ class DiscussChannel(models.Model):
                     'groups': [],
                     'lang': lang,
                     'name': name,
-                    'notif': notif,
+                    'notif': "email" if partner_share else "inbox",
                     'share': partner_share,
-                    'type': 'user' if not partner_share and notif else 'customer',
+                    'type': 'user' if not partner_share else 'customer',
                     'uid': uid,
                     'ushare': ushare,
                 })


### PR DESCRIPTION
Before this PR, mentioning an internal user in a channel would send an email to them if they have set `Send by email` in notification preferences.

After this PR, internal users mentioned won't receive email notifications, only partners without linked users or portal users will.

co-authored-by: vrgo-odoo <vrgo@odoo.com>

Task-4607456
