### PR TITLE
[FIX] auth_ldap,website: avoid visitor update for newly created users

### DIFF
--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -81,6 +81,10 @@ class ResUsers(models.Model):
         uid = super(ResUsers, cls).authenticate(db, login, password, user_agent_env)
         if uid and visitor_pre_authenticate_sudo:
             env = api.Environment(request.env.cr, uid, {})
+            # user may not always exist in request cursor for auto-provisioning modules like LDAP
+            if not env.user.exists():
+                return uid
+
             user_partner = env.user.partner_id
             visitor_current_user_sudo = env['website.visitor'].sudo().search([
                 ('partner_id', '=', user_partner.id)


### PR DESCRIPTION
Since [1], the website visitor update in the login process uses the request's environment, which might not yet have the user in the cursor for auto-provisioning modules like LDAP, where the user is created in a different cursor.

Steps to reproduce:
1. Install auth_ldap & website
2. Configure the website to have the correct domain
3. Configure the LDAP connection to create users
4. Logout and navigate to a website page (to create a visitor)
5. Login with an LDAP user -> traceback
6. Login again -> works

After this commit:
As the website visitor is not business-critical, the visitor is not updated to ensure no deadlock is reintroduced.

opw-4378487

cc @thle-odoo

[1]: https://github.com/odoo/odoo/commit/b241cf7de9329af1410b9dd45b161aa41926effb