### PR TITLE
[FIX] l10n_in: update `l10n_in_code` in UOM

### DIFF
--- a/addons/l10n_in/data/uom_data.xml
+++ b/addons/l10n_in/data/uom_data.xml
@@ -28,7 +28,7 @@
         <field name="l10n_in_code">MTR-METERS</field>
     </record>
     <record id="uom.product_uom_millimeter" model="uom.uom">
-        <field name="l10n_in_code">MLT-MILILITRE</field>
+        <field name="l10n_in_code">OTH-OTHERS</field>
     </record>
     <record id="uom.product_uom_km" model="uom.uom">
         <field name="l10n_in_code">KME-KILOMETRE</field>
@@ -64,7 +64,7 @@
         <field name="l10n_in_code">OTH-OTHERS</field>
     </record>
     <record id="uom.uom_square_foot" model="uom.uom">
-        <field name="l10n_in_code">OTH-OTHERS</field>
+        <field name="l10n_in_code">SQF-SQUARE FEET</field>
     </record>
     <record id="uom.product_uom_floz" model="uom.uom">
         <field name="l10n_in_code">OTH-OTHERS</field>


### PR DESCRIPTION
Purpose
=======
The Indian government updated its UOM code
https://einvoice1.gst.gov.in/Others/MasterCodes (select UQC Codes)

So In this commit, I have updated `l10n_in_code` in UOM  Mili Meter and Square Foot.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
