### PR TITLE
[FIX] spreadsheet_dashboard: do not share filter with same id

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -7,7 +7,7 @@
                 <div t-if="status === Status.Loaded"
                     class="o_filter_value_container"
                     t-foreach="filters"
-                    t-key="filter.id"
+                    t-key="activeDashboardId + '_' + filter.id"
                     t-as="filter">
                     <FilterValue
                         filter="filter"

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_test.js
@@ -209,3 +209,46 @@ QUnit.test(
         assert.equal(year.value, "");
     }
 );
+
+QUnit.test("Global filter with same id is not shared between dashboards", async function (assert) {
+    const spreadsheetData = {
+        globalFilters: [
+            {
+                id: "1",
+                type: "relation",
+                label: "Relation Filter",
+                modelName: "product",
+            },
+        ],
+    };
+    const serverData = getServerData(spreadsheetData);
+    serverData.models["spreadsheet.dashboard"].records.push({
+        id: 790,
+        name: "Spreadsheet dup. with Pivot",
+        json_data: JSON.stringify(spreadsheetData),
+        raw: JSON.stringify(spreadsheetData),
+        dashboard_group_id: 1,
+    });
+    serverData.models["spreadsheet.dashboard.group"].records[0].dashboard_ids = [789, 790];
+    const fixture = getFixture();
+    await createSpreadsheetDashboard({ serverData });
+    assert.containsNone(
+        fixture,
+        ".o-filter-value .o_tag_badge_text",
+        "It should not display any filter value"
+    );
+    await click(fixture.querySelector(".o-autocomplete--input.o_input"));
+    await click(fixture.querySelector(".dropdown-item"));
+    assert.containsN(
+        fixture,
+        ".o-filter-value .o_tag_badge_text",
+        1,
+        "It should not display any filter value"
+    );
+    await click(fixture.querySelector(".o_search_panel li:last-child"));
+    assert.containsNone(
+        fixture,
+        ".o-filter-value .o_tag_badge_text",
+        "It should not display any filter value"
+    );
+});


### PR DESCRIPTION
Steps to reproduce:
- Create a copy of the CRM lead dashboard
- Go to the duplicated dashboard, change some global filter
- Go to the CRM lead original dashboard => The global filter has the same value as the one in the duplicated dashboard
- Try to change a global filter => The data is filtered, but nothing change in the global filter topbar

This was caused by a faulty t-key, which was based on the filter id, which is not unique across dashboards. This commit changes the t-key to be based on the dashboard id and the filter id, so that the filter is unique across dashboards.

Task: 4636672

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
