### PR TITLE
[FIX] mail,*: less memory restrained between HOOT suite tests

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -210,7 +210,8 @@ export class Rtc extends Record {
     timeouts = new Map();
     /** @type {Map<number, number>} timeoutId by sessionId for download pausing delay */
     downloadTimeouts = new Map();
-    iceServers = Record.attr(DEFAULT_ICE_SERVERS, {
+    /** @type {{urls: string[]}[]} */
+    iceServers = Record.attr(undefined, {
         compute() {
             return this.iceServers ? this.iceServers : DEFAULT_ICE_SERVERS;
         },


### PR DESCRIPTION
Before this commit, when running a HOOT test suite with a dependency on `@mail`, the memory snapshot at end of suite test was higher than expected.

Steps to reproduce:

- run HOOT suite `global_filter_editor.test.js` with 51 tests
- make a snapshot of memory after test => observe that there's thousands of RecordList objects kept in memory (8976) instead of a few hundreds (176)

These tests do not make use of any mail code, but the manifest has dependency on `@mail` thus it loads mail store. This test suite is a good candidate to show constant memory issue from discuss code: 51 tests each having 176 record lists result in 8976 record lists in total.

The JS records are expected to be garbage collected after each test, thanks to store not being accessible from components and services (app is unmounted at end of test).

However, `Rtc.iceServers` field was preventing this and leads to keeping store in memory. This is happening because the default value of this field is `DEFAULT_ICE_SERVERS`, which is defined on window object globally and is shared among all the different stores in the test suite. The field is computed too, so an internal `onChange` also contributed in keeping a reference to observing this shared object.

This commit fixes the issue by providing a deep copy of this global variable as the default value of `iceServers`, allowing proper gc of store between tests of the suite.