### PR TITLE
[IMP] crm_livechat: lead should be created through chatbot step

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -785,6 +785,8 @@ class CrmLead(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
+            if not vals.get('type') and not vals.get('team_id') and (self.env.user._is_portal() or self.env.user._is_public()):
+                vals['type'] = 'lead' if self.env['res.groups']._is_feature_enabled('crm.group_use_lead') else 'opportunity'
             if vals.get('website'):
                 vals['website'] = self.env['res.partner']._clean_website(vals['website'])
         leads = super().create(vals_list)

--- a/addons/crm_livechat/tests/test_chatbot_lead.py
+++ b/addons/crm_livechat/tests/test_chatbot_lead.py
@@ -19,6 +19,19 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
         self.assertEqual(created_lead.team_id, self.sale_team)
         self.assertEqual(created_lead.type, 'opportunity')
 
+    def test_chatbot_create_lead_no_team(self):
+        self.step_create_lead.crm_team_id = self.env["crm.team"]
+
+        self.env["res.config.settings"].create({"group_use_lead": False}).execute()
+        self._play_session_with_lead()
+        created_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertEqual(created_lead.type, "opportunity", "An opportunity should be created")
+
+        self.env["res.config.settings"].create({"group_use_lead": True}).execute()
+        self._play_session_with_lead()
+        created_lead = self.env["crm.lead"].sudo().search([], limit=1, order="id desc")
+        self.assertEqual(created_lead.type, "lead", "A lead should be created")
+
     def test_chatbot_create_lead_and_forward_public_user(self):
         """Test create_lead_and_forward properly creates a lead, assigns it to an available sales
         team member, and forwards the discussion to that member."""


### PR DESCRIPTION
Issue:
When 'Leads' setting is on in CRM and no sales team is assigned to 'Create Lead'
and a portal or public user interacts with that chatbot to trigger that step,
an 'opportunity' is created instead of a 'lead'

Steps to reproduce:
1. Turn on the 'Leads' setting in CRM app
2. Navigate to Live Chat app and open any chatbot
3. Create a new step of type 'Create Lead' and don't assign any sales team
4. Trigger that step by interacting with chatbot through Test button or website

Current behavior:
An opportunity is created

Desired behavior:
A lead is created

task-4250641

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
