### PR TITLE
[FIX] discuss: prevent warning for expected video error

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_video.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_video.js
@@ -1,6 +1,14 @@
 /* @odoo-module */
 
-import { Component, onMounted, onPatched, useExternalListener, useRef, useState } from "@odoo/owl";
+import {
+    Component,
+    onMounted,
+    onPatched,
+    status,
+    useExternalListener,
+    useRef,
+    useState,
+} from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 /**
@@ -39,6 +47,9 @@ export class CallParticipantVideo extends Component {
             await this.root.el?.play?.();
             this.props.session.videoError = undefined;
         } catch (error) {
+            if (status(this) === "destroyed") {
+                return;
+            }
             this.props.session.videoError = error.name;
         }
     }


### PR DESCRIPTION
Before this commit, it was possible to have a `videoError` caused by (or happening during) the destruction of the video component.

This error should not be retained as playing the video is no longer useful when the component is destroyed.
