### PR TITLE
[REV] l10n_in: Revert commit b1546585a17cb502b568d3abeb70966d56c8c40b

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -72,7 +72,7 @@ class AccountMove(models.Model):
             else:
                 move.l10n_in_state_id = False
 
-    @api.depends('l10n_in_state_id', 'l10n_in_gst_treatment')
+    @api.depends('l10n_in_state_id')
     def _compute_fiscal_position_id(self):
 
         def _get_fiscal_state(move, foreign_state):


### PR DESCRIPTION
In this commit: https://github.com/odoo/odoo/commit/b1546585a17cb502b568d3abeb70966d56c8c40b

The `l10n_in_gst_treatment` field was added to the `depends` of the fiscal position's compute method,
which in turn depends on the `state` field.

However, this is causing unnecessary recomputation when posting or resetting
invoices to draft, leading to issues.

No Task ID




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
