### PR TITLE
[FIX] account, web: fix multiple invoices sending with Folder layout

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from markupsafe import Markup
 
 from odoo import _, api, models, modules, tools
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 
 class AccountMoveSend(models.AbstractModel):
@@ -331,6 +331,8 @@ class AccountMoveSend(models.AbstractModel):
 
             content, report_type = self.env['ir.actions.report'].with_company(company_id)._pre_render_qweb_pdf(pdf_report.report_name, res_ids=ids)
             content_by_id = self.env['ir.actions.report']._get_splitted_report(pdf_report.report_name, content, report_type)
+            if len(content_by_id) == 1 and False in content_by_id:
+                raise ValidationError(_("Cannot identify the invoices in the generated PDF: %s", ids))
 
             for invoice, invoice_data in group_invoices_data.items():
                 invoice_data['pdf_attachment_values'] = {

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -599,6 +599,7 @@
                 <t t-set="custom_layout_address" t-value="true"/>
                 <t t-call="web.address_layout"/>
             </div>
+            <h3 t-if="report_type == 'pdf'" t-out="layout_document_title" class="opacity-0" t-att-style="'height: 0px'"/>
             <t t-out="0"/>
         </div>
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Go to Settings and configure document layout
- Select Folder as layout
- Create an invoice with lot of products (~20) that would be printed on 2 pages
- Duplicate the created invoice
- From the list view, select both invoices
- Click on "Send" button
- Go to "Settings / Technical / Automation / Scheduled Actions"
- Open "Send invoices automatically" action
- Click on "Run Manually"

**Issue:**
A KeyError is raised in "_prepare_invoice_pdf_report" method from the following line:
`'raw': content_by_id[invoice.id]`
If the invoices have already been sent before clicking on "Run Manually", the traceback can be checked in the logs.

**Cause:**
Since this commit
https://github.com/odoo/odoo/commit/0e73d3f1751495786eb2b18384ea39f4da18e3fb a unique call to "wkhtmltopdf" is made to generate one PDF for all the invoices.
This PDF is then split in a dict having an entry for each invoice. When there is more pages than the number of invoices, we check the "outlines" generated by "wkhtmltopdf" to determine which pages are associated to which invoice.
"wkhtmltopdf" generates an "outline" for each heading tag (i.e. h1, h2,...).
As each layout is only using a heading tag (i.e. h2) for the document title, we can assume that each page between 2 heading tags and therefore outlines belongs to the same invoice.
The issue with the Folder layout is that the document title is defined in the header of the layout and not in the body as it is done for the other layouts.
But "wkhtmltopdf" only generates "outines" for heading tags in the body, ignoring those defined in the header.
In that case, the PDF cannot be split due to the lack of outlines and the dict only contains one element (the whole PDF) with False as key, which raises the error when executing this code `content_by_id[invoice.id]`.

**Solution:**
1) Instead of the KeyError, a UserError with a more useful message is raised instead.

2) A heading tag (h3) is added in the body of the Folder layout to allow "wkhtmltopdf" to generate the "outlines" from it.
This heading also contains the document title.
But in order to prevent having the document title displayed twice, these styles are applied to it:
- "opacity: 0" to hide the tag. "display: none" and "visibility: hidden" don't work. No "outline" is generated if there are used.
- "height: 0" to remove the space allocated to the hidden tag.
This is a very hacky solution but without it, it is not possible to send multiple documents that have more than one page.

opw-4592851
opw-4562932




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
