### PR TITLE
[IMP] account_edi_ubl_cii: add a default validation for Peppol endpoint

### DIFF
--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -246,6 +246,8 @@ class ResPartner(models.Model):
             return _("The Peppol endpoint is not valid. "
                      "It should contain exactly 10 digits (Company Registry number)."
                      "The expected format is: 1234567890")
+        if not re.match(r"^[a-zA-Z\d\-._~]{1,50}$", endpoint):
+            return _("The Peppol endpoint (%s) is not valid. It should contain only letters and digit.", endpoint)
 
     @api.model
     def _get_edi_builder(self, invoice_edi_format):


### PR DESCRIPTION
The Peppol spec defines a common rule for the endpoint format. This commit add it to try to keep data as clean as possible until the moment we'll add more validation depending on the EAS. https://docs.peppol.eu/edelivery/policies/PEPPOL-EDN-Policy-for-use-of-identifiers-4.3.0-2024-10-03.pdf

![image](https://github.com/user-attachments/assets/d8ab8b8d-71f5-4293-88a5-193a80004a26)

task-4438857
