### PR TITLE
[FIX] repair: use only consumable in product catalog from Repair

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -645,6 +645,9 @@ class Repair(models.Model):
 
         return {**default_data, **new_default_data}
 
+    def _get_product_catalog_domain(self):
+        return expression.AND([super()._get_product_catalog_domain(), [('type', '=', 'consu')]])
+
     def _get_product_catalog_order_data(self, products, **kwargs):
         product_catalog = super()._get_product_catalog_order_data(products, **kwargs)
         for product in products:

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -838,3 +838,12 @@ class TestRepair(common.TransactionCase):
             'quantity': 1.0,
         })]
         self.assertEqual(repair_order.lot_id, sn_1)
+
+    def test_add_product_from_catalog(self):
+        """Check that only consumable products are available in the catalog."""
+        catalog_action = self.repair0.action_add_from_catalog()
+        domain = catalog_action.get('domain')
+        self.assertEqual(self.product_service_order_repair.type, 'service')
+        self.assertEqual(self.product_consu_order_repair.type, 'consu')
+        self.assertTrue(self.product_consu_order_repair.filtered_domain(domain))
+        self.assertFalse(self.product_service_order_repair.filtered_domain(domain))


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a service product “S1”
- Create a repair order:
    - In the parts: - Click on the catalog

Problem:
You can select a service product, whereas the products in the repair parts should be restricted to consumable-type products only:

https://github.com/odoo/odoo/blob/f2923dec56b5ba2436bc244337c1e430a85e7e94/addons/stock/models/stock_move.py#L45-L48

opw-4687472

