### PR TITLE
[FIX] mrp: correct MO component reservation after scrap replenishment

### DIFF
--- a/addons/mrp/models/stock_scrap.py
+++ b/addons/mrp/models/stock_scrap.py
@@ -86,9 +86,5 @@ class StockScrap(models.Model):
         if self.production_id and self.production_id.procurement_group_id:
             values.update({
                 'group_id': self.production_id.procurement_group_id,
-                'move_dest_ids': self.production_id.procurement_group_id.stock_move_ids.filtered(
-                    lambda m: m.location_id == self.location_id
-                              and m.product_id == self.product_id
-                              and m.state not in ('assigned', 'done', 'cancel'))
             })
         super().do_replenish(values)


### PR DESCRIPTION
Before PRs https://github.com/odoo/odoo/pull/154912 and https://github.com/odoo/odoo/pull/177079, _free_reservation preserved MTO links by
retaining move_orig_ids, allowing Manufacturing Orders (MOs) to reserve
components from replenishment pickings.
PR https://github.com/odoo/odoo/pull/149054 added replenishment moves to the MO’s procurement.group and
assigned move_dest_ids to link them to component moves, supporting 2-step
manufacturing flows.
PR https://github.com/odoo/odoo/pull/154912 introduced the stock.break_mto parameter to conditionally preserve
move_orig_ids, while PR https://github.com/odoo/odoo/pull/177079 removed it, making move_orig_ids clearing
unconditional for MTO-to-MTS transitions, reintroducing a regression due to
the move_dest_ids assignment.

Steps to Reproduce
===================
1. Create an MO with a component qty of 20 units and confirm it.
2. Scrap 5 units of the component with Replenish enabled.
3. Validate the replenishment transfer.
4. Check the MO component line. The component qty is reduced to 5.

Issue
=====
The move_dest_ids assignment to replenishment moves (from https://github.com/odoo/odoo/pull/149054) prevents
 _trigger_assign from reserving correct MO component quantities when
move_orig_ids are cleared (per https://github.com/odoo/odoo/pull/177079), as the link to the original MO
requirements is broken.

Fix
===
Removed the move_dest_ids assignment for replenish moves enabling trigger_assign
to automatically reserve the correct component quantities, while maintaining the
MTO-to-MTS transition (cleared move_orig_ids) and the procurement.group
assignment.

Task: https://github.com/odoo/odoo/commit/44437975bdaf1e7c4f5540a5cb789d9db0ec0b0b