### PR TITLE
[FIX] mail_group: fix quoted elements display issue.

### DIFF
--- a/addons/mail_group/static/src/interactions/mail_group_message.js
+++ b/addons/mail_group/static/src/interactions/mail_group_message.js
@@ -23,12 +23,14 @@ export class MailGroupMessage extends Interaction {
 
         // By default hide the mention of the previous email for which we reply
         // And add a button "Read more" to show the mention of the parent email
-        const quoted = this.el.querySelector(".card-body *[data-o-mail-quote]");
-        const readMore = document.createElement("button");
-        readMore.classList.add("btn btn-light btn-sm ms-1");
-        readMore.innerText = ". . .";
-        quoted.insertBefore(readMore);
-        readMore.addEventListener("click", () => quoted.classList.toggle("visible"));
+        const quoted = this.el.querySelectorAll(".card-body *[data-o-mail-quote]");
+        if (quoted.length > 0)  {
+            const readMore = document.createElement("button");
+            readMore.classList.add("btn", "btn-light", "btn-sm", "ms-1");
+            readMore.innerText = ". . .";
+            quoted[0].before(readMore);
+            readMore.addEventListener("click", () => quoted.forEach((node) => node.classList.toggle("visible")));
+        }
     }
 
     /**


### PR DESCRIPTION
Problem 1:
The js selects only the first element with the html data-o-mail-quote attribute but there may be more than one. Thus, some elements were not displayed when user clicked on the "read more" button. Now, they are all displayed when the user clicks on this one.

Problem 2:
The js selects an element with the html data-o-mail-quote attribute and try to use js attributes of the returned object but this one can be null. Then the error occurs. From now, we use its attributes if its is not null.

Problem 3:
The add method of classList contains spaces. Now, the list of classes is split by commas.

Part-of: odoo/odoo#190032
Backport of: https://github.com/odoo/odoo/commit/37303f505c4486766822f9012b257b24ff19543a
