### PR TITLE
[FIX] web: avoid uninstall of sale matrix during click_all

### DIFF
--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -17,6 +17,8 @@ class TestMenusAdmin(odoo.tests.HttpCase):
     def test_01_click_everywhere_as_admin(self):
         if 'tour_enabled' in self.env['res.users']._fields:
             self.env.ref('base.user_admin').tour_enabled = False
+        if self.env['ir.module.module'].search([('name', '=', 'product_matrix'), ('state', '=', 'installed')]):
+            self.env.ref('base.group_user').implied_ids += self.env.ref('product.group_product_variant')  # avoid uninstall of sale / pruchase matrix
         menus = self.env['ir.ui.menu'].load_menus(False)
         for app_id in menus['root']['children']:
             with self.subTest(app=menus[app_id]['name']):


### PR DESCRIPTION
When the product matrix module is installed but the product variant feature group is is not activated, the matrix modules are uninstalled when saving the settings. This is the normal behavior.

Since the removal of the demo data for the tests, when the click everywhere test leaves some settings pages, the matrix modules are uninstalled causing the test to fail.

With this commit, the feature group is enabled before the test if the incriminated module is installed.

runbot error 161744

