### PR TITLE
[FIX] website: fix website visitor page_ids acl check

### DIFF
--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -133,7 +133,8 @@ class WebsiteVisitor(models.Model):
 
         for visitor in self:
             visitor_info = mapped_data.get(visitor.id, {'page_count': 0, 'visitor_page_count': 0, 'page_ids': set()})
-            visitor.page_ids = [(6, 0, visitor_info['page_ids'])]
+            # sudo - website.visitor: access to page_ids is restricted to group_website_designer
+            visitor.sudo().page_ids = [(6, 0, visitor_info['page_ids'])]
             visitor.visitor_page_count = visitor_info['visitor_page_count']
             visitor.page_count = visitor_info['page_count']
 

--- a/addons/website_livechat/tests/test_website_visitor.py
+++ b/addons/website_livechat/tests/test_website_visitor.py
@@ -2,7 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTestsCommon
-from odoo.tests import tagged
+from odoo.tests import new_test_user, tagged
+from odoo.exceptions import AccessError
 
 
 @tagged('website_visitor')
@@ -43,3 +44,10 @@ class WebsiteVisitorTestsLivechat(WebsiteVisitorTestsCommon):
             })]
         })
         return values
+
+    def test_visitor_page_statistics_access(self):
+        operator = new_test_user(self.env, "operator", groups="im_livechat.im_livechat_group_user")
+        visitor = self._get_last_visitor()
+        visitor.with_user(operator).page_count
+        with self.assertRaises(AccessError):
+            visitor.with_user(operator).page_ids


### PR DESCRIPTION
Before this commit, opening the kanban view of website visitor without website admin access would cause an ACL error.
Steps to reproduce:
- Log as user Marc Demo
- Open Live Chat menu
- Click on "Visitors" menu item in the top bar -> ACL error

This error appears in master since: https://github.com/odoo/odoo/pull/201565.
This happens because the the compute method of `page_count` (used in the kanban view) accesses `page_ids` which is restricted to website designers ("group_website_designer").
This commit fixes the issue by adding sudo in the compute for the page statistics.


task-4680786