### PR TITLE
[FIX] l10n_din5008: resize footer font

### DIFF
--- a/addons/l10n_din5008/static/src/scss/report_din5008.scss
+++ b/addons/l10n_din5008/static/src/scss/report_din5008.scss
@@ -106,7 +106,7 @@
                     vertical-align: baseline;
                     padding-right: 3mm;
                     li {
-                        font-size: 0.8em;
+                        font-size: 0.7em;
                         p {
                             line-height: 1.3em;
                         }


### PR DESCRIPTION
## Issue:
A standard IBAN always breaks into two lines on the DIN 5008 report.

## Steps to reproduce:
- Install l10n_de;
- Change to DE Company;
- Navigate to Settings;
- Under the Companies section, click `Configure Document Layout`;
- Select `DIN 5008` layout;
- Check footer display.

## Cause:
The commit 3a139b15a5270fb466b608b340013c93214557bb reset the font-size without thinking about the IBAN display.

opw-4680515

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
