### PR TITLE
[FIX] gamification: invalid user domain

### DIFF
--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -67,7 +67,7 @@ class GamificationChallenge(models.Model):
         res = super().default_get(fields_list)
         if 'user_domain' in fields_list and 'user_domain' not in res:
             user_group_id = self.env.ref('base.group_user')
-            res['user_domain'] = f'["&", ("all_group_ids", "=", {user_group_id.id}), ("active", "=", True)]'
+            res['user_domain'] = f'["&", ("all_group_ids", "in", [{user_group_id.id}]), ("active", "=", True)]'
         return res
 
     # description


### PR DESCRIPTION
Currently, an error occurs when opening a new gamification challenge.

Steps to Reproduce:
---
- Install the `Gamification` application
- Setting > Gamification Tools > Challenges
- Click NEW
- Error in Terminal

Traceback:
---
NotImplementedError

At [1], an incorrect domain was passed, which led to a NotImplementedError at [2].

After this commit - https://github.com/odoo/odoo/commit/4f13b617547a27c714af69529cf69d799bdb601c#diff-0346840e191cc12e28d8578cf78319e2bf932324ef9c7a270f14e5093064ff57

[1]- https://github.com/odoo/odoo/blob/1731c2aa14b0630c0a8a3505cbaa202776bac280/addons/gamification/models/gamification_challenge.py#L70

[2]- https://github.com/odoo/odoo/blob/1731c2aa14b0630c0a8a3505cbaa202776bac280/odoo/addons/base/models/res_groups.py#L216-L217

sentry-6474367890

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
