### PR TITLE
[IMP] web: improved file viewer to properly display transparent png images

### DIFF
--- a/addons/web/static/src/core/file_viewer/file_viewer.js
+++ b/addons/web/static/src/core/file_viewer/file_viewer.js
@@ -235,6 +235,7 @@ export class FileViewer extends Component {
         } else {
             style += "max-height: 100%; max-width: 100%;";
         }
+        style += `background: repeating-conic-gradient(#ccc 0deg 90deg, #fff 90deg 180deg) 50% / 20px 20px;`;
         return style;
     }
 


### PR DESCRIPTION
After this commit, the file viewer will use a checkerboard background instead of black when displaying transparent images. Previously, images with dark colors were difficult to distinguish due to the black background. The checkerboard pattern, a standard for viewing transparency, improves visibility for all image contrasts.

task-2664812





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
