### PR TITLE
[FIX] website, web: fix menu editor drag-and-drop

### DIFF
--- a/addons/web/static/src/core/utils/nested_sortable.js
+++ b/addons/web/static/src/core/utils/nested_sortable.js
@@ -180,8 +180,16 @@ export const useNestedSortable = makeDraggableHook({
     // placeholder accordingly.
     onDrag({ ctx, callHandler }) {
         const onMove = (prevPos) => {
-            if (!this._isAllowedNodeMove(ctx)) {
+            if (!ctx.isAllowed(ctx.current, ctx.elementSelector)) {
                 ctx.current.placeHolder.classList.add("d-none");
+                return;
+            } else if (this._hasReachMaxAllowedLevel(ctx)) {
+                // If the placeholder has reached its max allowed level, it is
+                // moved back to its previous position.
+                const previousSiblingEl = ctx.current.placeHolder
+                    .closest(ctx.listTagName)
+                    .closest(ctx.elementSelector);
+                previousSiblingEl.after(ctx.current.placeHolder);
                 return;
             }
             ctx.current.placeHolder.classList.remove("d-none");

--- a/addons/web/static/tests/core/utils/nested_sortable.test.js
+++ b/addons/web/static/tests/core/utils/nested_sortable.test.js
@@ -974,7 +974,7 @@ test("shouldn't drag above max level", async () => {
                     expect.step("end");
                     expect(element).toHaveAttribute("id", "dragged");
                     expect(element.parentElement.closest("#parent")).toBe(null);
-                    expect(".o_nested_sortable_placeholder.d-none").toHaveCount(1);
+                    expect(element.previousSibling).toHaveClass("o_nested_sortable_placeholder");
                 },
             });
         }

--- a/addons/website/static/src/components/dialog/dialog.scss
+++ b/addons/website/static/src/components/dialog/dialog.scss
@@ -2,4 +2,7 @@
     label {
         font-weight: $font-weight-bold;
     }
+    .o_nested_sortable_placeholder_realsize {
+        margin-bottom: 4px;
+    }
 }

--- a/addons/website/static/src/components/dialog/edit_menu.js
+++ b/addons/website/static/src/components/dialog/edit_menu.js
@@ -134,6 +134,20 @@ export class EditMenuDialog extends Component {
             onDrop: this._moveMenu.bind(this),
             isAllowed: this._isAllowedMove.bind(this),
             useElementSize: true,
+            /**
+             * @param {DOMElement} element - moved element
+             * @param {DOMElement} parent - parent element of where the element was moved
+             * @param {DOMElement} placeholder - hint element showing the current position
+             */
+            onMove: ({element, placeholder, parent}) => {
+                // Adapt the dragged menu item to match the width and position
+                // of the placeholder.
+                element.style.width = getComputedStyle(placeholder).width;
+                element.style.marginLeft =
+                    parent && (element.parentElement === this.menuEditor.el)
+                    ? "2rem"
+                    : "";
+            },
         });
     }
 

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -250,10 +250,9 @@ registerWebsitePreviewTour('edit_menus', {
         content: "Drag Mega at the top",
         trigger: '.oe_menu_editor li:contains("Megaaaaa!") .fa-bars',
         run(helpers) {
-            return helpers.drag_and_drop('.oe_menu_editor li:contains("Home")', {
-                position: {
-                    y: 27,
-                    left: 5,
+            return helpers.drag_and_drop(".oe_menu_editor li:contains('Home') .fa-bars", {
+                position : {
+                    top: 20,
                 },
                 relative: true,
             });


### PR DESCRIPTION
This commit fixes the following two issues in the menu creation dialog:

**Issue 1:**

- Install the Website app and go to the homepage.
- In the backend navbar, click on "Site" and then on "Menu Editor."
- Drag a menu item (without dropping it) to the right to create a sub-menu.
- The issue is that while dragging the menu item, when the placeholder is in a sub-menu position, the menu item keeps its original width instead of taking the width of a sub-menu item. This is confusing and unclear from a UX perspective.

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/7b89bde2-2b22-4d9c-9665-078bb0906e26)  | ![image](https://github.com/user-attachments/assets/d9cf0b4f-3d5c-4d33-ba3c-08756d580f20)  |

----------------

**Issue 2:**

- Install the Website app and go to the homepage.
- In the backend navbar, click on "Site" and then on "Menu Editor."
- Drag and drop the second menu item to the right to create a sub-menu.
- Drag another menu item (without dropping it) to the right to create a second sub-menu below the first one.
- Without releasing it, continue dragging it to the right.
- The issue is that the placeholder disappears at this point. To make it reappear, the menu item must be moved slightly to the left again. This results in a very poor user experience and makes sub-menu creation messy.

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/694d89d1-4391-4ffa-bb5e-21f8d6b1ffc3)  | ![image](https://github.com/user-attachments/assets/2c5e25d4-996a-4fde-9ed0-a52e1ed60923)  |

task-4422810