### PR TITLE
[16.0][FIX] account: Avoid fake duplicated move number

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1744,7 +1744,7 @@ class AccountMove(models.Model):
                 AND move2.journal_id = move.journal_id
                 AND move2.move_type = move.move_type
                 AND move2.id != move.id
-            WHERE move.id IN %s AND move2.state = 'posted'
+            WHERE move.id IN %s AND move2.state = 'posted' AND move2.name != '/'
         ''', [tuple(moves.ids)])
         res = self._cr.fetchall()
         if res:


### PR DESCRIPTION
Steps to reproduce the problem:

- Go to developer mode.
- Select several invoices.
- Press on Action > Resequence
- Put a different sequence, and press Confirm.

You get a message saying that the sequence is not unique, and all the sequences in the message appear as '/', being them the invoices we are trying to resequence.

Explanation: On the resequence wizard, all the selected moves are being set to have '/' as name, and doing the flushing.

https://github.com/odoo/odoo/blob/166a55f159dca1fba29fe9b1aed2a923994a6672/addons/account/wizard/account_resequence.py#L154

After that, the Python check is triggering the problem.

On runbot, it's not directly reproducible while you don't uninstall `account_sequence` module, which nullifies the constraint.
    
The solution found is to exclude '/' from the check.

@Tecnativa 