### PR TITLE
[FIX] hr_work_entry: Added country id as CH_UNPAID as it belongs to CH

### DIFF
--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -458,6 +458,7 @@
         <field name="code">CH_UNPAID</field>
         <field name="sequence">15</field>
         <field name="color">5</field>
+        <field name="country_id" ref="base.ch"/>
     </record>
 
     <record id="l10n_ch_swissdec_illness_wt" model="hr.work.entry.type">


### PR DESCRIPTION
### Root cause:
PR (https://github.com/odoo/odoo/pull/200327) did not add country code for CH_UNPAID

### Fix:
Added country_id for work entry CH_UNPAID as it belongs to Switzerland

task-4687446

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
