### PR TITLE
[FIX] website: Supports dynamic domain

### DIFF
--- a/addons/mail/tools/parser.py
+++ b/addons/mail/tools/parser.py
@@ -5,6 +5,7 @@ import ast
 
 from odoo import _, tools
 from odoo.exceptions import ValidationError
+from odoo.tools import safe_eval
 
 
 def parse_res_ids(res_ids):
@@ -33,3 +34,15 @@ def parse_res_ids(res_ids):
         raise ValidationError(error_msg)
 
     return res_ids
+
+
+def domain_eval(domain):
+    domain = domain.replace('.to_utc()', '')
+    evaluated_domain = safe_eval.safe_eval(domain, {
+        'context_today': safe_eval.datetime.datetime.today,
+        'datetime': safe_eval.datetime,
+        'dateutil': safe_eval.dateutil,
+        'relativedelta': safe_eval.dateutil.relativedelta.relativedelta,
+        'time': safe_eval.time,
+    })
+    return evaluated_domain

--- a/addons/website/controllers/model_page.py
+++ b/addons/website/controllers/model_page.py
@@ -5,6 +5,7 @@ import werkzeug
 from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.http import Controller, request, route
 from odoo.osv.expression import AND, OR
+from odoo.addons.mail.tools.parser import domain_eval
 
 
 class ModelPageController(Controller):
@@ -45,7 +46,7 @@ class ModelPageController(Controller):
         if not Model.check_access_rights("read", raise_exception=False):
             raise werkzeug.exceptions.Forbidden()
 
-        rec_domain = ast.literal_eval(page.record_domain or "[]")
+        rec_domain = domain_eval(page.record_domain or "[]")
         domains = [rec_domain]
 
         if record_slug:


### PR DESCRIPTION
Similar to: https://github.com/odoo/odoo/pull/184830

We've recently introduced a new operator: “is within” in the domain
selector, which can be used to find out whether a date is within a
dynamic range (e.g. within a month, within 4 days, within 3 weeks, etc.).
To works, this domain needs dynamic elements, such as `context_today`,
which is defined in `py_builtin.js` and dynamically retrieves the
current date.

https://github.com/odoo/odoo/blob/2fed354787b6190ee8bca91dc49746fcd0631dd8/addons/web/static/src/core/py_js/py_builtin.js#L77-L79

However, the problem isn't limited to this operator in the selector
domain, as it's only been available since 18.0, and this pr target is
17.0.s

In fact, it is possible in certain cases to use these fields via debug
mode, and there are several cases where `uid`, `user`, etc. are used.
There is therefore an inconsistency where users see the use of these
variables in these cases and when they try to use them elsewhere with,
for example, a field of this style:

`("date", "=", context_today())`, they get a traceback.
This happens mainly because, in Python, the domain is evaluated via
`literal_eval`, and since it contains variables that are designed for
the web, it causes a traceback because this function expects to receive
only a correctly formatted string, with no context and no variables.

This commit handles:
- website/model_page.py:
-
https://github.com/odoo/odoo/blob/2fed354787b6190ee8bca91dc49746fcd0631dd8/addons/website/controllers/model_page.py#L13-L18


https://github.com/odoo/odoo/blob/2fed354787b6190ee8bca91dc49746fcd0631dd8/addons/website/controllers/model_page.py#L47-L57

The enterprise commit (https://github.com/odoo/enterprise/pull/82564)
handles two other cases:

- web_studio/approval:
Here in this case there are several calls to literal_eval on domains
received from the web, notably to create and check its approval spec.
a function has been used to avoid rewriting the same thing several times
in the file.2

- marketing_automation/activity:
Here too, several calls are made to this file, as in the case of
approval, a function has been created to replace all calls to
`literal_eval`

In all three cases, the problem is the same: the problem is not only
present in `is_within` but in the fact that python has no way of
understanding the domain received from the web, so the same fix has been
applied everywhere:

- First, `to_utc()` is removed from the domain, since it's purely
client-side and this notion doesn't exist in et la the python server

- We replace the `literal_eval` call with `safe_eval`, which will do
more than just transform a string containing only a literal value of
type X into type X (e.g. tuple, string, number, array, etc.)

- `safe_eval` can therefore either evaluate expressions or execute
statements. In our case, what we really want is to evaluate just a
string like literal_eval with just one more context, and to be able to
define local or global values, such as defining `context_today()`

- For the moment, the values we use are the same as those used by
`is_within`, i.e.:
-- context_today()
-- relative_delta()
-- datetime

opw-4551335
opw-4672902
opw-4678894
opw-4669315
opw-4577091