### PR TITLE
[IMP] stock*: add extra products in po-returns

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -299,7 +299,7 @@ class PurchaseOrderLine(models.Model):
             params = line._get_select_sellers_params()
             seller = line.product_id._select_seller(
                 partner_id=line.partner_id,
-                quantity=line.product_qty,
+                quantity=abs(line.product_qty),  # in case of negative quantity from return
                 date=line.order_id.date_order and line.order_id.date_order.date() or fields.Date.context_today(line),
                 uom_id=line.product_uom_id,
                 params=params)

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -160,7 +160,7 @@ class PurchaseOrderLine(models.Model):
             if line.product_id and line.product_id.type == 'consu':
                 rounding = line.product_uom_id.rounding
                 # Prevent decreasing below received quantity
-                if float_compare(line.product_qty, line.qty_received, precision_rounding=rounding) < 0:
+                if 'previous_product_qty' in self.env.context and float_compare(line.product_qty, line.qty_received, precision_rounding=rounding) < 0:
                     raise UserError(_('You cannot decrease the ordered quantity below the received quantity.\n'
                                       'Create a return first.'))
 
@@ -182,7 +182,7 @@ class PurchaseOrderLine(models.Model):
                     pickings = line.order_id.picking_ids.filtered(lambda x: x.state not in ('done', 'cancel') and x.location_dest_id.usage in ('internal', 'transit', 'customer'))
                     picking = pickings and pickings[0] or False
                 if not picking:
-                    if not line.product_qty > line.qty_received:
+                    if not line.product_qty > line.qty_received or line.qty_received < 0:
                         continue
                     res = line.order_id._prepare_picking()
                     picking = self.env['stock.picking'].create(res)

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 
-from odoo import api, fields, models, _
+from odoo import api, Command, fields, models, _
 from odoo.osv.expression import AND
 
 
@@ -35,6 +35,41 @@ class StockPicking(models.Model):
     @api.model
     def _search_delay_pass(self, operator, value):
         return [('purchase_id.date_order', operator, value)]
+
+    def _action_done(self):
+        res = super()._action_done()
+        purchase_order_lines_vals = []
+        for move in self.move_ids:
+            purchase_order = move.picking_id.purchase_id or move.picking_id.return_id.purchase_id
+            # Creates new PO line only when pickings linked to a purchase order and
+            # for moves with qty. done and not already linked to a PO line.
+            if not purchase_order \
+                or (move.location_id.usage not in ['supplier', 'transit'] and not (move.location_dest_id.usage == 'supplier' and move.to_refund)) \
+                or move.purchase_line_id \
+                or not move.picked:
+                continue
+            product = move.product_id
+            if line := purchase_order.order_line.filtered(lambda l: l.product_id == product):
+                move.purchase_line_id = line[:1]
+                continue
+            quantity = move.quantity
+            if move.to_refund:
+                quantity *= -1
+            po_line_vals = {
+                'move_ids': [Command.link(move.id)],
+                'order_id': purchase_order.id,
+                'product_id': product.id,
+                'product_qty': 0,
+                'product_uom_id': move.product_uom.id,
+                'qty_received': quantity
+            }
+            if product.purchase_method == 'purchase':
+                # No unit price if the product is purchased on the ordered qty.
+                po_line_vals['price_unit'] = 0
+            purchase_order_lines_vals.append(po_line_vals)
+        if purchase_order_lines_vals:
+            self.env['purchase.order.line'].create(purchase_order_lines_vals)
+        return res
 
 
 class StockWarehouse(models.Model):

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import Form, tagged
+from odoo.tests import Command, Form, tagged
 
 from odoo.addons.sale.tests.common import TestSaleCommon
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
@@ -13,7 +13,7 @@ class TestSaleMRPAngloSaxonValuation(TestSaleCommon, ValuationReconciliationTest
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
+        cls.env.ref('base.group_user').write({'implied_ids': [Command.link(cls.env.ref('product.group_product_variant').id)]})
         cls.env.user.company_id.anglo_saxon_accounting = True
 
     @classmethod

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -184,6 +184,8 @@ class StockReturnPicking(models.TransientModel):
             subtype_xmlid='mail.mt_note',
         )
         for return_line in self.product_return_moves:
+            if not return_line.move_id:
+                continue
             return_line._process_line(exchange_picking)
 
         exchange_picking.action_confirm()

--- a/addons/stock_account/views/stock_account_views.xml
+++ b/addons/stock_account/views/stock_account_views.xml
@@ -51,5 +51,16 @@
             </field>
         </record>
 
+        <record id="view_picking_form_inherit_stock_account" model="ir.ui.view">
+            <field name="name">stock.picking.stock.account.form</field>
+            <field name="inherit_id" ref="stock.view_picking_form"/>
+            <field name="model">stock.picking</field>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='move_ids_without_package']/list" position="inside">
+                    <field name="to_refund" groups="base.group_no_one" optional="hide" column_invisible="not parent.return_id"/>
+                </xpath>
+            </field>
+        </record>
+
     </data>
 </odoo>


### PR DESCRIPTION
Allow to add extra products in returns related to purchase orders.
Make purchase flows on returns & exchange returns as close as possible
as the sale ones.

task: 4458900

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
