### PR TITLE
[FIX] base: unlink current company-dependent props before sync

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -637,6 +637,12 @@ class Partner(models.Model):
                 # value was already assigned for current company
                 ('company_id', '!=', self.env.company.id),
             ])
+            # prevent duplicate keys by removing existing properties from the partner
+            self.env['ir.property'].search([
+                ('fields_id', 'in', company_dependent_commercial_field_ids),
+                ('res_id', '=', f'res.partner,{self.id}'),
+                ('company_id', '!=', self.env.company.id),
+            ]).unlink()
             for prop in parent_properties:
                 prop.copy({'res_id': f'res.partner,{self.id}'})
 

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -754,6 +754,11 @@ class TestPartnerAddressCompany(TransactionCase):
             self.assertEqual(child_address.with_company(company_1).barcode, 'Company 1')
             self.assertEqual(child_address.with_company(company_2).barcode, 'Company 2')
 
+            child_address.parent_id = False
+
+            # Reassigning a parent (or a new one) shouldn't fail
+            child_address.parent_id = test_partner_company.id
+
     def test_company_change_propagation(self):
         """ Check propagation of company_id across children """
         User = self.env['res.users']


### PR DESCRIPTION
Versions
--------
- 17.0
- saas-17.4

Commit de302c2d3630 removed the `ir.property` model in 18.0+

Steps
-----
1. Have 2 companies;
2. set a payment term on a commercial partner;
3. switch to other company;
4. create a partner with commercial partner as their company & save;
5. remove the commercial partner & save;
6. re-add the commercial partner & save.

Issue
-----
> The operation cannot be completed: duplicate key value violates unique constraint "ir_property_unique_index"
> DETAIL: Key (fields_id, COALESCE(company_id, 0), COALESCE(res_id, ''::character varying))=(7155, 1, res.partner,381799) already exists.

Cause
-----
Commit 7690479 added the `_company_dependent_commercial_sync` method to sync properties between partners & their commercial partners.

It does this by looking for properties that exist from companies other than the current one, and attempts to copy them.

When copying them, it's possible it attempts to create a duplicate key.

Solution
--------
Unlink existing properties for the current partner before copying new ones.


opw-4679276