### PR TITLE
[FIX] purchase_stock,stock_account,account: exchange diff under stock valo account

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2693,6 +2693,14 @@ class AccountMoveLine(models.Model):
 
         return partials
 
+    def _get_exchange_journal(self, company):
+        return company.currency_exchange_journal_id
+
+    def _get_exchange_account(self, company, amount):
+        if amount > 0.0:
+            return company.expense_currency_exchange_account_id
+        return company.income_currency_exchange_account_id
+
     def _prepare_exchange_difference_move_vals(self, amounts_list, company=None, exchange_date=None, **kwargs):
         """ Prepare values to create later the exchange difference journal entry.
         The exchange difference journal entry is there to fix the debit/credit of lines when the journal items are
@@ -2712,9 +2720,7 @@ class AccountMoveLine(models.Model):
         if not company:
             return
 
-        journal = company.currency_exchange_journal_id
-        expense_exchange_account = company.expense_currency_exchange_account_id
-        income_exchange_account = company.income_currency_exchange_account_id
+        journal = self._get_exchange_journal(company)
         accounting_exchange_date = journal.with_context(move_date=exchange_date).accounting_date if journal else date.min
 
         move_vals = {
@@ -2747,10 +2753,7 @@ class AccountMoveLine(models.Model):
             else:
                 continue
 
-            if amount_residual_to_fix > 0.0:
-                exchange_line_account = expense_exchange_account
-            else:
-                exchange_line_account = income_exchange_account
+            exchange_line_account = self._get_exchange_account(company, amount_residual_to_fix)
 
             sequence = len(move_vals['line_ids'])
             line_vals = [

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import timedelta
 from freezegun import freeze_time
 
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
@@ -651,3 +652,55 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
                 {'journal_id': stock_journal_id,    'balance':  -1.79},
             ],
         )
+
+    def test_exchange_rate_difference_post_bill_prior_to_reception(self):
+        """ Billing/invoicing before validating a reception for some product that is valuated which
+        has incurred some (foreign) currency exchange difference in the time between those two
+        actions should result in that difference appearing under the 'Stock Valuation' account
+
+        (as opposed to the regular exchange account)
+        """
+        avco_prod = self.test_product_order
+        avco_prod.purchase_method = 'purchase'
+        tomorrow = fields.Date.today() + timedelta(days=1)
+        self.env.ref('base.EUR').active = True
+        self.env['res.currency.rate'].create([
+            {'name': fields.Date.today(), 'currency_id': self.ref('base.EUR'), 'rate': 0.9},
+            {'name': tomorrow, 'currency_id': self.ref('base.EUR'), 'rate': 0.8},
+        ])
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': self.ref('base.EUR'),
+            'order_line': [Command.create({
+                'product_id': avco_prod.id,
+                'product_qty': 10,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids
+        bill.invoice_date = fields.Date.today()
+        bill.action_post()
+        with (freeze_time(tomorrow)):
+            receipt = purchase_order.picking_ids
+            receipt.button_validate()
+
+            cd = self.company_data
+            stock_input_account, tax_purchase_account, account_payable_account, stock_valuation_account = (
+                cd['default_account_stock_in'],
+                cd['default_account_tax_purchase'],
+                cd['default_account_payable'],
+                cd['default_account_stock_valuation'],
+            )
+            self.assertRecordValues(
+                self.env['account.move.line'].search([], order='id asc'),
+                [
+                    {'account_id': stock_input_account.id,          'debit':  42.0,         'credit':   0.0},
+                    {'account_id': tax_purchase_account.id,         'debit':   6.3,         'credit':   0.0},
+                    {'account_id': account_payable_account.id,      'debit':   0.0,         'credit':  48.3},
+                    {'account_id': stock_input_account.id,          'debit':   0.0,         'credit': 420.0},
+                    {'account_id': stock_valuation_account.id,      'debit': 420.0,         'credit':   0.0},
+                    {'account_id': stock_input_account.id,          'debit': 382.67,        'credit':   0.0},
+                    {'account_id': stock_valuation_account.id,      'debit':   0.0,         'credit': 382.67},
+                ]
+            )

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -315,3 +315,19 @@ class AccountMoveLine(models.Model):
     @api.onchange('product_id')
     def _inverse_product_id(self):
         super(AccountMoveLine, self.filtered(lambda l: l.display_type != 'cogs'))._inverse_product_id()
+
+    def _get_exchange_journal(self, company):
+        if (
+            self and self.move_id.stock_valuation_layer_ids and
+            self.product_id.categ_id.property_valuation == 'real_time'
+        ):
+            return self.product_id.categ_id.property_stock_journal
+        return super()._get_exchange_journal(company)
+
+    def _get_exchange_account(self, company, amount):
+        if (
+            self and self.move_id.stock_valuation_layer_ids and
+            self.product_id.categ_id.property_valuation == 'real_time'
+        ):
+            return self.product_id.categ_id.property_stock_valuation_account_id
+        return super()._get_exchange_account(company, amount)


### PR DESCRIPTION
**Current behavior:**
When receiving product after having billed it already, if: A) the product is valuated,
B) the purchase is in a foreign currency,
C) there is an underlying exchange diff between time of bill and receiption

then the exchange difference account move will occur in the regular exchange account.

**Expected behavior:**
It should be for the stock valuation account.

**Steps to reproduce:**
*with anglo saxon accounting enabled*
1. Create a real-time valuated product invoiced on ordered qty
2. Activate a foreign currency, set some exchange rate for today and tomorrow (unique)
3. Make a purchase for the product, invoice -> post
4. The next day, receive the product
5. Check the exchange journal to see the offending AMLs

**Cause of the issue:**
In this flow, when the receipt is validated, at this point: *from `_validate_accounting_entries()`*
https://github.com/odoo/odoo/blob/7e7c1abeead0d4ef19ec15d50808ab33a642d25e/addons/stock_account/models/account_move.py#L185 the SVL linkage is somewhat broken because the bill's SVL was generated before the receiption's.

It means the exchange diff reconciliation proceeds as "usual" (without the `stock_account` module impacting the process) so the regular journal and accounts are used to record the amounts.

**Fix:**
Add overrides for getting the relevant journal and account(s) inside `_prepare_exchange_difference_move_vals()` in order to prevent `real_time` valuated product moves from generating AMLs in the ordinary exchange account (instead, use the stock journal and stock valuation account resp.)

opw-4655669