### PR TITLE
[FIX] web: handle multiple-pages quote display

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report_tables.scss
+++ b/addons/web/static/src/webclient/actions/reports/report_tables.scss
@@ -14,6 +14,12 @@ table.table {
 
 div#total {
     // Avoid crop in the total table if in middle of 2 pages
+    width: 100%;
+    display: table;
+    // override row style
+    --gutter-x: 0;
+    --gutter-y: 0;
+    margin: 0;
     page-break-inside: avoid;
 }
 

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -185,7 +185,7 @@
                            </tbody>
                        </table>
                        <div id="right-elements" t-attf-class="#{'col-5' if report_type != 'html' else 'col-12 col-md-5'} ms-5 d-inline-block float-end">
-                           <div id="total" class="clearfix row mt-n3">
+                           <div id="total" class="clearfix mt-n3">
                                <div class="ms-auto">
                                    <table class="o_total_table table table-borderless">
                                        <tbody><tr class="o_subtotal">


### PR DESCRIPTION
## Version:
18.0+

## Issue:
PDF quotes on multiple pages having only the total table on the last page encounter a display issue. The total table is cut and partially displayed at the bottom of the penultimate page.

## Steps to reproduce:
- Install Sales app;
- Navigate to the Settings app:
    - Under the `Companies` section, configure the document layout: - Ensure the `Bubble` (or `Boxed`) layout is selected;
- Navigate to the Sales app:
    - Create a new quote with 8x `Chair floor protection`;
    - Via the `Actions` gear button, print the `PDF Quote`.

## Cause:
Complete code refactoring for documents layouts styles introduced by https://github.com/odoo/odoo/pull/169512 has probably not been tested on that use case.

## Fix:
<img width="1105" alt="Capture d’écran 2025-04-03 à 10 25 58" src="https://github.com/user-attachments/assets/67bce15e-c5e9-40f8-9fbf-7721afc98ae5" />

opw-4624623
opw-4627809

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
