### PR TITLE
[FIX] account: remove unnecessary groups from test common class

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -299,7 +299,6 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_fsm_manager', # industry_fsm
                     'group_plm_manager', # mrp_plm
                     'group_planning_manager', # planning
-                    'group_sign_manager', # sign
                 ))
             ]).mapped('res_id')
         )

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -267,14 +267,7 @@ class AccountTestInvoicingCommon(ProductCommon):
                     # TODO: Progressively remove groups from this list, hopefully no groups share the same name.
                     # This is a consequence of moving groups from data to demo data: https://github.com/odoo/odoo/pull/198078
                     'group_account_manager', # account
-                    'fleet_group_manager', # fleet
                     'group_hr_manager', # hr
-                    'group_hr_attendance_manager', # hr_attendance
-                    'group_hr_contract_manager', # hr_contract
-                    'group_hr_holidays_manager', # hr_holidays
-                    'group_hr_recruitment_manager', # hr_recruitment
-                    'group_timesheet_manager', # hr_timesheet
-                    'group_lunch_manager', # lunch
                     'group_mrp_manager', # mrp
                     'group_pos_manager', # point_of_sale
                     'group_product_manager', # product
@@ -283,15 +276,9 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_sale_manager', # sales_team
                     'group_stock_manager', # stock
                     # enterprise groups
-                    'group_approval_manager', # approval
-                    'frontdesk_group_administrator', # frontdesk
-                    'group_helpdesk_manager', # helpdesk
-                    'group_hr_appraisal_manager', # hr_appraisal
                     'group_hr_payroll_manager', # hr_payroll
-                    'group_hr_recruitment_manager', # hr_referral -> duplicate from hr_recruitment /!\
                     'group_fsm_manager', # industry_fsm
                     'group_plm_manager', # mrp_plm
-                    'group_planning_manager', # planning
                 ))
             ]).mapped('res_id')
         )

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -282,11 +282,8 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_purchase_manager', # purchase
                     'group_sale_manager', # sales_team
                     'group_stock_manager', # stock
-                    'group_survey_user', # survey
-                    'group_website_slides_manager', # website_slides
                     # enterprise groups
                     'group_approval_manager', # approval
-                    'group_documents_manager', # documents
                     'frontdesk_group_administrator', # frontdesk
                     'group_helpdesk_manager', # helpdesk
                     'group_hr_appraisal_manager', # hr_appraisal

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -266,7 +266,6 @@ class AccountTestInvoicingCommon(ProductCommon):
                 ('name', 'in', (
                     # TODO: Progressively remove groups from this list, hopefully no groups share the same name.
                     # This is a consequence of moving groups from data to demo data: https://github.com/odoo/odoo/pull/198078
-                    'group_account_manager', # account
                     'group_hr_manager', # hr
                     'group_mrp_manager', # mrp
                     'group_pos_manager', # point_of_sale

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -267,7 +267,6 @@ class AccountTestInvoicingCommon(ProductCommon):
                     # TODO: Progressively remove groups from this list, hopefully no groups share the same name.
                     # This is a consequence of moving groups from data to demo data: https://github.com/odoo/odoo/pull/198078
                     'group_account_manager', # account
-                    'group_event_manager', # event
                     'fleet_group_manager', # fleet
                     'group_hr_manager', # hr
                     'group_hr_attendance_manager', # hr_attendance
@@ -286,7 +285,6 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_survey_user', # survey
                     'group_website_slides_manager', # website_slides
                     # enterprise groups
-                    'group_appointment_manager', # appointment
                     'group_approval_manager', # approval
                     'group_documents_manager', # documents
                     'frontdesk_group_administrator', # frontdesk

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -275,7 +275,6 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_hr_holidays_manager', # hr_holidays
                     'group_hr_recruitment_manager', # hr_recruitment
                     'group_timesheet_manager', # hr_timesheet
-                    'im_livechat_group_manager', # im_livechat
                     'group_lunch_manager', # lunch
                     'group_mrp_manager', # mrp
                     'group_pos_manager', # point_of_sale

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -284,7 +284,6 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_sale_manager', # sales_team
                     'group_stock_manager', # stock
                     'group_survey_user', # survey
-                    'group_website_designer', # website
                     'group_website_slides_manager', # website_slides
                     # enterprise groups
                     'group_appointment_manager', # appointment

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -272,7 +272,6 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_hr_manager', # hr
                     'group_hr_attendance_manager', # hr_attendance
                     'group_hr_contract_manager', # hr_contract
-                    'group_hr_expense_manager', # hr_expense
                     'group_hr_holidays_manager', # hr_holidays
                     'group_hr_recruitment_manager', # hr_recruitment
                     'group_timesheet_manager', # hr_timesheet

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -277,7 +277,6 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_timesheet_manager', # hr_timesheet
                     'im_livechat_group_manager', # im_livechat
                     'group_lunch_manager', # lunch
-                    'group_mass_mailing_user', # mass_mailing
                     'group_mrp_manager', # mrp
                     'group_pos_manager', # point_of_sale
                     'group_product_manager', # product
@@ -298,11 +297,9 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_hr_payroll_manager', # hr_payroll
                     'group_hr_recruitment_manager', # hr_referral -> duplicate from hr_recruitment /!\
                     'group_fsm_manager', # industry_fsm
-                    'group_marketing_automation_user', # marketing_automation
                     'group_plm_manager', # mrp_plm
                     'group_planning_manager', # planning
                     'group_sign_manager', # sign
-                    'group_social_manager', # social
                 ))
             ]).mapped('res_id')
         )

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -10,6 +10,8 @@ class TestUi(TestPointOfSaleHttpCommon):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.env.user.group_ids += cls.quick_ref('event.group_event_manager')
+
         cls.event_category = cls.env['pos.category'].create({
             'name': 'Events',
         })

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -43,7 +43,7 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         self.internal_project = self.env.company.internal_project_id
         self.internal_task_leaves = self.env.company.leave_timesheet_task_id
 
-        self.hr_leave_type_with_ts = self.env['hr.leave.type'].create({
+        self.hr_leave_type_with_ts = self.env['hr.leave.type'].sudo().create({
             'name': 'Time Off Type with timesheet generation',
             'requires_allocation': 'no',
         })

--- a/addons/test_sale_product_configurators/tests/test_event_sale_with_product_configurator.py
+++ b/addons/test_sale_product_configurators/tests/test_event_sale_with_product_configurator.py
@@ -16,6 +16,8 @@ class TestEventProductConfiguratorUi(AccountTestInvoicingCommon, HttpCase):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.env.user.group_ids += cls.quick_ref('event.group_event_manager')
+
         # Adding sale users to test the access rights
         cls.salesman = mail_new_test_user(
             cls.env,


### PR DESCRIPTION
Followup to https://github.com/odoo/odoo/pull/203271

This PR removes the groups that have little to no effects on the test, and fix the tests that get broken by them.
Further groups require more work.