### PR TITLE
[IMP] base: not storing password during identity check

### DIFF
--- a/addons/auth_passkey/models/res_users_identitycheck.py
+++ b/addons/auth_passkey/models/res_users_identitycheck.py
@@ -18,7 +18,7 @@ class ResUsersIdentitycheck(models.TransientModel):
         if self.auth_method == 'webauthn':
             try:
                 credential = {
-                    'webauthn_response': self.password,
+                    'webauthn_response': self.env.context.get('password'),
                     'type': 'webauthn',
                 }
                 self.create_uid._check_credentials(credential, {'interactive': True})

--- a/addons/portal/static/src/interactions/portal_security.js
+++ b/addons/portal/static/src/interactions/portal_security.js
@@ -172,13 +172,11 @@ export async function handleCheckIdentity(wrapped, ormService, dialogService) {
                         return false;
                     }
                     let result;
-                    await ormService.write("res.users.identitycheck", [checkId], {
-                        password: inputEl.value,
-                    });
                     try {
-                        result = await ormService.call("res.users.identitycheck", "run_check", [
-                            checkId,
-                        ]);
+                        result = await ormService.call("res.users.identitycheck", "run_check",
+                            [ checkId ],
+                            { 'context': {'password': inputEl.value} },
+                        );
                     } catch {
                         inputEl.classList.add("is-invalid");
                         inputEl.setCustomValidity(_t("Check failed"));

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1321,7 +1321,7 @@ class ResUsersIdentitycheck(models.TransientModel):
 
     request = fields.Char(readonly=True, groups=fields.NO_ACCESS)
     auth_method = fields.Selection([('password', 'Password')], default=lambda self: self._get_default_auth_method())
-    password = fields.Char()
+    password = fields.Char(store=False)
 
     def _get_default_auth_method(self):
         return 'password'
@@ -1330,7 +1330,7 @@ class ResUsersIdentitycheck(models.TransientModel):
         try:
             credential = {
                 'login': self.env.user.login,
-                'password': self.password,
+                'password': self.env.context.get('password'),
                 'type': 'password',
             }
             self.create_uid._check_credentials(credential, {'interactive': True})
@@ -1338,9 +1338,9 @@ class ResUsersIdentitycheck(models.TransientModel):
             raise UserError(_("Incorrect Password, try again or click on Forgot Password to reset your password."))
 
     def run_check(self):
+        # The password must be in the context with the key name `'password'`
         assert request, "This method can only be accessed over HTTP"
         self._check_identity()
-        self.password = False
 
         request.session['identity-check-last'] = time.time()
         ctx, model, ids, method, args, kwargs = json.loads(self.sudo().request)

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -499,7 +499,7 @@ class TestUsersIdentitycheck(HttpCase):
         form.password = 'admin@odoo'
         # The user clicks the button "Log out from all devices", which triggers a save then a call to the button method
         user_identity_check = form.save()
-        action = user_identity_check.run_check()
+        action = user_identity_check.with_context(password=form.password).run_check()
 
         # Test the session is no longer valid
         # Invalid session -> redirected from /web to /web/login

--- a/odoo/addons/base/views/res_users_identitycheck_views.xml
+++ b/odoo/addons/base/views/res_users_identitycheck_views.xml
@@ -17,7 +17,9 @@
                         </div>
                     </sheet>
                     <footer>
-                        <button string="Confirm Password" id="password_confirm" type="object" name="run_check" class="btn btn-primary" data-hotkey="q" invisible="auth_method != 'password'"/>
+                        <button string="Confirm Password" id="password_confirm" type="object" name="run_check"
+                            class="btn btn-primary" data-hotkey="q" invisible="auth_method != 'password'"
+                            context="{'password': password}"/>
                         <button string="Cancel" special="cancel" data-hotkey="z" class="btn btn-secondary"/>
                     </footer>
                 </form>


### PR DESCRIPTION
The `password` field is a sensitive field.

The aim of this commit is to ensure that the password is no longer stored in the database even for a short time.

task-4318785