### PR TITLE
[FIX] l10n_it_stock_ddt: correct rounding errors in Delivery Slip calculations

### DIFF
--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -128,7 +128,7 @@
                                     </td>
                                     <td>
                                         <t t-if="move.sale_line_id">
-                                            <t t-set="lst_price" t-value="move.sale_line_id.price_reduce_taxinc * move.quantity"/>
+                                            <t t-set="lst_price" t-value="move.sale_line_id.price_reduce_taxexcl * move.quantity + move.sale_line_id.price_tax"/>
                                         </t>
                                         <t t-else="">
                                             <t t-set="lst_price" t-value="move.product_id.lst_price * move.product_uom._compute_quantity(move.quantity, move.product_id.uom_id)"/>


### PR DESCRIPTION
1. Install `l10n_it_stock_ddt` (Accounting, Sales, Italian localization, Italian delivery slip)
2. Create an invoice with one or more products
3. Set the quantity on the order lines to a relatively high value, like 200
4. Set the unit price to include decimal values so that rounding becomes relevant
5. Confirm the invoice.
6. Click on the delivery smart button.
7. Click on Validate > Print.

The total for each product line and the overall total should be correctly calculated as the unit price multiplied by the quantity, then the tax must be added.

Doing this in incorrect order, can result in discrepancies per unit due to the rounding being done before applying the tax, and that becomes significant when a large number of items is sold.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4666634)
opw-4666634