### PR TITLE
[FIX] stock: remove tzinfo from search domain

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1880,7 +1880,7 @@ class StockPicking(models.Model):
             self.env.user, fields.Datetime.now()
         ).replace(hour=0, minute=0, second=0, microsecond=0)
 
-        start_today = start_today.astimezone(pytz.UTC)
+        start_today = start_today.astimezone(pytz.UTC).replace(tzinfo=None)
 
         start_yesterday = start_today + timedelta(days=-1)
         start_day_1 = start_today + timedelta(days=1)


### PR DESCRIPTION
Since #191549 the date category domain used to search Receipts uses datetimes with timezone informations leading to a warning.

See also #203047

The nightly click_all test is failing because of that warning.

runbot error 161877
