### PR TITLE
[FIX] pos*: Fix online payment on multiple devices

### DIFF
--- a/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
@@ -7,6 +7,12 @@ patch(SelfOrder.prototype, {
         await super.setup(...args);
         this.onlinePaymentStatus = null;
         this.data.connectWebSocket("ONLINE_PAYMENT_STATUS", ({ status, data }) => {
+            if (
+                data["pos.order"].length === 0 ||
+                data["pos.order"][0].uuid !== this.currentOrder.uuid
+            ) {
+                return;
+            }
             this.models.loadData(data, [], false);
             this.onlinePaymentStatus = status;
             this.paymentError = status === "fail";

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -17,7 +17,6 @@ export class EatingLocationPage extends Component {
 
     selectPreset(preset) {
         this.selfOrder.currentOrder.setPreset(preset);
-        this.selfOrder.currentTable = null;
         this.router.navigate("product_list");
     }
 

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -699,7 +699,6 @@ export class SelfOrder extends Reactive {
                 order_access_tokens: accessTokens,
                 table_identifier: tableIdentifier,
             });
-            this.models.loadData(data);
             this.selectedOrderUuid = null;
             const result = this.models.loadData(data);
             const openOrder = result["pos.order"]?.find((o) => o.state === "draft");


### PR DESCRIPTION
pos*: pos_online_payment_self_order, pos_self_order

Before this commit, when completing an order on a device in mobile with the online payment method, the payment status and the order was sent to all connected devices, even the one that were not working on this order. This commit fixes this issue by ensuring that the payment status and the order are only used by the device that is currently working on the order.

Also, when scanning a QR code linked to a table and then selecting a preset, the selected table was forgotten.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
