### PR TITLE
[IMP] auth_signup: add eye icon to password input fields

### DIFF
--- a/addons/auth_password_policy/static/src/css/password_field.css
+++ b/addons/auth_password_policy/static/src/css/password_field.css
@@ -3,7 +3,7 @@ div.o_field_password_meter {
 }
 
 meter.o_password_meter {
-    position: absolute;
+    /* position: absolute; */
     height: 15px;
     bottom: calc(50% - 7px);
     right: 5px;

--- a/addons/auth_password_policy_portal/views/templates.xml
+++ b/addons/auth_password_policy_portal/views/templates.xml
@@ -6,7 +6,7 @@
         </xpath>
         <!-- only put meter on first "new password" field since both must be identical -->
         <xpath expr="//input[@name='new1']" position="after">
-            <owl-component name="password_meter" props='{"selector": "input[name=new1]"}'/>
+            <owl-component name="password_meter" class="input-group-text bg-transparent" props='{"selector": "input[name=new1]"}'/>
         </xpath>
         <xpath expr="//input[@name='new1']" position="attributes">
             <attribute name="t-att-minlength">password_minimum_length</attribute>

--- a/addons/auth_password_policy_signup/static/src/public/scss/signup_policy.scss
+++ b/addons/auth_password_policy_signup/static/src/public/scss/signup_policy.scss
@@ -8,7 +8,7 @@
         // We can't use $input-heigh because it relies on em units
         // and the font size is defined in the input.
         bottom: ($input-line-height * $input-font-size) / 2 + $input-padding-y + o-to-rem($border-width);
-        transform: translateY(50%);
+        // transform: translateY(50%);
         inline-size: var(--PasswordMeter-width);
     }
 

--- a/addons/auth_password_policy_signup/views/signup_templates.xml
+++ b/addons/auth_password_policy_signup/views/signup_templates.xml
@@ -1,11 +1,11 @@
 <odoo>
     <template id="fields" inherit_id="auth_signup.fields"
               name="Password policy data for auth_signup">
-        <xpath expr="//input[@name='password']" position="after">
-            <owl-component name="password_meter" props='{"selector": "input[name=password]"}'/>
+        <xpath expr="//input[@id='password']" position="after"> 
+            <owl-component name="password_meter" class="input-group-text bg-transparent" props='{"selector": "input[name=password]"}'/>
         </xpath>
         <xpath expr="//input[@name='password']" position="attributes">
-            <attribute name="t-att-minlength">password_minimum_length</attribute>
+                <attribute name="t-att-minlength">password_minimum_length</attribute>
         </xpath>
     </template>
 </odoo>

--- a/addons/auth_signup/static/src/interactions/signup.js
+++ b/addons/auth_signup/static/src/interactions/signup.js
@@ -5,9 +5,21 @@ import { addLoadingEffect } from "@web/core/utils/ui";
 
 export class Signup extends Interaction {
     static selector = ".oe_signup_form, .oe_reset_password_form";
+
     dynamicContent = {
         _root: { "t-on-submit": this.onSubmit },
+        ".o_password_visibility_toggle": { "t-on-click": this.onTogglePassword },
+        ".o_password_visibility_toggle i": {
+            "t-att-class": (el) => ({
+                "fa-eye": !this.isPasswordVisible(el),
+                "fa-eye-slash": this.isPasswordVisible(el),
+            }),
+        },
     };
+
+    setup() {
+        this.passwordVisibilityMap = {};
+    }
 
     onSubmit() {
         const submitEl = this.el.querySelector('.oe_login_buttons > button[type="submit"]');
@@ -15,6 +27,20 @@ export class Signup extends Interaction {
             const removeLoadingEffect = addLoadingEffect(submitEl);
             this.registerCleanup(removeLoadingEffect);
         }
+    }
+
+    onTogglePassword(ev) {
+        const button = ev.currentTarget;
+        const targetId = button.dataset.target;
+        const input = this.el.querySelector(`#${targetId}`);
+        input.type = input.type === "password" ? "text" : "password";
+        this.passwordVisibilityMap[targetId] = input.type === "text";
+    }
+
+    isPasswordVisible(el) {
+        const button = el.parentElement;
+        const targetId = button.dataset.target;
+        return this.passwordVisibilityMap[targetId];
     }
 }
 

--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -25,14 +25,27 @@
             </div>
 
             <div class="mb-3 field-password pt-2">
-                <label for="password" class="form-label">Password</label>
-                <input type="password" name="password" id="password" class="form-control"
-                    required="required" t-att-autofocus="'autofocus' if only_passwords else None" placeholder="••••••••••"/>
+                <label for="password">Password</label>
+                 <div class="input-group">
+                    <input type="password" name="password" id="password"
+                        class="form-control form-control-sm"
+                        style="border-right: none;"
+                        required="required" t-att-autofocus="'autofocus' if only_passwords else None" />
+                    <button type="button" class="o_password_visibility_toggle input-group-text" data-target="password">
+                        <i class="fa fa-eye" aria-hidden="true"/>
+                    </button>
+                </div>
             </div>
 
             <div class="mb-3 field-confirm_password">
-                <label for="confirm_password" class="form-label">Confirm Password</label>
-                <input type="password" name="confirm_password" id="confirm_password" class="form-control" required="required" placeholder="••••••••••"/>
+                <label for="confirm_password">Confirm Password</label>
+                <div class="input-group">
+                    <input type="password" name="confirm_password" id="confirm_password"
+                        class="form-control form-control-sm" required="required" />
+                    <button type="button" class="o_password_visibility_toggle input-group-text" data-target="confirm_password">
+                        <i class="fa fa-eye" aria-hidden="true"/>
+                    </button>
+                </div>
             </div>
         </template>
 

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -475,27 +475,44 @@
                     <input type="hidden" name="op" value="password"/>
                     <div class="mb-3">
                         <label for="current">Password:</label>
-                        <input type="password" t-attf-class="form-control form-control-sm {{ 'is-invalid' if get_error(errors, 'password.old') else '' }}"
-                               id="current" name="old"
-                               autocomplete="current-password" required="required"/>
+                        <div t-attf-class="input-group {{ 'is-invalid' if get_error(errors, 'password.old') else '' }}">
+                            <input type="password" class="form-control form-control-sm"
+                                id="current" name="old"
+                                autocomplete="current-password" required="required"/>
+                            <button type="button" class="o_password_visibility_toggle input-group-text" data-target="current">
+                                <i class="fa fa-eye" aria-hidden="true"/>
+                            </button>
+                        </div>
                         <div class="invalid-feedback">
                             <t t-esc="get_error(errors, 'password.old')"/>
                         </div>
                     </div>
                     <div class="mb-3">
                         <label for="new">New Password:</label>
-                        <input type="password" t-attf-class="form-control form-control-sm {{ 'is-invalid' if get_error(errors, 'password.new1') else '' }}"
-                               id="new" name="new1"
-                               autocomplete="new-password" required="required"/>
+                        <div t-attf-class="input-group {{ 'is-invalid' if get_error(errors, 'password.new1') else '' }}">
+                            <input type="password" class="form-control form-control-sm"
+                            id="new" name="new1"
+                            style="border-right: none;"
+                            autocomplete="new-password" required="required"/>
+                            <button type="button" class="o_password_visibility_toggle input-group-text" data-target="new">
+                                <i class="fa fa-eye" aria-hidden="true"/>
+                            </button>
+                        </div>
                         <div class="invalid-feedback">
                             <t t-esc="get_error(errors, 'password.new1')"/>
                         </div>
                     </div>
                     <div class="mb-3">
                         <label for="new2">Verify New Password:</label>
-                        <input type="password" t-attf-class="form-control form-control-sm {{ 'is-invalid' if get_error(errors, 'password.new2') else '' }}"
-                               id="new2" name="new2"
-                               autocomplete="new-password" required="required"/>
+                        <div t-attf-class="input-group {{ 'is-invalid' if get_error(errors, 'password.new2') else '' }}">
+                            <input type="password" 
+                                class="form-control form-control-sm"
+                                id="new2" name="new2"
+                                autocomplete="new-password" required="required"/>
+                            <button type="button" class="o_password_visibility_toggle input-group-text" data-target="new2">
+                                <i class="fa fa-eye" aria-hidden="true"/>
+                            </button>
+                        </div>
                         <div class="invalid-feedback">
                             <t t-esc="get_error(errors, 'password.new2')"/>
                         </div>


### PR DESCRIPTION
added an eye icon to toggle password visibility on the signup and my account pages.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
