### PR TITLE
[FIX] sale: compute SO expected date only for goods products

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -706,7 +706,7 @@ class SaleOrder(models.Model):
 
     @api.depends('order_line.customer_lead', 'date_order', 'state')
     def _compute_expected_date(self):
-        """ For service and consumable, we only take the min dates. This method is extended in sale_stock to
+        """ For service and combo (non-goods) products, we avoid computing the expected date. This method is extended in sale_stock to
             take the picking_policy of SO into account.
         """
         self.mapped("order_line")  # Prefetch indication
@@ -715,7 +715,7 @@ class SaleOrder(models.Model):
                 order.expected_date = False
                 continue
             dates_list = order.order_line.filtered(
-                lambda line: not line.display_type and not line._is_delivery()
+                lambda line: line.product_id.type == 'consu' and not line.display_type and not line._is_delivery()
             ).mapped(lambda line: line and line._expected_date())
             if dates_list:
                 order.expected_date = order._select_expected_date(dates_list)

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -1026,6 +1026,36 @@ class TestSalesTeam(SaleCommon):
         self.assertEqual(order.amount_total, 252)
         self.assertEqual(order.amount_tax, 52)
 
+    def test_expected_date_with_storable_product(self):
+        '''
+        This test ensures the expected date is computed based on only goods(consu) products.
+        It's avoiding computation for non-goods products.
+        '''
+        sale_delay = 10.0
+        self.product.sale_delay = sale_delay
+
+        # Create a sale order with a consu product.
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'product_id': self.product.id,
+                'product_uom_qty': 1000,
+            })],
+        })
+
+        # Ensure that expected date is correctly computed based on the consu product's sale delay.
+        self.assertEqual(sale_order.expected_date, fields.Datetime.now() + timedelta(days=sale_delay))
+
+        # Add a service product and ensure the expected date remains unchanged.
+        sale_order.write({
+            'order_line': [Command.create({
+                'product_id': self.service_product.id,
+                'product_uom_qty': 1000,
+            })],
+        })
+        self.assertEqual(sale_order.expected_date, fields.Datetime.now() + timedelta(days=sale_delay))
+
+
 @tagged('post_install', '-at_install')
 class TestSaleMailComposerUI(MailCommon, HttpCase):
     @classmethod

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -561,7 +561,7 @@
                                     <group invisible="display_type">
                                         <label for="customer_lead"/>
                                         <div name="lead">
-                                            <field name="customer_lead" class="oe_inline"/> days
+                                            <field name="customer_lead" class="oe_inline" readonly="product_type != 'consu'"/> days
                                         </div>
                                         <field name="analytic_distribution" widget="analytic_distribution"
                                            groups="analytic.group_analytic_accounting"
@@ -691,7 +691,7 @@
                                     name="customer_lead"
                                     optional="hide"
                                     width="80px"
-                                    readonly="parent.state not in ['draft', 'sent', 'sale'] or is_downpayment"/>
+                                    readonly="parent.state not in ['draft', 'sent', 'sale'] or is_downpayment or product_type != 'consu'"/>
                                 <field name="price_unit" readonly="qty_invoiced &gt; 0"/>
                                 <field
                                     name="tax_ids"
@@ -858,7 +858,7 @@
                                 <label for="commitment_date" string="Delivery Date"/>
                                 <div name="commitment_date_div" class="o_row">
                                     <field name="commitment_date" readonly="state == 'cancel' or locked"/>
-                                    <span name="expected_date_span" class="text-muted">Expected: <field name="expected_date" class="oe_inline"/></span>
+                                    <span name="expected_date_span" invisible="not expected_date" class="text-muted">Expected: <field name="expected_date" class="oe_inline"/></span>
                                 </div>
                             </group>
                             <group name="sale_reporting" string="Tracking">

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -34,7 +34,7 @@
             <div name="commitment_date_div" position="replace">
                 <div class="o_row">
                     <field name="commitment_date"/>
-                    <span class="text-muted" invisible="effective_date and commitment_date">Expected: <field name="expected_date" class="oe_inline"/></span>
+                    <span class="text-muted" invisible="not expected_date or (effective_date and commitment_date)">Expected: <field name="expected_date" class="oe_inline"/></span>
                 </div>
                 <field name="effective_date" invisible="not effective_date"/>
                 <field name="delivery_status" invisible="state != 'sale'"/>


### PR DESCRIPTION
Issue Before This Commit:
============================

Currently, when computing the expected delivery date on a Sales Order (SO), non-goods products are also considered, leading to an inaccurate expected delivery date.

Steps to Reproduce:
============================

- Install the stock and sale_management modules.
- Set a Customer Lead Time in any storable (goods) product.
- Create a Sales Order (SO) and add that product.
- Check the Expected Date in the 'Other Info' tab. It reflects the lead time correctly.
- Now add a service or consumable product to that sale order.
- Recheck the Expected Date. it changes incorrectly due to the non-goods product.

With This Commit:
============================

It's happening because when you add a non-goods product, the system recomputes the expected date. Since a non-goods product does not have a lead time, it's take defaults to 0, resulting in an incorrect(today) expected date. Now, the expected date is computed only for goods products, avoiding recalculations for non-goods products and ensuring a consistent expected date.

Also expected date is remains hidden in the form view if not set.

task - [4605794](https://www.odoo.com/odoo/project/966/tasks/4605794)
