### PR TITLE
[FIX] point_of_sale: prevent stacktrace payment method

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -180,7 +180,7 @@ class PosOrder(models.Model):
         order.amount_paid = sum(order.payment_ids.mapped('amount'))
 
         if not draft and not float_is_zero(pos_order['amount_return'], prec_acc):
-            cash_payment_method = pos_session.payment_method_ids.filtered('is_cash_count')[:1]
+            cash_payment_method = order.payment_ids.payment_method_id.filtered("is_cash_count")[:1] or pos_session.payment_method_ids.filtered('is_cash_count')[:1]
             if not cash_payment_method:
                 raise UserError(_("No cash statement found for this session. Unable to record returned cash."))
             return_payment_vals = {

--- a/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
@@ -271,4 +271,21 @@ odoo.define('point_of_sale.tour.PaymentScreen', function (require) {
     );
 
     Tour.register('CashRoundingPayment', { test: true, url: '/pos/ui' }, getSteps());
+
+    startSteps();
+
+    ProductScreen.exec.addOrderline('Letter Tray', '5');
+    ProductScreen.check.selectedOrderlineHas('Letter Tray', '5.0');
+    ProductScreen.do.clickPartnerButton();
+    ProductScreen.do.clickCustomer('Nicole Ford');
+    ProductScreen.do.clickPayButton();
+
+    PaymentScreen.do.clickPaymentMethod('New Cash');
+    PaymentScreen.do.pressNumpad('5 5');
+    PaymentScreen.check.selectedPaymentlineHas('New Cash', '55');
+    PaymentScreen.do.clickInvoiceButton();
+    PaymentScreen.do.clickValidate();
+    ReceiptScreen.check.receiptIsThere();
+
+    Tour.register('MultipleCashPaymentMethod', { test: true, url: '/pos/ui' }, getSteps());
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -61,7 +61,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'name': 'Colleen Diaz'
         }])
 
-        cash_journal = journal_obj.create({
+        cls.cash_journal = journal_obj.create({
             'name': 'Cash Test',
             'type': 'cash',
             'company_id': main_company.id,
@@ -480,7 +480,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'journal_id': test_sale_journal.id,
             'invoice_journal_id': test_sale_journal.id,
             'payment_method_ids': [(0, 0, { 'name': 'Cash',
-                                            'journal_id': cash_journal.id,
+                                            'journal_id': cls.cash_journal.id,
                                             'receivable_account_id': account_receivable.id,
             })],
             'use_pricelist': True,
@@ -1110,3 +1110,12 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashRoundingPayment', login="accountman")
+
+    def test_multiple_cash_payment_method(self):
+        cash_method = self.env['pos.payment.method'].create({
+            'name': 'New Cash',
+            'journal_id': self.cash_journal.id,
+        })
+        self.main_pos_config.payment_method_ids += cash_method
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'MultipleCashPaymentMethod', login="accountman")


### PR DESCRIPTION
Steps to reproduce:
1) Create another payment method of type cash
2) Add to POS
3) Open a pos session
4) Set a customer
5) Add a product, check out
6) Select your new payment method
7) Make sure 'Invoice' is marked to generate an invoice

Issue:
 Validate -> error

Cause:
We have multiple cash payment method
We should only have one and the one selectd manually

opw-4503848
