### PR TITLE
[FIX] stock: check product compatibility for the default  RR route

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -326,13 +326,14 @@ class StockWarehouseOrderpoint(models.Model):
         """
         self = self.filtered(lambda o: not o.route_id)
         rules_groups = self.env['stock.rule']._read_group([
-            ('route_id.product_selectable', '!=', False),
+            '|', ('route_id.product_selectable', '!=', False),
+            ('route_id.product_categ_selectable', '!=', False),
             ('location_dest_id', 'in', self.location_id.ids),
             ('action', 'in', ['pull_push', 'pull']),
             ('route_id.active', '!=', False)
         ], ['location_dest_id', 'route_id'])
         for location_dest, route in rules_groups:
-            orderpoints = self.filtered(lambda o: o.location_id.id == location_dest.id)
+            orderpoints = self.filtered(lambda o: not o.route_id and route in (o.product_id.route_ids | o.product_id.categ_id.route_ids) and o.location_id.id == location_dest.id)
             orderpoints.route_id = route
 
     def _get_lead_days_values(self):

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -3,6 +3,7 @@
 
 from datetime import date, datetime, timedelta
 
+from odoo import Command
 from odoo.tests.common import Form, TransactionCase
 from odoo.tools import mute_logger
 from odoo.exceptions import UserError
@@ -521,6 +522,75 @@ class TestProcRule(TransactionCase):
         # Verify the location and the qty
         self.assertRecordValues(replenishments, [
             {'location_id': replenish_loc.id, 'qty_to_order': 3},
+        ])
+
+    def test_orderpoint_replenishment_view_3(self):
+        """
+        Create a selectable on product route and a product without routes. Verify that the orderpoint created
+        to replenish that product did not set the new route by default.
+        """
+        interdimensional_protal = self.env['stock.location'].create({
+            'name': 'Interdimensional portal',
+            'usage': 'internal',
+            'location_id': self.env.ref('stock.stock_location_stock').location_id.id,
+        })
+        lovely_route = self.env['stock.route'].create({
+            'name': 'Lovely Route',
+            'product_selectable': True,
+            'product_categ_selectable': True,
+            'sequence': 1,
+            'rule_ids': [Command.create({
+                'name': 'Interdimensional portal -> Stock',
+                'action': 'pull',
+                'picking_type_id': self.ref('stock.picking_type_internal'),
+                'location_src_id': interdimensional_protal.id,
+                'location_dest_id': self.ref('stock.stock_location_stock'),
+            })],
+        })
+        lovely_category = self.env['product.category'].create({
+            'name': 'Lovely Category',
+            'route_ids': [Command.set(lovely_route.ids)]
+        })
+        products = self.env['product.product'].create([
+            {
+                'name': 'Lovely product',
+                'type': 'product',
+                'route_ids': [Command.set([])],
+            },
+            {
+                'name': 'Lovely product with route',
+                'type': 'product',
+                'route_ids': [Command.set(lovely_route.ids)],
+            },
+            {
+                'name': 'Lovely product with categ route',
+                'type': 'product',
+                'route_ids': [Command.set([])],
+                'categ_id': lovely_category.id,
+            },
+        ])
+        moves = self.env['stock.move'].create([
+            {
+                'name': 'Create a demand move',
+                'location_id': self.ref('stock.stock_location_stock'),
+                'location_dest_id': self.partner.property_stock_customer.id,
+                'product_id': product.id,
+                'product_uom': product.uom_id.id,
+                'product_uom_qty': 1,
+            } for product in products
+        ])
+        moves._action_confirm()
+        # activate action of opening the replenishment view
+        self.env.flush_all()
+        self.env['stock.warehouse.orderpoint'].action_open_orderpoints()
+        replenishments = self.env['stock.warehouse.orderpoint'].search([
+            ('product_id', 'in', products.ids),
+        ])
+        # Verify that the route is unset
+        self.assertRecordValues(replenishments.sorted('product_id'), [
+            {'product_id': products[0].id, 'location_id': self.ref('stock.stock_location_stock'), 'route_id': False},
+            {'product_id': products[1].id, 'location_id': self.ref('stock.stock_location_stock'), 'route_id': lovely_route.id},
+            {'product_id': products[2].id, 'location_id': self.ref('stock.stock_location_stock'), 'route_id': lovely_route.id},
         ])
 
     def test_orderpoint_compute_warehouse_location(self):


### PR DESCRIPTION
### Issue: 

Currently, the default route set on an automatically created RR might not be set on the product.

### Steps to reproduce:

- In the settings: enable Multi-Steps Routes
- On your warehouse set Manufacture in 3 steps
- Create a storable product without any set route
- Create a need for that product, for instance by creating and confirming an SO for 1 unit.
- Inventory > Operations > Procurement > Replenishment
#### > A reordering rule was automatically created for your product but the manufacture route is set by default.

### Cause of the issue:

Entering the replenishment tab will create orderpoints and set their default routes:
https://github.com/odoo/odoo/blob/884130330b600b4356c640cb679c2bb8fdb833a0/addons/stock/models/stock_orderpoint.py#L478-L481 However, the `_set_default_route_id` does not check that the route found to match a given orderpoint is actually selected on the product of the orderpoint:
https://github.com/odoo/odoo/blob/884130330b600b4356c640cb679c2bb8fdb833a0/addons/stock/models/stock_orderpoint.py#L323-L336

opw-4681202
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
