### PR TITLE
[IMP] account*: Batch summary and Peppol fixes

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -36,7 +36,7 @@ class AccountMoveSend(models.AbstractModel):
         return {edi_key for edi_key, edi_vals in extra_edis.items() if edi_vals['is_applicable'](move)}
 
     @api.model
-    def _get_default_invoice_edi_format(self, move) -> str:
+    def _get_default_invoice_edi_format(self, move, **kwargs) -> str:
         """ By default, we generate the EDI format set on partner. """
         return move.partner_id.with_company(move.company_id).invoice_edi_format
 
@@ -58,22 +58,29 @@ class AccountMoveSend(models.AbstractModel):
 
         vals = {
             'sending_methods': get_setting('sending_methods', default_value={self._get_default_sending_method(move)}) or {},
-            'invoice_edi_format': get_setting('invoice_edi_format', default_value=self._get_default_invoice_edi_format(move)),
             'extra_edis': get_setting('extra_edis', default_value=self._get_default_extra_edis(move)) or {},
             'pdf_report': get_setting('pdf_report') or self._get_default_pdf_report_id(move),
             'author_user_id': get_setting('author_user_id', from_cron=from_cron) or self.env.user.id,
             'author_partner_id': get_setting('author_partner_id', from_cron=from_cron) or self.env.user.partner_id.id,
         }
+        vals['invoice_edi_format'] = get_setting('invoice_edi_format', default_value=self._get_default_invoice_edi_format(move, sending_methods=vals['sending_methods']))
         if 'email' in vals['sending_methods']:
             mail_template = get_setting('mail_template') or self._get_default_mail_template_id(move)
             mail_lang = get_setting('mail_lang') or self._get_default_mail_lang(move, mail_template)
+            mail_attachments_widget = self._get_default_mail_attachments_widget(
+                move,
+                mail_template,
+                invoice_edi_format=vals['invoice_edi_format'],
+                extra_edis=vals['extra_edis'],
+                pdf_report=vals['pdf_report'],
+            )
             vals.update({
                 'mail_template': mail_template,
                 'mail_lang': mail_lang,
                 'mail_body': get_setting('mail_body', default_value=self._get_default_mail_body(move, mail_template, mail_lang)),
                 'mail_subject': get_setting('mail_subject', default_value=self._get_default_mail_subject(move, mail_template, mail_lang)),
                 'mail_partner_ids': get_setting('mail_partner_ids', default_value=self._get_default_mail_partner_ids(move, mail_template, mail_lang).ids),
-                'mail_attachments_widget': get_setting('mail_attachments_widget', default_value=self._get_default_mail_attachments_widget(move, mail_template, extra_edis=vals['extra_edis'], pdf_report=vals['pdf_report'])),
+                'mail_attachments_widget': get_setting('mail_attachments_widget', default_value=mail_attachments_widget),
             })
         return vals
 
@@ -161,14 +168,14 @@ class AccountMoveSend(models.AbstractModel):
     # -------------------------------------------------------------------------
 
     @api.model
-    def _get_default_mail_attachments_widget(self, move, mail_template, extra_edis=None, pdf_report=None):
-        return self._get_placeholder_mail_attachments_data(move, extra_edis=extra_edis) \
+    def _get_default_mail_attachments_widget(self, move, mail_template, invoice_edi_format=None, extra_edis=None, pdf_report=None):
+        return self._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis) \
             + self._get_placeholder_mail_template_dynamic_attachments_data(move, mail_template, pdf_report=pdf_report) \
             + self._get_invoice_extra_attachments_data(move) \
             + self._get_mail_template_attachments_data(mail_template)
 
     @api.model
-    def _get_placeholder_mail_attachments_data(self, move, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         """ Returns all the placeholder data.
         Should be extended to add placeholder based on the sending method.
         :param: move:       The current move.
@@ -301,8 +308,10 @@ class AccountMoveSend(models.AbstractModel):
         return True
 
     @api.model
-    def _is_applicable_to_move(self, method, move):
+    def _is_applicable_to_move(self, method, move, **move_data):
         """ TO OVERRIDE - """
+        if method == 'email' and 'mail_partner_ids' in move_data:
+            return bool(move_data['mail_partner_ids'])
         return True
 
     @api.model
@@ -413,7 +422,7 @@ class AccountMoveSend(models.AbstractModel):
         to_send_mail = {
             move: move_data
             for move, move_data in moves_data.items()
-            if 'email' in move_data['sending_methods'] and self._is_applicable_to_move('email', move)
+            if 'email' in move_data['sending_methods'] and self._is_applicable_to_move('email', move, **move_data)
         }
         self._send_mails(to_send_mail)
 

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -680,6 +680,9 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.partner_a.email = None
         self.assertTrue(bool(self.partner_b.email))
         wizard = self.create_send_and_print(invoice1 + invoice2)
+        self.assertEqual(wizard.summary_data, {
+            'email': {'count': 1, 'label': 'by Email'},  # Only one will be actually sent by email
+        })
         self.assertTrue('account_missing_email' in wizard.alerts)
         self.assertEqual(wizard.alerts['account_missing_email']['level'], 'warning')
         wizard.action_send_and_print()
@@ -910,7 +913,9 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
 
         custom_subject = "turlututu"
-        wizard = self.create_send_and_print(invoice, mail_template_id=None, mail_subject=custom_subject)
+        wizard = self.create_send_and_print(invoice)
+        wizard.mail_template_id = None
+        wizard.mail_subject = custom_subject
 
         wizard.action_send_and_print(allow_fallback_pdf=True)
         message = self._get_mail_message(invoice)
@@ -1077,6 +1082,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
         self.assertFalse(invoice.invoice_pdf_report_id)
         wizard = self.create_send_and_print(invoice, sending_methods=[])
+        self.assertFalse(wizard.sending_methods)
         wizard.action_send_and_print()
         self.assertTrue(invoice.is_move_sent)
         self.assertTrue(invoice.invoice_pdf_report_id)

--- a/addons/account/wizard/account_move_send_batch_wizard.xml
+++ b/addons/account/wizard/account_move_send_batch_wizard.xml
@@ -14,7 +14,7 @@
                 </div>
 
                 <!-- Summary -->
-                <field name="summary_data" widget="account_batch_sending_summary" nolabel="1"/>
+                <field name="summary_data" invisible="not summary_data" widget="account_batch_sending_summary" nolabel="1"/>
 
                 <footer>
                     <button string="Send"

--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -55,12 +55,11 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         return super()._get_invoice_extra_attachments(move) + move.ubl_cii_xml_id
 
-    def _get_placeholder_mail_attachments_data(self, move, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         # EXTENDS 'account'
-        results = super()._get_placeholder_mail_attachments_data(move, extra_edis=extra_edis)
-        partner_edi_format = self._get_default_invoice_edi_format(move)
-        if move._need_ubl_cii_xml(partner_edi_format):
-            builder = move.partner_id.commercial_partner_id._get_edi_builder(partner_edi_format)
+        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
+        if move._need_ubl_cii_xml(invoice_edi_format):
+            builder = move.partner_id.commercial_partner_id._get_edi_builder(invoice_edi_format)
             filename = builder._export_invoice_filename(move)
             results.append({
                 'id': f'placeholder_{filename}',

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -13,7 +13,7 @@ class AccountMove(models.Model):
         selection=[
             ('ready', 'Ready to send'),
             ('to_send', 'Queued'),
-            ('skipped', 'Skipped'),
+            ('skipped', 'Skipped'),  # TODO remove this state in master, we now put a regular error.
             ('processing', 'Pending Reception'),
             ('done', 'Done'),
             ('error', 'Error'),

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -193,6 +193,11 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
                 'name': 'INV_2023_00001.pdf',
                 'placeholder': True,
             },
+            {
+                'mimetype': 'application/xml',
+                'name': 'INV_2023_00001_ubl_bis3.xml',
+                'placeholder': True,
+            },
         ])
 
         wizard.sending_methods = ['peppol']
@@ -379,12 +384,12 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             'invoice_sending_method': 'peppol',
         }])
         # but not valid for company 2
-        new_partner.with_company(company_2).peppol_verification_state = False
+        new_partner.with_company(company_2).invoice_edi_format = 'nlcius'
         self.assertRecordValues(new_partner.with_company(company_2), [{
-            'peppol_verification_state': False,
+            'peppol_verification_state': 'not_valid_format',
             'peppol_eas': '0208',
             'peppol_endpoint': '0477472701',
-            'invoice_edi_format': False,
+            'invoice_edi_format': 'nlcius',
             'invoice_sending_method': 'peppol',
         }])
         move_1 = self.create_move(new_partner)
@@ -395,10 +400,10 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
         wizard = self.create_send_and_print(move_1 + move_2 + move_3)
         wizard.action_send_and_print()
         self.assertEqual((move_1 + move_2 + move_3).mapped('is_being_sent'), [True, True, True])
-        # the cron is ran asynchronously and should be agnostic from the current self.env.company
+        # the cron is run asynchronously and should be agnostic from the current self.env.company
         self.env.ref('account.ir_cron_account_move_send').with_company(company_2).method_direct_trigger()
         # only move 1 & 2 should be processed, move_3 is related to an invalid partner (with regard to company_2) thus should fail to send
-        self.assertEqual((move_1 + move_2 + move_3).mapped('peppol_move_state'), ['processing', 'processing', 'skipped'])
+        self.assertEqual((move_1 + move_2 + move_3).mapped('peppol_move_state'), ['processing', 'processing', 'error'])
 
     def test_available_peppol_sending_methods(self):
         company_us = self.setup_other_company()['company']  # not a valid Peppol country
@@ -410,3 +415,62 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
         self.assertFalse('facturx' in self.valid_partner.available_peppol_edi_formats)
         self.valid_partner.invoice_sending_method = 'email'
         self.assertTrue('facturx' in self.valid_partner.available_peppol_edi_formats)
+
+    def test_peppol_default_ubl_bis3_single(self):
+        """In single invoice sending, if a partner is set on 'by Peppol' sending method,
+        and has no specific e-invoice format, we should default on BIS3
+        and generate invoices without errors.
+        """
+        self.valid_partner.invoice_sending_method = 'peppol'
+        self.valid_partner.invoice_edi_format = False
+
+        move = self.create_move(self.valid_partner)
+        move.action_post()
+        wizard = self.create_send_and_print(move)
+        self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
+        wizard.action_send_and_print()
+        self.assertTrue(move.ubl_cii_xml_id)
+        self.assertEqual(move.peppol_move_state, 'processing')
+
+    def test_peppol_default_ubl_bis3_multi(self):
+        """In multi-sending, if a partner is set on 'by Peppol' sending method, and
+        has no specific e-invoice format, we should default on BIS3
+        and generate invoices without errors.
+        """
+        self.valid_partner.invoice_sending_method = 'peppol'
+        self.valid_partner.invoice_edi_format = False
+
+        move_1 = self.create_move(self.valid_partner)
+        move_2 = self.create_move(self.valid_partner)
+        moves = (move_1 + move_2)
+        moves.action_post()
+        wizard = self.create_send_and_print(moves)
+        self.assertEqual(wizard.summary_data, {
+            'peppol': {'count': 2, 'label': 'by Peppol'},
+        })
+        wizard.action_send_and_print()
+        self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()
+
+        self.assertEqual(len(moves.ubl_cii_xml_id), 2)
+        self.assertEqual(moves.mapped('peppol_move_state'), ['processing', 'processing'])
+
+    def test_silent_error_while_creating_xml(self):
+        """When in multi/async mode, the generation of XML can fail silently (without raising).
+        This needs to be reflected as an error and put the move in Peppol Error state.
+        """
+        def mocked_export_invoice_constraints(self, invoice, vals):
+            return {'test_error_key': 'test_error_description'}
+
+        self.valid_partner.invoice_edi_format = 'ubl_bis3'
+        move_1 = self.create_move(self.valid_partner)
+        move_2 = self.create_move(self.valid_partner)
+        (move_1 + move_2).action_post()
+
+        wizard = self.create_send_and_print(move_1 + move_2)
+        with patch(
+            'odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20.AccountEdiXmlUBL20._export_invoice_constraints',
+            mocked_export_invoice_constraints
+        ):
+            wizard.action_send_and_print()
+            self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()
+        self.assertEqual(move_1.peppol_move_state, 'error')

--- a/addons/account_peppol/wizard/account_move_send_batch_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_batch_wizard.py
@@ -4,6 +4,14 @@ from odoo import models
 class AccountMoveSendBatchWizard(models.TransientModel):
     _inherit = 'account.move.send.batch.wizard'
 
+    def _compute_summary_data(self):
+        # EXTENDS 'account' - add checking of partner's validity
+        for wizard in self:
+            if peppol_moves := wizard.move_ids.filtered(lambda m: wizard._get_default_sending_method(m) == 'peppol'):
+                for move in peppol_moves:
+                    move.commercial_partner_id.button_account_peppol_check_partner_endpoint(company=move.company_id)
+        super()._compute_summary_data()
+
     def action_send_and_print(self, force_synchronous=False, allow_fallback_pdf=False):
         # EXTENDS 'account'
         self.ensure_one()

--- a/addons/account_peppol/wizard/account_move_send_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_wizard.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import api, models, _
+from odoo import models, _
 from odoo.exceptions import UserError
 
 class AccountMoveSendWizard(models.TransientModel):
@@ -47,16 +47,6 @@ class AccountMoveSendWizard(models.TransientModel):
                             ),
                         }
                     }
-
-    @api.depends('sending_methods')
-    def _compute_invoice_edi_format(self):
-        # EXTENDS 'account' - add default on bis3 if not set on partner's preferences and "by Peppol" is selected
-        super()._compute_invoice_edi_format()
-        for wizard in self:
-            if not wizard.invoice_edi_format and wizard.sending_methods and 'peppol' in wizard.sending_methods:
-                wizard.invoice_edi_format = wizard.move_id.partner_id._get_peppol_edi_format()
-            elif wizard.invoice_edi_format != self._get_default_invoice_edi_format(wizard.move_id) and wizard.sending_methods and 'peppol' not in wizard.sending_methods:
-                wizard.invoice_edi_format = None  # back to initial state if user unchecked 'by Peppol'
 
     def action_send_and_print(self, allow_fallback_pdf=False):
         # EXTENDS 'account'

--- a/addons/l10n_es_edi_facturae/models/account_move_send.py
+++ b/addons/l10n_es_edi_facturae/models/account_move_send.py
@@ -17,12 +17,11 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         return super()._get_invoice_extra_attachments(move) + move.l10n_es_edi_facturae_xml_id
 
-    def _get_placeholder_mail_attachments_data(self, move, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         # EXTENDS 'account'
-        results = super()._get_placeholder_mail_attachments_data(move, extra_edis=extra_edis)
+        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
 
-        partner_edi_format = self._get_default_invoice_edi_format(move)
-        if partner_edi_format == 'es_facturae' and move._l10n_es_edi_facturae_get_default_enable():
+        if invoice_edi_format == 'es_facturae' and move._l10n_es_edi_facturae_get_default_enable():
             filename = f'{move.name.replace("/", "_")}_facturae_signed.xml'
             results.append({
                 'id': f'placeholder_{filename}',

--- a/addons/l10n_es_edi_tbai/models/account_move_send.py
+++ b/addons/l10n_es_edi_tbai/models/account_move_send.py
@@ -22,9 +22,9 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         return super()._get_invoice_extra_attachments(move) + move.l10n_es_tbai_post_document_id.xml_attachment_id
 
-    def _get_placeholder_mail_attachments_data(self, move, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         # EXTENDS 'account'
-        results = super()._get_placeholder_mail_attachments_data(move, extra_edis=extra_edis)
+        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
 
         if (
             not move.l10n_es_tbai_post_document_id.xml_attachment_id

--- a/addons/l10n_jo_edi/models/account_move_send.py
+++ b/addons/l10n_jo_edi/models/account_move_send.py
@@ -40,9 +40,9 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         return super()._get_invoice_extra_attachments(move) + move.l10n_jo_edi_xml_attachment_id
 
-    def _get_placeholder_mail_attachments_data(self, move, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         # EXTENDS 'account'
-        res = super()._get_placeholder_mail_attachments_data(move, extra_edis=extra_edis)
+        res = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
 
         if not move.l10n_jo_edi_xml_attachment_id and 'jo_edi' in extra_edis:
             attachment_name = move._l10n_jo_edi_get_xml_attachment_name()

--- a/addons/l10n_vn_edi_viettel/models/account_move_send.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move_send.py
@@ -34,11 +34,10 @@ class AccountMoveSend(models.AbstractModel):
             + move.l10n_vn_edi_sinvoice_pdf_file_id
         )
 
-    def _get_placeholder_mail_attachments_data(self, move, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         # EXTENDS 'account'
-        results = super()._get_placeholder_mail_attachments_data(move, extra_edis=extra_edis)
-        partner_edi_format = self._get_default_invoice_edi_format(move)
-        if partner_edi_format == 'vn_sinvoice' and move._l10n_vn_edi_get_credentials_company():
+        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
+        if invoice_edi_format == 'vn_sinvoice' and move._l10n_vn_edi_get_credentials_company():
             results.extend([{
                 'id': 'placeholder_sinvoice.pdf',
                 'name': f'{move.company_id.vat}-{move.l10n_vn_edi_invoice_symbol.name}101.pdf',

--- a/addons/snailmail_account/models/account_move_send.py
+++ b/addons/snailmail_account/models/account_move_send.py
@@ -41,12 +41,12 @@ class AccountMoveSend(models.AbstractModel):
     # -------------------------------------------------------------------------
     # SENDING METHODS
     # -------------------------------------------------------------------------
-    def _is_applicable_to_move(self, method, move):
+    def _is_applicable_to_move(self, method, move, **move_data):
         # EXTENDS 'account'
         if method == 'snailmail':
             return self.env['snailmail.letter']._is_valid_address(move.partner_id)
         else:
-            return super()._is_applicable_to_move(method, move)
+            return super()._is_applicable_to_move(method, move, **move_data)
 
     def _hook_if_success(self, moves_data):
         # EXTENDS 'account'
@@ -55,7 +55,7 @@ class AccountMoveSend(models.AbstractModel):
         to_send = {
             move: move_data
             for move, move_data in moves_data.items()
-            if 'snailmail' in move_data['sending_methods'] and self._is_applicable_to_move('snailmail', move)
+            if 'snailmail' in move_data['sending_methods'] and self._is_applicable_to_move('snailmail', move, **move_data)
         }
         if to_send:
             self.env['snailmail.letter'].create([

--- a/addons/snailmail_account/wizard/account_move_send_batch_wizard.py
+++ b/addons/snailmail_account/wizard/account_move_send_batch_wizard.py
@@ -17,5 +17,5 @@ class AccountMoveSendBatchWizard(models.TransientModel):
         # EXTENDS 'account'
         super()._compute_summary_data()
         for wizard in self:
-            if 'snailmail' in wizard.summary_data:
+            if wizard.summary_data and 'snailmail' in wizard.summary_data:
                 wizard.summary_data['snailmail'].update({'extra': _('(Stamps: %s)', wizard.send_by_post_stamps)})


### PR DESCRIPTION
### [IMP] account: fix the summary of account.move.send.batch.wizard
*: account_peppol, snailmail_account

The summary was displaying wrong numbers of invoices.
Indeed, it was computed on default methods, instead of methods that are applicable
to the move. For example, if a move was not possible to send through Peppol because
the partner is not registered on the network, it was still displayed in the summary
of the batch sending (then not used when the async processing happened).

We also always put email as a fallback, even if no email is set, since it can
be added through the wizard.

task-no (review with TSB/PMAX)

----------------------------

### [FIX] account_peppol: Remove 'skipped' state of Peppol moves
This state doesn't really make sense. It only happens when there is
an error while generating the XML file to send, which can be considered
as a blocking error.

task-no

----------------------------

### [FIX] account_peppol: fix batch send of Peppol invoices when no format set

In previous commit[1], we set the BIS3 format on invoices that were meant to
be sent trough Peppol, even if no invoice_edi_format was set on the Partner.
This commit fixes some cases when sending multiple invoices with no
invoice_edi_format but Peppol as default sending method ended up
not being sent.

[1]: https://github.com/odoo/odoo/commit/84a0b81a258262e3bb9dbaa9c9f37796303a9dad

task-no