### PR TITLE
[FIX] stock_account: include return pick lots in valuation

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -56,7 +56,7 @@ class StockMove(models.Model):
             layers |= layers.stock_valuation_layer_ids
             if self.product_id.lot_valuated:
                 layers_by_lot = layers.grouped('lot_id')
-                prices = {}
+                prices = defaultdict(lambda: 0)
                 for lot, stock_layers in layers_by_lot.items():
                     qty = sum(stock_layers.mapped("quantity"))
                     val = sum(stock_layers.mapped("value"))

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -692,3 +692,21 @@ class TestLotValuation(TestStockValuationCommon):
         self.product1.tracking = 'lot'
         with self.assertRaises(UserError):
             self.product1.lot_valuated = True
+
+    def test_return_pick_valuation_with_original_not_valuated(self):
+        self.product1.lot_valuated = False
+        lot = self.env['stock.lot'].create({
+            'product_id': self.product1.id,
+            'name': 'test',
+        })
+        quant = self.env['stock.quant'].create({
+            'product_id': self.product1.id,
+            'lot_id': lot.id,
+            'location_id': self.stock_location.id,
+            'inventory_quantity': 100
+        })
+        quant.action_apply_inventory()
+        out_move = self._make_out_move(self.product1, 3, create_picking=True, lot_ids=[lot])
+        self.product1.lot_valuated = True
+        return_pick_ids = self._make_return(out_move, 1)
+        self.assertTrue(return_pick_ids)


### PR DESCRIPTION
Steps to reproduce:
- Install stock, stock_account, sales
- Create a product with pricing policy not standard(AVCO, FIFO)
- Track this product by lot and keep lot valuation **unchecked**
- Add a quant of the product with this lot
- Create a quotation on the product and confirm the SO
- Confirm the delivery
- Activate the lot valuation on the product
- Make a return delivery based on the delivery we had
- Confirm the return

**Issue**:
Traceback is thrown
```py
new_std_price = ((amount_unit * qty_avail) + (move_cost[lot] * qty)) / (qty_avail + qty)
KeyError: stock.lot(55,)
```
Because `move_cost` is a dictionary returned by `_get_price_unit()`, which gets the current lots’ valuations. Since the pick is a return one, then `_get_price_unit()` uses the original pick stock valuation layers and hence we were disabling the valuation on the original delivery then the layers don’t have the lot of the product valuated. Then the `move_cost` dict is not having the lot of the product while valuating it currently, hence the KeyError is thrown. This issue happens with the AVCO, FIFO because both valuation models depend on the already valuated lots values using the `_get_price_unit()`.

**FIX**:
Ensure `_get_price_unit()` properly handles cases where lot valuation was disabled at the time of the original move but is enabled later by adding lots of the return pick if not included in the valuation layers of original pick.

opw-4662744
opw-4660094

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
