### PR TITLE
[FIX] html_editor: arrow down key on file banner

### DIFF
--- a/addons/html_editor/static/src/main/media/file.scss
+++ b/addons/html_editor/static/src/main/media/file.scss
@@ -1,9 +1,8 @@
 .o_file_box, [data-embedded="file"] {
-    display: inline-block;
+    display: block;
     width: fit-content;
     min-width: 250px;
     margin: 3px;
-    vertical-align: middle;
 
     .alert.alert-info {
         border-radius: 5px;

--- a/addons/html_editor/static/tests/file.test.js
+++ b/addons/html_editor/static/tests/file.test.js
@@ -48,7 +48,7 @@ describe("file command", () => {
         expect(".odoo-editor-editable .o_file_box").toHaveCount(1);
     });
 
-    test("file card should have inline display, BS alert-info style and no download button", async () => {
+    test("file card should have block display, BS alert-info style and no download button", async () => {
         const { editor } = await setupEditor("<p>[]<br></p>");
         patchUpload(editor);
         execCommand(editor, "uploadFile");
@@ -56,7 +56,7 @@ describe("file command", () => {
         await waitFor('.o_file_box .o_file_name_container:contains("file.txt")');
         // Check that file card has inline display, with alert style.
         const fileCard = queryOne(".o_file_box");
-        expect(fileCard).toHaveStyle({ display: "inline-block" });
+        expect(fileCard).toHaveStyle({ display: "block" });
         expect(fileCard.firstElementChild).toHaveClass(["alert", "alert-info"]);
         // No download button in file card.
         expect(".o_file_box .fa-download").toHaveCount(0);
@@ -171,7 +171,7 @@ describe("zero width no-break space", () => {
         let content = getContent(el);
         // replace embedded component root with a <FILE/> placeholder for readability
         content = content.replace(/<span data-embedded="file".*?<\/span>/g, "<FILE/>");
-        expect(content).toBe("<p>\ufeff<FILE/>\ufeff<FILE/>\ufeff[]</p>");
+        expect(content).toBe("<p>\ufeff<FILE/>\ufeff<FILE/>\ufeff[]<br></p>");
     });
 
     test("should not add two contiguous ZWNBSP between two file cards (2)", async () => {
@@ -184,7 +184,7 @@ describe("zero width no-break space", () => {
         );
         press("Backspace");
         expect(getContent(el)).toBe(
-            '<p>abc\ufeff<span data-embedded="file" class="o_file_box"></span>\ufeff[]<span data-embedded="file" class="o_file_box"></span>\ufeff</p>'
+            '<p>abc\ufeff<span data-embedded="file" class="o_file_box"><br></span>\ufeff[]<span data-embedded="file" class="o_file_box"><br></span>\ufeff</p>'
         );
     });
 });


### PR DESCRIPTION
Before this commit:
- when a user placed the caret above or below a file banner 
and pressed the down or up arrow key, respectively,
The caret would not move past the banner.
- This unexpected behavior disrupted smooth navigation in the editor.

After this commit:
- We ensure that both the up and down arrow keys move correctly 
the caret across the banner, allowing seamless text navigation.

task-4671755