### PR TITLE
[FIX] point_of_sale: batch process to prevent memory error

### DIFF
--- a/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py
+++ b/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py
@@ -18,20 +18,20 @@ def migrate(cr, version):
     - pos_payment
     """
     def deduplicate_uuids(table):
-        cr.execute(
-            f"""
-                SELECT UNNEST(ARRAY_AGG(id))
-                  FROM {table}
-              GROUP BY uuid
-                HAVING COUNT(*) > 1
-            """
-        )
-
-        all_ids = [r[0] for r in cr.fetchall()]
-        for ids in cr.split_for_in_conditions(all_ids):
+        query = f"""
+        SELECT UNNEST(ARRAY_AGG(id))
+          FROM {table}
+         GROUP BY uuid
+        HAVING COUNT(*) > 1
+        """
+        while True:
+            cr.execute(query)
+            if not cr.rowcount:
+                break
+            ids = [r[0] for r in cr.fetchmany(100000)]
             cr.execute(
                 f"UPDATE {table} SET uuid = (%s::json)->>(id::text) WHERE id IN %s",
-                [Json({id_: str(uuid.uuid4()) for id_ in ids}), ids]
+                [Json({id_: str(uuid.uuid4()) for id_ in ids}), tuple(ids)]
             )
 
     deduplicate_uuids("pos_order")


### PR DESCRIPTION
Enhance query efficiency for large accrued data by implementing batch processing
Previously, fetchall() loaded all IDs at once, causing memory errors.


```sql
select count(*) from pos_order;
  count
----------
 16736714
(1 row)

select count(*) from pos_order_line;
  count
----------
 24988345
(1 row)

select count(*) from pos_payment;
  count
----------
 16430502
(1 row)
```

- Traceback

```python
Traceback (most recent call last):
  File "/home/odoo/src/odoo/18.0/odoo/service/server.py", line 1321, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-13>", line 2, in new
  File "/home/odoo/src/odoo/18.0/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/18.0/odoo/modules/registry.py", line 127, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 484, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 240, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/home/odoo/src/odoo/18.0/odoo/modules/migration.py", line 254, in migrate_module
    mod.migrate(self.cr, installed_version)
  File "/home/odoo/src/odoo/18.0/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py", line 38, in migrate
    deduplicate_uuids("pos_order_line")
  File "/home/odoo/src/odoo/18.0/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py", line 30, in deduplicate_uuids
    all_ids = [r[0] for r in cr.fetchall()]
MemoryError
```

opw - 4544050
upg - 2459515

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
