### PR TITLE
[FIX] purchase: avoid changing RFQ state on print

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -523,7 +523,7 @@ class PurchaseOrder(models.Model):
         return action
 
     def print_quotation(self):
-        self.write({'state': "sent"})
+        self.filtered(lambda po: po.state == 'draft').write({'state': "sent"})
         return self.env.ref('purchase.report_purchase_quotation').report_action(self)
 
     def button_approve(self, force=False):

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -837,3 +837,23 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertEqual(po.amount_untaxed, 15.0)
         po.company_id = company_a.id
         self.assertEqual(po.amount_untaxed, 10.0)
+
+    def test_print_purchase_order_without_state_change(self):
+        """
+        Check that printing a confirmed purchase order does not
+        reset its state.
+        """
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.partner_a
+        with po_form.order_line.new() as po_line:
+            po_line.product_id = self.product
+            po_line.product_qty = 1.0
+        po = po_form.save()
+        po.button_confirm()
+        self.assertEqual(po.state, 'purchase')
+        po.print_quotation()
+        self.assertEqual(po.state, 'purchase')
+        po.button_cancel()
+        self.assertEqual(po.state, 'cancel')
+        po.print_quotation()
+        self.assertEqual(po.state, 'cancel')


### PR DESCRIPTION
### Issue:

Since Commit 4cd4da13a1a2a88ec12636a4fe973f5069a613aa the `print_quotation` button can be called from the purchase form view no matter the state of the PO (prior it could only be called in "draft" and "sent" state):
https://github.com/odoo/odoo/blob/f862de4a7c3f2f9098fb56f8db8907034ebbc2f9/addons/purchase/views/purchase_views.xml#L141 However, that button changes the state of the PO:
https://github.com/odoo/odoo/blob/fd02d5dea0bce149799cbd8557b6e69c5c7bf49a/addons/purchase/models/purchase_order.py#L512-L513 In particular, if you confirm a PO and then print it, it will reset its "purchase" state to sent and you will be able to confirm it once more (as the `button_confirm` can be called both in "draft" and "sent" state) https://github.com/odoo/odoo/blob/f862de4a7c3f2f9098fb56f8db8907034ebbc2f9/addons/purchase/views/purchase_views.xml#L132 https://github.com/odoo/odoo/blob/f862de4a7c3f2f9098fb56f8db8907034ebbc2f9/addons/purchase/views/purchase_views.xml#L136

### Steps to reproduce:

- Create a purchase order for 1 unit of any product.
- Confirm the PO
- Print the PO
#### > You can confirm it again

opw-4678511
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
