### PR TITLE
[IMP] mail: Show More option added to expand attachments

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -85,7 +85,16 @@
                             attachments="attachments"
                             unlinkAttachment.bind="unlinkAttachment"
                             imagesHeight="100"
+                            attachmentsLimit="displayLimit"
                         />
+                        <t t-if="attachments.length > displayLimit or !state.showLimitedAttachments">
+                            <button class="btn btn-link" t-on-click="toggelShowAllAttachments">
+                                <t t-if="attachments.length !== displayLimit">
+                                    Show More... (<t t-esc="attachments.length - displayLimit"/> remaining)
+                                </t>
+                                <t t-else="">Show Less</t>
+                            </button>
+                        </t>
                         <FileUploader multiUpload="true" fileUploadClass="'o-mail-Chatter-fileUploader'" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                             <t t-set-slot="toggler">
                                 <button class="btn btn-link" type="button" t-att-disabled="!state.thread.hasWriteAccess">

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -111,6 +111,8 @@ patch(Chatter.prototype, {
             showActivities: true,
             showAttachmentLoading: false,
             showScheduledMessages: true,
+            showLimitedAttachments: true,
+            visibleAttachments: 10,
         });
         this.messageSearch = useMessageSearch();
         this.attachmentUploader = useAttachmentUploader(
@@ -329,6 +331,10 @@ patch(Chatter.prototype, {
     },
 
     onClickAddAttachments() {
+        if (this.state.visibleAttachments >= 10) {
+            this.state.showLimitedAttachments = true;
+            this.state.visibleAttachments = 10;
+        }
         if (this.attachments.length === 0) {
             return;
         }
@@ -450,6 +456,28 @@ patch(Chatter.prototype, {
 
     toggleScheduledMessages() {
         this.state.showScheduledMessages = !this.state.showScheduledMessages;
+    },
+
+    get displayLimit() {
+        return this.state.visibleAttachments;
+    },
+
+    toggelShowAllAttachments() {
+        const total = this.attachments.length;
+        const current = this.state.visibleAttachments;
+        if (this.state.showLimitedAttachments) {
+            const next = current + 10;
+            if (next >= total) {
+                this.state.visibleAttachments = total;
+                this.state.showLimitedAttachments = false;
+            } else {
+                this.state.visibleAttachments = next;
+            }
+        }
+        else {
+            this.state.visibleAttachments = 10;
+            this.state.showLimitedAttachments = true;
+        }
     },
 
     async unlinkAttachment(attachment) {

--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -32,7 +32,7 @@ class ImageActions extends Component {
  */
 export class AttachmentList extends Component {
     static components = { ImageActions };
-    static props = ["attachments", "unlinkAttachment", "imagesHeight", "messageSearch?"];
+    static props = ["attachments", "unlinkAttachment", "imagesHeight", "messageSearch?", "attachmentsLimit?"];
     static template = "mail.AttachmentList";
 
     setup() {

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -13,7 +13,7 @@
             <div class="d-flex flex-grow-1 flex-wrap mx-1 align-items-center" t-att-class="{
                 'justify-content-end': isInChatWindowAndIsAlignedRight and !env.inComposer,
                         }" role="menu" >
-                <div t-foreach="images" t-as="attachment" t-key="attachment.id"
+                <div t-foreach="images.slice(0, props.attachmentsLimit)" t-as="attachment" t-key="attachment.id"
                      t-att-aria-label="attachment.name"
                      class="o-mail-AttachmentImage d-flex position-relative flex-shrink-0 mw-100 mb-1 me-1 rounded o-viewable"
                      t-att-title="attachment.name"
@@ -40,7 +40,7 @@
             <div class="d-flex flex-wrap mt-1 mx-1">
                 <!-- t-attf-class overridden in extensions -->
                 <div
-                    t-foreach="cards" t-as="attachment" t-key="attachment.id"
+                    t-foreach="props.attachmentsLimit ? (images.length &lt; props.attachmentsLimit ? cards.slice(0, props.attachmentsLimit - images.length) : []) : cards" t-as="attachment" t-key="attachment.id"
                     class="o-mail-AttachmentCard d-flex rounded mb-1 me-1 mw-100 overflow-auto"
                     t-att-class="{
                                'ms-1': isInChatWindowAndIsAlignedRight,

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -649,6 +649,43 @@ test("upload attachment on draft record", async () => {
     await contains("button[aria-label='Attach files']", { text: "1" });
 });
 
+test("chatter: show more option", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({});
+    for (let i = 1; i <= 25; i++) {
+        pyEnv["ir.attachment"].create({
+            mimetype: "text/plain",
+            name: `File${i}.txt`,
+            res_id: partnerId,
+            res_model: "res.partner",
+        });
+    }
+    await start();
+    await openFormView("res.partner", partnerId);
+    await contains(".o-mail-Chatter");
+    await contains(".o-mail-Chatter-topbar");
+    await contains("button[aria-label='Attach files']");
+    await contains("button[aria-label='Attach files']", { text: "25" });
+    await contains(".o-mail-AttachmentBox", { count: 0 });
+    await click("button[aria-label='Attach files']");
+    await contains(".o-mail-AttachmentBox");
+    await contains("button", { text: "Show More... (15 remaining)" });
+    await contains(".o-mail-AttachmentCard", { count: 10 });
+    await click("button", { text: "Show More... (15 remaining)" });
+    await contains("button", { text: "Show More... (5 remaining)" });
+    await contains(".o-mail-AttachmentCard", { count: 20 });
+    await click("button", { text: "Show More... (5 remaining)" });
+    await contains("button", { text: "Show Less" });
+    await contains(".o-mail-AttachmentCard", { count: 25 });
+    await click("button", { text: "Show Less" });
+    await contains("button", { text: "Show More... (15 remaining)" });
+    await click("button", { text: "Show More... (15 remaining)" });
+    await contains("button", { text: "Show More... (5 remaining)" });
+    await click("button[aria-label='Attach files']");
+    await click("button[aria-label='Attach files']");
+    await contains("button", { text: "Show More... (15 remaining)" });
+});
+
 test("Follower count of draft record is set to 0", async () => {
     await start();
     await openFormView("res.partner");


### PR DESCRIPTION
In this commit:

1. Added 'Show More' option to expand attachments in chatter section.
2. Display limit is set to 10. if attachments is more than 10 then only 'Show More' button will be visible.
3. Also added 'Show Less' to collapse attachments.

Task - 4686857