### PR TITLE
[FIX] web_editor: restore missing method for AI insertion

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_alternatives_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_alternatives_dialog.js
@@ -57,6 +57,11 @@ export class ChatGPTAlternativesDialog extends ChatGPTDialog {
         this.state.alternativesMode = ev.currentTarget.getAttribute('data-mode');
         this._generateAlternatives(1);
     }
+    preventDialogMousedown(ev) {
+        // Prevent the default behavior of a mousedown event on the dialog
+        // itself so it doesn't cancel the user's text selection in the editor.
+        ev.preventDefault();
+    }
 
     //--------------------------------------------------------------------------
     // Private


### PR DESCRIPTION
**Problem**:
A method introduced in
[commit 6121365](https://github.com/odoo/odoo/pull/186881/commits/6121365a16bc2d380c457eafa38a9f52030dc3d0) was mistakenly removed during the forward-port to 17.4 in [commit 07439a1](https://github.com/odoo/odoo/pull/198061/commits/07439a1c63127aa077d1e7ba5245ecc3f3e2a245). This causes a traceback when inserting AI-generated text.

**Solution**:
Reintroduce the missing method to prevent traceback.

**Steps to reproduce**:
1. Add text in the editor.
2. Select the text.
3. Click **"AI"** in the toolbar.
4. Choose an alternative and click **"Insert"**.
   - **Issue**: Traceback occurs.

**opw-4642868**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
