### PR TITLE
[FIX] pos_event_sale: registration sale status

### DIFF
--- a/addons/pos_event_sale/__init__.py
+++ b/addons/pos_event_sale/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models

--- a/addons/pos_event_sale/__manifest__.py
+++ b/addons/pos_event_sale/__manifest__.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "PoS - Event Sale",
+    'category': "Technical",
+    'summary': 'Link module between pos_sale and pos_event',
+    'depends': ['pos_event', 'pos_sale'],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/pos_event_sale/models/__init__.py
+++ b/addons/pos_event_sale/models/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import event_registration

--- a/addons/pos_event_sale/models/event_registration.py
+++ b/addons/pos_event_sale/models/event_registration.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models, api
+
+
+class EventRegistration(models.Model):
+    _inherit = ['event.registration']
+
+    @api.depends('pos_order_id.state')
+    def _compute_registration_status(self):
+        super()._compute_registration_status()
+        for record in self.filtered("pos_order_id.id"):
+            if record.pos_order_id.state in ['paid', 'done', 'invoiced']:
+                record.sale_status = 'sold'
+                record.state = 'done'
+            else:
+                record.sale_status = 'to_pay'
+                record.state = 'draft'

--- a/addons/pos_event_sale/tests/__init__.py
+++ b/addons/pos_event_sale/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_frontend

--- a/addons/pos_event_sale/tests/test_frontend.py
+++ b/addons/pos_event_sale/tests/test_frontend.py
@@ -1,0 +1,112 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged
+from odoo.addons.pos_event.tests.test_frontend import TestUi
+from odoo import fields, Command
+
+
+@tagged('post_install', '-at_install')
+class TestPoSEventSale(TestUi):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_sale_status_event_in_pos(self):
+        self.pos_user.write({
+            'groups_id': [
+                (4, self.env.ref('event.group_event_user').id),
+            ]
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+
+        order_data = {
+            "amount_paid": 100,
+            "amount_tax": 0,
+            "amount_return": 0,
+            "amount_total": 100,
+            "date_order": fields.Datetime.to_string(fields.Datetime.now()),
+            "fiscal_position_id": False,
+            "lines": [
+                Command.create({
+                    "discount": 0,
+                    "pack_lot_ids": [],
+                    "price_unit": 100.0,
+                    "product_id": self.product_event.id,
+                    "price_subtotal": 100.0,
+                    "price_subtotal_incl": 100.0,
+                    "tax_ids": [],
+                    "qty": 1,
+                    "event_ticket_id": self.test_event.event_ticket_ids[0].id,
+                    "event_registration_ids": [
+                        (0, 0, {
+                            "event_id": self.test_event.id,
+                            "event_ticket_id": self.test_event.event_ticket_ids[0].id,
+                            "name": "Test Name",
+                            "email": "Test Email",
+                            "phone": "047123123198",
+                        }),
+                    ],
+                }),
+            ],
+            "name": "Order 12345-123-1234",
+            "partner_id": self.partner_a.id,
+            "session_id": self.main_pos_config.current_session_id.id,
+            "sequence_number": 2,
+            "payment_ids": [
+                    Command.create({
+                        "amount": 100,
+                        "name": fields.Datetime.now(),
+                        "payment_method_id": self.bank_payment_method.id,
+                    }),
+            ],
+            "uuid": "12345-123-1234",
+            "last_order_preparation_change": "{}",
+            "user_id": self.env.uid,
+            "to_invoice": False,
+        }
+
+        order_data_2 = {
+            "amount_paid": 100,
+            "amount_tax": 0,
+            "amount_return": 0,
+            "amount_total": 100,
+            "date_order": fields.Datetime.to_string(fields.Datetime.now()),
+            "fiscal_position_id": False,
+            "lines": [
+                Command.create({
+                    "discount": 0,
+                    "pack_lot_ids": [],
+                    "price_unit": 100.0,
+                    "product_id": self.product_event.id,
+                    "price_subtotal": 100.0,
+                    "price_subtotal_incl": 100.0,
+                    "tax_ids": [],
+                    "qty": 1,
+                    "event_ticket_id": self.test_event.event_ticket_ids[0].id,
+                    "event_registration_ids": [
+                        (0, 0, {
+                            "event_id": self.test_event.id,
+                            "event_ticket_id": self.test_event.event_ticket_ids[0].id,
+                            "name": "Test Name",
+                            "email": "Test Email",
+                            "phone": "047123123198",
+                        }),
+                    ],
+                }),
+            ],
+            "name": "Order 12345-123-1234",
+            "access_token": "12345-123-1234",
+            "partner_id": self.partner_a.id,
+            "session_id": self.main_pos_config.current_session_id.id,
+            "sequence_number": 2,
+            "payment_ids": [],
+            "uuid": "12345-123-4331",
+            "last_order_preparation_change": "{}",
+            "user_id": self.env.uid,
+            "to_invoice": False,
+            "state": "draft",
+        }
+        self.env['pos.order'].sync_from_ui([order_data, order_data_2])
+        sale_status = self.env['event.registration'].search([]).mapped("sale_status")
+        self.assertEqual(len(sale_status), 2)
+        self.assertIn('sold', sale_status)
+        self.assertIn('to_pay', sale_status)


### PR DESCRIPTION
Sale status was not correctly set when ticket where sold from the POS.

Steps to reproduce:
-------------------
* Create an event and make sure ticket can be sold in PoS
* Open PoS
* Add a ticket to the order and complete the order
* Add another ticket to the order but go to the backend to save it as
  draft
> Observation: The sale status of the order appears as 'free' when it
should be "Sold" and "Not Sold"

Why the fix:
------------
We make sure to take the state of the PoS order when the ticket has been
sold through the PoS.

opw-4584390