### PR TITLE
[IMP] account_peppol: make peppol mails great again

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -181,6 +181,21 @@ class PortalAccount(CustomerPortal):
         values = self._invoice_get_page_view_values(invoice_sudo, access_token, **kw)
         return request.render("account.portal_invoice_page", values)
 
+    @http.route(['/my/journal/<int:journal_id>/unsubscribe'], type='http', auth="user", methods=['GET', 'POST'], website=True)
+    def portal_my_journal_unsubscribe(self, journal_id, **kw):
+        journal = request.env['account.journal'].browse(int(journal_id)).exists()
+        if not journal:
+            return request.not_found()
+
+        journal = journal.with_company(journal.sudo().company_id.id)
+        completed = False
+
+        if request.httprequest.method == 'POST':
+            journal.button_unsubscribe_from_invoice_notifications()
+            completed = True
+
+        return request.render("account.portal_my_journal_mail_notifications", {'completed': completed})
+
     # ------------------------------------------------------------
     # My Home
     # ------------------------------------------------------------

--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -160,7 +160,7 @@
 </p>
         </template>
         <record id="mail_template_einvoice_notification" model="mail.template">
-            <field name="name">New eInvoice Notification</field>
+            <field name="name">New eInvoices Notification</field>
             <field name="subject">New Electronic Invoices Received</field>
             <field name="email_from">{{ object.company_id.email_formatted }}</field>
             <field name="email_to">{{ object.incoming_einvoice_notification_email }}</field>
@@ -169,17 +169,139 @@
             <field name="auto_delete" eval="True"/>
             <field name="description">Notification email for newly received eInvoices</field>
             <field name="body_html" type="html">
-<div style="margin: 0px; padding: 0px;">
-    <p style="margin: 0px; padding: 0px; font-size: 13px;">
-        Dear User,
-        <br /><br />
-        You have received <strong><t t-out="len(ctx.get('einvoices', ())) or 'new'"/></strong> electronic invoice(s) in
-        <strong><t t-out="object.name or 'Vendor Bills'"/></strong>.
-        These invoices are now available for review in Odoo.
-        <br /><br />
-        You can unsubscribe from these notifications from <strong><t t-out="object.name or 'Vendor Bills'"/></strong> journal settings.
-    </p>
-</div>
+
+<t t-set="invoices" t-value="ctx.get('einvoices', [])"/>
+<t t-set="invoice_preview_ids" t-value="','.join([str(i) for i in invoices.ids]) if invoices else ''"/>
+<t t-set="invoice_count" t-value="len(invoices)"/>
+<t t-set="MAX_TABLE_LINES" t-value="10"/>
+
+<table border="0" cellpadding="0" cellspacing="0"
+       style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;">
+    <tr>
+        <td align="center">
+            <table border="0" cellpadding="0" cellspacing="0" width="590"
+                   style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">
+                <!-- HEADER -->
+                <tr>
+                    <td align="center" style="min-width: 590px;">
+                        <table width="590" cellpadding="0" cellspacing="0"
+                               style="padding: 0px 8px; background-color: white; border-collapse:separate;">
+                            <tr>
+                                <td valign="middle">
+                                    <span style="font-size: 10px;">Notification</span>
+                                    <br/>
+                                    <span style="font-size: 20px; font-weight: bold;">
+                                        New Electronic Invoices Received
+                                    </span>
+                                    <div style="margin-bottom: 5px; margin-top: 18px;">
+                                        <a t-if="invoice_count != 1" t-attf-href="/odoo/accounting/action-account.action_account_moves_email_preview?active_ids={{ invoice_preview_ids }}"
+                                           target="_blank"
+                                           t-attf-style="padding: 8px 12px; font-size: 12px; color: {{ object.company_id.email_primary_color or '#FFFFFF' }}; text-decoration: none !important; font-weight: 400; background-color: {{ object.company_id.email_secondary_color or '#875A7B' }}; border-radius:3px">
+                                            Review Invoices
+                                        </a>
+                                        <a t-else="" t-attf-href="/odoo/accounting/{{ object.id }}/account.move/{{ invoices.id }}"
+                                           target="_blank"
+                                           t-attf-style="padding: 8px 12px; font-size: 12px; color: {{ object.company_id.email_primary_color or '#FFFFFF' }}; text-decoration: none !important; font-weight: 400; background-color: {{ object.company_id.email_secondary_color or '#875A7B' }}; border-radius:3px">
+                                            Review Invoice
+                                        </a>
+                                    </div>
+                                </td>
+                                <td valign="middle" align="right">
+                                    <t t-if="not object.company_id.uses_default_logo">
+                                        <img t-att-src="'/logo.png?company=%s' % object.company_id.id"
+                                             style="height: auto; width: 80px; margin-right: 10px;"
+                                             t-att-alt="'%s' % object.company_id.name"/>
+                                    </t>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" style="text-align:center;">
+                                    <hr style="background-color:#CCCCCC; border:none; height:1px; margin:16px 0;" />
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <!-- BODY -->
+                <tr>
+                    <td align="center">
+                        <table width="590" cellpadding="0" cellspacing="0"
+                               style="padding: 0px 8px; background-color: white; border-collapse:separate;">
+                            <tr>
+                                <td style="font-size: 14px;">
+                                    <p>
+                                        Dear <t t-out="object.company_id.name or 'Company'"/>,
+                                        <br/><br/>
+                                        You have received <strong><t t-out="invoice_count or 'new'"/></strong> invoice(s).
+                                        These invoices are now available for your review in Odoo.
+                                        <br/><br/>
+                                        <table width="100%" cellpadding="6" cellspacing="0"
+                                               style="border: 1px solid #DDDDDD; border-collapse: collapse; font-size: 13px; margin-bottom: 16px;">
+                                            <thead style="background-color: #F9F9F9; text-align: left;">
+                                                <tr>
+                                                    <th style="border: 1px solid #DDDDDD;">Invoice</th>
+                                                    <th style="border: 1px solid #DDDDDD;">Vendor</th>
+                                                    <th style="border: 1px solid #DDDDDD;">Date</th>
+                                                    <th style="border: 1px solid #DDDDDD;">Total</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <t t-set="MAX_TABLE_LINES" t-value="10"/>
+                                                <t t-foreach="invoices[:MAX_TABLE_LINES]" t-as="inv">
+                                                    <tr>
+                                                        <td style="border: 1px solid #DDDDDD;">
+                                                            <t t-out="inv.name or 'INV'"/>
+                                                        </td>
+                                                        <td style="border: 1px solid #DDDDDD;">
+                                                            <t t-out="inv.partner_id.name or 'Unknown'"/>
+                                                        </td>
+                                                        <td style="border: 1px solid #DDDDDD;">
+                                                            <t t-out="inv.invoice_date or 'Unknown'"/>
+                                                        </td>
+                                                        <td style="border: 1px solid #DDDDDD;">
+                                                            <t t-if="inv.amount_total is not None" t-out="inv.amount_total"
+                                                               t-options="{'widget': 'monetary', 'display_currency': inv.currency_id or object.company_id.currency_id}"/>
+                                                            <t t-else="">Unknown</t>
+                                                        </td>
+                                                    </tr>
+                                                </t>
+                                                <t t-if="invoice_count > MAX_TABLE_LINES">
+                                                    <tr>
+                                                        <td colspan="4" style="border: 1px solid #DDDDDD; text-align: center;">
+                                                            <strong>...</strong>
+                                                        </td>
+                                                    </tr>
+                                                </t>
+                                                <t t-if="invoice_count == 0">
+                                                    <tr>
+                                                        <td style="border: 1px solid #DDDDDD;">
+                                                            <t t-out="'INV'"/>
+                                                        </td>
+                                                        <td style="border: 1px solid #DDDDDD;">
+                                                            Example Vendor
+                                                        </td>
+                                                        <td style="border: 1px solid #DDDDDD;">
+                                                            2025-01-01
+                                                        </td>
+                                                        <td style="border: 1px solid #DDDDDD;">
+                                                            <t t-out="1234.56"
+                                                               t-options="{'widget': 'monetary', 'display_currency': object.company_id.currency_id}"/>
+                                                        </td>
+                                                    </tr>
+                                                </t>
+                                            </tbody>
+                                        </table>
+                                        Don’t want these emails? <a t-attf-href="/my/journal/{{ object.id }}/unsubscribe">Unsubscribe here</a> or update your <a t-attf-href="/mail/view?model=account.journal&amp;res_id={{ object.id }}"><t t-out="object.name or 'Vendor Bills'"/></a> journal settings.
+                                    </p>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
             </field>
         </record>
     </data>

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6342,6 +6342,9 @@ class AccountMove(models.Model):
         move_ctx = self.with_context(default_move_type=custom_values.get('move_type', 'entry'), default_journal_id=custom_values.get('journal_id'))
         move = super(AccountMove, move_ctx).message_new(msg_dict, custom_values=values)
         move._compute_name()  # because the name is given, we need to recompute in case it is the first invoice of the journal
+
+        move.journal_id._notify_einvoices_received(move)
+
         return move
 
     def _message_post_after_hook(self, new_message, message_values):

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -158,7 +158,7 @@
                                         />
                                         <field name="autocheck_on_post"/>
                                     </group>
-                                    <group string="Email Alias" name="group_email_alias"
+                                    <group string="Emails" name="group_email_alias"
                                            invisible="type not in ('general', 'sale', 'purchase')">
                                         <field name="display_alias_fields" invisible="1"/>
                                         <div class="o_row" colspan="2" invisible="display_alias_fields">
@@ -171,18 +171,13 @@
                                             <field name="alias_name" placeholder="alias"/>@
                                             <field name="alias_domain_id" placeholder="e.g. mycompany.com" options="{'no_create': True, 'no_open': True}"/>
                                         </div>
+                                        <field name="incoming_einvoice_notification_email" invisible="type != 'purchase'" placeholder="Enter an email to get notified"/>
                                     </group>
                                     <!-- edi -->
                                     <group name="group_edi_config" string="Electronic Data Interchange" invisible="1"/>
                                     <group string="Payment Communications" invisible="type != 'sale'">
                                         <field name="invoice_reference_type"/>
                                         <field name="invoice_reference_model" invisible="invoice_reference_type == 'none'"/>
-                                    </group>
-                                    <group string="Incoming E-Invoice Notifications" invisible="type != 'purchase'">
-                                        <field name="notify_on_incoming_einvoice"/>
-                                        <field name="incoming_einvoice_notification_email"
-                                               invisible="not notify_on_incoming_einvoice"
-                                               required="notify_on_incoming_einvoice and type == 'purchase'"/>
                                     </group>
                                 </group>
                             </page>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1844,6 +1844,23 @@
             </field>
         </record>
 
+        <record id="action_account_moves_email_preview" model="ir.actions.act_window">
+            <field name="name">Journal Entries</field>
+            <field name="res_model">account.move</field>
+            <field name="view_mode">list,kanban,form,activity</field>
+            <field name="view_id" ref="view_move_tree"/>
+            <field name="search_view_id" ref="view_account_move_filter"/>
+            <field name="domain">[('id', 'in', context.get('active_ids'))]</field>
+            <field name="help" type="html">
+              <p class="o_view_nocontent_smiling_face">
+                No journal entries selected
+              </p><p>
+                This view shows only the journal entries that were selected from another context,
+                such as for sending by email or reviewing a batch of records.
+              </p>
+            </field>
+        </record>
+
         <record id="action_move_out_invoice_type" model="ir.actions.act_window">
             <field name="name">Invoices</field>
             <field name="path">invoicing</field>

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -109,6 +109,32 @@
       </t>
     </template>
 
+    <template id="portal_my_journal_mail_notifications" name="My journal email notification settings">
+        <t t-call="portal.portal_layout">
+            <t t-set="breadcrumbs_searchbar" t-value="True"/>
+            <t t-call="portal.portal_searchbar">
+                <t t-set="title">Email Notifications</t>
+            </t>
+            <div class="row">
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title">Invoice Notifications</h5>
+                            <p class="card-text">You can unsubscribe from emails received upon invoice reception here.</p>
+                            <div t-if="completed" class="alert alert-success" role="alert">
+                                Successfully unsubscribed from invoice notifications
+                            </div>
+                            <form t-else="" method="POST">
+                                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                <button type="submit" class="btn btn-primary">Unsubscribe</button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+
     <template id="portal_invoice_page" name="Invoice/Bill" inherit_id="portal.portal_sidebar" primary="True">
         <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
             <t t-set="o_portal_fullwidth_alert" groups="sales_team.group_sale_salesman,account.group_account_invoice,account.group_account_readonly">

--- a/addons/account_peppol/data/mail_templates_email_layouts.xml
+++ b/addons/account_peppol/data/mail_templates_email_layouts.xml
@@ -28,5 +28,85 @@
                 </div>
             </xpath>
         </template>
+
+        <record id="mail_template_peppol_registration" model="mail.template">
+            <field name="name">Peppol: Registration update</field>
+            <field name="subject">Welcome to Peppol</field>
+            <field name="email_from">{{ object.email_formatted }}</field>
+            <field name="email_to">{{ object.account_peppol_contact_email }}</field>
+            <field name="use_default_to" eval="False"/>
+            <field name="model_id" ref="account.model_res_company"/>
+            <field name="auto_delete" eval="True"/>
+            <field name="description">Notification email for peppol registration state update</field>
+            <field name="body_html" type="html">
+<table border="0" cellpadding="0" cellspacing="0"
+       style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;">
+    <tr>
+        <td align="center">
+            <table border="0" cellpadding="0" cellspacing="0" width="590"
+                   style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">
+                <!-- HEADER -->
+                <tr>
+                    <td align="center" style="min-width: 590px;">
+                        <table width="590" cellpadding="0" cellspacing="0"
+                               style="padding: 0px 8px; background-color: white; border-collapse:separate;">
+                            <tr>
+                                <td valign="middle">
+                                    <span style="font-size: 10px;">Notification</span>
+                                    <br/>
+                                    <span style="font-size: 20px; font-weight: bold;">
+                                        Welcome to Peppol
+                                    </span>
+                                    <div style="margin-bottom: 5px; margin-top: 18px;">
+                                        <a t-attf-href="/odoo/accounting/" target="_blank"
+                                           t-attf-style="padding: 8px 12px; font-size: 12px; color: {{ object.email_primary_color or '#FFFFFF' }}; text-decoration: none !important; font-weight: 400; background-color: {{ object.email_secondary_color or '#875A7B' }}; border-radius:3px">
+                                            Send invoices
+                                        </a>
+                                    </div>
+                                </td>
+                                <td valign="middle" align="right">
+                                    <t t-if="not object.uses_default_logo">
+                                        <img t-att-src="'/logo.png?company=%s' % object.id"
+                                             style="height: auto; width: 80px; margin-right: 10px;"
+                                             t-att-alt="'%s' % object.name"/>
+                                    </t>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" style="text-align:center;">
+                                    <hr style="background-color:#CCCCCC; border:none; height:1px; margin:16px 0;" />
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <!-- BODY -->
+                <tr>
+                    <td align="center">
+                        <table width="590" cellpadding="0" cellspacing="0"
+                               style="padding: 0px 8px; background-color: white; border-collapse:separate;">
+                            <tr>
+                                <td style="font-size: 14px;">
+                                    <p>Dear <t t-out="object.name or ''">YourCompany</t>,</p>
+
+                                    <p>We have successfully added your company to the <strong>Peppol Network</strong>.</p>
+
+                                    <p>You can now <strong>send<t t-if="object.account_peppol_proxy_state == 'receiver'"> and receive</t></strong> electronic invoices via Odoo — completely free of charge.</p>
+
+                                    <p>Best regards,</p>
+
+                                    <p style="margin-bottom: 24px;">The Odoo Team</p>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+            </field>
+        </record>
+
     </data>
 </odoo>

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -285,7 +285,12 @@ class Account_Edi_Proxy_ClientUser(models.Model):
                 continue
 
             if proxy_user['peppol_state'] in ('sender', 'smp_registration', 'receiver', 'rejected'):
-                edi_user.company_id.account_peppol_proxy_state = proxy_user['peppol_state']
+                if edi_user.company_id.account_peppol_proxy_state != proxy_user['peppol_state']:
+                    edi_user.company_id.account_peppol_proxy_state = proxy_user['peppol_state']
+                    if proxy_user['peppol_state'] == 'receiver':
+                        # First-time receivers get their initial email here.
+                        # If already a sender, they'll receive a second (send+receive) welcome email.
+                        edi_user.company_id._account_peppol_send_welcome_email()
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -319,3 +319,14 @@ class ResCompany(models.Model):
             'external_provider': external_provider,
             'error_msg': error_msg,
         }
+
+    def _account_peppol_send_welcome_email(self):
+        self.ensure_one()
+        if self.account_peppol_proxy_state not in ('sender', 'receiver'):
+            return
+
+        mail_template = self.env.ref('account_peppol.mail_template_peppol_registration', raise_if_not_found=False)
+        if not mail_template:
+            return
+
+        mail_template.send_mail(self.id, force_send=True)

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -214,6 +214,12 @@ class PeppolRegistration(models.TransientModel):
             },
         }
         state = self.company_id.account_peppol_proxy_state
+
+        if state == 'sender':
+            # if user asked to register as a receiver, state would've been 'smp_registration'
+            # so this is the final registration state for sender-only registration
+            self.company_id._account_peppol_send_welcome_email()
+
         return self._action_send_notification(
             title=None,
             message=notifications[state]['message'],


### PR DESCRIPTION
UI of email notifications introduced by odoo/odoo#197233 doesn't look as cool as it could be.

This commit improves UI/UX of existing email upon bills reception and send emails upon (successful) registration with unsubscribe buttons, CTA and just better UI than plain text.

Also sends an einvoice notification email upon bill reception through email alias as it makes sense to consider it as an einvoice.

related: https://github.com/odoo/upgrade/pull/7545

task-4655585