### PR TITLE
[FIX] website_sale_stock: prevent ordering out of stock products

### DIFF
--- a/addons/website_sale_stock/controllers/main.py
+++ b/addons/website_sale_stock/controllers/main.py
@@ -1,11 +1,18 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.website_sale.controllers import main as website_sale_controller
-from odoo.tools import email_re
-from odoo import http, _
-from odoo.http import request
+from psycopg2.errors import LockNotAvailable
 from werkzeug.exceptions import BadRequest
+
+from odoo import http, _
+from odoo.exceptions import ValidationError
+from odoo.http import request
+from odoo.osv import expression
+from odoo.tools import email_re
+from odoo.tools.misc import mute_logger
+from odoo.tools.sql import SQL
+
+from odoo.addons.website_sale.controllers import main as website_sale_controller
 
 
 class WebsiteSale(website_sale_controller.WebsiteSale):
@@ -40,3 +47,31 @@ class CustomerPortal(website_sale_controller.CustomerPortal):
             **super()._sale_reorder_get_line_context(),
             'website_sale_stock_get_quantity': True,
         }
+
+
+class PaymentPortal(website_sale_controller.PaymentPortal):
+    def _validate_transaction_for_order(self, transaction, sale_order_id):
+        """
+        Throws a ValidationError if the free quantity of a product in the cart
+        is being updated to 0 by a concurrent transaction and allow_out_of_stock_order
+        is set to False.
+        """
+        super()._validate_transaction_for_order(transaction, sale_order_id)
+        sale_order = request.env['sale.order'].browse(sale_order_id).exists()
+        website = sale_order.website_id
+        restricted_products = request.env['product.product']
+        for product in sale_order.order_line.product_id:
+            if not product.allow_out_of_stock_order and (website._get_product_available_qty(product) - product._get_cart_qty(website) <= 0):
+                restricted_products |= product
+        if restricted_products:
+            ctx = {**request.env.context, 'warehouse': website._get_warehouse_available()}
+            quants_location_domain, __, __ = restricted_products.with_context(ctx)._get_domain_locations()
+            quants_domain = expression.AND([[('product_id', 'in', restricted_products.ids)], quants_location_domain])
+            query = request.env['stock.quant'].sudo()._search(quants_domain).select()
+            # Try to acquire a lock on stock.quants, throw an error if lock not available.
+            query = SQL('%s FOR NO KEY UPDATE NOWAIT', query)
+            try:
+                with mute_logger('odoo.sql_db'):
+                    request.env.cr.execute(query)
+            except LockNotAvailable:
+                raise ValidationError(_("Cannot process payment: the cart contains products that are currently out of stock."))

--- a/addons/website_sale_stock/data/website_sale_stock_demo.xml
+++ b/addons/website_sale_stock/data/website_sale_stock_demo.xml
@@ -6,4 +6,16 @@
     <record id="stock.product_cable_management_box_product_template" model="product.template">
         <field name="public_categ_ids" eval="[(6,0,[ref('website_sale.public_category_boxes')])]"/>
     </record>
+    <record id="website_sale_stock.limited_product" model="product.product">
+        <field name="type">product</field>
+        <field name="name">Limited Product</field>
+        <field name="sale_ok" eval="True"/>
+        <field name="website_published" eval="True"/>
+        <field name="allow_out_of_stock_order" eval="False"/>
+    </record>
+    <record id="website_sale_stock.limited_product_quant" model="stock.quant">
+        <field name="product_id" ref="website_sale_stock.limited_product"/>
+        <field name="quantity">5.0</field>
+        <field name="location_id" model="stock.location" eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>
+    </record>
 </odoo>

--- a/addons/website_sale_stock/tests/__init__.py
+++ b/addons/website_sale_stock/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_website_sale_stock_delivery
 from . import test_website_sale_stock_stock_notification
 from . import test_website_sale_stock_reorder_from_portal
 from . import test_website_sale_stock_stock_message
+from . import test_website_sale_stock_concurrent_orders

--- a/addons/website_sale_stock/tests/test_website_sale_stock_concurrent_orders.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_concurrent_orders.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from contextlib import closing
+
+from odoo.exceptions import ValidationError
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.payment.tests.common import PaymentCommon
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale_stock.controllers.main import PaymentPortal
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleStockConcurrentOrders(PaymentCommon):
+    def setUp(self):
+        super().setUp()
+        self.website = self.env.ref('website.default_website')
+        self.Controller = PaymentPortal()
+
+    def test_website_sale_stock_out_of_stock_products(self):
+        limited_product = self.env['product.product'].search([('name', 'ilike', 'Limited Product')])
+        if not limited_product:
+            self.skipTest('Cannot test concurrent transactions without demo data.')
+        default_transaction_values = {
+            'payment_method_id': self.payment_method_id,
+            'amount': 5.75,
+            'provider_id': self.provider.id,
+            'flow': 'redirect',
+            'token_id': None,
+            'tokenization_requested': False,
+            'landing_route': 'stub',
+        }
+        # Open a new cursor to simulate a concurrent transaction locking limited_product's quants.
+        with closing(self.registry.cursor()) as cr:
+            cr.execute("SELECT id FROM stock_quant WHERE product_id = %s FOR NO KEY UPDATE", [limited_product.id])
+            with MockRequest(self.env, website=self.website):
+                sale_order = self.website.sale_get_order(force_create=True)
+                sale_order.write({
+                    'order_line': [Command.create({'product_id': limited_product.id, 'product_uom_qty': 5.0})],
+                    'carrier_id': self.env.ref('delivery.free_delivery_carrier').id
+                })
+                # Try processing payment with another transaction locking the related quants.
+                with self.assertRaisesRegex(ValidationError, "the cart contains products that are currently out of stock"):
+                    self.Controller.shop_payment_transaction(sale_order.id, sale_order.access_token, **default_transaction_values)


### PR DESCRIPTION
Steps to reproduce:

 - Install website_sale_stock and payment_demo
 - Set allow_out_of_stock_order to False in settings
 - Create a storable product and publish it on ecommerce
 - Update the product on-hand quantity to 5.0
 - Go to /shop and add product to cart with quantity of 5.0
 - In another private window, go to /shop and add product with quantity of 5.0
 - Validate both payments at the same time.
 - The product's forecasted quantity is -5.0

Currently if we have two concurrent transactions that validate a cart for the same product with `allow_out_of_stock_order` to False, both will succeed. The forecasted quantity will be -5.0 at the end. That's because no quantity is updated when adding to cart and as long as the /payment requests do not complete, both transactions see the free_qty at 5.0.

This patch proposes to fix this by acquiring an explicit lock on quants that will be updated by the transactions. In case those quants are already locked by another concurrent transaction a ValidationError is raised and the payment process is aborted. That way, there's no more occurrences of negative stock quantity for limited products and users don't have to issue credit notes to customers to reimburse them.

We decided to lock quants as it's less invasive then locking the products themselves for instance. Locked quants are skipped in `_update_available_quantity` so there shouldn't be that many SerializationFailures in the backend with this new mechanism.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
