### PR TITLE
[FIX] website: properly resolve promise after saving google maps API key

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -296,8 +296,7 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
                 onMounted(() => this.props.onMounted(this.modalRef));
             }
             onClickSave() {
-                this.props.confirm(this.modalRef, this.state.apiKey);
-                this.props.close();
+                this.props.confirm(this.modalRef, this.state.apiKey, this.props.close);
             }
         };
 
@@ -309,7 +308,7 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
                         applyError.call($(modalRef.el), apiKeyValidation.message);
                     }
                 },
-                confirm: async (modalRef, valueAPIKey) => {
+                confirm: async (modalRef, valueAPIKey, close = undefined) => {
                     if (!valueAPIKey) {
                         applyError.call($(modalRef.el), _t("Enter an API Key"));
                         return;
@@ -320,7 +319,11 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
                     if (res.isValid) {
                         await this.orm.write("website", [websiteId], {google_maps_api_key: valueAPIKey});
                         invalidated = true;
-                        return true;
+                        if (close) {
+                            close();
+                        } else {
+                            resolve(true);
+                        }
                     } else {
                         applyError.call($(modalRef.el), res.message);
                     }


### PR DESCRIPTION
Steps to reproduce:

- Activate developer mode
- Install website Google Maps module
- Navigate to Website in edit mode
- Drop the google maps snippet
- Enter a correct API key
- The dialog closes but the snippet is removed

This is due to a promise not resolved when confirming the API key.
