### PR TITLE
[FIX] survey: prevent division by zero crash on leaderboard

### DIFF
--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -3,7 +3,7 @@
 
 from freezegun import freeze_time
 
-from odoo import _, fields
+from odoo import _, Command, fields
 from odoo.addons.survey.tests import common
 from odoo.tests.common import users
 
@@ -472,3 +472,38 @@ class TestSurveyInternals(common.TestSurveyCommon):
         returned_questions_and_pages = my_survey._get_pages_and_questions_to_show()
 
         self.assertEqual(question_and_page_ids - invalid_records, returned_questions_and_pages)
+
+    def test_survey_session_leaderboard(self):
+        """Check leaderboard rendering with small (max) scores values."""
+        start_time = fields.datetime(2023, 7, 7, 12, 0, 0)
+        test_survey = self.env['survey.survey'].create({
+            'title': 'Test This Survey',
+            'scoring_type': 'scoring_with_answers',
+            'session_question_start_time': start_time,
+            'session_start_time': start_time,
+            'session_state': 'in_progress',
+            'question_and_page_ids': [
+                Command.create({
+                    'question_type': 'simple_choice',
+                    'suggested_answer_ids': [
+                        Command.create({'value': 'In Asia', 'answer_score': 0.125, 'is_correct': True}),
+                        Command.create({'value': 'In Europe', 'answer_score': 0., 'is_correct': False}),
+                    ],
+                    'title': 'Where is india?',
+                }),
+            ]
+        })
+        question_1 = test_survey.question_and_page_ids[0]
+        answer_correct = question_1.suggested_answer_ids[0]
+        user_input = self.env['survey.user_input'].create({'survey_id': test_survey.id, 'is_session_answer': True})
+        user_input_line = self.env['survey.user_input.line'].create({
+            'user_input_id': user_input.id,
+            'question_id': question_1.id,
+            'answer_type': 'suggestion',
+            'suggested_answer_id': answer_correct.id,
+        })
+        self.assertEqual(user_input_line.answer_score, 0.125)
+        self.env['ir.qweb']._render('survey.user_input_session_leaderboard', {
+            'animate': True,
+            'leaderboard': test_survey._prepare_leaderboard_values()
+        })

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -184,8 +184,8 @@
                     </div>
                     <!-- We keep "18rem" of space to display the points / nickname.
                     Then, the length of the bar is a percentage of the attendee's score compared to the max_score. -->
-                    <t t-set="width_ratio" t-value="round(round(score['scoring_total']) / round(max_score), 3)"/>
-                    <t t-set="width_ratio_question" t-value="str(round(round(score.get('question_score', 0)) / round(score.get('max_question_score', 1)), 3))"/>
+                    <t t-set="width_ratio" t-value="round(round(score['scoring_total'], 3) / round(max_score, 3), 3)"/>
+                    <t t-set="width_ratio_question" t-value="str(round(round(score.get('question_score', 0), 3) / round(score.get('max_question_score', 1), 3), 3))"/>
                     <div class="o_survey_session_leaderboard_bar ms-2 align-top d-inline-block text-end fw-bold"
                         t-att-style="'width: calc(calc(%s - 18rem) * %s)' % ('100%', width_ratio)"
                         t-att-data-width-ratio="width_ratio">


### PR DESCRIPTION
Reproduce:
1. Make a scored live session survey
2. Add a single choice question with a <0.5 point answer (or < 1 with speed reward)
3. Create a live session
4. Join with one participant
5. Play the survey, have the participant answer correctly (after half the time for speed reward if that case is tested)
6. Proceed to leaderboard and expect a crash.

This happens because when `max_score` or `max_score_question` are <= 0.5, divisions by round(<=.5) are divisions by 0.

Using 3 digits for rounding has two advantages:
* It is very unlikely that an answer will have a value below 0.0006 (not 0 - that case is supported- but rounds to 0).
* It makes the template resilient to differences in precisions used for the various numbers (relevant in 17.4 where `answer_score` and `scoring_total` can be different by <0.01).

Task-4655784
