### PR TITLE
[FIX] survey: display company logo and name on survey certificate

### DIFF
--- a/addons/survey/report/survey_templates.xml
+++ b/addons/survey/report/survey_templates.xml
@@ -56,7 +56,7 @@
                             <span>Date</span>
                         </div>
                         <div class="certification-company">
-                            <span class="certification-company-logo" t-field="user_input.create_uid.sudo().company_id.partner_id.image_1920" t-options="{'widget': 'image'}" role="img"/>
+                            <span class="certification-company-logo" t-field="user_input.create_uid.sudo().company_id.logo" t-options="{'widget': 'image'}" role="img"/>
                         </div>
                     </div>
                     <div t-if="user_input.test_entry" class="test-entry"/>


### PR DESCRIPTION
## Issue:
Survey's PDF certifications no longer display the company logo when printed by other companies' users.

## Steps to reproduce:
- Create a survey with certification and ensure `Require Login` is checked;
- Share the survey (copy the `Survey Link`);
- In a private navigator (to ensure no login data are saved):
    - Log in as Demo user;
    - Answer the survey (using the copied link above);
- Go to Surveys / Participations;
- Enter the record of your test (`Contact` field should match Demo's data);
- Open the PDF certification in the chatter.

## Cause:
The company `logo` field is a Binary field related to the partner's `image_1920`.
The retrieval method was changed to access `partner_id.image_1920` directly with `sudo`, since `sudo` does not apply when accessing the related field (`logo`) directly.
However, this change broke the standard certification printing layout, likely due to rendering issues with the direct access method.

## Fix:
Reverts logo access back to the related field `company_id.logo` to restore compatibility with certification printing.
Partial revert of commit 9b4c4ad8d1a238c6f7f4bea52d3f64016a6ff325 as already applied by JKE on Odoo.
Ensures the certification printing is still allowed for other companies' users.

opw-4266445
opw-4657294

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
