### PR TITLE
[IMP] project_todo: enable history feature in todo app

### DIFF
--- a/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
@@ -1,7 +1,11 @@
-import { onWillStart } from "@odoo/owl";
+import { markup, onWillStart } from "@odoo/owl";
 
+import { HistoryDialog } from "@html_editor/components/history_dialog/history_dialog";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
+import { useService } from "@web/core/utils/hooks";
+import { escape } from "@web/core/utils/strings";
 import { FormControllerWithHTMLExpander } from "@resource/views/form_with_html_expander/form_controller_with_html_expander";
 import { TodoFormCogMenu } from "./todo_form_cog_menu";
 
@@ -18,13 +22,29 @@ export class TodoFormController extends FormControllerWithHTMLExpander {
 
     setup() {
         super.setup();
+        this.notifications = useService("notification");
         onWillStart(async () => {
             this.projectAccess = await user.hasGroup("project.group_project_user");
         });
     }
 
+    /**
+     * @override
+     */
+    getStaticActionMenuItems() {
+        return {
+            ...super.getStaticActionMenuItems(),
+            openHistoryDialog: {
+                sequence: 50,
+                icon: "fa fa-history",
+                description: _t("Version History"),
+                callback: () => this.openHistoryDialog(),
+            },
+        };
+    }
+
     get actionMenuItems() {
-        const actionToKeep = ["archive", "unarchive", "duplicate", "delete"];
+        const actionToKeep = ["archive", "unarchive", "duplicate", "delete", "openHistoryDialog"];
         const menuItems = super.actionMenuItems;
         const filteredActions =
             menuItems.action?.filter((action) => actionToKeep.includes(action.key)) || [];
@@ -47,5 +67,50 @@ export class TodoFormController extends FormControllerWithHTMLExpander {
         menuItems.action = filteredActions;
         menuItems.print = [];
         return menuItems;
+    }
+
+    async openHistoryDialog() {
+        const record = this.model.root;
+        const versionedFieldName = 'description';
+        const historyMetadata = record.data["html_field_history_metadata"]?.[versionedFieldName];
+        if (!historyMetadata) {
+            this.notifications.add(
+                escape(_t(
+                    "The To-do description lacks any past content that could be restored at the moment."
+                ))
+            );
+            return;
+        }
+
+        this.dialogService.add(
+            HistoryDialog,
+            {
+                title: _t("To-do History"),
+                noContentHelper: markup(
+                    `<span class='text-muted fst-italic'>${escape(
+                        _t(
+                            "The To-do description was empty at the time."
+                        )
+                    )}</span>`
+                ),
+                recordId: record.resId,
+                recordModel: this.props.resModel,
+                versionedFieldName,
+                historyMetadata,
+                restoreRequested: (html, close) => {
+                    this.dialogService.add(ConfirmationDialog, {
+                        title: _t("Are you sure you want to restore this version?"),
+                        body: _t("Restoring will replace the current content with the selected version. Any unsaved changes will be lost."),
+                        confirm: () => {
+                            const restoredData = {};
+                            restoredData[versionedFieldName] = html;
+                            record.update(restoredData);
+                            close();
+                        },
+                        confirmLabel: _t("Restore"),
+                    });
+                },
+            },
+        );
     }
 }

--- a/addons/project_todo/static/tests/tours/project_todo_history.js
+++ b/addons/project_todo/static/tests/tours/project_todo_history.js
@@ -1,0 +1,128 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+const baseDescriptionContent = "Test project todo history version";
+const descriptionField = `div.note-editable.odoo-editor-editable div.o-paragraph`;
+function changeDescriptionContentAndSave(newContent) {
+    const newText = `${baseDescriptionContent} ${newContent}`;
+    return [
+        {
+            // force focus on editable so editor will create initial p (if not yet done)
+            trigger: "div.note-editable.odoo-editor-editable",
+            run: "click",
+        },
+        {
+            trigger: descriptionField,
+            run: `editor ${newText}`,
+        },
+        {
+            trigger: "button.o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Wait the form is saved",
+            trigger: ".o_form_saved",
+        },
+    ];
+}
+
+registry.category("web_tour.tours").add("project_todo_history_tour", {
+    url: "/odoo",
+    steps: () => [stepUtils.showAppsMenuItem(), {
+        content: "Open the Todo app",
+        trigger: ".o_app[data-menu-xmlid='project_todo.menu_todo_todos']",
+        run: "click",
+    },
+    {
+        content: "Open Test Todo",
+        trigger: ".o_kanban_view .o_kanban_record:contains(Test History Todo)",
+        run: "click",
+    },
+        // edit the description content 3 times and save after each edit
+        ...changeDescriptionContentAndSave("0"),
+        ...changeDescriptionContentAndSave("1"),
+        ...changeDescriptionContentAndSave("2"),
+        ...changeDescriptionContentAndSave("3"),
+    {
+        content: "Go back to kanban view of todos. this step is added because it takes some time to save the changes, so it's a sort of timeout to wait a bit for the save",
+        trigger: ".o_back_button a",
+        run: "click",
+    },
+    {
+        content: "Open Test Todo",
+        trigger: ".o_kanban_view .o_kanban_record:contains(Test History Todo)",
+        run: "click",
+    },
+    {
+        content: "Open History Dialog",
+        trigger: ".o_form_view .o_cp_action_menus i.fa-cog",
+        run: "click",
+    },
+    {
+        trigger: ".dropdown-menu",
+    },
+    {
+        content: "Open History Dialog",
+        trigger: ".o_menu_item i.fa-history",
+        run: "click",
+    }, {
+        content: "Verify that 4 revisions are displayed (default empty description after the creation of the todo + 3 edits)",
+        trigger: ".modal .html-history-dialog .revision-list .btn",
+        run: function () {
+            const items = document.querySelectorAll(".revision-list .btn");
+            if (items.length !== 4) {
+                throw new Error('Expect 4 Revisions in the history dialog, got ' + items.length);
+            }
+        },
+    }, {
+        content: "Verify that the active revision (revision 4) is related to the third edit",
+        trigger: `.modal .history-container .tab-pane:contains("${baseDescriptionContent} 2")`,
+        run: "click",
+    }, {
+        content: "Go to the third revision related to the second edit",
+        trigger: ".modal .html-history-dialog .revision-list .btn:nth-child(2)",
+        run: "click",
+    }, {
+        content: "Verify that the active revision is the one clicked in the previous step",
+        trigger: `.modal .history-container .tab-pane:contains("${baseDescriptionContent} 1")`,
+        run: "click",
+    }, {
+        content: "Go to comparison tab",
+        trigger: ".modal .history-container .nav-item:contains(Comparison) a",
+        run: "click",
+    }, {
+        content: "Verify comparaison text",
+        trigger: ".modal .history-container .tab-pane",
+        run: function () {
+            const comparaisonHtml = this.anchor.innerHTML;
+            const correctHtml = `<added>${baseDescriptionContent} 1</added><removed>${baseDescriptionContent} 3</removed>`;
+            if (!comparaisonHtml.includes(correctHtml)) {
+                console.error(`Expect comparison to be ${correctHtml}, got ${comparaisonHtml}`);
+            }
+        },
+    }, {
+        content: "Click on Restore History btn to get back to the selected revision in the previous step",
+        trigger: ".modal button.btn-primary:contains(/^Restore history$/)",
+        run: "click",
+    }, {
+        content: "Verify the confirmation dialog is opened",
+        trigger: ".modal button.btn-primary:contains(/^Restore$/)",
+        run: "click",
+    }, {
+        content: "Verify that the description contains the right text after the restore",
+        trigger: descriptionField,
+        run: function () {
+            const p = this.anchor?.innerText;
+            const expected = `${baseDescriptionContent} 1`;
+            if (p !== expected) {
+                throw new Error(`Expect description to be ${expected}, got ${p}`);
+            }
+        }
+    }, {
+        trigger: "button.o_form_button_save",
+        run: "click",
+    }, {
+        content: "Wait the form is saved",
+        trigger: ".o_form_saved",
+    },
+]});

--- a/addons/project_todo/tests/test_todo_ui.py
+++ b/addons/project_todo/tests/test_todo_ui.py
@@ -62,3 +62,14 @@ class TestTodoUi(HttpCaseWithUserDemo):
             'email': 'mitchell.admin@example.com',
         })
         self.start_tour("/odoo", 'project_todo_main_functions', login='admin')
+
+    @users('admin')
+    def test_project_todo_history(self):
+        """This tour will check that the history works properly."""
+
+        self.env['project.task'].create({
+            'name': 'Test History Todo',
+            'project_id': False
+        })
+
+        self.start_tour('/odoo', 'project_todo_history_tour', login='admin')

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -83,6 +83,7 @@
             <form string="To-do"
                   class="o_todo_form_view"
                   js_class="todo_form">
+                <field name="html_field_history_metadata" invisible="1"/>
                 <header>
                     <field name="personal_stage_type_id"
                            domain="[('user_id','=',uid)]"


### PR DESCRIPTION
Purpose:
- Allow users to track and restore previous versions of their tasks using the "Version History" feature.

Specifications:
- Added a "Version History" action in the gear icon menu.
- Added a History Dialog Box to display all previous versions.
- Users can restore any previous version from the history.

Task-4236687