### PR TITLE
[IMP] web: highlight the required fields in an existing record

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -114,6 +114,9 @@ export class Record extends DataPoint {
         this._initialTextValues = { ...this._textValues };
 
         this._invalidFields.clear();
+        if (!this.isNew) {
+            this._checkValidity();
+        }
         this._savePoint = undefined;
     }
 
@@ -642,6 +645,9 @@ export class Record extends DataPoint {
         this._savePoint = undefined;
         this._setEvalContext();
         this._invalidFields.clear();
+        if (!this.isNew) {
+            this._checkValidity();
+        }
         this._closeInvalidFieldsNotification();
         this._closeInvalidFieldsNotification = () => {};
         this._restoreActiveFields();

--- a/addons/web/static/src/views/form/form_status_indicator/form_status_indicator.js
+++ b/addons/web/static/src/views/form/form_status_indicator/form_status_indicator.js
@@ -26,7 +26,7 @@ export class FormStatusIndicator extends Component {
                     this.saveButton.el.removeAttribute("disabled");
                 }
             },
-            () => [this.props.model.root.isValid]
+            () => [this.props.model.root.isValid, this.state.fieldIsDirty]
         );
 
         this.saveButton = useRef("save");
@@ -37,15 +37,12 @@ export class FormStatusIndicator extends Component {
     }
 
     get indicatorMode() {
-        if (this.props.model.root.isNew) {
-            return this.props.model.root.isValid ? "dirty" : "invalid";
-        } else if (!this.props.model.root.isValid) {
-            return "invalid";
-        } else if (this.props.model.root.dirty || this.state.fieldIsDirty) {
-            return "dirty";
-        } else {
-            return "saved";
+        const { isNew, isValid } = this.props.model.root;
+        const isDirty = this.props.model.root.dirty || this.state.fieldIsDirty;
+        if (isNew || isDirty) {
+            return isValid ? "dirty" : "invalid";
         }
+        return "saved";
     }
 
     async discard() {


### PR DESCRIPTION
**Before this PR:**
Required fields in an existing record are only highlighted when trying to save the record.

**After this PR:**
Required fields will always be highlighted in an existing record.

Task-4552032
