### PR TITLE
[FIX] website_slides: prevent error when creating new attendees

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -65,6 +65,10 @@ class SlideChannelPartner(models.Model):
             record.invitation_link = f'{record.channel_id.get_base_url()}/slides/{record.channel_id.id}/invite?invite_partner_id={record.partner_id.id}&invite_hash={invitation_hash}'
 
     def _compute_next_slide_id(self):
+        if not self.ids:
+            self.next_slide_id = False
+            return
+
         self.env['slide.channel.partner'].flush_model()
         self.env['slide.slide'].flush_model()
         self.env['slide.slide.partner'].flush_model()


### PR DESCRIPTION
Currently, this exception is raised when a user tries to create a new attendee.

Steps to Reproduce:

1. Install `website_slides` module.
2. Go to eLearning ->Reporting -> Attendees
3. Switch to the Pivot view and click on a count integer.
4. Open the List View and click the "New" button.
5. An error Occurs

Error:
```SyntaxError
syntax error at or near ")"
LINE 18:             WHERE SCP.id IN ()
```

This issue[1] occurs because the system runs a query expecting an existing record with an ID, but since the record isn't saved yet, `self.ids` is empty, causing the query to fail.

[1]- https://github.com/odoo/odoo/blob/fbee52705e0332f7134eb5505eac26677e38c168/addons/website_slides/models/slide_channel.py#L91

This fix ensures that if self.ids is empty, the system stops the process early and sets a proper value, preventing the query from failing.

sentry-6465821899

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
