### PR TITLE
[FIX] stock: delete the warning when snooze superuser-created orderpoint

### DIFF
--- a/addons/stock/wizard/stock_orderpoint_snooze.py
+++ b/addons/stock/wizard/stock_orderpoint_snooze.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.tools.date_utils import add
 
 
@@ -32,15 +32,3 @@ class StockOrderpointSnooze(models.TransientModel):
         self.orderpoint_ids.write({
             'snoozed_until': self.snoozed_until
         })
-        if self.orderpoint_ids.create_uid._is_superuser():
-            return {
-                'type': 'ir.actions.client',
-                'tag': 'display_notification',
-                'params': {
-                    'type': 'warning',
-                    'sticky': False,
-                    'message': _("This order point has been created automatically.\n"
-                                "snoozing it will not affect future ones created for the same product."),
-                    'next': {'type': 'ir.actions.act_window_close'},
-                }
-            }


### PR DESCRIPTION
Thanks to this fix:
https://github.com/odoo/odoo/commit/8ad00b8ee6340dba1e027bb27a8f05489b4253a9

we can revert this one:
https://github.com/odoo/odoo/pull/200777/commits/237feaee5fcf1e166bf39e78e8839b191f92c306

The pot file already deleted:
https://github.com/odoo/odoo/commit/0361582de7c28bb4847a9c4dbaa712b67f4ca577#diff-4424c1629e21b466bb7af6ab0cb3a674d1bf3e75d93e7e76cf77870dc5bcc853R8693-L9114

opw-4628611
