### PR TITLE
[FIX] sale_project{,_stock}: report COGS invoice lines as costs

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -486,6 +486,7 @@ class Project(models.Model):
             'materials': 7,
             'other_invoice_revenues': 9,
             'downpayments': 20,
+            'cost_of_goods_sold': 21,
         }
 
     def _get_service_policy_to_invoice_type(self):
@@ -620,6 +621,7 @@ class Project(models.Model):
             ('id', 'not in', included_invoice_line_ids)],
         ])
 
+    # TODO: rename method (+ variables and etc.) to reflect that this method now also gets `costs` items
     def _get_revenues_items_from_invoices(self, excluded_move_line_ids=None, with_action=True):
         """
         Get all revenues items from invoices, and put them into their own
@@ -646,51 +648,67 @@ class Project(models.Model):
         # account_move_line__move_id is the alias of the joined table account_move in the query
         # we can use it, because of the "move_id.move_type" clause in the domain of the query, which generates the join
         # this is faster than a search_read followed by a browse on the move_id to retrieve the move_type of each account.move.line
-        query_string, query_param = query.select('price_subtotal', 'parent_state', 'account_move_line.currency_id', 'account_move_line.analytic_distribution', 'account_move_line__move_id.move_type', 'move_id')
+        query_string, query_param = query.select('price_subtotal', 'parent_state', 'account_move_line.currency_id', 'account_move_line.analytic_distribution', 'account_move_line__move_id.move_type', 'move_id', 'display_type')
         self._cr.execute(query_string, query_param)
         invoices_move_line_read = self._cr.dictfetchall()
+        res = {
+            'revenues': {
+                'data': [], 'total': {'invoiced': 0.0, 'to_invoice': 0.0}
+            },
+            'costs': {
+                'data': [], 'total': {'billed': 0.0, 'to_bill': 0.0}
+            },
+        }
         if invoices_move_line_read:
+            revenues_lines = []
+            cogs_lines = []
             currency_ids = OrderedSet(iml['currency_id'] for iml in invoices_move_line_read)
-            move_ids = set()
-            amount_invoiced = amount_to_invoice = 0.0
-            for moves_read in invoices_move_line_read:
-                currency = self.env['res.currency'].browse(moves_read['currency_id']).with_prefetch(currency_ids)
-                price_subtotal = currency._convert(moves_read['price_subtotal'], self.currency_id, self.company_id)
-                # an analytic account can appear several time in an analytic distribution with different repartition percentage
-                analytic_contribution = sum(
-                    percentage for ids, percentage in moves_read['analytic_distribution'].items()
-                    if str(self.analytic_account_id.id) in ids.split(',')
-                ) / 100.
-                move_ids.add(moves_read['move_id'])
-                if moves_read['parent_state'] == 'draft':
-                    if moves_read['move_type'] == 'out_invoice':
-                        amount_to_invoice += price_subtotal * analytic_contribution
-                    else:  # moves_read['move_type'] == 'out_refund'
-                        amount_to_invoice -= price_subtotal * analytic_contribution
-                else:  # moves_read['parent_state'] == 'posted'
-                    if moves_read['move_type'] == 'out_invoice':
-                        amount_invoiced += price_subtotal * analytic_contribution
-                    else:  # moves_read['move_type'] == 'out_refund'
-                        amount_invoiced -= price_subtotal * analytic_contribution
-            # don't display the section if the final values are both 0 (invoice -> credit note)
-            if amount_invoiced != 0 or amount_to_invoice != 0:
-                section_id = 'other_invoice_revenues'
-                invoices_revenues = {
-                    'id': section_id,
-                    'sequence': self._get_profitability_sequence_per_invoice_type()[section_id],
-                    'invoiced': amount_invoiced,
-                    'to_invoice': amount_to_invoice,
-                }
-                if with_action and self.user_has_groups('sales_team.group_sale_salesman_all_leads, account.group_account_invoice, account.group_account_readonly'):
-                    invoices_revenues['action'] = self._get_action_for_profitability_section(list(move_ids), section_id)
-                return {
-                    'data': [invoices_revenues],
-                    'total': {
-                        'invoiced': amount_invoiced,
-                        'to_invoice': amount_to_invoice,
-                    },
-                }
-        return {'data': [], 'total': {'invoiced': 0.0, 'to_invoice': 0.0}}
+            for move_line in invoices_move_line_read:
+                if move_line['display_type'] == 'cogs':
+                    cogs_lines.append(move_line)
+                else:
+                    revenues_lines.append(move_line)
+            for moves, ml_type in ((revenues_lines, 'revenues'), (cogs_lines, 'costs')):
+                move_ids = set()
+                amount_invoiced = amount_to_invoice = 0.0
+                for moves_read in moves:
+                    currency = self.env['res.currency'].browse(moves_read['currency_id']).with_prefetch(currency_ids)
+                    price_subtotal = currency._convert(moves_read['price_subtotal'], self.currency_id, self.company_id)
+                    # an analytic account can appear several time in an analytic distribution with different repartition percentage
+                    analytic_contribution = sum(
+                        percentage for ids, percentage in moves_read['analytic_distribution'].items()
+                        if str(self.analytic_account_id.id) in ids.split(',')
+                    ) / 100.
+                    move_ids.add(moves_read['move_id'])
+                    if moves_read['parent_state'] == 'draft':
+                        if moves_read['move_type'] == 'out_invoice':
+                            amount_to_invoice += price_subtotal * analytic_contribution
+                        else:  # moves_read['move_type'] == 'out_refund'
+                            amount_to_invoice -= price_subtotal * analytic_contribution
+                    else:  # moves_read['parent_state'] == 'posted'
+                        if moves_read['move_type'] == 'out_invoice':
+                            amount_invoiced += price_subtotal * analytic_contribution
+                        else:  # moves_read['move_type'] == 'out_refund'
+                            amount_invoiced -= price_subtotal * analytic_contribution
+                # don't display the section if the final values are both 0 (invoice -> credit note)
+                if amount_invoiced != 0 or amount_to_invoice != 0:
+                    section_id = 'other_invoice_revenues' if ml_type == 'revenues' else 'cost_of_goods_sold'
+                    invoices_items = {
+                        'id': section_id,
+                        'sequence': self._get_profitability_sequence_per_invoice_type()[section_id],
+                        'invoiced' if ml_type == 'revenues' else 'billed': amount_invoiced,
+                        'to_invoice' if ml_type == 'revenues' else 'to_bill': amount_to_invoice,
+                    }
+                    if with_action and self.user_has_groups('sales_team.group_sale_salesman_all_leads,account.group_account_invoice,account.group_account_readonly'):
+                        invoices_items['action'] = self._get_action_for_profitability_section(list(move_ids), section_id)
+                    res[ml_type] = {
+                        'data': [invoices_items],
+                        'total': {
+                            'invoiced' if ml_type == 'revenues' else 'billed': amount_invoiced,
+                            'to_invoice' if ml_type == 'revenues' else 'to_bill': amount_to_invoice,
+                        },
+                    }
+        return res
 
     def _add_invoice_items(self, domain, profitability_items, with_action=True):
         sale_lines = self.env['sale.order.line'].sudo()._read_group(
@@ -702,9 +720,12 @@ class Project(models.Model):
             excluded_move_line_ids=sale_lines.invoice_lines.ids,
             with_action=with_action
         )
-        profitability_items['revenues']['data'] += revenue_items_from_invoices['data']
-        profitability_items['revenues']['total']['to_invoice'] += revenue_items_from_invoices['total']['to_invoice']
-        profitability_items['revenues']['total']['invoiced'] += revenue_items_from_invoices['total']['invoiced']
+        profitability_items['revenues']['data'] += revenue_items_from_invoices['revenues']['data']
+        profitability_items['revenues']['total']['to_invoice'] += revenue_items_from_invoices['revenues']['total']['to_invoice']
+        profitability_items['revenues']['total']['invoiced'] += revenue_items_from_invoices['revenues']['total']['invoiced']
+        profitability_items['costs']['data'] += revenue_items_from_invoices['costs']['data']
+        profitability_items['costs']['total']['to_bill'] += revenue_items_from_invoices['costs']['total']['to_bill']
+        profitability_items['costs']['total']['billed'] += revenue_items_from_invoices['costs']['total']['billed']
 
     def _get_profitability_items(self, with_action=True):
         profitability_items = super()._get_profitability_items(with_action)

--- a/addons/sale_project_stock/tests/__init__.py
+++ b/addons/sale_project_stock/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_sale_project_stock_profitability

--- a/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
+++ b/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
@@ -1,0 +1,97 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command, fields
+from odoo.addons.sale_project.tests.test_project_profitability import TestProjectProfitabilityCommon
+
+
+class TestSaleProjectStockProfitability(TestProjectProfitabilityCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        project_template = cls.env['project.project'].create({
+            'name': 'sale_project_stock project template',
+            'analytic_account_id': cls.analytic_account.id,
+        })
+        avco_real_time_product_category = cls.env['product.category'].create({
+            'name': 'avco real time',
+            'property_valuation': 'real_time',
+            'property_cost_method': 'average',
+        })
+        cls.cogs_account = cls.env['account.account'].search([
+            ('name', '=', 'Cost of Goods Sold'),
+            ('company_id', '=', cls.env.company.id),
+        ])
+        cls.avco_product = cls.env['product.product'].create({
+            'name': 'avco product',
+            'type': 'product',
+            'categ_id': avco_real_time_product_category.id,
+            'standard_price': 12.0,
+            'list_price': 24.0,
+        })
+        cls.product_superb_service = cls.env['product.product'].create({
+            'name': 'product that creates project on order',
+            'type': 'service',
+            'standard_price': 10.0,
+            'list_price': 20.0,
+            'service_tracking': 'project_only',
+            'project_template_id': project_template.id,
+        })
+
+    def test_report_invoice_items_anglo_saxon_automatic_valuation(self):
+        """ An invoice can have some lines which should be classified/displayed under the 'Costs'
+        section of a project's profitability report (specifically, COGS lines).
+        """
+        self.env.company.anglo_saxon_accounting = True
+        self.avco_product.categ_id.property_account_expense_categ_id = self.cogs_account.id
+        service_product = self.product_superb_service
+        avco_product = self.avco_product
+        other_avco_product = self.env['product.product'].create({
+            'name': 'other avco product',
+            'type': 'product',
+            'categ_id': avco_product.categ_id.id,
+            'standard_price': 16.0,
+            'list_price': 32.0,
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'product_id': service_product.id,
+                'product_uom_qty': 10,
+            }), Command.create({
+                'product_id': avco_product.id,
+                'product_uom_qty': 10,
+            }), Command.create({
+                'product_id': other_avco_product.id,
+                'product_uom_qty': 10,
+            })],
+        })
+        sale_order.action_confirm()
+        delivery = sale_order.picking_ids
+        delivery.move_ids.quantity = 10
+        delivery.button_validate()
+        sale_order._create_invoices()
+        invoice = sale_order.invoice_ids[0]
+        invoice.invoice_date = fields.Date.today()
+        invoice.action_post()
+        panel_data = sale_order.project_ids.get_panel_data()
+        self.assertEqual(
+            panel_data['profitability_items']['costs'],
+            {
+                'data': [{
+                    'action': {
+                        'args': f'["cost_of_goods_sold", [["id", "in", [{invoice.id}]]], {invoice.id}]',
+                        'name': 'action_profitability_items',
+                        'type': 'object',
+                    },
+                    'id': 'cost_of_goods_sold',
+                    'billed': -280.0,
+                    'sequence': 21,
+                    'to_bill': 0.0,
+                }],
+                'total': {
+                    'billed': -280.0,
+                    'to_bill': 0.0,
+                }
+            }
+        )


### PR DESCRIPTION
**Current behavior:**
Using auto valuation and anglo saxon accounting, when a project has some profitability report items for auto valued product, the COGS invoice lines will appear under the revenue section rather than the cost section of the project's profitability report.

**Expected behavior:**
COGS lines are shown as costs.

**Steps to reproduce:**
1. Create a service product that generates a project on sale, on the project template set a specific analytic account

2. Create another product with real time valuation and assign the COGS account on the product category's expense account

3. Sell some of the service product and the auto val product in the same order, deliver it -> generate invoice & post it

4. In the project's settings, open the profitability report observe that the invoice line for the cost of goods sold account entry is displayed as a negative revenue, rather than a cost

**Cause of the issue:**
In `sale_project` there is no logic to separate the COGS AMLs from the rest of an invoice's line ids.

**Fix:**
Transform the loop in `_get_revenues_items_from_invoices` https://github.com/odoo/odoo/blob/bb6a4fbb92b1a1a1e13e32b27c4c9f2813570fda/addons/sale_project/models/project.py#L656 into two loops such that the existing one iterates twice.

First iteration collects the `revenues` items data (exactly as it currently does)

Second iteration collects the `costs` items (cogs lines)

And the method will now return a dict of data for both `revenues` report items and `costs` report items (and should be renamed/refactored in master)

opw-4652472