### PR TITLE
[FIX] website_sale: prevent throwing exception when _verify_updated_quantity fail

### DIFF
--- a/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
+++ b/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
@@ -25,7 +25,7 @@ export class CartNotification extends Component {
                 },
             },
         },
-        currency_id: Number,
+        currency_id: {type: Number, optional: true},
         className: String,
         close: Function,
         refresh: Function,


### PR DESCRIPTION
Steps to reproduce:

- Force _verify_updated_quantity returns warning
- Add product to cart
- exception shown

Explanation:

- When _verify_updated_quantity returns warning, it will use WarningNotification in CartNotification only. However CartNotification required currency_id for AddToCartNotification, therefore exception throw.