### PR TITLE
[FIX] website_sale_loyalty: test promo main tour

### DIFF
--- a/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
@@ -102,7 +102,7 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
         },
         {
             content: "check free product is added",
-            trigger: '#wrap:has(div>h6:contains("Free Product - Small Cabinet"))',
+            trigger: '#wrap:has(div h6:contains("Free Product - Small Cabinet"))',
         },
         {
             content: "remove one cabinet from cart",
@@ -111,7 +111,7 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
         },
         {
             content: "check free product is removed",
-            trigger: '#wrap:not(:has(div>strong:contains("Free Product - Small Cabinet")))',
+            trigger: '#wrap:not(:has(div h6:contains("Free Product - Small Cabinet")))',
         },
         /* 4. Check /shop/payment does not break the `merged discount lines split per tax` (eg: with _compute_tax_ids) */
         {


### PR DESCRIPTION
In c52453f8374d988127b2a18f7b357058b01501 the Small Cabinet is not a direct child of the div because when the product is published and sellable it's contained in a `<a>` element. This `h6` was previously a `strong` but forgot to be adapted in the test.

Follow-up task-4387239

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
