### PR TITLE
[IMP] odoo: set technical objects private on cursor

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -233,7 +233,7 @@ class ImDispatch(threading.Thread):
              selectors.DefaultSelector() as sel:
             cr.execute("listen imbus")
             cr.commit()
-            conn = cr._cnx
+            conn = cr._cnx__
             sel.register(conn, selectors.EVENT_READ)
             while not stop_event.is_set():
                 if sel.select(TIMEOUT):

--- a/addons/bus/tests/test_notify.py
+++ b/addons/bus/tests/test_notify.py
@@ -67,7 +67,7 @@ class NotifyTests(TransactionCase):
             ).cursor() as cr, selectors.DefaultSelector() as sel:
                 cr.execute("listen imbus")
                 cr.commit()
-                conn = cr._cnx
+                conn = cr._cnx__
                 sel.register(conn, selectors.EVENT_READ)
                 while sel.select(timeout=5) and not stop_event.is_set():
                     conn.poll()

--- a/addons/event_booth_sale/models/event_booth_category.py
+++ b/addons/event_booth_sale/models/event_booth_category.py
@@ -119,7 +119,7 @@ class EventBoothCategory(models.Model):
                 'model': 'product.product',
                 'res_id': product_id,
             })
-        self.env.cr._obj.execute(
+        self.env.cr._obj__.execute(
             f'UPDATE {self._table} SET product_id = %s WHERE id IN %s;',
             (product_id, tuple(booth_category_ids))
         )

--- a/addons/event_product/models/event_type_ticket.py
+++ b/addons/event_product/models/event_type_ticket.py
@@ -86,7 +86,7 @@ class EventTypeTicket(models.Model):
                 'model': 'product.product',
                 'res_id': product_id,
             })
-        self.env.cr._obj.execute(
+        self.env.cr._obj__.execute(
             f'UPDATE {self._table} SET product_id = %s WHERE id IN %s;',
             (product_id, tuple(ticket_type_ids))
         )

--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -387,7 +387,7 @@ class GamificationChallenge(models.Model):
                               {date_clause}
                         """.format(date_clause=date_clause)
                 self.env.cr.execute(query, query_params)
-                user_with_goal_ids = {it for [it] in self.env.cr._obj}
+                user_with_goal_ids = {it for [it] in self.env.cr._obj__}
 
                 participant_user_ids = set(challenge.user_ids.ids)
                 user_squating_challenge_ids = user_with_goal_ids - participant_user_ids

--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -124,7 +124,7 @@ class SaleReport(models.Model):
             LEFT JOIN stock_picking_type picking ON picking.id = config.picking_type_id
             JOIN {currency_table} ON account_currency_table.company_id = pos.company_id
             """.format(
-            currency_table=self.env.cr.mogrify(currency_table).decode(self.env.cr.connection.encoding),
+            currency_table=self.env.cr.mogrify(currency_table).decode(self.env.cr.encoding),
             )
 
     def _where_pos(self):

--- a/addons/sale/report/sale_report.py
+++ b/addons/sale/report/sale_report.py
@@ -179,7 +179,7 @@ class SaleReport(models.Model):
 
     def _from_sale(self):
         currency_table = self.env['res.currency']._get_simple_currency_table(self.env.companies)
-        currency_table = self.env.cr.mogrify(currency_table).decode(self.env.cr.connection.encoding)
+        currency_table = self.env.cr.mogrify(currency_table).decode(self.env.cr.encoding)
         return f"""
             sale_order_line l
             LEFT JOIN sale_order s ON s.id=l.order_id

--- a/addons/web/controllers/json.py
+++ b/addons/web/controllers/json.py
@@ -218,7 +218,7 @@ class WebJsonController(http.Controller):
             try:
                 with action.pool.cursor(readonly=True) as ro_cr:
                     if not ro_cr.readonly:
-                        ro_cr.connection.set_session(readonly=True)
+                        ro_cr.set_session(readonly=True)
                     assert ro_cr.readonly
                     action_data = action.with_env(action.env(cr=ro_cr, su=False)).run()
             except psycopg2.errors.ReadOnlySqlTransaction as e:

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -69,7 +69,7 @@ def _predict_nextval(self, seq_id):
             (SELECT increment_by FROM pg_sequences WHERE sequencename = %s),
             is_called
         FROM %s""", seqname, seqtable)
-    if self.env.cr._cnx.server_version < 100000:
+    if self.env.cr.server_version < 100000:
         query = SQL("SELECT last_value, increment_by, is_called FROM %s", seqtable)
     [(last_value, increment_by, is_called)] = self.env.execute_query(query)
     if is_called:

--- a/odoo/addons/base/tests/test_profiler.py
+++ b/odoo/addons/base/tests/test_profiler.py
@@ -49,7 +49,7 @@ class TestSpeedscope(BaseCase):
                 'stack': [
                     ['/path/to/file_1.py', 10, 'main', 'do_stuff1(test=do_tests)'],
                     ['/path/to/file_1.py', 101, 'do_stuff1', 'cr.execute(query, params)'],
-                    ['/path/to/sql_db.py', 650, 'execute', 'res = self._obj.execute(query, params)'],
+                    ['/path/to/sql_db.py', 650, 'execute', 'res = self._obj__.execute(query, params)'],
                 ],
             }, {  # duplicate frame
                 'start': 4.0,
@@ -57,7 +57,7 @@ class TestSpeedscope(BaseCase):
                 'stack': [
                     ['/path/to/file_1.py', 10, 'main', 'do_stuff1(test=do_tests)'],
                     ['/path/to/file_1.py', 101, 'do_stuff1', 'cr.execute(query, params)'],
-                    ['/path/to/sql_db.py', 650, 'execute', 'res = self._obj.execute(query, params)'],
+                    ['/path/to/sql_db.py', 650, 'execute', 'res = self._obj__.execute(query, params)'],
                 ],
             }, {  # other frame
                 'start': 6.0,

--- a/odoo/addons/test_http/tests/test_registry.py
+++ b/odoo/addons/test_http/tests/test_registry.py
@@ -31,14 +31,14 @@ The other "what could go wrong" I can think about:
 def duplicate_db(db_source, db_dest):
     query = SQL("CREATE DATABASE %s ENCODING 'unicode' TEMPLATE %s", SQL.identifier(db_dest), SQL.identifier(db_source))
     with closing(db_connect('postgres').cursor()) as cr:
-        cr._cnx.autocommit = True
+        cr._cnx__.autocommit = True
         cr.execute(query)
 
 
 def drop_db(db):
     query = SQL("DROP DATABASE IF EXISTS %s", SQL.identifier(db))
     with closing(db_connect('postgres').cursor()) as cr:
-        cr._cnx.autocommit = True
+        cr._cnx__.autocommit = True
         cr.execute(query)
 
 

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -37,7 +37,7 @@ def database_identifier(cr, name: str) -> SQL:
 
     Use instead of `SQL.identifier` to accept all kinds of identifiers.
     """
-    name = quote_ident(name, cr._cnx)
+    name = quote_ident(name, cr._cnx__)
     return SQL(name)
 
 
@@ -107,7 +107,7 @@ def _create_empty_database(name):
         else:
             # database-altering operations cannot be executed inside a transaction
             cr.rollback()
-            cr._cnx.autocommit = True
+            cr._cnx__.autocommit = True
 
             # 'C' collate is only safe with template0, but provides more useful indexes
             cr.execute(SQL(
@@ -157,7 +157,7 @@ def exp_duplicate_database(db_original_name, db_name, neutralize_database=False)
     db = odoo.sql_db.db_connect('postgres')
     with closing(db.cursor()) as cr:
         # database-altering operations cannot be executed inside a transaction
-        cr._cnx.autocommit = True
+        cr._cnx__.autocommit = True
         _drop_conn(cr, db_original_name)
         cr.execute(SQL(
             "CREATE DATABASE %s ENCODING 'unicode' TEMPLATE %s",
@@ -185,7 +185,7 @@ def _drop_conn(cr, db_name):
     try:
         # PostgreSQL 9.2 renamed pg_stat_activity.procpid to pid:
         # http://www.postgresql.org/docs/9.2/static/release-9-2.html#AEN110389
-        pid_col = 'pid' if cr._cnx.server_version >= 90200 else 'procpid'
+        pid_col = 'pid' if cr.server_version >= 90200 else 'procpid'
 
         cr.execute("""SELECT pg_terminate_backend(%(pid_col)s)
                       FROM pg_stat_activity
@@ -205,7 +205,7 @@ def exp_drop(db_name):
     db = odoo.sql_db.db_connect('postgres')
     with closing(db.cursor()) as cr:
         # database-altering operations cannot be executed inside a transaction
-        cr._cnx.autocommit = True
+        cr._cnx__.autocommit = True
         _drop_conn(cr, db_name)
 
         try:
@@ -230,7 +230,7 @@ def exp_dump(db_name, format):
 
 @check_db_management_enabled
 def dump_db_manifest(cr):
-    pg_version = "%d.%d" % divmod(cr._obj.connection.server_version / 100, 100)
+    pg_version = "%d.%d" % divmod(cr.server_version / 100, 100)
     cr.execute("SELECT name, latest_version FROM ir_module_module WHERE state = 'installed'")
     modules = dict(cr.fetchall())
     manifest = {
@@ -357,7 +357,7 @@ def exp_rename(old_name, new_name):
     db = odoo.sql_db.db_connect('postgres')
     with closing(db.cursor()) as cr:
         # database-altering operations cannot be executed inside a transaction
-        cr._cnx.autocommit = True
+        cr._cnx__.autocommit = True
         _drop_conn(cr, old_name)
         try:
             cr.execute(SQL('ALTER DATABASE %s RENAME TO %s', database_identifier(cr, old_name), database_identifier(cr, new_name)))

--- a/odoo/tests/test_cursor.py
+++ b/odoo/tests/test_cursor.py
@@ -52,10 +52,10 @@ class TestCursor(BaseCursor):
             # we use self._cursor._obj for the savepoint to avoid having the
             # savepoint queries in the query counts, profiler, ...
             # Those queries are tests artefacts and should be invisible.
-            self._savepoint = Savepoint(self._cursor._obj)
+            self._savepoint = Savepoint(self._cursor._obj__)
             if self.readonly:
                 # this will simulate a readonly connection
-                self._cursor._obj.execute('SET TRANSACTION READ ONLY')  # use _obj to avoid impacting query count and profiler.
+                self._cursor._obj__.execute('SET TRANSACTION READ ONLY')  # use _obj to avoid impacting query count and profiler.
 
     def execute(self, *args, **kwargs) -> None:
         assert not self._closed, "Cannot use a closed cursor"
@@ -113,3 +113,8 @@ class TestCursor(BaseCursor):
         if self._now is None:
             self._now = datetime.now()
         return self._now
+
+    @property
+    def encoding(self) -> str:
+        return self._cursor.encoding
+


### PR DESCRIPTION
  - On the cursor object psycopg2 technical objects are not set as private and may be used improperly by developers.

    To avoid this, we make them private and force to use their mangled name to make sure they are really needed when used.


Sorry guys, it was meant to be a draft PR, still WIP.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
