### PR TITLE
[FIX] base: Prevent concurrent module operations

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -27426,6 +27426,14 @@ msgstr ""
 
 #. module: base
 #. odoo-python
+#: code:addons/base/models/ir_module.py:0
+msgid ""
+"Odoo is currently processing another module operation.\n"
+"Please try again later or contact your system administrator."
+msgstr ""
+
+#. module: base
+#. odoo-python
 #: code:addons/base/models/ir_actions_report.py:0
 msgid ""
 "Odoo is unable to merge the generated PDFs because of %(num_errors)s "


### PR DESCRIPTION
Before this commit, a user could start a module installation, abandon the loading page due to impatience, and attempt to start another installation. This could lead to various errors, such as `SERIALIZATION_FAILURE`, "Failed to load registry," or even a broken database.

Module operations (install/upgrade/uninstall) are executed in multiple transactions:
1. Dependency Check & State Update:
   - A transaction checks module dependencies, determines which modules need updating, and marks them as 'to install', 'to upgrade', or 'to remove'.
2. Registry Reload & Module Update:
   - The registry is reloaded, and modules are updated one by one in their own transactions, changing their states to 'installed' or 'uninstalled'.

This commit introduces two additional checks in step (1): a. If any module is already in an updating state, raise a `UserError` to prevent
   concurrent module operations in step (2).
b. If the transaction fails to acquire a `SELECT ... FOR UPDATE` lock on all
   `ir_module_module` records, raise a `UserError`, as this indicates another
   concurrent operation of step (1) has either acquired the lock or already
   modified some module states and committed.

These checks ensure proper concurrency control, preventing concurrent module operations

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
