### PR TITLE
[FIX] web: ensure IR Profile is enabled before proceeding further

### DIFF
--- a/addons/web/controllers/profiling.py
+++ b/addons/web/controllers/profiling.py
@@ -31,6 +31,8 @@ class Profiling(Controller):
             raise request.not_found()
         profile_str = profile
         profiles = request.env['ir.profile'].browse((int(p) for p in profile.split(',')))
+        if any(not profile._enabled_until() for profile in profiles):
+                raise request.not_found()
         if not kwargs and not action:
             context = {
                 'profile_str': profile_str,


### PR DESCRIPTION
This error occurs when users create an IR profile and open the `Speedscope URL` without ensuring that profiles are enabled.

Steps to Reproduce:
 - Install the `base` module.
 - Open the profile page in Settings.
 - Create an `IR Profile`.
 - Click on the Speedscope URL and click Open.

TypeError: the JSON object must be str, bytes or bytearray, not bool

This error occurs when the system fails to retrieve `init_stack_trace` because the IR Profile is not `enabled`.

This commit ensures that the system proceeds to check `init_stack_trace` only if the IR Profile is enabled.

Sentry-6466200993


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
