### PR TITLE
[FIX] mail: emoji in discuss text is slightly bigger

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -50,9 +50,9 @@
 @font-face {
     font-family: "text-emoji";
     src: local('Segoe UI'),
-         local('Apple Emoji'),
+         local('Apple Color Emoji'),
          local('Android Emoji'),
-         local('Noto Emoji'),
+         local('Noto Color Emoji'),
          local('Twitter Color Emoji'),
          local('Twitter Color'),
          local('EmojiOne Color'),


### PR DESCRIPTION
Follow-up of #202766

PR above fixed an issue with some emojis being represented as 4 emojis rather than 1. The change consisted in using non-colored emoji fonts.

However this change negatively affected font "text-emoji": emojis were no longer size-adjusted to 121%, thus emojis became too small.

This commit reverts the change of font to keep using the "color" versions, so that the size-adjustment of emojis is taken into account. The problem with family emojis is therefore back, but this is a less problem than the lack of size adjustment of the emojis in Discuss content.

Before
![Screenshot 2025-04-01 at 11 41 42](https://github.com/user-attachments/assets/65b3b1a0-d164-4fa1-a94f-7b93ac7f2e4f)

After
![Screenshot 2025-04-01 at 11 41 50](https://github.com/user-attachments/assets/53f2f924-b69f-4ab9-b17a-1f77290011a0)
