### PR TITLE
[FIX] point_of_sale: Cash rounding of change with tax included and ro…

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -5,6 +5,7 @@ import { formatDate, formatDateTime, serializeDateTime } from "@web/core/l10n/da
 import { omit } from "@web/core/utils/objects";
 import { parseUTCString, qrCodeSrc, random5Chars, uuidv4, gte, lt } from "@point_of_sale/utils";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
+import { roundCurrency } from "@point_of_sale/app/models/utils/currency";
 import { computeComboItems } from "./utils/compute_combo_items";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 
@@ -213,6 +214,7 @@ export class PosOrder extends Base {
     }
 
     getRoundedRemaining(roundingMethod, remaining) {
+        remaining = roundCurrency(remaining, this.currency);
         let { rounding_method: method, rounding } = roundingMethod;
         if (
             lt(remaining, 0, {

--- a/addons/point_of_sale/static/tests/tours/pos_cash_rounding_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_cash_rounding_tour.js
@@ -655,6 +655,23 @@ registry.category("web_tour.tours").add("test_cash_rounding_with_change", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_cash_rounding_up_with_change", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.addOrderline("product_a", "1"),
+            ProductScreen.addOrderline("product_b", "2"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("179"),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickNumpad("2 0 0"),
+
+            PaymentScreen.changeIs("21"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_cash_rounding_only_cash_method_with_change", {
     steps: () =>
         [

--- a/addons/point_of_sale/tests/test_pos_cash_rounding.py
+++ b/addons/point_of_sale/tests/test_pos_cash_rounding.py
@@ -407,3 +407,41 @@ class TestPosCashRounding(TestPointOfSaleHttpCommon):
                 'amount_total': 15.72,
                 'amount_paid': 15.7,
             }])
+
+    def test_cash_rounding_up_with_change(self):
+        self.cash_rounding_add_invoice_line = self.env['account.cash.rounding'].create({
+            'name': "cash_rounding_up_1",
+            'rounding': 1.00,
+            'rounding_method': 'UP',
+            'strategy': 'add_invoice_line',
+            'profit_account_id': self.env.company.default_cash_difference_income_account_id.id,
+            'loss_account_id': self.env.company.default_cash_difference_expense_account_id.id,
+        })
+        self.main_pos_config.write({
+            'rounding_method': self.cash_rounding_add_invoice_line.id,
+            'cash_rounding': True,
+            'only_round_cash_method': True,
+        })
+        tax_include = self.env['account.tax'].create({
+            'name': 'tax incl',
+            'type_tax_use': 'sale',
+            'amount_type': 'percent',
+            'amount': 7,
+            'price_include_override': 'tax_included',
+            'include_base_amount': True,
+        })
+        self.env['product.product'].create({
+            'name': "product_a",
+            'available_in_pos': True,
+            'list_price': 95.00,
+            'taxes_id': tax_include,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.env['product.product'].create({
+            'name': "product_b",
+            'available_in_pos': True,
+            'list_price': 42.00,
+            'taxes_id': tax_include,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.start_pos_tour('test_cash_rounding_up_with_change')


### PR DESCRIPTION
…unding method

**Problem:**
The bug is in pos, when the products are tax included and the rounding method is UP. When, the client is paying more cash than the amount, the change is not rounded as it should be.

**Steps to reproduce:**
- Open point Of Sale/Configuration/Taxes
- Create a new tax, with an amount of 7%
- In the Advanced option tab set "Included In Price" to "Tax Included"
- Create a product A with a Sales Price of 95$ and select the tax you created as the "Sales tax"
- Create a product B with a Sales Price of 42$ and select the tax you created as the "Sales tax"
- Open Accounting/Configuration/Management/Cash Roundings and create a new rounding
- As Rounding Precision select 1.00 (the bug can happen also with other values here)
- Set Rounding Strategy as "Add a rounding line"
- Set Rounding Method to "Up"
- Open the point of Sale app and open a store
- Select one product A and two product B in the order
- Click on payment and Cash
- Enter a cash value of 200$

**Current behavior:**
The Change has a value of 20

**Expected behavior:**
The change should have a value of 21

**Cause of the issue:**
In account_tax.js

tax_totals_summary.base_amount_currency takes the values of values.total_excluded_currency https://github.com/odoo/odoo/blob/b9535901fb5a4b2b32e3e6c6c84ae12aca3930d6/addons/account/static/src/helpers/account_tax.js#L871

values.total_excluded_currency is computed as the sum of two floats With the values of our steps it creates a floating-point rounding error (the value is 88.79+78.50=167.29000000000002 and the rounding error is 0.00000000000002) https://github.com/odoo/odoo/blob/b9535901fb5a4b2b32e3e6c6c84ae12aca3930d6/addons/account/static/src/helpers/account_tax.js#L1166

tax_totals_summary.base_amount_currency is then used in another float addition to compute total_amount_currency.Because it's the second float addition the rounding error increases. (the value calculated is 167.29000000000002+11.71=179.00000000000003 and now the rounding error is 0.00000000000003)
https://github.com/odoo/odoo/blob/b9535901fb5a4b2b32e3e6c6c84ae12aca3930d6/addons/account/static/src/helpers/account_tax.js#L1011

total_amount_currency is then used in pos_order.js to compute the remaining https://github.com/odoo/odoo/blob/b9535901fb5a4b2b32e3e6c6c84ae12aca3930d6/addons/point_of_sale/static/src/app/models/pos_order.js#L157 https://github.com/odoo/odoo/blob/b9535901fb5a4b2b32e3e6c6c84ae12aca3930d6/addons/point_of_sale/static/src/app/models/pos_order.js#L161

The remaining is used inside of the get_change method https://github.com/odoo/odoo/blob/b9535901fb5a4b2b32e3e6c6c84ae12aca3930d6/addons/point_of_sale/static/src/app/models/pos_order.js#L887 this 0.00000000000003 rounding error has propagated to there and the value is 20.99999999999997 instead of 21

Because the rounding error comes from two consecutive float addition it's too big to be compensated by epsilon (here epsilon has a value of 1.8651746813702624e-14 which brings the value to 20.99999999999999)
https://github.com/odoo/odoo/blob/b9535901fb5a4b2b32e3e6c6c84ae12aca3930d6/addons/web/static/src/core/utils/numbers.js#L71 Consequently when it's rounded down (the inversion from up to down is because the change value is negative) it's rounded to 20 instead of 21

**Fix:**
Because this rounding mistake only appears with the value of "remaining" I added a rounding inside getRoundedRemaining before applying any customized rounding method.

opw-4615638

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
