### PR TITLE
[FIX] point_of_sale: apply pricelist rules to the child categories

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -35,12 +35,13 @@ export class ProductProduct extends Base {
         const rulesIds = [...new Set([...productTmplRules, ...productRules])].map(
             (rule) => rule.id
         );
+        const parentCategoryIds = this.parentCategories;
         const availableRules =
             pricelist.item_ids?.filter(
                 (rule) =>
                     (rulesIds.includes(rule.id) || (!rule.product_id && !rule.product_tmpl_id)) &&
                     (!rule.product_id || rule.product_id.id === this.id) &&
-                    (!rule.categ_id || rule.categ_id.id === this.product_tmpl_id?.categ_id?.id)
+                    (!rule.categ_id || parentCategoryIds.includes(rule.categ_id.id))
             ) || [];
         this.uiState.applicablePricelistRules[pricelist.id] = availableRules.map((rule) => rule.id);
         return this.uiState.applicablePricelistRules[pricelist.id];

--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -173,12 +173,13 @@ export class ProductTemplate extends Base {
         }
         const productTmplRules = this["<-product.pricelist.item.product_tmpl_id"] || [];
         const rulesIds = [...new Set([...productTmplRules])].map((rule) => rule.id);
+        const parentCategoryIds = this.parentCategories;
         const availableRules =
             pricelist.item_ids?.filter(
                 (rule) =>
                     (rulesIds.includes(rule.id) || (!rule.product_id && !rule.product_tmpl_id)) &&
                     (!rule.product_tmpl_id || rule.product_tmpl_id.id === this.id) &&
-                    (!rule.categ_id || rule.categ_id.id === this.categ_id?.id)
+                    (!rule.categ_id || parentCategoryIds.includes(rule.categ_id.id))
             ) || [];
         this.uiState.applicablePricelistRules[pricelist.id] = availableRules.map((rule) => rule.id);
         return this.uiState.applicablePricelistRules[pricelist.id];

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -578,6 +578,17 @@ registry.category("web_tour.tours").add("AddMultipleSerialsAtOnce", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_pricelist_parent_category_rule", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Product with child category"),
+            ProductScreen.selectedOrderlineHas("Product with child category", "1", "50.0"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_product_create_update_from_frontend", {
     steps: () =>
         [

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1831,6 +1831,39 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_zero_decimal_places_currency', login="pos_user")
 
+    def test_pricelist_parent_category_rule(self):
+        parent_category = self.env['product.category'].create({
+            'name': 'Parent Category',
+        })
+        child_category = self.env['product.category'].create({
+            'name': 'Child Category',
+            'parent_id': parent_category.id,
+        })
+        self.env['product.product'].create({
+            'name': 'Product with child category',
+            'list_price': 100,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'categ_id': child_category.id,
+        })
+
+        pricelist = self.env['product.pricelist'].create({
+            'name': 'Test pricelist on category',
+            'item_ids': [(0, 0, {
+                'compute_price': 'fixed',
+                'fixed_price': 50,
+                'applied_on': '2_product_category',
+                'categ_id': parent_category.id,
+            })],
+        })
+
+        self.main_pos_config.write({
+            'pricelist_id': pricelist.id,
+            'available_pricelist_ids': [(6, 0, [pricelist.id])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_pricelist_parent_category_rule', login="pos_user")
+
     def test_product_create_update_from_frontend(self):
         ''' This test verifies product creation and updates product details from the POS frontend. '''
         self.pos_admin.write({


### PR DESCRIPTION
Before this commit, pricelist rules defined on a parent category were not applied to products belonging to its child categories.

opw-4685399

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
