### PR TITLE
[FIX] account,core: allow searching account roots again

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -432,7 +432,7 @@ class AccountAccount(models.Model):
             return NotImplemented
         roots = self.env['account.root'].browse(value)
         return Domain.OR(
-            Domain('placeholder_code', '=like', root.name + ('' if operator == 'in' and not root.parent_id else '%'))
+            Domain('placeholder_code', '=ilike', root.name + ('' if operator == 'in' and not root.parent_id else '%'))
             for root in roots
         )
 

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -887,7 +887,7 @@ class DomainCondition(Domain):
             "Unsupported operator on %(field_label)s %(model_label)s in %(domain)s",
             domain=repr(self),
             field_label=self._field(model).get_description(model.env, ['string'])['string'],
-            model_name=f"{model.env['ir.model']._get(model._name).name!r} ({model._name})",
+            model_label=f"{model.env['ir.model']._get(model._name).name!r} ({model._name})",
         ))
 
     def _to_sql(self, model: BaseModel, alias: str, query: Query) -> SQL:
@@ -1167,7 +1167,7 @@ def _optimize_like_str(condition, model):
 @field_type_optimization(['many2one', 'one2many', 'many2many'])
 def _optimize_relational_name_search(condition, model):
     """Search relational using `display_name`.
-    
+
     When a relational field is compared to a string, we actually want to make
     a condition on the `display_name` field.
     Negative conditions are translated into a "not any" for consistency.


### PR DESCRIPTION
After [this commit], the account roots could not be searched again. Furthermore, while raising an error to indicate this, this translated error also raised another error because of a missing variable.

This commit fixes both by
- modifying the `_search_account_root` method to search `placeholder_code` using `=ilike` instead of `=like`, since the latter is not supported;
- correcting the `kwargs` in the translation function raising an error in `_optimize_field_search_method` on domains if an operator is not supported.

[this commit]: https://github.com/odoo/odoo/commit/92301a5b300dec1ddfca44dc35318b83d67c56fa