### PR TITLE
[FIX] web: add top margin to kanban records

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -163,6 +163,10 @@
         word-wrap: break-word;
         word-break: break-word;
 
+        &:first-of-type {
+            margin-top: 1px;
+        }
+
         // do not break wrap inside buttons
         button {
             word-wrap: normal;


### PR DESCRIPTION
Steps to reproduce
==================

- Go to the project app
- Open any project
- zoom / dezoom a few times => At some point, the top border on the first kanban card will
   disappear.

Cause of the issue
==================

This is due to a negative margin on the bottom of kanban cards. This is made in order to have no duplicated border between cards.

Solution
========

We can set a top margin for the first card.

opw-4668595