### PR TITLE
[FIX] portal: correct use of services

### DIFF
--- a/addons/portal/static/src/interactions/portal_security.js
+++ b/addons/portal/static/src/interactions/portal_security.js
@@ -61,7 +61,7 @@ export class PortalSecurity extends Interaction {
             )
         );
 
-        const { duration } = await this.bindService("field").loadFields("res.users.apikeys.description", {
+        const { duration } = await this.services.field.loadFields("res.users.apikeys.description", {
             fieldNames: ["duration"],
         });
 
@@ -74,7 +74,7 @@ export class PortalSecurity extends Interaction {
             confirmLabel: _t("Confirm"),
             confirm: async ({ inputEl }) => {
                 const formData = Object.fromEntries(new FormData(inputEl.closest("form")));
-                const wizardId = await this.sevices.orm.create("res.users.apikeys.description", [{
+                const wizardId = await this.services.orm.create("res.users.apikeys.description", [{
                     name: formData['description'],
                     duration: formData['duration']
                 }]);


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Allow api key creation for portal users via settings
- Go to /my/security in debug mode
- New Api key
- Enter password
A traceback occurs.
A portal user can no longer create an API key.

Solution:
---------
Correct the use of services.