### PR TITLE
[FIX] html_editor: preserve toggle blocks titles inside div

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -78,7 +78,7 @@ export class ToggleBlockPlugin extends Plugin {
             this.updateToggleContentHints(this.editable)
         ),
         mount_component_handlers: this.setupNewToggle.bind(this),
-        normalize_handlers: this.normalize.bind(this),
+        normalize_handlers: withSequence(Infinity, this.normalize.bind(this)),
         selectionchange_handlers: [
             withSequence(1, this.removeSelectedToggleContentHints.bind(this)),
             withSequence(100, this.updateSelectedToggleContentHints.bind(this)),

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -870,7 +870,7 @@ describe("Insert (paste, drop) inside toggle title", () => {
             unformat(
                 `<div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                     <div data-embedded-editable="title">
-                        <p>Hello[]World</p>
+                        <div class="o-paragraph">Hello[]World</div>
                     </div>
                     <div data-embedded-editable="content">
                         <p>asdf</p>
@@ -883,10 +883,13 @@ describe("Insert (paste, drop) inside toggle title", () => {
             }
         );
         await embeddedToggleMountedPromise;
+        expect("[data-embedded-editable='title']").toHaveInnerHTML(`
+            <div class="o-paragraph">HelloWorld</div>
+        `);
         editor.shared.dom.insert(parseHTML(editor.document, `<p>New</p>`));
         addStep(editor);
         expect("[data-embedded-editable='title']").toHaveInnerHTML(`
-            <p>HelloNewWorld</p>
+            <div class="o-paragraph">HelloNewWorld</div>
         `);
         editor.shared.dom.insert(
             parseHTML(editor.document, `<div class="oe_unbreakable">brol</div>`)
@@ -899,7 +902,7 @@ describe("Insert (paste, drop) inside toggle title", () => {
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light"><i class="fa align-self-center fa-caret-right"></i></button>
                         <div class="flex-fill ms-1">
                             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
-                                <p>HelloNew</p>
+                                <div class="o-paragraph">HelloNew</div>
                             </div>
                         </div>
                     </div>
@@ -910,7 +913,7 @@ describe("Insert (paste, drop) inside toggle title", () => {
                     </div>
                 </div>
                 <div class="oe_unbreakable">brol</div>
-                <p>[]World</p>
+                <div class="o-paragraph">[]World</div>
             `)
         );
     });


### PR DESCRIPTION
There was an issue with toggle block titles when the `baseContainer` of the
editor was a `div`: the title was moved after the toggle block because the `div`
was not properly considered as a paragraph-related element.

What happens is that the normalization to set the `o-paragraph` class on a `div`
element is done as the last step of the normalization phase, to allow other
plugins to assign custom features to a neutral `div` which would prevent it from
being a `o-paragraph`. Therefore, normalize functions which depends on that class
should also have the `Infinity` sequence, and depend on the `baseContainer`
plugin, which is what is done in this commit to fix the issue.

task-4678392