### PR TITLE
[FIX] stock: find push rule based on active companies

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1056,7 +1056,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             warehouse_id = move.warehouse_id or move.picking_id.picking_type_id.warehouse_id
 
             ProcurementGroup = self.env['procurement.group']
-            if move.location_dest_id.company_id != self.env.company:
+            if move.location_dest_id.company_id not in self.env.companies:
                 ProcurementGroup = self.env['procurement.group'].sudo()
                 move = move.with_context(allowed_companies=self.env.user.company_ids.ids)
                 warehouse_id = False

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -3,6 +3,7 @@
 from odoo import Command
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo.tests import Form
+from odoo.tests.common import new_test_user
 
 
 class TestWarehouse(TestStockCommon):
@@ -850,3 +851,50 @@ class TestWarehouse(TestStockCommon):
         self.assertEqual(picking_out.picking_type_id, warehouse_B.pick_type_id)
         picking_out.button_validate()
         self.assertEqual(customer_move.move_dest_ids.warehouse_id, warehouse_B)
+
+    def test_multi_step_routes_multi_company(self):
+        """
+        Check the pickings of the multi-step routes are correctly generated
+        in multi-company set up.
+        """
+        companies = self.env['res.company'].create([
+            {'name': 'COMP1'},
+            {'name': 'COMP2'},
+        ])
+        warehouses = self.env['stock.warehouse'].create([
+            {
+                'name': 'Warehouse 1',
+                'company_id': companies.ids[0],
+                'code': 'WHC1',
+            },
+            {
+                'name': 'Warehouse 2',
+                'company_id': companies.ids[1],
+                'code': 'WHC2',
+            },
+        ])
+        warehouse = warehouses[0]
+        warehouse.delivery_steps = 'pick_ship'
+        user = new_test_user(self.env, login='bub', groups='stock.group_stock_user', company_id=companies.ids[1], company_ids=[Command.set(companies.ids)])
+        pick = self.env['stock.picking'].with_user(user).create({
+            'partner_id': self.partner.id,
+            'picking_type_id': warehouse.pick_type_id.id,
+            'location_id': warehouse.lot_stock_id.id,
+            'location_dest_id': warehouse.wh_output_stock_loc_id.id,
+            'company_id': companies.ids[0],
+            'move_ids': [Command.create({
+                'name': self.product.name,
+                'product_id': self.product.id,
+                'product_uom_qty': 1,
+                'product_uom': self.product.uom_id.id,
+                'company_id': companies.ids[0],
+                'location_id': warehouse.lot_stock_id.id,
+                'location_dest_id': warehouse.wh_output_stock_loc_id.id,
+            })]
+        })
+        pick.with_user(user).action_confirm()
+        pick.with_user(user).button_validate()
+        ship = pick.move_ids.move_dest_ids
+        self.assertRecordValues(ship, [{
+            'picking_type_id': warehouse.out_type_id.id, 'company_id': companies.ids[0], 'location_id': warehouse.wh_output_stock_loc_id.id,
+        }])


### PR DESCRIPTION
### Steps to reproduce:

- In the settings: enable Multi-steps route.
- Have two companies active (each with an existing warehouse): COMP 1, 2
- Put the warehouse of COMP 2 in delivery in 2 steps.
- With COMP 1 as main active company, create and confirm an SO for COMP2
> A pick picking has been created for COMP2
- Validate The pick picking
#### > The ship picking was not created

### Cause of the issue:

During the `_action_done`of the pick move, we will run a `_push_apply` on the move and try to trigger any push rule related to its destination. However, since de destination location of tha move (COMP2 output) does not belong to the main active company, the warehouse for which we search the rule is set to False and the rule ends up not being found: https://github.com/odoo/odoo/blob/cc05d9d50ac668eaa26363e1127f914897a4b125/addons/stock/models/stock_move.py#L1058-L1066

opw-4670760
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
