### PR TITLE
[IMP] web: add `fold_by_default` option for property separators and improve UI

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -48,7 +48,7 @@
                     <t t-set="fieldType" t-value="props.model.fields[fieldId].type"/>
                     <t t-if="!isInvisible(fieldInfo, slot.record)">
                         <li class="list-group-item d-flex text-nowrap align-items-center" t-att-class="fieldInfo.attrs.class"  t-att-data-tooltip="fieldType === 'html' ? '' : getFormattedValue(fieldId, slot.record)">
-                            <span class="fw-bold me-2" t-if="!fieldInfo.options.noLabel">
+                            <span class="fw-bold me-2" t-if="!fieldInfo.options.noLabel and fieldInfo.type !== 'properties'">
                                 <t t-if="fieldInfo.options.icon">
                                     <i t-attf-class="fa-fw {{fieldInfo.options.icon}} text-400" />
                                 </t>

--- a/addons/web/static/src/views/fields/properties/calendar_properties_field.js
+++ b/addons/web/static/src/views/fields/properties/calendar_properties_field.js
@@ -1,0 +1,16 @@
+import { registry } from "@web/core/registry";
+import { propertiesField, PropertiesField } from "./properties_field";
+
+export class CalendarPropertiesField extends PropertiesField {
+    static template = "web.CalendarPropertiesField";
+    async checkDefinitionWriteAccess() {
+        return false;
+    }
+}
+
+export const calendarPropertiesField = {
+    ...propertiesField,
+    component: CalendarPropertiesField,
+};
+
+registry.category("fields").add("calendar.properties", calendarPropertiesField);

--- a/addons/web/static/src/views/fields/properties/calendar_properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/calendar_properties_field.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <div t-name="web.CalendarPropertiesField" t-ref="properties" class="d-flex flex-column gap-3">
+        <div class="o_calendar_property_field d-flex"
+            t-foreach="propertiesList"
+            t-as="propertyConfiguration"
+            t-key="propertyConfiguration.name"
+            t-if="propertyConfiguration.value and propertyConfiguration.view_in_cards">
+            <span class="fw-bold me-2" t-out="propertyConfiguration.string"/>
+            <div class="text-truncate">
+                <PropertyValue
+                    id="generateUniqueDomID()"
+                    canChangeDefinition="state.canChangeDefinition"
+                    comodel="propertyConfiguration.comodel || ''"
+                    context="props.context"
+                    domain="propertyConfiguration.domain || '[]'"
+                    readonly="props.readonly"
+                    selection="propertyConfiguration.selection"
+                    string="propertyConfiguration.string"
+                    tags="propertyConfiguration.tags"
+                    type="propertyConfiguration.type"
+                    value="propertyConfiguration.value"
+                    onChange.bind="() => {}"
+                    onTagsChange.bind="() => {}"
+                />
+            </div>
+        </div>
+    </div>
+</templates>

--- a/addons/web/static/src/views/fields/properties/card_properties_field.js
+++ b/addons/web/static/src/views/fields/properties/card_properties_field.js
@@ -4,9 +4,8 @@ import { propertiesField, PropertiesField } from "./properties_field";
 export class CardPropertiesField extends PropertiesField {
     static template = "web.CardPropertiesField";
 
-    async _checkDefinitionAccess() {
-        // can not edit properties definition in cards
-        this.state.canChangeDefinition = false;
+    async checkDefinitionWriteAccess() {
+        return false;
     }
 }
 

--- a/addons/web/static/src/views/fields/properties/card_properties_field.js
+++ b/addons/web/static/src/views/fields/properties/card_properties_field.js
@@ -14,6 +14,5 @@ export const cardPropertiesField = {
     component: CardPropertiesField,
 };
 
-registry.category("fields").add("calendar.properties", cardPropertiesField);
 registry.category("fields").add("kanban.properties", cardPropertiesField);
 registry.category("fields").add("hierarchy.properties", cardPropertiesField);

--- a/addons/web/static/src/views/fields/properties/card_properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/card_properties_field.xml
@@ -8,7 +8,7 @@
                 t-key="propertyConfiguration.name"
                 t-if="propertyConfiguration.value and propertyConfiguration.view_in_cards">
                 <!-- We purposefully hide 'Falsy' values such as a False boolean or a 0 value integer field. -->
-                <div class="mw-100 text-truncate d-flex gap-2"
+                <div class="mw-100 text-truncate text-900 d-flex gap-2"
                     t-att-class="{'border rounded-3 ps-2' : propertyConfiguration.type === 'boolean'}">
                     <label t-if="['integer', 'float', 'date', 'datetime', 'boolean'].includes(propertyConfiguration.type)"
                         t-att-class="{'fw-bold' : propertyConfiguration.type !== 'boolean'}" t-out="propertyConfiguration.string"/>

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -651,7 +651,7 @@ export class PropertiesField extends Component {
                     parentFieldLabel: this.props.record.fields[this.definitionRecordField].string,
                 }
             ),
-            confirmLabel: _t("Delete"),
+            confirmLabel: _t("Delete Field"),
             confirm: () => {
                 const propertiesDefinitions = this.propertiesList;
                 propertiesDefinitions.find(

--- a/addons/web/static/src/views/fields/properties/properties_field.scss
+++ b/addons/web/static/src/views/fields/properties/properties_field.scss
@@ -55,6 +55,10 @@
 .o_field_property_label {
     width: 180px;
 
+    .fa-caret-down,
+    .fa-caret-right {
+        width: 8px;
+    }
     .o_field_property_open_popover,
     .oi-draggable {
         cursor: pointer;
@@ -96,7 +100,9 @@
     cursor: pointer;
     user-select: none;
     height: 20px;
-    box-shadow: 0 $border-width 0 $o-form-separator-color;
+    &:not(.folded) {
+        box-shadow: 0 $border-width 0 $o-form-separator-color;
+    }
 }
 
 .o_field_properties {

--- a/addons/web/static/src/views/fields/properties/properties_field.scss
+++ b/addons/web/static/src/views/fields/properties/properties_field.scss
@@ -55,17 +55,9 @@
 .o_field_property_label {
     width: 180px;
 
-    &:hover .o_field_property_open_popover,
-    .o_field_property_open_popover:focus,
-    &:hover .oi-draggable,
-    .oi-draggable:focus {
-        opacity: 1;
-    }
     .o_field_property_open_popover,
     .oi-draggable {
-        opacity: 0;
         cursor: pointer;
-        transition: 0.1s;
     }
     .o_field_property_open_popover:hover,
     .oi-draggable:hover {

--- a/addons/web/static/src/views/fields/properties/properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/properties_field.xml
@@ -11,8 +11,11 @@
                     t-att-property-name="propertiesListGroup.name || ''">
                     <div t-if="!propertiesListGroup.invisibleLabel"
                         class="o_field_property_label o_field_property_group_label d-flex flex-row w-100 mb-3 text-uppercase fw-bolder align-items-baseline pe-2"
-                        t-att-class="{'invisible': propertiesListGroup.columnSeparator}"
+                        t-att-class="{'invisible': propertiesListGroup.columnSeparator, 'folded': isFolded}"
                         t-on-click="() => this.onSeparatorClick(propertiesListGroup.name)">
+                        <div t-if="foldable" class="me-2">
+                            <i class="fa fa-fw" t-att-class="isFolded ? 'fa-caret-right' : 'fa-caret-down'"/>
+                        </div>
                         <span t-if="propertiesListGroup.title" t-out="propertiesListGroup.title"/>
                         <i
                             t-if="state.isInEditMode and !propertiesListGroup.columnSeparator"
@@ -20,15 +23,12 @@
                             t-on-click.prevent.stop="(event) => this.onPropertyEdit(event, propertiesListGroup.name)"/>
                         <i t-if="state.isInEditMode"
                             class="oi oi-draggable ms-1 d-none d-sm-block"/>
-                        <div t-if="foldable" class="ms-auto">
-                            <i class="fa me-1" t-att-class="isFolded ? 'fa-caret-right' : 'fa-caret-down'"/>
-                        </div>
                     </div>
                     <div
                         t-foreach="propertiesListGroup.elements"
                         t-as="propertyConfiguration"
                         t-key="propertyConfiguration.name"
-                        class="o_property_field o_wrap_label"
+                        class="o_property_field o_wrap_label text-900"
                         t-att-class="{
                             'd-flex flex-row': !env.isSmall and !isFolded, 'o_property_folded': isFolded,
                             'mb-4': renderedColumnsCount === 1, 'mb-3': renderedColumnsCount !== 1

--- a/addons/web/static/src/views/fields/properties/properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/properties_field.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.PropertiesField">
-        <div t-ref="properties" class="row"
-            t-att-class="{'d-none': propertiesList.length === 0 and !state.showAddButton}"
-            t-att-columns="renderedColumnsCount">
+        <div t-ref="properties" class="row" t-att-columns="renderedColumnsCount">
             <t t-set="unfoldedSeparators" t-value="state.unfoldedSeparators"/>
             <t t-set="_groupedPropertiesList" t-value="groupedPropertiesList"/>
             <t t-foreach="groupedPropertiesList" t-as="propertiesListGroup" t-key="propertiesListGroup_index">
@@ -17,10 +15,10 @@
                         t-on-click="() => this.onSeparatorClick(propertiesListGroup.name)">
                         <span t-if="propertiesListGroup.title" t-out="propertiesListGroup.title"/>
                         <i
-                            t-if="state.canChangeDefinition and !props.readonly and !propertiesListGroup.columnSeparator"
+                            t-if="state.isInEditMode and !propertiesListGroup.columnSeparator"
                             class="o_field_property_open_popover fa fa-pencil ms-3"
                             t-on-click.prevent.stop="(event) => this.onPropertyEdit(event, propertiesListGroup.name)"/>
-                        <i t-if="state.canChangeDefinition and !props.readonly"
+                        <i t-if="state.isInEditMode"
                             class="oi oi-draggable ms-1 d-none d-sm-block"/>
                         <div t-if="foldable" class="ms-auto">
                             <i class="fa me-1" t-att-class="isFolded ? 'fa-caret-right' : 'fa-caret-down'"/>
@@ -50,17 +48,16 @@
                                 New Property
                             </i>
                             <i
-                                t-if="state.canChangeDefinition and !props.readonly"
+                                t-if="state.isInEditMode"
                                 class="o_field_property_open_popover fa fa-pencil ms-2"
                                 t-on-click="(event) => this.onPropertyEdit(event, propertyConfiguration.name)"/>
-                            <i t-if="state.canChangeDefinition and !props.readonly"
+                            <i t-if="state.isInEditMode"
                                 class="oi oi-draggable ms-1 d-none d-sm-block"/>
                         </label>
                         <div class="o_property_field_value w-100">
                             <PropertyValue
                                 id="domId"
                                 canChangeDefinition="state.canChangeDefinition"
-                                checkDefinitionWriteAccess.bind="checkDefinitionWriteAccess ? checkDefinitionWriteAccess : () => {}"
                                 comodel="propertyConfiguration.comodel || ''"
                                 context="props.context"
                                 domain="propertyConfiguration.domain || '[]'"
@@ -76,11 +73,11 @@
                         </div>
                     </div>
                     <div
-                        t-if="propertiesListGroup_index === _groupedPropertiesList.length - 1 and state.showAddButton"
+                        t-if="propertiesListGroup_index === _groupedPropertiesList.length - 1"
                         class="o_field_property_add d-none d-sm-block"
                         t-att-class="{'g-col-2': props.columns !== 1}">
                         <button
-                            t-if="!props.readonly and state.canChangeDefinition and definitionRecordId"
+                            t-if="state.isInEditMode and definitionRecordId"
                             class="btn btn-light text-muted text-break m-0"
                             t-on-click="onPropertyCreate">
                             <i class="fa fa-plus"/>

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -353,6 +353,19 @@ export class PropertyDefinition extends Component {
         this.state.propertyDefinition = propertyDefinition;
     }
 
+    /**
+     * Ensure the section below the separator is folded/unfolded by default
+     * @param {boolean} checked
+     */
+    onFoldByDefaultChange(checked) {
+        const propertyDefinition = {
+            ...this.state.propertyDefinition,
+            fold_by_default: checked,
+        };
+        this.props.onChange(propertyDefinition);
+        this.state.propertyDefinition = propertyDefinition;
+    }
+
     /* --------------------------------------------------------
      * Private methods
      * -------------------------------------------------------- */

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -32,7 +32,6 @@ export class PropertyDefinition extends Component {
         fieldName: { type: String },
         readonly: { type: Boolean, optional: true },
         canChangeDefinition: { type: Boolean, optional: true },
-        checkDefinitionWriteAccess: { type: Function, optional: true },
         propertyDefinition: { optional: true },
         context: { type: Object },
         isNewlyCreated: { type: Boolean, optional: true },

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -169,6 +169,17 @@
                         onChange.bind="onViewInKanbanChange"
                     />
                 </div>
+                <div t-else="" class="o_field_property_definition_kanban d-contents mb-3 mb-sm-0">
+                    <label t-att-for="getUniqueDomID('fold')" class="o_form_label align-self-center text-900">
+                        Fold by default
+                    </label>
+                    <CheckBox
+                        id="getUniqueDomID('fold')"
+                        value="props.propertyDefinition.fold_by_default"
+                        disabled="props.readonly"
+                        onChange.bind="onFoldByDefaultChange"
+                    />
+                </div>
             </div>
         </div>
     </t>

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -98,7 +98,6 @@
                         tags="state.propertyDefinition.tags || []"
                         readonly="props.readonly"
                         canChangeTags="props.canChangeDefinition"
-                        checkDefinitionWriteAccess.bind="props.checkDefinitionWriteAccess ? props.checkDefinitionWriteAccess : () => {}"
                         deleteAction="'tags'"
                         onTagsChange.bind="onTagsChange"/>
                 </div>

--- a/addons/web/static/src/views/fields/properties/property_tags.js
+++ b/addons/web/static/src/views/fields/properties/property_tags.js
@@ -46,7 +46,6 @@ export class PropertyTags extends Component {
         deleteAction: { type: String },
         readonly: { type: Boolean, optional: true },
         canChangeTags: { type: Boolean, optional: true },
-        checkDefinitionWriteAccess: { type: Function, optional: true },
         // Select a new value
         onValueChange: { type: Function, optional: true },
         // Change the tags definition (can also receive a second
@@ -227,17 +226,9 @@ export class PropertyTags extends Component {
             return;
         }
 
-        if (!(await this.props.checkDefinitionWriteAccess())) {
-            this.notification.add(
-                _t("You need to be able to edit parent first to add property tags"),
-                { type: "warning" }
-            );
-            return;
-        }
-
         const newValue = newLabel ? newLabel.toLowerCase().replace(" ", "_") : "";
-
         const existingTag = this.props.tags.find((tag) => tag[0] === newValue);
+
         if (existingTag) {
             this.notification.add(_t("This tag is already available"), {
                 type: "warning",

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -60,7 +60,6 @@ export class PropertyValue extends Component {
         context: { type: Object },
         readonly: { type: Boolean, optional: true },
         canChangeDefinition: { type: Boolean, optional: true },
-        checkDefinitionWriteAccess: { type: Function, optional: true },
         selection: { type: Array, optional: true },
         tags: { type: Array, optional: true },
         onChange: { type: Function, optional: true },

--- a/addons/web/static/src/views/fields/properties/property_value.xml
+++ b/addons/web/static/src/views/fields/properties/property_value.xml
@@ -62,7 +62,6 @@
                     deleteAction="'value'"
                     readonly="props.readonly"
                     canChangeTags="props.canChangeDefinition"
-                    checkDefinitionWriteAccess.bind="props.checkDefinitionWriteAccess ? props.checkDefinitionWriteAccess : () => {}"
                     onValueChange.bind="onValueChange"
                     onTagsChange.bind="props.onTagsChange"/>
             </t>

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -503,8 +503,8 @@ export class FormController extends Component {
                 isAvailable: () => activeActions.addPropertyFieldValue,
                 sequence: 50,
                 icon: "fa fa-cogs",
-                description: _t("Add Properties"),
-                callback: () => this.model.bus.trigger("PROPERTY_FIELD:ADD_PROPERTY_VALUE"),
+                description: _t("Edit Properties"),
+                callback: () => this.model.bus.trigger("PROPERTY_FIELD:EDIT"),
             },
         };
     }

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -4985,7 +4985,13 @@ test(`calendar render properties in popover`, async () => {
 
     await clickEvent(1);
     const popover = getMockEnv().isSmall ? ".modal" : ".o_popover";
-    expect(queryAllTexts(`${popover} .o_field_properties .o_card_property_field`)).toEqual([
+    // Labels:
+    expect(queryAllTexts(`${popover} .o_calendar_property_field span.fw-bold`)).toEqual([
+        "My Char",
+        "My Selection",
+    ]);
+    // Values:
+    expect(queryAllTexts(`${popover} .o_calendar_property_field div.text-truncate`)).toEqual([
         "hello",
         "B",
     ]);

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -289,11 +289,10 @@ test("properties: no access to parent", async () => {
     expect(".o_field_properties").toHaveCount(1, { message: "The field must be in the view" });
 
     await toggleActionMenu();
-
-    expect(".o-dropdown--menu span:contains(Add Properties)").toHaveCount(1, {
-        message: "Show Add Properties btn in cog menu",
+    expect(".o-dropdown--menu span:contains(Edit Properties)").toHaveCount(1, {
+        message: "The 'Edit Properties' btn should be in the cog menu",
     });
-    await toggleMenuItem("Add Properties");
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
     expect(".o_field_properties:first-child .o_field_property_open_popover").toHaveCount(0, {
         message: "The edit definition button must not be in the view",
     });
@@ -328,10 +327,10 @@ test("properties: access to parent", async () => {
     expect(".o_field_properties").toHaveCount(1, { message: "The field must be in the view" });
 
     await toggleActionMenu();
-
-    expect(".o-dropdown--menu span:contains(Add Properties)").toHaveCount(1, {
-        message: "Show Add Properties btn in cog menu",
+    expect(".o-dropdown--menu span:contains(Edit Properties)").toHaveCount(1, {
+        message: "Show 'Edit Properties' btn in cog menu",
     });
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
 
     expect(".o_field_properties:first-child .o_field_property_open_popover").not.toBeEmpty({
         message: "The edit definition button must be in the view",
@@ -422,16 +421,14 @@ test("properties: add a new property", async () => {
     expect(".o_field_properties").toHaveCount(1);
 
     await toggleActionMenu();
-    await animationFrame();
-
-    expect(".o-dropdown--menu span:contains(Add Properties)").toHaveCount(1, {
-        message: "The add button must be in the cog menu",
+    expect(".o-dropdown--menu span:contains(Edit Properties)").toHaveCount(1, {
+        message: "The 'Edit Properties' btn should be in the cog menu",
     });
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
 
     // Create a new property
-    await click(".o-dropdown--menu span .fa-cogs");
-    await runAllTimers();
-    await animationFrame();
+    await click(".o_field_property_add button");
+    await waitFor(".o_property_field_popover");
 
     expect(".o_property_field_popover").toHaveCount(1, {
         message: "Should have opened the definition popover",
@@ -471,12 +468,15 @@ test("properties: selection", async () => {
                     </group>
                 </sheet>
             </form>`,
+        actionMenus: {},
     });
 
     expect(".o_field_properties").toHaveCount(1);
     expect(".o_property_field:nth-child(2) select").toHaveCount(1);
     expect(".o_property_field:nth-child(2) select").toHaveValue("b");
 
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
     // Edit the selection property
     await click(".o_property_field:nth-child(2) .o_field_property_open_popover");
     await animationFrame();
@@ -601,9 +601,13 @@ test("properties: float and integer", async () => {
                     </group>
                 </sheet>
             </form>`,
+        actionMenus: {},
     });
 
     expect(".o_field_properties").toHaveCount(1);
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
 
     // change type to float
     await click(".o_property_field:nth-child(2) .o_field_property_open_popover");
@@ -710,9 +714,14 @@ test("properties: move properties", async () => {
                     </group>
                 </sheet>
             </form>`,
+        actionMenus: {},
     });
 
     expect(".o_field_properties").toHaveCount(1, { message: "The field must be in the view" });
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+
     // Edit the selection property
     await click(".o_property_field:nth-child(2) .o_field_property_open_popover");
     await waitFor(".o_property_field_popover");
@@ -783,6 +792,7 @@ test("properties: tags", async () => {
                         </group>
                     </sheet>
                 </form>`,
+        actionMenus: {},
     });
 
     const createNewTag = async (selector, text) => {
@@ -792,6 +802,9 @@ test("properties: tags", async () => {
         await click(".o_field_property_dropdown_add .dropdown-item");
         await animationFrame();
     };
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
 
     await click(".o_property_field:nth-child(2) .o_field_property_open_popover");
     await animationFrame();
@@ -916,7 +929,11 @@ test("properties: many2one", async () => {
                     </group>
                 </sheet>
             </form>`,
+        actionMenus: {},
     });
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
 
     await click(".o_property_field:nth-child(2) .o_field_property_open_popover");
     await waitFor(".o_property_field_popover");
@@ -1002,9 +1019,14 @@ test("properties: many2many", async () => {
                     </group>
                 </sheet>
             </form>`,
+        actionMenus: {},
     });
 
     const getSelectedUsers = () => queryAllTexts(".o_property_field_value .o_tag_badge_text");
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+
     await click(".o_property_field:nth-child(2) .o_field_property_open_popover");
     await animationFrame();
     const popover = queryFirst(".o_property_field_popover");
@@ -1146,7 +1168,11 @@ test("properties: many2one 'Search more...'", async () => {
                     </group>
                 </sheet>
             </form>`,
+        actionMenus: {},
     });
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
 
     // Opening the popover
     await click('[property-name="many_2_one"] .o_field_property_open_popover');
@@ -1232,7 +1258,7 @@ test("properties: date(time) property manipulations", async () => {
         resId: 5000,
         arch: /* xml */ `<form><field name="company_id"/><field name="properties"/></form>`,
     });
-    expect.verifySteps(["get_views", "web_read", "has_access"]);
+    expect.verifySteps(["get_views", "web_read"]);
 
     // check initial properties
     expect("[property-name=property_1] .o_property_field_value input").toHaveValue("01/01/2019");
@@ -1303,9 +1329,13 @@ test("properties: name reset", async () => {
                     </group>
                 </sheet>
             </form>`,
+        actionMenus: {},
     });
 
     expect('.o_property_field[property-name="property_2"]').toHaveCount(1);
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
 
     // open the definition popover
     await click(".o_property_field:nth-child(2) .o_field_property_open_popover");
@@ -1705,14 +1735,15 @@ test("properties: default value", async () => {
 
     expect(".o_field_properties").toHaveCount(1);
 
-    // create a new property
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+
+    // add a new property field
+    await click(".o_field_property_add button");
+    await waitFor(".o_property_field_popover");
+
     // edit the default value and close the popover definition
     // because we just created the property, the default value should be propagated
-    await toggleActionMenu();
-    await click(".o-dropdown--menu span .fa-cogs");
-    await runAllTimers();
-    await animationFrame();
-
     await click(".o_field_property_definition_value input");
     await edit("First Default Value", { confirm: "Enter" });
     await animationFrame();
@@ -1768,9 +1799,11 @@ test("properties: default value date", async () => {
     });
     expect(".o_field_properties").toHaveCount(1, { message: "The field must be in the view" });
 
-    // add a new date property
     await toggleActionMenu();
-    await click(".o_popover span .fa-cogs");
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+
+    // add a new date property
+    await click(".o_field_property_add button");
     await waitFor(".o_property_field_popover");
     await changeType("date");
     expect(".o_property_field_popover .o_field_property_definition_type input").toHaveValue(
@@ -1816,7 +1849,11 @@ test("properties: close property popover once clicked on delete icon", async () 
                     </group>
                 </sheet>
             </form>`,
+        actionMenus: {},
     });
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
 
     // We open the property popover
     await click(".o_property_field:first-child .o_field_property_open_popover");
@@ -1831,7 +1868,7 @@ test("properties: close property popover once clicked on delete icon", async () 
 });
 
 /**
- * Check the behavior of the domain (properies with "definition_deleted" should be ignored).
+ * Check the behavior of the domain (properties with "definition_deleted" should be ignored).
  * In that case, some properties start without the flag "definition_deleted".
  */
 test("properties: form view and falsy domain, properties are not empty", async () => {
@@ -1855,7 +1892,12 @@ test("properties: form view and falsy domain, properties are not empty", async (
                     </group>
                 </sheet>
             </form>`,
+        actionMenus: {},
     });
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+
     expect(".o_test_properties_not_empty").toHaveCount(1);
 
     // delete a property, 2 properties left
@@ -1930,6 +1972,8 @@ test("properties: form view and falsy domain, properties are empty", async () =>
 test.tags("desktop");
 test("properties: separators layout", async () => {
     await makePropertiesGroupView([false, false, false, false]);
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
     await toggleSeparator("property_1", true);
     expect(getGroups()).toEqual([
         [
@@ -1978,9 +2022,7 @@ test("properties: separators layout", async () => {
     await click(".o_property_group[property-name='property_gen_2'] .o_field_property_group_label");
     await animationFrame();
     // create 3 new properties
-    await toggleActionMenu();
-    await animationFrame();
-    await click(".o-dropdown--menu span .fa-cogs");
+    await click(".o_field_property_add button");
     await animationFrame();
     await click(".o_field_property_add button");
     await animationFrame();
@@ -2127,6 +2169,9 @@ test("properties: separators move properties", async () => {
         [["SEPARATOR 6", "property_6"]],
     ]);
 
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+
     // move the first property down
     await click("[property-name='property_1'] .o_field_property_open_popover");
     await animationFrame();
@@ -2232,8 +2277,7 @@ test("properties: separators move properties", async () => {
     assertFolded([false, false, false, true]);
 
     // now, create a new property, it must unfold the last group
-    await toggleActionMenu();
-    await click(".o-dropdown--menu span .fa-cogs");
+    await click(".o_field_property_add button");
     await animationFrame();
     expect(getGroups()).toEqual([
         [
@@ -2275,8 +2319,11 @@ test("properties: separators drag and drop", async () => {
     const getPropertyHandleElement = (propertyName) =>
         queryFirst(`*[property-name='${propertyName}'] .oi-draggable`);
 
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+
     // if we move properties inside the same column, do not generate the group
-    await contains(getPropertyHandleElement("property_1"), { visible: false }).dragAndDrop(
+    await contains(getPropertyHandleElement("property_1")).dragAndDrop(
         getPropertyHandleElement("property_3")
     );
     expect(getGroups()).toEqual([
@@ -2294,7 +2341,7 @@ test("properties: separators drag and drop", async () => {
     ]);
 
     // but if we move a property in a different column, we need to generate the group
-    await contains(getPropertyHandleElement("property_3"), { visible: false }).dragAndDrop(
+    await contains(getPropertyHandleElement("property_3")).dragAndDrop(
         getPropertyHandleElement("property_4")
     );
     expect(getGroups()).toEqual([
@@ -2317,7 +2364,7 @@ test("properties: separators drag and drop", async () => {
     await click("div[property-name='property_gen_2'] .o_field_property_group_label");
 
     // drag and drop the firth property in the folded group
-    await contains(getPropertyHandleElement("property_5"), { visible: false }).dragAndDrop(
+    await contains(getPropertyHandleElement("property_5")).dragAndDrop(
         getPropertyHandleElement("property_gen_2")
     );
     // should unfold automatically
@@ -2336,7 +2383,7 @@ test("properties: separators drag and drop", async () => {
     ]);
 
     // drag and drop the first group at the second position
-    await contains(getPropertyHandleElement("property_gen_2"), { visible: false }).dragAndDrop(
+    await contains(getPropertyHandleElement("property_gen_2")).dragAndDrop(
         getPropertyHandleElement("property_gen_3")
     );
     expect(getGroups()).toEqual([
@@ -2354,7 +2401,7 @@ test("properties: separators drag and drop", async () => {
     ]);
 
     // move property 3 at the last position of the other group
-    await contains(getPropertyHandleElement("property_3"), { visible: false }).dragAndDrop(
+    await contains(getPropertyHandleElement("property_3")).dragAndDrop(
         getPropertyHandleElement("property_gen_2")
     );
     expect(getGroups()).toEqual([
@@ -2372,7 +2419,7 @@ test("properties: separators drag and drop", async () => {
     ]);
 
     // move property 3 at the first position of its group
-    await contains(getPropertyHandleElement("property_3"), { visible: false }).dragAndDrop(
+    await contains(getPropertyHandleElement("property_3")).dragAndDrop(
         getPropertyHandleElement("property_2")
     );
     expect(getGroups()).toEqual([
@@ -2390,7 +2437,7 @@ test("properties: separators drag and drop", async () => {
     ]);
 });
 
-test("properties: showAddButton option", async () => {
+test("properties: start in edit mode", async () => {
     onRpc("has_access", () => true);
     await mountView({
         type: "form",
@@ -2401,7 +2448,7 @@ test("properties: showAddButton option", async () => {
                 <sheet>
                     <group>
                         <field name="company_id"/>
-                        <field name="properties" showAddButton="True"/>
+                        <field name="properties" editMode="True"/>
                     </group>
                 </sheet>
             </form>`,
@@ -2420,7 +2467,7 @@ test("properties: no add properties action in cogmenu if no properties field", a
         actionMenus: {},
     });
     await toggleActionMenu();
-    expect(".o-dropdown--menu span:contains(Add Properties)").toHaveCount(0);
+    expect(".o-dropdown--menu span:contains(Edit Properties)").toHaveCount(0);
 });
 
 test.tags("desktop");
@@ -2495,22 +2542,22 @@ test("new property, change record, change property type", async () => {
             </form>`,
         actionMenus: {},
     });
-    // Add a new property
+
     await toggleActionMenu();
-    await click(".o_popover span .fa-cogs");
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
 
     await contains(".o_property_field .o_property_field_value input").edit("aze");
     await contains(".o_pager_next").click();
     expect(".o_property_field .o_property_field_value input").toHaveValue("");
     // Change second record's property type
-    await contains(".o_property_field .o_field_property_open_popover", { visible: false }).click();
+    await contains(".o_property_field .o_field_property_open_popover").click();
     await changeType("integer");
 
     await contains(".o_pager_previous").click();
     expect(".o_property_field .o_property_field_value input").toHaveValue("0");
 });
 
-test("property many2one, change proerty type from many2one to integer", async () => {
+test("property many2one, change property type from many2one to integer", async () => {
     Partner._records = [
         {
             id: 1,
@@ -2563,8 +2610,12 @@ test("property many2one, change proerty type from many2one to integer", async ()
             </form>`,
         actionMenus: {},
     });
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+
     // Change the record's property type
-    await contains(".o_property_field .o_field_property_open_popover", { visible: false }).click();
+    await contains(".o_property_field .o_field_property_open_popover").click();
     await changeType("integer");
 
     // save
@@ -2574,9 +2625,9 @@ test("property many2one, change proerty type from many2one to integer", async ()
 test.tags("desktop");
 test("properties: moving single property to 2nd group in auto split mode", async () => {
     await makePropertiesGroupView([false]);
-    const { moveTo, drop } = await contains(getPropertyHandleElement("property_1"), {
-        visible: false,
-    }).drag();
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+    const { moveTo, drop } = await contains(getPropertyHandleElement("property_1")).drag();
     const secondGroup = queryFirst(".o_property_group:last-of-type");
     await moveTo(secondGroup, "bottom");
     await drop();
@@ -2592,10 +2643,11 @@ test("properties: moving single property to 2nd group in auto split mode", async
 test.tags("desktop");
 test("properties: moving single property to 1st group", async () => {
     await makePropertiesGroupView([true, true, false]);
-
-    await contains(getPropertyHandleElement("property_3"), {
-        visible: false,
-    }).dragAndDrop(getPropertyHandleElement("property_1"));
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+    await contains(getPropertyHandleElement("property_3")).dragAndDrop(
+        getPropertyHandleElement("property_1")
+    );
     expect(getGroups()).toEqual([
         [
             ["SEPARATOR 1", "property_1"],
@@ -2608,10 +2660,12 @@ test("properties: moving single property to 1st group", async () => {
 test.tags("desktop");
 test("properties: split, moving property from 2nd group to 1st", async () => {
     await makePropertiesGroupView([true, false, false]);
-
-    await contains(getPropertyHandleElement("property_3"), {
-        visible: false,
-    }).dragAndDrop(getPropertyHandleElement("property_2"), "top");
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+    await contains(getPropertyHandleElement("property_3")).dragAndDrop(
+        getPropertyHandleElement("property_2"),
+        "top"
+    );
     expect(getGroups()).toEqual([
         [
             ["SEPARATOR 1", "property_1"],
@@ -2625,10 +2679,12 @@ test("properties: split, moving property from 2nd group to 1st", async () => {
 test.tags("desktop");
 test("properties: split, moving property from 1st group to 2nd", async () => {
     await makePropertiesGroupView([true, false, false, false, false, false]);
-
-    await contains(getPropertyHandleElement("property_3"), {
-        visible: false,
-    }).dragAndDrop(getPropertyHandleElement("property_6"), "top");
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties"); // Start the edition mode
+    await contains(getPropertyHandleElement("property_3")).dragAndDrop(
+        getPropertyHandleElement("property_6"),
+        "top"
+    );
     expect(getGroups()).toEqual([
         [
             ["SEPARATOR 1", "property_1"],

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -777,7 +777,7 @@ class PropertiesDefinition(Field):
     REQUIRED_KEYS = ('name', 'type')
     ALLOWED_KEYS = (
         'name', 'string', 'type', 'comodel', 'default',
-        'selection', 'tags', 'domain', 'view_in_cards',
+        'selection', 'tags', 'domain', 'view_in_cards', 'fold_by_default'
     )
     # those keys will be removed if the types does not match
     PROPERTY_PARAMETERS_MAP = {


### PR DESCRIPTION
This PR adds a new option for property separators, enabling users to specify whether the property fields under a separator should be initially collapsed when loading the view. This enhancement provides users with greater control over the view display, allowing them to hide less important fields for a cleaner interface.

[Task-4610816](https://www.odoo.com/odoo/all-tasks/4610816)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
