### PR TITLE
[FIX] core: field autojoin is missing not null check

### DIFF
--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -90,10 +90,10 @@ class TestSubqueries(TransactionCase):
             FROM "test_new_api_multi"
             LEFT JOIN "res_partner" AS "test_new_api_multi__partner"
                 ON ("test_new_api_multi"."partner" = "test_new_api_multi__partner"."id")
-            WHERE (
+            WHERE ("test_new_api_multi"."partner" IS NOT NULL AND (
                 "test_new_api_multi__partner"."name" LIKE %s
                 OR "test_new_api_multi__partner"."phone" LIKE %s
-            )
+            ))
             ORDER BY "test_new_api_multi"."id"
         """]):
             self.env['test_new_api.multi'].search([
@@ -917,7 +917,7 @@ class TestFlushSearch(TransactionCase):
             FROM "test_new_api_city"
             LEFT JOIN "test_new_api_country" AS "test_new_api_city__country_id"
                 ON ("test_new_api_city"."country_id" = "test_new_api_city__country_id"."id")
-            WHERE "test_new_api_city__country_id"."name" LIKE %s
+            WHERE ("test_new_api_city"."country_id" IS NOT NULL AND "test_new_api_city__country_id"."name" LIKE %s)
             ORDER BY "test_new_api_city"."id"
         ''']):
             self.brussels.country_id = self.france

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -457,12 +457,17 @@ class Many2one(_Relational[M]):
                 SQL.identifier(coalias, 'id'),
             ))
 
-            if operator == 'not any':
-                sql = value._to_sql(comodel, coalias, query)
-                if not can_be_null:
+            sql = value._to_sql(comodel, coalias, query)
+            if operator == 'any':
+                if can_be_null:
+                    return SQL("(%s IS NOT NULL AND %s)", sql_field, sql)
+                else:
+                    return sql
+            else:
+                if can_be_null:
+                    return SQL("(%s IS NULL OR (%s) IS NOT TRUE)", sql_field, sql)
+                else:
                     return SQL("(%s) IS NOT TRUE", sql)
-                return SQL("(%s IS NULL OR (%s) IS NOT TRUE)", sql_field, sql)
-            return value._to_sql(comodel, coalias, query)
 
         # execute search and generate condition with a SQL query
         domain_query = comodel.with_context(active_test=False)._search(value)


### PR DESCRIPTION
When using autojoin, the semantics of 'any' are "there exists X such as domain", if the field is nullable, we must ensure that the relation field is not null.

An example domain `('company_id.parent_id', '=', False)` means there exists a company without a parent. In general, this is expressed as `company_id IN (select ... parent_id is null)`. However, if we autojoin, the WHERE clause from the subquery is merged into the main query, but then, `parent_id` may be null either because it is null in the company table or because the company does not exist.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
