### PR TITLE
[FIX] account_edi_ubl_cii: Always use PDF-A/3

### DIFF
--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -193,8 +193,7 @@ class AccountMoveSend(models.TransientModel):
         writer.addAttachment('factur-x.xml', xml_facturx, subtype='text/xml')
 
         # PDF-A.
-        if invoice_data.get('ubl_cii_xml_options', {}).get('ubl_cii_format') == 'facturx' \
-                and not writer.is_pdfa:
+        if not writer.is_pdfa:
             try:
                 writer.convert_to_pdfa()
             except Exception as e:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The factur-x.xml attachment always appended to generated account PDFs gives the appearance that all such PDFs are Factur-X compliant when they are not.

Current behavior before PR:
Despite the use of PDF-A/3 being mandatory in the Factur-X specification, and the factur-x.xml being always generated and attached to account.move PDF reports, the PDF is only converted to PDF-A/3 when the Factur-X format is explicitly checked to be attached in the "Send and Print" wizard in the account move form view. If a PDF is generated under any other conditions, notably with the use of the "Print" actions, it is not converted to PDF-A/3.
This is extremely consumer-unfriendly behavior. The difference in the result between doing it "wrong" and doing it "right" is *impossible to notice* for the average end user, since you have to open the PDF in a text editor to read the metadata to discover whether it is PDF-A/3 or not. In addition, it's *not communicated* that the "Send & Print" wizard is the only way to generate a legal Factur-X PDF, and that the "Print" actions do not. This behavior is frankly *inconsistent*, there is no reason to assume that these buttons do not both generate valid Factur-X invoice PDFs.

Desired behavior after PR is merged:

Every invoice PDF has a Factur-X XML attached and is in the PDF-A/3 Format, suitable to be used as a Factur-X electronic invoice. This way, Odoo systems are automatically compliant with the Electronic Invoicing requirement laws, and also prevent customer confusion about why sometimes the generated PDFs are valid Factur-X and sometimes they are not despite having the XML attached.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
