### PR TITLE
[FIX] website: fix link popover colors

### DIFF
--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -305,3 +305,34 @@ body.editor_enable {
         user-select: none;
     }
 }
+// edit link popover
+$o-we-popover-bg: white;
+body.editor_enable {
+    .o_edit_menu_popover {
+        background-color: $o-we-popover-bg;
+        font-family: $o-we-font-family;
+
+        a {
+            color: $o-brand-primary;
+
+            &.text-muted {
+                color: rgba(0, 0, 0, 0.65) !important;
+            }
+        }
+        i:not(.js_edit_menu > i) {
+            color: rgba(0, 0, 0, 0.9);
+        }
+        &.bs-popover-top > .popover-arrow::after {
+            border-top-color: $o-we-popover-bg;
+        }
+        &.bs-popover-end > .popover-arrow::after {
+            border-right-color: $o-we-popover-bg;
+        }
+        &.bs-popover-bottom > .popover-arrow::after {
+            border-bottom-color: $o-we-popover-bg;
+        }
+        &.bs-popover-start > .popover-arrow::after {
+            border-left-color: $o-we-popover-bg;
+        }
+    }
+}

--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -9,6 +9,7 @@ $-mini-nav-size: 40px;
     @include o-position-absolute(0, auto, auto, 0);
     z-index: $zindex-modal;
     @include font-size($o-font-size-base);
+    font-family: $o-we-font-family;
 
     &::before {
         content: "";


### PR DESCRIPTION
Steps to reproduce the issue:

- Enter Website edit mode.
- Click on the "Theme" tab.
- Pick a black color for the website background (4th color button).
- Click on a link in the website navbar to make the link popover appear.
- Bug: The popover background is black, and its buttons are not visible as they are also black.

Bug introduced by this commit [1], where popover colors were updated to match the website's theme. The goal was to align popovers, such as the one for the e-commerce cart button, with the theme colors. However, the change unfortunately also affected the link editing popover, which should remain neutral as it is part of the interface elements.

[1]: https://github.com/odoo/odoo/commit/0d96be06faf8aad1a92183bd2b6371253980c7e6

task-4422810

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/a217c886-9521-4347-a0db-7d6cd7b6029b)  | ![image](https://github.com/user-attachments/assets/f06e4618-e896-430c-8063-bbe3dd534055)  |