### PR TITLE
[FIX] *: multiple tours

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -16,6 +16,7 @@ import { inLeftSide, negateStep } from "@point_of_sale/../tests/tours/utils/comm
 import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 import * as combo from "@point_of_sale/../tests/tours/utils/combo_popup_util";
+import { delay } from "@odoo/hoot-dom";
 
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
@@ -185,7 +186,14 @@ registry.category("web_tour.tours").add("pos_restaurant_sync_second_login", {
 
             // Test transfering an order
             ProductScreen.clickControlButton("Transfer"),
-            FloorScreen.clickTable("4"),
+            {
+                trigger: ".table:contains(4)",
+                async run(helpers) {
+                    await delay(500);
+                    await helpers.click();
+                },
+            },
+            Chrome.activeTableOrOrderIs("4"),
 
             // Test if products still get merged after transfering the order
             ProductScreen.totalAmountIs("4.40"),
@@ -199,11 +207,25 @@ registry.category("web_tour.tours").add("pos_restaurant_sync_second_login", {
             ReceiptScreen.clickNextOrder(),
             // At this point, there are no draft orders.
 
-            FloorScreen.clickTable("2"),
+            {
+                trigger: ".table:contains(2)",
+                async run(helpers) {
+                    await delay(500);
+                    await helpers.click();
+                },
+            },
+            Chrome.activeTableOrOrderIs("2"),
             ProductScreen.isShown(),
             ProductScreen.orderIsEmpty(),
             ProductScreen.clickControlButton("Transfer"),
-            FloorScreen.clickTable("4"),
+            {
+                trigger: ".table:contains(4)",
+                async run(helpers) {
+                    await delay(500);
+                    await helpers.click();
+                },
+            },
+            Chrome.activeTableOrOrderIs("4"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             ProductScreen.totalAmountIs("2.20"),
             Chrome.clickPlanButton(),

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -11,7 +11,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 const baseDescriptionContent = "Test project task history version";
-const descriptionField = `div.note-editable.odoo-editor-editable div.o-paragraph`;
 function changeDescriptionContentAndSave(newContent) {
     const newText = `${baseDescriptionContent} ${newContent}`;
     return [
@@ -21,17 +20,10 @@ function changeDescriptionContentAndSave(newContent) {
             run: "click",
         },
         {
-            trigger: descriptionField,
+            trigger: `div.note-editable[spellcheck='true'].odoo-editor-editable`,
             run: `editor ${newText}`,
         },
-        {
-            trigger: "button.o_form_button_save",
-            run: "click",
-        },
-        {
-            content: "Wait the form is saved",
-            trigger: ".o_form_saved",
-        },
+        ...stepUtils.saveForm(),
     ];
 }
 
@@ -85,7 +77,7 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         run: function () {
             const items = document.querySelectorAll(".revision-list .btn");
             if (items.length !== 4) {
-                throw new Error('Expect 4 Revisions in the history dialog, got ' + items.length);
+                console.error("Expect 4 Revisions in the history dialog, got " + items.length);
             }
         },
     }, {
@@ -124,12 +116,12 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         run: "click",
     }, {
         content: "Verify that the description contains the right text after the restore",
-        trigger: descriptionField,
+        trigger: `div.note-editable.odoo-editor-editable`,
         run: function () {
             const p = this.anchor?.innerText;
             const expected = `${baseDescriptionContent} 1`;
             if (p !== expected) {
-                throw new Error(`Expect description to be ${expected}, got ${p}`);
+                console.error(`Expect description to be ${expected}, got ${p}`);
             }
         }
     }, {
@@ -159,10 +151,7 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         content: 'Set task name',
         run: 'edit New task',
     },
-    {
-        trigger: "button.o_form_button_save",
-        run: "click",
-    },
+    ...stepUtils.saveForm(),
         ...changeDescriptionContentAndSave("0"),
         ...changeDescriptionContentAndSave("1"),
         ...changeDescriptionContentAndSave("2"),

--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -134,6 +134,9 @@ export class TourStepAutomatic extends TourStep {
     }
 
     get parentFrameIsReady() {
+        if (this.trigger.match(/\[is-ready=(true|false)\]/)) {
+            return true;
+        }
         const parentFrame = hoot.getParentFrame(this.element);
         return parentFrame && parentFrame.hasAttribute("is-ready")
             ? parentFrame.getAttribute("is-ready") === "true"

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -279,8 +279,15 @@ registerWebsitePreviewTour('test_html_editor_scss_2', {
         },
         {
             content: "confirm reset warning",
-            trigger: '.modal-footer .btn-primary',
+            trigger: ".modal:contains(careful) .modal-footer .btn-primary",
             run: "click",
+        },
+        {
+            content: "Wait for the reload of the iframe",
+            trigger: "[is-ready=false]:iframe #wrapwrap",
+        },
+        {
+            trigger: "[is-ready=true]:iframe #wrapwrap",
         },
         {
             trigger: `body:not(:has(div.ace_line:contains("${adminCssModif}")))`,

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -28,6 +28,10 @@ registerWebsitePreviewTour("website_media_dialog_undraw", {
     content: "Check that the media library is available",
     trigger: '.o_select_media_dialog:has(.o_we_search_select option[value="media-library"])',
 },
+{
+    content: "Ensure all images are loaded to avoid CORS is misconfigured on the API server, image will be treated as non-dynamic.",
+    trigger: ".modal .o_load_done_msg",
+},
 ]);
 
 registerWebsitePreviewTour("website_media_dialog_external_library", {

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -258,5 +258,8 @@ registerWebsitePreviewTour(
         },
         ...duplicateSinglePage,
         ...duplicateMultiplePage,
+        {
+            trigger: "td:contains('/test-duplicate-2-1')",
+        },
     ]
 );

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -98,14 +98,23 @@ for (let snippet of snippetsNames) {
             run: "click",
         });
     } else if (isModal) {
-        snippetSteps.splice(4, 3, {
-            content: `Hide the ${snippet.name} popup`,
-            trigger: `:iframe [data-snippet='${snippet.name}'] .s_popup_close`,
-            run: "click",
-        }, {
-            content: `Make sure ${snippet.name} is hidden`,
-            trigger: ":iframe body:not(.modal-open)",
-        });
+        snippetSteps.splice(
+            4,
+            3,
+            {
+                content: `Make sure ${snippet.name} is shown`,
+                trigger: ":iframe body.modal-open",
+            },
+            {
+                content: `Hide the ${snippet.name} popup`,
+                trigger: `:iframe [data-snippet='${snippet.name}'] .s_popup_close`,
+                run: "click",
+            },
+            {
+                content: `Make sure ${snippet.name} is hidden`,
+                trigger: ":iframe body:not(.modal-open)",
+            }
+        );
     } else if (isDropInOnlySnippet) {
         // The 'drop in only' snippets have their 'data-snippet' attribute
         // removed once they are dropped, so we need to use a different selector.

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -82,9 +82,11 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
+            trigger: ":iframe body:contains(Your payment has been successfully processed.)",
+        },
+        {
             content: "Verify that the amount displayed is 67",
             trigger: ':iframe span.oe_currency_value:contains("67.00")',
-            timeout: 10000, // Make sure the payment process animation is finished
         },
         {
             trigger: ":iframe [name=o_payment_status_alert]:contains(thank you!)",

--- a/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
+++ b/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
@@ -4,7 +4,6 @@ import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category('web_tour.tours').add('website_sale_collect_buy_product', {
     url: '/shop',
-    checkDelay: 50,
     steps: () => [
         ...tourUtils.searchProduct("Test CAC Product"),
         clickOnElement("Test Product", 'a:contains("Test CAC Product")'),


### PR DESCRIPTION
In this commit, we fix multiple indeterministic tours:

- website/static/tests/tours/media_dialog.js Add a step to ensure all images are loaded before exiting the tour to avoid message: "CORS is misconfigured on the API server, image will be treated as non-dynamic."
- project/static/tests/tours/project_task_history.js Use stepUtils.saveForm to ensure form is well saved before continue.
- website/static/tests/tours/snippets_all_drag_and_drop.js Remove a step that can cause undeterministic failure during tours.
- pos_restaurant/static/tests/tours/pos_restaurant_tour.js Add a delay when transfering the order.
- website/static/tests/tours/page_manager.js Add a last step to ensure reloading is done before exiting the tour to avoid "Error received after termination: TypeError: Failed to fetch" error.
- website/static/tests/tours/html_editor.js Add steps to wait the iframe reload.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
