### PR TITLE
[IMP] account: display partners no valid sdd mandate

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -892,6 +892,15 @@ class ResPartner(models.Model):
         """
         return []
 
+    def action_open_business_doc(self):
+        """
+        This method is called by the <x2many_buttons> widget. It's used when the user clicks on a link that redirects
+        to a partner.
+        :return: ir.actions.act_window for the concerned partner
+        """
+        self.ensure_one()
+        return self._get_records_action()
+
     # -------------------------------------------------------------------------
     # EDI
     # -------------------------------------------------------------------------


### PR DESCRIPTION
When users try to register one or multiple payments with 'SEPA Direct Debit' method, and one or more partners don't have a valid SEPA mandate, a banner alerts the user and mention the names of the concerned partners. This makes it easier for the user because he directly sees the partners for which he has to set a SEPA mandate.

task-4575537
runbot : https://runbot.odoo.com/runbot/bundle/18-0-sepa-missing-links-roto-353391