### PR TITLE
[IMP] im_livechat: improve session statistics view

### DIFF
--- a/addons/hr_livechat/__manifest__.py
+++ b/addons/hr_livechat/__manifest__.py
@@ -7,6 +7,7 @@ Bridge between HR and Livechat.""",
     'depends': ['hr', 'im_livechat'],
     'data': [
         'views/discuss_channel_views.xml',
+        'views/im_livechat_report_channel_views.xml',
     ],
     'auto_install': True,
     'author': 'Odoo S.A.',

--- a/addons/hr_livechat/views/im_livechat_report_channel_views.xml
+++ b/addons/hr_livechat/views/im_livechat_report_channel_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="im_livechat_report_channel_view_search" model="ir.ui.view">
+        <field name="name">im_livechat.report.channel.search</field>
+        <field name="model">im_livechat.report.channel</field>
+        <field name="inherit_id" ref="im_livechat.im_livechat_report_channel_view_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//*[@name='my_session']" position="after">
+                <filter name="my_team" domain="[('partner_id.user_ids.employee_id.member_of_department', '=', True)]" string="My Team"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -37,7 +37,7 @@ class Im_LivechatReportChannel(models.Model):
     # TODO DBE : Use Selection field - Need : Pie chart must show labels, not keys.
     rating_text = fields.Char('Satisfaction Rate', readonly=True)
     is_unrated = fields.Integer('Session not rated', readonly=True)
-    partner_id = fields.Many2one('res.partner', 'Operator', readonly=True)
+    partner_id = fields.Many2one("res.partner", "Agent", readonly=True)
     handled_by_bot = fields.Integer("Handled by Bot", readonly=True, aggregator="sum")
     handled_by_agent = fields.Integer("Handled by Agent", readonly=True, aggregator="sum")
     visitor_partner_id = fields.Many2one("res.partner", string="Customer", readonly=True)

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -6,7 +6,7 @@
             <field name="name">im_livechat.report.channel.pivot</field>
             <field name="model">im_livechat.report.channel</field>
             <field name="arch" type="xml">
-                <pivot string="Livechat Support Statistics" disable_linking="1" sample="1">
+                <pivot string="Livechat Support Statistics" sample="1">
                     <field name="partner_id" type="row"/>
                     <field name="nbr_channel" type="measure"/>
                     <field name="time_to_answer" type="measure"/>
@@ -16,11 +16,40 @@
             </field>
         </record>
 
+        <record id="im_livechat_report_channel_view_list" model="ir.ui.view">
+            <field name="name">im_livechat.report.channel.list</field>
+            <field name="model">im_livechat.report.channel</field>
+            <field name="arch" type="xml">
+                <list create="false">
+                    <field name="start_date" string="Session Date"/>
+                    <field name="channel_name" string="Participants"/>
+                    <field name="country_id"/>
+                    <field name="duration" widget="float_time"/>
+                    <field name="nbr_message" string="# Messages"/>
+                    <field name="rating_text" string="Rating Text"/>
+                </list>
+            </field>
+        </record>
+
+        <record id="im_livechat_report_channel_view_form" model="ir.ui.view">
+            <field name="name">im_livechat.report.channel.form</field>
+            <field name="model">im_livechat.report.channel</field>
+            <field name="arch" type="xml">
+                <form string="Channel Rule" class="o_livechat_rules_form" js_class="livechat_session_form">
+                    <sheet>
+                        <group>
+                            <field name="channel_name"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
         <record id="im_livechat_report_channel_view_graph" model="ir.ui.view">
             <field name="name">im_livechat.report.channel.graph</field>
             <field name="model">im_livechat.report.channel</field>
             <field name="arch" type="xml">
-                <graph string="Livechat Support Statistics" type="line" stacked="1" sample="1" disable_linking="1">
+                <graph string="Livechat Support Statistics" stacked="1" sample="1">
                     <field name="start_date" interval="day"/>
                     <field name="rating_text"/>
                 </graph>
@@ -32,28 +61,29 @@
             <field name="model">im_livechat.report.channel</field>
             <field name="arch" type="xml">
                 <search string="Search report">
-                    <field name="channel_name"/>
                     <field name="partner_id"/>
+                    <field name="channel_name"/>
+                    <field name="livechat_channel_id" string="Channel"/>
+                    <field name="country_id" string="Country"/>
                     <field name="visitor_partner_id"/>
-                    <filter name="last_24h" string="Last 24h" domain="[('start_date','&gt;', (context_today() - datetime.timedelta(days=1)).strftime('%Y-%m-%d') )]"/>
-                    <filter name="start_date_filter" string="This Week" domain="[
-                        ('start_date', '>=', (datetime.datetime.combine(context_today() + relativedelta(weeks=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),
-                        ('start_date', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
-                    <filter name="last_30_days" string="Last 30 Days" domain="[
-                        ('start_date', '>=', (datetime.datetime.combine(context_today() + relativedelta(months=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),
-                        ('start_date', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
-                    <filter name="this_year" string="This Year" domain="[
-                        ('start_date', '>=', (datetime.datetime.combine(context_today() + relativedelta(years=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),
-                        ('start_date', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(days=1,weekday=0), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
+                    <filter name="my_session" domain="[('partner_id.user_id', '=', uid)]" string="My Sessions"/>
                     <separator/>
-                    <filter name="filter_start_date" date="start_date"/>
+                    <filter name="not_answered" string="Not Answered" domain="[('is_without_answer', '=', 1)]"/>
+                    <separator/>
+                    <filter name="rating_happy" string="Happy" domain="[('rating_text','=', 'Happy')]"/>
+                    <filter name="rating_neutral" string="Neutral" domain="[('rating_text','=', 'Neutral')]"/>
+                    <filter name="rating_unhappy" string="Unhappy" domain="[('rating_text','=', 'Unhappy')]"/>
+                    <separator />
+                    <filter name="filter_start_date" string="Date" date="start_date"/>
                     <group expand="0" string="Group By...">
-                        <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'channel_id'}"/>
-                        <filter name="group_by_operator" string="Operator" domain="[('partner_id','!=', False)]" context="{'group_by':'partner_id'}"/>
+                        <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'livechat_channel_id'}"/>
+                        <filter name="group_by_operator" string="Agent" domain="[]" context="{'group_by': 'partner_id'}"/>
+                        <filter name="group_by_rating" string="Rating" domain="[]" context="{'group_by':'rating_text'}"/>
+                        <filter name="group_by_country" string="Country" domain="[]" context="{'group_by':'country_id'}"/>
                         <filter name="group_by_customer" domain="[]" context="{'group_by':'visitor_partner_id'}"/>
                         <separator orientation="vertical" />
-                        <filter name="group_by_hour" string="Creation date (hour)" domain="[]" context="{'group_by':'start_date_hour'}"/>
-                        <filter name="group_by_month" string="Creation date" domain="[]" context="{'group_by':'start_date:month'}" />
+                        <filter name="group_by_hour" string="Hour of Day" domain="[]" context="{'group_by':'start_date_hour'}"/>
+                        <filter name="group_by_month" string="Date" domain="[]" context="{'group_by':'start_date:month'}" />
                     </group>
                 </search>
             </field>
@@ -71,10 +101,12 @@
         <record id="im_livechat_report_channel_action" model="ir.actions.act_window">
             <field name="name">Sessions</field>
             <field name="res_model">im_livechat.report.channel</field>
-            <field name="view_mode">graph</field>
+            <field name="view_mode">graph,pivot</field>
             <field name="context">{"search_default_this_year":1}</field>
-            <field name="search_view_id" ref="im_livechat_report_channel_view_search"/>
-            <field name="help">Livechat Support Statistics allows you to easily check and analyse your company livechat session performance. Extract information about the missed sessions, the audience, the duration of a session, etc.</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">No data yet!</p>
+                <p>Track and improve livechat performance with insights on session activity, response time, customer ratings, and call interactions.</p>
+            </field>
         </record>
 
         <record id="im_livechat_report_channel_time_to_answer_action" model="ir.actions.act_window">


### PR DESCRIPTION
*=hr_livechat

### Purpose of this commit:

- Make the Pivot view and graph view clickable for the Session. Clicking on the list  should open the respective session in discuss
- Adapt the message when no record is present.
- Check for sample data

- **Changes in the Group-by:**
  1. Add 
     - `Rating`, `Country`, `Day of Week`, `Livechat Channel`
  2. Rename
     - `Operator` => `Agent`
     - `Creation date (hour)` => `Hour of Day`
     - `Creation day` => `Date`
  3. Remove
     - `Code`

- **Changes in the Filter:**
  1. Add
     - `My Session`, `My Team`
     - `Not Answered`
     - `Happy`, `Neutral`, `Unhappy`
  2. Rename
     - `Start Date of session` => `Date`
  3. Remove
     - `Missed Session`, `Treated Session`, `Last 24h`, `This Week`



part of task-4619177