### PR TITLE
[FIX] web: set a max-height on dropdown popover

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -149,7 +149,13 @@ export class Dropdown extends Component {
             env: this.__owl__.childEnv,
             holdOnHover: this.props.holdOnHover,
             onClose: () => this.state.close(),
-            onPositioned: (el, { direction }) => this.setTargetDirectionClass(direction),
+            onPositioned: (el, { direction, top }) => {
+                this.setTargetDirectionClass(direction);
+                if (top < 0) {
+                    el.style.top = 0;
+                }
+                this.setPopoverMaxHeight(el, direction, top);
+            },
             popoverClass: mergeClasses(
                 "o-dropdown--menu dropdown-menu mx-0",
                 { "o-dropdown--menu-submenu": this.hasParent },
@@ -300,6 +306,15 @@ export class Dropdown extends Component {
         };
         this.target.classList.remove(...Object.values(directionClasses));
         this.target.classList.add(directionClasses[direction]);
+    }
+
+    setPopoverMaxHeight(el, direction, top) {
+        const margins = `${getComputedStyle(el).marginTop} - ${getComputedStyle(el).marginBottom}`;
+        if (direction === "bottom") {
+            el.style.maxHeight = `calc(100dvh - ${top}px - ${margins})`;
+        } else if (direction === "top") {
+            el.style.maxHeight = `calc(${this.target.getBoundingClientRect().top}px - ${margins})`;
+        }
     }
 
     openPopover() {

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -805,6 +805,68 @@ test("t-if t-else as toggler", async () => {
     expect(DROPDOWN_MENU).toHaveCount(1);
 });
 
+test("cap dropdown's popover height with too many items", async () => {
+    class HugeDropdown extends Component {
+        static components = { Dropdown, DropdownItem };
+        static props = [];
+        static template = xml`
+            <div class="outside">outside</div>
+            <Dropdown t-props="dropdownProps">
+                <button t-ref="button" style="top: 40%;">Dropdown</button>
+                <t t-set-slot="content">
+                    <t t-foreach="[...Array(50).keys()]" t-as="number" t-key="number">
+                        <DropdownItem class="'item-' + number" t-out="'Item ' + number"/>
+                    </t>
+                </t>
+            </Dropdown>
+        `;
+        setup() {
+            this.button = useRef("button");
+        }
+    }
+    const dropdownComp = await mountWithCleanup(HugeDropdown);
+    await click(DROPDOWN_TOGGLE);
+    await animationFrame();
+    expect(".popover").toHaveStyle({ bottom: "0px" });
+    const computedHeight =
+        parseFloat(getComputedStyle(document.documentElement).height) -
+        dropdownComp.button.el.getBoundingClientRect().bottom -
+        8;
+    // Compare floored values to avoid float pixel rounding errors.
+    expect(parseInt(getComputedStyle(queryOne(".popover")).maxHeight)).toBe(
+        parseInt(computedHeight)
+    );
+});
+
+test("cap dropup's popover height with too many items", async () => {
+    class HugeDropdown extends Component {
+        static components = { Dropdown, DropdownItem };
+        static props = [];
+        static template = xml`
+            <div class="outside">outside</div>
+            <Dropdown t-props="dropdownProps">
+                <button t-ref="button" style="top: 55%;">Dropdown</button>
+                <t t-set-slot="content">
+                    <t t-foreach="[...Array(50).keys()]" t-as="number" t-key="number">
+                        <DropdownItem class="'item-' + number" t-out="'Item ' + number"/>
+                    </t>
+                </t>
+            </Dropdown>
+        `;
+        setup() {
+            this.button = useRef("button");
+        }
+    }
+    const dropdownComp = await mountWithCleanup(HugeDropdown);
+    await click(DROPDOWN_TOGGLE);
+    await animationFrame();
+    expect(".popover").toHaveStyle({ top: "0px" });
+    // Compare floored values to avoid float pixel rounding errors.
+    expect(parseInt(getComputedStyle(queryOne(".popover")).maxHeight)).toBe(
+        parseInt(dropdownComp.button.el.getBoundingClientRect().top - 8)
+    );
+});
+
 test("Dropdown in dialog in dropdown, first dropdown should stay open when clicking inside the second one", async () => {
     const env = await makeMockEnv();
 


### PR DESCRIPTION
The Dropdown component does not set a max-height on its popover when its
opened. As a consequence, if you have many items in the dropdown, you
won't be able to scroll down and see the last ones.