### PR TITLE
[IMP] {stock_}delivery: restrict delivery carrier selection in pickings

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -128,13 +128,8 @@ class SaleOrder(models.Model):
         view_id = self.env.ref('delivery.choose_delivery_carrier_view_form').id
         if self.env.context.get('carrier_recompute'):
             name = _('Update shipping cost')
-            carrier = self.carrier_id
         else:
             name = _('Add a shipping method')
-            carrier = (
-                self.with_company(self.company_id).partner_shipping_id.property_delivery_carrier_id
-                or self.with_company(self.company_id).partner_shipping_id.commercial_partner_id.property_delivery_carrier_id
-            )
         return {
             'name': name,
             'type': 'ir.actions.act_window',
@@ -145,7 +140,7 @@ class SaleOrder(models.Model):
             'target': 'new',
             'context': {
                 'default_order_id': self.id,
-                'default_carrier_id': carrier.id,
+                'default_carrier_id': self.carrier_id,
                 'default_total_weight': self._get_estimated_weight()
             }
         }

--- a/addons/delivery/wizard/choose_delivery_carrier.py
+++ b/addons/delivery/wizard/choose_delivery_carrier.py
@@ -17,6 +17,7 @@ class ChooseDeliveryCarrier(models.TransientModel):
         'delivery.carrier',
         string="Shipping Method",
         required=True,
+        domain="[('id', 'in', available_carrier_ids)]",
     )
     delivery_type = fields.Selection(related='carrier_id.delivery_type')
     delivery_price = fields.Float()

--- a/addons/delivery/wizard/choose_delivery_carrier_views.xml
+++ b/addons/delivery/wizard/choose_delivery_carrier_views.xml
@@ -5,10 +5,9 @@
         <field name="model">choose.delivery.carrier</field>
         <field name="arch" type="xml">
             <form>
-                <field name='available_carrier_ids' invisible="1"/>
                 <group>
                     <group>
-                        <field name="carrier_id" domain="[('id', 'in', available_carrier_ids)]"/>
+                        <field name="carrier_id"/>
                         <label name="carried_weight_label" for="total_weight" groups="uom.group_uom"/>
                         <div name="carried_weight" class="o_row" groups="uom.group_uom">
                             <field name="total_weight"/>


### PR DESCRIPTION
This commit applies the same restrictions applied on sale orders when selecting a delivery carrier, on stock pickings. Therefore, consistency is ensured between both models.

Task-4555994

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
