### PR TITLE
[FIX] spreadsheet: error message on field with no aggregator

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -586,7 +586,7 @@ export class OdooPivotModel extends PivotModel {
         }
         const field = this.metaData.fields[measure.fieldName];
         if (!field.aggregator) {
-            throw new Error(`Field ${field} doesn't have a default aggregator`);
+            throw new Error(`Field ${measure.fieldName} doesn't have a default aggregator`);
         }
         return `${measure.fieldName}:${field.aggregator}`;
     }


### PR DESCRIPTION
The error message displayed when the measure was on a field with no aggregator was generated was wrong. It was generated with a stringified object `[object Object]` instead of the field name.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
