### PR TITLE
[FIX] stock: quantities appear twice in picking operations print

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -121,7 +121,7 @@
                                         <td class="text-end">
                                             <span t-field="ml.quantity">3.00</span>
                                             <span t-field="ml.product_uom_id" groups="uom.group_uom">units</span>
-                                            <span t-if="ml.move_id.packaging_uom_id">
+                                            <span t-if="ml.move_id.packaging_uom_id and ml.move_id.packaging_uom_id != ml.product_uom_id" groups="uom.group_uom">
                                                 <span t-if="o.state != 'done'">
                                                     (<span t-field="ml.move_id.packaging_uom_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.packaging_uom_id.name"/>)
                                                 </span>


### PR DESCRIPTION
Steps:
- Sales/rental app > New/select order
- Add a 'Deliverable' product and confirm order
- Click on 'Delivery'  stat button.
- Cog menu > print > picking operations

Issue:
- when there is no packaging selected for product or units are same, quantity gets printed 2 times
  in the picking operations print.

Cause:
- There is no check added for comparing 'uom' of product & packaging.

Fix:
- checking similarity between product uom & packaging uom before printing solves the issue.

Affected version - saas-18.1
opw-4661359
