### PR TITLE
[FIX] l10n_in: do not depend on the state for l10n_in_gst_treatment

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -36,7 +36,7 @@ class AccountMove(models.Model):
     l10n_in_reseller_partner_id = fields.Many2one('res.partner', 'Reseller', domain=[('vat', '!=', False)], help="Only Registered Reseller")
     l10n_in_journal_type = fields.Selection(string="Journal Type", related='journal_id.type')
 
-    @api.depends('partner_id', 'partner_id.l10n_in_gst_treatment', 'state')
+    @api.depends('partner_id', 'partner_id.l10n_in_gst_treatment')
     def _compute_l10n_in_gst_treatment(self):
         indian_invoice = self.filtered(lambda m: m.country_code == 'IN')
         for record in indian_invoice:

--- a/addons/l10n_in/tests/test_partner_details_on_invoice.py
+++ b/addons/l10n_in/tests/test_partner_details_on_invoice.py
@@ -93,12 +93,6 @@ class TestReports(AccountTestInvoicingCommon):
                 'l10n_in_gst_treatment': 'regular',
             }]
         )
-        invoice_2.button_draft()
-        self.assertRecordValues(invoice_2, [{
-            'state': 'draft',
-            'l10n_in_gst_treatment': self.partner_a.l10n_in_gst_treatment,
-            'l10n_in_state_id': expected_pos_id,
-        }])
 
     def test_partner_change_with_invoice(self):
         out_invoice = self.init_invoice(


### PR DESCRIPTION
In a previous PR https://github.com/odoo/odoo/pull/203445 we added a dependency on fiscal position in l10n_in on the gst treatment.

The problem, is that gst treatment depends on the state and this way it is possible that fiscal position changes when confirming an invoice.

In any case, it is also better that the gst treatment of the invoice does not depend on the state as you do not want it to suddenly change when you reset to draft.

So, we removed to dependency of the state for the
l10n_in_gst_treatment on invoice.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
