### PR TITLE
[FIX] payment_flutterwave: redirect user on token authorization

### DIFF
--- a/addons/payment_flutterwave/__manifest__.py
+++ b/addons/payment_flutterwave/__manifest__.py
@@ -14,6 +14,11 @@
 
         'data/payment_provider_data.xml',
     ],
+    'assets': {
+        'web.assets_frontend': [
+            'payment_flutterwave/static/src/js/payment_form.js',
+        ],
+    },
     'application': False,
     'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',

--- a/addons/payment_flutterwave/const.py
+++ b/addons/payment_flutterwave/const.py
@@ -32,7 +32,7 @@ SUPPORTED_CURRENCIES = [
 
 # Mapping of transaction states to Flutterwave payment statuses.
 PAYMENT_STATUS_MAPPING = {
-    'pending': ['pending auth'],
+    'pending': ['pending', 'pending auth'],
     'done': ['successful'],
     'cancel': ['cancelled'],
     'error': ['failed'],

--- a/addons/payment_flutterwave/controllers/main.py
+++ b/addons/payment_flutterwave/controllers/main.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import hmac
+import json
 import logging
 import pprint
 
@@ -16,6 +17,7 @@ _logger = logging.getLogger(__name__)
 
 class FlutterwaveController(http.Controller):
     _return_url = '/payment/flutterwave/return'
+    _auth_return_url = '/payment/flutterwave/auth_return'
     _webhook_url = '/payment/flutterwave/webhook'
 
     @http.route(_return_url, type='http', methods=['GET'], auth='public')
@@ -34,6 +36,15 @@ class FlutterwaveController(http.Controller):
 
         # Redirect the user to the status page.
         return request.redirect('/payment/status')
+
+    @http.route(_auth_return_url, type='http', methods=['GET'], auth='public')
+    def flutterwave_return_from_authorization(self, response):
+        """ Process the response sent by Flutterwave after authorization.
+
+        :param str response: The stringified JSON response.
+        """
+        data = json.loads(response)
+        return self.flutterwave_return_from_checkout(**data)
 
     @http.route(_webhook_url, type='http', methods=['POST'], auth='public', csrf=False)
     def flutterwave_webhook(self):

--- a/addons/payment_flutterwave/models/payment_transaction.py
+++ b/addons/payment_flutterwave/models/payment_transaction.py
@@ -19,6 +19,22 @@ _logger = logging.getLogger(__name__)
 class PaymentTransaction(models.Model):
     _inherit = 'payment.transaction'
 
+    def _get_specific_processing_values(self, processing_values):
+        """ Override of payment to redirect pending token-flow transactions.
+
+        If the financial institution insists on 3-D Secure authentication, this
+        override will redirect the user to the provided authorization page.
+
+        Note: `self.ensure_one()`
+        """
+        res = super()._get_specific_processing_values(processing_values)
+        if self._flutterwave_is_authorization_pending():
+            res['auth_redirect_form_html'] = self.env['ir.qweb']._render(
+                self.provider_id.redirect_form_view_id.id,
+                {'api_url': self.provider_reference},
+            )
+        return res
+
     def _get_specific_rendering_values(self, processing_values):
         """ Override of payment to return Flutterwave-specific rendering values.
 
@@ -74,6 +90,7 @@ class PaymentTransaction(models.Model):
             raise UserError("Flutterwave: " + _("The transaction is not linked to a token."))
 
         first_name, last_name = payment_utils.split_partner_name(self.partner_name)
+        base_url = self.provider_id.get_base_url()
         data = {
             'token': self.token_id.provider_ref,
             'email': self.token_id.flutterwave_customer_email,
@@ -84,6 +101,7 @@ class PaymentTransaction(models.Model):
             'first_name': first_name,
             'last_name': last_name,
             'ip': payment_utils.get_customer_ip_address(),
+            'redirect_url': urls.url_join(base_url, FlutterwaveController._auth_return_url),
         }
 
         # Make the payment request to Flutterwave.
@@ -112,7 +130,7 @@ class PaymentTransaction(models.Model):
         if provider_code != 'flutterwave' or len(tx) == 1:
             return tx
 
-        reference = notification_data.get('tx_ref')
+        reference = notification_data.get('tx_ref') or notification_data.get('txRef')
         if not reference:
             raise ValidationError("Flutterwave: " + _("Received data with missing reference."))
 
@@ -146,6 +164,10 @@ class PaymentTransaction(models.Model):
         self.provider_reference = verified_data['id']
         payment_status = verified_data['status'].lower()
         if payment_status in PAYMENT_STATUS_MAPPING['pending']:
+            auth_url = notification_data.get('meta', {}).get('authorization', {}).get('redirect')
+            if auth_url:
+                # will be set back to the actual value after moving away from pending
+                self.provider_reference = auth_url
             self._set_pending()
         elif payment_status in PAYMENT_STATUS_MAPPING['done']:
             self._set_done()
@@ -197,3 +219,11 @@ class PaymentTransaction(models.Model):
                 'ref': self.reference,
             },
         )
+
+    def _flutterwave_is_authorization_pending(self):
+        return self.filtered_domain([
+            ('provider_code', '=', 'flutterwave'),
+            ('operation', '=', 'online_token'),
+            ('state', '=', 'pending'),
+            ('provider_reference', 'ilike', 'https'),
+        ])

--- a/addons/payment_flutterwave/static/src/js/payment_form.js
+++ b/addons/payment_flutterwave/static/src/js/payment_form.js
@@ -1,0 +1,42 @@
+odoo.define('payment_flutterwave.payment_form', require => {
+    'use strict';
+
+    const checkoutForm = require('payment.checkout_form');
+    const manageForm = require('payment.manage_form');
+
+    const flutterwaveMixin = {
+        /**
+         * Allow forcing redirect to authorization url for Flutterwave token flow.
+         *
+         * @override method from payment.payment_form_mixin
+         * @private
+         * @param {string} provider_code - The code of the token's provider
+         * @param {number} tokenId - The id of the token handling the transaction
+         * @param {object} processingValues - The processing values of the transaction
+         * @return {undefined}
+         */
+        _processTokenPayment: (provider_code, tokenId, processingValues) => {
+            if (provider_code === 'flutterwave' && processingValues.auth_redirect_form_html) {
+                // Append the redirect form to the body
+                const $redirectForm = $(processingValues.auth_redirect_form_html).attr(
+                    'id', 'o_payment_redirect_form'
+                );
+
+                // Authorization happens via POST instead of GET
+                $redirectForm[0].setAttribute('method', 'post');
+
+                // Ensures external redirections when in an iframe.
+                $redirectForm[0].setAttribute('target', '_top');
+                $(document.getElementsByTagName('body')[0]).append($redirectForm);
+
+                // Submit the form
+                $redirectForm.submit();
+            } else {
+                this._super(provider_code, tokenId, processingValues);
+            }
+        }
+    };
+
+    checkoutForm.include(flutterwaveMixin);
+    manageForm.include(flutterwaveMixin);
+});


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have a payment token saved via Flutterwave;
2. use token to pay for an order.

Issue
-----
Error: Provide a valid redirect url

Cause
-----
Flutterwave now mandates authorization for tokenized flows. They provide an authorization url for this, and expect to receive a redirect url value to return to afterwards.

Solution
--------
Solution partially based on the Ogone redirect flow added in 0ed92bcc9791

The authorization url is provided in the notification data. Store this in the `provider_reference` field if the transaction is pending.

When processing the pending transaction, initiate a redirect flow, which redirects the user to the authorization url.

opw-4669110