### PR TITLE
[FIX] sale_project: fix refunds for service products

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -394,7 +394,7 @@ class SaleOrderLine(models.Model):
                 project = map_sol_project.get(so_line.id) or so_line.order_id.project_id
                 if project and so_line.product_uom_qty > 0:
                     so_line._timesheet_create_task(project)
-                else:
+                elif not project:
                     raise UserError(_(
                         "A project must be defined on the quotation %(order)s or on the form of products creating a task on order.\n"
                         "The following product need a project in which to put its task: %(product_name)s",

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1188,3 +1188,14 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
             so2.order_line.project_id,
             "The project of `so1` should be set to the project that was generated at SO confirmation."
         )
+
+    def test_so_with_service_product_negative_qty(self):
+        so = self.env['sale.order'].create({'partner_id': self.partner.id})
+        sol = self.env['sale.order.line'].create({
+            'order_id': so.id,
+            'product_id': self.product_order_service2.id,
+            'product_uom_qty': -5,
+        })
+        so.action_confirm()
+        self.assertFalse(self.product_order_service2.project_id.task_ids)
+        self.assertFalse(sol.task_id)


### PR DESCRIPTION
Steps to reproduce:
- Install sale, project apps
- Create a service product that creates a task in a project
- Create a quotation with this product and order line qty < 0
- Confirm the quotation to a sales order

A traceback is thrown stating that the product lacks a project to create a task in. In previous versions, negative qty sales orders were allowed as refunds, but no task was created for them.

The issue is in `_timesheet_service_generation`, where -ve qty is treated as if no project is set for the product. This is incorrect since refunds should be allowed for service products.

This fix ensures that negative qty sales orders function as refunds without triggering task creation.

opw-4669488

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
