### PR TITLE
[IMP] mail: allow creation of thread within thread

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -131,7 +131,7 @@ class DiscussChannel(models.Model):
         if failing_channels := self.sudo().filtered(
             lambda c: c.parent_channel_id
             and (
-                c.parent_channel_id.parent_channel_id
+                c.parent_channel_id.parent_channel_id.parent_channel_id
                 or c.parent_channel_id.channel_type not in ["channel", "group"]
                 or c.parent_channel_id.channel_type != c.channel_type
             )

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -141,7 +141,19 @@ export class DiscussSidebarChannel extends Component {
     }
 
     get subChannels() {
-        return this.env.filteredThreads?.(this.thread.sub_channel_ids) ?? [];
+        const result = [];
+        const threads = this.env.filteredThreads?.(this.thread.sub_channel_ids) ?? [];
+
+        for (const thread of threads) {
+            result.push(thread);
+
+            if (thread.sub_channel_ids) {
+                const subthreads = this.env.filteredThreads?.(thread.sub_channel_ids) ?? [];
+                result.push(...subthreads);
+            }
+        }
+
+        return result;
     }
 
     showThread(sub) {

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -63,7 +63,8 @@ const threadPatch = {
         super.delete(...arguments);
     },
     get hasSubChannelFeature() {
-        return ["channel", "group"].includes(this.channel_type) && !this.parent_channel_id;
+        return ["channel", "group"].includes(this.channel_type) && 
+               (!this.parent_channel_id || !this.parent_channel_id.parent_channel_id);
     },
     get isEmpty() {
         return !this.from_message_id && super.isEmpty;

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -56,8 +56,10 @@ class TestDiscussSubChannels(HttpCase):
         parent = self.env["discuss.channel"].create({"name": "General"})
         parent._create_sub_channel()
         sub_channel = parent.sub_channel_ids[0]
+        sub_channel._create_sub_channel()
+        sub_channel_thread = sub_channel.sub_channel_ids[0]
         with self.assertRaises(ValidationError):
-            sub_channel._create_sub_channel()
+            sub_channel_thread._create_sub_channel()
 
     def test_04_sub_channel_panel_search(self):
         bob_user = new_test_user(self.env, "bob_user", groups="base.group_user")


### PR DESCRIPTION
After this commit:
-Allows the creation of threads inside other threads 
 within the mail module.
-Sub-threads are added at the same indent level as their parent thread, 
 preventing excessive indentation.

Current:
-Threads cannot be nested within other threads.

After:
-Threads can now be nested.
-Sub-threads maintain the same indent level as the parent thread, 
 ensuring a clean UI.

Task: [4656524](https://www.odoo.com/odoo/my-tasks/4656524)