### PR TITLE
[FIX] mail: prevent traceback on clicking 'Unfollow' in email footer

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -174,7 +174,9 @@ class MailController(http.Controller):
 
     # csrf is disabled here because it will be called by the MUA with unpredictable session at that time
     @http.route('/mail/unfollow', type='http', auth='public', csrf=False)
-    def mail_action_unfollow(self, model, res_id, pid, token, **kwargs):
+    def mail_action_unfollow(self, model=None, res_id=None, pid=None, token=None, **kwargs):
+        if not (model or res_id or pid or token):
+            return request.not_found()
         comparison, record, __ = MailController._check_token_and_record_or_redirect(model, int(res_id), token)
         if not comparison or not record:
             raise AccessError(_('Non existing record or wrong token.'))

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -50,5 +50,5 @@ class MailController(mail.MailController):
 
     # Add website=True to support the portal layout
     @http.route('/mail/unfollow', type='http', website=True)
-    def mail_action_unfollow(self, model, res_id, pid, token, **kwargs):
+    def mail_action_unfollow(self, model=None, res_id=None, pid=None, token=None, **kwargs):
         return super().mail_action_unfollow(model, res_id, pid, token, **kwargs)


### PR DESCRIPTION
**Issue:**
Currently, a `typeError` occurs when clicking the `Unfollow` link in an email footer.

**Steps to Produce:**
- Create a meeting and add attendees (e.g., Marc Demo for demo data) using a calendar.
- Navigate to `Settings > Technical > Email > Emails`.
- Open the invitation email and click `Unfollow`
- Trackback occurs.

**Error Log:**
TypeError:MailController.mail_action_unfollow() missing 4 required positional
          arguments: `'model', 'res_id', 'pid', and 'token'`

**Root Cause:**
The /mail/unfollow route is being triggered without `'model', 'res_id', 'pid', and 'token'` parameters at [1], causing an error.
[1]- https://github.com/odoo/odoo/blob/f3d000be70b1eb7b32ce6552900ecf126e1b116c/addons/portal/controllers/mail.py#L53

**Fix:**
This commit ensure that user will be redirected to a `Not Found` page, preventing an error.

sentry - 4952598215

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
