### PR TITLE
[FIX] mail: ensure multiple mentions display correctly in a single message

### DIFF
--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -154,7 +154,7 @@ class UseSuggestion {
             after = text.substring(position, text.length);
         }
         if (option.partner) {
-            this.composer.mentionedPartners.add({
+            this.composer.mentionedPartners.push({
                 id: option.partner.id,
                 type: "partner",
             });
@@ -163,7 +163,7 @@ class UseSuggestion {
             this.composer.mentionedRoles.add(option.role);
         }
         if (option.thread) {
-            this.composer.mentionedChannels.add({
+            this.composer.mentionedChannels.push({
                 model: "discuss.channel",
                 id: option.thread.id,
             });


### PR DESCRIPTION
Before this PR:  
- When mentioning the same user or channel multiple times in a single message, only the first mention was displayed correctly.  
- Subsequent mentions were not recognized or rendered properly.  
- If multiple users had the same name, the second mention incorrectly linked to a different user instead of maintaining the correct reference.  

    > **Example:**  
    > Given two different users with the same name:  
    > **User1**: Marc Demo  
    > **User2**: Marc Demo  
    >   
    > When mentioning in a message:  
    > ```
    > @Marc Demo(User1) @Marc Demo(User1) @Marc Demo(User2)
    > ```  
    > The incorrect result:  
    > ```
    > @Marc Demo(User1 with mention link) @Marc Demo(User2 with mention link) @Marc Demo(plain text)
    > ```  
    > The second mention incorrectly linked to **User2** instead of **User1**.  

After this PR:  
- All mentions of the same user or channel within a single message are displayed correctly.  
- Ensures correct mapping of mentions, even when multiple users have the same name.  

Task - 3531939  
