### PR TITLE
[FIX] sale: allow setting sales admin as salesperson on orders

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -208,8 +208,8 @@ class SaleOrder(models.Model):
         compute='_compute_user_id',
         store=True, readonly=False, precompute=True, index=True,
         tracking=2,
-        domain=lambda self: "[('group_ids', '=', {}), ('share', '=', False), ('company_ids', '=', company_id)]".format(
-            self.env.ref("sales_team.group_sale_salesman").id
+        domain=lambda self: "[('all_group_ids', 'in', {}), ('share', '=', False), ('company_ids', '=', company_id)]".format(
+            self.env.ref("sales_team.group_sale_salesman").ids
         ))
     team_id = fields.Many2one(
         comodel_name='crm.team',


### PR DESCRIPTION
Versions
--------
- saas-18.2
- master

Steps
-----
1. Create a new user with Sales / Adminstrator rights;
2. create a sales order;
3. assign new user to sales order.

Issue
-----
User doesn't show up in the dropdown.

Cause
-----
Commit 34a50e83e6540 changed which results you get when searching on groups. Previously, any implied group would be included by default. Now, you have to use the `all_group_ids` to include transitive groups.

Solution
--------
Use `all_group_ids` in the `user_id` field's domain.

opw-4662889