### PR TITLE
[FIX] web_tour: disable demo tours in test mode

### DIFF
--- a/addons/web_tour/models/res_users.py
+++ b/addons/web_tour/models/res_users.py
@@ -1,4 +1,4 @@
-from odoo import models, fields, api
+from odoo import models, fields, api, modules
 
 
 class ResUsers(models.Model):
@@ -10,7 +10,7 @@ class ResUsers(models.Model):
     def _compute_tour_enabled(self):
         demo_modules_count = self.env['ir.module.module'].sudo().search_count([('demo', '=', True)])
         for user in self:
-            user.tour_enabled = user._is_admin() and demo_modules_count == 0
+            user.tour_enabled = user._is_admin() and demo_modules_count == 0 and not modules.module.current_test
 
     @api.model
     def switch_tour_enabled(self, val):


### PR DESCRIPTION
When there is no demo data, the demo tours are activated by checking a compute field on res.users model.

Now that the tests are run without the demo data, the demo tour system is activated during the click_all test leading to confusing bugs.

With this commit, the demo tours are deactivated in test mode.

