### PR TITLE
[FIX] survey: provide translations to frontend

### DIFF
--- a/addons/survey/models/__init__.py
+++ b/addons/survey/models/__init__.py
@@ -8,3 +8,4 @@ from . import survey_user_input
 from . import badge
 from . import challenge
 from . import res_partner
+from . import ir_http

--- a/addons/survey/models/ir_http.py
+++ b/addons/survey/models/ir_http.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = ["ir.http"]
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        modules = super()._get_translation_frontend_modules_name()
+        return modules + ["survey"]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit addresses translations not being exposed to the frontend for the survey module.

Current behavior before PR:

For surveys, no translatable terms existing in JavaScript are being translated. This mainly concerns `survey_form.js`.
Lack of translations there easily results in a mix of languages being shown to a user answering a survey.

Desired behavior after PR is merged:

Translatable terms defined in JavaScript are translated to the user's language.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
