### PR TITLE
[FIX] website_event_exhibitor: remove deleted chat_room_id

### DIFF
--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -132,9 +132,6 @@ class ExhibitorController(WebsiteEventController):
             raise Forbidden()
         sponsor = sponsor.sudo()
 
-        if 'widescreen' not in options and sponsor.chat_room_id and sponsor.is_in_opening_hours:
-            options['widescreen'] = True
-
         return request.render(
             "website_event_exhibitor.event_exhibitor_main",
             self._event_exhibitor_get_values(event, sponsor, **options)


### PR DESCRIPTION
How to reproduce:
-  Create a sponsor
-  Select the sponsor type 'Exhibitor' or 'Online Exhibitor'
-  Click on 'Go to website' stat button.

Technical:
We have removed jitsi related modules (https://github.com/odoo/odoo/pull/198587), but `chat_room_id` was left behind in exhibitor's controller thus resulting in the Traceback.

After this commit:
There will be no traceback, and user can see the website page.

Task-4689434
