### PR TITLE
[UPD] purchase: separate function for filtering mergeable lines

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -756,15 +756,7 @@ class PurchaseOrder(models.Model):
                 # Merge RFQs into the oldest purchase order
                 rfqs -= oldest_rfq
                 for rfq_line in rfqs.order_line:
-                    existing_line = oldest_rfq.order_line.filtered(lambda l: l.display_type not in ['line_note', 'line_section'] and
-                                                                                l.product_id == rfq_line.product_id and
-                                                                                l.product_uom == rfq_line.product_uom and
-                                                                                l.product_packaging_id == rfq_line.product_packaging_id and
-                                                                                l.product_packaging_qty == rfq_line.product_packaging_qty and
-                                                                                l.analytic_distribution == rfq_line.analytic_distribution and
-                                                                                l.discount == rfq_line.discount and
-                                                                                abs(l.date_planned - rfq_line.date_planned).total_seconds() <= 86400  # 24 hours in seconds
-                                                                        )
+                    existing_line = oldest_rfq.order_line._filter_mergeable_rfq_lines(rfq_line)
                     if len(existing_line) > 1:
                         existing_line[0].product_qty += sum(existing_line[1:].mapped('product_qty'))
                         existing_line[1:].unlink()

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -670,6 +670,18 @@ class PurchaseOrderLine(models.Model):
             'view_mode': 'form',
         }
 
+    def _filter_mergeable_rfq_lines(self, rfq_line):
+        return self.filtered(
+            lambda l: l.display_type not in ['line_note', 'line_section'] and
+                 l.product_id == rfq_line.product_id and
+                 l.product_uom == rfq_line.product_uom and
+                 l.product_packaging_id == rfq_line.product_packaging_id and
+                 l.product_packaging_qty == rfq_line.product_packaging_qty and
+                 l.analytic_distribution == rfq_line.analytic_distribution and
+                 l.discount == rfq_line.discount and
+                 abs(l.date_planned - rfq_line.date_planned).total_seconds() <= 86400 # 24 hours in seconds
+        )
+
     def _merge_po_line(self, rfq_line):
         self.product_qty += rfq_line.product_qty
         self.price_unit = min(self.price_unit, rfq_line.price_unit)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Separate access point for mergeable PO lines. This makes it possible for inheriting modules to modify which PO lines should be mergeable and which not.

Current behavior before PR:
The filtering of mergeable PO lines happens within the merge function and is not accessible by inherited classes.

Desired behavior after PR is merged:
The separate function `_filter_mergeable_rfq_lines()` can be accessed and the behaviour adapted to client's needs.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
