### PR TITLE
[FIX] stock{,_dropshipping}: report customer lots from dropships

### DIFF
--- a/addons/stock_dropshipping/__init__.py
+++ b/addons/stock_dropshipping/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from . import report
 
 
 def uninstall_hook(env):

--- a/addons/stock_dropshipping/report/__init__.py
+++ b/addons/stock_dropshipping/report/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import stock_lot_customer

--- a/addons/stock_dropshipping/report/stock_lot_customer.py
+++ b/addons/stock_dropshipping/report/stock_lot_customer.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockLotReport(models.Model):
+    _inherit = 'stock.lot.report'
+
+    def _join_on_picking_type_and_partner(self):
+        return """
+            JOIN stock_picking_type AS type
+            ON picking.picking_type_id = type.id and (type.code = 'outgoing' or type.code = 'dropship')
+            LEFT JOIN sale_order as so ON so.id = picking.sale_id
+            JOIN res_partner AS partner
+            ON partner.id = CASE
+                WHEN type.code = 'dropship' THEN so.partner_id
+                ELSE picking.partner_id
+            END
+        """

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -350,3 +350,32 @@ class TestDropship(common.TransactionCase):
             {'product_id': subcontracted_service.id, 'product_uom_qty': 1.0, 'qty_delivered': 0.0},
             {'product_id': self.dropship_product.id, 'product_uom_qty': 0.0, 'qty_delivered': 1.0},
         ])
+
+    def test_dropship_lot_product_appears_in_stock_lot_report(self):
+        dropship_product = self.lot_dropship_product
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({
+                'product_id': dropship_product.id,
+                'product_uom_qty': 2,
+            })],
+        })
+        sale_order.action_confirm()
+        purchase_order = sale_order.procurement_group_id.purchase_line_ids.order_id
+        purchase_order.button_confirm()
+        dropship_picking = purchase_order.picking_ids
+        dropship_picking.move_line_ids.lot_name = 'dropship product lot'
+        dropship_picking.move_ids.picked = True
+        dropship_picking.button_validate()
+        for model in (self.env['sale.order'], self.env['stock.picking']):
+            model.flush_model()
+
+        customer_lots = self.env['stock.lot.report'].search([('partner_id', '=', self.customer.id)])
+        self.assertRecordValues(
+            customer_lots,
+            [{
+                'lot_id': dropship_picking.move_line_ids.lot_id.id,
+                'picking_id': dropship_picking.id,
+                'quantity': 2.0,
+            }]
+        )


### PR DESCRIPTION
**Current behavior:**
In the *Contacts* application, with a partner record open, you can view the lots associated with that customer (used in orders for that partner(?)).

Lots that were delivered to that partner via dropship transfers do not appear here.

**Expected behavior:**
Dropship lots are there.

**Steps to reproduce:**
1. Create a dropship product (route, vendor, ..) tracked by lot

2. Sell 1 of that product to some partner, confirm the ensuing purchase & dropship transfer

3. Go to *Contact* -> open the customer -> `Lot/Serial Numbers` smart button -> lot is not there

**Cause of the issue:**
`StockLotReport` only looks for `outgoing` (delivery) picking type pickings.

**Fix:**
Override the join on `PickingType` and `ResPartner` such that dropship pickings can also be collected here.

opw-4559129