### PR TITLE
[IMP] mail : Press 'End' or 'Alt+ArrowDown' to mark as read & jump to latest

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -104,6 +104,10 @@ export class ChatWindow extends Component {
     }
 
     onKeydown(ev) {
+        const hotkey = getActiveHotkey(ev);
+        if(hotkey === "alt" || hotkey === "control"){
+            return; // to allow hotkeys in windows and macOS
+        }
         const chatWindow = toRaw(this.props.chatWindow);
         if (ev.key === "Escape" && this.threadActions.activeAction) {
             this.threadActions.activeAction.close();
@@ -114,7 +118,7 @@ export class ChatWindow extends Component {
             return;
         }
         ev.stopPropagation(); // not letting home menu steal my CTRL-C
-        switch (getActiveHotkey(ev)) {
+        switch (hotkey) {
             case "escape":
                 if (
                     isEventHandled(ev, "NavigableList.close") ||

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -26,6 +26,7 @@ import { Transition } from "@web/core/transition";
 import { Deferred } from "@web/core/utils/concurrency";
 import { useBus, useRefListener, useService } from "@web/core/utils/hooks";
 import { escape } from "@web/core/utils/strings";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 
 export const PRESENT_VIEWPORT_THRESHOLD = 1;
 /**
@@ -106,6 +107,7 @@ export class Thread extends Component {
         this.present = useRef("load-newer");
         this.jumpPresentRef = useRef("jump-present");
         this.root = useRef("messages");
+        useHotkey(this.jumpPresentHotkey, () => this.jumpToPresent());
         this.visibleState = useVisible("messages", () => {
             this.updateShowJumpPresent();
         });
@@ -255,6 +257,10 @@ export class Thread extends Component {
                 toRaw(nextProps.thread).fetchNewMessages();
             }
         });
+    }
+
+    get jumpPresentHotkey() {
+        return this.props.order === "asc" ? "ArrowDown" : "ArrowUp";
     }
 
     computeJumpPresentPosition() {

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -70,7 +70,7 @@
 </t>
 
 <t t-name="mail.Thread.jumpPresent">
-    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-fixed p-2 rounded-circle lh-1 m-n3 user-select-none btn btn-light shadow-sm border border-secondary" t-att-class="{ 'bottom-0': env.inChatter and !env.inChatter.aside }" t-ref="jump-present" t-on-click="() => this.jumpToPresent()" title="Jump to Present"><i class="oi text-muted" t-att-class="{ 'oi-chevron-down': props.order === 'asc', 'oi-chevron-up': props.order !== 'asc' }"/></button>
+    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-fixed p-2 rounded-circle lh-1 m-n3 user-select-none btn btn-light shadow-sm border border-secondary" t-att-class="{ 'bottom-0': env.inChatter and !env.inChatter.aside }" t-ref="jump-present" t-on-click="() => this.jumpToPresent()" title="Jump to Present" t-att-data-hotkey="jumpPresentHotkey"><i class="oi text-muted" t-att-class="{ 'oi-chevron-down': props.order === 'asc', 'oi-chevron-up': props.order !== 'asc' }"/></button>
 </t>
 
 <t t-name="mail.Thread.loadOlder">

--- a/addons/mail/static/tests/discuss_app/jump_to_present.test.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present.test.js
@@ -21,6 +21,7 @@ import {
     scroll,
     start,
     startServer,
+    triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { PRESENT_VIEWPORT_THRESHOLD } from "@mail/core/common/thread";
 
@@ -49,6 +50,33 @@ test("Basic jump to present when scrolling to outdated messages", async () => {
     await click("[title='Jump to Present']");
     await contains("[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
+});
+
+test("Jump to present when pressing hotkey ArrowUp", async () => {
+    patchUiSize({ size: SIZES.XXL });
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Demo User" });
+    for (let i = 0; i < 20; i++) {
+        pyEnv["mail.message"].create({
+            body: "Non Empty Body ".repeat(100),
+            message_type: "comment",
+            model: "res.partner",
+            res_id: partnerId,
+        });
+    }
+    await start();
+    await openFormView("res.partner", partnerId);
+    await contains(".o-mail-Message", { count: 20 });
+    await contains(".o-mail-Thread");
+    expect(document.querySelector(".o-mail-Chatter").scrollHeight).toBeGreaterThan(
+        PRESENT_VIEWPORT_THRESHOLD * document.querySelector(".o-mail-Chatter").clientHeight,
+        { message: "should have enough scroll height to trigger jump to present" }
+    );
+    await contains(".o-mail-Chatter", { scroll: 0 });
+    await scroll(".o-mail-Chatter", "bottom");
+    await isInViewportOf("[title='Jump to Present']", ".o-mail-Thread");
+    await triggerHotkey("ArrowUp");
+    await contains(".o-mail-Chatter", { scroll: 0 });
 });
 
 test("Basic jump to present when scrolling to outdated messages (DESC, chatter aside)", async () => {


### PR DESCRIPTION
[IMP] mail : Press 'End' or 'Alt + Down Arrow' to mark as read & jump to latest

Improved user experience in Discuss app.

Before this commit:
- There was no way to scroll down to the last message in Discuss using the
  keyboard.
- Users had to manually scroll to view the latest messages.

After this commit:
- Users can now use the 'End' key or 'Alt + Down Arrow' keyboard shortcut to
  directly jump to the most recent message in Discuss, improving accessibility
  and navigation efficiency.

This enhances the user experience by providing quick keyboard-based navigation
and better message handling.

task-4686576