### PR TITLE
[FIX] website_sale: missing context in products

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -111,15 +111,12 @@ class WebsiteSnippetFilter(models.Model):
                     domain,
                     [('id', 'in', products_ids)],
                 ])
-                filtered_ids = set(self.env['product.product'].with_context(
-                    display_default_code=False,
-                    add2cart_rerender=True,
-                )._search(domain, limit=limit))
+                filtered_ids = set(self.env['product.product']._search(domain, limit=limit))
                 # `search` will not keep the order of tracked products; however, we want to keep
                 # that order (latest viewed first).
-                products = self.env['product.product'].browse(
-                    [product_id for product_id in products_ids if product_id in filtered_ids]
-                )
+                products = self.env['product.product'].with_context(
+                    display_default_code=False, add2cart_rerender=True,
+                ).browse([product_id for product_id in products_ids if product_id in filtered_ids])
 
         return products
 


### PR DESCRIPTION
This commit rectifies a fix (c0b7a8c2faae53ab62a747297e7f3a56c4d1d061) where the original context of the returned recordset was inadvertently omitted.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
