### PR TITLE
[IMP] core: module_graph 'test_' loading

### DIFF
--- a/odoo/addons/base/tests/test_module_graph.py
+++ b/odoo/addons/base/tests/test_module_graph.py
@@ -110,3 +110,21 @@ class TestGraph(BaseCase):
             [['base'], ['module3', 'module4', 'module1', 'module5', 'module2']],
             ['base', 'module1', 'module2']
         )
+
+    def test_graph_order_with_test_modules(self):
+        dependency = {
+            'base': [],
+            'module1': ['base'],
+            'test_z': ['base'],
+            'test_a': ['test_z'],
+            'module2': ['module1'],
+            'module3': ['module1'],
+            'module4': ['module2', 'module3'],
+            'test_c': ['module1'],
+            'test_b': ['test_z', 'module4'],
+        }
+        self._test_graph_order(
+            dependency,
+            [['base'], ['test_c', 'module4', 'module2', 'test_a', 'module3', 'test_b', 'module1', 'test_z']],
+            ['base', 'test_z', 'test_a', 'module1', 'test_c', 'module2', 'module3', 'module4', 'test_b']
+        )


### PR DESCRIPTION
For a module starting with 'test_', we want it to be loaded right after its last loaded dependency in the 'load' mode.

task-id: 4677678

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
