### PR TITLE
[FIX] sale_timesheet: respect uom user-defined defaults for products

### DIFF
--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -76,11 +76,18 @@ class ProductTemplate(models.Model):
     @api.onchange('type', 'service_type', 'service_policy')
     def _onchange_service_fields(self):
         for record in self:
+            default_uom_id = self.env['ir.default']._get_model_defaults('product.template').get('uom_id')
+            default_uom = self.env['uom.uom'].browse(default_uom_id)
             if record.type == 'service' and record.service_type == 'timesheet' and \
                not (record._origin.service_policy and record.service_policy == record._origin.service_policy):
-                record.uom_id = self.env.ref('uom.product_uom_hour')
+                if default_uom and default_uom.category_id == self.env.ref('uom.uom_categ_wtime'):
+                    record.uom_id = default_uom
+                else:
+                    record.uom_id = self.env.ref('uom.product_uom_hour')
             elif record._origin.uom_id:
                 record.uom_id = record._origin.uom_id
+            elif default_uom:
+                record.uom_id = default_uom
             else:
                 record.uom_id = self._get_default_uom_id()
             record.uom_po_id = record.uom_id
@@ -148,11 +155,18 @@ class ProductProduct(models.Model):
     @api.onchange('type', 'service_type', 'service_policy')
     def _onchange_service_fields(self):
         for record in self:
+            default_uom_id = self.env['ir.default']._get_model_defaults('product.product').get('uom_id')
+            default_uom = self.env['uom.uom'].browse(default_uom_id)
             if record.type == 'service' and record.service_type == 'timesheet' and \
                not (record._origin.service_policy and record.service_policy == record._origin.service_policy):
-                record.uom_id = self.env.ref('uom.product_uom_hour')
+                if default_uom and default_uom.category_id == self.env.ref('uom.uom_categ_wtime'):
+                    record.uom_id = default_uom
+                else:
+                    record.uom_id = self.env.ref('uom.product_uom_hour')
             elif record._origin.uom_id:
                 record.uom_id = record._origin.uom_id
+            elif default_uom:
+                record.uom_id = default_uom
             else:
                 record.uom_id = self._get_default_uom_id()
             record.uom_po_id = record.uom_id

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -3,6 +3,7 @@
 from odoo.addons.sale_timesheet.tests.common import TestCommonSaleTimesheet
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
+from odoo.tests.common import Form
 
 
 @tagged('-at_install', 'post_install')
@@ -921,3 +922,64 @@ class TestSaleService(TestCommonSaleTimesheet):
                 hours_delivered,
                 f"{amount} hours delivered should round the same for invoice & timesheet",
             )
+
+    def test_service_product_uom_default(self):
+        """
+        Test that user-defined UoM default is respected when creating a product or product variant
+        """
+        uom_cm = self.env.ref('uom.product_uom_cm')
+        uom_day = self.env.ref('uom.product_uom_day')
+        uom_hour = self.env.ref('uom.product_uom_hour')
+        test_user = self.env['res.users'].create({
+            'name': 'test user',
+            'login': 'test_uom_default_user',
+            'email': 'test_uom_default@example.com',
+        })
+        self.env['ir.default'].set('product.template', 'uom_id',
+                                   uom_cm.id, user_id=test_user.id, company_id=self.env.company.id)
+        self.env['ir.default'].set('product.product', 'uom_id',
+                                   uom_cm.id, user_id=test_user.id, company_id=self.env.company.id)
+
+        # - product.template
+        product_form = Form(self.env['product.template'].with_user(test_user))
+        product_form.name = 'product test'
+        product = product_form.save()
+        self.assertEqual(product.uom_id, uom_cm, "UoM default was not respected")
+
+        product_form = Form(self.env['product.template'].with_user(test_user))
+        product_form.name = 'timesheet service'
+        product_form.detailed_type = 'service'
+        product_form.service_policy = 'delivered_timesheet'
+        product = product_form.save()
+        self.assertEqual(product.uom_id, uom_hour, "UoM should be hours for timesheet service when default is not a time unit")
+
+        self.env['ir.default'].set('product.template', 'uom_id',
+                                   uom_day.id, user_id=test_user.id, company_id=self.env.company.id)
+        product_form = Form(self.env['product.template'].with_user(test_user))
+        product_form.name = 'timesheet service'
+        product_form.detailed_type = 'service'
+        product_form.service_policy = 'delivered_timesheet'
+        product = product_form.save()
+        self.assertEqual(product.uom_id, uom_day, "time UoM default was not respected")
+
+        # - product.product
+        product_form = Form(self.env['product.product'].with_user(test_user))
+        product_form.name = 'product variant test'
+        product = product_form.save()
+        self.assertEqual(product.uom_id, uom_cm, "UoM default was not respected")
+
+        product_form = Form(self.env['product.product'].with_user(test_user))
+        product_form.name = 'timesheet service'
+        product_form.detailed_type = 'service'
+        product_form.service_policy = 'delivered_timesheet'
+        product = product_form.save()
+        self.assertEqual(product.uom_id, uom_hour, "UoM should be hours for timesheet service when default is not a time unit")
+
+        self.env['ir.default'].set('product.product', 'uom_id',
+                                   uom_day.id, user_id=test_user.id, company_id=self.env.company.id)
+        product_form = Form(self.env['product.product'].with_user(test_user))
+        product_form.name = 'timesheet service'
+        product_form.detailed_type = 'service'
+        product_form.service_policy = 'delivered_timesheet'
+        product = product_form.save()
+        self.assertEqual(product.uom_id, uom_day, "time UoM default was not respected")


### PR DESCRIPTION
**Issue:**
When User-defined Defaults are set for Unit of Measure (product.template or product.product) and sale_timesheet module is installed, the uom default is not respected.

**Steps to reproduce:**
- ensure sale_timesheet module is installed
- settings > technical > user-defined Defaults
- create a default for unit of measure (product.template) other than hour
- create a new product of type service

The issue occurs in both product.template and product.product

opw-4604491