### PR TITLE
[FIX] website: form with success message show message


### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -32,11 +32,6 @@ export class Form extends Interaction {
                 "d-none": this.isHidden,
             })
         },
-        ".s_website_form_end_message": {
-            "t-att-class": () => ({
-                "d-none": !this.isHidden,
-            })
-        },
         "input[type=file]": { "t-on-change": this.changeFile },
         "input.o_add_files_button": { "t-on-click": this.clickAddFilesButton },
         ".s_website_form_field[data-type=binary]": { "t-on-click": this.clickFileDelete }, // delegate on ".o_file_delete"
@@ -438,6 +433,8 @@ export class Form extends Interaction {
                             await delay(400);
 
                             this.isHidden = true;
+                            this.el.parentElement.querySelector('.s_website_form_end_message').classList.remove('d-none');
+                            this.updateContent();
                             break;
                         }
                         default: {

--- a/addons/website/static/tests/interactions/snippets/form.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.test.js
@@ -297,6 +297,34 @@ test("form submit result cleaned but not removed on stop", async () => {
     expect(queryOne("#s_website_form_result").children.length).toEqual(0);
 });
 
+test("successful form with message on success", async () => {
+    await startInteractions(`
+        <div id="wrapwrap">
+            <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form" data-name="Form">
+                <div class="container-fluid">
+                    <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="message" data-success-page="/contactus-thank-you">
+                        <div class="s_website_form_rows row s_col_no_bgcolor">
+                            <div class="mb-0 py-2 col-12 s_website_form_submit text-end s_website_form_no_submit_label" data-name="Submit Button">
+                                <div style="width: 200px;" class="s_website_form_label"/>
+                                <span id="s_website_form_result"></span>
+                                <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
+                            </div>
+                        </div>
+                    </form>
+                    <div class="s_website_form_end_message d-none">Yeah</div>
+                </div>
+            </section>
+        </div>
+    `);
+    onRpc("/website/form/mail.mail", async () => {
+        return {"id": 7};
+    }, {"pure": true});
+    await click("a.s_website_form_send");
+    await advanceTime(400); // Debounce delay.
+    expect(queryOne(".s_website_form_end_message")).not.toHaveClass(['d-none']);
+    expect(queryOne(".s_website_form form")).toHaveClass(['d-none']);
+});
+
 test("form prefilled conditional", async () => {
     onRpc("res.users", "read", ({ parent }) => {
         const result = parent();


### PR DESCRIPTION
Scenario:
- add a form to a website page with "On Success" set to "Show Message"
- send the form

Result: the form is emptied but the success message is not shown

Issue: the dynamicContent hiding the form was not updated, also the
success message is outside the form so the dynamicContent doesn't
updates it.

Fix: restore the previous code and call updateContent.

Note: without the fix, the added tests fail with the form that is still
shown, and the message on success that is not shown.

opw-4687880
opw-4681865
opw-4701021
opw-4719489

__pr note:__ pr modified to add test

__pr note:__ commit message modified to add other issue numbers