### PR TITLE
[IMP] sale: allow to easily apply note style on order_line

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -539,13 +539,13 @@
                             <t t-foreach="lines_to_report" t-as="line">
 
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
-
+                                <t t-set="is_note" t-value="line.display_type == 'line_note'"/>
                                 <tr
                                     t-att-class="'fw-bold o_line_section' if (
                                         line.display_type == 'line_section'
                                         or line.product_type == 'combo'
                                     )
-                                    else 'fst-italic o_line_note' if line.display_type == 'line_note'
+                                    else 'fst-italic o_line_note' if is_note
                                     else ''"
                                 >
                                     <t
@@ -591,7 +591,7 @@
                                         <t t-set="current_section" t-value="line"/>
                                         <t t-set="current_subtotal" t-value="0"/>
                                     </t>
-                                    <t t-if="line.display_type == 'line_note'">
+                                    <t t-if="is_note">
                                         <td colspan="99">
                                             <span t-field="line.name"/>
                                         </td>


### PR DESCRIPTION
Since https://github.com/odoo/enterprise/pull/73438 several display_type values on sale.order.line behave as line_note. This commit helps overrding the template to make sure the correct style is applied.

taskid: 4690494

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
