### PR TITLE
[IMP] pos_self_order: scan QR linked to a table should not ask to select table

### DIFF
--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -8,7 +8,7 @@ from odoo.http import request
 class PosSelfKiosk(http.Controller):
     @http.route(["/pos-self/<config_id>", "/pos-self/<config_id>/<path:subpath>"], auth="public", website=True, sitemap=True)
     def start_self_ordering(self, config_id=None, access_token=None, table_identifier=None, subpath=None):
-        pos_config, _, config_access_token = self._verify_entry_access(config_id, access_token, table_identifier)
+        pos_config, table, config_access_token = self._verify_entry_access(config_id, access_token, table_identifier)
         return request.render(
                 'pos_self_order.index',
                 {
@@ -18,6 +18,7 @@ class PosSelfKiosk(http.Controller):
                         'currencies': request.env["res.currency"].get_all_currencies(),
                         'data': {
                             'config_id': pos_config.id,
+                            'table_id': table.id if table else False,
                             'self_ordering_mode': pos_config.self_ordering_mode,
                         },
                         "base_url": request.env['pos.session'].get_base_url(),

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -5,6 +5,7 @@ import { PopupTable } from "@pos_self_order/app/components/popup_table/popup_tab
 import { _t } from "@web/core/l10n/translation";
 import { OrderWidget } from "@pos_self_order/app/components/order_widget/order_widget";
 import { PresetInfoPopup } from "@pos_self_order/app/components/preset_info_popup/preset_info_popup";
+import { session } from "@web/session";
 
 export class CartPage extends Component {
     static template = "pos_self_order.CartPage";
@@ -19,6 +20,7 @@ export class CartPage extends Component {
             fillInformations: false,
             cancelConfirmation: false,
         });
+        this.setDefaultTable();
     }
 
     get lines() {
@@ -185,6 +187,15 @@ export class CartPage extends Component {
             this.selfOrder.notification.add(_t("You cannot edit a posted orderline !"), {
                 type: "danger",
             });
+        }
+    }
+
+    setDefaultTable() {
+        if (session.data.table_id) {
+            const table = this.selfOrder.models["restaurant.table"].get(session.data.table_id);
+            this.selfOrder.currentOrder.table_id = table;
+            this.selfOrder.currentTable = table;
+            this.router.addTableIdentifier(table);
         }
     }
 }


### PR DESCRIPTION
After this PR:
======
- If the QR code includes the table ID, users will no longer need to select  a table manually.

Task: 4663940
