### PR TITLE
[FIX] account_edi_ubl_cii: embed factur-x in custom PDF report

### DIFF
--- a/addons/account_edi_ubl_cii/models/ir_actions_report.py
+++ b/addons/account_edi_ubl_cii/models/ir_actions_report.py
@@ -18,8 +18,12 @@ class IrActionsReport(models.Model):
             collected_streams
             and res_ids
             and len(res_ids) == 1
-            and (self._is_invoice_report(report_ref) or self._get_report(report_ref).report_name in custom_templates)
-            and not self.env.context.get('from_account_move_send')  # only triggered from the 'print' action report
+            and (
+                # only triggered from the "Print" action for default template
+                self._is_invoice_report(report_ref) and not self.env.context.get('from_account_move_send')
+                # triggered from "Print" and "Send & Print" actions for custom templates
+                or self._get_report(report_ref).report_name in custom_templates
+            )
         ):
             # Generate and embed Factur-X
             invoice = self.env['account.move'].browse(res_ids)


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and Studio

- Go to "Accounting / Customers / Invoices"
- Enable Studio and go to "Reports" tab
- Duplicate "Invoices without Payment" report
- Note the id of this custom report (e.g. account.report_invoice_copy_1)

- Go to "Settings / Technical / Email / Email Templates"
- Open "Invoice: Sending"
- In "Settings" tab, set the custom report as dynamic report

- Go to "Settings / Technical / Parameters / System Parameters"
- Add a new parameter:
  * Key: account.custom_templates_facturx_list
  * Value: [id of the custom report] (e.g. account.report_invoice_copy_1)

- Create an invoice
- Confirm the invoice
- Send the the invoice via "Send & Print" button
- Check the attached PDF

**Issue:**
2 PDF are sent: the default invoice report and the custom one as configured on the email template.
The default one has the factur-x version embedded in it, but not the custom one.

**Cause:**
The hook that embed factur-x into the PDF is called after the creation of the default PDF report.
The custom reports (i.e. the dynamic ones) are created afterwards.
However, the code that should trigger the hook for these ones is only doing it when coming from "Print" action and not from "Send & Print" action.

**Solution:**
Also trigger the hook to embed factur-x in custom report when using "Send & Print" action.

opw-4645564



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
