### PR TITLE
[IMP] auth_totp: unify _check_credentials and totp checks

### DIFF
--- a/addons/auth_totp/controllers/home.py
+++ b/addons/auth_totp/controllers/home.py
@@ -43,7 +43,11 @@ class Home(web_home.Home):
         elif user and request.httprequest.method == 'POST' and kwargs.get('totp_token'):
             try:
                 with user._assert_can_auth(user=user.id):
-                    user._totp_check(int(re.sub(r'\s', '', kwargs['totp_token'])))
+                    credentials = {
+                        'type': user._mfa_type(),
+                        'token': int(re.sub(r'\s', '', kwargs['totp_token'])),
+                    }
+                    user._check_credentials(credentials, {'interactive': True})
             except AccessDenied as e:
                 error = str(e)
             except ValueError:

--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -63,14 +63,17 @@ class ResUsers(models.Model):
     def _get_session_token_fields(self):
         return super()._get_session_token_fields() | {'totp_secret'}
 
-    def _totp_check(self, code):
-        sudo = self.sudo()
-        key = base64.b32decode(sudo.totp_secret)
-        match = TOTP(key).match(code)
-        if match is None:
-            _logger.info("2FA check: FAIL for %s %r", self, sudo.login)
-            raise AccessDenied(_("Verification failed, please double-check the 6-digit code"))
-        _logger.info("2FA check: SUCCESS for %s %r", self, sudo.login)
+    def _check_credentials(self, credentials, env):
+        if credentials['type'] == 'totp':
+            sudo = self.sudo()
+            key = base64.b32decode(sudo.totp_secret)
+            match = TOTP(key).match(credentials['token'])
+            if match is None:
+                _logger.info("2FA check: FAIL for %s %r", self, sudo.login)
+                raise AccessDenied(_("Verification failed, please double-check the 6-digit code"))
+            _logger.info("2FA check: SUCCESS for %s %r", self, sudo.login)
+        else:
+            return super()._check_credentials(credentials, env)
 
     def _totp_try_setting(self, secret, code):
         if self.totp_enabled or self != self.env.user:

--- a/addons/auth_totp_mail/models/res_users.py
+++ b/addons/auth_totp_mail/models/res_users.py
@@ -136,21 +136,20 @@ class ResUsers(models.Model):
         if self._mfa_type() == 'totp_mail':
             return '/web/login/totp'
 
-    def _totp_check(self, code):
-        self._totp_rate_limit('code_check')
-        user = self.sudo()
-        if user._mfa_type() != 'totp_mail':
-            return super()._totp_check(code)
-
-        key = user._get_totp_mail_key()
-        match = TOTP(key).match(code, window=3600, timestep=3600)
-        if match is None:
-            _logger.info("2FA check (mail): FAIL for %s %r", user, user.login)
-            raise AccessDenied(_("Verification failed, please double-check the 6-digit code"))
-        _logger.info("2FA check(mail): SUCCESS for %s %r", user, user.login)
-        self._totp_rate_limit_purge('code_check')
-        self._totp_rate_limit_purge('send_email')
-        return True
+    def _check_credentials(self, credentials, env):
+        if credentials['type'] == 'totp_mail':
+            self._totp_rate_limit('code_check')
+            user = self.sudo()
+            key = user._get_totp_mail_key()
+            match = TOTP(key).match(credentials['token'], window=3600, timestep=3600)
+            if match is None:
+                _logger.info("2FA check (mail): FAIL for %s %r", user, user.login)
+                raise AccessDenied(_("Verification failed, please double-check the 6-digit code"))
+            _logger.info("2FA check(mail): SUCCESS for %s %r", user, user.login)
+            self._totp_rate_limit_purge('code_check')
+            self._totp_rate_limit_purge('send_email')
+        else:
+            return super()._check_credentials(credentials, env)
 
     def _get_totp_mail_key(self):
         self.ensure_one()


### PR DESCRIPTION
  - Make the totp code checks go through the `_check_credentials` method to unify the code.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
