### PR TITLE
[REF] spreadsheet: remove global globalFiltersFieldMatchers

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
@@ -1,8 +1,5 @@
 import { Domain } from "@web/core/domain";
-import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { ChartDataSource } from "../data_source/chart_data_source";
-import { sprintf } from "@web/core/utils/strings";
-import { _t } from "@web/core/l10n/translation";
 import { OdooUIPlugin } from "@spreadsheet/plugins";
 
 export class OdooChartUIPlugin extends OdooUIPlugin {
@@ -17,16 +14,6 @@ export class OdooChartUIPlugin extends OdooUIPlugin {
 
         /** @type {Record<string, ChartDataSource>} */
         this.charts = {};
-
-        globalFiltersFieldMatchers["chart"] = {
-            ...globalFiltersFieldMatchers["chart"],
-            getTag: async (chartId) => {
-                const model = await this.getChartDataSource(chartId).getModelLabel();
-                return sprintf(_t("Chart - %s"), model);
-            },
-            waitForReady: () => this._getOdooChartsWaitForReady(),
-            getFields: (chartId) => this.getChartDataSource(chartId).getFields(),
-        };
     }
 
     beforeHandle(cmd) {
@@ -205,16 +192,6 @@ export class OdooChartUIPlugin extends OdooUIPlugin {
     _setChartDataSource(chartId) {
         const chart = this.getters.getChart(chartId);
         chart.setDataSource(this.getChartDataSource(chartId));
-    }
-
-    /**
-     *
-     * @return {Promise[]}
-     */
-    _getOdooChartsWaitForReady() {
-        return this.getters
-            .getOdooChartIds()
-            .map((chartId) => this.getChartDataSource(chartId).loadMetadata());
     }
 
     _getOdooChartDataSourceId(chartId) {

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -8,6 +8,10 @@ import { RELATIVE_DATE_RANGE_TYPES } from "@spreadsheet/helpers/constants";
 import { monthsOptions } from "@spreadsheet/assets_backend/constants";
 import { QUARTER_OPTIONS } from "@web/search/utils/dates";
 
+import { Registry } from "@spreadsheet/o_spreadsheet/o_spreadsheet";
+
+export const globalFieldMatchingRegistry = new Registry();
+
 /**
  * @typedef {import("@spreadsheet").FieldMatching} FieldMatching
  */

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
@@ -1,9 +1,10 @@
 /** @ts-check */
 
-export const globalFiltersFieldMatchers = {};
-
 import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
-import { checkFilterValueIsValid } from "@spreadsheet/global_filters/helpers";
+import {
+    checkFilterValueIsValid,
+    globalFieldMatchingRegistry,
+} from "@spreadsheet/global_filters/helpers";
 import { _t } from "@web/core/l10n/translation";
 import { escapeRegExp } from "@web/core/utils/strings";
 import { OdooCorePlugin } from "@spreadsheet/plugins";
@@ -192,13 +193,17 @@ export class GlobalFiltersCorePlugin extends OdooCorePlugin {
             return {};
         }
 
-        for (const matcher of Object.values(globalFiltersFieldMatchers)) {
-            for (const dataSourceId of matcher.getIds()) {
-                const model = matcher.getModel(dataSourceId);
+        for (const matcher of globalFieldMatchingRegistry.getAll()) {
+            for (const dataSourceId of matcher.getIds(this.getters)) {
+                const model = matcher.getModel(this.getters, dataSourceId);
                 if (model === newModel) {
                     const fieldMatching = {};
                     for (const filter of globalFilters) {
-                        const matchedField = matcher.getFieldMatching(dataSourceId, filter.id);
+                        const matchedField = matcher.getFieldMatching(
+                            this.getters,
+                            dataSourceId,
+                            filter.id
+                        );
                         if (matchedField) {
                             fieldMatching[filter.id] = {
                                 chain: matchedField.chain,

--- a/addons/spreadsheet/static/src/index.js
+++ b/addons/spreadsheet/static/src/index.js
@@ -15,6 +15,8 @@
 
 /** TODO: Introduce a position parameter to the plugin registry in order to load them in a specific order */
 import * as spreadsheet from "@odoo/o-spreadsheet";
+import { _t } from "@web/core/l10n/translation";
+
 const { corePluginRegistry, coreViewsPluginRegistry, featurePluginRegistry } =
     spreadsheet.registries;
 
@@ -37,6 +39,63 @@ import {
 import { PivotCoreGlobalFilterPlugin } from "./pivot/plugins/pivot_core_global_filter_plugin";
 import { PivotOdooUIPlugin } from "./pivot/plugins/pivot_odoo_ui_plugin";
 import { ListCoreGlobalFilterPlugin } from "./list/plugins/list_core_global_filter_plugin";
+import { globalFieldMatchingRegistry } from "./global_filters/helpers";
+
+globalFieldMatchingRegistry.add("pivot", {
+    getIds: (getters) =>
+        getters
+            .getPivotIds()
+            .filter(
+                (id) =>
+                    getters.getPivotCoreDefinition(id).type === "ODOO" &&
+                    getters.getPivotFieldMatch(id)
+            ),
+    getDisplayName: (getters, pivotId) => getters.getPivotName(pivotId),
+    getTag: (getters, pivotId) =>
+        _t("Pivot #%(pivot_id)s", { pivot_id: getters.getPivotFormulaId(pivotId) }),
+    getFieldMatching: (getters, pivotId, filterId) =>
+        getters.getPivotFieldMatching(pivotId, filterId),
+    getModel: (getters, pivotId) => {
+        const pivot = getters.getPivotCoreDefinition(pivotId);
+        return pivot.type === "ODOO" && pivot.model;
+    },
+    waitForReady: (getters) =>
+        getters
+            .getPivotIds()
+            .map((pivotId) => getters.getPivot(pivotId))
+            .filter((pivot) => pivot.type === "ODOO")
+            .map((pivot) => pivot.loadMetadata()),
+    getFields: (getters, pivotId) => getters.getPivot(pivotId).getFields(),
+});
+
+globalFieldMatchingRegistry.add("list", {
+    getIds: (getters) => getters.getListIds().filter((id) => getters.getListFieldMatch(id)),
+    getDisplayName: (getters, listId) => getters.getListName(listId),
+    getTag: (getters, listId) => _t(`List #%(list_id)s`, { list_id: listId }),
+    getFieldMatching: (getters, listId, filterId) => getters.getListFieldMatching(listId, filterId),
+    getModel: (getters, listId) => getters.getListDefinition(listId).model,
+    waitForReady: (getters) =>
+        getters.getListIds().map((listId) => getters.getListDataSource(listId).loadMetadata()),
+    getFields: (getters, listId) => getters.getListDataSource(listId).getFields(),
+});
+
+globalFieldMatchingRegistry.add("chart", {
+    getIds: (getters) => getters.getOdooChartIds(),
+    getDisplayName: (getters, chartId) => getters.getOdooChartDisplayName(chartId),
+    getFieldMatching: (getters, chartId, filterId) =>
+        getters.getOdooChartFieldMatching(chartId, filterId),
+    getModel: (getters, chartId) =>
+        getters.getChart(chartId).getDefinitionForDataSource().metaData.resModel,
+    getTag: async (getters, chartId) => {
+        const chartModel = await getters.getChartDataSource(chartId).getModelLabel();
+        return _t("Chart - %(chart_model)s", { chart_model: chartModel });
+    },
+    waitForReady: (getters) =>
+        getters
+            .getOdooChartIds()
+            .map((chartId) => getters.getChartDataSource(chartId).loadMetadata()),
+    getFields: (getters, chartId) => getters.getChartDataSource(chartId).getFields(),
+});
 
 corePluginRegistry.add("OdooGlobalFiltersCorePlugin", GlobalFiltersCorePlugin);
 corePluginRegistry.add("PivotOdooCorePlugin", PivotOdooCorePlugin);

--- a/addons/spreadsheet/static/src/list/plugins/list_core_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_global_filter_plugin.js
@@ -1,6 +1,4 @@
 import { CommandResult } from "../../o_spreadsheet/cancelled_reason";
-import { _t } from "@web/core/l10n/translation";
-import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { checkFilterFieldMatching } from "@spreadsheet/global_filters/helpers";
 import { deepCopy } from "@web/core/utils/objects";
 import { OdooCorePlugin } from "@spreadsheet/plugins";
@@ -19,13 +17,6 @@ export class ListCoreGlobalFilterPlugin extends OdooCorePlugin {
 
         /** @type {Object.<string, GFLocalList>} */
         this.fieldMatchings = {};
-        globalFiltersFieldMatchers["list"] = {
-            getIds: () => Object.keys(this.fieldMatchings),
-            getDisplayName: (listId) => this.getters.getListName(listId),
-            getTag: (listId) => _t(`List #%(list_id)s`, { list_id: listId }),
-            getFieldMatching: (listId, filterId) => this.getListFieldMatching(listId, filterId),
-            getModel: (listId) => this.getters.getListDefinition(listId).model,
-        };
     }
 
     /**
@@ -142,7 +133,7 @@ export class ListCoreGlobalFilterPlugin extends OdooCorePlugin {
     import(data) {
         if (data.lists) {
             for (const [id, list] of Object.entries(data.lists)) {
-                this._addList(id, list.fieldMatching);
+                this._addList(id, list.fieldMatching ?? {});
             }
         }
     }

--- a/addons/spreadsheet/static/src/list/plugins/list_core_view_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_view_plugin.js
@@ -2,7 +2,6 @@ import * as spreadsheet from "@odoo/o-spreadsheet";
 import { getFirstListFunction } from "../list_helpers";
 import { Domain } from "@web/core/domain";
 import { ListDataSource } from "../list_data_source";
-import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { OdooCoreViewPlugin } from "@spreadsheet/plugins";
 
 const { astToFormula } = spreadsheet;
@@ -31,12 +30,6 @@ export class ListCoreViewPlugin extends OdooCoreViewPlugin {
         this.lists = {};
 
         this.custom = config.custom;
-
-        globalFiltersFieldMatchers["list"] = {
-            ...globalFiltersFieldMatchers["list"],
-            getFields: (listId) => this.getListDataSource(listId).getFields(),
-            waitForReady: () => this.getListsWaitForReady(),
-        };
     }
 
     beforeHandle(cmd) {
@@ -325,16 +318,6 @@ export class ListCoreViewPlugin extends OdooCoreViewPlugin {
         const dataSource = this.getListDataSource(id);
         await dataSource.load();
         return dataSource;
-    }
-
-    /**
-     *
-     * @return {Promise[]}
-     */
-    getListsWaitForReady() {
-        return this.getters
-            .getListIds()
-            .map((listId) => this.getListDataSource(listId).loadMetadata());
     }
 
     isListUnused(listId) {

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_global_filter_plugin.js
@@ -9,9 +9,6 @@
  */
 
 import { CommandResult } from "../../o_spreadsheet/cancelled_reason";
-import { _t } from "@web/core/l10n/translation";
-import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
-import { sprintf } from "@web/core/utils/strings";
 import { checkFilterFieldMatching } from "@spreadsheet/global_filters/helpers";
 import { deepCopy } from "@web/core/utils/objects";
 import { OdooCorePlugin } from "@spreadsheet/plugins";
@@ -23,23 +20,6 @@ export class PivotCoreGlobalFilterPlugin extends OdooCorePlugin {
 
         /** @type {Object.<string, GFLocalPivot>} */
         this.pivots = {};
-        globalFiltersFieldMatchers["pivot"] = {
-            getIds: () =>
-                this.getters
-                    .getPivotIds()
-                    .filter(
-                        (id) =>
-                            this.getters.getPivotCoreDefinition(id).type === "ODOO" &&
-                            id in this.pivots
-                    ),
-            getDisplayName: (pivotId) => this.getters.getPivotName(pivotId),
-            getTag: (pivotId) => sprintf(_t("Pivot #%s"), this.getters.getPivotFormulaId(pivotId)),
-            getFieldMatching: (pivotId, filterId) => this.getPivotFieldMatching(pivotId, filterId),
-            getModel: (pivotId) => {
-                const pivot = this.getters.getPivotCoreDefinition(pivotId);
-                return pivot.type === "ODOO" && pivot.model;
-            },
-        };
     }
 
     /**
@@ -77,7 +57,7 @@ export class PivotCoreGlobalFilterPlugin extends OdooCorePlugin {
             case "DUPLICATE_PIVOT": {
                 const { pivotId, newPivotId } = cmd;
                 const pivotDefinition = this.getters.getPivotCoreDefinition(pivotId);
-                if(pivotDefinition.type !== "ODOO") {
+                if (pivotDefinition.type !== "ODOO") {
                     break;
                 }
                 const pivot = deepCopy(this.pivots[pivotId]);
@@ -109,7 +89,7 @@ export class PivotCoreGlobalFilterPlugin extends OdooCorePlugin {
         if (pivot.type !== "ODOO") {
             return {};
         }
-        return this.pivots[id].fieldMatching;
+        return this.pivots[id]?.fieldMatching || {};
     }
 
     /**
@@ -175,7 +155,7 @@ export class PivotCoreGlobalFilterPlugin extends OdooCorePlugin {
     import(data) {
         if (data.pivots) {
             for (const [id, pivot] of Object.entries(data.pivots)) {
-                this._addPivot(id, pivot.fieldMatching);
+                this._addPivot(id, pivot.fieldMatching ?? {});
             }
         }
     }

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_view_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_view_global_filter_plugin.js
@@ -1,7 +1,6 @@
 import { FILTER_DATE_OPTION, monthsOptions } from "@spreadsheet/assets_backend/constants";
 import { Domain } from "@web/core/domain";
 import { NO_RECORD_AT_THIS_POSITION } from "../pivot_model";
-import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { OdooCoreViewPlugin } from "@spreadsheet/plugins";
 
 const { DateTime } = luxon;
@@ -72,12 +71,6 @@ export class PivotCoreViewGlobalFilterPlugin extends OdooCoreViewPlugin {
     ]);
     constructor(config) {
         super(config);
-
-        globalFiltersFieldMatchers["pivot"] = {
-            ...globalFiltersFieldMatchers["pivot"],
-            waitForReady: () => this._getPivotsWaitForReady(),
-            getFields: (pivotId) => this.getters.getPivot(pivotId).getFields(),
-        };
     }
 
     beforeHandle(cmd) {
@@ -194,7 +187,9 @@ export class PivotCoreViewGlobalFilterPlugin extends OdooCoreViewPlugin {
                             }
                         }
                         // A group by value of "none"
-                        if (value === false) break;
+                        if (value === false) {
+                            break;
+                        }
                         if (JSON.stringify(currentValue) !== `[${value}]`) {
                             transformedValue = [value];
                         }
@@ -248,17 +243,5 @@ export class PivotCoreViewGlobalFilterPlugin extends OdooCoreViewPlugin {
             .filter((pivotId) => this.getters.getPivot(pivotId).type === "ODOO")) {
             this._addDomain(pivotId);
         }
-    }
-
-    /**
-     *
-     * @return {Promise[]}
-     */
-    _getPivotsWaitForReady() {
-        return this.getters
-            .getPivotIds()
-            .map((pivotId) => this.getters.getPivot(pivotId))
-            .filter((pivot) => pivot.type === "ODOO")
-            .map((pivot) => pivot.loadMetadata());
     }
 }

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_chart.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_chart.test.js
@@ -3,9 +3,9 @@ import { mockDate } from "@odoo/hoot-mock";
 import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { describe, expect, test } from "@odoo/hoot";
 
-import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { createSpreadsheetWithChart } from "@spreadsheet/../tests/helpers/chart";
 import { addGlobalFilter, setGlobalFilterValue } from "@spreadsheet/../tests/helpers/commands";
+import { globalFieldMatchingRegistry } from "@spreadsheet/global_filters/helpers";
 
 describe.current.tags("headless");
 defineSpreadsheetModels();
@@ -92,13 +92,13 @@ test("field matching is removed when chart is deleted", async function () {
         sheetId: model.getters.getActiveSheetId(),
         id: chartId,
     });
-    expect(globalFiltersFieldMatchers["chart"].getIds()).toEqual([], {
+    expect(globalFieldMatchingRegistry.get("chart").getIds(model.getters)).toEqual([], {
         message: "it should have removed the chart and its fieldMatching and datasource altogether",
     });
     model.dispatch("REQUEST_UNDO");
     expect(model.getters.getChartFieldMatch(chartId)[filter.id]).toEqual(matching);
     model.dispatch("REQUEST_REDO");
-    expect(globalFiltersFieldMatchers["chart"].getIds()).toEqual([]);
+    expect(globalFieldMatchingRegistry.get("chart").getIds(model.getters)).toEqual([]);
 });
 
 test("field matching is removed when filter is deleted", async function () {


### PR DESCRIPTION
Before this commit, we used a global object `globalFiltersFieldMatchers` to store the different functions to be called to manipulate the field matchers (`getIds`, ...) with abstracting the datasources (pivot, list, chart). The downside of this approach is that this object is replaced at each model instantiation, and so re-using an old Model instance could lead to unexpected behaviors.

This commit removes this global object and instead uses a registry with functions that takes `getters` as first argument.

Task: 4684668

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
