### PR TITLE
[FIX] l10n_it_stock_ddt: compute price for product with packaging

### DIFF
--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -128,7 +128,7 @@
                                     </td>
                                     <td>
                                         <t t-if="move.sale_line_id">
-                                            <t t-set="lst_price" t-value="move.sale_line_id.price_reduce_taxinc * move.quantity"/>
+                                            <t t-set="lst_price" t-value="move.sale_line_id.price_reduce_taxinc * move.product_id.uom_id._compute_quantity(move.quantity, move.sale_line_id.product_uom_id)"/>
                                         </t>
                                         <t t-else="">
                                             <t t-set="lst_price" t-value="move.product_id.lst_price * move.product_uom._compute_quantity(move.quantity, move.product_id.uom_id)"/>


### PR DESCRIPTION
### Steps to reproduce:

- Install  l10n_it_stock_ddt and enable product packaging.
- Create a storable product with a sale price of 1 and that can be packed by pack of 6.
- Create and confirm an SO for 1 pack of 6.
- Validate the delivery for 6 units.
- Print the DO.
#### > The price correspond to the price of 6 pack of 6.

### Cause of the issue:

The `packaging` and product `uom` have been merged in 18.1. As such, the quantity used in the report template needs to be recomputed based on the uom conversion:
https://github.com/odoo/odoo/blob/195e3fb3fbba355e40f55f4ef88ea9ae52545908/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml#L130-L131

opw-4683247
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
