### PR TITLE
[FIX] l10n_cl: standardise invoice total table styles

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -261,7 +261,8 @@
             <tr class="o_total">
                 <td><strong>Total</strong></td>
                 <td class="text-end">
-                    <span t-out="subtotal_amounts['total_amount']" t-options="{'widget': 'monetary', 'display_currency': subtotal_amounts['main_currency']}"/>
+                    <span t-if="0" t-out="subtotal_amounts['total_amount']" t-options="{'widget': 'monetary', 'display_currency': subtotal_amounts['main_currency']}"/>
+                    <strong t-out="subtotal_amounts['total_amount']" t-options="{'widget': 'monetary', 'display_currency': subtotal_amounts['main_currency']}"/>
                 </td>
             </tr>
         </tr>


### PR DESCRIPTION
## Version:
18.0+

## Issue:
PDF invoices in boxed document layout always display a black font for total amount value only for Chile. This black font is not easily readable for most background colors (incl. standard background).

## Steps to reproduce:
- Navigate to the Settings app:
    - Under the `Companies` section, configure the document layout: - Ensure the `Boxed` layout is selected;
- Navigate to the Invoicing app:
    - Open any invoice record from `Customers / Invoices`;
    - Via the `Actions` gear button, print the `PDF without Payment`.

## Cause:
Template inconsistency compared to standard report template: https://github.com/odoo/odoo/blob/3ebd200a76d490ed97bc164e80ed2837fb2f650f/addons/account/views/report_invoice.xml#L443-L450.

opw-4698105

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
