### PR TITLE
[REV] account: Wrongly modified matching feature behavior

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1053,8 +1053,6 @@ class AccountChartTemplate(models.AbstractModel):
                 "auto_reconcile": True,
                 "match_nature": 'both',
                 "match_same_currency": True,
-                "match_text_location_note": True,
-                "match_text_location_reference": True,
                 "allow_payment_tolerance": True,
                 "payment_tolerance_type": 'percentage',
                 "payment_tolerance_param": 0,
@@ -1067,8 +1065,6 @@ class AccountChartTemplate(models.AbstractModel):
                 "auto_reconcile": False,
                 "match_nature": 'both',
                 "match_same_currency": True,
-                "match_text_location_note": True,
-                "match_text_location_reference": True,
                 "allow_payment_tolerance": False,
                 "match_partner": True,
             }


### PR DESCRIPTION
The reverted commit was not a fix but a modification of a behavior we did not want to do in stable.

This reverts commit 5c0cd2141779e4534b332e0282ce37883fcc0a5f.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
