### PR TITLE
[FIX] pos_loyalty: failing test due to missing product template

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -100,6 +100,7 @@ patch(PosStore.prototype, {
                         ) {
                             this.addLineToCurrentOrder({
                                 product_id: reward.reward_product_id,
+                                product_tmpl_id: reward.reward_product_id.product_tmpl_id,
                                 qty: reward.reward_product_qty || 1,
                             });
                         }


### PR DESCRIPTION
Currently the following tests
- test_loyalty_free_product_rewards
- test_loyalty_free_product_rewards_2

may fail with the error

```
TypeError: Cannot read properties of undefined (reading 'sale_line_warn')
    at Proxy.addLineToCurrentOrder (http://127.0.0.1:8959/web/assets/eb52e48/point_of_sale.assets_prod.min.js:17244:235)
    at Proxy.addLineToCurrentOrder (http://127.0.0.1:8959/web/assets/eb52e48/point_of_sale.assets_prod.min.js:17415:14)
    at http://127.0.0.1:8959/web/assets/eb52e48/point_of_sale.assets_prod.min.js:16996:532
```

This occurs because, since 5620a16d55091b0ed74feee694a02252e3d13c17, when adding a line to current order we should specify the product template id