### PR TITLE
[FIX] resource: fix division by zero if attendance records are empty

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -521,7 +521,8 @@ class ResourceCalendar(models.Model):
             if len(self) == 1 and self.flexible_hours:
                 day_days[start.date()] += interval_hours / self.hours_per_day if self.hours_per_day else 0
             else:
-                day_days[start.date()] += sum(meta.mapped('duration_days')) * interval_hours / sum(meta.mapped('duration_hours'))
+                duration_hours = meta.mapped('duration_hours')
+                day_days[start.date()] += sum(meta.mapped('duration_days')) * interval_hours / sum(duration_hours) if duration_hours else 0
 
         return {
             # Round the number of days to the closest 16th of a day.


### PR DESCRIPTION
> Description of the issue/feature this PR addresses:

If the interval payload is empty or lacks a duration, calculating the duration in days may lead to a division by zero.

To prevent this, we skip computing the duration in days when the resource.calendar.attendance record is unusable. Since the payload is empty in such cases, there's no need to update the duration proportion, as there are no hours to process.

opw-4618378
upg-2708964

> Current behavior before PR:

Division by zero when computing duration in days of intervals.

> Desired behavior after PR is merged:

If the payload (resource.calendar.attendance) is empty or doesn't have duration in days, it will not contribute to the final duration in days of the interval.

EDIT: [Traceback group #1938](https://upgrade.odoo.com/web#id=1938&menu_id=107&cids=1&active_id=2732417&model=upgrade.request.traceback.group&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
