### PR TITLE
[FIX] hw_posbox_homepage: current db status

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -126,9 +126,9 @@ class StatusPage extends Component {
                             <td class="col-3"><i class="me-1 fa fa-fw fa-id-card"/>Name</td>
                             <td class="col-3" t-out="state.data.hostname"/>
                         </tr>
-                        <tr t-if="state.data.odoo_server_url">
+                        <tr t-if="state.data.server_status">
                             <td class="col-3"><i class="me-1 fa fa-fw fa-database"/>Database</td>
-                            <td class="col-3" t-out="state.data.odoo_server_url"/>
+                            <td class="col-3" t-out="state.data.server_status"/>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
On the IoT box status display, there is supposed to be an entry showing the URL of the connected database. However, prior to this commit it was using the incorrect key (`odoo_server_url` instead of `server_status`). This commit fixes the functionality by using the correct key.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
