### PR TITLE
[FIX] hr_holidays: correctly display available time off days for accr…

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -455,6 +455,9 @@ class HolidaysType(models.Model):
                     },
                     leave_type.requires_allocation,
                     leave_type.id)
+                for recheck in extra_data[employee][leave_type]['to_recheck_leaves']:
+                    lt_info[1]['virtual_remaining_leaves'] -= recheck.number_of_days
+                    lt_info[1]['leaves_requested'] += recheck.number_of_days
                 for excess_date, excess_days in extra_data[employee][leave_type]['excess_days'].items():
                     amount = excess_days['amount']
                     lt_info[1]['virtual_excess_data'].update({


### PR DESCRIPTION
…ual allocations

**Issue:**
When an employee has an accrual-type time off allocation and also has future time off requests, the Days Available count displayed in the Time Off dashboard and the Time Off smart button on the employee's page is incorrect. The displayed value incorrectly includes future leave days as available, even though they are already scheduled to be taken.

**Steps to Reproduce:**
1. Install the Employees and Time Off apps.
2. Navigate to Time Off > Management > Allocations and ensure the employee has only Regular Allocation.
3. Create a new Accrual Allocation for the employee with the following details: -Allocation Type: "Accrual Allocation"
-Allocation Plan: "Seniority Plan"
-Start Date: Jan 1, 2024
-End Date: Dec 31, 2024 (ensuring expiration)
-Allocation Amount: 1 day (or any value >0)
4. Navigate to Employees > Select Employee Anita Oliver.
5. Click the Time Off smart button.
6. Create a new leave request for the employee: 
-Start Date: A future date (e.g., June 10, 2025)
-End Date: A later future date (e.g., June 20, 2025) 
-Number of Days: 10
-Approve the leave request.
8. See that the Days available show an incorrect value

**Expected Behavior**: The Days Available count should exclude future-approved time off days, accurately reflecting only the days still available for new requests.

**Actual Behavior**: The Days Available count includes future-approved leave days, making it appear as though the employee has more available days than they actually do.

**Root Cause**

When an employee has accrual-based time off allocations, any future time off requests are incorrectly included in the available days calculation because the `_get_consumed_leaves()` method (https://github.com/odoo/odoo/blob/bb6a4fbb92b1a1a1e13e32b27c4c9f2813570fda/addons/hr_holidays/models/hr_employee.py#L142) adds these future leaves to `to_recheck_leaves_per_leave_type`, but they are not properly deducted when computing available days. The `get_allocation_data()` method (https://github.com/odoo/odoo/blob/bb6a4fbb92b1a1a1e13e32b27c4c9f2813570fda/addons/hr_holidays/models/hr_leave_type.py#L416), which sets the available days, only considers `excess_days` for recomputation while ignoring `to_recheck_leaves`, causing future leaves to remain in the available balance. Similarly, `_compute_allocation_remaining_display()` (https://github.com/odoo/odoo/blob/bb6a4fbb92b1a1a1e13e32b27c4c9f2813570fda/addons/hr_holidays/models/hr_employee_base.py#L107) does not exclude `to_recheck_leaves` when determining the available days for the smart button display

**Fix**
To solve the issue, `to_recheck_leaves` is properly subtracted, preventing future leaves from inflating the displayed balance.

Opw-4480007
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
