### PR TITLE
[FIX] spreadsheet: export list field matching

### DIFF
--- a/addons/spreadsheet/static/src/list/plugins/list_core_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_global_filter_plugin.js
@@ -151,7 +151,7 @@ export class ListCoreGlobalFilterPlugin extends OdooCorePlugin {
      * @param {Object} data
      */
     export(data) {
-        for (const id in this.lists) {
+        for (const id in this.fieldMatchings) {
             data.lists[id].fieldMatching = this.fieldMatchings[id];
         }
     }

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -453,6 +453,42 @@ test("Can import/export filters", async function () {
     });
 });
 
+test("Can import/export filters of only list", async function () {
+    const spreadsheetData = {
+        version: 16,
+        lists: {
+            1: {
+                id: 1,
+                columns: ["foo", "contact_name"],
+                domain: [],
+                model: "partner",
+                orderBy: [],
+                context: {},
+                fieldMatching: {
+                    41: { type: "date", chain: "date" },
+                    42: { type: "date", chain: "date" },
+                },
+            },
+        },
+        globalFilters: [LAST_YEAR_LEGACY_FILTER, LAST_YEAR_GLOBAL_FILTER],
+    };
+    const { model } = await createModelWithDataSource({ spreadsheetData });
+
+    let listDomain = model.getters.getListComputedDomain("1");
+    expect(listDomain.length).toBe(7, {
+        message: "it should have updated the list domain",
+    });
+
+    const newModel = new Model(model.exportData(), {
+        custom: model.config.custom,
+    });
+
+    listDomain = newModel.getters.getListComputedDomain("1");
+    expect(listDomain.length).toBe(7, {
+        message: "it should have updated the list domain",
+    });
+});
+
 test("Relational filter with undefined value", async function () {
     const { model } = await createSpreadsheetWithPivot();
     await addGlobalFilter(


### PR DESCRIPTION
Since f53ed4a567894c07f96fc4cc320c24c396ca2927, the list field matching was not exported correctly. The issue was that variables used in the export (`lists`) were not defined anymore.
`#ILoveTypescript`

Task: 4689319

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
