### PR TITLE
[FIX] web: use updated values in mobile pager

### DIFF
--- a/addons/web/static/src/core/pager/pager.js
+++ b/addons/web/static/src/core/pager/pager.js
@@ -1,7 +1,7 @@
 import { useAutofocus } from "../utils/hooks";
 import { clamp } from "../utils/numbers";
 
-import { Component, useExternalListener, useState, EventBus } from "@odoo/owl";
+import { Component, EventBus, useEffect, useExternalListener, useState } from "@odoo/owl";
 
 export const PAGER_UPDATED_EVENT = "PAGER:UPDATED";
 export const pagerBus = new EventBus();
@@ -42,6 +42,19 @@ export class Pager extends Component {
         });
         this.inputRef = useAutofocus();
         useExternalListener(document, "mousedown", this.onClickAway, { capture: true });
+        let firstMount = true;
+        useEffect(
+            () => {
+                if (!firstMount && this.env.isSmall) {
+                    pagerBus.trigger(PAGER_UPDATED_EVENT, {
+                        value: this.value,
+                        total: this.props.total,
+                    });
+                }
+                firstMount = false;
+            },
+            () => [this.props.offset, this.props.limit, this.props.total]
+        );
     }
 
     /**
@@ -134,12 +147,6 @@ export class Pager extends Component {
         try {
             await this.props.onUpdate({ offset, limit }, hasNavigated);
         } finally {
-            if (this.env.isSmall) {
-                pagerBus.trigger(PAGER_UPDATED_EVENT, {
-                    value: this.value,
-                    total: this.props.total,
-                });
-            }
             this.state.isDisabled = false;
             this.state.isEditing = false;
         }

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -57,6 +57,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { makeErrorFromResponse } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
+import { config as transitionConfig } from "@web/core/transition";
 import { SIZES } from "@web/core/ui/ui_service";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { redirect } from "@web/core/utils/urls";
@@ -11788,4 +11789,21 @@ test("executing new action, closes dialog, and avoid reload previous view", asyn
         "get_views",
         "web_search_read",
     ]);
+});
+
+test.tags("mobile")(`pager is up to date`, async () => {
+    patchWithCleanup(transitionConfig, { disabled: true });
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="foo"/></form>`,
+        resIds: [1, 2],
+        resId: 1,
+    });
+    await contains(`.o_pager_next`).click();
+    await animationFrame();
+    expect(".o_pager_indicator").toHaveCount(1, {
+        message: "the pager indicator should be displayed",
+    });
+    expect(".o_pager_indicator").toHaveText("2 / 2");
 });


### PR DESCRIPTION
Steps to reproduce
==================

- Use a mobile viewport
- Go to any list/kanban view
- Open a record
- Use the pager to switch to the next record => "1 / x" is displayed where x is the total amount of records
- Click next => "2 / x" is displayed
- Click previous => "3 / x" is displayed

The pager is displaying the values before the switch has been made.

Cause of the issue
==================

When sending `this.value` on the `PAGER_UPDATED_EVENT` bus, the props have not been updated yet. This means that we send the previous value.

Solution
========

We send the event once either the offset, limit or total props have been
updated.

opw-4666878