### PR TITLE
[FIX] pos_online_payment: fix traceback when paying with online method

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -239,7 +239,7 @@ patch(PaymentScreen.prototype, {
             }
         }
 
-        await this.postPushOrderResolve([this.currentOrder.server_id]);
+        await this.postPushOrderResolve([this.currentOrder.id]);
 
         this.afterOrderValidation(true);
     },


### PR DESCRIPTION
Currently, when payin with an online payment method a traceack appears.

Steps to reproduce:
-------------------
* Create an online payment method (use Demo)
* Associate this payment method with a shop
* Open the shop
* Create an order
* Pay with online payment method
> Observation: Traceback: Cannot read properties of undefined (reading 'isPaid')

Why the fix:
------------
`server_id` does not exist anymore. Forwarding this fix: https://github.com/odoo/odoo/commit/926ba1890e54a46f10202afa2eb3f7bc176b2812

opw-4639109
