### PR TITLE
[FIX] mrp: avoid incorrect final product variant reset on bom update

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -394,7 +394,7 @@ class MrpProduction(models.Model):
         for production in self:
             bom = production.bom_id
             if bom and (
-                not production.product_id or bom.product_tmpl_id != production.product_tmpl_id
+                not production.product_id or bom.product_tmpl_id != production.product_id.product_tmpl_id
                 or bom.product_id and bom.product_id != production.product_id
             ):
                 production.product_id = bom.product_id or bom.product_tmpl_id.product_variant_id


### PR DESCRIPTION
### Issue:

Tldr: If a field A depends on an other computed field B and if the value of A is used in the computation of the field B, the ORM will consider that the value of A is false  (or empty record set) in the computation of B.

On the `mrp.production` model, the `product_tmpl_id` is a related non stored field:
https://github.com/odoo/odoo/blob/4cb362fcc3c2ba2489ef1de7c20c9a4fd8921ab8/addons/mrp/models/mrp_production.py#L82 depending on the `product_id` field. This means that if we need to access the value of that field, we will first need to access the value of the `product_id` field. However, the `product_id` field is a computed field: https://github.com/odoo/odoo/blob/4cb362fcc3c2ba2489ef1de7c20c9a4fd8921ab8/addons/mrp/models/mrp_production.py#L62-L66 So that if its value is marked as dirty in the cache at the moment we try to access the value of the `product_tmpl_id` of the we will launch a call of its compute method. This is problematic because the 'related' that launched the compute is used inside the compute method: https://github.com/odoo/odoo/blob/4cb362fcc3c2ba2489ef1de7c20c9a4fd8921ab8/addons/mrp/models/mrp_production.py#L397 This is probelmatic because it would technically lead to an infinite recursion loop. So, to avoid any of these situation, when the computation of the `mrp.production.product_tmpl_id` has been started the filed has been marked as protected and is used as "False" in each of the subsequent computations:
https://github.com/odoo/odoo/blob/4cb362fcc3c2ba2489ef1de7c20c9a4fd8921ab8/odoo/fields.py#L1295-L1299 In particular, we will compute the `product_id` of the mrp.production considering that the `product_tmpl_id` is false and we will therefore set a wrong value on the bom.

### Steps to reproduce:

Using studio, you can create a set of fields linked to the 'product.template' and `mrp.production` models and an automated rule that will force a situation where the above situation will be triggered with the following flow:
- Create a product with 2 variants.
- Create a bom for the template of these products and one bom line:
    - 1 x COMP
- Create and confirm an MO for 1 unit of variant 2.
- Change the bom line to 2 x COMP.
#### > Return to the MO and click on update bom, the `product_id` of the MO has been altered to variant 1.

The details of the set up are the following:
1. Create a new field with the following configuration: Name: x_studio_1 Model: Product Field Type: many2one Stored: True Related Model: res.partner
2. Create a new field with the following configuration: Name: x_studio_2 Model: Manufacturing Order Field Type: char Stored: True Readonly: True Related Field Definition: product_tmpl_id.x_studio_1.name
3. Create an automation rule on the manufacturing order model that trigger on save and that trigger's the action of updating the record responsible to Joel willis.

### Fix:

We should not rely on the related field `mrp.production.product_tmpl_id` inside the compute method of the `mrp.production.product_id`. Particularly since we can access this value using the direct path to this value. This avoids any recursion issue.

opw-4658754
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
