### PR TITLE
[FIX] sale_management: fix sale test

### DIFF
--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -51,17 +51,19 @@ registry.category("web_tour.tours").add("sale_signature_without_name", {
     steps: () => [
         {
             content: "Sign & Pay",
-            trigger: "iframe .o_portal_sale_sidebar .btn-primary",
+            trigger:
+                ".o_portal_sale_sidebar .btn-primary, iframe .o_portal_sale_sidebar .btn-primary",
             run: "click",
         },
         {
             content: "click submit",
-            trigger: "iframe .o_portal_sign_submit:enabled",
+            trigger: ".o_portal_sign_submit:enabled, iframe .o_portal_sign_submit:enabled",
             run: "click",
         },
         {
             content: "check error because no name",
-            trigger: 'iframe .o_portal_sign_error_msg:contains("Signature is missing.")',
+            trigger:
+                '.o_portal_sign_error_msg:contains("Signature is missing."), iframe .o_portal_sign_error_msg:contains("Signature is missing.")',
             run: () => {},
         },
     ],

--- a/addons/sale/tests/test_controllers.py
+++ b/addons/sale/tests/test_controllers.py
@@ -93,24 +93,3 @@ class TestSaleSignature(HttpCaseWithUserPortal):
         )
 
         self.start_tour("/", 'sale_signature', login="portal")
-
-    def test_02_portal_sale_signature_without_name_tour(self):
-        """The goal of this test is to make sure the portal user can sign SO even witout a name."""
-
-        portal_user_partner = self.partner_portal
-        # create a SO to be signed
-        portal_user_partner.name = ""
-        sales_order = self.env['sale.order'].create({
-            'name': 'test SO',
-            'partner_id': portal_user_partner.id,
-            'state': 'sent',
-            'require_payment': False,
-        })
-        self.env['sale.order.line'].create({
-            'order_id': sales_order.id,
-            'product_id': self.env['product.product'].create({'name': 'A product'}).id,
-        })
-
-        action = sales_order.action_preview_sale_order()
-
-        self.start_tour(action['url'], 'sale_signature_without_name', login="admin")

--- a/addons/sale_management/tests/test_sale_ui.py
+++ b/addons/sale_management/tests/test_sale_ui.py
@@ -17,3 +17,24 @@ class TestUi(AccountTestInvoicingCommon, HttpCase):
     def test_03_sale_quote_tour(self):
         self.env['res.partner'].create({'name': 'Agrolait', 'email': 'agro@lait.be'})
         self.start_tour("/web", 'sale_quote_tour', login="admin", step_delay=100)
+
+    def test_04_portal_sale_signature_without_name_tour(self):
+        """The goal of this test is to make sure the portal user can sign SO even witout a name."""
+
+        portal_user_partner = self.env['res.partner'].create({'name': 'Agrolait', 'email': 'agro@lait.be'})
+        # create a SO to be signed
+        portal_user_partner.name = ""
+        sales_order = self.env['sale.order'].create({
+            'name': 'test SO',
+            'partner_id': portal_user_partner.id,
+            'state': 'sent',
+            'require_payment': False,
+        })
+        self.env['sale.order.line'].create({
+            'order_id': sales_order.id,
+            'product_id': self.env['product.product'].create({'name': 'A product'}).id,
+        })
+
+        action = sales_order.action_preview_sale_order()
+
+        self.start_tour(action['url'], 'sale_signature_without_name', login="admin")


### PR DESCRIPTION
since https://github.com/odoo/odoo/pull/202318

`test_02_portal_sale_signature_without_name_tour` was on started via `sale` module but only worked with `sale_management`
this commit move the test to be started directly from `sale_management`