### PR TITLE
[IMP] orm: Model.filtered(Domain) 

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -262,10 +262,10 @@ class HrLeave(models.Model):
         ])
         for holiday in self:
             conflicting_holidays = all_leaves.filtered_domain([
-                ('employee_id', '=', holiday.employee_id.id),
+                ('employee_id', 'in', holiday.employee_id.ids),
                 ('date_from', '<', holiday.date_to),
                 ('date_to', '>', holiday.date_from),
-                ('id', '!=', holiday.id),
+                ('id', 'not in', holiday.ids),
             ])
             if not conflicting_holidays:
                 holiday.dashboard_warning_message = False

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1190,8 +1190,7 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         with self.assertRaisesRegex(ValueError, r"^Invalid operator.*\('create_date', '>>', 'foo'\)$"):
             Country.search([('create_date', '>>', 'foo')])
 
-        # TODO make it "Invalid operator"" for consistency
-        with self.assertRaisesRegex(ValueError, r"^stray % in format '%'$"):
+        with self.assertRaisesRegex(ValueError, r"^Invalid operator"):
             Country.search([]).filtered_domain([('create_date', '>>', 'foo')])
 
         with self.assertRaisesRegex(ValueError, r"Invalid isoformat string"):

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -1925,8 +1925,8 @@ class PropertiesSearchCase(TransactionExpressionCase, TestPropertiesMixin):
         self.assertFalse(messages)
         messages = self._search(self.env['test_orm.message'], [('attributes.mychar', 'ilike', 'test')])
         self.assertEqual(messages, self.message_1 | self.message_2)
-        messages = self.env['test_orm.message'].search([('attributes.mychar', 'not ilike', 'test')])  # FIXME return message_3
-        self.assertFalse(messages)
+        messages = self.env['test_orm.message'].search([('attributes.mychar', 'not ilike', 'test')])
+        self.assertEqual(messages, self.message_3)
         messages = self._search(self.env['test_orm.message'], [('attributes.mychar', 'ilike', '"test"')])
         self.assertFalse(messages)
 
@@ -2152,13 +2152,16 @@ class PropertiesSearchCase(TransactionExpressionCase, TestPropertiesMixin):
         result = self._search(Model, [('attributes.mychar', 'ilike', 'hélène')])
         self.assertEqual(self.message_1 | self.message_2, result)
 
-        result = Model.search([('attributes.mychar', 'not ilike', 'Helene')])  # FIXME use _search
+        result = self._search(Model, [('attributes.mychar', 'not ilike', 'Helene')])
         self.assertNotIn(self.message_1, result)
         self.assertNotIn(self.message_2, result)
 
-        result = Model.search([('attributes.mychar', 'not ilike', 'hélène')])  # FIXME use _serach
+        result = self._search(Model, [('attributes.mychar', 'not ilike', 'hélène')])
         self.assertNotIn(self.message_1, result)
         self.assertNotIn(self.message_2, result)
+
+        result = self._search(Model, [('attributes.mychar', 'not ilike', '')])
+        self.assertFalse(result)
 
     def test_properties_field_search_orderby_string(self):
         """Test that we can order record by properties string values."""

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -2152,6 +2152,9 @@ class PropertiesSearchCase(TransactionExpressionCase, TestPropertiesMixin):
         result = self._search(Model, [('attributes.mychar', 'ilike', 'hélène')])
         self.assertEqual(self.message_1 | self.message_2, result)
 
+        result = self._search(Model, [('attributes.mychar', '=ilike', 'hél%')])
+        self.assertEqual(self.message_1 | self.message_2, result)
+
         result = self._search(Model, [('attributes.mychar', 'not ilike', 'Helene')])
         self.assertNotIn(self.message_1, result)
         self.assertNotIn(self.message_2, result)

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import babel.dates
 
+from odoo.addons.base.tests.test_expression import TransactionExpressionCase
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Command, Domain
 from odoo.tests import Form, TransactionCase, users
@@ -1881,14 +1882,13 @@ class PropertiesCase(TestPropertiesMixin):
             messages[1]['attributes']['many2many']
 
 
-class PropertiesSearchCase(TestPropertiesMixin):
+class PropertiesSearchCase(TransactionExpressionCase, TestPropertiesMixin):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.messages = cls.message_1 | cls.message_2 | cls.message_3
         cls.env['test_orm.message'].search([('id', 'not in', cls.messages.ids)]).unlink()
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_boolean(self):
         # search on boolean
         self.message_1.attributes = [{
@@ -1898,18 +1898,17 @@ class PropertiesSearchCase(TestPropertiesMixin):
             'definition_changed': True,
         }]
         self.message_2.attributes = {'myboolean': False}
-        messages = self.env['test_orm.message'].search([('attributes.myboolean', '=', True)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myboolean', '=', True)])
         self.assertEqual(messages, self.message_1)
-        messages = self.env['test_orm.message'].search([('attributes.myboolean', '!=', False)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myboolean', '!=', False)])
         self.assertEqual(messages, self.message_1)
-        messages = self.env['test_orm.message'].search([('attributes.myboolean', '=', False)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myboolean', '=', False)])
         # message 2 has a falsy boolean properties
         # message 3 doesn't have the properties (key in dict doesn't exist)
         self.assertEqual(messages, self.message_2 | self.message_3)
-        messages = self.env['test_orm.message'].search([('attributes.myboolean', '!=', True)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myboolean', '!=', True)])
         self.assertEqual(messages, self.message_2 | self.message_3)
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_char(self):
         # search on text properties
         self.message_1.attributes = [{
@@ -1920,15 +1919,15 @@ class PropertiesSearchCase(TestPropertiesMixin):
         }]
         self.message_2.attributes = {'mychar': 'TeSt'}
 
-        messages = self.env['test_orm.message'].search([('attributes.mychar', '=', 'Test')])
+        messages = self._search(self.env['test_orm.message'], [('attributes.mychar', '=', 'Test')])
         self.assertEqual(messages, self.message_1, "Should be able to search on a properties field")
-        messages = self.env['test_orm.message'].search([('attributes.mychar', '=', '"Test"')])
+        messages = self._search(self.env['test_orm.message'], [('attributes.mychar', '=', '"Test"')])
         self.assertFalse(messages)
-        messages = self.env['test_orm.message'].search([('attributes.mychar', 'ilike', 'test')])
+        messages = self._search(self.env['test_orm.message'], [('attributes.mychar', 'ilike', 'test')])
         self.assertEqual(messages, self.message_1 | self.message_2)
-        messages = self.env['test_orm.message'].search([('attributes.mychar', 'not ilike', 'test')])
+        messages = self.env['test_orm.message'].search([('attributes.mychar', 'not ilike', 'test')])  # FIXME return message_3
         self.assertFalse(messages)
-        messages = self.env['test_orm.message'].search([('attributes.mychar', 'ilike', '"test"')])
+        messages = self._search(self.env['test_orm.message'], [('attributes.mychar', 'ilike', '"test"')])
         self.assertFalse(messages)
 
         for forbidden_char in '! ()"\'.':
@@ -1945,7 +1944,7 @@ class PropertiesSearchCase(TestPropertiesMixin):
         self.message_3.discussion = self.message_2.discussion
         self.message_3.attributes = [{'name': 'mychar', 'value': False}]
         self.assertEqual(self._get_sql_properties(self.message_3), {'mychar': False})
-        messages = self.env['test_orm.message'].search([('attributes.mychar', '=', False)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.mychar', '=', False)])
         self.assertEqual(messages, self.message_3)
 
         # search falsy properties when the key doesn't exist in the dict
@@ -1955,13 +1954,14 @@ class PropertiesSearchCase(TestPropertiesMixin):
             "UPDATE test_orm_message SET attributes = '{}' WHERE id = %s",
             [self.message_3.id],
         )
-        messages = self.env['test_orm.message'].search([('attributes.mychar', '=', False)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.mychar', '=', False)])
         self.assertEqual(messages, self.message_2 | self.message_3)
 
-        messages = self.env['test_orm.message'].search([('attributes.mychar', '!=', False)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.mychar', '!=', False)])
         self.assertEqual(messages, self.message_1)
 
         # message 1 property contain a string but is not falsy so it's not returned
+        # TODO comparing to True makes no sense
         messages = self.env['test_orm.message'].search([('attributes.mychar', '!=', True)])
         self.assertEqual(messages, self.message_2 | self.message_3)
 
@@ -1974,13 +1974,12 @@ class PropertiesSearchCase(TestPropertiesMixin):
             [self.message_3.id],
         )
 
-        messages = self.env['test_orm.message'].search([('attributes.mychar', '=', False)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.mychar', '=', False)])
         self.assertEqual(messages, self.message_2 | self.message_3)
 
-        messages = self.env['test_orm.message'].search([('attributes.mychar', '!=', False)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.mychar', '!=', False)])
         self.assertEqual(messages, self.message_1)
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_float(self):
         # search on float
         self.message_1.attributes = [{
@@ -1990,18 +1989,17 @@ class PropertiesSearchCase(TestPropertiesMixin):
             'definition_changed': True,
         }]
         self.message_2.attributes = {'myfloat': 5.55}
-        messages = self.env['test_orm.message'].search([('attributes.myfloat', '>', 4.4)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myfloat', '>', 4.4)])
         self.assertEqual(messages, self.message_2)
-        messages = self.env['test_orm.message'].search([('attributes.myfloat', '<', 4.4)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myfloat', '<', 4.4)])
         self.assertEqual(messages, self.message_1)
-        messages = self.env['test_orm.message'].search([('attributes.myfloat', '>', 1.1)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myfloat', '>', 1.1)])
         self.assertEqual(messages, self.message_1 | self.message_2)
-        messages = self.env['test_orm.message'].search([('attributes.myfloat', '<=', 1.1)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myfloat', '<=', 1.1)])
         self.assertFalse(messages)
-        messages = self.env['test_orm.message'].search([('attributes.myfloat', '=', 3.14)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myfloat', '=', 3.14)])
         self.assertEqual(messages, self.message_1)
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_integer(self):
         # search on integer
         self.messages.discussion = self.discussion_1
@@ -2014,19 +2012,18 @@ class PropertiesSearchCase(TestPropertiesMixin):
         self.message_2.attributes = {'myint': 111}
         self.message_3.attributes = {'myint': -2}
 
-        messages = self.env['test_orm.message'].search([('attributes.myint', '>', 4)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myint', '>', 4)])
         self.assertEqual(messages, self.message_1 | self.message_2)
-        messages = self.env['test_orm.message'].search([('attributes.myint', '<', 4)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myint', '<', 4)])
         self.assertEqual(messages, self.message_3)
-        messages = self.env['test_orm.message'].search([('attributes.myint', '=', 111)])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myint', '=', 111)])
         self.assertEqual(messages, self.message_2)
         # search on the JSONified value (operator "->>")
-        messages = self.env['test_orm.message'].search([('attributes.myint', 'ilike', '1')])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myint', 'ilike', '1')])
         self.assertEqual(messages, self.message_2)
-        messages = self.env['test_orm.message'].search([('attributes.myint', 'not ilike', '1')])
+        messages = self._search(self.env['test_orm.message'], [('attributes.myint', 'not ilike', '1')])
         self.assertEqual(messages, self.message_1 | self.message_3)
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_many2many(self):
         self.messages.discussion = self.discussion_1
         partners = self.env['res.partner'].create([{'name': 'A'}, {'name': 'B'}, {'name': 'C'}])
@@ -2039,25 +2036,27 @@ class PropertiesSearchCase(TestPropertiesMixin):
         }]
         self.message_2.attributes = {'mymany2many': [partners[1].id]}
         self.message_3.attributes = {'mymany2many': [partners[2].id]}
+
+        # NOTE: filtered won't work because each message can point to a
+        # different model or even have a different data type
         messages = self.env['test_orm.message'].search(
-            [('attributes.mymany2many', 'in', partners[0].id)])
+            [('attributes.mymany2many', 'in', partners[0].ids)])
         self.assertEqual(messages, self.message_1)
         messages = self.env['test_orm.message'].search(
-            [('attributes.mymany2many', 'in', partners[1].id)])
+            [('attributes.mymany2many', 'in', partners[1].ids)])
         self.assertEqual(messages, self.message_1 | self.message_2)
         messages = self.env['test_orm.message'].search(
-            [('attributes.mymany2many', 'in', partners[2].id)])
+            [('attributes.mymany2many', 'in', partners[2].ids)])
         self.assertEqual(messages, self.message_1 | self.message_3)
         messages = self.env['test_orm.message'].search(
-            [('attributes.mymany2many', 'not in', partners[0].id)])
+            [('attributes.mymany2many', 'not in', partners[0].ids)])
         self.assertEqual(messages, self.message_2 | self.message_3)
 
         # IN operator (not supported on many2many and return weird results)
         messages = self.env['test_orm.message'].search(
-            [('attributes.mymany2many', 'in', [partners[0].id, partners[1].id])])
+            [('attributes.mymany2many', 'in', partners[0:2].ids)])
         self.assertEqual(messages, self.message_2)  # should be self.message_1 | self.message_2
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_many2one(self):
         self.messages.discussion = self.discussion_1
         self.message_1.attributes = [{
@@ -2070,6 +2069,8 @@ class PropertiesSearchCase(TestPropertiesMixin):
         self.message_2.attributes = {'mypartner': self.partner_2.id}
         self.message_3.attributes = {'mypartner': False}
 
+        # NOTE: filtered won't work because each message can point to a
+        # different model or even have a different data type
         messages = self.env['test_orm.message'].search(
             [('attributes.mypartner', 'in', [self.partner.id, self.partner_2.id])])
         self.assertEqual(messages, self.message_1 | self.message_2)
@@ -2082,7 +2083,6 @@ class PropertiesSearchCase(TestPropertiesMixin):
             [('attributes.mypartner', 'ilike', self.partner.display_name)])
         self.assertFalse(messages, "The ilike on relational properties is not supported")
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_tags(self):
         self.messages.discussion = self.discussion_1
         self.message_1.attributes = [{
@@ -2128,7 +2128,6 @@ class PropertiesSearchCase(TestPropertiesMixin):
         messages = self.env['test_orm.message'].search([('attributes.mytags', 'not in', ['a', 'b'])])
         self.assertEqual(messages, self.message_3)
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_unaccent(self):
         if not self.registry.has_unaccent:
             # To enable unaccent feature:
@@ -2147,21 +2146,20 @@ class PropertiesSearchCase(TestPropertiesMixin):
         }]
         self.message_2.attributes = {'mychar': 'Helene'}
 
-        result = Model.search([('attributes.mychar', 'ilike', 'Helene')])
+        result = self._search(Model, [('attributes.mychar', 'ilike', 'Helene')])
         self.assertEqual(self.message_1 | self.message_2, result)
 
-        result = Model.search([('attributes.mychar', 'ilike', 'hélène')])
+        result = self._search(Model, [('attributes.mychar', 'ilike', 'hélène')])
         self.assertEqual(self.message_1 | self.message_2, result)
 
-        result = Model.search([('attributes.mychar', 'not ilike', 'Helene')])
+        result = Model.search([('attributes.mychar', 'not ilike', 'Helene')])  # FIXME use _search
         self.assertNotIn(self.message_1, result)
         self.assertNotIn(self.message_2, result)
 
-        result = Model.search([('attributes.mychar', 'not ilike', 'hélène')])
+        result = Model.search([('attributes.mychar', 'not ilike', 'hélène')])  # FIXME use _serach
         self.assertNotIn(self.message_1, result)
         self.assertNotIn(self.message_2, result)
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_orderby_string(self):
         """Test that we can order record by properties string values."""
         (self.message_1 | self.message_2 | self.message_3).discussion = self.discussion_1
@@ -2190,7 +2188,6 @@ class PropertiesSearchCase(TestPropertiesMixin):
         self.assertEqual(result[1], self.message_1)
         self.assertEqual(result[2], self.message_2)
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_order_integer(self):
         """Test that we can order record by properties integer values."""
         (self.message_1 | self.message_2 | self.message_3).discussion = self.discussion_1
@@ -2219,7 +2216,6 @@ class PropertiesSearchCase(TestPropertiesMixin):
         self.assertEqual(result[1], self.message_3)
         self.assertEqual(result[2], self.message_1)
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_order_injection(self):
         """Check the restriction on the property name."""
         self.message_1.attributes = [{
@@ -2244,12 +2240,10 @@ class PropertiesSearchCase(TestPropertiesMixin):
                 with self.assertRaises(UserError), self.assertQueryCount(0):
                     self.env['test_orm.message'].search(domain=[], order=order)
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search(self):
         with self.assertRaises(ValueError):
             self.env['test_orm.message'].search([('attributes', '=', '"Test"')])
 
-    @mute_logger('odoo.fields')
     def test_properties_field_search_read_false(self):
         Model = self.env['test_orm.message']
 

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -2059,11 +2059,11 @@ class PropertiesSearchCase(TestPropertiesMixin):
 
     @mute_logger('odoo.fields')
     def test_properties_field_search_many2one(self):
-        # many2one are just like integer
         self.messages.discussion = self.discussion_1
         self.message_1.attributes = [{
             'name': 'mypartner',
-            'type': 'integer',
+            'type': 'many2one',
+            'comodel': 'res.partner',
             'value': self.partner.id,
             'definition_changed': True,
         }]

--- a/odoo/addons/test_orm/tests/test_search.py
+++ b/odoo/addons/test_orm/tests/test_search.py
@@ -1,3 +1,4 @@
+from odoo.addons.base.tests.test_expression import TransactionExpressionCase
 from odoo.fields import Command
 from odoo.tests import TransactionCase
 
@@ -1130,7 +1131,7 @@ class TestFlushSearch(TransactionCase):
         self.assertEqual(self.env['test_orm.custom.table_query_sql'].search([]).sum_quantity, 25)
 
 
-class TestDatePartNumber(TransactionCase):
+class TestDatePartNumber(TransactionExpressionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -1166,25 +1167,29 @@ class TestDatePartNumber(TransactionCase):
             result = Person.search([('birthday.iso_week_number', '=', '6')])
             self.assertEqual(result, self.person)
 
+    def test_datetime_filtered(self):
+        Person = self.env["test_orm.person"].with_context(active_test=False)
+        self.assertEqual(self._search(Person, [('birthday.month_number', '=', 2)]), self.person)
+
     def test_many2one(self):
-        result = self.env["test_orm.lesson"].search([('teacher_id.birthday.month_number', '=', 2)])
+        result = self._search(self.env["test_orm.lesson"], [('teacher_id.birthday.month_number', '=', 2)])
         self.assertEqual(result, self.lesson)
 
     def test_many2many(self):
-        result = self.env["test_orm.lesson"].search([('attendee_ids.birthday.month_number', '=', 2)])
+        result = self._search(self.env["test_orm.lesson"], [('attendee_ids.birthday.month_number', '=', 2)])
         self.assertEqual(result, self.lesson)
 
     def test_related_field(self):
-        result = self.env["test_orm.lesson"].search([('teacher_birthdate.month_number', '=', 2)])
+        result = self._search(self.env["test_orm.lesson"], [('teacher_birthdate.month_number', '=', 2)])
         self.assertEqual(result, self.lesson)
 
     def test_inherit(self):
         account = self.env["test_orm.person.account"].create({"person_id": self.person.id, "activation_date": "2020-03-09"})
 
-        result = self.env["test_orm.person.account"].search([('activation_date.quarter_number', '=', 1)])
+        result = self._search(self.env["test_orm.person.account"], [('activation_date.quarter_number', '=', 1)])
         self.assertEqual(result, account)
 
-        result = self.env["test_orm.person.account"].search([('person_id.birthday.month_number', '=', 2)])
+        result = self._search(self.env["test_orm.person.account"], [('person_id.birthday.month_number', '=', 2)])
         self.assertEqual(result, account)
 
 

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1381,6 +1381,23 @@ class Field(typing.Generic[T]):
 
     ############################################################################
     #
+    # Expressions and filtering of records
+    #
+
+    def expression_getter(self, field_expr: str) -> Callable[[BaseModel], typing.Any]:
+        """ Given some field expression (what you find in domain conditions),
+        return a function that returns the corresponding expression for a record::
+
+            field = record._fields['create_date']
+            get_value = field.expression_getter('create_date.month_number')
+            month_number = get_value(record)
+        """
+        if field_expr == self.name:
+            return self.__get__
+        raise ValueError(f"Expression not supported on {self}: {field_expr!r}")
+
+    ############################################################################
+    #
     # Alternatively stored fields: if fields don't have a `column_type` (not
     # stored as regular db columns) they go through a read/create/write
     # protocol instead

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -7,8 +7,11 @@ import functools
 import collections
 import itertools
 import logging
+import operator as pyoperator
+import re
 import typing
 import warnings
+from collections.abc import Set as AbstractSet
 from operator import attrgetter
 
 from psycopg2.extras import Json as PsycopgJson
@@ -28,6 +31,7 @@ if typing.TYPE_CHECKING:
     from .identifiers import IdType
     from .registry import Registry
     from .types import BaseModel, DomainType, ModelType, Self, ValuesType
+    M = typing.TypeVar("M", bound=BaseModel)
 T = typing.TypeVar("T")
 
 IR_MODELS = (
@@ -38,6 +42,7 @@ IR_MODELS = (
 COMPANY_DEPENDENT_FIELDS = (
     'char', 'float', 'boolean', 'integer', 'text', 'many2one', 'date', 'datetime', 'selection', 'html'
 )
+PYTHON_INEQUALITY_OPERATOR = {'<': pyoperator.lt, '>': pyoperator.gt, '<=': pyoperator.le, '>=': pyoperator.ge}
 
 _logger = logging.getLogger('odoo.fields')
 
@@ -1395,6 +1400,89 @@ class Field(typing.Generic[T]):
         if field_expr == self.name:
             return self.__get__
         raise ValueError(f"Expression not supported on {self}: {field_expr!r}")
+
+    def filter_function(self, records: M, field_expr: str, operator: str, value) -> Callable[[M], M]:
+        assert operator not in NEGATIVE_CONDITION_OPERATORS, "only positive operators are implemented"
+        getter = self.expression_getter(field_expr)
+        # assert not isinstance(value, (SQL, Query))
+
+        # -------------------------------------------------
+        # operator: in (equality)
+        if operator == 'in':
+            assert isinstance(value, COLLECTION_TYPES) and value, \
+                f"filter_function() 'in' operator expects a collection, not a {type(value)}"
+            if not isinstance(value, AbstractSet):
+                value = set(value)
+            if False in value or self.falsy_value in value:
+                if len(value) == 1:
+                    return lambda rec: not getter(rec)
+                return lambda rec: (val := getter(rec)) in value or not val
+            return lambda rec: getter(rec) in value
+
+        # -------------------------------------------------
+        # operator: like
+        if operator.endswith('like'):
+            # we may get a value which is not a string
+            if operator.endswith('ilike'):
+                # ilike uses unaccent and lower-case comparison
+                unaccent_python = records.env.registry.unaccent_python
+
+                def unaccent(x):
+                    return unaccent_python(str(x).lower()) if x else ''
+            else:
+                def unaccent(x):
+                    return str(x) if x else ''
+
+            # build a regex that matches the SQL-like expression
+            # note that '\' is used for escaping in SQL
+            def build_like_regex(value: str, exact: bool):
+                yield '^' if exact else '.*'
+                escaped = False
+                for char in value:
+                    if escaped:
+                        escaped = False
+                        yield re.escape(char)
+                    elif char == '\\':
+                        escaped = True
+                    elif char == '%':
+                        yield '.*'
+                    elif char == '_':
+                        yield '.'
+                    else:
+                        yield re.escape(char)
+                if exact:
+                    yield '$'
+                # no need to match r'.*' in else because we only use .match()
+
+            like_regex = re.compile("".join(build_like_regex(unaccent(value), "=" in operator)))
+            return lambda rec: like_regex.match(unaccent(getter(rec)))
+
+        # -------------------------------------------------
+        # operator: inequality
+        if pyop := PYTHON_INEQUALITY_OPERATOR.get(operator):
+            can_be_null = False
+            if (null_value := self.falsy_value) is not None:
+                value = value or null_value
+                can_be_null = (
+                    null_value < value if operator == '<' else
+                    null_value > value if operator == '>' else
+                    null_value <= value if operator == '<=' else
+                    null_value >= value  # operator == '>='
+                )
+
+            def check_inequality(rec):
+                rec_value = getter(rec)
+                try:
+                    if rec_value is False or rec_value is None:
+                        return can_be_null
+                    return pyop(rec_value, value)
+                except (ValueError, TypeError):
+                    # ignoring error, type mismatch
+                    return False
+            return check_inequality
+
+        # -------------------------------------------------
+        raise NotImplementedError(f"Invalid simple operator {operator!r}")
 
     ############################################################################
     #

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -121,3 +121,12 @@ class Id(Field[IdType | typing.Literal[False]]):
         # do not flush, just return the identifier
         assert self.store, 'id field must be stored'
         return SQL.identifier(alias, self.name)
+
+    def expression_getter(self, field_expr):
+        if field_expr != 'id.origin':
+            return super().expression_getter(field_expr)
+
+        def getter(record):
+            return (id_ := record._ids[0]) or getattr(id_, 'origin', None) or False
+
+        return getter

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -724,10 +724,13 @@ class Properties(Field):
         if isinstance(value, str):
             sql_left = SQL("(%s ->> %s)", raw_sql_field, property_name)  # JSONified value
             sql_right = SQL("%s", value)
-            return SQL(
+            sql = SQL(
                 "%s%s%s",
                 unaccent(sql_left), sql_operator, unaccent(sql_right),
             )
+            if Domain.is_negative_operator(operator):
+                sql = SQL("(%s OR %s IS NULL)", sql, sql_left)
+            return sql
 
         sql_right = SQL("%s", json.dumps(value))
         return SQL(

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -714,12 +714,19 @@ class Properties(Field):
             combine_sql = SQL(" OR ") if operator == 'in' else SQL(" AND ")
             return SQL("(%s)", combine_sql.join(sqls))
 
-        sql_operator = SQL_OPERATORS[operator]
-        if operator in ('ilike', 'not ilike'):
-            value = f'%{value}%'
-            unaccent = model.env.registry.unaccent
-        else:
-            unaccent = lambda x: x  # noqa: E731
+        unaccent = lambda x: x  # noqa: E731
+        if operator.endswith('like'):
+            if operator.endswith('ilike'):
+                unaccent = model.env.registry.unaccent
+            if '=' in operator:
+                value = str(value)
+            else:
+                value = f'%{value}%'
+
+        try:
+            sql_operator = SQL_OPERATORS[operator]
+        except KeyError:
+            raise ValueError(f"Invalid operator {operator} for Properties")
 
         if isinstance(value, str):
             sql_left = SQL("(%s ->> %s)", raw_sql_field, property_name)  # JSONified value

--- a/odoo/orm/fields_temporal.py
+++ b/odoo/orm/fields_temporal.py
@@ -10,9 +10,10 @@ from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT as DATETIME_FORMAT
 from odoo.tools import SQL, date_utils
 
 from .fields import Field, _logger
-from .utils import READ_GROUP_NUMBER_GRANULARITY
+from .utils import parse_field_expr, READ_GROUP_NUMBER_GRANULARITY
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Callable
     from odoo.tools import Query
 
     from .models import BaseModel
@@ -30,6 +31,51 @@ class BaseDate(Field[T | typing.Literal[False]], typing.Generic[T]):
     end_of = staticmethod(date_utils.end_of)
     add = staticmethod(date_utils.add)
     subtract = staticmethod(date_utils.subtract)
+
+    def expression_getter(self, field_expr):
+        _fname, property_name = parse_field_expr(field_expr)
+        if not property_name:
+            return super().expression_getter(field_expr)
+
+        get_value = self.__get__
+        get_property = self._expression_property_getter(property_name)
+        return lambda record: (value := get_value(record)) and get_property(value)
+
+    def _expression_property_getter(self, property_name: str) -> Callable[[T], typing.Any]:
+        """ Return a function that maps a field value (date or datetime) to the
+        given ``property_name``.
+        """
+        match property_name:
+            case 'tz':
+                return lambda value: value
+            case 'year_number':
+                return lambda value: value.year
+            case 'quarter_number':
+                return lambda value: value.month // 4 + 1
+            case 'month_number':
+                return lambda value: value.month
+            case 'iso_week_number':
+                return lambda value: value.isocalendar().week
+            case 'day_of_year':
+                return lambda value: value.timetuple().tm_yday
+            case 'day_of_month':
+                return lambda value: value.day
+            case 'day_of_week':
+                return lambda value: value.timetuple().tm_wday
+            case 'hour_number' if self.type == 'datetime':
+                return lambda value: value.hour
+            case 'minute_number' if self.type == 'datetime':
+                return lambda value: value.minute
+            case 'second_number' if self.type == 'datetime':
+                return lambda value: value.second
+            case 'hour_number' | 'minute_number' | 'second_number':
+                # for dates, it is always 0
+                return lambda value: 0
+        assert property_name not in READ_GROUP_NUMBER_GRANULARITY, f"Property not implemented {property_name}"
+        raise ValueError(
+            f"Error when processing the granularity {property_name} is not supported. "
+            f"Only {', '.join(READ_GROUP_NUMBER_GRANULARITY.keys())} are supported"
+        )
 
     def property_to_sql(self, field_sql: SQL, property_name: str, model: BaseModel, alias: str, query: Query) -> SQL:
         sql_expr = field_sql
@@ -230,6 +276,22 @@ class Datetime(BaseDate[datetime]):
             the time portion will be midnight (00:00:00).
         """
         return value.strftime(DATETIME_FORMAT) if value else False
+
+    def expression_getter(self, field_expr: str) -> Callable[[BaseModel], typing.Any]:
+        if field_expr == self.name:
+            return self.__get__
+        _fname, property_name = parse_field_expr(field_expr)
+        get_property = self._expression_property_getter(property_name)
+
+        def getter(record):
+            dt = self.__get__(record)
+            if not dt:
+                return False
+            if (tz := record.env.context.get('tz')) and tz in pytz.all_timezones_set:
+                dt = dt.astimezone(pytz.timezone(tz))
+            return get_property(dt)
+
+        return getter
 
     def convert_to_cache(self, value, record, validate=True):
         return self.to_datetime(value)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Rewrite `BaseModel.filtered_domain` and `BaseModel.filtered` by delegating the implementation to the `Domain` class.
To ease the implementation, we introduce methods on fields: to transforms a field expression into a function, and one that implements the filtering function (similar to what field_to_sql does).


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
