### PR TITLE
[FIX] mrp: hide kit column for subcontracting resupply pickings

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -752,7 +752,8 @@ class StockMove(models.Model):
 
     def _prepare_procurement_values(self):
         res = super()._prepare_procurement_values()
-        res['bom_line_id'] = self.bom_line_id.id
+        if self.bom_line_id.bom_id.type == 'phantom':
+            res['bom_line_id'] = self.bom_line_id.id
         return res
 
     def action_open_reference(self):


### PR DESCRIPTION
Issue Before This Commit:
============================

Currently, the kit column is also shown for subcontracting resupply pickings, even when the product is not part of kit.

Steps to Reproduce:
============================

- Install the mrp_subcontracting module.
- Create a final product with a subcontracting BOM.
- Add a component and select the route 'resupply subcontractor on order'.
- Purchase the final product.
- Check the resupply picking.

With This Commit:
============================

The kit column is now correctly hidden for subcontracting resupply pickings. It will only be displayed if the product is used as a component in a BOM for a kit. This ensures the column is only shown for products that are part of a kit, improving the clarity and accuracy of the UI.

task - [4596282](https://www.odoo.com/odoo/my-tasks/4596282)
