### PR TITLE
[FIX] web: disable demo tours in click_all

### DIFF
--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -16,6 +16,8 @@ _logger = logging.getLogger(__name__)
 class TestMenusAdmin(odoo.tests.HttpCase):
     allow_end_on_form = True
     def test_01_click_everywhere_as_admin(self):
+        if 'tour_enabled' in self.env['res.users']._fields:
+            self.env.ref('base.user_admin').tour_enabled = False
         menus = self.env['ir.ui.menu'].load_menus(False)
         for app_id in menus['root']['children']:
             with self.subTest(app=menus[app_id]['name']):


### PR DESCRIPTION
The previous fix in #204089 didn't work as expected because the `tour_enabled` field is depending on the creation date. As the field is stored and the base user is created before the start of the tests, the demo tours are enabled for the click_all for admin.

With this commit, the field is explicitly set to False before starting the click all for admin.
