### PR TITLE
[IMP] base: ease sessions token fields override

### DIFF
--- a/addons/auth_passkey/models/res_users.py
+++ b/addons/auth_passkey/models/res_users.py
@@ -77,6 +77,9 @@ class ResUsers(models.Model):
 
     def _get_session_token_query_params(self):
         params = super()._get_session_token_query_params()
-        params['select'] = SQL("%s, ARRAY_AGG(key.id ORDER BY key.id DESC)", params['select'])
+        params['select'] = SQL(
+            "%s, ARRAY_AGG(key.id ORDER BY key.id DESC) FILTER (WHERE key.id IS NOT NULL) as auth_passkey_key_ids",
+            params['select']
+        )
         params['joins'] = SQL("%s LEFT JOIN auth_passkey_key key ON res_users.id = key.create_uid", params['joins'])
         return params

--- a/odoo/service/security.py
+++ b/odoo/service/security.py
@@ -17,8 +17,17 @@ def compute_session_token(session, env):
 def check_session(session, env, request=None):
     self = env['res.users'].browse(session.uid)
     expected = self._compute_session_token(session.sid)
-    if expected and consteq(expected, session.session_token):
-        if request:
-            env['res.device.log']._update_device(request)
-        return True
+    if expected:
+        if consteq(expected, session.session_token):
+            if request:
+                env['res.device.log']._update_device(request)
+            return True
+        # If the session token is not valid, we check if the legacy version works
+        # and convert the session token to the new one
+        legacy_expected = self._legacy_session_token_hash_compute(session.sid)
+        if legacy_expected and consteq(legacy_expected, session.session_token):
+            session.session_token = expected
+            if request:
+                env['res.device.log']._update_device(request)
+            return True
     return False


### PR DESCRIPTION
      - Before this commit, we compute session token using the values of
        specific fields stored on `res.users`.
    
        The values only were hashed. For better security we now also hash
        the field name associated to the values.
    
        We also allow to easily override the fields used for the session
        computation by passing them through `_session_token_hash_compute`
    
        This feature will not invalidate existing session and will upgrade
        older valid session using the new computed session token

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
