### PR TITLE
[FIX] base_automation: subtract the relative offset

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -1034,8 +1034,8 @@ class BaseAutomation(models.Model):
         # we can search for the records to trigger
         # find the relative dates
         relative_offset = DATE_RANGE[automation.trg_date_range_type] * automation.trg_date_range
-        relative_until = until + relative_offset
-        relative_last_run = last_run + relative_offset
+        relative_until = until - relative_offset
+        relative_last_run = last_run - relative_offset
         if date_field.type == 'date':
             # find records that have a date in past, but were not yet executed that day
             time_domain = Domain(date_field.name, '>', relative_last_run.date()) & Domain(date_field.name, '<=', relative_until.date())

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -899,6 +899,8 @@ if env.context.get('old_values', None):  # on write
             "trigger": "on_time",
             "model_id": model.id,
             "trg_date_id": model.field_id.filtered(lambda f: f.name == 'date_automation_last').id,
+            "trg_date_range": 2,
+            "trg_date_range_type": "minutes",
         })
 
         with patch.object(automation.__class__, '_process', side_effect=automation._process) as mock:
@@ -906,15 +908,15 @@ if env.context.get('old_values', None):  # on write
                 past_date = now - datetime.timedelta(1)
                 self.env["base.automation.lead.test"].create({
                     'name': f'lead {i}',
-                    # 2 without a date, 8 set in past, 5 set in future
+                    # 2 without a date, 8 set in past, 5 set in future (10, 11, ... minutes after now)
                     'date_automation_last': False if i < 2 else past_date if i < 10 else now + datetime.timedelta(minutes=i),
                 } for i in range(15))
-            with common.freeze_time('2020-01-01 03:01:01'), patch.object(self.env.cr, '_now', datetime.datetime.now()):
+            with common.freeze_time('2020-01-01 03:02:01'), patch.object(self.env.cr, '_now', datetime.datetime.now()):
                 # process records
                 self.env["base.automation"]._cron_process_time_based_actions(auto_commit=False)
                 self.assertEqual(mock.call_count, 10)
                 self.assertEqual(automation.last_run, self.env.cr.now())
-            with common.freeze_time('2020-01-01 03:11:59'), patch.object(self.env.cr, '_now', datetime.datetime.now()):
+            with common.freeze_time('2020-01-01 03:13:59'), patch.object(self.env.cr, '_now', datetime.datetime.now()):
                 # 2 in the future (because of timing)
                 # 10 previously done records because we use the date_automation_last as trigger without delay
                 self.env["base.automation"]._cron_process_time_based_actions(auto_commit=False)


### PR DESCRIPTION
The offset is incorrectly added, but it should be subtracted. The offset if positive to indicate after some delay, so we must use `now - relative_offset`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
