### PR TITLE
[FIX] web: no negate in _createBetweenOperator

### DIFF
--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -867,19 +867,13 @@ function _createBetweenOperator(c, [child1, child2]) {
         return;
     }
     if (c.value === "&" && child1.operator === ">=" && child2.operator === "<=") {
-        return condition(
-            child1.path,
-            "between",
-            normalizeValue([child1.value, child2.value]),
-            c.negate
-        );
+        return condition(child1.path, "between", normalizeValue([child1.value, child2.value]));
     }
     if (c.value === "|" && child1.operator === "<" && child2.operator === ">") {
         return condition(
             child1.path,
             "is_not_between",
-            normalizeValue([child1.value, child2.value]),
-            c.negate
+            normalizeValue([child1.value, child2.value])
         );
     }
 }

--- a/addons/web/static/tests/core/tree_editor/condition_tree.test.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree.test.js
@@ -105,7 +105,6 @@ test("domainFromTree . treeFromDomain", () => {
     const toTest = [
         {
             domain: `[("foo", "=", False)]`,
-            result: `[("foo", "=", False)]`,
         },
         {
             domain: `[("foo", "=", true)]`,
@@ -117,35 +116,34 @@ test("domainFromTree . treeFromDomain", () => {
         },
         {
             domain: `[("foo", "=?", False)]`,
-            result: `[("foo", "=?", False)]`,
         },
         {
             domain: `["!", ("foo", "=?", False)]`,
-            result: `["!", ("foo", "=?", False)]`,
         },
         {
             domain: `[("foo", "=ilike", "%hello")]`,
-            result: `[("foo", "=ilike", "%hello")]`,
         },
         {
             domain: `["&", ("foo", ">=", 1), ("foo", "<=", 3)]`,
-            result: `["&", ("foo", ">=", 1), ("foo", "<=", 3)]`,
         },
         {
             domain: `["&", ("foo", ">=", 1), ("foo", "<=", uid)]`,
-            result: `["&", ("foo", ">=", 1), ("foo", "<=", uid)]`,
         },
         {
             domain: `["&", ("foo", ">=", context_today().strftime("%Y-%m-%d")), ("foo", "<=", (context_today() + relativedelta(weeks = 1)).strftime("%Y-%m-%d"))]`,
-            result: `["&", ("foo", ">=", context_today().strftime("%Y-%m-%d")), ("foo", "<=", (context_today() + relativedelta(weeks = 1)).strftime("%Y-%m-%d"))]`,
         },
         {
             domain: `["&", ("foo", ">=", datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")), ("foo", "<=", datetime.datetime.combine(context_today() + relativedelta(months = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S"))]`,
-            result: `["&", ("foo", ">=", datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")), ("foo", "<=", datetime.datetime.combine(context_today() + relativedelta(months = 1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S"))]`,
+        },
+        {
+            domain: `["!", "&", ("foo", ">=", 1), ("foo", "<=", uid)]`,
+        },
+        {
+            domain: `["!", "|", ("foo", "<", 1), ("foo", ">", uid)]`,
         },
     ];
     for (const { domain, result } of toTest) {
-        expect(domainFromTree(treeFromDomain(domain))).toBe(result);
+        expect(domainFromTree(treeFromDomain(domain))).toBe(result || domain);
     }
 });
 


### PR DESCRIPTION
Before this commit, a domain like
["!", "&", ("foo", ">=", 1), ("foo", "<=", uid)]
would become after application of the composition domainFromTree . treeFromDomain
["!", "!", "&" ("foo", ">=", 1), ("foo", "<=", uid)].
