### PR TITLE
[FIX] base: ensure field is visible

### DIFF
--- a/odoo/addons/base/tests/test_form_create.py
+++ b/odoo/addons/base/tests/test_form_create.py
@@ -23,7 +23,7 @@ class TestFormCreate(TransactionCase):
         partner_form = Form(self.env['res.partner'])
         partner_form.name = 'a partner'
         # YTI: Clean that brol
-        if hasattr(self.env['res.partner'], 'property_account_payable_id'):
+        if hasattr(self.env['res.partner'], 'property_account_payable_id') and partner_form.is_coa_installed:
             property_account_payable_id = self.env['account.account'].create({
                 'name': 'Test Account',
                 'account_type': 'liability_payable',


### PR DESCRIPTION
When updating `res.partner` form view in test, we need to make sure the fields are visible. In this test the fields `res.partner.property_account_payable_id` and `res.partner.property_account_receivable_id` are not visible if `res.partner.is_coa_installed` is false.

ref:
https://github.com/odoo/odoo/pull/189341
https://github.com/odoo/enterprise/pull/74994

The check for field `property_account_payable_id` implies that the account module is installed, which is where the field `is_coa_installed` is defined as well.

the error is seen on runbot [here](https://runbot.odoo.com/odoo/runbot.build.error/135207)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
