### PR TITLE
[IMP] sale_project: Task Template for Service Products

### DIFF
--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from lxml import etree
-from psycopg2.errors import CheckViolation
 
 from odoo import Command, _
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
@@ -115,7 +114,7 @@ class TestProjectSubtasks(TestProjectCommon):
         self.assertTrue(child_task.display_in_project, "As the subtask isn't in the same project as its parent, it should be displayed")
 
         # 3)
-        with self.assertRaises(CheckViolation):
+        with self.assertRaises(ValidationError):
             child_task.project_id = False
 
         # 3bis)

--- a/addons/sale_project/__init__.py
+++ b/addons/sale_project/__init__.py
@@ -24,3 +24,10 @@ def uninstall_hook(env):
         ('python_method', 'in', ['action_open_project_invoices', 'action_view_sos'])
     ])
     actions.domain = [(0, '=', 1)]
+
+    env.ref("project.ir_rule_private_task").write({'domain_force': "[\
+        ('project_id.privacy_visibility', '!=', 'followers'),\
+            '|', '|', ('project_id', '!=', False),\
+            ('parent_id', '!=', False),\
+            ('user_ids', 'in', user.id),\
+        ]"})

--- a/addons/sale_project/__manifest__.py
+++ b/addons/sale_project/__manifest__.py
@@ -21,6 +21,7 @@ This module allows to generate a project/task from sales orders.
         'views/sale_project_portal_templates.xml',
         'views/project_update_template.xml',
         'views/project_sharing_views.xml',
+        'views/project_task_template.xml',
         'views/project_views.xml',
         'data/sale_project_data.xml',
     ],

--- a/addons/sale_project/models/product_template.py
+++ b/addons/sale_project/models/product_template.py
@@ -36,6 +36,11 @@ class ProductTemplate(models.Model):
     project_template_id = fields.Many2one(
         'project.project', 'Project Template', company_dependent=True, copy=True,
     )
+
+    task_template_id = fields.Many2one(
+        'project.task', 'Task Template', domain=[('is_task_template', '=', True)],
+        company_dependent=True, copy=True,
+    )
     service_policy = fields.Selection('_selection_service_policy', string="Service Invoicing Policy", compute_sudo=True, compute='_compute_service_policy', inverse='_inverse_service_policy', tracking=True)
     service_type = fields.Selection(selection_add=[
         ('milestones', 'Project Milestones'),

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -115,6 +115,7 @@ class SaleOrder(models.Model):
             projects_per_so[project.sale_order_id.id] |= project
         for order in self:
             projects = order.order_line.mapped('product_id.project_id')
+            projects |= order.tasks_ids.mapped('project_id') if self.env.user.has_group('project.group_project_user') else projects
             projects |= order.order_line.mapped('project_id')
             projects |= projects_per_so[order.id or order._origin.id]
             if not is_project_manager:

--- a/addons/sale_project/security/sale_project_security.xml
+++ b/addons/sale_project/security/sale_project_security.xml
@@ -12,4 +12,18 @@
         <field name="perm_read" eval="1"/>
     </record>
 
+    <record id="project.ir_rule_private_task" model="ir.rule">
+        <field name="domain_force">[
+            '|','|',
+                ('is_task_template', '=', True),
+                ('parent_id.is_task_template', '=', True),
+            '&amp;',
+                ('project_id.privacy_visibility', '!=', 'followers'),
+            '|', '|', 
+                ('project_id', '!=', False),
+                ('parent_id', '!=', False),
+                ('user_ids', 'in', user.id),
+        ]</field>
+    </record>
+    
 </odoo>

--- a/addons/sale_project/tests/__init__.py
+++ b/addons/sale_project/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_res_config_settings
 from . import test_sale_project
 from . import test_so_line_milestones
 from . import test_sale_project_dashboard
+from . import test_task_template

--- a/addons/sale_project/tests/test_task_template.py
+++ b/addons/sale_project/tests/test_task_template.py
@@ -1,0 +1,83 @@
+from odoo import Command
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.exceptions import AccessError
+from odoo.tests.common import TransactionCase, users
+
+
+class TestTaskTemplate(TransactionCase):
+
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+        self.partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+        })
+        self.manager = mail_new_test_user(self.env, 'Project admin', groups='project.group_project_manager')
+        self.user = mail_new_test_user(self.env, 'Project user', groups='project.group_project_user')
+        self.project = self.env['project.project'].create({'name': 'home design'})
+        self.project_con = self.env['project.project'].create({'name': 'home con'})
+        self.task_template = self.env['project.task'].create({
+            'name': "home con",
+            'is_task_template': True,
+            'child_ids': [
+                Command.create({
+                    'name': 'home arch',
+                    'allocated_hours': 20,
+                }),
+                Command.create({
+                    'name': 'home pool',
+                    'allocated_hours': 20,
+                    'active': False,
+                    'task_template_project_id': self.project_con.id
+                }),
+                Command.create({
+                    'name': 'home con',
+                    'allocated_hours': 20,
+                    'task_template_project_id': self.project_con.id
+                })]
+        })
+        self.product0 = self.env['product.product'].create({
+            'name': 'Test0',
+            'type': 'service',
+            'service_tracking': 'task_global_project', 'project_id': self.project.id,
+            'task_template_id': self.task_template.id
+        })
+
+        self.product1 = self.env['product.product'].create({
+            'name': 'Test1',
+            'type': 'service',
+            'service_tracking': 'task_global_project', 'project_id': self.project.id,
+            'task_template_id': self.task_template.id
+        })
+
+    def test_task_template_behavior(self):
+        """
+            Test the task template behavior
+        """
+        order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product0.id,
+                }),
+                Command.create({
+                    'product_id': self.product1.id,
+                })]
+        })
+        order.action_confirm()
+        task_count = self.env['project.task'].with_context(active_test=False).search_count([('sale_line_id', 'in', order.order_line.ids)])
+        self.assertEqual(order.tasks_count, 2, msg="Expected 2 tasks to be generated from the task template, but the count does not match.")
+        self.assertEqual(task_count, 3, msg="Expected 3 tasks incl. archived to be generated from the task template, but the count does not match.")
+        self.assertEqual(order.tasks_ids[0].allocated_hours, 40, msg="Expected task's hours to be 20 from the task template, but the hours does not match.")
+        self.assertEqual(order.project_count, 2, msg="Expected 2 project to be linked to Sale order the count does not match.")
+
+    @users('Project admin', 'Project user')
+    def test_check_task_template_accessibility(self):
+        """
+            Test the task template read access rights
+            The project user and project admin should have read access rights to task template.
+        """
+        try:
+            self.assertEqual(len(self.env['project.task'].browse(self.task_template.id).child_ids), 2)
+        except AccessError:
+            raise RuntimeError("Task Template is accessible to this project.group_project_manager, project.group_project_user group.")

--- a/addons/sale_project/views/product_views.xml
+++ b/addons/sale_project/views/product_views.xml
@@ -21,6 +21,11 @@
                     <label for='project_template_id'/>
                 </div>
                 <field name="project_template_id" context="{'active_test': False, 'default_allow_billable': True}" invisible="service_tracking not in ['task_in_project', 'project_only']" nolabel="1" placeholder="Empty project"/>
+                <div class="o_td_label d-inline-flex" invisible="service_tracking not in ['task_in_project', 'task_global_project']">
+                    <label for='task_template_id' />
+                </div>
+                <field groups="project.group_project_user" name="task_template_id" context="{'form_view_ref': 'sale_project.project_task_template_view_form', 'default_is_task_template': True, 'mode': 'edit'}" invisible="service_tracking not in ['task_in_project', 'task_global_project']" nolabel="1" placeholder="Empty Task template" />
+                <field groups="!project.group_project_user" name="task_template_id" options="{'no_open': True, 'no_create_edit': True, 'no_create': True }" context="{'active_test': False, 'default_allow_billable': True}" invisible="service_tracking not in ['task_in_project', 'task_global_project']" nolabel="1" placeholder="Empty Task template" />
                 <field name="service_policy"
                     string="Invoicing Policy"
                     invisible="type != 'service' or sale_ok == False"

--- a/addons/sale_project/views/project_task_template.xml
+++ b/addons/sale_project/views/project_task_template.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="project_task_template_view_form" model="ir.ui.view">
+        <field name="name">project.task.template.form</field>
+        <field name="model">project.task</field>
+        <field name="arch" type="xml">
+            <form string="" open_form_view="True">
+                <sheet>
+                    <group>
+                        <div class="oe_title">
+                            <label for="name" string="Task Template" />
+                            <h1>
+                                <field name="name" placeholder="e.g. Standard Task Template" />
+                            </h1>
+                        </div>
+                    </group>
+                    <group>
+                        <field groups="base.group_multi_company" class="oe_inline" name="company_id" options="{'no_open': True, 'no_create': True}" placeholder="Visible to all Company"/>
+                    </group>
+                    <notebook name="Task Template">
+                        <page string="Tasks">
+                            <field name="child_ids" context="{'form_view_ref': 'sale_project.view_task_template_form2_inherit',
+                                            'list_view_ref': 'sale_project.project_task_template_view_list'}" />
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_task_template_form2_inherit">
+        <field name="name">project.task.template.task.form</field>
+        <field name="model">project.task</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="project.view_task_form2" />
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="attributes">
+                <attribute name="invisible">"1"</attribute>
+            </xpath>
+            <xpath expr="//field[@name='project_id']" position="replace">
+                <field name="task_template_project_id" />
+                <field name="is_task_template" invisible="1" context="{'default_is_task_template': False}" />
+            </xpath>
+            <xpath expr="//label[@for='date_deadline']" position="attributes">
+                <attribute name="invisible">"1"</attribute>
+            </xpath>
+            <xpath expr="//div[@id='date_deadline_and_recurring_task']" position="attributes">
+                <attribute name="invisible">"1"</attribute>
+            </xpath>
+            <xpath expr="//page[@name='sub_tasks_page']" position="attributes">
+                <attribute name="invisible">"1"</attribute>
+            </xpath>
+            <xpath expr="//page[@name='extra_info']//field[@name='parent_id']" position="attributes">
+                <attribute name="invisible">"1"</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="project_task_template_view_list" model="ir.ui.view">
+        <field name="name">project.task.template.list</field>
+        <field name="model">project.task</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name" />
+            </list>
+        </field>
+    </record>
+    
+    <record id="project_task_template_action" model="ir.actions.act_window">
+        <field name="name">Task Template</field>
+        <field name="res_model">project.task</field>
+        <field name="view_mode">list,form</field>
+        <field name="domain">[('is_task_template', '=', True)]</field>
+        <field name="context">{'default_is_task_template': True}</field>
+    </record>
+
+    <record model="ir.actions.act_window.view" id="project_task_template_action_list">
+        <field name="sequence" eval="1" />
+        <field name="view_mode">list</field>
+        <field name="view_id" ref="project_task_template_view_list" />
+        <field name="act_window_id" ref="project_task_template_action" />
+    </record>
+
+    <record model="ir.actions.act_window.view" id="project_task_template_action_form">
+        <field name="sequence" eval="2" />
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="project_task_template_view_form" />
+        <field name="act_window_id" ref="project_task_template_action" />
+    </record>
+
+    <record id="project.action_view_all_task" model="ir.actions.act_window">
+    <field name="domain">[
+        '!',
+        '|',
+            ('is_task_template', '=', True),
+            ('parent_id.is_task_template', '=', True)
+    ]</field>
+    </record>
+
+    <menuitem id="menu_task_template" name="Task Template" action="project_task_template_action" parent="project.menu_main_pm" sequence="99" />    
+
+</odoo>


### PR DESCRIPTION
This commit introduces a Task Template feature.
- A Task Template field is added to the Product Template.
- Selection is limited to Service products with 'Create on Order' set
  to `Task` or `Project & Task`.
- When a template is selected, its tasks are automatically assigned to
  the project on sales order confirmation.
- The existing behavior is maintained when no template is selected.

task-4369824



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
