### PR TITLE
Nilvera, UBL: Missing cac:Person node

### DIFF
--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -82,6 +82,11 @@
                 <cbc:Telephone t-out="contact_vals.get('telephone')"/>
                 <cbc:ElectronicMail t-out="contact_vals.get('electronic_mail')"/>
             </cac:Contact>
+            <cac:Person>
+                <t t-set="person_vals" t-value="vals.get('person_vals', {})"/>
+                <cbc:FirstName t-out="person_vals.get('first_name')"/>
+                <cbc:FamilyName t-out="person_vals.get('family_name')"/>
+            </cac:Person>
         </t>
     </template>
 

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -90,6 +90,17 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'electronic_mail': partner.email,
         }
 
+    def _get_partner_person_vals(self, partner):
+        """
+        This is optional and meant to be overridden when required under the form:
+        {
+            'first_name': str,
+            'family_name': str,
+        }.
+        Should return a dict.
+        """
+        return {}
+
     def _get_partner_party_vals(self, partner, role):
         return {
             'partner': partner,
@@ -99,6 +110,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'party_tax_scheme_vals': self._get_partner_party_tax_scheme_vals_list(partner.commercial_partner_id, role),
             'party_legal_entity_vals': self._get_partner_party_legal_entity_vals_list(partner.commercial_partner_id),
             'contact_vals': self._get_partner_contact_vals(partner),
+            'person_vals': self._get_partner_person_vals(partner),
         }
 
     def _get_invoice_period_vals_list(self, invoice):

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -110,6 +110,16 @@ class AccountEdiXmlUblTr(models.AbstractModel):
             vals.pop('registration_address_vals', None)
         return vals_list
 
+    def _get_partner_person_vals(self, partner):
+        if not partner.is_company:
+            name_parts = partner.name.split(' ', 1)
+            return {
+                'first_name': name_parts[0],
+                # If no family name is present, use a zero-width space (U+200B) to ensure the XML tag is rendered. This is required by Nilvera.
+                'family_name': name_parts[1] if len(name_parts) > 1 else '\u200B',
+            }
+        return super()._get_partner_person_vals(partner)
+
     def _get_delivery_vals_list(self, invoice):
         # EXTENDS account.edi.xml.ubl_21
         delivery_vals = super()._get_delivery_vals_list(invoice)


### PR DESCRIPTION
Contains two commits. One adds the node in `account_edi_ubl_cii` module and one to adapt the Nilvera e-invoice to use it.