### PR TITLE
[FIX] l10n_hu_edi: Fix mapping for uom 'liter'

### DIFF
--- a/addons/l10n_hu_edi/data/uom.uom.csv
+++ b/addons/l10n_hu_edi/data/uom.uom.csv
@@ -4,7 +4,7 @@
 "uom.product_uom_hour","HOUR"
 "uom.product_uom_meter","METER"
 "uom.product_uom_km","KILOMETER"
-"uom.product_uom_litre","LITRE"
+"uom.product_uom_litre","LITER"
 "uom.product_uom_cubic_meter","CUBIC_METER"
 "uom.product_uom_kgm","KILOGRAM"
 "uom.product_uom_ton","TON"

--- a/addons/l10n_hu_edi/models/uom_uom.py
+++ b/addons/l10n_hu_edi/models/uom_uom.py
@@ -16,7 +16,7 @@ class ProductUoM(models.Model):
             ('HOUR', 'Hour'),
             ('MINUTE', 'Minute'),
             ('MONTH', 'Month'),
-            ('LITRE', 'Litre'),
+            ('LITER', 'Liter'),
             ('KILOMETER', 'Kilometer'),
             ('CUBIC_METER', 'Cubic meter'),
             ('METER', 'Meter'),


### PR DESCRIPTION
LITRE is used instead of LITER in the uom definition, it causes a NAV validation error and the invoice cannot be submitted.

task-4661729