### PR TITLE
[IMP] orm: domain optimization should call first basic then full

### DIFF
--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -876,3 +876,14 @@ class TestDomainOptimize(TransactionCase):
             (self.number_domain & self.number_domain).optimize(model),
             self.number_domain
         )
+
+    def test_optimize_level_by_level(self):
+        def search_foo(model, operator, value):
+            # groups values to check that it is called once
+            return [('name', '=', str(tuple(value)))]
+
+        self.patch(self.registry['test_new_api.bar'], '_search_foo', search_foo)
+        bar = self.env['test_new_api.bar']
+        domain = Domain('foo', '=', 4) | Domain('foo', '=', 5)
+        domain = domain.optimize(bar, full=True)
+        self.assertEqual(domain, Domain('name', 'in', OrderedSet(['(4, 5)'])))

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -391,12 +391,23 @@ class Domain:
         if self._opt_level >= level:
             return self
 
-        # determine a fixpoint for _optimize()
-        previous, domain, count = None, self, 0
-        while domain != previous:
-            if (count := count + 1) > MAX_OPTIMIZE_ITERATIONS:
-                raise RecursionError("Domain.optimize: too many loops")
-            previous, domain = domain, domain._optimize(model, full)
+        domain = self
+
+        if domain._opt_level < OptimizationLevel.BASIC:
+            # determine a fixpoint for _optimize() for level BASIC
+            previous, count = None, 0
+            while domain != previous:
+                if (count := count + 1) > MAX_OPTIMIZE_ITERATIONS:
+                    raise RecursionError("Domain.optimize: too many loops")
+                previous, domain = domain, domain._optimize(model, False)
+
+        if full and domain._opt_level < OptimizationLevel.FULL:
+            # determine a fixpoint for _optimize() for level FULL
+            previous, count = None, 0
+            while domain != previous:
+                if (count := count + 1) > MAX_OPTIMIZE_ITERATIONS:
+                    raise RecursionError("Domain.optimize: too many loops")
+                previous, domain = domain, domain._optimize(model, True)
 
         # set the optimization level if necessary (unlike DomainBool, for instance)
         if domain._opt_level < level:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When performing optimizations, first perform all basic optimizations and then the rest of optimizations. As basic optimizations could remove or merge some conditions, this allows to run the more advanced optimizations only once.

Current behavior before PR:
An example use case are `Field.search` methods.

    ['|', ('searchable', 'any', D1), ('searchable', 'any', D2)]
    -> ['|', _search_searchable('any', D1), _search_searchable('any', D2)]

Desired behavior after PR is merged:

    ['|', ('searchable', 'any', D1), ('searchable', 'any', D2)]
    -> [('searchable', 'any', D1 | D2)]
    -> _search_searchable('any', D1 | D2)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
