### PR TITLE
[FIX] l10n_us: Fix duplicate labels shown on res.partner.bank form

### DIFF
--- a/addons/l10n_us/views/res_partner_bank_views.xml
+++ b/addons/l10n_us/views/res_partner_bank_views.xml
@@ -6,11 +6,10 @@
         <field name="inherit_id" ref="base.view_partner_bank_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='clearing_number']" position="attributes">
-                <attribute name="nolabel">1</attribute>
+                <attribute name="invisible" add="show_aba_routing" separator=" or "/>
             </xpath>
-            <field name="clearing_number" position="before">
-                <label for="clearing_number" invisible="show_aba_routing"/>
-                <label for="clearing_number" string="ABA/Routing" invisible="not show_aba_routing"/>
+            <field name="clearing_number" position="after">
+                <field name="clearing_number" string="ABA/Routing" invisible="not show_aba_routing"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
When having multiple localizations having different names for the clearing number field, label duplicates on the form view.

task-4630586

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
