### PR TITLE
[FIX] point_of_sale: fix preset timing traceback

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.js
@@ -52,7 +52,7 @@ export class PresetSlotsPopup extends Component {
 
     isSelected(slot, preset) {
         const order = this.pos.getOrder();
-        return order.preset_time.ts === slot.datetime.ts && order.preset_id?.id === preset.id;
+        return order.preset_time?.ts === slot.datetime.ts && order.preset_id?.id === preset.id;
     }
 
     getSlotsForDate(preset, date) {


### PR DESCRIPTION
Fix traceback when trying to set the `preset_time` on a PoS order.

Steps to reproduce :
- Activate prests in PoS config
- Enable `Timing` inside Eat In preset
- Open PoS
- Create new order
- Try to set slot `preset_time` by opening the popup
- Traceback appear

task-id: 4684049


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
