### PR TITLE
[FIX] sale_timesheet: prevent installation error if record rule is missing

### DIFF
--- a/addons/sale_timesheet/security/sale_timesheet_security.xml
+++ b/addons/sale_timesheet/security/sale_timesheet_security.xml
@@ -8,10 +8,10 @@
             Therefore, we need to override this rule to change the domain, and then the
             rules for the account.analytic.line defined in timesheet will be apply.
          -->
-        <record id="account.account_analytic_line_rule_readonly_user" model="ir.rule">
+        <record id="account.account_analytic_line_rule_readonly_user" model="ir.rule" forcecreate="0">
             <field name="domain_force">[('project_id', '=', False)]</field>
         </record>
-        <record id="account.account_analytic_line_rule_billing_user" model="ir.rule">
+        <record id="account.account_analytic_line_rule_billing_user" model="ir.rule" forcecreate="0">
             <field name="domain_force">[('project_id', '=', False)]</field>
         </record>
 


### PR DESCRIPTION
Currently, an error occurs when installing or upgrading the `sale_timesheet` module if the user has manually deleted the referenced record rule.

**Steps to reproduce:**
- Install the `account` module.
- Delete the `account.analytic.line.readonly.user` record rule.
- Install the `sale_timesheet` module.
- Observe the error.

**Error:**
`ParseError: while parsing /home/odoo/src/odoo/saas-18.2/addons/sale_timesheet/security/sale_timesheet_security.xml ...`

The issue occurs because the `sale_timesheet` module overrides the `account.account_analytic_line_rule_readonly_user` record rule in its security XML file - [1]. However, if the parent rule is missing, the system fails to apply the override, resulting in a `ParseError`.

[1] - https://github.com/odoo/odoo/blob/9c864204e84b2d769eeedffe6aa2b2263cf3889f/addons/sale_timesheet/security/sale_timesheet_security.xml#L11

This commit ensures that the rules are only updated if they already exist, avoiding an error if the referenced rule has been deleted.

Sentry - 6489805050