### PR TITLE
[FIX] hr_org_chart: fix employee org chart behavior

### DIFF
--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.js
@@ -5,8 +5,9 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { onEmployeeSubRedirect } from './hooks';
+import { scrollTo } from "@web/core/utils/scrolling";
 
-const { Component, onWillStart, onWillRender, useState } = owl;
+const { Component, onWillStart, onWillUpdateProps, onPatched, useState, useRef, onMounted } = owl;
 
 function useUniquePopover() {
     const popover = usePopover();
@@ -64,22 +65,102 @@ export class HrOrgChart extends Field {
         this.lastParent = null;
         this._onEmployeeSubRedirect = onEmployeeSubRedirect();
 
-        onWillStart(this.handleComponentUpdate.bind(this));
-        onWillRender(this.handleComponentUpdate.bind(this));
+        this.isScrollable = false;
+        this.maxDisplayedEmployees = 7;
+        this.orgChartRef = useRef("org_chart");
+        this.scrollUpBtn = useRef("scroll_up_btn");
+        this.scrollDownBtn = useRef("scroll_down_btn");
+        this.currentEmployeeIndex = 0;
+
+        onWillStart(async () => {
+            this.employee = this.props.record.data;
+            // the widget is either dispayed in the context of a hr.employee form or a res.users form
+            this.state.employee_id =
+                this.employee.employee_ids !== undefined
+                    ? this.employee.employee_ids.resIds[0]
+                    : this.employee.id;
+            const parentId =
+                this.employee.parent_id && this.employee.parent_id[0]
+                    ? this.employee.parent_id[0]
+                    : false;
+            const forceReload =
+                this.lastRecord !== this.props.record ||
+                this.lastParent != parentId;
+            this.lastParent = parentId;
+            this.lastRecord = this.props.record;
+            await this.fetchEmployeeData(
+                this.state.employee_id,
+                parentId,
+                forceReload
+            );
+        });
+
+        onMounted(this.handleComponentUpdate.bind(this));
+
+        onWillUpdateProps(async (nextProps) => {
+            const newParentId =
+                nextProps.record.data.parent_id &&
+                nextProps.record.data.parent_id[0]
+                    ? nextProps.record.data.parent_id[0]
+                    : false;
+            const newEmployeeId = nextProps.record.data.id || false;
+            if (
+                this.lastParent !== newParentId ||
+                this.state.employee_id !== newEmployeeId
+            ) {
+                this.lastParent = newParentId;
+                await this.fetchEmployeeData(newEmployeeId, true);
+            }
+            this.state.employee_id = newEmployeeId;
+        });
+
+        onPatched(this.handleComponentUpdate.bind(this));
     }
 
-    /**
-     * Called on start and on render
-     */
-    async handleComponentUpdate() {
-        this.employee = this.props.record.data;
-        // the widget is either dispayed in the context of a hr.employee form or a res.users form
-        this.state.employee_id = this.employee.employee_ids !== undefined ? this.employee.employee_ids.resIds[0] : this.employee.id;
-        const manager = this.employee.parent_id || this.employee.employee_parent_id;
-        const forceReload = this.lastRecord !== this.props.record || this.lastParent != manager;
-        this.lastParent = manager;
-        this.lastRecord = this.props.record;
-        await this.fetchEmployeeData(this.state.employee_id, forceReload);
+    handleComponentUpdate(){
+        if (this.managers || this.children) {
+            const entries = document.querySelectorAll(".o_org_chart_entry");
+            if (this.isScrollable) {
+                this.scrollUpBtn.el.style.visibility = "visible";
+                this.scrollDownBtn.el.style.visibility = "visible";
+                if (!this.managers_more) {
+                    this.scrollUpBtn.el.style.visibility = "hidden";
+                }
+                if (
+                    this.managers.length -
+                        this.excess_managers_count +
+                        1 +
+                        this.children.length <=
+                    this.maxDisplayedEmployees
+                ) {
+                    this.scrollDownBtn.el.style.visibility = "hidden";
+                }
+            }
+            if (entries.length === 0) {
+                this.orgChartRef.el.style.maxHeight = "none";
+                return;
+            }
+            let maxAllowedEntriesHeight = 0;
+            for (
+                let i = this.excess_managers_count;
+                i <
+                Math.min(
+                    this.maxDisplayedEmployees + this.excess_managers_count,
+                    entries.length
+                );
+                i++
+            ) {
+                maxAllowedEntriesHeight +=
+                    entries[i].getBoundingClientRect().height;
+            }
+            this.orgChartRef.el.style.maxHeight = `${maxAllowedEntriesHeight}px`;
+
+            this.currentEmployeeIndex = this.excess_managers_count || 0;
+
+            scrollTo(entries[this.managers.length + (this.children.length > 0)], {
+                scrollable: this.orgChartRef.el,
+            });
+        }
     }
 
     async fetchEmployeeData(employeeId, force = false) {
@@ -96,6 +177,7 @@ export class HrOrgChart extends Field {
                 '/hr/get_org_chart',
                 {
                     employee_id: employeeId,
+                    new_parent_id: this.lastParent,
                     context: Component.env.session.user_context,
                 }
             );
@@ -109,7 +191,8 @@ export class HrOrgChart extends Field {
             this.children = orgData.children;
             this.managers_more = orgData.managers_more;
             this.self = orgData.self;
-            this.render(true);
+            this.excess_managers_count = orgData.excess_managers_count;
+            this.isScrollable = this.managers.length > 0 || this.children.length > 0;
         }
     }
 
@@ -134,9 +217,46 @@ export class HrOrgChart extends Field {
         this.actionService.doAction(action); 
     }
 
-    async _onEmployeeMoreManager(managerId) {
-        await this.fetchEmployeeData(managerId);
-        this.state.employee_id = managerId;
+    _onScrollUp() {
+        if (this.isScrollable) {
+            const entries = document.querySelectorAll(".o_org_chart_entry");
+            this.currentEmployeeIndex = Math.max(
+                0,
+                this.currentEmployeeIndex - 1
+            );
+            scrollTo(entries[this.currentEmployeeIndex], {
+                scrollable: this.orgChartRef.el,
+            });
+            this.scrollDownBtn.el.style.visibility = "visible";
+            if (this.currentEmployeeIndex == 0) {
+                this.scrollUpBtn.el.style.visibility = "hidden";
+            }
+        }
+    }
+
+    _onScrollDown() {
+        if (this.isScrollable) {
+            const entries = document.querySelectorAll(".o_org_chart_entry");
+            const numOfDisplayedEmployees =
+                this.maxDisplayedEmployees - (this.children.length === 0);
+            this.currentEmployeeIndex = Math.min(
+                entries.length - numOfDisplayedEmployees,
+                this.currentEmployeeIndex + 1
+            );
+            scrollTo(
+                entries[this.currentEmployeeIndex + numOfDisplayedEmployees - 1],
+                {
+                    scrollable: this.orgChartRef.el,
+                }
+            );
+            this.scrollUpBtn.el.style.visibility = "visible";
+            if (
+                this.currentEmployeeIndex ==
+                entries.length - numOfDisplayedEmployees
+            ) {
+                this.scrollDownBtn.el.style.visibility = "hidden";
+            }
+        }
     }
 }
 

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.scss
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.scss
@@ -5,6 +5,7 @@
     }
 
     .o_org_chart_entry {
+        scroll-snap-align: start;
         .o_media_object {
             width: $o-hr-org-chart-entry-pic-small-size;
             height: $o-hr-org-chart-entry-pic-small-size;
@@ -30,8 +31,16 @@
         padding-left: $o-hr-org-chart-entry-pic-size * .6;
     }
 
+    .o_org_chart_group_wrapper{
+        overflow:  hidden;
+        scroll-snap-type: y mandatory;
+        scroll-behavior: smooth;
+        padding-left: 2px;
+        position: relative;
+    }
+    
     // ORGANIGRAM LINES
-    .o_org_chart_group_up .o_treeEntry {
+    .o_org_chart_group_wrapper > .o_org_chart_group_up {
         --treeEntry-padding-h: 0px;
         --treeEntry--before-top: 50%;
         --treeEntry--after-display: none;

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.xml
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.xml
@@ -71,55 +71,52 @@
 
         -->
     <t t-set="emp_count" t-value="0"/>
-    <div t-if='managers.length &gt; 0' class="o_org_chart_group_up position-relative">
-        <div t-if='managers_more' class="o_org_chart_more pe-3">
-            <a href="#" t-att-data-employee-id="managers[0].id" class="o_employee_more_managers d-block bg-100 px-3" t-on-click.prevent="() => this._onEmployeeMoreManager(managers[0].id)">
-                <i class="fa fa-angle-double-up" role="img" aria-label="More managers" title="More managers"/>
+    <div t-if="isScrollable" class="position-relative">
+        <div class="o_org_chart_scroll_up pe-3" t-ref="scroll_up_btn">
+            <a href="#" class="o_employee_more_managers d-block px-3" t-on-click.prevent="() => this._onScrollUp()">
+                <i class="fa fa-angle-double-up" role="img" aria-label="Scroll managers up" title="Scroll managers up"/>
             </a>
         </div>
-
-        <t t-foreach="managers" t-as="employee" t-key="employee_index">
-            <t t-set="emp_count" t-value="emp_count + 1"/>
-            <t t-call="hr_org_chart.hr_org_chart_employee">
-                <t t-set="employee_type" t-value="'manager'"/>
-            </t>
-        </t>
     </div>
-
-    <t t-if="children.length || managers.length" t-call="hr_org_chart.hr_org_chart_employee">
-        <t t-set="employee_type" t-value="'self'"/>
-        <t t-set="employee" t-value="self"/>
-    </t>
-
-    <t t-if="!children.length &amp;&amp; !managers.length">
-        <div class="alert alert-info" role="alert">
-            <p><b>No hierarchy position.</b></p>
-            <p>This employee has no manager or subordinate.</p>
-            <p>In order to get an organigram, set a manager and save the record.</p>
+    
+    <div class="o_org_chart_group_wrapper" t-ref="org_chart">
+        <div t-if="managers.length" class="o_org_chart_group_up">
+            <t t-foreach="managers" t-as="employee" t-key="employee_index">
+                <t t-set="emp_count" t-value="emp_count + 1"/>
+                <t t-call="hr_org_chart.hr_org_chart_employee">
+                    <t t-set="employee_type" t-value="'manager'"/>
+                </t>
+            </t>
         </div>
-    </t>
 
-    <div t-if="children.length" t-attf-class="o_org_chart_group_down position-relative #{managers.length &gt; 0 ? 'o_org_chart_has_managers' : ''}">
-        <t t-foreach="children" t-as="employee" t-key="employee_index">
-            <t t-set="emp_count" t-value="emp_count + 1"/>
-            <t t-if="emp_count &lt; 20">
+        <t t-if="children.length || managers.length" t-call="hr_org_chart.hr_org_chart_employee">
+            <t t-set="employee_type" t-value="'self'"/>
+            <t t-set="employee" t-value="self"/>
+        </t>
+
+        <t t-if="!children.length &amp;&amp; !managers.length">
+            <div class="alert alert-info" role="alert">
+                <p><b>No hierarchy position.</b></p>
+                <p>This employee has no manager or subordinate.</p>
+                <p>In order to get an organigram, set a manager and save the record.</p>
+            </div>
+        </t>
+
+        <div t-if="children.length" t-attf-class="o_org_chart_group_down position-relative #{managers.length &gt; 0 ? 'o_org_chart_has_managers' : ''}">
+            <t t-foreach="children" t-as="employee" t-key="employee_index">
                 <t t-call="hr_org_chart.hr_org_chart_employee">
                     <t t-set="employee_type" t-value="'sub'"/>
                 </t>
             </t>
-        </t>
+        </div>
+    </div>
 
-        <t t-if="(children.length + managers.length) &gt; 19">
-            <div class="o_org_chart_entry o_org_chart_more d-flex overflow-visible">
-                <div class="o_media_left position-relative">
-                    <a href="#"
-                        t-att-data-employee-id="self.id"
-                        t-att-data-employee-name="self.name"
-                        class="o_org_chart_show_more o_employee_sub_redirect btn btn-link ps-2"
-                        t-on-click.prevent="_onEmployeeSubRedirect">See All</a>
-                </div>
-            </div>
-        </t>
+    <div t-if="isScrollable" class="position-relative">
+        <div class="o_org_chart_scroll_down pe-3" t-ref="scroll_down_btn">
+            <a href="#" class="o_employee_more_managers d-block px-3" t-on-click.prevent="() => this._onScrollDown()">
+                <i class="fa fa-angle-double-down" role="img" aria-label="Scroll managers down" title="Scroll managers down"/>
+            </a>
+        </div>
     </div>
 </t>
 

--- a/addons/hr_org_chart/static/tests/hr_org_chart_tests.js
+++ b/addons/hr_org_chart/static/tests/hr_org_chart_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { getFixture } from "@web/../tests/helpers/utils";
+import { getFixture, click, nextTick } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 
 let target;
@@ -188,4 +188,195 @@ QUnit.module("hr_org_chart", {
         assert.containsOnce(target, '.o_org_chart_group_down .o_org_chart_entry_sub', "the chart should have 1 subordinate");
         assert.containsOnce(target, '.o_org_chart_entry_self', "the chart should have only once the current employee");
     });
+    QUnit.test("hr org chart: scroll in chart", async function (assert) {
+        assert.expect(15);
+
+        await makeView({
+            type: "form",
+            resModel: 'hr_employee',
+            serverData: serverData,
+            arch:
+                '<form>' +
+                    '<sheet>' +
+                        '<div id="o_employee_container"><div id="o_employee_main">' +
+                            '<div id="o_employee_right">' +
+                                '<field name="child_ids" widget="hr_org_chart"/>' +
+                            '</div>' +
+                        '</div></div>' +
+                    '</sheet>' +
+                '</form>',
+            resId: 1,
+            mockRPC: function (route, args) {
+                if (route === '/hr/get_org_chart') {
+                    assert.ok('employee_id' in args, "it should have 'employee_id' as argument");
+                    return Promise.resolve({
+                        children: [{
+                            direct_sub_count: 0,
+                            indirect_sub_count: 0,
+                            job_id: 2,
+                            job_name: 'Sub-Gooroo',
+                            link: 'fake_link',
+                            name: 'Michael Hawkins',
+                            id: 2,
+                        },
+                        {
+                            direct_sub_count: 0,
+                            indirect_sub_count: 0,
+                            job_id: 14,
+                            job_name: 'CTO',
+                            link: 'cto_link',
+                            name: 'Henry Ford',
+                            id: 14,
+                        }
+                    ],
+                        managers: [
+                            {
+                                direct_sub_count: 1,
+                                indirect_sub_count: 9,
+                                job_id: 7,
+                                job_name: 'Project Manager',
+                                link: 'project_manager_link',
+                                name: 'Alice Smith',
+                                id: 7,
+                            },
+                            {
+                                direct_sub_count: 1,
+                                indirect_sub_count: 8,
+                                job_id: 8,
+                                job_name: 'Team Lead',
+                                link: 'team_lead_link',
+                                name: 'Bob Johnson',
+                                id: 8,
+                            },
+                            {
+                                direct_sub_count: 1,
+                                indirect_sub_count: 7,
+                                job_id: 9,
+                                job_name: 'Senior Engineer',
+                                link: 'senior_engineer_link',
+                                name: 'Charlie Brown',
+                                id: 9,
+                            },
+                            {
+                                direct_sub_count: 1,
+                                indirect_sub_count: 6,
+                                job_id: 10,
+                                job_name: 'Junior Engineer',
+                                link: 'junior_engineer_link',
+                                name: 'Diana Prince',
+                                id: 10,
+                            },
+                            {
+                                direct_sub_count: 1,
+                                indirect_sub_count: 5,
+                                job_id: 11,
+                                job_name: 'Intern',
+                                link: 'intern_link',
+                                name: 'Eve Adams',
+                                id: 11,
+                            },
+                            {
+                                direct_sub_count: 1,
+                                indirect_sub_count: 4,
+                                job_id: 12,
+                                job_name: 'Director',
+                                link: 'director_link',
+                                name: 'Frank White',
+                                id: 12,
+                            },
+                            {
+                                direct_sub_count: 1,
+                                indirect_sub_count: 3,
+                                job_id: 13,
+                                job_name: 'CEO',
+                                link: 'ceo_link',
+                                name: 'Grace Hopper',
+                                id: 13,
+                            }
+                        ],
+                        managers_more: true,
+                        self: {
+                            direct_sub_count: 2,
+                            id: 1,
+                            indirect_sub_count: 2,
+                            job_id: 1,
+                            job_name: 'Gooroo',
+                            link: 'fake_link',
+                            name: 'Antoine Langlais',
+                        },
+                        excess_managers_count: 2,
+                    });
+                } else if (route === '/hr/get_redirect_model') {
+                  return Promise.resolve('hr.employee');
+                }
+            }
+        });
+        const entries = $(target.querySelectorAll('.o_org_chart_entry'));
+        const scrollUpButton = $(target.querySelector('.o_org_chart_scroll_up>a'));
+        const scrollDownButton = $(target.querySelector('.o_org_chart_scroll_down>a'));
+        const entriesWrapper = $(target.querySelector('.o_org_chart_group_wrapper'));
+        // the count of all displayed employees in the chart should be 10
+        assert.strictEqual(entries.length, 10,
+            "the chart should have 10 child");
+        await waitToScroll();
+        // check that that the first two managers are not displayed yet in the chart
+        assert.strictEqual(isElementOverflowingParent(entries[0], entriesWrapper[0]), true,
+            "the first manager should be displayed the chart");
+        assert.strictEqual(isElementOverflowingParent(entries[1], entriesWrapper[0]), true,
+            "the second manager should be displayed the chart");
+        // assert the scroll up button is in the dom
+        assert.strictEqual(scrollUpButton.length, 1,
+            "the scroll up button should be in the dom");
+        // assert the scroll down button is in the dom
+        assert.strictEqual(scrollDownButton.length, 1,
+            "the scroll down button should be in the dom");
+        // scroll up twice
+        await click(scrollUpButton[0]);
+        await click(scrollUpButton[0]);
+        await waitToScroll();
+        // assert that the first two managers are now displayed in the chart
+        assert.strictEqual(isElementOverflowingParent(entries[0], entriesWrapper[0]), false,
+            "the first manager should not be displayed the chart");
+        assert.strictEqual(isElementOverflowingParent(entries[1], entriesWrapper[0]), false,
+            "the second manager should not be displayed the chart");
+        // assert the scroll up button is hidden the dom
+        assert.strictEqual(target.querySelector(".o_org_chart_scroll_up").style.visibility, "hidden",
+            "the scroll up button should be hidden");
+        // scroll down three times
+        await click(scrollDownButton[0]);
+        await click(scrollDownButton[0]);
+        await click(scrollDownButton[0]);
+        await waitToScroll();
+        // assert that the first three managers are now not displayed in the chart
+        assert.strictEqual(isElementOverflowingParent(entries[0], entriesWrapper[0]), true,
+            "the first manager should be displayed the chart");
+        assert.strictEqual(isElementOverflowingParent(entries[1], entriesWrapper[0]), true,
+            "the second manager should be displayed the chart");
+        assert.strictEqual(isElementOverflowingParent(entries[2], entriesWrapper[0]), true,
+            "the third manager should be displayed the chart");
+        // assert that the two subordinates are displayed in the chart
+        assert.strictEqual(isElementOverflowingParent(entries[8], entriesWrapper[0]), false,
+            "the first subordinate should not be displayed the chart");
+        assert.strictEqual(isElementOverflowingParent(entries[9], entriesWrapper[0]), false,
+            "the second subordinate should not be displayed the chart");
+        // assert the scroll down button is hidden the dom
+        assert.strictEqual(target.querySelector(".o_org_chart_scroll_down").style.visibility, "hidden",
+            "the scroll down button should be hidden");
+    });
 });
+
+async function waitToScroll(count = 12){
+    for (let i = 0; i < count; i++){
+        await nextTick();
+    }
+}
+
+function isElementOverflowingParent(child, parent) {
+    const childRect = child.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+
+    return (
+      childRect.top < parentRect.top ||
+      childRect.top > parentRect.bottom
+    );
+  }


### PR DESCRIPTION
After this commit, the employee org chart behavior is modified. The chart now displays all employee managers and subordinates, which can be navigated using two scroll buttons with smooth behavior. Moreover, if an employee's manager changes, the chart updates before saving the employee's information.

task-4609465

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
