### PR TITLE
[FIX] iot_box_image: remove openbox package

### DIFF
--- a/addons/iot_box_image/configuration/packages.txt
+++ b/addons/iot_box_image/configuration/packages.txt
@@ -15,7 +15,6 @@ libpq-dev
 libffi-dev
 localepurge
 nginx-full
-openbox
 printer-driver-all
 python3
 python3-cups


### PR DESCRIPTION
In #202722, the IoT box was switched to wayland/labwc and so openbox was removed from the packages. However, in the forward port to saas-18.2 (#203089) when the PR had to be adapted for the `packages.txt` file, `openbox` was accidentally left on the list. This commit simply removes the unneeded dependency.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
