### PR TITLE
[FIX] account: _increase_rank without tracking

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -824,7 +824,7 @@ class ResPartner(models.Model):
         except LockError:
             _logger.debug('Another transaction already locked partner rows. Cannot update partner ranks.')
             return
-        records = self.sudo()
+        records = self.sudo().with_context(tracking_disable=True)
         for record in records:
             record[field] += n
 


### PR DESCRIPTION
The function used to do the update directly in SQL and now we use the ORM (#197653). As a performance improvement, we can just disable tracking when setting the rank so that the implementation is closer to what it was.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
