### PR TITLE
[IMP] mail: enable expandable images in activities

### DIFF
--- a/addons/mail/data/mail_templates_chatter.xml
+++ b/addons/mail/data/mail_templates_chatter.xml
@@ -18,7 +18,9 @@
     </p>
     <t t-if="activity.note and activity.note != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'"><!-- <p></br></p> -->
         <div class="o_mail_note_title fw-bold">Original note:</div>
-        <div t-field="activity.note"/>
+            <div class="o_mail_activity_note_content">
+                <div t-field="activity.note"/>
+            </div>
     </t>
     <div t-if="feedback">
         <div class="fw-bold">Feedback:</div>

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -41,6 +41,7 @@ import { discussComponentRegistry } from "./discuss_component_registry";
 import { NotificationMessage } from "./notification_message";
 import { useLongPress } from "@mail/utils/common/hooks";
 import { ActionList } from "./action_list";
+import { useFileViewer } from "@web/core/file_viewer/file_viewer_hook";
 
 /**
  * @typedef {Object} Props
@@ -130,6 +131,7 @@ export class Message extends Component {
         this.ui = useService("ui");
         this.openReactionMenu = this.openReactionMenu.bind(this);
         this.optionsDropdown = useDropdownState();
+        this.fileViewer = useFileViewer();
         useChildSubEnv({
             message: this.props.message,
             alignedRight: this.isAlignedRight,
@@ -371,6 +373,19 @@ export class Message extends Component {
      * @param {MouseEvent} ev
      */
     async onClick(ev) {
+        const img = ev.target.closest('.o_mail_activity_note_content img');
+        if (img) {
+            ev.stopPropagation();
+            const imgName = img.src ? decodeURIComponent(img.src.split('/').pop().split('?')[0]) : '';
+            const fileModel = {
+                isImage: true,
+                isViewable: true,
+                name: imgName,
+                defaultSource: img.src,
+                downloadUrl: img.src,
+            };
+        this.fileViewer.open(fileModel);
+    }
         if (this.store.handleClickOnLink(ev, this.props.thread)) {
             return;
         }

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -15,6 +15,12 @@
         outline: 1px solid rgba($o-action, .125);
         outline-offset: -1px;
     }
+
+    .o_mail_activity_note_content {
+        img {
+            cursor: zoom-in;
+        }
+    }
 }
 
 .o-mail-Message-date {

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -43,7 +43,7 @@
                     </tbody>
                 </table>
             </div>
-            <div t-if="props.activity.note" class="o-mail-Activity-note text-break" t-out="props.activity.note"/>
+            <div t-if="props.activity.note" class="o-mail-Activity-note text-break" t-att-class="state.fileModel.name ? 'o-viewable' : ''" t-att-title="state.fileModel.name" tabindex="0" t-on-click="() => fileViewer.open(state.fileModel)" t-out="props.activity.note"/>
             <div t-if="props.activity.mail_template_ids?.length > 0" class="o-mail-Activity-mailTemplates">
                 <ActivityMailTemplate activity="props.activity" onActivityChanged="props.onActivityChanged"/>
             </div>


### PR DESCRIPTION
In this commit:
 - Users can now expand the images when attached to activities by clicking an image for a better viewing experience, with options to zoom, reset, print and download.

task - 4599796