### PR TITLE
[IMP] hr_payroll: remove redundant 'Default' keyword from structure type title

### DIFF
--- a/addons/hr_contract/models/hr_payroll_structure_type.py
+++ b/addons/hr_contract/models/hr_payroll_structure_type.py
@@ -10,7 +10,7 @@ class HrPayrollStructureType(models.Model):
 
     name = fields.Char('Salary Structure Type')
     default_resource_calendar_id = fields.Many2one(
-        'resource.calendar', 'Default Working Hours',
+        'resource.calendar', 'Working Hours',
         default=lambda self: self.env.company.resource_calendar_id)
     country_id = fields.Many2one(
         'res.country',


### PR DESCRIPTION
The field label in the Structure Type List View displayed 'Default,' which was unnecessary as selected records are always default.

This update includes:
- Removing the 'Default' keyword from the Structure Type List View title.
- Ensuring consistency in the form view and salary structure view.

Task - 4674220

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr