### PR TITLE
[FIX] website_sale: .product_price removed

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1319,11 +1319,10 @@
 
     <template id="product_price">
         <div
-            t-if="not combination_info['prevent_zero_price_sale']"
             itemprop="offers"
             itemscope="itemscope"
             itemtype="http://schema.org/Offer"
-            t-attf-class="product_price mt-2 mb-3 d-inline-block"
+            t-attf-class="product_price mt-2 mb-3 {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-block'}}"
         >
             <h3 class="css_editable_mode_hidden">
                 <span class="oe_price"
@@ -1347,7 +1346,11 @@
                     </bdi>
                 </del>
             </h3>
-            <h3 class="css_non_editable_mode_hidden decimal_precision" t-att-data-precision="str(website.currency_id.decimal_places)">
+            <h3
+                t-if="editable"
+                class="css_non_editable_mode_hidden decimal_precision"
+                t-att-data-precision="str(website.currency_id.decimal_places)"
+            >
                 <span t-field="product.list_price"
                       t-options="{'widget': 'monetary', 'display_currency': product.currency_id}"/>
                 <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>


### PR DESCRIPTION
In a previous commit 4a6af867dd2eb13659c93e553d5e553cacb3048d, price was intended to be hidden when prevent zero sale is enabled.

However the fix wrongly removed the outer div containing also the editable price that can be updated from the editor.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
