### PR TITLE
[IMP] core: make related_sudo fields use SQL joins when possible

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -459,11 +459,23 @@ class Test_New_ApiRelated(models.Model):
 
     foo_id_bar_name = fields.Char('foo_id_bar_name', related='foo_id.bar_name', related_sudo=False)
 
-    foo_bar_id = fields.Many2one(string='foo_bar_id', related='foo_id.bar_id', related_sudo=False)
-    foo_bar_id_name = fields.Char('foo_bar_id_name', related='foo_bar_id.name', related_sudo=False)
+    foo_bar_id = fields.Many2one(related='foo_id.bar_id', related_sudo=False, string='Bar')
+    foo_bar_id_name = fields.Char(related='foo_bar_id.name', related_sudo=False, string='Bar Name')
 
-    foo_bar_sudo_id = fields.Many2one(string='foo_bar_sudo_id', related='foo_id.bar_id', related_sudo=True)
-    foo_bar_sudo_id_name = fields.Char('foo_bar_sudo_id_name', related='foo_bar_sudo_id.name', related_sudo=False)
+    foo_bar_sudo_id = fields.Many2one(related='foo_id.bar_id', related_sudo=True, string='Bar Sudo')
+    foo_bar_sudo_id_name = fields.Char(related='foo_bar_sudo_id.name', related_sudo=False, string='Bar Sudo Name')
+
+    foo_bar_ids = fields.Many2many(related='foo_id.bar_ids', related_sudo=False)
+    foo_bar_sudo_ids = fields.Many2many(related='foo_id.bar_ids', related_sudo=True, string='Bars Sudo')
+
+    foo_foo_ids = fields.One2many(related='foo_id.foo_ids', related_sudo=False)
+    foo_foo_sudo_ids = fields.One2many(related='foo_id.foo_ids', related_sudo=True, string='Foos Sudo')
+
+    foo_binary_att = fields.Binary(related='foo_id.binary_att', related_sudo=False)
+    foo_binary_att_sudo = fields.Binary(related='foo_id.binary_att', related_sudo=True, string='Binary Att Sudo')
+
+    foo_binary_bin = fields.Binary(related='foo_id.binary_bin', related_sudo=False)
+    foo_binary_bin_sudo = fields.Binary(related='foo_id.binary_bin', related_sudo=True, string='Binary Bin Sudo')
 
 
 class Test_New_ApiRelated_Foo(models.Model):
@@ -472,6 +484,10 @@ class Test_New_ApiRelated_Foo(models.Model):
 
     name = fields.Char()
     bar_id = fields.Many2one('test_new_api.related_bar')
+    bar_ids = fields.Many2many('test_new_api.related_bar', string='Bars')
+    foo_ids = fields.One2many('test_new_api.related', 'foo_id', string='Foos')
+    binary_att = fields.Binary()
+    binary_bin = fields.Binary(attachment=False)
     bar_name = fields.Char('bar_name', related='bar_id.name', related_sudo=False)
 
 

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -495,7 +495,7 @@ class Test_New_ApiRelated_Bar(models.Model):
     _name = 'test_new_api.related_bar'
     _description = 'test_new_api.related_bar'
 
-    name = fields.Char()
+    name = fields.Char(required=True)
 
 
 class Test_New_ApiRelated_Inherits(models.Model):

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -1031,7 +1031,7 @@ class TestSearchRelated(TransactionCase):
                         OR "test_new_api_related_foo"."bar_id" IN (
                             SELECT "test_new_api_related_bar"."id"
                             FROM "test_new_api_related_bar"
-                            WHERE ("test_new_api_related_bar"."name" IN %s OR "test_new_api_related_bar"."name" IS NULL)
+                            WHERE "test_new_api_related_bar"."name" IN %s
                         )
                     )
                 )

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -442,11 +442,9 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."name" IN %s
-            )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE "test_new_api_related__foo_id"."name" IN %s
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -511,11 +509,9 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."bar_id" IN %s
-            )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE "test_new_api_related__foo_id"."bar_id" IN %s
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -524,15 +520,13 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."bar_id" IN (
-                    SELECT "test_new_api_related_bar"."id"
-                    FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" IN %s
-                    AND "test_new_api_related_bar"."id" < %s
-                )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE "test_new_api_related__foo_id"."bar_id" IN (
+                SELECT "test_new_api_related_bar"."id"
+                FROM "test_new_api_related_bar"
+                WHERE "test_new_api_related_bar"."name" IN %s
+                AND "test_new_api_related_bar"."id" < %s
             )
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
@@ -594,15 +588,13 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE EXISTS (
-                    SELECT 1
-                    FROM "test_new_api_related_bar_test_new_api_related_foo_rel" AS "test_new_api_related_foo__bar_ids"
-                    WHERE "test_new_api_related_foo__bar_ids"."test_new_api_related_foo_id" = "test_new_api_related_foo"."id"
-                    AND "test_new_api_related_foo__bar_ids"."test_new_api_related_bar_id" IN %s
-                )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE EXISTS (
+                SELECT 1
+                FROM "test_new_api_related_bar_test_new_api_related_foo_rel" AS "test_new_api_related__foo_id__bar_ids"
+                WHERE "test_new_api_related__foo_id__bar_ids"."test_new_api_related_foo_id" = "test_new_api_related__foo_id"."id"
+                AND "test_new_api_related__foo_id__bar_ids"."test_new_api_related_bar_id" IN %s
             )
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
@@ -612,19 +604,17 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE EXISTS (
-                    SELECT 1
-                    FROM "test_new_api_related_bar_test_new_api_related_foo_rel" AS "test_new_api_related_foo__bar_ids"
-                    WHERE "test_new_api_related_foo__bar_ids"."test_new_api_related_foo_id" = "test_new_api_related_foo"."id"
-                    AND "test_new_api_related_foo__bar_ids"."test_new_api_related_bar_id" IN (
-                        SELECT "test_new_api_related_bar"."id"
-                        FROM "test_new_api_related_bar"
-                        WHERE "test_new_api_related_bar"."name" IN %s
-                        AND "test_new_api_related_bar"."id" < %s
-                    )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE EXISTS (
+                SELECT 1
+                FROM "test_new_api_related_bar_test_new_api_related_foo_rel" AS "test_new_api_related__foo_id__bar_ids"
+                WHERE "test_new_api_related__foo_id__bar_ids"."test_new_api_related_foo_id" = "test_new_api_related__foo_id"."id"
+                AND "test_new_api_related__foo_id__bar_ids"."test_new_api_related_bar_id" IN (
+                    SELECT "test_new_api_related_bar"."id"
+                    FROM "test_new_api_related_bar"
+                    WHERE "test_new_api_related_bar"."name" IN %s
+                    AND "test_new_api_related_bar"."id" < %s
                 )
             )
             AND "test_new_api_related"."id" < %s
@@ -683,15 +673,13 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."id" IN (
-                    SELECT "test_new_api_related"."foo_id"
-                    FROM "test_new_api_related"
-                    WHERE "test_new_api_related"."id" IN %s
-                    AND "test_new_api_related"."foo_id" IS NOT NULL
-                )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE "test_new_api_related__foo_id"."id" IN (
+                SELECT "test_new_api_related"."foo_id"
+                FROM "test_new_api_related"
+                WHERE "test_new_api_related"."id" IN %s
+                AND "test_new_api_related"."foo_id" IS NOT NULL
             )
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
@@ -701,16 +689,16 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."id" IN (
-                    SELECT "test_new_api_related"."foo_id"
-                    FROM "test_new_api_related"
-                    WHERE "test_new_api_related"."name" IN %s
-                    AND "test_new_api_related"."id" < %s
-                    AND "test_new_api_related"."foo_id" IS NOT NULL
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE "test_new_api_related__foo_id"."id" IN (
+                SELECT "test_new_api_related"."foo_id"
+                FROM "test_new_api_related"
+                WHERE (
+                     "test_new_api_related"."foo_id" IS NOT NULL
+                    AND "test_new_api_related"."name" IN %s
                 )
+                AND "test_new_api_related"."id" < %s
             )
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
@@ -759,12 +747,10 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."id" IN (
-                    SELECT res_id FROM ir_attachment WHERE res_model = %s AND res_field = %s
-                )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE "test_new_api_related__foo_id"."id" IN (
+                SELECT res_id FROM ir_attachment WHERE res_model = %s AND res_field = %s
             )
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
@@ -774,11 +760,9 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."binary_bin" IS NOT NULL
-            )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE "test_new_api_related__foo_id"."binary_bin" IS NOT NULL
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -797,15 +781,11 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."bar_id" IN (
-                    SELECT "test_new_api_related_bar"."id"
-                    FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" IN %s
-                )
-            )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            LEFT JOIN "test_new_api_related_bar" AS "test_new_api_related__foo_id__bar_id"
+                ON ("test_new_api_related__foo_id"."bar_id" = "test_new_api_related__foo_id__bar_id"."id")
+            WHERE "test_new_api_related__foo_id__bar_id"."name" IN %s
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -868,19 +848,16 @@ class TestSearchRelated(TransactionCase):
         """]):
             model.search([('foo_bar_id_name', '=', 'a')])
 
-        # bypass security for foo_id.bar_id, but not for name
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."bar_id" IN (
-                    SELECT "test_new_api_related_bar"."id"
-                    FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" IN %s
-                    AND "test_new_api_related_bar"."id" < %s
-                )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            WHERE "test_new_api_related__foo_id"."bar_id" IN (
+                SELECT "test_new_api_related_bar"."id"
+                FROM "test_new_api_related_bar"
+                WHERE "test_new_api_related_bar"."name" IN %s
+                AND "test_new_api_related_bar"."id" < %s
             )
             AND "test_new_api_related"."id" < %s
             ORDER BY "test_new_api_related"."id"
@@ -1018,12 +995,11 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
             WHERE (
-                "test_new_api_related"."foo_id" NOT IN (
-                    SELECT "test_new_api_related_foo"."id"
-                    FROM "test_new_api_related_foo"
-                    WHERE "test_new_api_related_foo"."name" IN %s
-                ) OR "test_new_api_related"."foo_id" IS NULL
+                "test_new_api_related__foo_id"."name" NOT IN %s
+                OR "test_new_api_related__foo_id"."name" IS NULL
             )
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -1032,13 +1008,11 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
             WHERE (
-                "test_new_api_related"."foo_id" IS NULL
-                OR "test_new_api_related"."foo_id" IN (
-                    SELECT "test_new_api_related_foo"."id"
-                    FROM "test_new_api_related_foo"
-                    WHERE ("test_new_api_related_foo"."name" IN %s OR "test_new_api_related_foo"."name" IS NULL)
-                )
+                "test_new_api_related__foo_id"."name" IN %s
+                OR "test_new_api_related__foo_id"."name" IS NULL
             )
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -1085,20 +1059,13 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            LEFT JOIN "test_new_api_related_bar" AS "test_new_api_related__foo_id__bar_id"
+                ON ("test_new_api_related__foo_id"."bar_id" = "test_new_api_related__foo_id__bar_id"."id")
             WHERE (
-                "test_new_api_related"."foo_id" IS NULL
-                OR "test_new_api_related"."foo_id" IN (
-                    SELECT "test_new_api_related_foo"."id"
-                    FROM "test_new_api_related_foo"
-                    WHERE (
-                        "test_new_api_related_foo"."bar_id" IS NULL
-                        OR "test_new_api_related_foo"."bar_id" IN (
-                            SELECT "test_new_api_related_bar"."id"
-                            FROM "test_new_api_related_bar"
-                            WHERE ("test_new_api_related_bar"."name" IN %s OR "test_new_api_related_bar"."name" IS NULL)
-                        )
-                    )
-                )
+                "test_new_api_related__foo_id__bar_id"."name" IN %s
+                OR "test_new_api_related__foo_id__bar_id"."name" IS NULL
             )
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -1107,15 +1074,11 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_new_api_related"."id"
             FROM "test_new_api_related"
-            WHERE "test_new_api_related"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."bar_id" IN (
-                    SELECT "test_new_api_related_bar"."id"
-                    FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" NOT IN %s
-                )
-            )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related__foo_id"
+                ON ("test_new_api_related"."foo_id" = "test_new_api_related__foo_id"."id")
+            LEFT JOIN "test_new_api_related_bar" AS "test_new_api_related__foo_id__bar_id"
+                ON ("test_new_api_related__foo_id"."bar_id" = "test_new_api_related__foo_id__bar_id"."id")
+            WHERE "test_new_api_related__foo_id__bar_id"."name" NOT IN %s
             ORDER BY "test_new_api_related"."id"
         """]):
             model.search([('foo_bar_name_sudo', '!=', False)])
@@ -1148,11 +1111,9 @@ class TestSearchRelated(TransactionCase):
             FROM "test_new_api_related_inherits"
             LEFT JOIN "test_new_api_related" AS "test_new_api_related_inherits__base_id"
                 ON ("test_new_api_related_inherits"."base_id" = "test_new_api_related_inherits__base_id"."id")
-            WHERE "test_new_api_related_inherits__base_id"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."name" IN %s
-            )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related_inherits__base_id__foo_id"
+                ON ("test_new_api_related_inherits__base_id"."foo_id" = "test_new_api_related_inherits__base_id__foo_id"."id")
+            WHERE "test_new_api_related_inherits__base_id__foo_id"."name" IN %s
             AND "test_new_api_related_inherits__base_id"."id" < %s
             ORDER BY "test_new_api_related_inherits"."id"
         """]):
@@ -1179,15 +1140,11 @@ class TestSearchRelated(TransactionCase):
             FROM "test_new_api_related_inherits"
             LEFT JOIN "test_new_api_related" AS "test_new_api_related_inherits__base_id"
                 ON ("test_new_api_related_inherits"."base_id" = "test_new_api_related_inherits__base_id"."id")
-            WHERE "test_new_api_related_inherits__base_id"."foo_id" IN (
-                SELECT "test_new_api_related_foo"."id"
-                FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."bar_id" IN (
-                    SELECT "test_new_api_related_bar"."id"
-                    FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" IN %s
-                )
-            )
+            LEFT JOIN "test_new_api_related_foo" AS "test_new_api_related_inherits__base_id__foo_id"
+                ON ("test_new_api_related_inherits__base_id"."foo_id" = "test_new_api_related_inherits__base_id__foo_id"."id")
+            LEFT JOIN "test_new_api_related_bar" AS "test_new_api_related_inherits__base_id__foo_id__bar_id"
+                ON ("test_new_api_related_inherits__base_id__foo_id"."bar_id" = "test_new_api_related_inherits__base_id__foo_id__bar_id"."id")
+            WHERE "test_new_api_related_inherits__base_id__foo_id__bar_id"."name" IN %s
             AND "test_new_api_related_inherits__base_id"."id" < %s
             ORDER BY "test_new_api_related_inherits"."id"
         """]):

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -887,6 +887,8 @@ class DomainCondition(Domain):
         ))
 
     def _to_sql(self, model: BaseModel, alias: str, query: Query) -> SQL:
+        field = self._field(model)
+        model._check_field_access(field, 'read')
         return model._condition_to_sql(alias, self.field_expr, self.operator, self.value, query)
 
 

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -224,8 +224,6 @@ class Binary(Field):
     def condition_to_sql(self, field_expr: str, operator: str, value, model: BaseModel, alias: str, query: Query) -> SQL:
         if not self.attachment or field_expr != self.name:
             return super().condition_to_sql(field_expr, operator, value, model, alias, query)
-        # check permission
-        model._check_field_access(self, 'read')
         assert operator in ('in', 'not in') and set(value) == {False}, "Should have been done in Domain optimization"
         return SQL(
             "%s%s(SELECT res_id FROM ir_attachment WHERE res_model = %s AND res_field = %s)",

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -423,7 +423,7 @@ class Many2one(_Relational[M]):
         fname = field_expr
         comodel = model.env[self.comodel_name]
         sql_field = model._field_to_sql(alias, fname, query)
-        can_be_null = self not in model.env.registry.not_null_fields
+        can_be_null = self.can_be_null(model, alias, query)
 
         if not isinstance(value, Domain):
             # value is SQL or Query

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -679,7 +679,6 @@ class _RelationalMulti(_Relational[M], typing.Generic[M]):
 
     def condition_to_sql(self, field_expr: str, operator: str, value, model: BaseModel, alias: str, query: Query) -> SQL:
         assert field_expr == self.name, "Supporting condition only to field"
-        model._check_field_access(self, 'read')
         comodel = model.env[self.comodel_name]
 
         # update the operator to 'any'

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -2722,10 +2722,12 @@ class BaseModel(metaclass=MetaModel):
         given by the triple ``(field_expr, operator, value)`` with the given
         table alias, and in the context of the given query.
 
-        The method is also responsible for checking that the field is accessible
-        for reading, and should include metadata in the result object to make
-        sure that the necessary fields are flushed before executing the final
-        SQL query.
+        The method should include metadata in the result object to make sure
+        that the necessary fields are flushed before executing the final SQL
+        query.
+
+        The caller of this method is responsible for checking that the field is
+        accessible for reading.
         """
         assert operator in domains.STANDARD_CONDITION_OPERATORS, \
             f"Invalid operator {operator!r} for SQL in domain term {(field_expr, operator, value)!r}"


### PR DESCRIPTION
This was already doable for grouping, aggregating and ordering on such fields.  We now also use joins for searching.

See also https://github.com/odoo/enterprise/pull/82557