### PR TITLE
[FIX] mail: show 'Mark as Unread' button in mobile view

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -422,6 +422,7 @@ export class Message extends Component {
                 message: this.props.message,
                 thread: this.props.thread,
                 isFirstMessage: this.props.isFirstMessage,
+                isOriginThread: this.isOriginThread,
                 openReactionMenu: () => this.openReactionMenu(),
                 state: this.state,
             },

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.js
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.js
@@ -10,6 +10,7 @@ export class MessageActionMenuMobile extends Component {
         "close?",
         "thread?",
         "isFirstMessage?",
+        "isOriginThread",
         "openReactionMenu?",
         "state",
     ];
@@ -39,6 +40,10 @@ export class MessageActionMenuMobile extends Component {
 
     get state() {
         return this.props.state;
+    }
+
+    get isOriginThread() {
+        return this.props.isOriginThread;
     }
 
     async onClickAction(action) {


### PR DESCRIPTION
Before this commit,
The 'Mark as Unread' button was missing in the mobile view. 
This happened because the `set-new-message-separator` action depended on `component.isOriginThread`, which is present on `Message` but not in `MessageActionMenuMobile`, used in mobile.

This commit resolves the issue by passing the `isOriginThread` property from `Message` to `MessageActionMenuMobile`.
As a result, the 'Mark as Unread' button appears correctly in the mobile view.

task-[4686591](https://www.odoo.com/odoo/project/1519/tasks/4686591)