### PR TITLE
[IMP] purchase: redirect to merged RFQs list/form view after merge

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -875,7 +875,7 @@
     </record>
 
     <record id="action_merger" model="ir.actions.server">
-        <field name="name">Merge</field>
+        <field name="name">Merge RFQs</field>
         <field name="model_id" ref="purchase.model_purchase_order"/>
         <field name="binding_model_id" ref="purchase.model_purchase_order"/>
         <field name='group_ids' eval="[(4, ref('account.group_account_invoice'))]"/>


### PR DESCRIPTION
- Renamed the action `Merge` to `Merge RFQs` for better clarity.
- When merging RFQs, users are now redirected to a list/form of merged RFQs
  instead of just seeing a notification. which improves user experience by
  immediately showing the merged RFQs and no need to find them manually.

Task ID: [4627179](https://www.odoo.com/odoo/project/966/tasks/4627179)