### PR TITLE
[FIX] website: properly remove tabs in s_tabs snippet

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -241,6 +241,14 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         if (snippetSaveOptionEl) {
             snippetSaveOptionEl.dataset.selector += ", .s_searchbar_input";
         }
+        // TODO remove in 18.0
+        const navTabsStyleEl = $html.find(`[data-js="NavTabsStyle"]`)[0];
+        if (navTabsStyleEl) {
+            const divEl = document.createElement("div");
+            divEl.setAttribute("data-js", "TabsNavItems");
+            divEl.setAttribute("data-selector", ".nav-item");
+            navTabsStyleEl.append(divEl);
+        }
     },
     /**
      * Depending of the demand, reconfigure they gmap key or configure it

--- a/addons/website/static/src/snippets/s_tabs/options.js
+++ b/addons/website/static/src/snippets/s_tabs/options.js
@@ -99,9 +99,12 @@ options.registry.NavTabs = options.registry.MultipleItems.extend({
      */
     _removeItemCallback($target) {
         const $targetNavLink = this.$(`.nav-item a[href="#${$target.attr('id')}"]`);
-        const $navLinkToShow = this.$navLinks.eq((this.$navLinks.index($targetNavLink) + 1) % this.$navLinks.length);
+        const linkIndex = (this.$navLinks.index($targetNavLink) + 1) % this.$navLinks.length;
+        const $navLinkToShow = this.$navLinks.eq(linkIndex);
+        const $tabPaneToShow = this.$tabPanes.eq(linkIndex);
         $targetNavLink.parent().remove();
         this._findLinksAndPanes();
+        $tabPaneToShow[0].classList.add("active", "show");
         $navLinkToShow.tab('show');
     },
 });
@@ -134,7 +137,7 @@ options.registry.NavTabsStyle = options.Class.extend({
         const isVertical = widgetValue === 'vertical';
         this.$target.toggleClass('row s_col_no_resize s_col_no_bgcolor', isVertical);
         this.$target.find('.s_tabs_nav:first .nav').toggleClass('flex-column', isVertical);
-        this.$target.find('.s_tabs_nav:first > .nav-link').toggleClass('py-2', isVertical);
+        this.$target.find('.s_tabs_nav:first .nav .nav-link').toggleClass('py-2', isVertical);
         this.$target.find('.s_tabs_nav:first').toggleClass('col-md-3', isVertical);
         this.$target.find('.s_tabs_content:first').toggleClass('col-md-9', isVertical);
     },
@@ -155,4 +158,10 @@ options.registry.NavTabsStyle = options.Class.extend({
         }
         return this._super(...arguments);
     },
+});
+
+// Prevent `.nav-items` to be deleted from the bin button
+// as it is bypassing the "add(+)/remove(-)" behaviour
+options.registry.TabsNavItems = options.Class.extend({
+    forceNoDeleteButton: true,
 });


### PR DESCRIPTION
Steps to reproduce:

- Enter website edit mode.
- Drag and drop the Tabs snippet onto the page.
- Click on the third tab to activate it.
- Click the minus (-) button to remove the tab.
- No other tab is activated after removal,
  leaving the tab content area empty.

This commit ensures that if a tab is removed, the next available tab
is activated automatically.

This commit fixes another minor issue:
When the direction option is set to "vertical", the expected vertical
padding was not applied due to an incorrect selector.
