### PR TITLE
[FIX] l10n_in_edi: Update state code validation for partners

### DIFF
--- a/addons/l10n_in_edi/i18n/l10n_in_edi.pot
+++ b/addons/l10n_in_edi/i18n/l10n_in_edi.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0+e\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 14:12+0000\n"
-"PO-Revision-Date: 2023-01-06 14:12+0000\n"
+"POT-Creation-Date: 2025-04-03 05:48+0000\n"
+"PO-Revision-Date: 2025-04-03 05:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,83 +16,95 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
-msgid ""
-"\n"
-"- City required min 3 and max 100 characters"
+msgid "- City required min 3 and max 100 characters"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
-msgid ""
-"\n"
-"- Email address should be valid and not more then 100 characters"
+msgid "- Email address should be valid and not more then 100 characters"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
-msgid ""
-"\n"
-"- Mobile number should be minimum 10 or maximum 12 digits"
+msgid "- Mobile number should be minimum 10 or maximum 12 digits"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
-msgid ""
-"\n"
-"- State required min 3 and max 50 characters"
+msgid "- State TIN Number must be exactly 2 digits."
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
-msgid ""
-"\n"
-"- Street required min 3 and max 100 characters"
+msgid "- State required min 3 and max 50 characters"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
-msgid ""
-"\n"
-"- Street2 should be min 3 and max 100 characters"
+msgid "- Street required min 3 and max 100 characters"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
-msgid ""
-"\n"
-"- Zip code required 6 digits"
+msgid "- Street2 should be min 3 and max 100 characters"
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/account_edi_format.py:0
+#, python-format
+msgid "- Zip code required 6 digits"
 msgstr ""
 
 #. module: l10n_in_edi
 #: model_terms:ir.ui.view,arch_db:l10n_in_edi.res_config_settings_view_form_inherit_l10n_in_edi
 msgid ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
+"<span class=\"o_form_label\">Setup E-invoice</span>\n"
+"                            <span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" aria-label=\"Values set here are company-specific.\" groups=\"base.group_multi_company\" role=\"img\"/>"
 msgstr ""
 
 #. module: l10n_in_edi
 #: model_terms:ir.ui.view,arch_db:l10n_in_edi.l10n_in_einvoice_report_invoice_document_inherit
-msgid "<strong>Ack. Date:</strong>"
+msgid "<strong>Acknowledgement:</strong>"
 msgstr ""
 
 #. module: l10n_in_edi
 #: model_terms:ir.ui.view,arch_db:l10n_in_edi.l10n_in_einvoice_report_invoice_document_inherit
-msgid "<strong>Ack. No:</strong>"
+msgid "<strong>IRN:</strong>"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/res_config_settings.py:0
+#, python-format
+msgid "API credentials validated successfully"
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Buy Credits"
+msgstr ""
+
+#. module: l10n_in_edi
+#: model_terms:ir.ui.view,arch_db:l10n_in_edi.res_config_settings_view_form_inherit_l10n_in_edi
+msgid "Buy credits"
 msgstr ""
 
 #. module: l10n_in_edi
@@ -122,6 +134,13 @@ msgstr ""
 #. module: l10n_in_edi
 #: model:ir.model,name:l10n_in_edi.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_in_edi
+#: model_terms:ir.ui.view,arch_db:l10n_in_edi.res_config_settings_view_form_inherit_l10n_in_edi
+msgid ""
+"Costs 1 credit per transaction. Free 200 credits will be available for the "
+"first time."
 msgstr ""
 
 #. module: l10n_in_edi
@@ -178,26 +197,28 @@ msgid "Enable the use of production credentials"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Ensure GST Number set on company setting and API are Verified."
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/res_config_settings.py:0
+#, python-format
+msgid "Go to Company"
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid "HSN code is not set in product %s"
 msgstr ""
 
 #. module: l10n_in_edi
-#: model_terms:ir.ui.view,arch_db:l10n_in_edi.external_layout_bold_inherit_l10n_in_edi
-#: model_terms:ir.ui.view,arch_db:l10n_in_edi.external_layout_boxed_inherit_l10n_in_edi
-#: model_terms:ir.ui.view,arch_db:l10n_in_edi.external_layout_standard_inherit_l10n_in_edi
-#: model_terms:ir.ui.view,arch_db:l10n_in_edi.external_layout_striped_inherit_l10n_in_edi
-msgid "IRN:"
-msgstr ""
-
-#. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/res_config_settings.py:0
 #, python-format
 msgid ""
@@ -225,12 +246,23 @@ msgid "Indian Electronic Invoicing"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Invalid HSN Code (%s) in product %s"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"Invoice lines having a negative amount are not allowed to generate the IRN. "
+"Please create a credit note instead."
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Invoice number should not be more than 16 characters"
@@ -239,6 +271,13 @@ msgstr ""
 #. module: l10n_in_edi
 #: model:ir.model,name:l10n_in_edi.model_account_move
 msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Negative discount is not allowed, set in line %s"
 msgstr ""
 
 #. module: l10n_in_edi
@@ -257,9 +296,17 @@ msgid "Password"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Please buy more credits and retry: "
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/res_config_settings.py:0
+#, python-format
+msgid "Please enter a GST number in company."
 msgstr ""
 
 #. module: l10n_in_edi
@@ -268,11 +315,16 @@ msgid "Production Environment"
 msgstr ""
 
 #. module: l10n_in_edi
-#: model_terms:ir.ui.view,arch_db:l10n_in_edi.res_config_settings_view_form_inherit_l10n_in_edi
-msgid "Setup E-invoice"
+#. odoo-python
+#: code:addons/l10n_in_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"Set an appropriate GST tax on line \"%s\" (if it's zero rated or nil rated "
+"then select it also)"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -282,6 +334,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -292,6 +345,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_move.py:0
 #, python-format
 msgid ""
@@ -300,6 +354,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -318,9 +373,17 @@ msgid "Verify Username and Password"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid "You have insufficient credits to send this document!"
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/res_config_settings.py:0
+#, python-format
+msgid "You must enable production environment to buy credits"
 msgstr ""
 
 #. module: l10n_in_edi
@@ -329,6 +392,7 @@ msgid "documentation"
 msgstr ""
 
 #. module: l10n_in_edi
+#. odoo-python
 #: code:addons/l10n_in_edi/models/account_edi_format.py:0
 #, python-format
 msgid "product is required to get HSN code"

--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -258,6 +258,11 @@ class AccountEdiFormat(models.Model):
             message.append(_("- City required min 3 and max 100 characters"))
         if partner.country_id.code == "IN" and not re.match("^.{3,50}$", partner.state_id.name or ""):
             message.append(_("- State required min 3 and max 50 characters"))
+        if (
+            partner.country_id.code == "IN"
+            and not re.match(r"^(?!0+$)([0-9]{2})$", partner.state_id.l10n_in_tin or "")
+        ):
+            message.append(_("- State TIN Number must be exactly 2 digits."))
         if partner.country_id.code == "IN" and not re.match("^[0-9]{6,}$", partner.zip or ""):
             message.append(_("- Zip code required 6 digits"))
         if partner.phone and not re.match("^[0-9]{10,12}$",


### PR DESCRIPTION
Previously the `state name` of partner is validating,
but as per government API json schema `state tin number` is required.

After this commit:
- The validation now checks the state tin number instead of the state name,
  ensuring it is a valid and min 1 and max-2 digit number.  


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
