### PR TITLE
[IMP] website_sale, *: cart summary offcanvas and design

### DIFF
--- a/addons/l10n_br_website_sale/views/templates.xml
+++ b/addons/l10n_br_website_sale/views/templates.xml
@@ -2,13 +2,13 @@
 <odoo>
 
     <template id="total" inherit_id="website_sale.total">
-        <tr id="order_total_untaxed" position="attributes">
+        <tr name="o_order_total_untaxed" position="attributes">
             <attribute name="t-attf-class" add="#{'d-none' if website.company_id.country_code == 'BR' else ''}" separator=" "/>
         </tr>
-        <tr id="order_total_taxes" position="attributes">
+        <tr name="o_order_total_taxes" position="attributes">
             <attribute name="t-attf-class" add="#{'d-none' if website.company_id.country_code == 'BR' else ''}" separator=" "/>
         </tr>
-        <tr id="order_total" position="attributes">
+        <tr name="o_order_total" position="attributes">
             <attribute name="t-attf-class" add="#{'border-top' if website.company_id.country_code != 'BR' else ''}" separator=" "/>
         </tr>
     </template>

--- a/addons/payment_demo/views/payment_demo_templates.xml
+++ b/addons/payment_demo/views/payment_demo_templates.xml
@@ -33,7 +33,7 @@
              t-att-data-provider-code="provider_sudo.code"
         >
             <button type="button"
-                    class="btn btn-primary mt-2 w-100"
+                    class="btn btn-primary w-100"
                     data-bs-toggle="modal"
                     t-attf-data-bs-target="#o_payment_demo_modal_{{provider_sudo.id}}"
             >

--- a/addons/website_event_sale/views/website_sale_templates.xml
+++ b/addons/website_event_sale/views/website_sale_templates.xml
@@ -26,8 +26,8 @@
         </xpath>
     </template>
 
-    <template id="cart_summary_inherit_website_event_sale" inherit_id="website_sale.checkout_layout">
-        <xpath expr="//td[@name='website_sale_cart_summary_product_name']/h6" position="after">
+    <template id="cart_summary_inherit_website_event_sale" inherit_id="website_sale.cart_summary_content">
+        <xpath expr="//td[@name='website_sale_cart_summary_product_name']/span" position="after">
             <span t-if="line.event_slot_id" class="text-muted" t-out="line.event_slot_id.display_name"/>
         </xpath>
     </template>

--- a/addons/website_sale/static/src/interactions/address.js
+++ b/addons/website_sale/static/src/interactions/address.js
@@ -1,21 +1,27 @@
-import { patch } from '@web/core/utils/patch';
 import { CustomerAddress } from '@portal/interactions/address';
+import { patch } from '@web/core/utils/patch';
 
 patch(CustomerAddress.prototype, {
     // /shop/address
 
     setup() {
         super.setup();
-        this.submitButton = document.getElementsByName('website_sale_main_button')[0];
-        if (this.submitButton) {
+        // There is two main buttons in the DOM for mobile or desktop. User can switch from one mode
+        // to the other by rotating their tablet.
+        this.submitButtons = document.getElementsByName("website_sale_main_button");
+        if (this.submitButtons) {
             this._boundSaveAddress = this.saveAddress.bind(this);
-            this.submitButton.addEventListener('click', this._boundSaveAddress);
+            this.submitButtons.forEach(
+                submitButton => submitButton.addEventListener('click', this._boundSaveAddress)
+            );
         }
     },
 
     destroy() {
-        if (this.submitButton) {
-            this.submitButton.removeEventListener('click', this._boundSaveAddress);
+        if (this.submitButtons) {
+            this.submitButtons.forEach(
+                submitButton => submitButton.removeEventListener('click', this._boundSaveAddress)
+            );
         }
         super.destroy();
     },

--- a/addons/website_sale/static/src/interactions/cart_summary.js
+++ b/addons/website_sale/static/src/interactions/cart_summary.js
@@ -1,0 +1,48 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+export class WebsiteSaleTotalCardStickyReactive extends Interaction {
+    static selector = ".o_website_sale_checkout_container";
+
+    dynamicContent = {
+        ".o_total_card": {
+            "t-att-style": () => ({
+                "opacity": "1",
+                "top": `${this.position || 16}px`,
+            }),
+        }
+    };
+
+    setup() {
+        this.position = 16;
+    }
+
+    start() {
+        this._adaptToHeaderChange();
+        this.registerCleanup(this.services.website_menus.registerCallback(this._adaptToHeaderChange.bind(this)));
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     */
+
+    _adaptToHeaderChange() {
+        let position = 16; // Add 1rem equivalent in px to provide a visual gap by default
+
+        for (const el of this.el.ownerDocument.querySelectorAll(".o_top_fixed_element")) {
+            position += el.offsetHeight;
+        }
+
+        if (this.position !== position) {
+            this.position = position;
+            this.updateContent();
+        }
+    }
+}
+registry
+    .category("public.interactions")
+    .add("website.website_sale_total_card_sticky_reactive", WebsiteSaleTotalCardStickyReactive);

--- a/addons/website_sale/static/src/js/cart.js
+++ b/addons/website_sale/static/src/js/cart.js
@@ -2,7 +2,6 @@ import { Component } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { rpc } from "@web/core/network/rpc";
 import { debounce } from "@web/core/utils/timing";
-import { utils as uiUtils } from "@web/core/ui/ui_service";
 import publicWidget from "@web/legacy/js/public/public_widget";
 
 import wSaleUtils from "@website_sale/js/website_sale_utils";
@@ -109,45 +108,6 @@ publicWidget.registry.websiteSaleCart = publicWidget.Widget.extend({
             // Propagating the change to the express checkout forms
             Component.env.bus.trigger('cart_amount_changed', [data.amount, data.minor_amount]);
         });
-    },
-});
-
-publicWidget.registry.websiteSaleCartNavigation = publicWidget.Widget.extend({
-    selector: '.o_website_sale_checkout',
-
-    /**
-     * For mobile screens, `.o_cta_navigation_container` has an absolute position causing
-     * overlapping issues with nearby divs, therefore the height of `.o_website_sale_checkout` needs
-     * to include the height of the absolute div and needs to be updated every time an element on
-     * the checkout is expanded (i.e. payment methods, cart summary)
-     *
-     * @override
-     */
-    start() {
-        const ctaNavigation = document.querySelector('.o_cta_navigation_container')
-        if (uiUtils.isSmall() && ctaNavigation) {
-            const updateCheckoutHeight = () => {
-                const updatedHeight = ctaNavigation.offsetTop + ctaNavigation.offsetHeight
-                this.el.style.height = `${updatedHeight}px`;
-            }
-            this.resizeObserver = new ResizeObserver(updateCheckoutHeight);
-            const paymentForm = document.getElementById('o_payment_form');
-            const cartSummary = document.getElementById('o_wsale_accordion_item');
-            if (paymentForm) {
-                this.resizeObserver.observe(paymentForm);
-            }
-            if (cartSummary) {
-                this.resizeObserver.observe(cartSummary);
-            }
-        }
-    },
-
-    /**
-     * @override
-     */
-    destroy() {
-        this.resizeObserver?.disconnect();
-        this._super.apply(this, arguments);
     },
 });
 

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -19,25 +19,25 @@ export function assertCartAmounts({taxes = false, untaxed = false, total = false
     if (taxes) {
         steps.push({
             content: 'Check if the tax is correct',
-            trigger: `tr#order_total_taxes .oe_currency_value:contains(/^${taxes}$/)`,
+            trigger: `tr[name="o_order_total_taxes"] .oe_currency_value:contains(/^${taxes}$/)`,
         });
     }
     if (untaxed) {
         steps.push({
             content: 'Check if the subtotal is correct',
-            trigger: `tr#order_total_untaxed .oe_currency_value:contains(/^${untaxed}$/)`,
+            trigger: `tr[name="o_order_total_untaxed"] .oe_currency_value:contains(/^${untaxed}$/)`,
         });
     }
     if (total) {
         steps.push({
             content: 'Check if the total is correct',
-            trigger: `tr#order_total .oe_currency_value:contains(/^${total}$/)`,
+            trigger: `tr[name="o_order_total"] .oe_currency_value:contains(/^${total}$/)`,
         });
     }
     if (delivery) {
         steps.push({
             content: 'Check if the delivery is correct',
-            trigger: `tr#order_delivery .oe_currency_value:contains(/^${delivery}$/)`,
+            trigger: `tr[name='o_order_delivery'] .oe_currency_value:contains(/^${delivery}$/)`,
         });
     }
     return steps

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -427,7 +427,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
         }
         if ($aSubmit.hasClass('a-submit-loading')) {
             var loading = '<span class="fa fa-cog fa-spin"/>';
-            var fa_span = $aSubmit.find('span[class*="fa"]');
+            var fa_span = $aSubmit.find('i[class*="fa"]');
             if (fa_span.length) {
                 fa_span.replaceWith(loading);
             } else {

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -70,7 +70,9 @@ function updateCartNavBar(data) {
     }
 
     $(".js_cart_lines").first().before(data['website_sale.cart_lines']).end().remove();
-    $("#cart_total").replaceWith(data['website_sale.total']);
+    document.querySelectorAll('div.o_cart_total').forEach(
+        div => div.innerHTML = data['website_sale.total']
+    );
     if (data.cart_ready) {
         document.querySelector("a[name='website_sale_main_button']")?.classList.remove('disabled');
     } else {

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1077,6 +1077,11 @@ a.no-decoration {
 }
 
 .o_website_sale_checkout {
+    main {
+        display: flex;
+        flex-direction: column;
+    }
+
     #shop_cart {
         &.o_img_ratio_4_3 {
             --card-product-img-ratio: 4/3;
@@ -1112,56 +1117,42 @@ a.no-decoration {
         }
     }
 
+    .o_cart_item_count {
+        font-variant-numeric: tabular-nums;
+    }
+
     .o_total_card {
-        // The accordion have to mimick the styling of a card
-        background-color: $card-bg;
-        border: $border-width solid $border-color;
-        border-radius: $card-border-radius;
+        @include media-breakpoint-down(lg) {
+            position: static;
+            border: none;
 
-        .accordion-item {
-            @include o-bg-color(rgba($card-bg, $o-card-body-bg-opacity));
+            .o_checkout_cart_total {
+                border-top: $border-width solid $border-color;
+            }
+        }
+    }
+
+    .o_mobile_summary {
+        margin-left: -$grid-gutter-width * .5;
+        margin-right: -$grid-gutter-width * .5;
+        padding: $spacer $grid-gutter-width * .5;
+
+        @include media-breakpoint-down(lg) {
+            box-shadow: $box-shadow-lg;
+        }
+    }
+
+    .o_wsale_scrollable_table {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+
+        &::-webkit-scrollbar {
+            display: none;
         }
 
-        // TODO VCR This value should adapt to the offsetHeight
-        // of the header this is an arbitrary value as a temporary solution
-        // to offset the summary regarding the tallest header (Magazine)
         @include media-breakpoint-up(lg) {
-            top: 9rem;
-        }
-
-        @include media-breakpoint-down(lg) {
-            border: 0;
-
-            .card-body, .accordion-item, .accordion-button {
-                border-radius: 0;
-                background-color: var(--o-cc1-bg) !important;
-                color: inherit;
-            }
-        }
-    }
-
-    #cart_total {
-        @include media-breakpoint-down(lg) {
-            padding-top: map-get($spacers, 3);
-            border-top: $border-width solid $border-color;
-        }
-    }
-
-    .o_wsale_accordion {
-        .accordion-button{
-            background-color: unset;
-        }
-
-        .o_wsale_scrollable_table {
-            -ms-overflow-style: none;
-            scrollbar-width: none;
-            &::-webkit-scrollbar {
-              display: none;
-            }
-            @include media-breakpoint-up(lg) {
-                overflow-y: scroll;
-                height: 15rem;
-            }
+            overflow-y: scroll;
+            height: 15rem;
         }
     }
 
@@ -1183,22 +1174,15 @@ a.no-decoration {
         }
     }
 
-    div[name="o_express_checkout_container"] {
-        margin-bottom: -#{map-get($spacers, 3)};
-        margin-top: map-get($spacers, 3);
+    .o_address_signin {
+        @include media-breakpoint-down(md) {
+            border-radius: $border-radius;
+            background-color: $gray-100;
+        }
     }
 
     button[name="o_payment_submit_button"] {
         margin-left: 0 !important;
-    }
-
-    // We can't technically duplicate navigations CTA therefore we use
-    // an absolute positioning to move the CTA from the summary to the
-    // bottom of the page.
-    @include media-breakpoint-down(lg){
-        .o_cta_navigation_container {
-            padding: 0 calc(var(--gutter-x) * .5);
-        }
     }
 
     a.disabled {

--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
@@ -42,7 +42,7 @@ registry
             },
             {
                 content: "Verify the order's total price",
-                trigger: 'tr#order_total_untaxed:contains(93.00)',
+                trigger: 'tr[name="o_order_total_untaxed"]:contains(93.00)',
             },
             // Assert that the combo quantity can be updated in the cart.
             {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2629,12 +2629,16 @@
             - redirect: The route to redirect to when a customer enters a coupon; default: `None`.
             - website_sale_order: The current order.
         -->
-        <form t-attf-action="/shop/pricelist#{redirect and '?r=' + redirect or ''}"
-            method="post" name="coupon_code">
+        <form
+            class="mb-3"
+            t-attf-action="/shop/pricelist#{redirect and '?r=' + redirect or ''}"
+            method="post"
+            name="coupon_code"
+        >
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
-            <div class="input-group w-100 my-2">
+            <div class="input-group w-100">
                 <input name="promo" class="form-control" type="text" placeholder="Discount code..." t-att-value="website_sale_order.pricelist_id.code or None"/>
-                <a href="#" role="button" class="btn btn-secondary a-submit">Apply</a>
+                <a href="#" role="button" class="btn btn-light a-submit border">Apply</a>
             </div>
         </form>
         <t t-if="request.params.get('code_not_available')" name="code_not_available">
@@ -2653,8 +2657,13 @@
         <!-- Checkout context:
             - website_sale_order: The current order.
         -->
-        <div t-attf-class="#{_container_classes} d-flex #{_form_send_navigation and 'flex-column flex-lg-row align-items-lg-center' or 'flex-column'} mb-5 mb-lg-0 pt-4">
+        <div t-attf-class="#{_container_classes} d-flex #{_form_send_navigation and 'flex-column flex-lg-row align-items-lg-center' or 'flex-column'} gap-2">
             <t t-if="website_sale_order and website_sale_order.website_order_line">
+                <t
+                    t-if="(website.account_on_checkout != 'mandatory' or
+                            not website.is_public_user()) and show_shorter_cart_summary"
+                    t-call="payment.express_checkout"
+                />
                 <t t-if="current_website_checkout_step_href == '/shop/confirm_order'">
                     <div t-if="not errors and not website_sale_order.amount_total"
                          name="o_website_sale_free_cart">
@@ -2683,19 +2692,25 @@
                     </a>
                 </t>
             </t>
-            <div t-if="not hide_payment_button" t-attf-class="position-relative #{_form_send_navigation and 'd-flex d-lg-none' or 'd-flex'} w-100 justify-content-center align-items-center my-2 opacity-75">
+            <div
+                t-if="not hide_payment_button"
+                t-attf-class="position-relative #{_form_send_navigation and 'd-flex d-lg-none' or 'd-none d-lg-flex'} w-100 justify-content-center align-items-center opacity-75"
+            >
                 <hr class="w-100"/>
                 <span class="px-3">or</span>
                 <hr class="w-100"/>
             </div>
             <t t-if="previous_website_checkout_step">
-                <a t-att-href="previous_website_checkout_step.step_href" class="text-center">
+                <a
+                    t-att-href="previous_website_checkout_step.step_href"
+                    class="pt-2 pt-lg-0 text-center"
+                >
                     <i class="fa fa-angle-left me-2 fw-light"/>
                     <span t-field="previous_website_checkout_step.back_button_label"/>
                 </a>
             </t>
             <t t-else="">
-                <a t-att-href="'/shop'" class="text-center">
+                <a t-att-href="'/shop'" class="pt-2 pt-lg-0 text-center">
                     <i class="fa fa-angle-left me-2 fw-light"/>
                     Continue shopping
                 </a>
@@ -2859,8 +2874,11 @@
                     >
                         <t t-if="is_anonymous_cart">
                             <div class="d-flex flex-column flex-md-row align-items-center justify-content-between mb-1">
-                                <h4 class="w-100">Details</h4>
-                                <div t-if="website.account_on_checkout != 'disabled'" class="w-100 text-end">
+                                <h4 class="w-100 w-md-auto">Details</h4>
+                                <div
+                                    t-if="website.account_on_checkout != 'disabled'"
+                                    class="o_address_signin d-flex d-md-block justify-content-between align-items-center p-3 p-md-0 w-100 text-md-end"
+                                >
                                     <span class="align-middle">Already have an account?</span>
                                     <a
                                         role="button"
@@ -2977,7 +2995,7 @@
                     </div>
                 </t>
             </div>
-            <div class="oe_structure clearfix mb-3" id="oe_structure_website_sale_payment_1"/>
+            <div class="oe_structure clearfix" id="oe_structure_website_sale_payment_1"/>
 
             <div t-if="not errors and website_sale_order.amount_total" name="website_sale_non_free_cart">
                 <div id="payment_method" class="o_not_editable mb-3">
@@ -3018,6 +3036,8 @@
             - show_shorter_cart_summary: Whether to show the shorter cart_summary (without items
                                          summary and with express checkout buttons) or the full;
                                          default: `None`.
+            - show_mobile_cart_summary: Whether to show the mobile offcanvas cart_summary;
+                                        default: `True`.
             - oe_structure: The structure element to append at the bottom of the page;
                             default: `None`.
         -->
@@ -3030,125 +3050,126 @@
             <t t-set="show_navigation_button" t-value="True if show_navigation_button is None else show_navigation_button"/>
             <t t-set="expand_order_summary" t-value="not show_navigation_button"/>
             <t t-set="show_wizard_checkout" t-value="True if show_wizard_checkout is None else show_wizard_checkout"/>
-            <div id="wrap">
-                <div class="oe_website_sale o_website_sale_checkout container py-2">
-                    <div t-attf-class="row #{show_navigation_button and 'position-relative'} #{not show_wizard_checkout and 'mt32'} mb32">
+            <t
+                t-set="show_mobile_cart_summary"
+                t-value="True if show_mobile_cart_summary is None else show_mobile_cart_summary"
+            />
+            <t t-set="body_classname" t-value="'o_website_sale_checkout'"/>
+            <div id="wrap" class="d-flex flex-column flex-grow-1">
+                <div class="oe_website_sale o_website_sale_checkout_container container d-flex flex-column flex-grow-1 py-lg-2">
+                    <div t-attf-class="row #{not show_wizard_checkout and 'mt32'} mb32">
                         <div t-if="show_wizard_checkout" class="col-12">
                             <t t-call="website_sale.wizard_checkout"/>
                         </div>
-                        <div t-if="show_shorter_cart_summary"
-                             class="offset-xl-1 col-lg-5 col-xl-4 order-2"
-                             id="o_cart_summary">
-                            <div class="o_total_card card sticky-lg-top"
-                                 t-if="website_sale_order and website_sale_order.website_order_line">
-                                <div class="card-body p-0 p-lg-4">
-                                    <t t-call="website_sale.total"/>
-                                    <t
-                                        t-if="website.account_on_checkout != 'mandatory' or
-                                              not website.is_public_user()"
-                                        t-call="payment.express_checkout"
-                                    />
+                        <!-- Checkout Page Content | Left Column -->
+                        <div class="oe_clear_stucture oe_cart col-12 col-lg-7">
+                            <t t-out="0"/>
+                        </div>
+                        <!-- Short Checkout Summary displayed on /cart | Right Column -->
+                        <div
+                            t-if="show_shorter_cart_summary"
+                            class="offset-xxl-1 col-lg-5 col-xxl-4"
+                        >
+                            <div
+                                t-if="website_sale_order and website_sale_order.website_order_line"
+                                class="o_total_card card sticky-lg-top"
+                            >
+                                <div class="card-body p-0 p-lg-4" name="o_cart_total_card_body">
+                                    <t t-call="website_sale.total">
+                                        <t
+                                            t-set="_cart_total_classes"
+                                            t-valuef="o_checkout_cart_total pt-2 pt-lg-0"
+                                        />
+                                    </t>
                                     <t t-call="website_sale.navigation_buttons"/>
                                 </div>
                             </div>
                         </div>
-                        <div t-else=""
-                             class="o_wsale_accordion accordion sticky-lg-top offset-xl-1 col-12 col-lg-5 col-xl-4 order-lg-2 rounded"
-                             id="o_wsale_total_accordion">
-                            <div class="o_total_card sticky-lg-top">
-                                <div id="o_wsale_total_accordion_item" class="accordion-item p-lg-4 border-0">
-                                    <div class="accordion-header d-block align-items-center mb-2">
-                                        <button
-                                            t-attf-class="accordion-button pt-0 pb-1 px-0 {{ not expand_order_summary and 'collapsed' }}"
-                                            t-att-aria-expanded="expand_order_summary and 'True' or 'False'"
-                                            data-bs-toggle="collapse"
-                                            data-bs-target="#o_wsale_accordion_item"
-                                            aria-controls="o_wsale_accordion_item"
-                                        >
-                                            <div class="d-flex flex-wrap">
-                                                <b class="w-100">Order summary</b>
-                                                <span t-out="str(website_sale_order.cart_quantity)"/>
-                                                &amp;nbsp;item(s)&amp;nbsp;-&amp;nbsp;
-                                                <span id="amount_total_summary"
-                                                    class="monetary_field ms-1"
-                                                    t-field="website_sale_order.amount_total"
-                                                    t-options='{"widget": "monetary", "display_currency": website_sale_order.currency_id}'/>
-                                            </div>
-                                        </button>
-                                    </div>
-                                    <div name="cart_summary_info" t-if="not website_sale_order or not website_sale_order.website_order_line" class="alert alert-info">
-                                        Your cart is empty!
-                                    </div>
-                                    <div id="o_wsale_accordion_item"
-                                        t-attf-class="accordion-collapse collapse mb-4 pt-4 mb-lg-0 {{ expand_order_summary and 'show' }}"
-                                        data-bs-parent="#o_wsale_total_accordion">
-                                        <div t-att-class="len(website_sale_order.website_order_line) &gt; 3 and 'o_wsale_scrollable_table mt-n4 me-n4 pe-4'">
-                                            <table t-if="website_sale_order and website_sale_order.website_order_line"
-                                                class="table accordion-body mb-0"
-                                                id="cart_products">
-                                                <tbody>
-                                                    <tr t-foreach="website_sale_order.website_order_line" t-as="line" t-att-class="line_last and 'border-transparent'">
-                                                        <t t-set="o_cart_sum_padding_top"
-                                                        t-value="'pt-3' if line_size &gt; 1 and not line_first else 'pt-0'"/>
-                                                        <td t-if="not line.product_id" colspan="2"/>
-                                                        <t t-else="">
-                                                            <td t-attf-class="td-img ps-0 #{o_cart_sum_padding_top}">
-                                                                <span t-if="not line._is_sellable() and line.product_id.image_128">
-                                                                    <img t-att-src="image_data_uri(line.product_id.image_128)" class="o_image_64_max img rounded" t-att-alt="line.name_short"/>
-                                                                </span>
-                                                                <span t-else=""
-                                                                    t-field="line.product_id.image_128"
-                                                                    t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'o_image_64_max rounded'}"
-                                                                />
-                                                            </td>
-                                                            <td t-attf-class="#{o_cart_sum_padding_top} td-product_name td-qty w-100"
-                                                                name='website_sale_cart_summary_product_name'>
-                                                                <h6>
-                                                                    <t t-out="int(line.product_uom_qty)" />
-                                                                    <t t-if="line._get_shop_warning(clear=False)">
-                                                                        <i class="fa fa-warning text-warning"
-                                                                        role="img"
-                                                                        t-att-title="line._get_shop_warning()"
-                                                                        aria-label="Warning"/>
-                                                                    </t>
-                                                                    x
-                                                                    <t t-out="line.name_short"/>
-                                                                </h6>
-                                                            </td>
-                                                        </t>
-                                                        <td t-attf-class="#{o_cart_sum_padding_top} td-price pe-0 text-end"
-                                                            name="website_sale_cart_summary_line_price">
-                                                            <t t-call="website_sale.cart_product_price">
-                                                                <t
-                                                                    t-set="product_price"
-                                                                    t-value="line._get_cart_display_price()"
-                                                                />
-                                                            </t>
-                                                        </td>
-                                                    </tr>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                        <t t-if='website_sale_order'>
-                                            <t t-set='warning' t-value='website_sale_order._get_shop_warning(clear=False)' />
-                                            <div t-if='warning' class="alert alert-warning" role="alert">
-                                                <strong>Warning!</strong> <t t-esc='website_sale_order._get_shop_warning()'/>
-                                            </div>
+                        <!-- Full Checkout Summary displayed on all checkout pages | Right Column -->
+                        <div
+                            t-else=""
+                            class="d-none d-lg-block offset-xxl-1 col-12 col-lg-5 col-xxl-4 rounded"
+                        >
+                            <div class="o_total_card card sticky-lg-top mb-3 mb-lg-0">
+                                <div class="card-body p-lg-4 pt-lg-3">
+                                    <div class="d-none d-lg-block">
+                                        <t t-call="website_sale.cart_summary_content"/>
+                                        <t t-call="website_sale.total">
+                                            <t
+                                                t-set="_cart_total_classes"
+                                                t-valuef="border-top pt-2"
+                                            />
                                         </t>
                                     </div>
-                                    <t t-call="website_sale.total">
-                                        <t t-set="_cart_total_classes" t-valuef="border-top pt-2"/>
-                                    </t>
-                                    <div t-if="show_navigation_button" class="o_cta_navigation_container position-absolute position-lg-static start-0 top-100 col-12">
+                                    <div
+                                        t-if="show_navigation_button"
+                                        class="o_cta_navigation_container px-0"
+                                    >
                                         <t t-call="website_sale.navigation_buttons"/>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <div t-attf-class="oe_clear_stucture oe_cart col-12 col-lg-7">
-                            <t t-out="0"/>
-                        </div>
                     </div>
+                    <!-- Mobile Order Summary | Bottom of page and Offcanvas -->
+                    <t t-if="not show_shorter_cart_summary and show_mobile_cart_summary">
+                        <div class="o_mobile_summary d-lg-none sticky-bottom mt-auto bg-body">
+                            <button
+                                class="btn btn-light d-flex justify-content-between align-items-center gap-2 w-100 mb-2"
+                                data-bs-toggle="offcanvas"
+                                href="#o_cart_summary_offcanvas"
+                                role="button"
+                                aria-controls="o_cart_summary_offcanvas"
+                            >
+                                Order
+                                <span
+                                    id="amount_total_summary"
+                                    class="monetary_field ms-auto"
+                                    t-field="website_sale_order.amount_total"
+                                    t-options='{"widget": "monetary", "display_currency": website_sale_order.currency_id}'
+                                />
+                                <span
+                                    class="o_cart_item_count badge ms-1 top-0 bg-primary"
+                                    t-out="str(website_sale_order.cart_quantity)"
+                                />
+                                <i class="fa fa-angle-right ms-2" role="img"/>
+                            </button>
+                            <t
+                                t-if="show_navigation_button"
+                                t-call="website_sale.navigation_buttons"
+                            />
+                        </div>
+                        <div
+                            id="o_cart_summary_offcanvas"
+                            class="offcanvas offcanvas-end"
+                            tabindex="-1"
+                            aria-labelledby="o_cart_summary_offcanvas"
+                        >
+                            <div class="offcanvas-body">
+                                <t t-call="website_sale.cart_summary_content"/>
+                            </div>
+                            <div class="offcanvas-footer p-3">
+                                <a href="/shop/cart" class="btn btn-link w-100">
+                                    Coupon, Gift card, Promo-code?
+                                </a>
+                                <t t-call="website_sale.total">
+                                    <t t-set="hide_promotions" t-value="True"/>
+                                    <t
+                                        t-set="_cart_total_classes"
+                                        t-valuef="border-top px-3 pt-2 mx-n3"
+                                    />
+                                </t>
+                                <button
+                                    class="btn btn-light w-100"
+                                    type="button"
+                                    data-bs-dismiss="offcanvas"
+                                    aria-label="Close"
+                                >
+                                    Close
+                                </button>
+                            </div>
+                        </div>
+                    </t>
                 </div>
                 <!-- This is the drag-and-drop area for website building blocs at the end of each
                      checkout page. The templates created in the database to store blocs are hooked
@@ -3159,10 +3180,90 @@
         </t>
     </template>
 
+    <!-- Called in `website_sale.checkout_layout` and `website_sale.confirmation`. -->
+    <template id="website_sale.cart_summary_content">
+        <div
+            t-if="not website_sale_order or not website_sale_order.website_order_line"
+            name="cart_summary_info"
+            class="alert alert-info"
+        >
+            Your cart is empty!
+        </div>
+        <div>
+            <div t-att-class="len(website_sale_order.website_order_line) &gt; 3 and 'o_wsale_scrollable_table'">
+                <table
+                    t-if="website_sale_order and website_sale_order.website_order_line"
+                    class="o_cart_products_table table mb-0"
+                >
+                    <tbody>
+                        <tr
+                            t-foreach="website_sale_order.website_order_line"
+                            t-as="line"
+                            t-att-class="line_last and 'border-transparent'"
+                        >
+                            <td class="td-img ps-0 pt-3">
+                                <div class="position-relative">
+                                    <span
+                                        t-if="not line._is_sellable() and line.product_id.image_128"
+                                    >
+                                        <img
+                                            t-att-src="image_data_uri(line.product_id.image_128)"
+                                            class="o_image_64_max img rounded"
+                                            t-att-alt="line.name_short"
+                                        />
+                                    </span>
+                                    <span
+                                        t-else=""
+                                        t-field="line.product_id.image_128"
+                                        t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'o_image_64_max rounded'}"
+                                    />
+                                    <span class="o_cart_item_count badge bg-secondary position-absolute top-0 start-100 translate-middle">
+                                        <t t-out="int(line.product_uom_qty)" />
+                                        <i
+                                            t-if="line._get_shop_warning(clear=False)"
+                                            class="fa fa-warning"
+                                            role="img"
+                                            t-att-title="line._get_shop_warning()"
+                                            aria-label="Warning"
+                                        />
+                                    </span>
+                                </div>
+                            </td>
+                            <td
+                                class="td-product_name td-qty w-100 pt-3"
+                                name="website_sale_cart_summary_product_name"
+                            >
+                                <span class="text-wrap">
+                                    <t t-out="line.name_short"/>
+                                </span>
+                            </td>
+                            <td class="td-price pe-0 pt-3 text-end"
+                                name="website_sale_cart_summary_line_price">
+                                <t t-call="website_sale.cart_product_price">
+                                    <t
+                                        t-set="product_price"
+                                        t-value="line._get_cart_display_price()"
+                                    />
+                                </t>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <t t-if='website_sale_order'>
+                <t t-set='warning' t-value='website_sale_order._get_shop_warning(clear=False)' />
+                <div t-if='warning' class="alert alert-warning" role="alert">
+                    <strong>Warning!</strong> <t t-esc='website_sale_order._get_shop_warning()'/>
+                </div>
+            </t>
+        </div>
+    </template>
+
     <!-- /shop/confirmation route -->
     <template id="confirmation">
         <t t-call="website_sale.checkout_layout">
             <t t-set="show_wizard_checkout" t-value="False"/>
+            <t t-set="show_mobile_cart_summary" t-value="False"/>
             <t t-set="show_navigation_button" t-value="False"/>
             <t t-set="show_footer" t-value="True"/>
             <t t-set="additional_title">Shop - Confirmed</t>
@@ -3209,23 +3310,39 @@
             </div>
             <div class="oe_structure mt-3" id="oe_structure_website_sale_confirmation_2"/>
             <input t-if='website.plausible_shared_key' type='hidden' class='js_plausible_push' data-event-name='Shop' t-attf-data-event-params='{"CTA": "Order Confirmed", "amount": "#{"%3s-%3s" % (max(0, round(website_sale_order.amount_total/100)*100 - 50), round(website_sale_order.amount_total/100)*100 + 50)}"}' />
+            <div class="d-lg-none">
+                <t t-call="website_sale.cart_summary_content"/>
+                <t t-call="website_sale.total">
+                    <t
+                        t-set="_cart_total_classes"
+                        t-valuef="border-top pt-2"
+                    />
+                </t>
+            </div>
         </t>
     </template>
 
     <!-- Called in `website_sale.checkout_layout`. -->
     <template id="total">
-        <div id="cart_total" t-if="website_sale_order and website_sale_order.website_order_line" t-att-class="_cart_total_classes">
+        <!-- Layout customization parameters:
+            - _cart_total_classes: CSS classes to append on the root div of the total template;
+                                   default `None`.
+        -->
+        <div
+            t-if="website_sale_order and website_sale_order.website_order_line"
+            t-attf-class="o_cart_total #{_cart_total_classes}"
+        >
             <table class="table mb-0">
                 <tr
                     t-if="website_sale_order._has_deliverable_products()"
-                    id="order_delivery"
+                    name="o_order_delivery"
                 >
-                    <td class="ps-0 pt-1 pb-2 border-0 text-muted" colspan="2">
+                    <td class="ps-0 pt-0 pb-2 border-0 text-muted" colspan="2">
                         Delivery
                     </td>
-                    <td class="text-end pe-0 pt-1 pb-2 border-0">
+                    <td class="text-end pe-0 pt-0 pb-2 border-0">
                         <span
-                            id="message_no_dm_set"
+                            name="o_message_no_dm_set"
                             t-att-class="'d-none' if website_sale_order.carrier_id else ''"
                             title="Price will be updated after choosing a delivery method"
                         >
@@ -3239,8 +3356,8 @@
                         />
                     </td>
                 </tr>
-                <tr id="order_total_untaxed">
-                    <td id="cart_total_subtotal"
+                <tr name="o_order_total_untaxed">
+                    <td
                         class="border-0 pb-2 ps-0 pt-0 text-start text-muted"
                         colspan="2">
                         Subtotal
@@ -3252,7 +3369,7 @@
                               t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
                     </td>
                 </tr>
-                <tr id="order_total_taxes">
+                <tr name="o_order_total_taxes">
                     <td colspan="2" class="text-muted border-0 p-0 pe-3 pb-2">Taxes</td>
                     <td class="text-end border-0 p-0 ps-3 pb-2">
                         <span t-field="website_sale_order.amount_tax"
@@ -3261,9 +3378,9 @@
                               t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
                     </td>
                 </tr>
-                <tr id="order_total" class="border-top">
-                    <td colspan="2" class="border-0 ps-0 pt-3"><strong>Total</strong></td>
-                    <td class="text-end border-0 px-0 pt-3">
+                <tr name="o_order_total" class="border-top">
+                    <td colspan="2" class="border-0 ps-0 pt-2"><strong>Total</strong></td>
+                    <td class="text-end border-0 px-0 pt-2">
                         <strong t-field="website_sale_order.amount_total"
                                 class="monetary_field text-end p-0"
                                 t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
@@ -3280,7 +3397,7 @@
             - redirect: The route to redirect to when a customer enters a coupon; default: `None`.
             - website_sale_order: The current order.
         -->
-        <xpath expr="//div[@id='cart_total']//table/tr[last()]" position="after">
+        <xpath expr="//div[contains(@t-attf-class, 'o_cart_total')]//table/tr[last()]" position="after">
             <tr t-if="not hide_promotions">
                 <td colspan="3" class="text-end text-xl-end border-0 p-0">
                 <span>

--- a/addons/website_sale_loyalty/static/src/js/checkout.js
+++ b/addons/website_sale_loyalty/static/src/js/checkout.js
@@ -4,11 +4,11 @@ WebsiteSaleCheckout.include({
     /**
      * @override
      */
-    _updateCartSummary(result) {
+    _updateCartSummary(result, targetEl) {
         this._super.apply(this, arguments);
         if (result.amount_delivery_discounted) {
             // Update discount of the order
-            const cart_summary_shipping_reward = document.querySelector(
+            const cart_summary_shipping_reward = targetEl.querySelector(
                 '[data-reward-type="shipping"]'
             );
             if (cart_summary_shipping_reward) {
@@ -16,7 +16,7 @@ WebsiteSaleCheckout.include({
             }
         }
         if (result.discount_reward_amounts) {
-            const cart_summary_discount_rewards = document.querySelectorAll(
+            const cart_summary_discount_rewards = targetEl.querySelectorAll(
                 '[data-reward-type=discount]'
             );
             if (cart_summary_discount_rewards.length !== result.discount_reward_amounts.length) {

--- a/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
@@ -10,7 +10,7 @@ registry.category("web_tour.tours").add('shop_sale_ewallet', {
         ...wsTourUtils.addToCart({productName: "TEST - Gift Card"}),
         wsTourUtils.goToCart(),
         {
-            trigger: 'a:contains("Pay with eWallet")',
+            trigger: 'a[name="o_loyalty_claim"]:contains("Use")',
             run() {
                 const rewards = document.querySelectorAll('form[name="claim_reward"]');
                 if (rewards.length === 1) {

--- a/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
@@ -44,7 +44,7 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
         },
         {
             content: "check loyalty points",
-            trigger: '.oe_website_sale_gift_card span:contains("372.03 Points")',
+            trigger: '.oe_website_sale_gift_card strong[name="o_loyalty_points"]:contains("372.03")',
         },
         /* 2. Add some cabinet to get a free one, play with quantity */
         {
@@ -79,7 +79,7 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
             ...tourUtils.addToCart({productName: "Taxed Product"}),
             tourUtils.goToCart({quantity: 3}),
         {
-            trigger: ".oe_currency_value:contains(/74.00/):not(#cart_total)",
+            trigger: ".oe_currency_value:contains(/74.00/):not(div[name='o_cart_total'])",
         },
         {
             content: "check reduction amount got recomputed and merged both discount lines into one only",

--- a/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
@@ -8,9 +8,9 @@ import {
     pay,
 } from "@website_sale/js/tours/tour_utils";
 
-function assertRewardAmounts(rewards, visibleOnly) {
+function assertRewardAmounts(rewards) {
     const steps = [];
-    const currencyValue = `.oe_currency_value${visibleOnly ? ":visible" : ":not(:visible)"}`;
+    const currencyValue = `.oe_currency_value:visible`;
     for (const [reward, amount] of Object.entries(rewards)) {
         steps.push({
             content: `check if ${reward} reward is correct`,
@@ -28,10 +28,6 @@ function selectDelivery(provider) {
     };
 }
 
-const waitForPaymentPage = {
-    content: "wait for Payment page to load",
-    trigger: ".o_total_card:contains(Order summary)",
-};
 
 const webTours = registry.category("web_tour.tours");
 
@@ -63,10 +59,9 @@ webTours.add("check_shipping_discount", {
         ...assertRewardAmounts({ shipping: "- 6.00" }),
         {
             content: "pay with eWallet",
-            trigger: "form[name=claim_reward] a.btn-primary:contains(Pay with eWallet)",
+            trigger: "form[name=claim_reward] a[name='o_loyalty_claim']:contains('Use')",
             run: "click",
         },
-        waitForPaymentPage,
         ...assertRewardAmounts({ discount: "- 304.00" }),
         selectDelivery("delivery1"),
         ...assertCartAmounts({ delivery: "5.00" }),
@@ -87,7 +82,7 @@ webTours.add("update_shipping_after_discount", {
         goToCart(),
         {
             content: "use eWallet to check it doesn't impact `free_over` shipping",
-            trigger: "a.btn-primary:contains(Pay with eWallet)",
+            trigger: "a[name='o_loyalty_claim']:contains('Use')",
             run: "click",
         },
         {
@@ -102,7 +97,6 @@ webTours.add("update_shipping_after_discount", {
         }),
         ...assertRewardAmounts({ discount: "- 100.00" }),
         confirmOrder(),
-        waitForPaymentPage,
         {
             content: "enter discount code",
             trigger: "form[name=coupon_code] input[name=promo]",
@@ -119,11 +113,11 @@ webTours.add("update_shipping_after_discount", {
         }),
         {
             content: "check discount code discount doesn't apply to shipping",
-            trigger: '[data-reward-type=discount] .oe_currency_value:not(:visible):contains(/^- 50.00$/)',
+            trigger: '[data-reward-type=discount] .oe_currency_value:contains(/^- 50.00$/)',
         },
         {
             content: "check eWallet discount applies to shipping ($50 for Plumbus + $5 for delivery)",
-            trigger: '[data-reward-type=discount] .oe_currency_value:not(:visible):contains(/^- 55.00$/)',
+            trigger: '[data-reward-type=discount] .oe_currency_value:contains(/^- 55.00$/)',
         },
     ],
 });

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -8,53 +8,73 @@
     </template>
 
     <template id="modify_code_form" inherit_id="website_sale.total" name="Loyalty, coupon, gift card">
-        <xpath expr="//div[@id='cart_total']//table/tr[last()]" position="after">
+        <xpath expr="//div[contains(@t-attf-class, 'o_cart_total')]//table/tr[last()]" position="after">
             <tr t-if="not hide_promotions" class="oe_website_sale_gift_card">
                 <td colspan="3" class="text-center text-xl-end border-0 p-0">
                     <span class=''>
                         <t t-if="request.params.get('code_not_available')">
-                            <div class="alert alert-danger text-start mt16" role="alert">
+                            <div class="alert alert-danger text-start small" role="alert">
                                 Invalid or expired promo code.
                             </div>
                         </t>
                         <t t-if="website_sale_order.get_promo_code_error(delete=False)">
-                            <div class="alert alert-danger text-start mt16" role="alert">
+                            <div class="alert alert-danger text-start small" role="alert">
                                 <t t-esc="website_sale_order.get_promo_code_error()"/>
                             </div>
                         </t>
                         <t t-if="website_sale_order">
                             <t t-if="website_sale_order.get_promo_code_success_message(delete=False)">
-                                <div class="alert alert-success text-start mt16" role="alert">
+                                <div class="alert alert-success text-start small" role="alert">
                                     You have successfully applied the following code: <strong t-esc="website_sale_order.get_promo_code_success_message()"/>
                                 </div>
                             </t>
                             <t t-foreach="website_sale_order._get_claimable_and_showable_rewards().items()" t-as="coupon_reward">
                                 <t t-set="coupon" t-value="coupon_reward[0]"/>
                                 <t t-set="rewards" t-value="coupon_reward[1]"/>
+                                <t t-set="is_loyalty" t-value="rewards[0].program_id.program_type == 'loyalty'"/>
+
+                                <div
+                                    t-if="is_loyalty"
+                                    class="alert alert-primary d-flex justify-content-between align-items-center mb-0 p-2 rounded-bottom-0"
+                                    role="alert"
+                                >
+                                    <strong class="text-start small" t-out="coupon_reward[0].point_name"/>
+                                    <strong
+                                        class="small"
+                                        name="o_loyalty_points"
+                                        t-out="website_sale_order._get_real_points_for_coupon(coupon)"
+                                    />
+                                </div>
+
                                 <t t-foreach="rewards" t-as="reward">
                                     <form t-att-action="'/shop/claimreward%s' % (redirect and '?r=' + redirect or '')"
                                         method="post" name="claim_reward">
                                         <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                                         <input type="hidden" name="reward_id" t-att-value="reward.id"/>
                                         <input type="hidden" name="code" t-att-value="coupon.code"/>
-                                        <div class="alert alert-success text-start mt16" role="alert">
-                                            <div class="d-flex flex-row">
+                                        <div t-attf-class="{{'border border-primary-subtle border-top-0 p-2 text-start' if is_loyalty else 'alert alert-primary p-2 text-start'}} {{'rounded-bottom mb-3' if is_loyalty and reward_last else ''}}">
+                                            <div class="d-flex gap-2 align-items-center">
                                                 <div class="flex-grow-1 text-break">
                                                     <t t-set="program" t-value="reward.program_id"/>
                                                     <t t-set="points" t-value="coupon._format_points(website_sale_order._get_real_points_for_coupon(coupon))"/>
                                                     <t t-if="program.program_type not in ['ewallet', 'promo_code', 'loyalty'] and (program.trigger == 'with_code' or (program.trigger == 'auto' and program.applies_on == 'future'))">
                                                         <t t-if="program.program_type == 'gift_card'">
-                                                            <strong t-esc="reward.description"/>
-                                                            <strong> - </strong>
-                                                            <strong t-esc="points"/>
+                                                            <strong class="small">
+                                                                <t t-out="reward.description"/>
+                                                                -
+                                                                <t t-out="points"/>
+                                                            </strong>
                                                         </t>
                                                         <t t-elif="program.program_type == 'coupons'">
-                                                            <strong>Coupons - </strong><strong t-esc="reward.description"/>
+                                                            <strong class="small">
+                                                                Coupons -
+                                                                <t t-out="reward.description"/>
+                                                            </strong>
                                                         </t>
                                                         <t t-elif="program.trigger == 'auto' and program.applies_on == 'future'">
-                                                            <strong t-esc="reward.description"/>
+                                                            <strong class="small" t-out="reward.description"/>
                                                         </t>
-                                                        <div class="text-muted d-md-block small">
+                                                        <div class="d-md-block small">
                                                             <span t-if="coupon and not coupon.program_id.is_nominative">
                                                                 Code:
                                                                 <t t-esc="coupon.code[-4:].rjust(14, '&#8902;')"/>
@@ -69,22 +89,29 @@
                                                         </div>
                                                     </t>
                                                     <t t-elif="program.program_type == 'promo_code'">
-                                                        <strong t-esc="reward.description"/>
+                                                        <strong class="small" t-out="reward.description"/>
                                                     </t>
                                                     <t t-else="">
-                                                        <strong t-esc="reward.description"/>
+                                                        <div
+                                                            t-if="program.program_type == 'ewallet'"
+                                                            class="d-flex justify-content-between align-items-center h-100 me-2"
+                                                        >
+                                                            <strong class="small" t-out="reward.description"/>
+                                                            <strong class="small" t-out="points"/>
+                                                        </div>
+                                                        <strong
+                                                            t-else=""
+                                                            class="small"
+                                                            t-out="reward.description"
+                                                        />
                                                         <div t-if="program.portal_visible">
                                                             <t t-if="not program.is_nominative">
                                                                 <span t-out="points"/>
                                                             </t>
-                                                            <t t-else="">
-                                                                <span>You have <t t-out="points"/></span>
-                                                                <span t-if="program.program_type == 'ewallet'"> in your ewallet</span>
-                                                                <t t-else="">
-                                                                    <br/>
-                                                                    <span>Costs <t t-out="coupon._format_points(reward.required_points)"/></span>
-                                                                </t>
-                                                            </t>
+                                                            <small
+                                                                t-elif="program.program_type != 'ewallet'"
+                                                                t-out="coupon._format_points(reward.required_points)"
+                                                            />
                                                         </div>
                                                     </t>
                                                     <select
@@ -101,12 +128,14 @@
                                                         </option>
                                                     </select>
                                                 </div>
-                                                <div class="justify-content-end">
-                                                    <a class="btn btn-primary a-submit" href="#" role="button">
-                                                        <t t-if="reward.program_id.program_type == 'ewallet'">
-                                                            Pay with eWallet
-                                                        </t>
-                                                        <t t-elif="(reward.program_id.trigger == 'with_code' and reward.program_id.program_type != 'promo_code') or (reward.program_id.trigger == 'auto' and reward.program_id.applies_on == 'future')">
+                                                <div class="d-flex align-items-center">
+                                                    <a
+                                                        class="btn btn-sm btn-primary a-submit"
+                                                        href="#"
+                                                        role="button"
+                                                        name="o_loyalty_claim"
+                                                    >
+                                                        <t t-if="(reward.program_id.trigger == 'with_code' and reward.program_id.program_type != 'promo_code') or (reward.program_id.trigger == 'auto' and reward.program_id.applies_on == 'future')">
                                                             Use
                                                         </t>
                                                         <t t-else="">Claim</t>
@@ -148,7 +177,7 @@
     </template>
 
     <template id="cart_discount" name="Show Discount in Subtotal" active="False" inherit_id="website_sale.total">
-        <xpath expr="//tr[@id='order_total_untaxed']" position="before">
+        <xpath expr="//tr[@name='o_order_total_untaxed']" position="before">
             <tr t-if="website_sale_order and website_sale_order.reward_amount">
             <td class="text-end border-0 text-muted" title="Discounted amount">Discount:</td>
             <td class="text-xl-end border-0 text-muted">
@@ -200,8 +229,8 @@
         </xpath>
     </template>
 
-    <template id="cart_summary_inherit_website_gift_card_sale" inherit_id="website_sale.checkout_layout">
-        <xpath expr="//td[@name='website_sale_cart_summary_product_name']/h6" position="after">
+    <template id="cart_summary_inherit_website_gift_card_sale" inherit_id="website_sale.cart_summary_content">
+        <xpath expr="//td[@name='website_sale_cart_summary_product_name']/span" position="after">
             <t t-call="sale_loyalty.used_gift_card"/>
         </xpath>
     </template>

--- a/addons/website_sale_slides/views/website_sale_templates.xml
+++ b/addons/website_sale_slides/views/website_sale_templates.xml
@@ -43,9 +43,9 @@
 </template>
 
 <template id="cart_summary_inherit_website_sale_slides"
-          inherit_id="website_sale.checkout_layout"
+          inherit_id="website_sale.cart_summary_content"
           name="Course Cart right column">
-    <xpath expr="//td[@name='website_sale_cart_summary_product_name']/h6" position="after">
+    <xpath expr="//td[@name='website_sale_cart_summary_product_name']/span" position="after">
         <div t-if="line.product_id.channel_ids"
              t-foreach="line.product_id.channel_ids.filtered(lambda course: course.enroll == 'payment')"
              t-as="course"


### PR DESCRIPTION
*: payment_demo,website_event_sale,website_sale,website_sale_loyalty,
website_sale_slides

> [!NOTE]
> <strong>NOT BLOCKING</strong>
> - `l10n_cl_edi_website_sale`, `10n_mx_edi_website_sale` and `extra_info` checkout pages still have duplicated buttons, to be solved after/in https://github.com/odoo/odoo/pull/198847

The summary is taking too much space on small viewports in the checkout.

The goal is to introduce an offcanvas on mobile which contains the
summary and the total table. This also includes small practical and
design revisions.

- Continue & Offcanvas trigger button sticky at the bottom of the page.
- Reviewed spacing
- Items count on top of the image to save horizontal space
- Reordered columns in the code to not rely on order classes
- Move the `o_website_sale_checkout` on the body to apply flex layout on
the `main`
- ! Renders the `express_checkout` button in the button container to
avoid the CSS ugly workaround
- ! Remove the `position-absolute` ugly  workaround for the CTA in the
checkout
- Review the design of the loyalty gift cards, eWallet, loyalty points.
- This PR removes the possibility to add a loyalty coupon/code passed the /cart page on mobile. 
 We might change this in the future.

Enterprise PR: https://github.com/odoo/enterprise/pull/82719
task-4594964

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/75fda671-79ce-4f5e-aea1-1164ae7ddd58) | ![image](https://github.com/user-attachments/assets/df8735eb-24ba-4dae-b769-a64b5bf72cc4) |
| ![image](https://github.com/user-attachments/assets/75a20a8c-75b9-493e-bb34-ac4255a41e5a) | ![image](https://github.com/user-attachments/assets/c054d70e-c10f-4a65-8591-0c434215c5ac) |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
