### PR TITLE
[REF] account, purchase, sale: do not rely on followers

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -264,14 +264,14 @@
     <record id="account_invoice_rule_portal" model="ir.rule">
         <field name="name">Portal Personal Account Invoices</field>
         <field name="model_id" ref="account.model_account_move"/>
-        <field name="domain_force">[('state', 'not in', ('cancel', 'draft')), ('move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')), ('message_partner_ids','child_of',[user.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('state', 'not in', ('cancel', 'draft')), ('move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')), ('partner_id','child_of',[user.commercial_partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
     <record id="account_invoice_line_rule_portal" model="ir.rule">
         <field name="name">Portal Invoice Lines</field>
         <field name="model_id" ref="account.model_account_move_line"/>
-        <field name="domain_force">[('parent_state', 'not in', ('cancel', 'draft')), ('move_id.move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')), ('move_id.message_partner_ids','child_of',[user.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('parent_state', 'not in', ('cancel', 'draft')), ('move_id.move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')), ('move_id.partner_id','child_of',[user.commercial_partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -317,27 +317,6 @@ class TestAccountMove(AccountTestInvoicingCommon):
             with self.assertRaisesRegex(UserError, "You cannot modify the following readonly fields on a posted move"):
                 self.test_move.write({field: False})
 
-    def test_add_followers_on_post(self):
-        # Add some existing partners, some from another company
-        company = self.env['res.company'].create({'name': 'Oopo'})
-        company.flush_recordset()
-        existing_partners = self.env['res.partner'].create([{
-            'name': 'Jean',
-            'company_id': company.id,
-        },{
-            'name': 'Paulus',
-        }])
-        self.test_move.message_subscribe(existing_partners.ids)
-
-        user = new_test_user(self.env, login='jag', groups='account.group_account_invoice')
-
-        move = self.test_move.with_user(user)
-        partner = self.env['res.partner'].create({'name': 'Belouga'})
-        move.partner_id = partner
-
-        move.action_post()
-        self.assertEqual(move.message_partner_ids, self.env.user.partner_id | existing_partners | partner)
-
     def test_misc_move_onchange(self):
         ''' Test the behavior on onchanges for account.move having 'entry' as type. '''
 

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -144,7 +144,8 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 )
                 self.assertEqual(
                     move.message_partner_ids,
-                    self.user_accountman.partner_id + move.partner_id,
+                    self.user_accountman.partner_id,
+                    'Customer should not be automatically added as follower'
                 )
 
     @users('user_account')
@@ -475,12 +476,6 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
         with self.mock_mail_gateway(mail_unlink_sent=False):
             composer.action_send_and_print()
 
-        self.assertMailMail(
-            test_move.partner_id,
-            'sent',
-            author=self.user_account_other.partner_id,
-            content='access_token=',
-        )
         self.assertMailMail(
             additional_partner,
             'sent',

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -19,7 +19,6 @@ class PurchaseOrder(models.Model):
     _name = 'purchase.order'
     _inherit = ['portal.mixin', 'product.catalog.mixin', 'mail.thread', 'mail.activity.mixin']
     _description = "Purchase Order"
-    _mail_thread_customer = True
     _rec_names_search = ['name', 'partner_ref']
     _order = 'priority desc, id desc'
 
@@ -547,8 +546,6 @@ class PurchaseOrder(models.Model):
                 order.button_approve()
             else:
                 order.write({'state': 'to approve'})
-            if order.partner_id not in order.message_partner_ids:
-                order.message_subscribe([order.partner_id.id])
         return True
 
     def button_cancel(self):

--- a/addons/purchase/security/purchase_security.xml
+++ b/addons/purchase/security/purchase_security.xml
@@ -53,7 +53,7 @@
     <record id="portal_purchase_order_user_rule" model="ir.rule">
         <field name="name">Portal Purchase Orders</field>
         <field name="model_id" ref="purchase.model_purchase_order"/>
-        <field name="domain_force">['|', ('message_partner_ids','child_of',[user.commercial_partner_id.id]),('partner_id', 'child_of', [user.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('partner_id', 'child_of', [user.commercial_partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_unlink" eval="1"/>
         <field name="perm_write" eval="1"/>
@@ -76,7 +76,7 @@
     <record id="portal_purchase_order_line_rule" model="ir.rule">
         <field name="name">Portal Purchase Order Lines</field>
         <field name="model_id" ref="purchase.model_purchase_order_line"/>
-        <field name="domain_force">['|',('order_id.message_partner_ids','child_of',[user.commercial_partner_id.id]),('order_id.partner_id','child_of',[user.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('order_id.partner_id','child_of',[user.commercial_partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
     <record model="ir.rule" id="purchase_bill_union_comp_rule">

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -160,14 +160,14 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertEqual(localized_date_planned, po.get_localized_date_planned(po.date_planned.strftime('%Y-%m-%d %H:%M:%S')))
 
         # check vendor is a message recipient
-        self.assertTrue(po.partner_id in po.message_partner_ids)
+        self.assertFalse(po.partner_id in po.message_partner_ids, 'Customer should not automatically be added in followers')
 
         # check reminder send
         old_messages = po.message_ids
         po._send_reminder_mail()
         messages_send = po.message_ids - old_messages
         self.assertTrue(messages_send)
-        self.assertTrue(po.partner_id in messages_send.mapped('partner_ids'))
+        self.assertFalse(po.partner_id in po.message_partner_ids, 'Customer should not automatically be added in followers')
 
         po.action_acknowledge()
         self.assertTrue(po.acknowledged)
@@ -193,7 +193,7 @@ class TestPurchase(AccountTestInvoicingCommon):
         po.button_confirm()
 
         # check vendor is a message recipient
-        self.assertTrue(po.partner_id in po.message_partner_ids)
+        self.assertFalse(po.partner_id in po.message_partner_ids, 'Customer should not automatically be added in followers')
 
         old_messages = po.message_ids
         po._send_reminder_mail()

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -30,13 +30,13 @@ class CustomerPortal(payment_portal.PaymentPortal):
 
     def _prepare_quotations_domain(self, partner):
         return [
-            ('message_partner_ids', 'child_of', [partner.commercial_partner_id.id]),
+            ('partner_id', 'child_of', [partner.commercial_partner_id.id]),
             ('state', '=', 'sent')
         ]
 
     def _prepare_orders_domain(self, partner):
         return [
-            ('message_partner_ids', 'child_of', [partner.commercial_partner_id.id]),
+            ('partner_id', 'child_of', [partner.commercial_partner_id.id]),
             ('state', '=', 'sale'),
         ]
 

--- a/addons/sale/data/sale_demo.xml
+++ b/addons/sale/data/sale_demo.xml
@@ -512,7 +512,6 @@
         <field name="state">sent</field>
         <field name="team_id" ref="sales_team.team_sales_department"/>
         <field name="date_order" eval="(DateTime.today() - relativedelta(months=1)).strftime('%Y-%m-%d %H:%M')"/>
-        <field name="message_partner_ids" eval="[(4, ref('base.partner_demo_portal'))]"/>
         <field name="tag_ids" eval="[(4, ref('sales_team.categ_oppor4'))]"/>
     </record>
 
@@ -544,7 +543,6 @@
         <field name="user_id" ref="base.user_admin"/>
         <field name="team_id" ref="sales_team.team_sales_department"/>
         <field name="date_order" eval="(DateTime.today() - relativedelta(months=1)).strftime('%Y-%m-%d %H:%M')"/>
-        <field name="message_partner_ids" eval="[(4, ref('base.partner_demo_portal'))]"/>
     </record>
 
     <record id="portal_sale_order_line_4" model="sale.order.line">

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1022,7 +1022,6 @@ class SaleOrder(models.Model):
     def action_quotation_send(self):
         """ Opens a wizard to compose an email, with relevant mail template loaded by default """
         self.filtered(lambda so: so.state in ('draft', 'sent')).order_line._validate_analytic_distribution()
-        lang = self.env.context.get('lang')
 
         ctx = {
             'default_model': 'sale.order',
@@ -1039,7 +1038,6 @@ class SaleOrder(models.Model):
         else:
             ctx.update({
                 'force_email': True,
-                'model_description': self.with_context(lang=lang).type_name,
             })
             if not self.env.context.get('hide_default_template'):
                 mail_template = self._find_mail_template()
@@ -1048,8 +1046,6 @@ class SaleOrder(models.Model):
                         'default_template_id': mail_template.id,
                         'mark_so_as_sent': True,
                     })
-                if mail_template and mail_template.lang:
-                    lang = mail_template._render_lang(self.ids)[self.id]
             else:
                 for order in self:
                     order._portal_ensure_token()

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -38,7 +38,6 @@ class SaleOrder(models.Model):
     _name = 'sale.order'
     _inherit = ['portal.mixin', 'product.catalog.mixin', 'mail.thread', 'mail.activity.mixin', 'utm.mixin']
     _description = "Sales Order"
-    _mail_thread_customer = True
     _order = 'date_order desc, id desc'
     _check_company_auto = True
 
@@ -996,12 +995,7 @@ class SaleOrder(models.Model):
     def write(self, vals):
         if 'pricelist_id' in vals and any(so.state == 'sale' for so in self):
             raise UserError(_("You cannot change the pricelist of a confirmed order !"))
-        res = super().write(vals)
-        if vals.get('partner_id'):
-            self.filtered(lambda so: so.state in ('sent', 'sale')).message_subscribe(
-                partner_ids=[vals['partner_id']],
-            )
-        return res
+        return super().write(vals)
 
     #=== ACTION METHODS ===#
 
@@ -1126,9 +1120,6 @@ class SaleOrder(models.Model):
         if any(order.state != 'draft' for order in self):
             raise UserError(_("Only draft orders can be marked as sent directly."))
 
-        for order in self:
-            order.message_subscribe(partner_ids=order.partner_id.ids)
-
         self.write({'state': 'sent'})
 
     def action_confirm(self):
@@ -1146,11 +1137,6 @@ class SaleOrder(models.Model):
                 raise UserError(error_msg)
 
         self.order_line._validate_analytic_distribution()
-
-        for order in self:
-            if order.partner_id in order.message_partner_ids:
-                continue
-            order.message_subscribe([order.partner_id.id])
 
         self.write(self._prepare_confirmation_values())
 

--- a/addons/sale/security/ir_rules.xml
+++ b/addons/sale/security/ir_rules.xml
@@ -24,7 +24,7 @@
     <record id="sale_order_rule_portal" model="ir.rule">
         <field name="name">Portal Personal Quotations/Sales Orders</field>
         <field name="model_id" ref="sale.model_sale_order"/>
-        <field name="domain_force">[('message_partner_ids','child_of',[user.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('partner_id','child_of',[user.commercial_partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_unlink" eval="True"/>
         <field name="perm_write" eval="True"/>
@@ -35,7 +35,7 @@
     <record id="sale_order_line_rule_portal" model="ir.rule">
         <field name="name">Portal Sales Orders Line</field>
         <field name="model_id" ref="sale.model_sale_order_line"/>
-        <field name="domain_force">[('order_id.message_partner_ids','child_of',[user.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('order_id.partner_id','child_of',[user.commercial_partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 

--- a/addons/sale/tests/test_controllers.py
+++ b/addons/sale/tests/test_controllers.py
@@ -20,7 +20,8 @@ class TestAccessRightsControllers(HttpCase, SaleCommon):
     def test_access_controller(self):
         private_so = self.sale_order
         portal_so = self.sale_order.copy()
-        portal_so.message_subscribe(self.user_portal.partner_id.ids)
+        # set portal as customer to give portal access
+        portal_so.partner_id = self.user_portal.partner_id.id
 
         portal_so._portal_ensure_token()
         token = portal_so.access_token
@@ -98,6 +99,8 @@ class TestSaleSignature(HttpCaseWithUserPortal):
             self.env['mail.template'].browse(email_ctx.get('default_template_id')),
             subtype_xmlid='mail.mt_comment',
         )
-        self.assertEqual(sales_order.message_partner_ids, portal_user_partner)
+        self.assertFalse(
+            sales_order.message_partner_ids,
+            'Do not automatically set customer as follower, will be suggested recipient')
 
         self.start_tour("/", 'sale_signature', login="portal")

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -225,7 +225,9 @@ class TestSaleOrder(SaleCommon):
         self.sale_order.action_quotation_sent()
 
         self.assertEqual(self.sale_order.state, 'sent')
-        self.assertIn(self.sale_order.partner_id, self.sale_order.message_follower_ids.partner_id)
+        self.assertNotIn(
+            self.sale_order.partner_id, self.sale_order.message_partner_ids,
+            'Customer should not be added automatically in followers')
 
         self.env.user.group_ids += self.env.ref('sale.group_auto_done_setting')
         self.sale_order.action_confirm()
@@ -336,25 +338,6 @@ class TestSaleOrder(SaleCommon):
 
         self.assertFalse(public_user.has_group('sale.group_auto_done_setting'))
         self.assertTrue(self.sale_order.locked)
-
-    def test_draft_quotation_followers(self):
-        sale_order = self.env['sale.order'].create({
-            'partner_id': self.partner1.id,
-        })
-
-        sale_order.partner_id = self.partner2
-
-        self.assertNotIn(self.partner2, sale_order.message_partner_ids)
-
-    def test_sent_quotation_followers(self):
-        sale_order = self.env['sale.order'].create({
-            'partner_id': self.partner1.id,
-        })
-        sale_order.action_quotation_sent()
-
-        sale_order.partner_id = self.partner2
-
-        self.assertIn(self.partner2, sale_order.message_partner_ids)
 
     def test_so_discount_is_not_reset(self):
         """ Discounts should not be recomputed on order confirmation """

--- a/addons/sale_stock/security/sale_stock_security.xml
+++ b/addons/sale_stock/security/sale_stock_security.xml
@@ -6,7 +6,7 @@
         <record id="stock_picking_rule_portal" model="ir.rule">
             <field name="name">Portal Follower Transfers</field>
             <field name="model_id" ref="stock.model_stock_picking"/>
-            <field name="domain_force">['|', '|', ('message_partner_ids', 'in', [user.partner_id.id]), ('partner_id', '=', user.partner_id.id), ('sale_id.partner_id', '=', user.partner_id.id)]</field>
+            <field name="domain_force">['|', ('partner_id', '=', user.partner_id.id), ('sale_id.partner_id', '=', user.partner_id.id)]</field>
             <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         </record>
     </data>

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1237,9 +1237,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
             )
             with request.env.protecting([order_sudo._fields['pricelist_id']], order_sudo):
                 order_sudo.partner_id = new_partner_sudo
-
-            # Add the new partner as follower of the cart
-            order_sudo._message_subscribe(order_sudo.partner_id.ids)
         elif not self._are_same_addresses(billing_address, order_sudo.partner_invoice_id):
             # Check if a child partner doesn't already exist with the same informations. The
             # phone isn't always checked because it isn't sent in shipping information with

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -282,10 +282,6 @@ class SaleOrder(models.Model):
             delivery_method = self._get_preferred_delivery_method(delivery_methods)
             self._set_delivery_method(delivery_method)
 
-        if 'partner_id' in fnames:
-            # Only add the main partner as follower of the order
-            self._message_subscribe([partner_id])
-
     def _cart_add(self, product_id:int, quantity:int|float=1.0, **kwargs):
         """Add quantity of the given product to the current sales order.
 


### PR DESCRIPTION
Since recently [1] customers are found using default or suggested
recipients for communications. Both chatter and templates proposes
them by default. Followers should now be mostly be internal users
that want to receive news from a record while customers should be
actively displayed and chosen.

In this commit we change customer ACL of move / SO / PO from
being based on followers to being based on 'partner_id' field. This
removes some use cases like adding followers to share the document.
However sharing links with specific tokens should be the way to go.

Continuation of external followers removal, already started at [2].

[1] See odoo/odoo#201514
[2] See odoo/odoo#185240