### PR TITLE
[IMP] discuss: adding utility methods for action conditions

### DIFF
--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -104,7 +104,7 @@ class TestOutOfOfficePerformance(TestHrHolidaysCommon, TransactionCaseWithUserDe
     @users('__system__', 'demo')
     @warmup
     def test_leave_im_status_performance_partner_offline(self):
-        with self.assertQueryCount(__system__=3, demo=3):
+        with self.assertQueryCount(__system__=4, demo=4):
             self.assertEqual(self.employer_partner.im_status, 'offline')
 
     @users('__system__', 'demo')
@@ -118,7 +118,7 @@ class TestOutOfOfficePerformance(TestHrHolidaysCommon, TransactionCaseWithUserDe
     @warmup
     def test_leave_im_status_performance_partner_leave_offline(self):
         self.leave.write({'state': 'validate'})
-        with self.assertQueryCount(__system__=3, demo=3):
+        with self.assertQueryCount(__system__=4, demo=4):
             self.assertEqual(self.hr_partner.im_status, 'leave_offline')
 
     def test_search_absent_employee(self):

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -156,12 +156,7 @@ function transformAction(component, id, action) {
             return action.componentProps?.(component, this);
         },
         get condition() {
-            if (!action?.condition) {
-                return true;
-            }
-            return typeof action.condition === "function"
-                ? action.condition(component)
-                : action.condition;
+            return composerActionsInternal.condition(component, id, action);
         },
         get disabledCondition() {
             return action.disabledCondition?.(component);
@@ -203,6 +198,17 @@ function transformAction(component, id, action) {
         setup: action.setup,
     };
 }
+
+export const composerActionsInternal = {
+    condition(component, id, action) {
+        if (!action?.condition) {
+            return true;
+        }
+        return typeof action.condition === "function"
+            ? action.condition(component)
+            : action.condition;
+    },
+};
 
 export function useComposerActions() {
     const component = useComponent();

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -178,7 +178,7 @@ function transformAction(component, id, action) {
         mobileCloseAfterClick: action.mobileCloseAfterClick ?? true,
         /** Condition to display this action. */
         get condition() {
-            return action.condition(component);
+            return messageActionsInternal.condition(component, id, action);
         },
         /** Icon for the button this action. */
         get icon() {
@@ -204,6 +204,12 @@ function transformAction(component, id, action) {
         setup: action.setup,
     };
 }
+
+export const messageActionsInternal = {
+    condition(component, id, action) {
+        return action.condition(component);
+    },
+};
 
 export function useMessageActions() {
     const component = useComponent();

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -103,10 +103,7 @@ function transformAction(component, id, action) {
         },
         /** Condition to display this action. */
         get condition() {
-            if (action.condition === undefined) {
-                return true;
-            }
-            return action.condition(component);
+            return threadActionsInternal.condition(component, id, action);
         },
         /** Condition to disable the button of this action (but still display it). */
         get disabledCondition() {
@@ -208,6 +205,15 @@ function transformAction(component, id, action) {
         toggle: action.toggle,
     };
 }
+
+export const threadActionsInternal = {
+    condition(component, id, action) {
+        if (action.condition === undefined) {
+            return true;
+        }
+        return action.condition(component);
+    },
+};
 
 export function useThreadActions() {
     const component = useComponent();

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -31,7 +31,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search im_livechat_expertise_res_users_settings_rel (_format_settings)
     #       - search mail_canned_response
     #       - fetch res_groups_users_rel (for search mail_canned_response that user can use)
-    _query_count_init_store = 14
+    _query_count_init_store = 15
     # Queries for _query_count_init_messaging (in order):
     #   1: insert res_device_log
     #   1: fetch res_users (for current user, first occurence _get_channels_as_member of _init_messaging)
@@ -142,7 +142,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search user (_author_to_store)
     #       - fetch user (_author_to_store)
     #       - _compute_rating_stats
-    _query_count_discuss_channels = 58
+    _query_count_discuss_channels = 59
 
     def setUp(self):
         super().setUp()

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -43,8 +43,8 @@ class TestPerfSessionInfo(common.HttpCase):
 
         # cold fields cache - warm ormcache:
         # - Only web: 5
-        # - All modules: 25
-        with self.assertQueryCount(25):
+        # - All modules: 26
+        with self.assertQueryCount(26):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),

--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -368,3 +368,6 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 # Whitelist the shop floor module
 !mrp_workorder
 !mrp_workorder/**
+
+!ai
+!ai/**


### PR DESCRIPTION
This PR introduces three new objects in the `composer_actions`, `message_actions`, and `thread_actions` files.

The purpose of these objects is to facilitate the overriding of the `condition` function which is used to decide whether or not to render an action in discuss components. As such, the objects (`composerActionInternal`, `messageActionInternal`, and `threadActionInternal`) only contain one method `condition`.

task-id: 4526285

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
