### PR TITLE
[FIX] pos_restaurant: multi printer fix

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1596,7 +1596,7 @@ export class PosStore extends WithLazyGetterTrap {
                     return;
                 }
 
-                this.printChanges(order, orderChange, reprint);
+                await this.printChanges(order, orderChange, reprint);
             } catch (e) {
                 console.info("Failed in printing the changes in the order", e);
             }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -565,3 +565,18 @@ registry.category("web_tour.tours").add("FinishResidualOrder", {
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_multiple_preparation_printer_different_categories", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Product 1"),
+            ProductScreen.clickDisplayedProduct("Product 2"),
+            ProductScreen.clickOrderButton(),
+            Dialog.bodyIs("Failed in printing Printer 1, Printer 2 changes of the order"),
+            Dialog.confirm(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -492,3 +492,49 @@ class TestFrontend(TestFrontendCommon):
         line_2 = self.env['pos.order.line'].search([('full_product_name', '=', 'product_2')])
         self.assertEqual(line_1.tax_ids, self.tax_sale_a)
         self.assertEqual(line_2.tax_ids, self.tax_sale_a)
+
+    def test_multiple_preparation_printer_different_categories(self):
+        """This test make sure that no empty receipt are sent when using multiple printer with different categories
+           The tour will check that we tried did not try to print two receipt. We can achieve that by checking the content
+           of the error message. Because we do not have real printer an error message will be displayed, this will contain
+           all the receipt that failed to print. If it contains more than 1 it means that we tried to print a second receipt
+           and it should not be the case here. The only one we should see is 'Detailed Receipt'
+        """
+        pos_category_1 = self.env['pos.category'].create({'name': 'Category 1'})
+        pos_category_2 = self.env['pos.category'].create({'name': 'Category 2'})
+        printer_1 = self.env['pos.printer'].create({
+            'name': 'Printer 1',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(pos_category_2.ids)],
+        })
+        printer_2 = self.env['pos.printer'].create({
+            'name': 'Printer 2',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(pos_category_1.ids)],
+        })
+
+        self.main_pos_config.write({
+            'is_order_printer': True,
+            'printer_ids': [Command.set([printer_1.id, printer_2.id])],
+        })
+
+        self.product_1 = self.env['product.product'].create({
+            'name': 'Product 1',
+            'available_in_pos': True,
+            'list_price': 10,
+            'pos_categ_ids': [(6, 0, [pos_category_1.id])],
+            'taxes_id': False,
+        })
+
+        self.product_2 = self.env['product.product'].create({
+            'name': 'Product 2',
+            'available_in_pos': True,
+            'list_price': 10,
+            'pos_categ_ids': [(6, 0, [pos_category_2.id])],
+            'taxes_id': False,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_multiple_preparation_printer_different_categories', login="pos_user")


### PR DESCRIPTION
Steps to reproduce:
------------------------
* Create 2 products with 2 different PoS categories
* Create 2 printers to print one of each categories
* Open PoS and add the 2 products to the order
* Send the order in preparation
> Observations: You get a traceback

Why the fix:
------------------------
The issue is that when printing on 2 different printers the order (that was never sent to the server) was synchronised during the printing process. This caused the original order to lose all reference to other object like pos_config, pos_session, etc. To fix this we make sure to synchronise the order before printing and using the synchronised version of the order to print.

opw-4662737