### PR TITLE
[FIX] html_editor: fix scroll behavior on selection change

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -23,7 +23,8 @@ import {
     normalizeDeepCursorPosition,
     normalizeFakeBR,
 } from "../utils/selection";
-import { scrollTo } from "@web/core/utils/scrolling";
+import { isElement } from "../utils/dom_info";
+import { closestScrollableY } from "@web/core/utils/scrolling";
 
 /**
  * @typedef { Object } EditorSelection
@@ -111,21 +112,50 @@ function getUnselectedEdgeNodes(selection) {
 }
 
 /**
- * Check if an element is in the viewport.
- *
- * @param {HTMLElement} element - The element to check.
- * @param {Object} [options] - Options for the observer.
- * @param {number} [options.threshold=0.5] - The intersection observer threshold.
- * @returns {Promise<boolean>} - A promise that resolves with a boolean indicating whether the element is in the viewport.
+ * Scrolls the view to a specific node's position in the document
+ * @param {Selection} selection - The current document selection
+ * @returns {void}
  */
-function isElementInViewport(element, options = { threshold: 0.5 }) {
-    return new Promise((resolve) => {
-        const observer = new IntersectionObserver(([entry]) => {
-            resolve(entry.isIntersecting);
-            observer.disconnect();
-        }, options);
-        observer.observe(element);
-    });
+function scrollToSelection(selection) {
+    const range = selection.getRangeAt(0);
+    const container = closestScrollableY(range.startContainer.parentElement);
+    if (!container) {
+        // If the container is not scrollable we don't scroll
+        return;
+    }
+    let rect = range.getBoundingClientRect();
+    // If the range is invisible (0 width & height) and selection is collapsed,
+    // it's likely inside an empty paragraph.
+    // In that case, we try to get the bounding rect from a nearby child element
+    // within the anchorNode to better get position the selection.
+    if (
+        rect.width === 0 &&
+        rect.height === 0 &&
+        selection.isCollapsed &&
+        selection.anchorNode.hasChildNodes()
+    ) {
+        const target =
+            selection.anchorNode.childNodes[selection.anchorOffset] ||
+            selection.anchorNode.childNodes[selection.anchorOffset - 1];
+        if (isElement(target)) {
+            rect = target.getBoundingClientRect();
+        }
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    const offsetTop = rect.top - containerRect.top + container.scrollTop;
+    const offsetBottom = rect.bottom - containerRect.top + container.scrollTop;
+
+    if (rect.height >= containerRect.height) {
+        // Selection is larger than scrollable so we do nothing.
+        return;
+    }
+    // Simulate the "nearest" behavior by scrolling to the closest top/bottom edge
+    if (rect.top < containerRect.top) {
+        container.scrollTo({ top: offsetTop, behavior: "instant" });
+    } else if (rect.bottom > containerRect.bottom) {
+        container.scrollTo({ top: offsetBottom - container.clientHeight, behavior: "instant" });
+    }
 }
 
 /**
@@ -176,15 +206,11 @@ export class SelectionPlugin extends Plugin {
 
     setup() {
         this.resetSelection();
-        this.addDomListener(this.document, "selectionchange", async () => {
+        this.addDomListener(this.document, "selectionchange", () => {
             this.updateActiveSelection();
             const selection = this.document.getSelection();
-            if (selection.isCollapsed && this.isSelectionInEditable(selection)) {
-                const element = closestElement(selection.focusNode);
-                const isInViewport = await isElementInViewport(element);
-                if (!isInViewport) {
-                    scrollTo(element);
-                }
+            if (this.isSelectionInEditable(selection)) {
+                scrollToSelection(selection);
             }
         });
         this.addDomListener(this.editable, "mousedown", (ev) => {


### PR DESCRIPTION
**Problem**:
Scroll was not working properly on selection change.

**Solution**:
Use the `getBoundingClientRect` of `Range` to calculate scrolling, which is more accurate in this case. Handle edge cases where the range consists only of `br` elements, which have no size or position.

**Steps to reproduce**:
1. Go to Project → Task.
2. Type something and press `Shift + Enter` two or three times.
3. Press `Shift + Enter` twice.
4. Add a large image, making the scrollbar appear.
5. Go to the top and try selecting the text.
   - **Issue**: The scroll automatically moves down to the image every time, preventing selection of the intended text.

**opw-4686994**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
