### PR TITLE
[FIX] base: fixes invalid_locators compute method

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -330,6 +330,8 @@ actual arch.
             specs = collections.deque([etree.fromstring(view.arch)])
             while specs:
                 spec = specs.popleft()
+                if isinstance(spec, etree._Comment):
+                    continue
                 if spec.tag == 'data':
                     specs.extend(spec)
                     continue

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -324,7 +324,9 @@ actual arch.
     @api.depends('arch', 'inherit_id')
     def _compute_invalid_locators(self):
         self.invalid_locators = []
-        for view in self.filtered('inherit_id'):
+        for view in self:
+            if not view.inherit_id or not view.arch:
+                continue
             source = view.with_context(ir_ui_view_tree_cut_off_view=view)._get_combined_arch()
             invalid_locators = []
             specs = collections.deque([etree.fromstring(view.arch)])

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -465,6 +465,7 @@ class TestViewInheritance(ViewCase):
             'model': self.model,
             'name': "child_view",
             'arch': """<data>
+                <!-- One comment: should be ignored -->
                 <field name="id" position="before">
                     <div class="parasite" />
                 </field>

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -406,6 +406,14 @@ class TestViewInheritance(ViewCase):
             'active': False,
         })
 
+        child_primary_no_arch = self.View.create({
+            'model': self.model,
+            'name': "child_view",
+            'inherit_id': base_view.id,
+            'priority': 18,
+            'active': False,
+        })
+
         self.assertEqual(
             child_view.invalid_locators,
             [
@@ -426,6 +434,8 @@ class TestViewInheritance(ViewCase):
                 }
             ],
         )
+
+        self.assertEqual(child_primary_no_arch.invalid_locators, False)
 
     def test_invalid_locators_with_valid_xpath(self):
         """ Check ir.ui.view's invalid_locators field is computed correctly."""


### PR DESCRIPTION
### [FIX] base: fix invalid_locators for empty arch.

The `_compute_invalid_locators` crashed when the view is a primary and has no arch (`ValueError: can only parse strings`).

Fix this by ignoring views without arch.

### [FIX] base: fix invalid_locators for comments.

The `_compute_invalid_locators` doesn't ignore XML comments. Then when a comment appears inside the arch, the ORM threw a `TypeError` because ` spec.tag` is not JSON serializable for comment nodes.

Fix this by ignoring comments.


### To check that the code is robust
```python
all_views = self.env['ir.ui.view'].search([])
for view in all_views:
     assert not view.invalid_locators
```
Not assert not raised on a runbot database (all modules installed) with these fixes and the one located in https://github.com/odoo/odoo/pull/202048
