### PR TITLE
[PERF] account: change index to trigram for name

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -52,7 +52,7 @@ class AccountMoveLine(models.Model):
     move_name = fields.Char(
         string='Number',
         related='move_id.name', store=True,
-        index='btree',
+        index='trigram',
     )
     parent_state = fields.Selection(related='move_id.state', store=True)
     date = fields.Date(

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -315,7 +315,7 @@
                     <field name="partner_id"/>
                     <field name="journal_id"/>
                     <field name="move_id" string="Journal Entry" filter_domain="[
-                        '|', '|', ('move_id.name', 'ilike', self), ('move_id.ref', 'ilike', self), ('move_id.partner_id', 'ilike', self)]"/>
+                        '|', '|', ('move_name', 'ilike', self), ('ref', 'ilike', self), ('move_id.partner_id', 'ilike', self)]"/>
                     <field name="tax_ids" />
                     <field name="tax_line_id" string="Originator Tax"/>
                     <field name="reconcile_model_id"/>


### PR DESCRIPTION
This is a continuation on this pr
https://github.com/odoo/enterprise/pull/81851

The index needs to be a trigram so it can be used with
ilike queries. The current btree is only hit on exact matches
or prefix matching.

related to this support ticket:
https://www.odoo.com/odoo/project/49/tasks/4644308




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
