### PR TITLE
[FIX] l10n_ke_edi_tremol: correct filter definition

### DIFF
--- a/addons/l10n_ke_edi_tremol/views/account_move_view.xml
+++ b/addons/l10n_ke_edi_tremol/views/account_move_view.xml
@@ -59,7 +59,7 @@
             <field name="inherit_id" ref="account.view_account_invoice_filter" />
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='journal_id']" position="after">
-                    <field name="l10n_ke_cu_invoice_number" string="Kenya CU Invoice Number" filter_domain="[('l10n_ke_cu_invoice_number', 'ilike', self')]" />
+                    <field name="l10n_ke_cu_invoice_number" string="Kenya CU Invoice Number" operator="ilike" />
                 </xpath>
                 <xpath expr="//filter[@name='cancel']" position="after">
                     <separator/>


### PR DESCRIPTION
The domain was syntactically wrong.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
