### PR TITLE
[FIX] project: fixed project_history_tour causing issue in runbot

### DIFF
--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -163,6 +163,10 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         trigger: "button.o_form_button_save",
         run: "click",
     },
+    {
+        content: "Wait the form is saved",
+        trigger: ".o_form_saved",
+    },
         ...changeDescriptionContentAndSave("0"),
         ...changeDescriptionContentAndSave("1"),
         ...changeDescriptionContentAndSave("2"),


### PR DESCRIPTION
To reproduce the issue run the tour in slow 4G mode in network of developer tools. The issue occurs due to the fact that changes are made during saving of form and which just refreshes due to the model being loaded and tour tries to save the changes which don't exist and cant find the save button thus failing tour. Now we add a step to make sure form is saved first and then changes are made.

Pre saas-17.4 there was a legacy function which determines if element is visible or not and this was changed in the PR: 
https://github.com/odoo/odoo/pull/187894 it is replaced by hoot `isVisible`. 


task-4690327
