### PR TITLE
[REM] account: remove unused res.partner fields.

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -487,11 +487,6 @@ class ResPartner(models.Model):
             days_since_oldest_invoice = (fields.Date.context_today(self) - oldest_invoice_date).days
             partner.days_sales_outstanding = ((partner.credit / total_invoiced_tax_included) * days_since_oldest_invoice) if total_invoiced_tax_included else 0
 
-    def _compute_journal_item_count(self):
-        AccountMoveLine = self.env['account.move.line']
-        for partner in self:
-            partner.journal_item_count = AccountMoveLine.search_count([('partner_id', 'in', partner.ids)])
-
     def _compute_available_invoice_template_pdf_report_ids(self):
         moves = self.env['account.move']
 
@@ -542,12 +537,10 @@ class ResPartner(models.Model):
         compute='_credit_debit_get', search=_debit_search, string='Total Payable',
         help="Total amount you have to pay to this vendor.",
         groups='account.group_account_invoice,account.group_account_readonly')
-    debit_limit = fields.Monetary('Payable Limit')
     total_invoiced = fields.Monetary(compute='_invoice_total', string="Total Invoiced",
         groups='account.group_account_invoice,account.group_account_readonly')
     currency_id = fields.Many2one('res.currency', compute='_get_company_currency', readonly=True,
         string="Currency") # currency of amount currency
-    journal_item_count = fields.Integer(compute='_compute_journal_item_count', string="Journal Items")
     property_account_payable_id = fields.Many2one('account.account', company_dependent=True,
         string="Account Payable",
         domain="[('account_type', '=', 'liability_payable'), ('deprecated', '=', False)]",
@@ -726,7 +719,7 @@ class ResPartner(models.Model):
     @api.model
     def _commercial_fields(self):
         return super(ResPartner, self)._commercial_fields() + \
-            ['debit_limit', 'property_account_payable_id', 'property_account_receivable_id', 'property_account_position_id',
+            ['property_account_payable_id', 'property_account_receivable_id', 'property_account_position_id',
              'property_payment_term_id', 'property_supplier_payment_term_id', 'credit_limit']
 
     def action_view_partner_invoices(self):


### PR DESCRIPTION
Follow-up of odoo/odoo#203901

Remove the store field `res.partner`.`debit_limit`, not really used since the begin of the universe (004a0b996ff8f269451e07346f71a129a1f3fbaf) (Also used one day in test of enterprise repo: c2db8703ea15b44ee88666d56e383b114919d700)

Remove `res.partner`.`journal_item_count`, unused since c04065abd8f62c9a211c8fa824f5eecf68e61b73. And the compute is actually inefficient.

https://github.com/odoo/upgrade/pull/7473