### PR TITLE
[FIX] sale_project: use SOL description as task name

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -271,6 +271,9 @@ class SaleOrderLine(models.Model):
             title = self.product_id.name
             description = '<br/>'.join(sale_line_name_parts)
         else:
+            if len(sale_line_name_parts) > 1 and sale_line_name_parts[1]:
+                # if there's multiple lines, skip the product name part
+                sale_line_name_parts.pop(0)
             title = sale_line_name_parts[0]
             description = '<br/>'.join(sale_line_name_parts[1:])
 

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -133,12 +133,14 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         })
 
         so_line_order_task_in_global = SaleOrderLine.create({
+            'name': f"{self.product_order_service2.name}\n[TEST1]\nGlobal project",
             'product_id': self.product_order_service2.id,
             'product_uom_qty': 10,
             'order_id': sale_order.id,
         })
 
         so_line_order_new_task_new_project = SaleOrderLine.create({
+            'name': f"{self.product_order_service3.display_name}\n[TEST2]\nNew project",
             'product_id': self.product_order_service3.id,
             'product_uom_qty': 10,
             'order_id': sale_order.id,
@@ -157,9 +159,27 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         # service_tracking 'task_global_project'
         self.assertFalse(so_line_order_task_in_global.project_id, "Only task should be created, project should not be linked")
         self.assertEqual(self.project_global.tasks.sale_line_id, so_line_order_task_in_global, "Global project's task should be linked to so line")
+        self.assertEqual(
+            so_line_order_task_in_global.task_id.name,
+            f"{sale_order.name} - [TEST1]",
+            "Task name in global project should include SO name & partial line description",
+        )
+        self.assertEqual(
+            str(so_line_order_task_in_global.task_id.description),
+            '<p>Global project</p>',
+        )
         #  service_tracking 'task_in_project'
         self.assertTrue(so_line_order_new_task_new_project.project_id, "Sales order line should be linked to newly created project")
         self.assertTrue(so_line_order_new_task_new_project.task_id, "Sales order line should be linked to newly created task")
+        self.assertEqual(
+            so_line_order_new_task_new_project.task_id.name,
+            "[TEST2]",
+            "Task name in new project should only include partial line description",
+        )
+        self.assertEqual(
+            str(so_line_order_new_task_new_project.task_id.description),
+            '<p>New project</p>',
+        )
         # service_tracking 'project_only'
         self.assertFalse(so_line_order_only_project.task_id, "Task should not be created")
         self.assertTrue(so_line_order_only_project.project_id, "Sales order line should be linked to newly created project")


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a service product that creates a task on confirm;
2. add product to a SO;
3. add description to the line;
4. confirm the order;
5. go to the task.

Issue
-----
The task only has the SO and service product name as title. This is different from earlier versions, where it would include the first line of the line's description.

Cause
-----
When creating a task from an order line, it uses the first line of the line name as part of the task name, and adds the rest to the description.

Starting from 18.0, the product & description columns are merged in order & invoice views. A side-effect of this, is that the product name will always be present as the first line of the product, and any added description will start from the second line. Consequently, it's no longer possible to add a description to the line that would get used as task name.

Solution
--------
Use the first two lines of the sale line name to form a task title.

opw-4634149
opw-4637902