### PR TITLE
[FIX] loyalty: use placeholder for gift card product 

### DIFF
--- a/addons/loyalty/models/product_template.py
+++ b/addons/loyalty/models/product_template.py
@@ -1,11 +1,24 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
+
 from odoo import _, api, models
 from odoo.exceptions import UserError
+from odoo.tools import file_open
 
 
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """ Override of `product` to set a default image for gift cards. """
+        templates = super().create(vals_list)
+        if templates and self.env.context.get('loyalty_is_gift_card_product'):
+            with file_open('loyalty/static/img/gift_card.png', 'rb') as f:
+                gift_card_placeholder = base64.b64encode(f.read())
+            templates.image_1920 = gift_card_placeholder
+        return templates
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_loyalty_products(self):

--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -94,7 +94,13 @@
                                 id="trigger_products"
                                 invisible="program_type not in ['gift_card', 'ewallet']"
                             >
-                                <field name="trigger_product_ids" widget="many2many_tags"/>
+                                <field
+                                    name="trigger_product_ids"
+                                    widget="many2many_tags"
+                                    context="{
+                                        'loyalty_is_gift_card_product': program_type == 'gift_card'
+                                    }"
+                                />
                             </div>
                             <field name="payment_program_discount_product_id" groups="base.group_no_one" invisible="program_type not in ('gift_card', 'ewallet')"/>
                             <field name="mail_template_id" invisible="program_type not in ('gift_card', 'ewallet')"/>

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -23,17 +23,18 @@
 
     <template id="product_cart_lines" inherit_id="website_sale.cart_lines" active="True">
         <xpath expr="//div[@name='o_wsale_cart_line_button_container']/a" position="after">
-            <span class="text-300">|</span>
-            <a
-                t-if="line._is_sellable()"
-                href="#"
-                class="o_add_wishlist js_delete_product small"
-                t-att-data-product-template-id="line.product_id.product_tmpl_id.id"
-                t-att-data-product-product-id="line.product_id.id"
-                data-action="o_wishlist"
-            >
-                Save for Later
-            </a>
+            <t t-if="line._is_sellable()">
+                <span class="text-300">|</span>
+                <a
+                    href="#"
+                    class="o_add_wishlist js_delete_product small"
+                    t-att-data-product-template-id="line.product_id.product_tmpl_id.id"
+                    t-att-data-product-product-id="line.product_id.id"
+                    data-action="o_wishlist"
+                >
+                    Save for Later
+                </a>
+            </t>
         </xpath>
 
         <xpath expr="//div[@name='o_wsale_cart_line_button_container_mobile']/button" position="before">


### PR DESCRIPTION
A new placeholder for gift cards was introduced in https://github.com/odoo/odoo/commit/c52453f8374d988127b2a18f7b357058b01501d9. This placeholder is only applied to the discount product (when a customer uses a gift card).

After this commit, the placeholder will also be applied on gift card products (the ones customers buy from the website).

Followup of task-4387239