### PR TITLE
[FIX] web: improve image quality for resized WebP images

### DIFF
--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -188,6 +188,8 @@ export class ImageField extends Component {
                 const ctx = canvas.getContext("2d");
                 ctx.fillStyle = "transparent";
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
+                ctx.imageSmoothingEnabled = true;
+                ctx.imageSmoothingQuality = "high";
                 ctx.drawImage(
                     image,
                     0,


### PR DESCRIPTION
Enable canvas image smoothing with high quality settings to improve the visual output of resized images.

The issue was most noticeable in the 128px version, which appeared blurry or pixelated.

<img width="1279" alt="Screenshot 2025-04-02 at 11 03 17" src="https://github.com/user-attachments/assets/dd2c9f92-1ad9-409b-9c17-184059dc5adf" />

opw-4689905

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
