### PR TITLE
[FIX] web_editor: ensure visibility of "Autoconvert to Relative Link"

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -524,7 +524,11 @@
                     &.o_long_title {
                         width: fit-content !important;
                         padding-right: 10px !important;
+                        flex: 1 1 auto;
                     }
+                }
+                we-button .o_switch {
+                    min-width: fit-content;
                 }
                 .highlighted-text {
                     color: white;


### PR DESCRIPTION
**Problem**:
When the text is long, the switch for "Autoconvert to Relative Link" is not visible.

**Solution**:
Adjust CSS to properly display the switch when the text is long.

**Before**:
![image](https://github.com/user-attachments/assets/324db4ab-70cc-4e88-8ecc-6df89e9fd54f)

**After**:
![image](https://github.com/user-attachments/assets/6ab270c3-00a5-49cf-8b71-2f5dc2bbde0a)

**Steps to Reproduce**:
1. Change language to **Dutch**.
2. Open the **website editor**.
3. Click on any **link**.
4. Copy your current link and paste it into the link input to trigger the "Autoconvert to Relative Link" switch.
   - **Issue**: The switch is not visible.

**opw-4558476**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
