### PR TITLE
[FIX] account_peppol: Only log peppol state for concerned companies

### DIFF
--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -330,14 +330,16 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             }])
 
         new_partner.peppol_endpoint = '0477472701'
+        new_partner.button_account_peppol_check_partner_endpoint()
         self.assertRecordValues(
             new_partner, [{
-                'peppol_verification_state': 'valid',  # should validate automatically
+                'peppol_verification_state': 'valid',
                 'peppol_eas': '0208',
                 'peppol_endpoint': '0477472701',
             }])
 
         new_partner.peppol_endpoint = '3141592654'
+        new_partner.button_account_peppol_check_partner_endpoint()
         self.assertRecordValues(
             new_partner, [{
                 'peppol_verification_state': 'not_valid',
@@ -350,6 +352,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             'invoice_edi_format': 'xrechnung',
             'peppol_endpoint': '0477472701',
         })
+        new_partner.button_account_peppol_check_partner_endpoint()
         self.assertRecordValues(
             new_partner, [{
                 'peppol_verification_state': 'not_valid_format',


### PR DESCRIPTION
Previously, we were checking the validity of a partner for all companies. We now restrict this check to only happen on companies that are sender, pending receiver and receiver on Peppol.
Also remove the re-computation on every write of the partners. We only (re-)compute the value:
1. When creating the partner.
2. When opening the Send (& Print) wizard.

task-4684314
