### PR TITLE
[FIX] point_of_sale: allow importing orders from debug window

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -898,6 +898,9 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                 }
                 return result;
             },
+            getNewId() {
+                return uuid(model);
+            },
             // aliases
             getAllBy() {
                 return this.readAllBy(...arguments);

--- a/addons/point_of_sale/static/src/app/utils/debug/debug_widget.js
+++ b/addons/point_of_sale/static/src/app/utils/debug/debug_widget.js
@@ -144,6 +144,8 @@ export class DebugWidget extends Component {
             );
 
             for (const order of jsonData) {
+                const orderId = this.pos.models["pos.order"].getNewId();
+                order.id = orderId;
                 for (const rel of manyRel) {
                     const model = this.pos.models[rel.relation];
 
@@ -164,6 +166,11 @@ export class DebugWidget extends Component {
                         data[rel.relation] = [];
                     }
 
+                    for (const record of records) {
+                        record.id = this.pos.models[rel.relation].getNewId();
+                        record[rel.inverse_name] = orderId;
+                    }
+
                     data[rel.relation].push(...records);
                 }
 
@@ -171,7 +178,8 @@ export class DebugWidget extends Component {
             }
 
             const missing = await this.pos.data.missingRecursive(data);
-            this.pos.data.models.loadData(this.models, missing, [], true);
+            const records = this.pos.data.models.loadData(this.pos.models, missing, [], true);
+            this.pos.addPendingOrder(records["pos.order"].map((order) => order.id));
             this.notification.add(_t("%s orders imported", data["pos.order"].length));
         }
     }


### PR DESCRIPTION
Before this commit, it was possible to export paid orders from the debug window, but importing them was not possible. This commit allows importing orders, making the export/import flow complete and usable for debugging or data transfer purposes.

opw-4688082

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
