### PR TITLE
[FIX] account_payment: ensure consistent invoice and payment journal entry account_id

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -163,6 +163,10 @@ class PaymentTransaction(models.Model):
             **extra_create_values,
         }
 
+        payment_term_lines = self.invoice_ids.line_ids.filtered(lambda line: line.display_type == 'payment_term')
+        if payment_term_lines:
+            payment_values['destination_account_id'] = payment_term_lines[0].account_id.id
+
         for invoice in self.invoice_ids:
             next_payment_values = invoice._get_invoice_next_payment_values()
             if next_payment_values['installment_state'] == 'epd' and self.amount == next_payment_values['amount_due']:


### PR DESCRIPTION

- Configure a payment method (e.g. `"demo"`) with an outstanding receipt account in the bank journal used by the website (automatic invoicing enabled). Enable Automatic Invoice for online payment.
- Create a partner on the website using an incognito window. In the backend change their default property_account_receivable_id. Assign them a fiscal position where the receivable account is mapped to another account.
- Make a purchase using the `"demo"` payment method with the new partner.

The generated invoice and its corresponding journal entry do not share the same `account_id` (Account Receivable).

The invoice uses the `account_id` computed in `_compute_account_id` of `account.move.line`, which is not necessarily the same as the `account_id` set on the partner.

After this commit, the payment uses the same `account_id` as the related invoice, (same as _create_payment_vals_from_wizard)  avoiding any discrepancy.

opw-4669927

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
