### PR TITLE
[IMP] test_lint: test ref for new code

### DIFF
--- a/odoo/addons/test_lint/tests/__init__.py
+++ b/odoo/addons/test_lint/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import test_dunderinit
 from . import test_checkers
+from . import test_diffcase
 from . import test_pylint
 from . import test_pofile
 from . import test_docstring
@@ -12,6 +13,7 @@ from . import test_markers
 from . import test_onchange_domains
 from . import test_orm_import
 from . import test_override_signatures
+from . import test_ref
 from . import test_routes
 from . import test_i18n
 from . import test_test_holes

--- a/odoo/addons/test_lint/tests/data/test_diff_case.xml
+++ b/odoo/addons/test_lint/tests/data/test_diff_case.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- user 2 is the human admin user -->
+        <record id="user_admin" model="res.users">
+            <field name="login">admin</field><field name="password">admin</field>
+            <field name="partner_id" ref="base.partner_admin"
+            /> <!-- end of user admin -->
+            <field name="company_id" ref="main_company"/>
+            <field name="company_ids" eval="[Command.link(ref('main_company'))]"/>
+            <field name="group_ids" eval="[Command.set([])]"/>
+            <field name="signature">Administrator</field>
+        </record> <!-- end of user admin -->
+
+        <!-- user admin settings first line
+        second line -->
+        <record
+            id="user_admin_settings"
+            model="res.users.settings"
+            forcecreate="0">
+            <field name="user_id" ref="base.user_admin"/>
+        </record>
+
+        <template id="payevent_0004_xml_report">
+            <!-- <Record_Delimiter DocumentID="1.1" DocumentType="PARENT" DocumentName="PAYEVNT" RelatedDocumentID=""/> -->
+            <tns:PAYEVNT
+                xsi:schemaLocation="http://www.sbr.gov.au/ato/payevnt ato.payevnt.0004.2020.01.00.xsd" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.sbr.gov.au/ato/payevnt"
+            >
+                <tns:Rp>
+                    <tns:SoftwareInformationBusinessManagementSystemId t-esc="employer['SoftwareInformationBusinessManagementSystemId']"/>
+                    <tns:AustralianBusinessNumberId t-esc="employer['AustralianBusinessNumberId']"/>
+                </tns:Rp>
+            </tns:PAYEVNT>
+        </template>
+    </data>
+</odoo>

--- a/odoo/addons/test_lint/tests/test_diffcase.py
+++ b/odoo/addons/test_lint/tests/test_diffcase.py
@@ -1,0 +1,98 @@
+from odoo.tests import BaseCase
+from odoo.tests.diffcase import DiffCase
+from odoo.tools import file_path
+
+
+class TestDiffCase(BaseCase):
+    def get_diff_linenos(self, filepath: str, *args, expected_lines: int | None = None) -> set[int]:
+        """ get the line numbers of the lines that are in the args and check if the number of lines is expected_lines """
+        modified_lines: set[str] = {l.strip() for l in args}
+        diff_linenos: set[int] = set()
+        with open(filepath, encoding='utf-8') as f:
+            for lineno, line in enumerate(f, start=1):
+                if line.strip() in modified_lines:
+                    diff_linenos.add(lineno)
+        if expected_lines is not None:
+            self.assertEqual(len(diff_linenos), expected_lines)
+        return diff_linenos
+
+    def test_get_xml_elements(self):
+        abs_path = file_path('test_lint/tests/data/test_diff_case.xml')
+        diff_linenos = self.get_diff_linenos(
+            abs_path,
+            'model="res.users.settings"',   # line in a multi-line start tag
+            expected_lines=1,
+        )
+
+        element_tree, elements_info = DiffCase.parse_xml_file(abs_path, diff_linenos)
+        elements = [e for e in element_tree.iter() if isinstance(e.tag, str) and elements_info[e].start_tag_in_diff]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0].tag, 'record')
+        self.assertEqual(elements[0].get('model', None), 'res.users.settings')
+
+        diff_linenos = self.get_diff_linenos(
+            abs_path,
+            '<field name="login">admin</field><field name="password">admin</field>',  # 2 elements in a single line
+            expected_lines=1,
+        )
+        element_tree, elements_info = DiffCase.parse_xml_file(abs_path, diff_linenos)
+        elements = [e for e in element_tree.iter() if isinstance(e.tag, str) and elements_info[e].start_tag_in_diff]
+        self.assertEqual(len(elements), 2)
+        self.assertEqual(elements[0].tag, 'field')
+        self.assertEqual(elements[0].get('name', None), 'login')
+        self.assertEqual(elements[1].tag, 'field')
+        self.assertEqual(elements[1].get('name', None), 'password')
+
+        diff_linenos = self.get_diff_linenos(
+            abs_path,
+            '/> <!-- end of user admin -->',  # start tag closes in a different line
+            expected_lines=1,
+        )
+        element_tree, elements_info = DiffCase.parse_xml_file(abs_path, diff_linenos)
+        elements = [e for e in element_tree.iter() if isinstance(e.tag, str) and elements_info[e].start_tag_in_diff]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0].tag, 'field')
+        self.assertEqual(elements[0].get('ref', None), 'base.partner_admin')
+
+        diff_linenos = self.get_diff_linenos(
+            abs_path,
+            'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://www.sbr.gov.au/ato/payevnt"',  # line in a namespace
+            expected_lines=1,
+        )
+        element_tree, elements_info = DiffCase.parse_xml_file(abs_path, diff_linenos)
+        elements = [e for e in element_tree.iter() if isinstance(e.tag, str) and elements_info[e].start_tag_in_diff]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0].tag, '{http://www.sbr.gov.au/ato/payevnt}PAYEVNT')
+
+        diff_linenos = self.get_diff_linenos(
+            abs_path,
+            '<tns:Rp>',  # start tag of a namespace
+            expected_lines=1,
+        )
+        element_tree, elements_info = DiffCase.parse_xml_file(abs_path, diff_linenos)
+        elements = [e for e in element_tree.iter() if isinstance(e.tag, str) and elements_info[e].start_tag_in_diff]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0].tag, '{http://www.sbr.gov.au/ato/payevnt}Rp')
+
+        diff_linenos = self.get_diff_linenos(
+            abs_path,
+            '</record> <!-- end of user admin -->',  # comment after end tag
+            '<!-- user admin settings first line',  # first line of a multi-line comment
+            'second line -->',  # last line of a multi-line comment
+            expected_lines=3,
+        )
+        element_tree, elements_info = DiffCase.parse_xml_file(abs_path, diff_linenos)
+        elements = [e for e in element_tree.iter() if isinstance(e.tag, str) and elements_info[e].start_tag_in_diff]
+        self.assertFalse(elements)
+
+        # The <?xml version="1.0" encoding="utf-8"?> won't be parsed by iterparse
+        # We don't handle it for simplicity. As a result, it will be treated as part of the first element by the implementation
+        diff_linenos = self.get_diff_linenos(
+            abs_path,
+            '<?xml version="1.0" encoding="utf-8"?>',  # xml declaration
+            expected_lines=1,
+        )
+        element_tree, elements_info = DiffCase.parse_xml_file(abs_path, diff_linenos)
+        elements = [e for e in element_tree.iter() if isinstance(e.tag, str) and elements_info[e].start_tag_in_diff]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0].tag, 'odoo')

--- a/odoo/addons/test_lint/tests/test_ref.py
+++ b/odoo/addons/test_lint/tests/test_ref.py
@@ -1,0 +1,416 @@
+import ast
+import logging
+import mmap
+import os
+import tokenize
+from collections.abc import Collection
+from lxml import etree
+from pathlib import Path
+from typing import Literal
+from unidiff import PatchedFile
+
+from odoo.tests.diffcase import DiffCase, DiffFile, DiagnosticKind, DiagnosticMessage
+from odoo.modules.module import _get_manifest_cached, get_modules, get_module_path
+from odoo.tools.convert import nodeattr2bool, xml_import
+
+_logger = logging.getLogger(__name__)
+
+
+PY_ENV_REF = DiagnosticKind(
+    name='ref_env_call',
+    body='Found env.ref() calls without raise_if_not_found=False',
+    suggestion='Add raise_if_not_found=False to the env.ref() call'
+)
+
+PY_ENV_REF_DELETABLE = DiagnosticKind(
+    name='ref_env_call_deletable',
+    body='Found env.ref() calls without raise_if_not_found=False and the reference is handled with raise_if_not_found=False somewhere else',
+    suggestion='Add raise_if_not_found=False to the env.ref() call'
+)
+
+XML_ID_FORCECREATE = DiagnosticKind(
+    name='xml_id_forcecreate',
+    body='Found record id for foreign module without forcecreate',
+    suggestion='Add forcecreate="1" to the record'
+)
+
+XML_ID_NOUPDATE = DiagnosticKind(
+    name='xml_id_noupdate',
+    body='Found record id for foreign module with forcecreate="0" but not in "noupdate"',
+    suggestion='Move the record data to noupdate="1"'
+)
+
+XML_REF = DiagnosticKind(
+    name='xml_ref',
+    body='Found field ref for foreign module',
+    suggestion='Use eval()'
+)
+
+XML_REF_DELETABLE = DiagnosticKind(
+    name='xml_ref_deletable',
+    body='Found field ref for foreign module and the reference is handled with raise_if_not_found=False somewhere else',
+    suggestion='Use eval()'
+)
+
+XML_EVAL = DiagnosticKind(
+    name='xml_eval',
+    body='Found eval uses ref() for foreign module without raise_if_not_found=False',
+    suggestion='Add raise_if_not_found=False to the ref() call'
+)
+
+XML_EVAL_DELETABLE = DiagnosticKind(
+    name='xml_eval_deletable',
+    body='Found eval uses ref() for foreign module without raise_if_not_found=False and the reference is handled with raise_if_not_found=False somewhere else',
+    suggestion='Add raise_if_not_found=False to the ref() call'
+)
+
+
+class EvalRefVisitor(ast.NodeVisitor):
+    def __init__(self, protected_xml_ids=None, deletable_xml_ids=None, mode: Literal['diagnose', 'find_deletable'] = 'diagnose'):
+        self.protected_xml_ids = set() if protected_xml_ids is None else protected_xml_ids
+        self.deletable_xml_ids = set() if deletable_xml_ids is None else deletable_xml_ids
+        self.mode = mode
+
+        self.diagnostic_kinds: list[DiagnosticKind] = []
+
+    def _check_ref(self, node) -> None:
+        if not node.args:
+            return None
+        ref = node.args[0]
+        if isinstance(ref, ast.Constant) and ref.value in self.protected_xml_ids:
+            return None
+
+        raise_if_not_found = True  # default to True
+        for keyword in node.keywords:
+            if keyword.arg == 'raise_if_not_found':
+                if isinstance(keyword.value, ast.Constant) and keyword.value.value is False:
+                    raise_if_not_found = False
+
+        if raise_if_not_found:
+            if self.mode == 'diagnose':
+                if isinstance(ref, ast.Constant) and ref.value in self.deletable_xml_ids:
+                    diagnostic_kind = PY_ENV_REF_DELETABLE
+                else:
+                    diagnostic_kind = PY_ENV_REF
+                self.diagnostic_kinds.append(diagnostic_kind)
+        elif self.mode == 'find_deletable' and isinstance(ref, ast.Constant):
+            self.deletable_xml_ids.add(ref.value)
+
+    def visit_Call(self, node):
+        """Check for env.ref calls."""
+        if isinstance(node.func, ast.Name) and node.func.id == 'ref':
+            self._check_ref(node)
+
+        self.generic_visit(node)
+
+
+class FileEnvRefVisitor(ast.NodeVisitor):
+    def __init__(self, diff_file: DiffFile, protected_xml_ids=None, deletable_xml_ids=None, mode: Literal['diagnose', 'find_deletable'] = 'diagnose'):
+        self.diff_file = diff_file
+        self.protected_xml_ids = set() if protected_xml_ids is None else protected_xml_ids
+        self.deletable_xml_ids = set() if deletable_xml_ids is None else deletable_xml_ids
+        self.mode = mode
+
+        self.diagnostics: list[DiagnosticMessage] = []
+        self.env_ref_names = set()  # Track variables that store env.ref
+        self.try_except_value_error: list[dict] = []  # Track try ... except ValueError blocks
+
+    def _check_ref(self, node) -> None:
+        if self.mode == 'diagnose' and not self._is_node_in_diff(node):
+            return None
+        if not node.args:
+            return None
+        ref = node.args[0]
+        if isinstance(ref, ast.Constant) and ref.value in self.protected_xml_ids:
+            return None
+
+        raise_if_not_found = True  # default to True
+        for keyword in node.keywords:
+            if keyword.arg == 'raise_if_not_found':
+                if isinstance(keyword.value, ast.Constant) and keyword.value.value is False:
+                    raise_if_not_found = False
+
+        if raise_if_not_found and not self._is_in_value_error_handler(node):
+            if self.mode == 'diagnose':
+                if isinstance(ref, ast.Constant) and ref.value in self.deletable_xml_ids:
+                    diagnostic_kind = PY_ENV_REF_DELETABLE
+                else:
+                    diagnostic_kind = PY_ENV_REF
+                self.diagnostics.append(diagnostic_kind(self.diff_file, node.lineno, node.end_lineno))
+        elif self.mode == 'find_deletable' and isinstance(ref, ast.Constant):
+            self.deletable_xml_ids.add(ref.value)
+
+    def _is_node_in_diff(self, node):
+        """Check if any line of the node is in the diff"""
+        return self.diff_file.is_lineno_in_diff(node.lineno, node.end_lineno)
+
+    def _is_in_value_error_handler(self, node):
+        """Check if the node is within a try block that handles ValueError."""
+        for try_block in self.try_except_value_error:
+            if try_block['start'] <= node.lineno <= try_block['end']:
+                return True
+        return False
+
+    def visit_Try(self, node):
+        """Record the try ... except ValueError block which can safely handle ref() calls"""
+        except_value_error = False
+        for handler in node.handlers:
+            if isinstance(handler.type, ast.Name) and handler.type.id == 'ValueError':
+                except_value_error = True
+            elif isinstance(handler.type, ast.Tuple):
+                for exc in handler.type.elts:
+                    if isinstance(exc, ast.Name) and exc.id == 'ValueError':
+                        except_value_error = True
+
+        if except_value_error:
+            self.try_except_value_error.append({
+                'start': node.body[0].lineno,
+                'end': node.body[-1].lineno,
+            })
+        self.generic_visit(node)
+        if except_value_error:
+            self.try_except_value_error.pop()
+
+    def visit_Assign(self, node):
+        """Record ref_=env.ref to check ref_() in visit_Call"""
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            value = node.value
+            if (isinstance(value, ast.Attribute) and value.attr == 'ref' and
+                isinstance(value.value, (ast.Name, ast.Attribute))):
+                current = value.value
+
+                if (isinstance(current, ast.Attribute) and current.attr == 'env') or \
+                    (isinstance(current, ast.Name) and current.id == 'env'):
+                    self.env_ref_names.add(node.targets[0].id)
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        """Check env.ref() and ref_() calls recorded in visit_Assign"""
+        if isinstance(node.func, ast.Attribute) and node.func.attr == 'ref':
+            current = node.func.value
+
+            if isinstance(current, ast.Attribute) and current.attr == 'env':
+                # xxx.env.ref()
+                self._check_ref(node)
+            elif isinstance(current, ast.Name) and current.id == 'env':
+                # env.ref()
+                self._check_ref(node)
+
+        elif isinstance(node.func, ast.Name) and node.func.id in self.env_ref_names:
+            # ref_=env.ref and check ref_()
+            self._check_ref(node)
+
+        self.generic_visit(node)
+
+
+def check_ref_for_python_file(diff_file: DiffFile, protected_xml_ids: Collection[str] = (), deletable_xml_ids: Collection[str] = ()) -> list[DiagnosticMessage]:
+    _logger.info('Checking %s', diff_file.path)
+    with open(diff_file.path, encoding="utf-8") as f:
+        content = f.read()
+    try:
+        tree = ast.parse(content)
+        visitor = FileEnvRefVisitor(diff_file, protected_xml_ids, deletable_xml_ids)
+        visitor.visit(tree)
+        return visitor.diagnostics
+    except SyntaxError:
+        _logger.error('Syntax error in %s', diff_file.path)
+        return []
+
+
+def check_ref_for_data_xml_element(element: etree._Element, linenos: tuple[int, int], diff_file: DiffFile, noupdate: bool = False, protected_xml_ids: Collection[str] = (), deletable_xml_ids: Collection[str] = ()) -> list[DiagnosticMessage]:
+
+    def is_ref_risky(ref: str) -> bool:
+        xml_id = ref if '.' in ref else f'{diff_file.module_name}.{ref}'
+        if xml_id in protected_xml_ids:
+            return False
+        # if the file is a data file we trust all reference for the current module's records,
+        # in case these records are created in another file while installing the module
+        return not xml_id.startswith(f'{diff_file.module_name}.')
+
+    diagnostics = []
+    if element.tag == 'record':
+        id_attr = element.attrib.get('id')
+        if not (id_attr and is_ref_risky(id_attr)):
+            return diagnostics
+        forcecreate = nodeattr2bool(element.attrib, 'forcecreate', True)
+        # for non-existing risky foreign module xmlid
+        if 'forcecreate' not in element.attrib:
+            # ``Exception("Cannot update missing record")``
+            diagnostics.append(XML_ID_FORCECREATE(diff_file, *linenos))
+        elif not noupdate and not forcecreate:
+            # ``Exception("Cannot update missing record")``
+            diagnostics.append(XML_ID_NOUPDATE(diff_file, *linenos))
+
+    elif element.tag == 'field':
+        ref_attr = element.attrib.get('ref')
+        if ref_attr:
+            if is_ref_risky(ref_attr):
+                diagnostics.append(XML_REF(diff_file, *linenos))
+        if eval_attr := element.attrib.get('eval'):
+            # parse as python ast, check function ref
+            # add to issues if ref for foreign module without raise_if_not_found=False
+            tree = ast.parse(eval_attr.strip())
+            visitor = EvalRefVisitor(protected_xml_ids=protected_xml_ids, deletable_xml_ids=deletable_xml_ids)
+            visitor.visit(tree)
+            diagnostics.extend({
+                PY_ENV_REF: XML_EVAL,
+                PY_ENV_REF_DELETABLE: XML_EVAL_DELETABLE,
+            }[dk](diff_file, *linenos)
+            for dk in visitor.diagnostic_kinds)
+    return diagnostics
+
+
+def _get_module_model_files(module: str) -> list[str]:
+    """get all python files in module/ and module/models/ directory"""
+    if not (module_path := get_module_path(module)):
+        return []
+    python_files = [str(f) for f in Path(module_path).glob('*.py') if not f.name.startswith('__')]
+    for root, _, files in os.walk(os.path.join(module_path, 'models')):
+        python_files.extend(os.path.join(root, f) for f in files if f.endswith('.py'))
+    return python_files
+
+
+def _get_module_data_xml_files(module: str) -> list[str]:
+    """get all data xml files in manifest['data']"""
+    if not (module_path := get_module_path(module)):
+        return []
+    manifest = _get_manifest_cached(module)
+    return [
+        os.path.join(module_path, data_file)
+        for data_file in manifest['data']
+        if data_file.endswith('.xml')
+    ]
+
+
+def _get_protected_xml_ids() -> set[str]:
+    """Get protected records from all python files in addons.
+
+    Scans for comments in the format "# PROTECT module.record_name" in Python files
+
+    Returns:
+        set[str]: Set of protected record external IDs
+    """
+
+    protected = set()
+    _logger.info('Getting protected records from Python files')
+
+    for module in get_modules():
+        if module.startswith('test_'):
+            continue
+        for py_file in _get_module_model_files(module):
+            with open(py_file, 'rb') as f:
+                try:
+                    with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                        if mm.find(b'# PROTECT ') == -1:
+                            continue
+                except ValueError as e:
+                    if e.args == ('cannot mmap an empty file',):
+                        continue
+                    raise
+            try:
+                with tokenize.open(py_file) as f:
+                    tokens = tokenize.generate_tokens(f.readline)
+                    for token in tokens:
+                        if token.type == tokenize.COMMENT and token.string.startswith('# PROTECT '):
+                            external_id = token.string.split('PROTECT ', 1)[1].strip()
+                            if external_id.count('.') == 1:
+                                protected.add(external_id)
+            except tokenize.TokenError:
+                continue
+    return protected
+
+
+def _get_deletable_xml_ids(protected_xml_ids: set[str]) -> set[str]:
+    """Get deletable records from all python files in addons.
+
+    Scans codes with ``ref(xmlid, raise_if_not_found=False)`` in Python files and xml files
+    and with ``ref(xmlid)`` in ``try ... except ValueError`` blocks in Python files
+    these xmlids are treated as deletable
+
+    Returns:
+        set[str]: Set of deletable record external IDs
+    """
+    deletable_xml_ids = set()
+    for module in get_modules():
+        if module.startswith('test_'):
+            continue
+        for py_file in _get_module_model_files(module):
+            with open(py_file, encoding='utf-8') as f:
+                content = f.read()
+            try:
+                tree = ast.parse(content)
+                visitor = FileEnvRefVisitor(DiffFile('', PatchedFile()), protected_xml_ids, deletable_xml_ids, mode='find_deletable')
+                visitor.visit(tree)
+            except etree.XMLSyntaxError:
+                # usually because the xml is empty
+                continue
+        for xml_file in _get_module_data_xml_files(module):
+            with open(xml_file, 'rb') as f:
+                try:
+                    elements = etree.parse(f, None)
+                except etree.XMLSyntaxError:
+                    # usually because the xml is empty
+                    continue
+            for element in elements.iter():
+                if element.tag == 'field' and (eval_attr := element.attrib.get('eval')):
+                    tree = ast.parse(eval_attr.strip())
+                    visitor = EvalRefVisitor(protected_xml_ids, deletable_xml_ids, mode='find_deletable')
+                    visitor.visit(tree)
+    return deletable_xml_ids
+
+
+class TestRef(DiffCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.protected_xml_ids = _get_protected_xml_ids()
+        cls.deletable_xml_ids = _get_deletable_xml_ids(cls.protected_xml_ids)
+
+    def test_env_ref_usage(self):
+        """Check for env.ref calls without raise_if_not_found=False."""
+        for diff_file in self.diff_files['.py'].values():
+            if not os.path.exists(diff_file.path):
+                continue
+            if not diff_file.module_name or diff_file.module_name.startswith('test_') or diff_file.path_to_module.startswith('tests/'):
+                continue
+            self.diagnostices.extend(check_ref_for_python_file(diff_file, self.protected_xml_ids, self.deletable_xml_ids))
+
+    def test_data_xml_ref_usage(self):
+        """Check for ref for foreign modules."""
+        for diff_file in self.diff_files['.xml'].values():
+            if not os.path.exists(diff_file.path):
+                continue
+            manifest = _get_manifest_cached(diff_file.module_name)
+            if not manifest or diff_file.module_name == 'base' or diff_file.module_name.startswith('test_'):
+                continue
+            if not diff_file.path_to_module in manifest['data']:
+                continue
+            protected_xml_ids = set(self.protected_xml_ids)
+            elements, elements_info = self.parse_xml_file(diff_file.path)
+
+            _logger.info('Checking %s', diff_file.path)
+            noupdates = {None: False}  # dummy element None as the parent for the root element
+            for element in elements.iter():
+                if not isinstance(element.tag, str):
+                    # skip comment and pi
+                    continue
+                element_info = elements_info[element]
+                parent = element.getparent()
+                if element.tag in xml_import.DATA_ROOTS:
+                    noupdate = noupdates[element] = nodeattr2bool(element, 'noupdate', noupdates[parent])
+                else:
+                    noupdate = noupdates[element] = noupdates[parent]
+
+                if element.tag == 'record':
+                    # Check if this record can be created. If creatable, it becomes a valid reference for subsequent data in
+                    # this file, so add it to the local protected_xml_ids
+                    if not (id_attr := element.attrib.get('id')):
+                        continue
+                    xml_id = id_attr if '.' in id_attr else f'{diff_file.module_name}.{id_attr}'
+                    forcecreate = nodeattr2bool(element, 'forcecreate')  # explicit truthy forcecreate
+                    if not xml_id.startswith(diff_file.module_name + '.') and forcecreate:
+                        # forcecreated records for foreign modules can be safely referenced
+                        protected_xml_ids.add(xml_id)
+
+                if element_info.start_tag_in_diff:
+                    self.diagnostices.extend(check_ref_for_data_xml_element(element, element_info.start_tag_linenos, diff_file, noupdate, protected_xml_ids, self.deletable_xml_ids))

--- a/odoo/cli/test_diff.py
+++ b/odoo/cli/test_diff.py
@@ -1,0 +1,58 @@
+import json
+import logging
+import os
+
+from odoo.cli.command import Command
+from odoo.modules.module import initialize_sys_path
+from odoo.netsvc import init_logger
+from odoo.tools import config
+
+_logger = logging.getLogger(__name__)
+
+
+class TestDiff(Command):
+    """ Run the diff tests in the test_lint module """
+    name = 'test_diff'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.parser.add_argument('--diff-dir', type=str, required=True,
+                               help='Specify the absolute path for git diff files. Diff files are .txt files whose first line is the absolute path of the file of the git project. And the rest of the file is the git diff of the file for the code.')
+        self.parser.add_argument('--gen-diff', action='store_true',
+                               help='Generate git diff files for git projects in the addons path based on their current branch name and save them in diff-dir')
+        self.parser.add_argument('--output', type=str,
+                               help='Specify the path for ruff-like JSON results output')
+        self.parser.add_argument('--test-tags', type=str, dest="test_tags",
+                               help='Specify test tags to filter tests.')
+
+    def run(self, cmdargs):
+        init_logger()
+        parsed_args = self.parser.parse_args(args=cmdargs)
+        config._parse_config([
+            '--test-enable',
+            '--test-tags', parsed_args.test_tags,
+        ])
+        initialize_sys_path()
+
+        if parsed_args.gen_diff:
+            from odoo.tests.diffcase import generate_diff  # noqa: PLC0415
+            generate_diff(parsed_args.diff_dir)
+
+        from odoo.tests.diffcase import DiffCase  # noqa: PLC0415
+        DiffCase.diff_dir = parsed_args.diff_dir
+
+        from odoo.tests import loader  # noqa: PLC0415
+        suite = loader.make_suite(['test_lint'], 'test_diff')
+        if suite.countTestCases():
+            loader.run_suite(suite)
+
+        if parsed_args.output:
+            os.makedirs(os.path.dirname(os.path.abspath(parsed_args.output)), exist_ok=True)
+            with open(parsed_args.output, 'w', encoding='utf-8') as f:
+                json.dump(DiffCase.diagnostices, f, indent=2, default=lambda x: x.to_ruff())
+        else:
+            if DiffCase.diagnostices:
+                for diagnostic in DiffCase.diagnostices:
+                    _logger.warning(diagnostic.to_log())
+            else:
+                _logger.info('No issue found')

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2574,8 +2574,9 @@ def tagged(*tags):
         obj.test_tags = (getattr(obj, 'test_tags', set()) | include) - exclude
         at_install = 'at_install' in obj.test_tags
         post_install = 'post_install' in obj.test_tags
-        if not (at_install ^ post_install):
-            _logger.warning('A tests should be either at_install or post_install, which is not the case of %r', obj)
+        no_install = 'no_install' in obj.test_tags
+        if at_install + post_install + no_install != 1:
+            _logger.warning('A tests should be either at_install or post_install or no_install, which is not the case of %r', obj)
         return obj
     return tags_decorator
 

--- a/odoo/tests/diffcase.py
+++ b/odoo/tests/diffcase.py
@@ -1,0 +1,330 @@
+import functools
+import logging
+import os
+import re
+import subprocess
+
+from collections import defaultdict
+from lxml import etree
+
+from unidiff import PatchSet, PatchedFile
+
+import odoo.addons
+
+from .common import BaseCase
+from odoo.tools import OrderedSet, config, lazy_classproperty
+from odoo.tools.which import which
+
+_logger = logging.getLogger(__name__)
+
+
+class DiffFile:
+
+    @lazy_classproperty
+    def addons_paths(cls) -> list[str]:
+        return [
+            os.path.normpath(os.path.normcase(addons_path)) + os.sep
+            for addons_path in odoo.addons.__path__
+        ]
+
+    def __init__(self, repo_path: str, patched_file: PatchedFile):
+
+        self.path = os.path.join(repo_path, patched_file.path)  # /Users/username/project/odoo/odoo/addons/base/models/res_partner.py
+        """ absolute path of the file """
+
+        self.path_to_addons: str = self.extract_path_to_addons(self.path) or ''  # base/models/res_partner.py
+        """ relative path of the file to one of the odoo addons path """
+
+        self.module_name: str = self.path_to_addons.split(os.sep)[0]  # base
+        """ module name of the file """
+
+        self.path_to_module: str = self.path_to_addons[len(self.module_name) + len(os.sep):]  # models/res_partner.py
+        """ relative path of the file to the odoo module's path """
+
+        self.patched_file: PatchedFile = patched_file
+        """ the patched file object from unidiff """
+
+    @functools.cached_property
+    def diff_linenos(self) -> set[int]:
+        """ line numbers of new lines in the git diff of the file """
+        # TBD:
+        # use list[tuple[int, int]] instead of set[int] which only stores sorted [(start_lineno, end_lineno), ...]
+        # and use bisect to check if the given line numbers are in the diff O(log(n))
+        diff_linenos = set()
+        for hunk in self.patched_file:
+            for line in hunk:
+                if line.is_added and line.target_line_no:
+                    diff_linenos.add(line.target_line_no)
+        return diff_linenos
+
+    @classmethod
+    def extract_path_to_addons(cls, abs_path: str) -> str | None:
+        """ extract the relative path of the file to its odoo addons path """
+        for addons_path in cls.addons_paths:
+            if abs_path.startswith(addons_path) and len(abs_path) > len(addons_path):
+                odoo_path = abs_path[len(addons_path):].strip(os.sep)
+                return odoo_path
+        return None
+
+    def is_lineno_in_diff(self, start_lineno: int, end_lineno: int = 0) -> bool:
+        """ check if the any given line in [start_lineno, end_lineno] inclusively is in the diff """
+        if not end_lineno:
+            end_lineno = start_lineno
+        return any(line_no in self.diff_linenos for line_no in range(start_lineno, end_lineno + 1))
+
+
+class DiagnosticKind:
+    def __init__(self, name: str, body: str, suggestion: str):
+        self.name: str = name
+        """ The identifier of the diagnostic. """
+        self.body: str = body
+        """ The message body to display to the user, to explain the diagnostic. """
+        self.suggestion: str = suggestion
+        """ The message to display to the user, to explain the suggested fix. """
+
+    def __call__(self, file: DiffFile, start: int | tuple[int, int], end: int | tuple[int, int] | None = None) -> 'DiagnosticMessage':
+        return DiagnosticMessage(self, file, start, end)
+
+
+class DiagnosticMessage:
+    def __init__(self, kind: DiagnosticKind, file: DiffFile, start: int | tuple[int, int], end: int | tuple[int, int] | None = None):
+        self.kind: DiagnosticKind = kind
+        self.file: DiffFile = file
+        self.start = (start, 0) if isinstance(start, int) else start
+        self.end = (end, 0) if isinstance(end, int) else end if end else self.start
+
+    def to_ruff(self) -> dict:
+        # ruff like result
+        result = {
+            'code': self.kind.name,
+            'location': {
+                'row': self.start[0],
+                'column': self.start[1] or 1,
+            },
+            'end_location': {
+                'row': self.end[0],
+                'column': self.end[1] or 1,
+            },
+            'filename': self.file.path,
+            'message': self.kind.body,
+        }
+        if self.kind.suggestion:
+            result['fix'] = {
+                'message': self.kind.suggestion,
+            }
+        return result
+
+    def to_log(self) -> str:
+        return f'{self.file.path}:{self.start[0]} {self.kind.body}'
+
+
+def get_repos() -> list[str]:
+    """ get all git repos in the given path """
+    repo_paths = OrderedSet()
+    for addon_path in config['addons_path']:
+        try:
+            git = which('git')
+            repo_path = subprocess.run(
+                [git, 'rev-parse', '--show-toplevel'],
+                capture_output=True,
+                check=False,
+                text=True,
+                cwd=addon_path
+            ).stdout.strip()
+            if repo_path:
+                repo_paths.add(repo_path)
+        except Exception as e:
+            continue
+    _logger.info('Found %s repos', len(repo_paths))
+    return list(repo_paths)
+
+
+def get_base_version(repo_path: str) -> str:
+    """ use git to get the base version of the current Odoo branch """
+    try:
+        branch_name = subprocess.run(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            capture_output=True,
+            check=False,
+            text=True,
+            cwd=repo_path
+        ).stdout.strip()
+    except Exception as e:
+        _logger.warning('Cannot get git base version for %s, %s', repo_path, e)
+        return ''
+
+    # master-xxx / saas-18.1-xxx / 18.0-xxx
+    pattern = r'^(master|saas-\d+\.\d+|\d+\.\d+)(?:-|$)'
+    match = re.match(pattern, branch_name)
+    if match:
+        return match.group(1)
+    _logger.warning('Cannot get git base version of %s for %s', branch_name, repo_path)
+    return ''
+
+
+def generate_diff(output_dir: str):
+    os.makedirs(output_dir, exist_ok=True)
+
+    for file in os.listdir(output_dir):
+        if file.endswith('.txt'):
+            os.remove(os.path.join(output_dir, file))
+
+    repos = get_repos()
+    if len({os.path.basename(repo) for repo in repos}) == len(repos):
+        repo_names = {repo: os.path.basename(repo) for repo in repos}
+    else:
+        repo_names = {repo: repo.replace(os.sep, '.').strip('.') for repo in repos}
+
+    for repo in repos:
+        base_version = get_base_version(repo)
+        if not base_version:
+            continue
+        diff_file_path = os.path.join(output_dir, f'{repo_names[repo]}_diff.txt')
+
+        try:
+            git = which('git')
+            diff_command = [git, 'diff', '--unified=0', '--merge-base', base_version]
+
+            with open(diff_file_path, 'w', encoding='utf-8') as f:
+                f.write(f'{repo}\n')  # Write repo path as first line
+
+                diff_output = subprocess.run(
+                    diff_command,
+                    capture_output=True,
+                    check=False,
+                    text=False,
+                    cwd=repo
+                ).stdout.decode(errors="replace")
+
+                f.write(diff_output)
+
+            _logger.info('Generated diff file for %s at %s', repo, diff_file_path)
+
+        except Exception as e:
+            _logger.warning('Cannot generate diff for %s:\n%s', repo, e)
+
+
+class ElementInfo:
+    def __init__(self, element: etree._Element):
+        self.element = element
+
+        self.start_tag_linenos = (0, 0)
+        """(first_line_no_of_the_start_tag, last_line_no_of_the_start_tag)"""
+
+        self.end_tag_lineno = 0
+        """last_line_no_of_the_end_tag"""
+
+        self.start_tag_in_diff = False
+        """if the start tag is in the diff"""
+
+
+class DiffCase(BaseCase):
+    test_tags = {'no_install', 'standard', 'test_diff'}
+
+    diff_files: dict[str, dict[str, DiffFile]] = defaultdict(dict)
+    """ {file_extension: {abs_path: diff_file}} """
+
+    diff_dir: str | None = None
+    """ Path to a directory containing .txt diff files """
+
+    diagnostices: list[DiagnosticMessage] = []
+
+    @classmethod
+    def parse_xml_file(cls, abs_path: str, diff_linenos: set[int] | None = None) -> tuple[etree.ElementTree, dict[etree._Element, ElementInfo]]:
+        assert abs_path.endswith('.xml')
+        if diff_linenos is None:
+            diff_file = cls.diff_files['.xml'].get(abs_path)
+            if not diff_file:
+                return etree.ElementTree(None), {}
+            diff_linenos = diff_file.diff_linenos
+
+        with open(abs_path, 'rb') as fp:
+            try:
+                event_elements = list(etree.iterparse(fp, events=('start', 'end', 'comment', 'pi')))
+            except etree.XMLSyntaxError:
+                # usually because the xml is empty
+                return etree.ElementTree(None), {}
+        element_tree = event_elements[0][1].getroottree() if event_elements else etree.ElementTree(None)
+        elements_info = {}
+
+        previous_line = 1
+        for event, element in event_elements:
+            if event == 'start':
+                element_info = elements_info[element] = ElementInfo(element)
+                # element.sourceline is the line number of the last line of the start tag
+                element_info.start_tag_linenos = (previous_line, element.sourceline)
+                element_info.start_tag_in_diff = any(line in diff_linenos for line in range(previous_line, element.sourceline + 1))                
+                previous_line = element.sourceline
+                if element.text:
+                    previous_line += element.text.count('\n')
+            elif event == 'end':
+                element_info = elements_info[element]
+                # We assume the end tag is always on a single line.
+                # Bad example that we don't support:
+                #     </record
+                #     >
+                if element.tail:
+                    previous_line += element.tail.count('\n')
+                element_info.end_tag_lineno = previous_line
+            else:  # 'comment', 'pi'
+                # tricky case:
+                # if the xml file starts/ends with a comment, the comment.getroottree()
+                # will return the root tree. But the comment won't be in tree.iter()
+                # so element_tree[_element] will get KeyError
+                previous_line = element.sourceline
+                if element.tail:
+                    previous_line += element.tail.count('\n')
+
+        return element_tree, elements_info
+
+    @classmethod
+    def setUpClass(cls):
+        """Parse a custom diff file and initialize the diff_files dictionary"""
+        if cls.diff_files:
+            return
+        cls.diff_files['.py']
+
+        if cls.diff_dir is None:
+            raise ValueError('DiffCase.diff_dir is not set')
+        if not os.path.isdir(cls.diff_dir):
+            raise ValueError(f"'{cls.diff_dir}' is not a directory")
+
+        for filename in os.listdir(cls.diff_dir):
+            if not filename.endswith('.txt'):
+                continue
+
+            file_path = os.path.join(cls.diff_dir, filename)
+            _logger.info('Processing diff file: %s', file_path)
+
+            try:
+                with open(file_path, encoding='utf-8') as f:
+                    repo_path = f.readline().strip()
+                    if not os.path.isdir(repo_path):
+                        _logger.warning('Invalid repository path: %s', repo_path)
+                        continue
+
+                    # Read the rest of the file content for diff
+                    diff_content = f.read()
+
+                    # Parse diff using unidiff
+                    if PatchSet is None:
+                        raise ImportError('unidiff is not installed')
+                    patch_set = PatchSet.from_string(diff_content)
+
+                    # Process each patched file
+                    for patched_file in patch_set:
+                        abs_path = os.path.join(repo_path, patched_file.path)
+                        diff_file = DiffFile(repo_path, patched_file)
+
+                        # Add line numbers from the diff
+                        for hunk in patched_file:
+                            for line in hunk:
+                                if line.is_added and line.target_line_no:
+                                    diff_file.diff_linenos.add(line.target_line_no)
+
+                        # Store the diff file based on file extension
+                        ext = os.path.splitext(abs_path)[1].lower()
+                        cls.diff_files[ext][abs_path] = diff_file
+
+            except Exception as e:
+                _logger.error('Error processing diff file %s: %s', file_path, e)


### PR DESCRIPTION
[IMP] test_lint: add test for reference used in the new code

## protected_xml_ids
comments in python files like
`# PROTECT module_name.imd_name`
will add `module_name.imd_name` in a `protected_xml_ids` as logical always existing xmlids and won't trigger warnings in the test

## deletable_xml_ids
also if a reference is used with safely somewhere else, e.g.
```py
ref('module.xml_name', raise_if_not_found=False)
```
or
```py
try
  ...
  ref('module.xml_name')
except ValueError
  ...
```
the xmlid will be added to `deletable_xml_ids`, unsafely using a deletable_xml_ids will have extra messages.
`the reference is handled with raise_if_not_found=False somewhere else`


## the below use cases will be raised

Python: ref without `raise_if_not_found=False` or not in `try ... except ValueError`
```py
self.env.ref()

env.ref()

xxx = self.env.ref
xxx()
```

manifest['data'] XML: ref for another module
```
<record>: without "forececreate"
	id="another_module.xxx"
<field>:
	ref="another_module.xxx"
	eval="ref()"
```

manifest['demo'] XML
ignored

other XML: ref for foreign module xmlid
```
<record>: without/bad "forececreate"
	id="xxx"
<field>:
	ref="xxx"
	eval="ref()"
```




taskid: 4629825

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
