### PR TITLE
[IMP] l10n_es: a better calculation for determining if an invoice is …

### DIFF
--- a/addons/l10n_es/models/account_move.py
+++ b/addons/l10n_es/models/account_move.py
@@ -8,11 +8,16 @@ class AccountMove(models.Model):
     l10n_es_is_simplified = fields.Boolean("Is Simplified",
                                            compute="_compute_l10n_es_is_simplified", readonly=False, store=True)
 
-    @api.depends('partner_id')
+    @api.depends('partner_id', 'amount_total_signed')
     def _compute_l10n_es_is_simplified(self):
         simplified_partner = self.env.ref('l10n_es.partner_simplified', raise_if_not_found=False)
         for move in self:
-            move.l10n_es_is_simplified = (
-                (not move.partner_id and move.move_type in ('in_receipt', 'out_receipt')) or
-                (simplified_partner and move.partner_id == simplified_partner)
+            move.l10n_es_is_simplified = (move.country_code == 'ES') and (
+                (not move.partner_id and move.move_type in ('in_receipt', 'out_receipt'))
+                or (simplified_partner and move.partner_id == simplified_partner)
+                or (move.move_type in ('out_invoice', 'out_refund')
+                    and not move.commercial_partner_id.vat
+                    and move.currency_id.compare_amounts(abs(move.amount_total_signed), 400) <= 0  # standard simplified invoice limit
+                    and move.commercial_partner_id.country_id in self.env.ref('base.europe').country_ids
+                )
             )


### PR DESCRIPTION
…simplfied

When the partner has no VAT and it is within Europe and it is below the simplified invoice limit, we could indicate the invoice as simplified by default.

If it is wrong, the user can still change it.

opw-4633564

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
