### PR TITLE
[FIX] point_of_sale: fix exception when creating payment method

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -114,7 +114,8 @@ class PosPaymentMethod(models.Model):
             if pm.journal_id and pm.journal_id.type not in ['cash', 'bank']:
                 raise UserError(_("Only journals of type 'Cash' or 'Bank' could be used with payment methods."))
             if pm.journal_id and pm.journal_id.type == 'bank':
-                pm.outstanding_account_id = self.env['account.payment']._get_outstanding_account('inbound')
+                chart_template = self.with_context(allowed_company_ids=self.env.company.root_id.ids).env['account.chart.template']
+                pm.outstanding_account_id = chart_template.ref('account_journal_payment_debit_account_id', raise_if_not_found=False) or self.company_id.transfer_account_id
         if self.is_cash_count:
             self.use_payment_terminal = False
 


### PR DESCRIPTION
Fix issue when trying to create new payment methods and no `account_journal_payment_debit_account_id` exist in the current chart template.

Calling `_get_outstanding_account('inbound')` on an empty `account.payment` was failing because `self.env.company` was not properly set. This issue only occurred when the outstanding account was not found in the chart template, leading to an exception.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
