### PR TITLE
[FIX] html_editor: enable AI/Translation button on valid selection

### DIFF
--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
@@ -70,9 +70,9 @@ export class ChatGPTPlugin extends Plugin {
 
     isNotReplaceableByAI(selection = this.dependencies.selection.getEditableSelection()) {
         const isEmpty = !selection.textContent().replace(/\s+/g, "");
-        const cannotReplace = [...selection.commonAncestorContainer.childNodes].find(
-            (el) => this.dependencies.split.isUnsplittable(el) || !isContentEditable(el)
-        );
+        const cannotReplace = this.dependencies.selection
+            .getTraversedNodes()
+            .find((el) => this.dependencies.split.isUnsplittable(el) || !isContentEditable(el));
         return cannotReplace || isEmpty;
     }
 

--- a/addons/html_editor/static/tests/chatgpt.test.js
+++ b/addons/html_editor/static/tests/chatgpt.test.js
@@ -138,6 +138,16 @@ test("Translate/ChatGPT should be disabled if selection spans across non editabl
     await animationFrame();
     await tick();
     expect(".o-we-toolbar [name='translate']").toHaveAttribute("disabled");
+
+    setContent(el, '<div>a[b</div><div>c]d</div><div class="oe_unbreakable">e</div>');
+    await animationFrame();
+    await tick();
+    expect(".o-we-toolbar [name='translate']").not.toHaveAttribute("disabled");
+
+    setContent(el, '<div>a[b</div><div>cd</div><div class="oe_unbreakable">e]</div>');
+    await animationFrame();
+    await tick();
+    expect(".o-we-toolbar [name='translate']").toHaveAttribute("disabled");
 });
 
 test("ChatGPT alternatives dialog generates alternatives for each button", async () => {


### PR DESCRIPTION
**Problem**:
If the selection does not include unsplittable nodes but the `commonAncestorContainer` contains one, the AI/Translation button will be disabled.

**Solution**:
Instead of relying on `commonAncestorContainer`, check only the traversed nodes to determine if the selection is valid.

**Steps to reproduce**:
1. Open Full Composer with a signature.
2. Add text.
3. Select only the text you added.
   - **Issue**: The AI/Translation button is disabled.

**opw-4649819**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
