### PR TITLE
[FIX] sale_stock: add dependencies in forecast widget

### DIFF
--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -92,6 +92,7 @@ export const qtyAtDateWidget = {
         { name: 'free_qty_today', type: 'float'},
         { name: 'forecast_expected_date', type: 'datetime'},
         { name: 'is_mto', type: 'boolean'},
+        { name: 'move_ids', type: 'one2many'},
         { name: 'qty_available_today', type: 'float'},
         { name: 'qty_to_deliver', type: 'float'},
         { name: 'scheduled_date', type: 'datetime'},


### PR DESCRIPTION
Steps to reproduce:
- Create a sale order
- Add a line using a storable product
- Click on the forecast icon then 'View Forecast'

Issue:
A traceback occurs

Previous commit [1] didn't transfer all dependencies of the widget into the `fieldDependencies`. In the process, `move_ids` was forgotten, thus making the opening of the forecast impossible.

[1] 6e69b1d

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
