### PR TITLE
[FIX] core: fix force upgrade script

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -392,7 +392,7 @@ def load_modules(
         if not graph:
             _logger.critical('module base cannot be loaded! (hint: verify addons-path)')
             raise ImportError('Module `base` cannot be loaded! (hint: verify addons-path)')
-        if update_module and tools.config['update']:
+        if update_module and upgrade_modules:
             for pyfile in tools.config['pre_upgrade_scripts']:
                 odoo.modules.migration.exec_script(cr, graph['base'].installed_version, pyfile, 'base', 'pre')
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/189000, the `config['update']` becomes static. Using `upgrade_modules` instead `config['update']` in case the registry is loaded multiple times.

Details https://github.com/odoo/odoo/pull/202014/files#r1999022512

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
