### PR TITLE
[IMP] mail: hide internal sub-types for partners followers

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -120,7 +120,8 @@ class ThreadController(http.Controller):
         record = request.env[follower.res_model].browse(follower.res_id)
         record.check_access("read")
         # find current model subtypes, add them to a dictionary
-        subtypes = record._mail_get_message_subtypes()
+        is_internal = any(user._is_internal() for user in follower.partner_id.user_ids)
+        subtypes = record._mail_get_message_subtypes(is_internal=is_internal)
         store = Store().add(subtypes, ["name"]).add(follower, ["subtype_ids"])
         return {
             "store_data": store.get_result(),

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -130,7 +130,8 @@ class ThreadController(StoreController):
         record = request.env[follower.res_model].browse(follower.res_id)
         record.check_access("read")
         # find current model subtypes, add them to a dictionary
-        subtypes = record._mail_get_message_subtypes()
+        is_internal = any(user._is_internal() for user in follower.partner_id.user_ids)
+        subtypes = record._mail_get_message_subtypes(is_internal=is_internal)
         if follower.partner_id.partner_share:
             subtypes = subtypes.filtered(lambda subtype: not subtype.internal)
         store = Store().add(subtypes, ["name"]).add(follower, ["subtype_ids"])

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -839,10 +839,14 @@ class Base(models.AbstractModel):
     # DISCUSS
     # ------------------------------------------------------------
 
-    def _mail_get_message_subtypes(self):
+    def _mail_get_message_subtypes(self, is_internal=False):
+        domain = [] if is_internal else [("internal", "=", False)]
         return self.env['mail.message.subtype'].search([
-            '&', ('hidden', '=', False),
-            '|', ('res_model', '=', self._name), ('res_model', '=', False)])
+            *domain,
+            ("hidden", "=", False),
+            "|", ("res_model", "=", self._name),
+            ("res_model", "=", False)
+        ])
 
     # ------------------------------------------------------------
     # GATEWAY: NOTIFICATION

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -753,10 +753,16 @@ class Base(models.AbstractModel):
     # DISCUSS
     # ------------------------------------------------------------
 
-    def _mail_get_message_subtypes(self):
-        return self.env['mail.message.subtype'].search([
-            '&', ('hidden', '=', False),
-            '|', ('res_model', '=', self._name), ('res_model', '=', False)])
+    def _mail_get_message_subtypes(self, is_internal=False):
+        domain = (
+            Domain("hidden", "=", False)
+            & (Domain("res_model", "=", self._name) | Domain("res_model", "=", False))
+        )
+        if not is_internal:
+            domain = Domain("internal", "=", False) & domain
+        return self.env['mail.message.subtype'].search_fetch(
+            domain, ["name", "res_model", "internal", "sequence", "parent_id"],
+        )
 
     # ------------------------------------------------------------
     # GATEWAY: NOTIFICATION

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -737,16 +737,29 @@ async function read_subscription_data(request) {
     const MailFollowers = this.env["mail.followers"];
     /** @type {import("mock_models").MailMessageSubtype} */
     const MailMessageSubtype = this.env["mail.message.subtype"];
+    /** @type {import("mock_models").ResUsers} */
+    const ResUsers = this.env["res.users"];
 
     const { follower_id } = await parseRequestParams(request);
     const [follower] = MailFollowers.browse(follower_id);
-    const subtypes = MailMessageSubtype.search([
+    const linkedUsers = ResUsers.search([["partner_id", "=", follower.partner_id]]);
+    const is_internal = linkedUsers.length > 0;
+    let domain = [
         "&",
         ["hidden", "=", false],
         "|",
         ["res_model", "=", follower.res_model],
         ["res_model", "=", false],
-    ]);
+    ];
+    if (!is_internal) {
+        domain = [
+            "&",
+            ["internal", "=", false],
+            ...domain
+        ];
+    }
+    
+    const subtypes = MailMessageSubtype.search(domain);
     return {
         store_data: new mailDataHelpers.Store(
             MailMessageSubtype.browse(subtypes),

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message_subtype.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message_subtype.js
@@ -4,6 +4,7 @@ export class MailMessageSubtype extends models.ServerModel {
     _name = "mail.message.subtype";
 
     default = fields.Generic({ default: true });
+    internal = fields.Boolean({ default: false });
     subtype_xmlid = fields.Char();
 
     _records = [

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -13,6 +13,7 @@ from . import test_mail_activity
 from . import test_mail_blacklist
 from . import test_mail_canned_response
 from . import test_mail_composer
+from . import test_mail_followers
 from . import test_mail_mail
 from . import test_mail_message
 from . import test_mail_message_translate

--- a/addons/mail/tests/test_mail_followers.py
+++ b/addons/mail/tests/test_mail_followers.py
@@ -1,0 +1,43 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.common_controllers import MailControllerCommon
+
+
+class TestMailFollowersController(MailControllerCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.test_record = cls.env['res.partner'].create({'name': 'Test Thread'})
+        cls.subtype_internal = cls.env.ref('mail.mt_note')
+        cls.subtype_public = cls.env.ref('mail.mt_comment')
+
+    def test_read_subscription_data_hides_internal_for_external_follower(self):
+        """Internal subtypes must not be available subscription options for an external partner follower."""
+        follower = self.env['mail.followers'].create({
+            'partner_id': self.partner_portal.id,
+            'res_model': 'res.partner',
+            'res_id': self.test_record.id,
+        })
+        self.authenticate(self.user_employee.login, self.user_employee.login)
+        result = self.make_jsonrpc_request(
+            '/mail/read_subscription_data',
+            {'follower_id': follower.id},
+        )
+        self.assertNotIn(self.subtype_internal.id, result['subtype_ids'])
+        self.assertIn(self.subtype_public.id, result['subtype_ids'])
+
+    def test_read_subscription_data_shows_internal_for_internal_follower(self):
+        """Internal subtypes must be available subscription options for an internal user follower."""
+        follower = self.env['mail.followers'].create({
+            'partner_id': self.partner_employee.id,
+            'res_model': 'res.partner',
+            'res_id': self.test_record.id,
+        })
+        self.authenticate(self.user_employee.login, self.user_employee.login)
+        result = self.make_jsonrpc_request(
+            '/mail/read_subscription_data',
+            {'follower_id': follower.id},
+        )
+        self.assertIn(self.subtype_internal.id, result['subtype_ids'])
+        self.assertIn(self.subtype_public.id, result['subtype_ids'])

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -910,8 +910,8 @@ class ProjectProject(models.Model):
             return self.env.ref('project.mt_project_stage_change')
         return super()._track_log_get_default_subtype(track_init_values)
 
-    def _mail_get_message_subtypes(self):
-        res = super()._mail_get_message_subtypes()
+    def _mail_get_message_subtypes(self, is_internal=False):
+        res = super()._mail_get_message_subtypes(is_internal)
         if len(self) == 1:
             waiting_subtype = self.env.ref('project.mt_project_task_waiting')
             if not self.allow_task_dependencies and waiting_subtype in res:

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -886,8 +886,8 @@ class ProjectProject(models.Model):
             return self.env.ref('project.mt_project_stage_change')
         return super()._track_subtype(init_values)
 
-    def _mail_get_message_subtypes(self):
-        res = super()._mail_get_message_subtypes()
+    def _mail_get_message_subtypes(self, is_internal=False):
+        res = super()._mail_get_message_subtypes(is_internal)
         if len(self) == 1:
             waiting_subtype = self.env.ref('project.mt_project_task_waiting')
             if not self.allow_task_dependencies and waiting_subtype in res:

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1615,8 +1615,8 @@ class ProjectTask(models.Model):
             return self.env.ref(mail_message_subtype_per_state[self.state])
         return super()._track_log_get_default_subtype(track_init_values)
 
-    def _mail_get_message_subtypes(self):
-        res = super()._mail_get_message_subtypes()
+    def _mail_get_message_subtypes(self, is_internal=False):
+        res = super()._mail_get_message_subtypes(is_internal)
         if not self.stage_id.rating_active:
             res -= self.env.ref('project.mt_task_rating')
         if len(self) == 1:

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1553,8 +1553,8 @@ class ProjectTask(models.Model):
             return self.env.ref(mail_message_subtype_per_state[self.state])
         return super()._track_subtype(init_values)
 
-    def _mail_get_message_subtypes(self):
-        res = super()._mail_get_message_subtypes()
+    def _mail_get_message_subtypes(self, is_internal=False):
+        res = super()._mail_get_message_subtypes(is_internal)
         if not self.stage_id.rating_active:
             res -= self.env.ref('project.mt_task_rating')
         if len(self) == 1:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
When editing the subscription of a follower from the Chatter, all
sub-types are displayed as available options regardless of whether the
follower is an internal user or an external partner. This means internal-
only sub-types appear as configurable options even for portal/customer 
followers, where subscribing to them makes no practical difference.


**Current behavior before PR:**
----------------------------------------------
- All sub-types are displayed as available subscription options for all followers without distinction
- Internal-only sub-types (internal=True) appear in the subscription dialog even when the follower is an external/portal partner
- Configuring these sub-types for external partners has no effect since they will never receive those notifications


**Desired behavior after PR is merged:**
----------------------------------------------
- Internal-only sub-types are hidden from the available subscription options when the follower being configured is an external partner
- The filtering is based on the follower's partner type, not on the identity of the user viewing the subscription dialog
- Internal user followers continue to see all sub-types as before
- Existing subscription behavior for new followers remains unchanged

Task-3056372

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr