### PR TITLE
[FIX] l10n_se: Fix partner address form

### DIFF
--- a/addons/l10n_se/data/res_country_data.xml
+++ b/addons/l10n_se/data/res_country_data.xml
@@ -21,8 +21,6 @@
                             readonly="type == 'contact' and parent_id"/>
                     <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'
                             readonly="type == 'contact' and parent_id"/>
-                    <field name="state_id" class="o_address_state" placeholder="State..." options='{"no_open": True}'
-                            readonly="type == 'contact' and parent_id"/>
                 </div>
             </form>
         </field>


### PR DESCRIPTION
The address bloc in the Swedish localization had a blank line at the top and a duplicate state field at the end. This commit removes both to have a cleaner address display.

Task ID: 4673123




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
