### PR TITLE
[FIX] website_event_booth: resolve traceback when booking booth

### DIFF
--- a/addons/website_event_booth/static/src/interactions/booth_registration.js
+++ b/addons/website_event_booth/static/src/interactions/booth_registration.js
@@ -32,7 +32,7 @@ export class BoothRegistration extends Interaction {
             }),
         },
         "button.o_wbooth_registration_submit": {
-            "t-att-disabled": () => this.isSelectionEmpty,
+            "t-att-disabled": () => !this.isSelectionEmpty,
         },
     };
 
@@ -165,7 +165,7 @@ export class BoothRegistration extends Interaction {
         }
         this.updateBoothsList();
         this.showBoothCategoryDescription();
-        this.isSelectionEmpty = !!this.countSelectedBooths().length;
+        this.isSelectionEmpty = !!this.countSelectedBooths();
     }
 
     /**
@@ -183,7 +183,7 @@ export class BoothRegistration extends Interaction {
      */
     onBoothChange(ev, currentTargetEl) {
         currentTargetEl.closest(".form-check").classList.remove("text-danger");
-        this.isSelectionEmpty = !!this.countSelectedBooths().length;
+        this.isSelectionEmpty = !!this.countSelectedBooths();
     }
 
     async onSubmitClick() {


### PR DESCRIPTION
Steps to reproduce
====================
- Go to an event that has a booth option.
- Try to book a booth without selecting a location.

Technical
==========
- Here ```countSelectedBooths``` method is already returning the length as an integer, and so doing again .length on an integer leads to an alteration in the value of ```isSelectionEmpty```
- Also, we inverted the value of ```isSelectionEmpty``` because when the location is not selected button needs to be disabled
- An issue arises during our recent interaction conversion https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba

Task-4680767