### PR TITLE
[FIX] hr_recruitment_skills: pass `stage_id` correctly

### DIFF
--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -119,7 +119,7 @@ class HrApplicant(models.Model):
         self.with_context(just_moved=True).write(
             {
                 "job_id": self.env["hr.job"].browse(self.env.context.get("active_id")).id,
-                "stage_id": self.env.ref("hr_recruitment.stage_job0"),
+                "stage_id": self.env.ref("hr_recruitment.stage_job0").id,
             }
         )
         action = self.env["ir.actions.actions"]._for_xml_id("hr_recruitment.action_hr_job_applications")


### PR DESCRIPTION
Steps to reproduce:
1. Add a job position and configure it to require a skill
2. Add an application with the same skill
3. Go to the applications by the jobs and search for matching applicants
4. Select the applicant and click on "Move to this Job Position"

Traceback:
```
psycopg2.ProgrammingError: can't adapt type 'hr.recruitment.stage'
```

The issue happens because in `action_add_to_job`, `stage_id` is passed as the object itself, and not the id.

opw-4626114



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
