### PR TITLE
[FIX] stock[barcode]: fix missing lot group

### DIFF
--- a/addons/stock/tests/test_picking_tours.py
+++ b/addons/stock/tests/test_picking_tours.py
@@ -122,6 +122,7 @@ class TestStockPickingTour(HttpCase):
             {'lot_id': lot_2.id, 'quantity': 10.0},
         ])
         url = self._get_picking_url(delivery.id)
+        self.env.ref('base.user_admin').write({'group_ids': [Command.link(self.env.ref('stock.group_production_lot').id)]})
         self.start_tour(url, 'test_add_new_line_in_detailled_op', login='admin', timeout=100)
         self.assertRecordValues(delivery.move_line_ids.sorted("quantity"), [
             {'quantity': 2.0, 'lot_id': lot_1.id},


### PR DESCRIPTION
'group_production_lot' is needed for the following runbot tests to pass

TestStockPickingTour.test_add_new_line_in_detailled_op TestBarcodeClientAction.test_filter_on_barcode
TestInventoryAdjustmentBarcodeClientAction.test_inventory_adjustment_tracked_product_multilocation TestInventoryAdjustmentBarcodeClientAction.test_inventory_setting_count_entire_locations_on TestPickingBarcodeClientAction.test_remaining_decimal_accuracy TestPickingBarcodeClientAction.test_scan_aggregate_barcode TestPickingBarcodeClientAction.test_scrap

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
