### PR TITLE
[FIX] html_editor: prevent scroll on emoji insertion

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -894,7 +894,7 @@ export class SelectionPlugin extends Plugin {
             return;
         }
         // Manualy focusing the editable is necessary to avoid some non-deterministic error in the HOOT unit tests.
-        this.editable.focus();
+        this.editable.focus({ preventScroll: true });
         const { anchorNode, anchorOffset, focusNode, focusOffset } = editableSelection;
         const selection = this.document.getSelection();
         if (selection) {


### PR DESCRIPTION
**Current behavior before PR:**

- Inserting an emoji using the emoji picker caused the page to scroll up.

**Desired behavior after PR is merged:**

- The page no longer scrolls up when an emoji is inserted using the emoji picker.

task:4686860

