### PR TITLE
[FIX] mail: emoji in discuss text is slightly bigger

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -155,7 +155,6 @@
 }
 
 .o-mail-Composer-input {
-    font-family: "text-emoji", $font-family-base;
     max-height: Min(400px, 60vh);
     resize: none;
 

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -8,6 +8,11 @@ $o-discuss-talkingColor: lighten($success, 10%);
     filter: brightness(1.2);
 }
 
+.o-mail-emoji {
+    font-size: 121%;
+    line-height: $display-line-height;
+}
+
 .o-bg-black {
     background-color: rgba(0, 0, 0, var(--bg-opacity, 1));
 }

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -47,24 +47,7 @@
     }
 }
 
-@font-face {
-    font-family: "text-emoji";
-    src: local('Segoe UI'),
-         local('Apple Emoji'),
-         local('Android Emoji'),
-         local('Noto Emoji'),
-         local('Twitter Color Emoji'),
-         local('Twitter Color'),
-         local('EmojiOne Color'),
-         local('EmojiOne'),
-         local(EmojiSymbols),
-         local(Symbola);
-    unicode-range: U+231A-231B, U+23E9-23EC, U+23F0, U+23F3, U+25FD-25FE, U+2614-2615, U+2648-2653, U+267F, U+2693, U+26A1, U+26AA-26AB, U+26BD-26BE, U+26C4-26C5, U+26CE, U+26D4, U+26EA, U+26F2-26F3, U+26F5, U+26FA, U+26FD, U+2705, U+270A-270B, U+2728, U+274C, U+274E, U+2753-2755, U+2757, U+2795-2797, U+27B0, U+27BF, U+2B1B-2B1C, U+2B50, U+2B55, U+FE0F, U+1F004, U+1F0CF, U+1F18E, U+1F191-1F19A, U+1F1E6-1F1FF, U+1F201, U+1F21A, U+1F22F, U+1F232-1F236, U+1F238-1F23A, U+1F250-1F251, U+1F300-1F320, U+1F32D-1F335, U+1F337-1F393, U+1F3A0-1F3CA, U+1F3CF-1F3D3, U+1F3E0-1F3F0, U+1F3F4, U+1F3F8-1F43E, U+1F440, U+1F442-1F4FC, U+1F4FF-1F53D, U+1F54B-1F567, U+1F57A, U+1F595-1F596, U+1F5A4, U+1F5FB-1F64F, U+1F680-1F6CC, U+1F6D0-1F6D2, U+1F6D5-1F6D7, U+1F6DC-1F6DF, U+1F6EB-1F6EC, U+1F6F4-1F6FC, U+1F7E0-1F7EB, U+1F7F0, U+1F90C-1F93A, U+1F93C-1F945, U+1F947-1FA7C, U+1FA80-1FAC5, U+1FACE-1FADB, U+1FAE0-1FAE8, U+1FAF0-1FAF8;
-    size-adjust: 121%;
-}
-
 .o-mail-Message-body {
-    font-family: "text-emoji", $font-family-base;
 
     &:not(.o-note) {
         padding-left: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -80,7 +80,7 @@
                                                             'align-self-start rounded-end-3 rounded-bottom-3': !props.message.composer and !message.is_note,
                                                             'flex-grow-1': props.message.composer,
                                                             }" t-ref="body">
-                                                    <i t-if="message.isEmpty" class="text-muted opacity-75" t-esc="message.inlineBody"/>
+                                                    <i t-if="message.isEmpty" class="text-muted opacity-75" t-out="message.inlineBody"/>
                                                     <Composer t-elif="props.message.composer" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
                                                     <t t-else="">
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>

--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -51,7 +51,9 @@ export class OutOfFocusService {
                 notificationTitle = author.name;
             }
         }
-        const notificationContent = message.previewText.substring(0, PREVIEW_MSG_MAX_SIZE);
+        const notificationContent = message.previewText
+            .toString()
+            .substring(0, PREVIEW_MSG_MAX_SIZE);
         this.sendNotification({
             message: notificationContent,
             sound: message.thread?.model === "discuss.channel",

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -36,7 +36,7 @@
                             <i class="fa me-1" t-att-class="message.previewIcon"/>
                             <t t-out="message.previewText" />
                         </t>
-                        <span t-else="" t-esc="message?.previewText" t-att-class="{ 'opacity-75': message?.isEmpty }"/>
+                        <span t-else="" t-out="message?.previewText" t-att-class="{ 'opacity-75': message?.isEmpty }"/>
                     </t>
                     <t t-set-slot="icon">
                         <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" member="thread.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -54,11 +54,7 @@
     }
 }
 
-.o-mail-NotificationItem-text {
-    font-family: "text-emoji", $font-family-base;
-
-    &:before {
-        // invisible character so that typing status bar has constant height, regardless of text content.
-        content: "\200b"; /* unicode zero width space character */
-    }
+.o-mail-NotificationItem-text:before {
+    // invisible character so that typing status bar has constant height, regardless of text content.
+    content: "\200b"; /* unicode zero width space character */
 }

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -38,7 +38,7 @@
                                 <t t-if="message" t-call="mail.message_preview_prefix">
                                     <t t-set="message" t-value="message"/>
                                 </t>
-                                <t t-esc="message?.inlineBody"/>
+                                <t t-out="message?.inlineBody"/>
                             </div>
                         </button>
                     </t>

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -333,7 +333,7 @@ export const EMOJI_REGEX = /\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\u200d/gu;
  * @param {string|ReturnType<markup>} content
  * @returns {ReturnType<markup>}
  */
-export function wrapEmojisWithTitles(content) {
+export function decorateEmojis(content) {
     if (!loader.loaded || !content) {
         return content;
     }
@@ -352,7 +352,7 @@ export function wrapEmojisWithTitles(content) {
             span,
             htmlReplaceAll(node.textContent, loader.loaded.emojiRegex, (codepoints) =>
                 markup(
-                    `<span title="${htmlFormatList(
+                    `<span class="o-mail-emoji" title="${htmlFormatList(
                         loader.loaded.emojiValueToShortcodes[codepoints],
                         { style: "unit-narrow" }
                     )}">${htmlEscape(codepoints)}</span>`

--- a/addons/mail/static/tests/utils/decorate_emojis.test.js
+++ b/addons/mail/static/tests/utils/decorate_emojis.test.js
@@ -1,4 +1,4 @@
-import { wrapEmojisWithTitles } from "@mail/utils/common/format";
+import { decorateEmojis } from "@mail/utils/common/format";
 import { expect, test } from "@odoo/hoot";
 import { markup } from "@odoo/owl";
 import { makeMockEnv } from "@web/../tests/web_test_helpers";
@@ -8,23 +8,25 @@ const Markup = markup().constructor;
 test("emojis in text content are wrapped with title and marked up", async () => {
     await makeMockEnv();
     await loadEmoji();
-    const result = wrapEmojisWithTitles("😇");
+    const result = decorateEmojis("😇");
     expect(result).toBeInstanceOf(Markup);
-    expect(result.toString()).toEqual('<span title=":innocent: :halo:">😇</span>');
+    expect(result.toString()).toEqual(
+        '<span class="o-mail-emoji" title=":innocent: :halo:">😇</span>'
+    );
 });
 
 test("emojis in attributes are not wrapped with title", async () => {
     await makeMockEnv();
     await loadEmoji();
-    const result = wrapEmojisWithTitles(markup("<span title='😇'>test</span>"));
+    const result = decorateEmojis(markup("<span title='😇'>test</span>"));
     expect(result.toString()).toEqual('<span title="😇">test</span>');
 });
 
 test("unsafe content is escaped when wrapping emojis with title", async () => {
     await makeMockEnv();
     await loadEmoji();
-    const result = wrapEmojisWithTitles("<img src='javascript:alert(\"xss\")'/>😇");
+    const result = decorateEmojis("<img src='javascript:alert(\"xss\")'/>😇");
     expect(result.toString()).toEqual(
-        '&lt;img src=\'javascript:alert("xss")\'/&gt;<span title=":innocent: :halo:">😇</span>'
+        '&lt;img src=\'javascript:alert("xss")\'/&gt;<span class="o-mail-emoji" title=":innocent: :halo:">😇</span>'
     );
 });


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/202766

PR above fixed an issue with some emojis being represented as 4 emojis rather than 1. The change consisted in using non-colored emoji fonts.

However this change negatively affected font "text-emoji": emojis were no longer size-adjusted to 121%, thus emojis became too small.

This commit fixes the issue by removing completely the "text-emoji" font family and instead the size adjustment of emojis is made thanks to `wrapEmojisInTitle`, which has been renamed to `decorateEmojis` to take into account the new use with font-size adjustment.

This emoji side adjustment is desired in chat bubble preview and messaging menu item, so related fields have been adapted to use `decorateEmojis`, including the inline textual preview of message.

Size before https://github.com/odoo/odoo/pull/202766
![0](https://github.com/user-attachments/assets/6f321383-0e3c-46e1-a22a-737afce85551)

Size after https://github.com/odoo/odoo/pull/202766 and before this fix
![1](https://github.com/user-attachments/assets/7a806910-0685-4972-8750-b225a8e1116f)

Size after this fix
![2](https://github.com/user-attachments/assets/98f3ff74-f4d7-4f6f-97ee-571d0bd7b200)
