### PR TITLE
[FIX] point_of_sale,pos_mrp: allow pos user to sell with basic rights

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -52,10 +52,6 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
                 (4, cls.env.ref('point_of_sale.group_pos_user').id),
             ],
         })
-        # When pos_mrp installed, protects from access error to mpr.bom (read when opening product info popup)
-        if group_mrp_user := cls.env.ref('mrp.group_mrp_user', raise_if_not_found=False):
-            cls.pos_user.write({'groups_id': [Command.link(group_mrp_user.id)]})
-
         cls.pos_admin = cls.env['res.users'].create({
             'name': 'A powerful PoS man!',
             'login': 'pos_admin',

--- a/addons/pos_mrp/__manifest__.py
+++ b/addons/pos_mrp/__manifest__.py
@@ -12,6 +12,14 @@
 This is a link module between Point of Sale and Mrp.
 """,
     'depends': ['point_of_sale', 'mrp'],
+    'data': [
+        'security/ir.model.access.csv',
+    ],
+    'assets': {
+        'web.assets_tests': [
+            'pos_mrp/static/tests/tours/**/*',
+        ],
+    },
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/pos_mrp/security/ir.model.access.csv
+++ b/addons/pos_mrp/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mrp_bom_pos_user,mrp.bom,mrp.model_mrp_bom,point_of_sale.group_pos_user,1,0,0,0
+access_mrp_bom_line_pos_user,mrp.bom.line,mrp.model_mrp_bom_line,point_of_sale.group_pos_user,1,0,0,0

--- a/addons/pos_mrp/static/tests/tours/pos_mrp_tour.js
+++ b/addons/pos_mrp/static/tests/tours/pos_mrp_tour.js
@@ -1,0 +1,31 @@
+/** @odoo-module */
+
+import * as PaymentScreen from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
+import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/helpers/ReceiptScreenTourMethods";
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_ship_later_kit_and_mto_manufactured_product", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.clickProductInfo("Finished"),
+            ProductScreen.priceOnProductInfoIs("10.00"),
+            ProductScreen.clickCloseProductInfo(),
+            ProductScreen.clickProductInfo("Basic Kit"),
+            ProductScreen.priceOnProductInfoIs("10.00"),
+            ProductScreen.clickCloseProductInfo(),
+            ProductScreen.addOrderline("Finished", "1"),
+            ProductScreen.addOrderline("Basic Kit", "1"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Partner Full"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickShipLaterButton(),
+            PaymentScreen.shippingLaterHighlighted(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptIsThere(),
+        ].flat(),
+});

--- a/addons/pos_mrp/tests/__init__.py
+++ b/addons/pos_mrp/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_frontend
 from . import test_pos_mrp_flow

--- a/addons/pos_mrp/tests/test_frontend.py
+++ b/addons/pos_mrp/tests/test_frontend.py
@@ -1,0 +1,81 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo.tests import tagged
+from odoo import Command
+
+
+@tagged('post_install', '-at_install')
+class TestUi(TestPointOfSaleHttpCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        # Ensure minimum rights (avoid new groups added through modules installation)
+        group_internal_user = cls.env.ref('base.group_user')
+        group_pos_user = cls.env.ref('point_of_sale.group_pos_user')
+        cls.pos_user.groups_id = [Command.set([group_internal_user.id, group_pos_user.id])]
+
+        categ = cls.env.ref('product.product_category_all')
+
+        cls.basic_kit, cls.finished, cls.component_a, cls.component_b = cls.env['product.product'].create([{
+            'name': name,
+            'type': 'product',
+            'categ_id': categ.id,
+            'available_in_pos': True,
+            'list_price': 10.0,
+            'standard_price': 1.0,
+            'taxes_id': False,
+        } for name in ['Basic Kit', 'Finished', 'Component A', 'Component B']])
+
+        cls.simple_kit_bom, cls.finished_bom = cls.env['mrp.bom'].create([{
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': bom_type,
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': cls.component_a.id,
+                    'product_qty': 1,
+                }),
+                Command.create({
+                    'product_id': cls.component_b.id,
+                    'product_qty': 1,
+                }),
+            ],
+        } for product, bom_type in [
+            (cls.basic_kit, 'phantom'),
+            (cls.finished, 'normal'),
+        ]])
+
+    def test_ship_later_kit_and_mto_manufactured_product(self):
+        """
+        Ship Later PoS. Sell a kit and a manufactured product. Before selling
+        them, the PoS user reads their product information. The second one has
+        both MTO and manufacture routes. Once sold, the delivery should contain
+        the manufactured product and the kit's components. Thanks to the routes,
+        there should also be a MO for the manufactured product.
+        """
+        self.main_pos_config.write({
+            'cash_control': False,
+            'ship_later': True,
+        })
+
+        mto_route = self.env.ref('stock.route_warehouse0_mto')
+        manu_route = self.env.ref('mrp.route_warehouse0_manufacture')
+        mto_route.active = True
+        self.finished.route_ids = [Command.set((mto_route | manu_route).ids)]
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        url = "/pos/ui?config_id=%d" % self.main_pos_config.id
+        self.start_tour(url, 'test_ship_later_kit_and_mto_manufactured_product', login="pos_user")
+
+        picking = self.env['stock.picking'].search([('partner_id', '=', self.partner_full.id)], limit=1)
+        self.assertRecordValues(picking.move_ids, [
+            {'product_id': self.finished.id, 'product_qty': 1.0},
+            {'product_id': self.component_a.id, 'product_qty': 1.0},
+            {'product_id': self.component_b.id, 'product_qty': 1.0},
+        ])
+
+        finished_sm = picking.move_ids[0]
+        self.assertEqual(finished_sm.move_orig_ids.production_id.product_id, self.finished)


### PR DESCRIPTION
PoS user can't open the product information on the product screen of
a PoS session.

This is because it will lead to the compute of the quantities. Doing
so, we will first go in the override of mrp, in case the product is
a kit. This will query the BoM model. However, a PoS user hasn't any
access to the module.

The fix follows the same logic as
- account: https://github.com/odoo/odoo/commit/fe6b351e04b7aa7d311cc07362d82f9843dde862
- purchase: https://github.com/odoo/odoo/commit/e9d80990e0f907be7799c6449afd6cd19502d604
- sale: at least since https://github.com/odoo/odoo/commit/43977deb713ef8df02690d9000f9becff8d9d610

This commit also reverts:
https://github.com/odoo/odoo/commit/98428145c4917bfcf8436569ab7560524d957880
Which is actually the reason why this commit is written: we should
not have to give those rights to a PoS user