### PR TITLE
[FIX] base: prevent translation error when importing CSV files

### DIFF
--- a/odoo/addons/base/i18n/ro.po
+++ b/odoo/addons/base/i18n/ro.po
@@ -21874,7 +21874,7 @@ msgstr "Nu s-a găsit nici o înregistrare care să se potrivească cu %(field_t
 #. odoo-python
 #: code:addons/base/models/ir_fields.py:0
 msgid "No matching record found for %(field_type)s '%(value)s' in field '%%(field)s' and the following error was encountered when we attempted to create one: %(error_message)s"
-msgstr "Nu s-a găsit nicio înregistrare de potrivire pentru %(field_type)s '%(value)s' în câmpul '%%' (câmp) și a apărut următoarea eroare când am încercat să creăm una: %(error_message)s"
+msgstr "Nu s-a găsit nicio înregistrare de potrivire pentru %(field_type)s '%(value)s' în câmpul '%%(field)s' și a apărut următoarea eroare când am încercat să creăm una: %(error_message)s"
 
 #. module: base
 #: model_terms:ir.actions.act_window,help:base.open_module_tree


### PR DESCRIPTION
When importing a CSV referencing a related record, an error occurs if the system attempts to create a missing record, and the exception message is incorrectly translated.

**Steps to reproduce:**
- Install the `l10n_ro` module.
- Switch the user's language to **Romania**.
- Import [this](https://drive.google.com/file/d/1D5OZGeCICaySijNVxhSeopru--1iwU96/view?usp=sharing) CSV file into the Journal model (`account.journal`).
- Click `Test` button, select `"Creează valori noi"` for `Default Account`, and click again.
- Observe the error.

**Error:**
`ValueError: unsupported format character ''' (0x27) at index 74`

The Romanian translation contains an incorrect use of `'%%' (câmp)` leads to formatting issues - [1]; 
the correct placeholder `'%%(field)s'` should be used to match the original message format.

This commit corrects the Romanian translation to properly format the field name.

[1] - https://github.com/odoo/odoo/blob/4bdbe64928259ddffc93f9c0e60113fc1673e203/odoo/addons/base/i18n/ro.po#L21877

Sentry - 6494943085