### PR TITLE
[FIX] website_crm_partner_assign: remove left-over use of mobile field

### DIFF
--- a/addons/website_crm_partner_assign/static/src/interactions/crm_partner_assign.js
+++ b/addons/website_crm_partner_assign/static/src/interactions/crm_partner_assign.js
@@ -76,7 +76,6 @@ export class CRMPartnerAssign extends Interaction {
             {
                 partner_name: this.contactFormEl.querySelector(".partner_name").value,
                 phone: this.contactFormEl.querySelector(".phone").value,
-                mobile: this.contactFormEl.querySelector(".mobile").value,
                 email_from: this.contactFormEl.querySelector(".email_from").value,
                 street: this.contactFormEl.querySelector(".street").value,
                 street2: this.contactFormEl.querySelector(".street2").value,

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -685,7 +685,7 @@
                                 </div>
                             </div>
                             <div>
-                                <div t-field="opportunity.partner_id" t-options='{"widget": "contact", "fields": ["email", "phone", "mobile"]}'/>
+                                <div t-field="opportunity.partner_id" t-options='{"widget": "contact", "fields": ["email", "phone"]}'/>
                             </div>
                             <address t-if="opportunity.street or opportunity.street2 or opportunity.city or opportunity.zip or opportunity.state_id or opportunity.country_id"
                             class="col d-flex align-items-baseline mb-0 mt-2">
@@ -838,10 +838,6 @@
                                     <div class="mb-3">
                                         <label class="col-form-label" for="phone">Phone</label>
                                         <input type="text" name="phone" class="form-control phone" t-att-value="opportunity.phone"/>
-                                    </div>
-                                    <div class="mb-3">
-                                        <label class="col-form-label" for="mobile">Mobile</label>
-                                        <input type="text" name="mobile" class="form-control mobile" t-att-value="opportunity.mobile"/>
                                     </div>
                                     <div class="mb-3">
                                         <label class="col-form-label" for="email_from">Email</label>


### PR DESCRIPTION
Since odoo/odoo@6b820eb6fc6f the `mobile` field has been removed from `res.partner` and `crm.lead` models, so it's crashing when opening an opportunity on the portal or when trying to update the contact information on it.

This commit remove the left-over mobile field use in template and interaction.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
