### PR TITLE
[FIX] account: update journal and sequence when changing payment journal

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -980,11 +980,13 @@ class AccountPayment(models.Model):
             pay.move_id \
                 .with_context(skip_invoice_sync=True) \
                 .write({
+                'name': '/',  # Set the name to '/' to allow it to be changed
                 'date': pay.date,
                 'partner_id': pay.partner_id.id,
                 'currency_id': pay.currency_id.id,
                 'partner_bank_id': pay.partner_bank_id.id,
                 'line_ids': line_ids_commands,
+                'journal_id': pay.journal_id.id,
             })
 
     @api.model


### PR DESCRIPTION
When changing the journal on a draft payment, the linked journal entry was not updated. This caused two issues:

The journal entry kept the old journal.

The sequence (move name) was not updated to match the new journal.

Now, when the journal is changed on a draft payment, both the journal and its sequence are correctly updated.

task-4688823

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
