### PR TITLE
[FIX] *: right documentation links

### DIFF
--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -163,7 +163,7 @@
                             <setting string="Geolocation"
                                      help="Geolocate your partners"
                                      id="base_geolocalize"
-                                     documentation="https://www.odoo.com/documentation/17.0/applications/general/integrations/geolocation.html">
+                                     documentation="/applications/general/integrations/geolocation.html">
                                 <field name="module_base_geolocalize"/>
                                 <div class="content-group" invisible="not module_base_geolocalize" name="base_geolocalize_warning">
                                     <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to choose your Geo Provider.</div>

--- a/addons/l10n_it_edi_doi/__manifest__.py
+++ b/addons/l10n_it_edi_doi/__manifest__.py
@@ -11,7 +11,7 @@
     Add support for the Declaration of Intent (Dichiarazione di Intento) to the Italian localization.
     """,
     'category': 'Accounting/Localizations',
-    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations/italy.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/italy.html',
     'data': [
         'security/ir.model.access.csv',
         'data/invoice_it_template.xml',

--- a/addons/l10n_it_edi_withholding/__manifest__.py
+++ b/addons/l10n_it_edi_withholding/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {
@@ -19,7 +18,7 @@ Withholding and Pension Fund handling for the E-invoice implementation for Italy
     Please also update the Italian Accounting module (l10n_it) when you install this module.
     """,
     'category': 'Accounting/Localizations/EDI',
-    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/accounting/fiscal_localizations/localizations/italy.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/accounting/fiscal_localizations/localizations/italy.html',
     'data': [
         'data/account_withholding_report_data.xml',
         'data/invoice_it_template.xml',

--- a/addons/l10n_sa/__manifest__.py
+++ b/addons/l10n_sa/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '2.0',
     'author': 'Odoo S.A., DVIT.ME (http://www.dvit.me)',
     'category': 'Accounting/Localizations/Account Charts',
-    'website': 'https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations/saudi_arabia.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/saudi_arabia.html',
     'description': """
 Saudi Arabia Accounting Module
 ===========================================================

--- a/addons/l10n_us_account/__manifest__.py
+++ b/addons/l10n_us_account/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'United States - Accounting',
-    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['us'],
     'version': '1.0',

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -251,7 +251,7 @@
                 <setting
                     id="abandoned_carts_setting"
                     string="Automatically send abandoned checkout emails"
-                    documentation="https://www.odoo.com/documentation/18.0/applications/websites/ecommerce/ecommerce_management/order_handling.html#abandoned-cart"
+                    documentation="/applications/websites/ecommerce/ecommerce_management/order_handling.html#abandoned-cart"
                     help="Mail only sent to signed in customers with items available for sale in carts created after the feature activation.">
                     <field name="send_abandoned_cart_email"/>
 


### PR DESCRIPTION
We're on master branch, hardcoded links in manifests should target master (like most do already).

Also, in settings views, doc links should be specified as a path, not as a full link, the widget will deduce it according to the database version.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
