### PR TITLE
[FIX] hw_drivers: revert auto-checkout

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -113,7 +113,6 @@ class Manager(Thread):
         # Set scheduled actions
         schedule and schedule.every().day.at("00:00").do(helpers.get_certificate_status)
         schedule and schedule.every().day.at("00:00").do(helpers.reset_log_level)
-        schedule and platform.system() == 'Linux' and schedule.every().monday.at("00:00").do(helpers.check_git_branch, force_checkout=True)
 
         # Set up the websocket connection
         ws_client = WebsocketClient(self.ws_channel)

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -182,11 +182,10 @@ def check_certificate():
 
 @toggleable
 @require_db
-def check_git_branch(force_checkout=False, server_url=None):
+def check_git_branch(server_url=None):
     """Check if the local branch is the same as the connected Odoo DB and
     checkout to match it if needed.
 
-    :param force_checkout: Force the checkout to the db branch even if it's the same as the local one.
     :param server_url: The URL of the connected Odoo database (provided by decorator).
     """
     try:
@@ -216,7 +215,7 @@ def check_git_branch(force_checkout=False, server_url=None):
             db_branch,
         )
 
-        if db_branch != local_branch or force_checkout:
+        if db_branch != local_branch:
             try:
                 with writable():
                     subprocess.run(git + ['branch', '-m', db_branch], check=True)


### PR DESCRIPTION
This commit partially reverts commit a635539, as its behaviour was deemed too risky to the stability of the IoT box. The latest code is still checked out on boot, but it no longer happens automatically every Monday.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
