### PR TITLE
[IMP] mail: improve detection of Outlook reply quotes

### DIFF
--- a/doc/cla/individual/kafai-lam.md
+++ b/doc/cla/individual/kafai-lam.md
@@ -1,0 +1,11 @@
+Canada, 2025-03-31
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Ka Fai Lam lamkafai1997@gmail.com https://github.com/kafai-lam

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -214,7 +214,12 @@ def tag_quote(el):
     is_signature_wrapper = 'odoo_signature_wrapper' in el_class or 'gmail_signature' in el_class or el_id == "Signature"
     is_outlook_auto_message = 'appendonsend' in el_id
     # gmail and outlook reply quote
-    is_outlook_reply_quote = 'divRplyFwdMsg' in el_id
+    is_outlook_reply_quote = (
+        'divRplyFwdMsg' in el_id
+        or 'x_divRplyFwdMsg' in el_id
+        or 'mail-editor-reference-message-container' in el_id
+        or 'ms-outlook-mobile-reference-message' in el_class
+    )
     is_gmail_quote = 'gmail_quote' in el_class
     is_quote_wrapper = is_signature_wrapper or is_gmail_quote or is_outlook_reply_quote
     if is_quote_wrapper:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Quotes in emails replied to using the MacOS or iOS Outlook clients cannot be detected because these clients use `#x_divRplyFwdMsg` (for MacOS) and `#mail-editor-reference-message-container` or `.ms-outlook-mobile-reference-message` (for iOS) instead of `#divRplyFwdMsg`.

Desired behavior after PR is merged:

Email quotes replied to using the MacOS or iOS Outlook clients can now be detected.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr