### PR TITLE
[FIX] account,account_edi_ubl_cii: wrong compute invoice_edi_format

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -670,9 +670,10 @@ class ResPartner(models.Model):
         return self.env['res.partner.bank'].search(domain)
 
     @api.depends_context('company')
+    @api.depends('commercial_partner_id.country_code')
     def _compute_invoice_edi_format(self):
         for partner in self:
-            if partner.commercial_partner_id.invoice_edi_format_store == 'none':
+            if not partner.commercial_partner_id or partner.commercial_partner_id.invoice_edi_format_store == 'none':
                 partner.invoice_edi_format = False
             else:
                 partner.invoice_edi_format = partner.commercial_partner_id.invoice_edi_format_store or partner.commercial_partner_id._get_suggested_invoice_edi_format()

--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -189,11 +189,6 @@ class ResPartner(models.Model):
         # because we need to extend depends in l10n modules
         return ['country_code', 'vat', 'company_registry']
 
-    @api.depends(lambda self: self._peppol_eas_endpoint_depends())
-    def _compute_invoice_edi_format(self):
-        # EXTENDS 'account' - add depends
-        super()._compute_invoice_edi_format()
-
     @api.depends_context('company')
     @api.depends('invoice_edi_format')
     def _compute_is_ubl_format(self):


### PR DESCRIPTION
Typically, the field commercial_partner_id on res.partner is not displayed on the Form view. However, adding it via Studio or other means will lead to an error if the following conditions are met.

Issue
We click New to start creating a new record (still in NewId phase) We trigger an onchange that will lead to invoice_edi_format being computed When clicking New the commercial_partner_id is computed initially. However, this value isn't present on the Form view yet which leaves the field empty until we actually save (and create) the record. Prior to this, if another onchange is called we'll pass commercial_partner_id as False in the onchange, eventually erroring out when we try to call a method on the value's record.

Solution:
After multiple fixes and refactor, it looks like dependencies on the compute are no longer relevant. Indeed, `_get_suggested_invoice_edi_format` only depends on the commercial partner's country code now. Also only compute the edi format if the commercial partner is set.

opw-4630096
