### PR TITLE
[IMP] orm: always call field.search when present

### DIFF
--- a/odoo/addons/test_new_api/tests/test_one2many.py
+++ b/odoo/addons/test_new_api/tests/test_one2many.py
@@ -454,10 +454,7 @@ class One2manyCase(TransactionExpressionCase):
         self._search(Team, [('id', 'parent_of', team1.id)])
         self._search(Team, [('id', 'child_of', team1.id)])
 
-    @mute_logger('odoo.domains')
     def test_create_one2many_with_unsearchable_field(self):
-        # odoo.domains is muted as reading a non-stored and unsearchable field will log an error and makes the runbot red
-
         unsearchableO2M = self.env['test_new_api.unsearchable.o2m']
 
         # Create a parent record
@@ -493,8 +490,6 @@ class One2manyCase(TransactionExpressionCase):
 
         # invalidating the cache to force reading one2many again
         self.env.invalidate_all()
-        # Make sure the parent_record1 only has its own child records
-        self.assertEqual(parent_record1.child_ids.ids, children[parent_record1.id])
-
-        # Make sure the parent_record2 only has its own child records
-        self.assertEqual(parent_record2.child_ids.ids, children[parent_record2.id])
+        with self.assertRaisesRegex(ValueError, r'it is not stored'):
+            # Make sure the parent_record1 only has its own child records
+            self.assertEqual(parent_record1.child_ids.ids, children[parent_record1.id])

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -139,6 +139,7 @@ class Field(typing.Generic[T]):
         For instance, all ``'='`` are transformed to ``'in'``, and boolean
         fields conditions are made such that operator is ``'in'``/``'not in'``
         and value is ``[True]``.
+
         The method should ``return NotImplemented`` if it does not support the
         operator.
         In that case, the ORM can try to call it with other, semantically
@@ -146,6 +147,10 @@ class Field(typing.Generic[T]):
         its corresponding negative operator is not implemented.
         The method must return a :ref:`reference/orm/domains` that replaces
         ``(field, operator, value)`` in its domain.
+
+        Note that a stored field can actually have a search method. The search
+        method will be invoked to rewrite the condition. This may be useful for
+        sanitizing the values used in the condition, for instance.
 
         .. code-block:: python
 
@@ -610,7 +615,7 @@ class Field(typing.Generic[T]):
         self.compute = self._compute_related
         if self.inherited or not (self.readonly or field.readonly):
             self.inverse = self._inverse_related
-        if field._description_searchable:
+        if not self.store and field._description_searchable:
             # allow searching on self only if the related field is searchable
             self.search = self._search_related
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Instead of calling `field.search` on only non-stored fields, call it always if it is defined. This allows to hook domain rewrites without the need to wait until `_condition_to_sql` is called and makes the behaviour more consistent. We also stop ignoring fields that do not have a search method and are not stored: in that case, `field_to_sql` should implement the behaviour or crash.

Current behavior before PR:
- stored searchable: keeps domain as-is
- stored non-searchable: keeps domain as-is
- non-stored searchable: uses the search method
- non-stored non-searchable: logs error, and rewrite it as `Domain.FALSE`

Desired behavior after PR is merged:
- stored searchable: uses the search method
- stored non-searchable: keeps domain as-is
- non-stored searchable: uses the search method
- non-stored non-searchable: keeps domain as-is

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
