### PR TITLE
[FIX] l10n_tr_nilvera*: move UNECE code mapping to l10n_tr_nilvera

### DIFF
--- a/addons/account/models/uom_uom.py
+++ b/addons/account/models/uom_uom.py
@@ -40,6 +40,10 @@ class UoM(models.Model):
             'uom.product_uom_cubic_meter': 'MTQ',
             'uom.product_uom_cubic_inch': 'INQ',
             'uom.product_uom_cubic_foot': 'FTQ',
+            'uom.uom_square_meter': 'MTK',
+            'uom.uom_square_foot': 'FTK',
+            'uom.product_uom_yard': 'YRD',
+            'uom.product_uom_millimeter': 'MMT',
         }
         xml_ids = self._get_external_ids().get(self.id, [])
         matches = list(set(xml_ids) & set(mapping.keys()))

--- a/addons/l10n_tr_nilvera/models/__init__.py
+++ b/addons/l10n_tr_nilvera/models/__init__.py
@@ -3,3 +3,4 @@ from . import l10n_tr_nilvera_alias
 from . import res_company
 from . import res_config_settings
 from . import res_partner
+from . import uom_uom

--- a/addons/l10n_tr_nilvera/models/uom_uom.py
+++ b/addons/l10n_tr_nilvera/models/uom_uom.py
@@ -1,0 +1,40 @@
+from odoo import models
+
+UOM_TO_UNECE_CODE = {
+    'l10n_tr_nilvera.product_uom_pk': 'PK',
+    'l10n_tr_nilvera.product_uom_pf': 'PF',
+    'l10n_tr_nilvera.product_uom_cr': 'CR',
+    'l10n_tr_nilvera.product_uom_standard_cubic_meter': 'SM3',
+    'l10n_tr_nilvera.product_uom_sa': 'SA',
+    'l10n_tr_nilvera.product_uom_cmq': 'CMQ',
+    'l10n_tr_nilvera.product_uom_mlt': 'MLT',
+    'l10n_tr_nilvera.product_uom_mmq': 'MMQ',
+    'l10n_tr_nilvera.product_uom_cmk': 'CMK',
+    'l10n_tr_nilvera.product_uom_bg': 'BG',
+    'l10n_tr_nilvera.product_uom_bx': 'BX',
+    'l10n_tr_nilvera.product_uom_pr': 'PR',
+    'l10n_tr_nilvera.product_uom_mgm': 'MGM',
+    'l10n_tr_nilvera.product_uom_mon': 'MON',
+    'l10n_tr_nilvera.product_uom_gt': 'GT',
+    'l10n_tr_nilvera.product_uom_ann': 'ANN',
+    'l10n_tr_nilvera.product_uom_d61': 'D61',
+    'l10n_tr_nilvera.product_uom_d62': 'D62',
+    'l10n_tr_nilvera.product_uom_pa': 'PA',
+    'l10n_tr_nilvera.product_uom_mwh': 'MWH',
+    'l10n_tr_nilvera.product_uom_kwh': 'KWH',
+    'l10n_tr_nilvera.product_uom_kwt': 'KWT',
+    'l10n_tr_nilvera.product_uom_set': 'SET',
+}
+
+
+class Uom(models.Model):
+    _inherit = 'uom.uom'
+
+    def _get_unece_code(self):
+        """ This depends on the mapping from https://developer.nilvera.com/en/code-lists#birim-kodlari """
+        unece_code = super()._get_unece_code()
+        if unece_code == 'C62':
+            xml_id = self.get_external_id()
+            if xml_id and self.id in xml_id:
+                return UOM_TO_UNECE_CODE.get(xml_id[self.id], 'C62')
+        return unece_code

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -1,31 +1,5 @@
 from odoo import models
 
-UOM_TO_UNECE_CODE = {
-    'l10n_tr_nilvera.product_uom_pk': 'PK',
-    'l10n_tr_nilvera.product_uom_pf': 'PF',
-    'l10n_tr_nilvera.product_uom_cr': 'CR',
-    'l10n_tr_nilvera.product_uom_standard_cubic_meter': 'SM3',
-    'l10n_tr_nilvera.product_uom_sa': 'SA',
-    'l10n_tr_nilvera.product_uom_cmq': 'CMQ',
-    'l10n_tr_nilvera.product_uom_mlt': 'MLT',
-    'l10n_tr_nilvera.product_uom_mmq': 'MMQ',
-    'l10n_tr_nilvera.product_uom_cmk': 'CMK',
-    'l10n_tr_nilvera.product_uom_bg': 'BG',
-    'l10n_tr_nilvera.product_uom_bx': 'BX',
-    'l10n_tr_nilvera.product_uom_pr': 'PR',
-    'l10n_tr_nilvera.product_uom_mgm': 'MGM',
-    'l10n_tr_nilvera.product_uom_mon': 'MON',
-    'l10n_tr_nilvera.product_uom_gt': 'GT',
-    'l10n_tr_nilvera.product_uom_ann': 'ANN',
-    'l10n_tr_nilvera.product_uom_d61': 'D61',
-    'l10n_tr_nilvera.product_uom_d62': 'D62',
-    'l10n_tr_nilvera.product_uom_pa': 'PA',
-    'l10n_tr_nilvera.product_uom_mwh': 'MWH',
-    'l10n_tr_nilvera.product_uom_kwh': 'KWH',
-    'l10n_tr_nilvera.product_uom_kwt': 'KWT',
-    'l10n_tr_nilvera.product_uom_set': 'SET',
-}
-
 
 class AccountEdiXmlUblTr(models.AbstractModel):
     _name = "account.edi.xml.ubl.tr"
@@ -180,22 +154,13 @@ class AccountEdiXmlUblTr(models.AbstractModel):
     def _get_invoice_line_price_vals(self, line):
         # EXTEND 'account.edi.common'
         invoice_line_price_vals = super()._get_invoice_line_price_vals(line)
-        invoice_line_price_vals['base_quantity_attrs'] = {'unitCode': self._get_uom_unece_code(line)}
+        invoice_line_price_vals['base_quantity_attrs'] = {'unitCode': line.product_uom_id._get_unece_code()}
         return invoice_line_price_vals
 
     def _get_invoice_line_vals(self, line, line_id, taxes_vals):
         invoice_line_vals = super()._get_invoice_line_vals(line, line_id, taxes_vals)
-        invoice_line_vals['line_quantity_attrs'] = {'unitCode': self._get_uom_unece_code(line)}
+        invoice_line_vals['line_quantity_attrs'] = {'unitCode': line.product_uom_id._get_unece_code()}
         return invoice_line_vals
-
-    def _get_uom_unece_code(self, line):
-        """ This depends on the mapping from https://developer.nilvera.com/en/code-lists#birim-kodlari """
-        uom = super()._get_uom_unece_code(line)
-        if uom == 'C62':
-            xmlid = line.product_uom_id.get_external_id()
-            if xmlid and line.product_uom_id.id in xmlid:
-                return UOM_TO_UNECE_CODE.get(xmlid[line.product_uom_id.id], 'C62')
-        return uom
 
     # -------------------------------------------------------------------------
     # IMPORT


### PR DESCRIPTION
The UNECE code mapping for Nilvera was done in l10n_tr_nilvera_einvoice.
here at #193030 
However later that was needed in l10n_tr_nilvera_edespatch and 
that too in stock_move.
This PR moves the mapping from l10n_tr_nilvera_einvoice to l10n_tr_nilvera
so that it can be used by both einvoice and edespatch.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
