### PR TITLE
[FIX] web: prevent traceback while clicking breadcrumb after browser back

### DIFF
--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -38,7 +38,14 @@ export class WebClient extends Component {
         this.state = useState({
             fullscreen: false,
         });
-        useBus(routerBus, "ROUTE_CHANGE", this.loadRouterState);
+        useBus(routerBus, "ROUTE_CHANGE", async () => {
+            document.body.style.pointerEvents = "none";
+            try {
+                await this.loadRouterState();
+            } finally {
+                document.body.style.pointerEvents = "auto";
+            }
+        });
         useBus(this.env.bus, "ACTION_MANAGER:UI-UPDATED", ({ detail: mode }) => {
             if (mode !== "new") {
                 this.state.fullscreen = mode === "fullscreen";


### PR DESCRIPTION
Before this commit:
When a user opened a form view and clicked browser's Back button, then
immediately clicked on the breadcrumb, a traceback occurred.

After this commit:
Navigation works smoothly without crashes.

Task-4667911