### PR TITLE
[FIX] web: display "No records" only if no create

### DIFF
--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -388,7 +388,7 @@ QUnit.module('partner_autocomplete', {
         assert.containsN(
             autocompleteContainer,
             ".o-autocomplete--dropdown-item",
-            7,  //3 suggestions + create + search more + create & edit + search worldwide
+            6,  // create + create & edit + 3 partner suggestions + search worldwide
             "Odoo autocomplete options should be shown"
         );
     });

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -385,6 +385,7 @@ export class Many2XAutocomplete extends Component {
         } else {
             this.lastProm = this.abortableSearch(request);
             const records = await this.lastProm.promise;
+            addSearchMore = records.length > 0;
             if (records.length) {
                 for (const record of records) {
                     options.push({
@@ -392,8 +393,7 @@ export class Many2XAutocomplete extends Component {
                         record,
                     });
                 }
-            } else {
-                addSearchMore = false;
+            } else if (!this.activeActions.createEdit && !this.props.quickCreate) {
                 options.push({
                     label: _t("No records"),
                     classList: "o_m2o_no_result",

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -929,7 +929,7 @@ test("empty many2one field", async () => {
 
     expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(2);
     expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(0);
-    expect(".dropdown-menu li.o_m2o_no_result").toHaveCount(1);
+    expect(".dropdown-menu li.o_m2o_no_result").toHaveCount(0);
 });
 
 test("empty readonly many2one field", async () => {


### PR DESCRIPTION
Since task 4652321, the many2one menu item "No records" is always displayed if there is no record found by the search. This commit reverts the behavior. The item "No records" is now displayed if no record is found AND the many2one has not the permission of creation.