### PR TITLE
[IMP] purchase_stock: fix vendor vs supplier redundancy in Replenishment

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -123,8 +123,8 @@ class Orderpoint(models.Model):
 
     show_supplier = fields.Boolean('Show supplier column', compute='_compute_show_suppplier')
     supplier_id = fields.Many2one(
-        'product.supplierinfo', string='Supplier', check_company=True,
-        domain="['|', ('product_id', '=', product_id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product_tmpl_id)]")
+        'product.supplierinfo', string='Vendor Pricelist', check_company=True,
+        domain="['|', ('product_id', '=', product_id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product_tmpl_id)]", _description_groupable=lambda _: False)
     vendor_id = fields.Many2one(related='supplier_id.partner_id', string="Vendor", store=True)
     purchase_visibility_days = fields.Float(default=0.0, help="Visibility Days applied on the purchase routes.")
     product_supplier_id = fields.Many2one('res.partner', compute='_compute_product_supplier_id', store=True, string='Product Supplier')


### PR DESCRIPTION
Task: 4642595

Description of the issue/feature this PR addresses:

Custom filters in Replenishment display "Vendor" and "Supplier" fields
separately. In some contexts, both of these words mean the same thing,
which might be confusing for the users. Because of that, the "Supplier"
field is being renamed to "Vendor Pricelist".

Moreover, at the moment grouping by "Vendor" and "Vendor Pricelist" has
the same effect. For that reason, "Vendor Pricelist" is being removed
from "Add Custom Group" dropdown.

Current behavior before PR:

Desired behavior after PR is merged:

![vendor_supplier_custom_filter](https://github.com/user-attachments/assets/98cccdbe-5e35-485e-a31c-32dfd0bdb44a)
![vendor_supplier_custom_group](https://github.com/user-attachments/assets/4425a823-1a6c-4f7f-9dd1-07c26fb07fe3)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
