### PR TITLE
[FIX] MRP: prevent KeyError when indexing res with a missing key

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -120,6 +120,8 @@ class StockWarehouseOrderpoint(models.Model):
             ['orderpoint_id', 'product_uom_id'],
             ['product_qty:sum'])
         for orderpoint, uom, product_qty_sum in productions_group:
+            if orderpoint.id not in res:
+                continue
             res[orderpoint.id] += uom._compute_quantity(
                 product_qty_sum, orderpoint.product_uom, round=False)
 
@@ -135,6 +137,8 @@ class StockWarehouseOrderpoint(models.Model):
             date_start, date_finished, orderpoint = prod.date_start, prod.date_finished, prod.orderpoint_id
             lead_days_date = datetime.combine(orderpoint.lead_days_date, time.max)
             if date_start <= lead_days_date < date_finished:
+                if orderpoint.id not in res:
+                    continue
                 res[orderpoint.id] += prod.product_uom_id._compute_quantity(
                         prod.product_qty, orderpoint.product_uom, round=False)
         return res


### PR DESCRIPTION
When modifying fields in a replenishment rule with an associated Manufacturing 
Order (MO) in a confirmed state and a lead_timedate between 
date_start and date_finished, the orderpoint.id 
sometimes contained <NewId>. This resulted in a KeyError when attempting to 
index res[orderpoint.id] in _quantity_in_progress.

Steps to reproduce:
Install MRP
Go to Inventory > Operations > Replenishment

1. Click new > select product `[[D_0045_GR] Stool (Grey)]` and set min and max as 1
2. Press 'Order' button of selected product
3. Open Bill of material of product `[D_0045] Stool`
4. Go to the Miscellaneous Page and make Manuf. Lead Time it 10 days and save it.
5. Open manufacturing order of product `[[D_0045_GR] Stool (Grey)]`
6. Select Scheduled Date Field and put it 2 days into the future if date is 2
    future date should be 4.
7. Go back to Inventory App Operations>Replenishment.
8. Remove default filters To Reorder and Not Snoozed.
9. Stool Grey should now be visible make the `Min = 2` and then only click on Max
    Value (Not anywhere else, do not save it).


KeyError: 8

Solution:
1.Check if the orderpoint exist in res
2.If the key does not exist we initialize it. 
3.This ensures there are no key errors.

Sentry - 6135193468

