### PR TITLE
[FIX] l10n_sa_edi: QR missing from POS invoice

### DIFF
--- a/addons/l10n_sa_edi/__manifest__.py
+++ b/addons/l10n_sa_edi/__manifest__.py
@@ -26,6 +26,7 @@ E-invoice implementation for Saudi Arabia; Integration with ZATCA
         'data/ubl_21_zatca.xml',
         'data/res_country_data.xml',
         'wizard/l10n_sa_edi_otp_wizard.xml',
+        'wizard/account_move_send_views.xml',
         'wizard/account_move_reversal_views.xml',
         'views/account_tax_views.xml',
         'views/account_journal_views.xml',

--- a/addons/l10n_sa_edi/wizard/__init__.py
+++ b/addons/l10n_sa_edi/wizard/__init__.py
@@ -1,3 +1,4 @@
 from . import account_move_reversal
 from . import account_debit_note
 from . import l10n_sa_edi_otp_wizard
+from . import account_move_send

--- a/addons/l10n_sa_edi/wizard/account_move_send.py
+++ b/addons/l10n_sa_edi/wizard/account_move_send.py
@@ -1,0 +1,53 @@
+from odoo import api, models, fields
+
+
+class AccountMoveSend(models.TransientModel):
+    _inherit = 'account.move.send'
+
+    l10n_sa_edi_enable_zatca = fields.Boolean(compute='_compute_l10n_sa_edi_enable_zatca', string="ZATCA")
+
+    @api.depends('move_ids')
+    def _compute_l10n_sa_edi_enable_zatca(self):
+        # After sending the invoice to ZATCA it will be false
+        for wizard in self:
+            wizard.l10n_sa_edi_enable_zatca = any(wizard._get_default_l10n_sa_edi_enable_zatca(m) for m in wizard.move_ids)
+
+    @api.model
+    def _is_sa_edi_applicable(self, move):
+        zatca_document = move.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'sa_zatca' and d.state == 'to_send')
+        return move.country_code == 'SA' and move.move_type in ('out_invoice', 'out_refund') and zatca_document and move.state != 'draft'
+
+    @api.model
+    def _get_default_l10n_sa_edi_enable_zatca(self, move):
+        return not move.invoice_pdf_report_id and self._is_sa_edi_applicable(move)
+
+    def _get_wizard_values(self):
+        # EXTENDS 'account'
+        values = super()._get_wizard_values()
+        values['l10n_sa_edi_zatca'] = self.l10n_sa_edi_enable_zatca
+        return values
+
+    def _get_placeholder_mail_attachments_data(self, move):
+        # EXTENDS 'account'
+        results = super()._get_placeholder_mail_attachments_data(move)
+
+        if self._is_sa_edi_applicable(move):
+            filename = self.env['account.edi.xml.ubl_21.zatca']._export_invoice_filename(move)
+            results.append({
+                'id': f'placeholder_{filename}',
+                'name': filename,
+                'mimetype': 'application/xml',
+                'placeholder': True,
+            })
+
+        return results
+
+    def _call_web_service_before_invoice_pdf_render(self, invoices_data):
+        # EXTENDS 'account'
+        super()._call_web_service_before_invoice_pdf_render(invoices_data)
+
+        to_process = self.env['account.move']
+        for invoice, invoice_data in invoices_data.items():
+            if invoice_data.get('l10n_sa_edi_zatca'):
+                to_process |= invoice
+        to_process.action_process_edi_web_services()

--- a/addons/l10n_sa_edi/wizard/account_move_send_views.xml
+++ b/addons/l10n_sa_edi/wizard/account_move_send_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="account_move_send_form" model="ir.ui.view">
+        <field name="name">account.move.send.form</field>
+        <field name="model">account.move.send</field>
+        <field name="inherit_id" ref="account.account_move_send_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='advanced_options']" position="inside">
+                <field name="l10n_sa_edi_enable_zatca" invisible="1"/>
+                <div name="option_zatca_xml"
+                     invisible="not l10n_sa_edi_enable_zatca">
+                    <field name="l10n_sa_edi_enable_zatca"/>
+                    <b><label for="l10n_sa_edi_enable_zatca"/></b>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Backport of f4d01f191ed54cc1dcccda3141e2f3594e2f9154

Users of SA localization needs to add a QR (resulting from the EDI validation) to their official invoices. This should occurs also for point of sales invoices but this is currently not working.

Steps to reproduce:
- With SA localization setup
- Open POS session
- Add a product
- Invoice to a customer
- Validate order
- Check generated invoice

Issue: QR is missing

This occurs because we print the invoice before sending it to ZATCA. This way we generate an invoice without the needed fiscal information

When applied this commit will make sure we send the invoice to zatca when we generate the official pdf, either in the send&print action or via POS invoicing

opw-4562837

