### PR TITLE
[IMP] web: search model: no split of edited domains

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -518,7 +518,11 @@ export class SearchBar extends Component {
             resModel,
             domain,
             context: this.env.searchModel.domainEvalContext,
-            onConfirm: (domain) => this.env.searchModel.splitAndAddDomain(domain, groupId),
+            onConfirm: (nextDomain) => {
+                if (nextDomain !== domain) {
+                    this.env.searchModel.splitAndAddDomain(nextDomain, groupId);
+                }
+            },
             disableConfirmButton: (domain) => domain === `[]`,
             title: _t("Modify Condition"),
             isDebugMode: this.env.searchModel.isDebugMode,

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -32,7 +32,7 @@
                         class="position-absolute start-0 top-0 bottom-0 end-0 bg-inherit opacity-0 opacity-100-hover"
                         t-att-class="{'px-2 transition-base': !facet.icon}"
                         >
-                        <i class="fa fa-fw fa-cog"/>
+                        <i class="fa fa-fw fa-pencil"/>
                     </span>
                     <span t-if="env.searchModel.canOrderByCount and facet.type === 'groupBy' and !env.searchModel.orderByCount"
                         class="position-absolute start-0 top-0 bottom-0 end-0 bg-inherit opacity-0 opacity-100-hover"

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1,5 +1,10 @@
+import { EventBus, toRaw } from "@odoo/owl";
 import { makeContext } from "@web/core/context";
 import { Domain } from "@web/core/domain";
+import { getDefaultDomain } from "@web/core/domain_selector/utils";
+import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_selector_dialog";
+import { _t } from "@web/core/l10n/translation";
+import { rpcBus } from "@web/core/network/rpc";
 import { evaluateExpr } from "@web/core/py_js/py";
 import { user } from "@web/core/user";
 import { groupBy, sortBy } from "@web/core/utils/arrays";
@@ -14,15 +19,7 @@ import {
     rankInterval,
     yearSelected,
 } from "./utils/dates";
-import { FACET_COLORS, FACET_ICONS } from "./utils/misc";
-
-import { EventBus, toRaw } from "@odoo/owl";
-import { getDefaultDomain } from "@web/core/domain_selector/utils";
-import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_selector_dialog";
-import { _t } from "@web/core/l10n/translation";
-import { domainFromTree, treeFromDomain } from "@web/core/tree_editor/condition_tree";
-import { useGetTreeDescription, useMakeGetFieldDef } from "@web/core/tree_editor/utils";
-import { rpcBus } from "@web/core/network/rpc";
+import { FACET_COLORS, FACET_ICONS, useGetDomainFacets } from "./utils/misc";
 
 const { DateTime } = luxon;
 
@@ -174,9 +171,6 @@ export class SearchModel extends EventBus {
         this.env = env;
         this.setup(services, args);
     }
-    /**
-     * @override
-     */
     setup(services) {
         // services
         const { field: fieldService, name: nameService, orm, view, dialog } = services;
@@ -186,8 +180,7 @@ export class SearchModel extends EventBus {
         this.dialog = dialog;
         this.orderByCount = false;
 
-        this.getDomainTreeDescription = useGetTreeDescription(fieldService, nameService);
-        this.makeGetFieldDef = useMakeGetFieldDef(fieldService);
+        this.getDomainFacets = useGetDomainFacets(fieldService, nameService);
 
         // used to manage search items related to date/datetime fields
         this.referenceMoment = DateTime.local();
@@ -704,45 +697,69 @@ export class SearchModel extends EventBus {
             context = makeContext(contexts);
         }
 
-        const getFieldDef = await this.makeGetFieldDef(this.resModel, treeFromDomain(domain));
-        const tree = treeFromDomain(domain, { distributeNot: !this.isDebugMode, getFieldDef });
-        const trees = !tree.negate && tree.value === "&" ? tree.children : [tree];
-        const promises = trees.map(async (tree) => {
-            const description = await this.getDomainTreeDescription(this.resModel, tree);
-            const preFilter = {
-                description,
-                domain: domainFromTree(tree),
-                invisible: "True",
-                type: "filter",
-            };
-            if (context) {
-                preFilter.context = context;
-            }
-            return preFilter;
-        });
-
-        const preFilters = await Promise.all(promises);
-
         this.blockNotification = true;
 
+        let queryItemIndex;
         if (group) {
             const firstActiveItem = group.activeItems[0];
             const firstSearchItem = this.searchItems[firstActiveItem.searchItemId];
+            queryItemIndex = this.query.findIndex(
+                (queryElem) => queryElem.searchItemId === firstActiveItem.searchItemId
+            );
             const { type } = firstSearchItem;
             if (type === "favorite") {
                 const activeItemGroupBys = this._getSearchItemGroupBys(firstActiveItem);
-                for (const activeItemGroupBy of activeItemGroupBys) {
-                    const [fieldName, interval] = activeItemGroupBy.split(":");
-                    this.createNewGroupBy(fieldName, { interval, invisible: true });
+                let createNewGroupBys = Boolean(activeItemGroupBys.length);
+                if (
+                    createNewGroupBys &&
+                    this.defaultGroupBy &&
+                    this.env.config.viewType === "kanban"
+                ) {
+                    const currentGroupBy = this._getGroupBy({ fallbackOnDefault: false });
+                    if (JSON.stringify(currentGroupBy) === JSON.stringify(this.defaultGroupBy)) {
+                        createNewGroupBys = false;
+                    }
                 }
-                const index = this.query.length - activeItemGroupBys.length;
-                this.query = [...this.query.slice(index), ...this.query.slice(0, index)];
+                if (createNewGroupBys) {
+                    for (const activeItemGroupBy of activeItemGroupBys) {
+                        const [fieldName, interval] = activeItemGroupBy.split(":");
+                        this.createNewGroupBy(fieldName, { interval, invisible: true });
+                    }
+                    const index = this.query.length - activeItemGroupBys.length;
+                    this.query = [...this.query.slice(index), ...this.query.slice(0, index)];
+                }
             }
             this.deactivateGroup(groupId);
         }
 
-        for (const preFilter of preFilters) {
-            this.createNewFilters([preFilter]);
+        const [facet] = await this.getDomainFacets(this.resModel, domain);
+
+        const id = this.nextId++;
+        const filter = {
+            description: _t(`Custom filter`),
+            facet,
+            domain,
+            invisible: "True",
+            type: "filter",
+            groupId: this.nextGroupId++,
+            groupNumber: this.nextGroupNumber++,
+            id,
+        };
+        if (context) {
+            filter.context = context;
+        }
+
+        this.searchItems[id] = filter;
+
+        const queryElem = { searchItemId: id };
+        if (queryItemIndex === undefined) {
+            this.query.push(queryElem);
+        } else {
+            this.query = [
+                ...this.query.slice(0, queryItemIndex),
+                queryElem,
+                ...this.query.slice(queryItemIndex),
+            ];
         }
 
         this.blockNotification = false;
@@ -1423,7 +1440,7 @@ export class SearchModel extends EventBus {
                         filter_domain: this._getFilterDomain(filter.id),
                         expand: filter.expand,
                         group_by: filter.groupBy || false,
-                        group_domain: this._getGroupDomain(filter),
+                        group_domain: this._getFilterGroupDomain(filter),
                         limit: filter.limit,
                         search_domain: searchDomain,
                     }
@@ -1534,15 +1551,10 @@ export class SearchModel extends EventBus {
             domains.push(this.globalDomain);
         }
         for (const group of groups) {
-            const groupActiveItemDomains = [];
-            for (const activeItem of group.activeItems) {
-                const domain = this._getSearchItemDomain(activeItem);
-                if (domain) {
-                    groupActiveItemDomains.push(domain);
-                }
+            const groupDomain = this._getGroupDomain(group);
+            if (groupDomain) {
+                domains.push(groupDomain);
             }
-            const groupDomain = Domain.or(groupActiveItemDomains);
-            domains.push(groupDomain);
         }
 
         // we need to manage (optional) facets, deactivateGroup, clearQuery,...
@@ -1555,27 +1567,46 @@ export class SearchModel extends EventBus {
         return params.raw ? domain : domain.toList(this.domainEvalContext);
     }
 
+    _getGroupDomain(group) {
+        const groupActiveItemDomains = [];
+        for (const activeItem of group.activeItems) {
+            const domain = this._getSearchItemDomain(activeItem);
+            if (domain) {
+                groupActiveItemDomains.push(domain);
+            }
+        }
+        if (groupActiveItemDomains.length) {
+            return Domain.or(groupActiveItemDomains);
+        }
+        return null;
+    }
+
     _getFacets() {
         const facets = [];
         const groups = this._getGroups();
         for (const group of groups) {
-            const groupActiveItemDomains = [];
             const values = [];
             let title;
             let type;
             for (const activeItem of group.activeItems) {
-                const domain = this._getSearchItemDomain(activeItem);
-                if (domain) {
-                    groupActiveItemDomains.push(domain);
-                }
                 const searchItem = this.searchItems[activeItem.searchItemId];
                 switch (searchItem.type) {
                     case "field_property":
                     case "field": {
-                        type = "field";
-                        title = searchItem.description;
-                        for (const autocompleteValue of activeItem.autocompletValues) {
-                            values.push(autocompleteValue.labelForFacet || autocompleteValue.label);
+                        // searchItem is the unique item of the group
+                        const { autocompleteValues } = activeItem;
+                        const operators = new Set(
+                            autocompleteValues.map(({ operator }) => operator)
+                        );
+                        if (searchItem.filterDomain || operators.size === 1) {
+                            type = "field";
+                            title = searchItem.description;
+                            for (const { label, labelForFacet } of autocompleteValues) {
+                                values.push((labelForFacet || label).trim());
+                            }
+                        } else {
+                            type = "filter";
+                            values.push(searchItem.description);
                         }
                         break;
                     }
@@ -1604,7 +1635,15 @@ export class SearchModel extends EventBus {
                     }
                     default: {
                         type = searchItem.type;
-                        values.push(searchItem.description);
+                        if (searchItem.facet) {
+                            type = searchItem.facet.type;
+                            if (searchItem.facet.title) {
+                                title = searchItem.facet.title;
+                            }
+                            values.push(...searchItem.facet.values);
+                        } else {
+                            values.push(searchItem.description);
+                        }
                     }
                 }
             }
@@ -1625,9 +1664,12 @@ export class SearchModel extends EventBus {
                 }
                 facet.color = FACET_COLORS[type];
             }
-            if (groupActiveItemDomains.length) {
-                facet.domain = Domain.or(groupActiveItemDomains).toString();
+
+            const groupDomain = this._getGroupDomain(group);
+            if (groupDomain) {
+                facet.domain = groupDomain.toString();
             }
+
             facets.push(facet);
         }
         const hasAGroupByFacet = facets.some((f) => f.type === "groupBy");
@@ -1740,9 +1782,13 @@ export class SearchModel extends EventBus {
      * coming from an active favorite (if any) come first, then come the
      * groupBys comming from the active filters of type 'groupBy' in the order
      * defined in this.query. If no groupBys are found, one tries to
-     * find some grouBys in this.globalContext.
+     * find some groupBys in this.globalGroupBy or this.defaultGroupBy.
+     * @param {Object} [options={}]
+     * @param {boolean} [options.fallbackOnDefault=true]
+     * @returns {string[]}
      */
-    _getGroupBy() {
+    _getGroupBy(options = {}) {
+        const fallbackOnDefault = "fallbackOnDefault" in options ? options.fallbackOnDefault : true;
         const groups = this._getGroups();
         const groupBys = [];
         for (const group of groups) {
@@ -1757,7 +1803,7 @@ export class SearchModel extends EventBus {
             ? groupBys
             : this.globalGroupBy.length
             ? this.globalGroupBy.slice()
-            : this.defaultGroupBy?.slice() || [];
+            : (fallbackOnDefault && this.defaultGroupBy?.slice()) || [];
         return typeof groupBy === "string" ? [groupBy] : groupBy;
     }
 
@@ -1771,7 +1817,7 @@ export class SearchModel extends EventBus {
      * @param {Filter} filter
      * @returns {Object<string, Array[]> | Array[] | null}
      */
-    _getGroupDomain(filter) {
+    _getFilterGroupDomain(filter) {
         const { fieldName, groups, enableCounters } = filter;
         const { type: fieldType } = this.searchViewFields[fieldName];
 
@@ -1867,10 +1913,10 @@ export class SearchModel extends EventBus {
                     activeItem.intervalIds.push(queryElem.intervalId);
                 } else if ("autocompleteValue" in queryElem) {
                     if (!activeItem) {
-                        activeItem = { searchItemId, autocompletValues: [] };
+                        activeItem = { searchItemId, autocompleteValues: [] };
                         activeItems.push(activeItem);
                     }
-                    activeItem.autocompletValues.push(queryElem.autocompleteValue);
+                    activeItem.autocompleteValues.push(queryElem.autocompleteValue);
                 } else {
                     if (!activeItem) {
                         activeItem = { searchItemId };
@@ -1974,7 +2020,7 @@ export class SearchModel extends EventBus {
                 // should set {'field1': [value1, value2]} in the context
                 let context = {};
                 if (searchItem.context) {
-                    const self = activeItem.autocompletValues.map(
+                    const self = activeItem.autocompleteValues.map(
                         (autocompleValue) => autocompleValue.value
                     );
                     context = evaluateExpr(searchItem.context, { self });
@@ -2018,7 +2064,7 @@ export class SearchModel extends EventBus {
         switch (searchItem.type) {
             case "field_property":
             case "field": {
-                return this._getFieldDomain(searchItem, activeItem.autocompletValues);
+                return this._getFieldDomain(searchItem, activeItem.autocompleteValues);
             }
             case "dateFilter": {
                 return this._getDateFilterDomain(searchItem, activeItem.generatorIds);

--- a/addons/web/static/src/search/utils/misc.js
+++ b/addons/web/static/src/search/utils/misc.js
@@ -1,3 +1,19 @@
+import { _t } from "@web/core/l10n/translation";
+import {
+    connector,
+    formatValue,
+    isTree,
+    treeFromDomain,
+} from "@web/core/tree_editor/condition_tree";
+import { getOperatorLabel } from "@web/core/tree_editor/tree_editor_operator_editor";
+import {
+    simplifyTree,
+    useMakeGetConditionDescription,
+    useMakeGetFieldDef,
+} from "@web/core/tree_editor/utils";
+import { ensureArray } from "@web/core/utils/arrays";
+import { useService } from "@web/core/utils/hooks";
+
 export const FACET_ICONS = {
     filter: "fa fa-filter",
     groupBy: "oi oi-group",
@@ -23,3 +39,168 @@ export const GROUPABLE_TYPES = [
     "selection",
     "tags",
 ];
+
+export function facet(values, title) {
+    values = ensureArray(values);
+    if (typeof title === "string") {
+        return { type: "field", title, values, separator: _t("or") };
+    }
+    return {
+        type: "filter",
+        values,
+        separator: _t("or"),
+        icon: FACET_ICONS.filter,
+        color: FACET_COLORS.filter,
+    };
+}
+
+function groupBy(array, ...fns) {
+    if (fns.length === 0) {
+        return array;
+    }
+    const groups = new Map();
+    const [fn, ...remainingFns] = fns;
+    for (const element of array) {
+        const v = fn(element);
+        if (!groups.has(v)) {
+            groups.set(v, []);
+        }
+        groups.get(v).push(element);
+    }
+    const result = new Map();
+    for (const [v, g] of groups) {
+        result.set(v, groupBy(g, ...remainingFns));
+    }
+    return result;
+}
+
+function groupByTypeThenByPath(trees) {
+    return groupBy(
+        trees,
+        (t) => t.type,
+        (t) => (t.type === "condition" ? formatValue(t.path) : null)
+    );
+}
+
+function getShortPathDescription(pathDescription) {
+    return pathDescription.split(" \u2794 ").at(-1);
+}
+
+function processValueDescription(valueDescription, operator) {
+    const { values } = valueDescription;
+    switch (operator) {
+        case "is_not_between":
+        case "between":
+            return `( ${values[0]} ${_t("and")} ${values[1]} )`;
+        case "last":
+        case "not_last":
+        case "next":
+        case "not_next":
+            return values.join(" ");
+        default:
+            return values;
+    }
+}
+
+function getTreeFacet(tree, getFieldDef, getConditionDescription) {
+    if (tree.negate) {
+        return facet(_t("Custom filter"));
+    }
+
+    if (tree.type === "condition") {
+        const { pathDescription, valueDescription } = getConditionDescription(tree);
+        const shortPathDescription = getShortPathDescription(pathDescription);
+        if (isTree(tree.value)) {
+            return facet(shortPathDescription);
+        }
+        if (["set", "not_set", "today", "not_today"].includes(tree.operator)) {
+            return facet(getOperatorLabel(tree.operator).toString(), shortPathDescription);
+        }
+        return facet(
+            processValueDescription(valueDescription, tree.operator),
+            shortPathDescription
+        );
+    }
+
+    if (tree.children.length === 0) {
+        return facet(tree.value === "&" ? _t("True") : _t("False"));
+    }
+    if (tree.children.length === 1) {
+        return getTreeFacet(tree.children[0], getFieldDef, getConditionDescription);
+    }
+
+    const groups = groupByTypeThenByPath(tree.children);
+    if (groups.size > 1) {
+        return facet(_t("Custom filter"));
+    }
+    if (tree.children.some((c) => c.negate) || groups.get("condition").size > 1) {
+        return facet(_t("Custom filter"));
+    }
+
+    // all children are conditions on the same path without negate
+
+    let shortPathDescription = null;
+    let operator = null;
+    const values = [];
+    for (const child of tree.children) {
+        const { pathDescription, valueDescription } = getConditionDescription(child);
+        if (shortPathDescription === null) {
+            shortPathDescription = getShortPathDescription(pathDescription);
+        }
+        if (operator === null) {
+            operator = child.operator;
+        }
+        if (
+            tree.value === "&" ||
+            isTree(child.value) ||
+            formatValue(child.operator) !== formatValue(operator)
+        ) {
+            return facet(shortPathDescription);
+        }
+        if (valueDescription) {
+            values.push(processValueDescription(valueDescription, operator));
+        }
+    }
+
+    if (["set", "not_set", "today", "not_today"].includes(operator)) {
+        return facet(getOperatorLabel(operator).toString(), shortPathDescription);
+    }
+
+    return facet(values, shortPathDescription);
+}
+
+function isAndConnector(tree) {
+    return tree.type === "connector" && !tree.negate && tree.value === "&";
+}
+
+export function useGetDomainFacets(fieldService, nameService) {
+    fieldService ||= useService("field");
+    nameService ||= useService("name");
+    const makeGetFieldDef = useMakeGetFieldDef(fieldService);
+    const makeGetConditionDescription = useMakeGetConditionDescription(fieldService, nameService);
+    return async (resModel, domain, options = {}) => {
+        const getFieldDef = await makeGetFieldDef(resModel, treeFromDomain(domain));
+        const tree = simplifyTree(treeFromDomain(domain, { distributeNot: true, getFieldDef }));
+        const getConditionDescription = await makeGetConditionDescription(
+            resModel,
+            tree,
+            getFieldDef
+        );
+        const trees = [];
+        if (options.splitAndConnector && isAndConnector(tree)) {
+            const groups = groupByTypeThenByPath(tree.children);
+            for (const [type, group] of groups) {
+                for (const [, subGroup] of group) {
+                    if (type === "connector") {
+                        trees.push(...subGroup);
+                    } else {
+                        trees.push(connector("&", subGroup));
+                    }
+                }
+            }
+        } else {
+            trees.push(tree);
+        }
+        return trees.map((tree) => getTreeFacet(tree, getFieldDef, getConditionDescription));
+    };
+}

--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -1,18 +1,17 @@
-import { _t } from "@web/core/l10n/translation";
 import { Component, useState } from "@odoo/owl";
 import { Domain, InvalidDomainError } from "@web/core/domain";
 import { DomainSelector } from "@web/core/domain_selector/domain_selector";
+import { useGetDefaultLeafDomain } from "@web/core/domain_selector/utils";
 import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_selector_dialog";
-import { EvaluationError } from "@web/core/py_js/py_builtin";
+import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
+import { EvaluationError } from "@web/core/py_js/py_builtin";
 import { registry } from "@web/core/registry";
+import { useBus, useOwnedDialogs, useService } from "@web/core/utils/hooks";
+import { useRecordObserver } from "@web/model/relational_model/utils";
+import { useGetDomainFacets } from "@web/search/utils/misc";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
 import { standardFieldProps } from "../standard_field_props";
-import { useBus, useService, useOwnedDialogs } from "@web/core/utils/hooks";
-import { useGetTreeDescription, useMakeGetFieldDef } from "@web/core/tree_editor/utils";
-import { useGetDefaultLeafDomain } from "@web/core/domain_selector/utils";
-import { treeFromDomain } from "@web/core/tree_editor/condition_tree";
-import { useRecordObserver } from "@web/model/relational_model/utils";
 
 export class DomainField extends Component {
     static template = "web.DomainField";
@@ -35,8 +34,7 @@ export class DomainField extends Component {
 
     setup() {
         this.orm = useService("orm");
-        this.getDomainTreeDescription = useGetTreeDescription();
-        this.makeGetFieldDef = useMakeGetFieldDef();
+        this.getDomainFacets = useGetDomainFacets();
         this.getDefaultLeafDomain = useGetDefaultLeafDomain();
         this.addDialog = useOwnedDialogs();
 
@@ -143,10 +141,7 @@ export class DomainField extends Component {
         let promises = [];
         const domain = this.getDomain(props);
         try {
-            const getFieldDef = await this.makeGetFieldDef(resModel, treeFromDomain(domain));
-            const tree = treeFromDomain(domain, { distributeNot: !this.env.debug, getFieldDef });
-            const trees = !tree.negate && tree.value === "&" ? tree.children : [tree];
-            promises = trees.map((tree) => this.getDomainTreeDescription(resModel, tree));
+            promises = await this.getDomainFacets(resModel, domain, { splitAndConnector: true });
         } catch (error) {
             if (error.data?.name === "builtins.KeyError" && error.data.message === resModel) {
                 // we don't want to support invalid models

--- a/addons/web/static/src/views/fields/domain/domain_field.xml
+++ b/addons/web/static/src/views/fields/domain/domain_field.xml
@@ -18,15 +18,20 @@
                                 </t>
                             </t>
                             <t t-foreach="state.facets" t-as="facet" t-key="facet_index">
-                                <div class="d-inline-flex align-items-stretch text-nowrap px-1 position-relative"
+                                <div class="o_searchview_facet position-relative d-inline-flex align-items-stretch rounded-2 bg-200 text-nowrap opacity-trigger-hover mw-100"
                                     role="listitem"
                                     tabindex="0"
-                                    >
-                                    <div class="o_searchview_facet_label rounded-start-2 btn btn-primary rounded-end-0 p-0" role="button">
-                                        <i class="px-1 small fa fa-filter" role="image"/>
+                                >
+                                    <div class="o_searchview_facet_label position-relative rounded-start-2 px-1 rounded-end-0 p-0 btn btn-primary" role="img">
+                                        <i t-if="facet.icon" class="small fa-fw" t-att-class="facet.icon" role="image"/>
+                                        <small t-else="" class="px-1" t-esc="facet.title"/>
                                     </div>
-                                    <div class="o_facet_values d-flex align-items-center px-2 bg-200 rounded-end-2 text-wrap">
-                                        <small class="o_facet_value" t-esc="facet"/>
+
+                                    <div class="o_facet_values position-relative d-flex flex-wrap align-items-center px-2 rounded-end-2 text-wrap overflow-hidden">
+                                        <t t-foreach="facet.values" t-as="facetValue" t-key="facetValue_index">
+                                            <em t-if="!facetValue_first" class="o_facet_values_sep small fw-bold mx-1 opacity-50" t-esc="facet.separator"/>
+                                            <small class="o_facet_value text-truncate" t-esc="facetValue" t-att-title="facetValue"/>
+                                        </t>
                                     </div>
                                 </div>
                             </t>

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -1029,7 +1029,7 @@ test("domain field can be foldable", async function () {
     // Fold domain selector
     await contains(".o_field_domain a i").click();
 
-    expect(".o_field_domain .o_facet_values:contains('Color index is equal 2')").toHaveCount(1);
+    expect(".o_field_domain .o_searchview_facet").toHaveText("Color index\n2");
 });
 
 test("add condition in empty foldable domain", async function () {
@@ -1108,7 +1108,7 @@ test("folded domain field with any operator", async function () {
                 </sheet>
             </form>`,
     });
-    expect(`.o_field_domain .o_facet_values`).toHaveText("Company matches ( Id is equal 1 )");
+    expect(".o_field_domain .o_searchview_facet").toHaveText("Company");
 });
 
 test("foldable domain, search_count delayed", async function () {
@@ -1133,7 +1133,7 @@ test("foldable domain, search_count delayed", async function () {
     });
     expect(".o_domain_show_selection_button").toHaveCount(0);
     expect(".o_tree_editor").toHaveCount(0);
-    expect(`.o_field_domain .o_facet_values`).toHaveText("Id is equal 1");
+    expect(".o_field_domain .o_searchview_facet").toHaveText("Id\n1");
     def.resolve();
     await animationFrame();
     expect(".o_domain_show_selection_button").toHaveCount(1);
@@ -1159,5 +1159,5 @@ test("folded domain field with withinh operator", async function () {
                 </sheet>
             </form>`,
     });
-    expect(`.o_field_domain .o_facet_values`).toHaveText("Datetime next 2 months");
+    expect(".o_field_domain .o_searchview_facet").toHaveText("Datetime\n2 months");
 });

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -2499,7 +2499,7 @@ test("shorten descriptions of long lists", async () => {
         readonly: true,
     });
     expect(".o_tree_editor_condition").toHaveText(
-        `Id\nis in\n(\n${values.slice(0, 20).join("\n,\n")}\n,\n...\n)`
+        `Id\nis in\n(\n${values.slice(0, 4).join("\n,\n")}\n,\n...\n)`
     );
 });
 

--- a/addons/web/static/tests/search/misc.test.js
+++ b/addons/web/static/tests/search/misc.test.js
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "@odoo/hoot";
+import {
+    defineModels,
+    fields,
+    getService,
+    makeMockEnv,
+    models,
+} from "@web/../tests/web_test_helpers";
+import { facet, useGetDomainFacets } from "@web/search/utils/misc";
+
+class TestModel extends models.Model {
+    name = fields.Char();
+    char = fields.Char();
+    float = fields.Float();
+    integer = fields.Integer();
+    boolean = fields.Boolean();
+    date = fields.Date();
+    datetime = fields.Datetime();
+    selection = fields.Selection({
+        selection: [
+            ["1", "One"],
+            ["2", "Two"],
+        ],
+    });
+    many2one = fields.Many2one({ relation: "test.model" });
+
+    _records = [
+        {
+            id: 1,
+            name: "Record 1",
+            char: "a",
+            float: 1.5,
+            integer: 1,
+            boolean: true,
+            date: "2025-04-04",
+            datetime: "2025-04-04 00:00:00",
+            selection: "1",
+            many2one: 2,
+        },
+        {
+            id: 2,
+            name: "Record 2",
+            char: "b",
+            float: 2.5,
+            integer: 2,
+            boolean: false,
+            date: "2025-04-04",
+            datetime: "2025-04-04 23:59:59",
+            selection: "2",
+            many2one: 1,
+        },
+    ];
+}
+
+defineModels([TestModel]);
+
+describe.current.tags("headless");
+
+test("useGetDomainFacets", async () => {
+    await makeMockEnv();
+    const fieldService = getService("field");
+    const nameService = getService("name");
+    const getDomainFacets = useGetDomainFacets(fieldService, nameService);
+
+    const toTest = [
+        { domain: `[]`, result: [facet("True")] },
+        { domain: `[(1, "=", 1)]`, result: [facet(1, "1")] },
+        { domain: `[(0, "=", 1)]`, result: [facet(1, "0")] },
+        {
+            domain: `[("char", "=", "a")]`,
+            result: [facet("a", "Char")],
+        },
+        {
+            domain: `[("char", "=", False)]`,
+            result: [facet("not set", "Char")],
+        },
+        {
+            domain: `[("char", "!=", False)]`,
+            result: [facet("set", "Char")],
+        },
+        {
+            domain: `[("integer", "=", 1)]`,
+            result: [facet(1, "Integer")],
+        },
+        {
+            domain: `[("float", "=", 1.5)]`,
+            result: [facet(1.5, "Float")],
+        },
+        {
+            domain: `[("boolean", "=", False)]`,
+            result: [facet("not set", "Boolean")],
+        },
+        {
+            domain: `[("boolean", "!=", False)]`,
+            result: [facet("set", "Boolean")],
+        },
+        {
+            domain: `[("boolean", "=", True)]`,
+            result: [facet("set", "Boolean")],
+        },
+        {
+            domain: `[("boolean", "!=", True)]`,
+            result: [facet("not set", "Boolean")],
+        },
+        {
+            domain: `[("many2one", "=", 1)]`,
+            result: [facet("Record 1", "Many2one")],
+        },
+        {
+            domain: `[("many2one.many2one", "=", 1)]`,
+            result: [facet("Record 1", "Many2one")],
+        },
+        {
+            domain: `[("date", "=", "2025-04-04")]`,
+            result: [facet("04/04/2025", "Date")],
+        },
+        {
+            domain: `[("datetime", "=", "2025-04-04 00:00:00")]`,
+            result: [facet("04/04/2025 01:00:00", "Datetime")],
+        },
+        {
+            domain: `[("selection", "=", "1")]`,
+            result: [facet("One", "Selection")],
+        },
+        {
+            domain: `["&", ("char", "=", "a"), ("char", "=", False)]`,
+            result: [facet("Char")],
+        },
+        {
+            domain: `["|", ("char", "=", "a"), ("char", "=", "b")]`,
+            result: [facet(["a", "b"], "Char")],
+        },
+        {
+            domain: `["|", ("char", "=", "a"), ("char", "=", False)]`, // = False => virtual operator not_set
+            result: [facet("Char")],
+        },
+        {
+            domain: `["&", ("char", "=", "a"), ("boolean", "=", False)]`,
+            options: { splitAndConnector: true },
+            result: [facet("a", "Char"), facet("not set", "Boolean")],
+        },
+        {
+            domain: `["&", "&", ("char", "=", "a"), ("char", "=", "b"), ("integer", "=", 1)]`,
+            options: { splitAndConnector: true },
+            result: [facet("Char"), facet(1, "Integer")],
+        },
+        {
+            domain: `["!", "&", ("char", "=", "a"), ("boolean", "=", False)]`,
+            options: { splitAndConnector: true },
+            result: [facet("Custom filter")],
+        },
+        {
+            domain: `["|", ("char", "=", "a"), ("boolean", "=", False)]`,
+            options: { splitAndConnector: true },
+            result: [facet("Custom filter")],
+        },
+        {
+            domain: `["!", "|", ("char", "=", "a"), ("boolean", "=", False)]`,
+            options: { splitAndConnector: true },
+            result: [facet("a", "Char"), facet("set", "Boolean")],
+        },
+        {
+            domain: `["&", ("char", "=", "a"), ("boolean", "=", False)]`,
+            result: [facet("Custom filter")],
+        },
+        {
+            domain: `[("many2one", "=", 1)]`,
+            result: [facet("Record 1", "Many2one")],
+        },
+        {
+            domain: `[("many2one", "in", [1, 2])]`,
+            result: [facet(["Record 1", "Record 2"], "Many2one")],
+        },
+        {
+            domain: `["&", ("integer", ">=", 1), ("integer", "<=", 2)]`,
+            result: [facet("( 1 and 2 )", "Integer")],
+        },
+        {
+            domain: `[("many2one", "any", [])]`,
+            result: [facet("Many2one")],
+        },
+        {
+            domain: `[("boolean", "in", [True, False])]`,
+            result: [facet([true, false], "Boolean")],
+        },
+        {
+            domain: `["&", ("char", ">=", "l"), ("char", "<=", "t")]`,
+            result: [facet(["( l and t )"], "Char")],
+        },
+        {
+            domain: `["&", ("date", ">=", (context_today() + relativedelta(months = -1)).strftime("%Y-%m-%d")), ("date", "<=", context_today().strftime("%Y-%m-%d"))]`,
+            result: [facet(["1 months"], "Date")],
+        },
+    ];
+
+    for (const { domain, options, result } of toTest) {
+        const facets = await getDomainFacets("test.model", domain, options);
+        expect(facets).toEqual(result);
+    }
+});

--- a/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
@@ -214,7 +214,7 @@ test("edit a favorite with a groupby", async () => {
     ];
 
     onRpc("/web/domain/validate", () => true);
-    await mountWithSearch(SearchBar, {
+    const searchBar = await mountWithSearch(SearchBar, {
         resModel: "foo",
         searchMenuTypes: ["groupBy"], // we need it to have facet (see facets getter in search_model)
         searchViewId: false,
@@ -232,7 +232,8 @@ test("edit a favorite with a groupby", async () => {
     await editValue("abcde");
     await contains(`.modal footer button`).click();
     expect(`.modal`).toHaveCount(0);
-    expect(getFacetTexts()).toEqual(["Bar", "Foo contains abcde"]);
+    expect(getFacetTexts()).toEqual(["Foo\nabcde", "Bar"]);
+    expect(searchBar.env.searchModel.domain).toEqual([["foo", "ilike", "abcde"]]);
 
     await toggleSearchBarMenu();
     expect(`.o_group_by_menu .o_menu_item:not(.o_add_custom_group_menu)`).toHaveCount(0);

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -699,18 +699,13 @@ test("Add a custom filter", async () => {
     await clickOnButtonAddBranch(-1);
     await clickOnButtonAddBranch(-1);
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual([
-        "Filter",
-        "Id is equal 1",
-        "Id is equal 1",
-        "( Id is equal 1 and Id is equal 1 ) or Id is in ( 1 , 1 )",
-    ]);
+    expect(getFacetTexts()).toEqual(["Filter", "Custom filter"]);
     expect(searchBar.env.searchModel.domain).toEqual([
         "&",
         ["foo", "=", "abc"],
         "&",
-        ["id", "=", 1],
         "&",
+        ["id", "=", 1],
         ["id", "=", 1],
         "|",
         "|",
@@ -745,7 +740,7 @@ test("Add a custom filter containing an expression", async () => {
         `[("foo", "in", [uid, 1, "a"])]`
     );
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual([`Foo is in ( uid , 1 , "a" )`]);
+    expect(getFacetTexts()).toEqual([`Foo\nuid\nor\n1\nor\n"a"`]);
     expect(searchBar.env.searchModel.domain).toEqual([
         ["foo", "in", [7, 1, "a"]], // uid = 7
     ]);
@@ -767,10 +762,11 @@ test("Add a custom filter containing a between operator", async () => {
     await toggleSearchBarMenu();
     await openAddCustomFilterDialog();
     await contains(`.o_domain_selector_debug_container textarea`).edit(
-        `[("id", "between", [0, 10])]`
+        `[("id", ">=", 0), ("id", "<=", 10)]`
     );
+
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual([`Id is between 0 and 10`]);
+    expect(getFacetTexts()).toEqual([`Id\n( 0 and 10 )`]);
     expect(searchBar.env.searchModel.domain).toEqual(["&", ["id", ">=", 0], ["id", "<=", 10]]);
 });
 
@@ -792,7 +788,7 @@ test("consistent display of ! in debug mode", async () => {
     expect(".o_tree_editor_row .dropdown-toggle").toHaveText("none");
 
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual([`! ( Foo is equal 1 or Id is equal 2 )`]);
+    expect(getFacetTexts()).toEqual([`Custom filter`]);
     expect(searchBar.env.searchModel.domain).toEqual(["!", "|", ["foo", "=", 1], ["id", "=", 2]]);
 });
 
@@ -812,26 +808,26 @@ test("display of (not) set in facets", async () => {
     await openAddCustomFilterDialog();
     await selectOperator("not_set");
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Id not set"]);
+    expect(getFacetTexts()).toEqual(["Id\nnot set"]);
     expect(searchBar.env.searchModel.domain).toEqual([["id", "=", false]]);
 
     await contains(".o_searchview_facet_label").click();
     await selectOperator("set");
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Id set"]);
+    expect(getFacetTexts()).toEqual(["Id\nset"]);
     expect(searchBar.env.searchModel.domain).toEqual([["id", "!=", false]]);
 
     await contains(".o_searchview_facet_label").click();
     await openModelFieldSelectorPopover();
     await contains(".o_model_field_selector_popover_item_name:contains(Boolean)").click();
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Boolean set"]);
+    expect(getFacetTexts()).toEqual(["Boolean\nset"]);
     expect(searchBar.env.searchModel.domain).toEqual([["boolean", "!=", false]]);
 
     await contains(".o_searchview_facet_label").click();
     await selectOperator("not_set");
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Boolean not set"]);
+    expect(getFacetTexts()).toEqual(["Boolean\nnot set"]);
     expect(searchBar.env.searchModel.domain).toEqual([["boolean", "=", false]]);
 });
 
@@ -878,24 +874,17 @@ test("display names in facets", async () => {
     await toggleSearchBarMenu();
     await openAddCustomFilterDialog();
     await contains(`.o_domain_selector_debug_container textarea`).edit(
-        `[("bar", "=", 1 ), ("bar", "in", [2, 5555]), ("bar", "!=", false), ("id", "=", 2)]`
+        `["|", ("bar", "=", 1 ), ("bar", "in", [2, 5555])]`
     );
     await contains(".modal footer button").click();
 
     expect(getFacetTexts()).toEqual([
-        "Bar is equal John",
-        "Bar is in ( David , Inaccessible/missing record ID: 5555 )",
-        "Bar is not equal false",
-        "Id is equal 2",
+        "Bar\nJohn\nor\nDavid\nor\nInaccessible/missing record ID: 5555",
     ]);
     expect(searchBar.env.searchModel.domain).toEqual([
-        "&",
+        "|",
         ["bar", "=", 1],
-        "&",
         ["bar", "in", [2, 5555]],
-        "&",
-        ["bar", "!=", false],
-        ["id", "=", 2],
     ]);
 });
 
@@ -934,7 +923,7 @@ test("display names in facets (with a property)", async () => {
     );
     await contains(".modal footer button").click();
 
-    expect(getFacetTexts()).toEqual(["Properties \u2794 M2O is equal John"]);
+    expect(getFacetTexts()).toEqual(["M2O\nJohn"]);
     expect(searchBar.env.searchModel.domain).toEqual([["properties.m2o", "=", 1]]);
 });
 
@@ -1047,6 +1036,6 @@ test("shorten descriptions of long lists", async function () {
         `[("id", "in", [${values}])]`
     );
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual([`Id is in ( ${values.slice(0, 20).join(" , ")} , ... )`]);
+    expect(getFacetTexts()).toEqual([`Id\n${[...values.slice(0, 4), "..."].join("\nor\n")}`]);
     expect(searchBar.env.searchModel.domain).toEqual([["id", "in", values]]);
 });


### PR DESCRIPTION
Before this commit, edit/create a domain in the search bar menu (via the domain selector) would create at least one facet (possibly several) in the search bar with a description of the domain.

It was annoying for several reasons:
- the domain facet could be rather long since the domain can be complex.
- when several facets are created, the domain can no more be edited as a whole.

With this commit, we simply create a single facet with a simple description (following roughly the logic):
  - if the filter is based on a single field and a single operator, the description is of the form: field_descr: v1 or v2 or ...
  - if the filter is based on a single field but multiple operators, the description is of the form: fa-filter: field_descr.
  - if the filter is more complex, the description is "Custom filter"

Since the domain can still be inspected by opening the domain selector, this should be fine.

The same kind of logic is used when using the search bar autocompletion.

Note that in the domain field, we still split the domain in several facets if possible since this allows us to display more information but without the drawback mentionned above: it is still possible to edit (in edit mode of course) the domain as a whole by clicking on any facet.

Task ID: 4671295