### PR TITLE
[IMP] payment: Allow public access to payment method management with token

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -190,7 +190,7 @@ class PaymentPortal(portal.CustomerPortal):
     def _get_payment_page_template_xmlid(self, **kwargs):
         return 'payment.pay'
 
-    @http.route('/my/payment_method', type='http', methods=['GET'], auth='user', website=True)
+    @http.route('/my/payment_method', type='http', methods=['GET'], auth='public', website=True)
     def payment_method(self, **kwargs):
         """ Display the form to manage payment methods.
 


### PR DESCRIPTION
Before this commit:
-  `/my/payment_method` required login, blocking public access.
- Users with an access token were still redirected to login.

After this commit:
- Set auth='public' to allow access with a valid access token.
- Verifies access token to ensure security and smooth management.

Task:4656239
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
