### PR TITLE
[FIX] html_editor: fix hint text visibility in editor

### DIFF
--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -139,7 +139,7 @@ export class PowerButtonsPlugin extends Plugin {
     getPlaceholderWidth(block) {
         this.dependencies.history.disableObserver();
         const clone = block.cloneNode(true);
-        clone.innerText = clone.getAttribute("placeholder");
+        clone.innerText = clone.getAttribute("o-we-hint-text");
         clone.style.width = "fit-content";
         clone.style.visibility = "hidden";
         this.editable.appendChild(clone);

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -8,6 +8,7 @@ import { onRpc } from "@web/../tests/web_test_helpers";
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { PowerboxPlugin } from "../src/main/powerbox/powerbox_plugin";
 
 describe.tags("desktop");
 describe("visibility", () => {
@@ -61,12 +62,19 @@ describe("visibility", () => {
 
     test("should not overlap with long placeholders", async () => {
         const placeholder = "This is a very very very very long placeholder";
+        class TestPowerboxPlugin extends PowerboxPlugin {
+            setup() {
+                super.setup();
+                this.resources.hints.text = placeholder;
+            }
+        }
         const tempP = document.createElement("p");
         tempP.innerText = placeholder;
         tempP.style.width = "fit-content";
-        const { el } = await setupEditor(
-            `<p placeholder="${placeholder}" class="o-we-hint">[]<br></p>`
-        );
+        const Plugins = [...MAIN_PLUGINS.filter((p) => p.id !== "powerbox"), TestPowerboxPlugin];
+        const { el } = await setupEditor("<p>[]<br></p>", {
+            config: { Plugins },
+        });
         el.appendChild(tempP);
         const placeholderWidth = tempP.getBoundingClientRect().width;
         el.removeChild(tempP);
@@ -104,18 +112,16 @@ describe("buttons", () => {
     });
 
     test("should open image selector using power buttons", async () => {
-        onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
-            return [
-                {
-                    id: 1,
-                    name: "logo",
-                    mimetype: "image/png",
-                    image_src: "/web/static/img/logo2.png",
-                    access_token: false,
-                    public: true,
-                },
-            ];
-        });
+        onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => [
+            {
+                id: 1,
+                name: "logo",
+                mimetype: "image/png",
+                image_src: "/web/static/img/logo2.png",
+                access_token: false,
+                public: true,
+            },
+        ]);
         await setupEditor("<p>[]<br></p>");
         click(".o_we_power_buttons .power_button.fa-file-image-o");
         await animationFrame();


### PR DESCRIPTION
**Problem**:
The fix introduced in
[commit 0eb27d6](https://github.com/odoo/odoo/pull/203858/commits/0eb27d6c74f1a576090f01b85055f621b8bb310f) is not working correctly because the implementation was updated to use `o-we-hint-text` instead of `placeholder`.

**Solution**:
Ensure the fix applies to `o-we-hint-text` instead of `placeholder`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
