### PR TITLE
[IMP] l10n_in_ewaybill: update address field editability for E-waybill

### DIFF
--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -241,14 +241,17 @@ class L10nInEwaybill(models.Model):
     )
     def _compute_is_editable(self):
         for ewaybill in self:
-            is_incoming = ewaybill._is_incoming()
-            is_overseas = (
-                ewaybill._get_billing_partner().l10n_in_gst_treatment in ('overseas', 'special_economic_zone')
-            )
-            ewaybill.is_bill_to_editable = not is_incoming
-            ewaybill.is_bill_from_editable = is_incoming
-            ewaybill.is_ship_from_editable = is_incoming and is_overseas
-            ewaybill.is_ship_to_editable = not is_incoming and not is_overseas
+            if ewaybill.account_move_id:
+                ewaybill.is_bill_to_editable = False
+                ewaybill.is_bill_from_editable = False
+                ewaybill.is_ship_from_editable = True
+                ewaybill.is_ship_to_editable = True
+            else:
+                is_incoming = ewaybill._is_incoming()
+                ewaybill.is_bill_to_editable = not is_incoming
+                ewaybill.is_bill_from_editable = is_incoming
+                ewaybill.is_ship_from_editable = not is_incoming
+                ewaybill.is_ship_to_editable = is_incoming
 
     def _compute_content(self):
         dependent_fields = self._get_ewaybill_dependencies()


### PR DESCRIPTION
Ensure correct editability of Bill To, Bill From, Ship To, and Ship From
 fields based on stock and accounting moves.

- For accounting moves:
  - Always allow editing of Ship To and Ship From
  - Keep Bill To and Bill From readonly
- For stock moves:
  - Incoming: Bill From and Ship To are editable
  - Outgoing: Bill To and Ship From are editable

task-4680493