### PR TITLE
[FIX] mail: message '(edited)' inline to content

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -193,6 +193,7 @@ export class Message extends Component {
                 this.message.translationValue,
                 this.props.messageSearch?.searchTerm,
                 this.message.body,
+                this.message.composer,
             ]
         );
     }
@@ -409,6 +410,8 @@ export class Message extends Component {
         if (!bodyEl) {
             return;
         }
+        const editedEl = bodyEl.querySelector(".o-mail-Message-edited");
+        editedEl?.replaceChildren(renderToElement("mail.Message.edited"));
         const linkEls = bodyEl.querySelectorAll(".o_channel_redirect");
         for (const linkEl of linkEls) {
             const text = linkEl.textContent.substring(1); // remove '#' prefix

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -23,10 +23,6 @@
     opacity: 50%;
 }
 
-.o-mail-Message-edited {
-    display: none;
-}
-
 .o-mail-Message-seenContainer {
     font-size: 0.65rem;
     right: 2px;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -90,7 +90,6 @@
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
                                                         <t t-elif="state.showTranslation" t-out="message.translationValue"/>
                                                         <t t-elif="message.body" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
-                                                        <em t-if="message.edited" class="smaller fw-bold text-500"> (edited)</em>
                                                         <p class="fst-italic text-muted small" t-if="state.showTranslation">
                                                             <t t-if="message.translationSource" t-esc="translatedFromText"/>
                                                         </p>
@@ -129,6 +128,10 @@
             </div>
         </ActionSwiper>
     </t>
+
+<t t-name="mail.Message.edited">
+    <em class="smaller fw-bold text-500"> (edited)</em>
+</t>
 
 <t t-name="mail.Message.actions">
     <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions d-print-none"

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -130,6 +130,11 @@ test("Can edit message comment in chatter", async () => {
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-content", { text: "edited message (edited)" });
+    // save without change should keep (edited)
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message a", { text: "save" });
+    await contains(".o-mail-Message-content", { text: "edited message (edited)" });
 });
 
 test("Can edit message comment in chatter (mobile)", async () => {


### PR DESCRIPTION
Before this commit, when a message is edited, the "(edited)" label was put under the text content.

This happened because the "(edited)" label is added after the message text content. The text content is html, and usually this is a `<p>` in discuss conversations, automatically added by the html_sanitize on the `mail.message@body` field.

This commit fixes the issue by making the `.o-mail-Message-edited` node display the edited label at this place. This node with this classname is appended to content when a message has been edited. Since message edited in Discuss are making the last paragraph of message text content inline, so that the "(edited)" label is put inline with the message content.

Before / After
<img width="255" alt="Screenshot 2025-03-31 at 14 36 25" src="https://github.com/user-attachments/assets/15478ee5-5703-4747-b5ae-8cbc5582a5a8" /> <img width="249" alt="Screenshot 2025-03-31 at 14 36 05" src="https://github.com/user-attachments/assets/c1d2cc24-f4bb-443b-bb03-e0f53682170b" />
