### PR TITLE
[FIX] iot_box_image: enable wifi at boot

### DIFF
--- a/addons/iot_box_image/overwrite_after_init/etc/rc.local
+++ b/addons/iot_box_image/overwrite_after_init/etc/rc.local
@@ -11,6 +11,9 @@
 #
 # By default this script does nothing.
 
+# Ensure Wi-Fi radio is enabled
+nmcli radio wifi on
+
 # Print the IP address
 _IP=$(hostname -I) || true
 if [ "$_IP" ]; then


### PR DESCRIPTION
In addition to the fix in #204331 to unblock Wi-Fi, we additionally need to ensure the Wi-Fi radio is enabled at boot as it is no longer the default. This commit adds the command in `rc.local` so that it is run every boot.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
