### PR TITLE
[FIX] iot_box_image: fix wifi being blocked

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -213,6 +213,9 @@ PKGS_TO_INSTALL="
     wlr-randr \
     xdotool"
 
+# Prevent Wi-Fi blocking
+apt-get -y remove rfkill
+
 echo "Acquire::Retries "16";" > /etc/apt/apt.conf.d/99acquire-retries
 # KEEP OWN CONFIG FILES DURING PACKAGE CONFIGURATION
 # http://serverfault.com/questions/259226/automatically-keep-current-version-of-config-files-when-apt-get-install


### PR DESCRIPTION
In the Wayland upgrade PR (#202722), the base Raspberry Pi OS image was updated to the November 2024 version. A side effect of this is that Wi-fi is now being blocked by default, with the following message appearing in the shell:

> Wi-Fi is currently blocked by rfkill.
> Use raspi-config to set the country before use.

IoT boxes are deployed in multiple countries and need to work by default without any configuration, so there is no sensible default we can provide. Instead, we fix the issue by simply uninstalling the `rfkill` package at build time.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
