### PR TITLE
[FIX] mail: remove 'Select duration' in Discuss 'Mute all' menu

### DIFF
--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
@@ -20,7 +20,6 @@
                 </div>
                 <div class="flex-grow-1"/>
                 <select class="form-select w-auto d-flex" t-on-change="onChangeMuteDuration">
-                    <option value="default">Select duration</option>
                     <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
                         <option t-att-value="mute.value" t-esc="mute.name" t-att-selected="mute.value === state.selectedDuration"/>
                     </t>


### PR DESCRIPTION
Before this commit, when muting all conversations in the menu Configuration > Notification settings of Discuss app, the turn back until item had the option "Select duration".

This item was intended as the default option, to let user know this is a widget to select an item. However, the option is pre-selected to "Until I turn it back on", and the widget is visually very obvious it can be changed to another option.

Therefore the "Select duration" has no reason to exist, thus this is simply removed in this commit,

Task-4208113

Before
<img width="654" alt="Screenshot 2025-03-31 at 15 49 10" src="https://github.com/user-attachments/assets/0f642940-d42f-43e2-a48e-ac50bde3528e" />

After
<img width="654" alt="Screenshot 2025-03-31 at 15 48 48" src="https://github.com/user-attachments/assets/1fcbbd4d-ae19-445c-afee-b18f894943b2" />

