### PR TITLE
[FIX] l10n_es_edi_facturae: add extra info for invoice lines in XML

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -106,6 +106,7 @@
             <InvoiceLine>
                 <ReceiverTransactionReference t-out="line.get('ReceiverTransactionReference')"/>
                 <FileReference t-out="line.get('FileReference')"/>
+                <ReceiverContractReference t-out="line.get('ReceiverContractReference')"/>
                 <FileDate t-out="line.get('FileDate')"/>
                 <SequenceNumber t-out="line.get('SequenceNumber')"/>
                 <ItemDescription t-out="line['ItemDescription']"/>

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -219,6 +219,7 @@ class AccountMove(models.Model):
         }
         taxes = []
         taxes_withheld = []
+        invoice_ref = self.ref[:20] if self.ref else False
         for line in self.invoice_line_ids:
             if line.display_type in {'line_section', 'line_note'}:
                 continue
@@ -255,12 +256,13 @@ class AccountMove(models.Model):
             receiver_transaction_reference = (
                 line.sale_line_ids.order_id.client_order_ref[:20]
                 if 'sale_line_ids' in line._fields and line.sale_line_ids.order_id.client_order_ref
-                else False
+                else invoice_ref
             )
 
             invoice_line_values.update({
                 'ReceiverTransactionReference': receiver_transaction_reference,
-                'FileReference': self.ref[:20] if self.ref else False,
+                'FileReference': invoice_ref,
+                'ReceiverContractReference': invoice_ref,
                 'FileDate': fields.Date.context_today(self),
                 'ItemDescription': line.name,
                 'Quantity': line.quantity,

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -116,7 +116,9 @@
       </InvoiceTotals>
       <Items>
         <InvoiceLine>
+          <ReceiverTransactionReference>ABCD-2023-001</ReceiverTransactionReference>
           <FileReference>ABCD-2023-001</FileReference>
+          <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -138,7 +140,9 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
+          <ReceiverTransactionReference>ABCD-2023-001</ReceiverTransactionReference>
           <FileReference>ABCD-2023-001</FileReference>
+          <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_es_edi_facturae
- Switch to a Spanish company (e.g. ES Company)
- Create an invoice:
  * Customer: [a Spanish customer] (e.g. Ayuntamiento De Bilbao)
  * Product: [any]
  * Customer Reference: [anything]
- Confirm the invoice
- Generate Facturae edi file via "Send & Print" button
- Check the generated XML

**Issue:**
When submitting the XML to FACe service, the XML is rejected because "ReceiverTransactionReference" and "ReceiverContractReference" are not defined for each "InvoiceLine" element.
There are just defined for the invoice in general in "FileReference" element.
According to the official documentation
https://www.facturae.gob.es/formato/Paginas/version-3-2.aspx they can be defined in "InvoiceIssueData" and "InvoiceLine". FACe seems to require it in "InvoiceLine".

**Solution:**
Also add "ReceiverContractReference" in "InvoiceLine" and fall back on customer reference of the invoice for "ReceiverTransactionReference" of the line.

opw-4579987




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
