### PR TITLE
[IMP] mail_bot: remove odoobot_status field

### DIFF
--- a/addons/mail_bot/views/res_users_views.xml
+++ b/addons/mail_bot/views/res_users_views.xml
@@ -1,21 +1,5 @@
 <?xml version="1.0"?>
 <odoo><data>
-    <!-- Update Preferences form !-->
-    <record id="res_users_view_form_preferences" model="ir.ui.view">
-        <field name="name">res.users.view.form.preferences.mail_bot</field>
-        <field name="model">res.users</field>
-        <field name="inherit_id" ref="mail.view_users_form_simple_modif_mail"/>
-        <field name="arch" type="xml">
-            <data>
-                <field name="notification_type" position="after">
-                    <field name="odoobot_state" groups="base.group_no_one"
-                        readonly="0"
-                        invisible="share"/>
-                </field>
-            </data>
-        </field>
-    </record>
-
     <!-- Update user form !-->
     <record id="res_users_view_form" model="ir.ui.view">
         <field name="name">res.users.view.form.mail_bot</field>

--- a/addons/mail_bot_hr/views/res_users_views.xml
+++ b/addons/mail_bot_hr/views/res_users_views.xml
@@ -11,21 +11,6 @@
             </field>
         </record>
 
-        <record id="res_users_view_form_preferences" model="ir.ui.view">
-            <field name="name">res.users.preferences.form.inherit</field>
-            <field name="model">res.users</field>
-            <field name="inherit_id"
-                   ref="mail_bot.res_users_view_form_preferences" />
-            <field name="arch" type="xml">
-                <field name="odoobot_state" position="before">
-                    <field name="can_edit" invisible="1"/>
-                </field>
-                <xpath expr="//field[@name='odoobot_state']" position="attributes">
-                    <attribute name="readonly">not can_edit</attribute>
-                </xpath>
-            </field>
-        </record>
-
         <record id="res_users_view_form_profile" model="ir.ui.view">
             <field name="name">res.users.profile.form.inherit</field>
             <field name="model">res.users</field>


### PR DESCRIPTION
In this commit
-------------------------------------------
- odoobot_status field is removed from preference form view

task: 4341705

Related PR: https://github.com/odoo/upgrade/pull/7482