### PR TITLE
[IMP] mail: show notification when accessing deleted or archived thread

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -354,6 +354,11 @@ export class Store extends BaseStore {
             this.Thread.getOrFetch({ model, id }).then((thread) => {
                 if (thread) {
                     thread.open({ focus: true });
+                } else {
+                    this.env.services.notification.add(
+                        _t("This thread is no longer available."),
+                        { type: "danger" }
+                    );
                 }
             });
             return true;


### PR DESCRIPTION
**Current behavior before PR:**

- Clicking on a thread name from the notification after archiving or deleting it in the channel form view does nothing, leading to unclear user feedback.

**Desired behavior after PR is merged:**

- A red toast notification stating 'This thread is no longer available.' is displayed, ensuring users receive clear feedback when trying to access a deleted or archived thread.

task-[4629812](https://www.odoo.com/odoo/project/1519/tasks/4629812)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
