### PR TITLE
[FIX] project: fix project_test_tour in runbot

### DIFF
--- a/addons/project/static/tests/tours/project_tour.js
+++ b/addons/project/static/tests/tours/project_tour.js
@@ -99,7 +99,12 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_create_input input",
         content: 'Give the sub-task a name',
         run: "edit newer subtask && click .o_kanban_renderer",
-    }, {
+    },
+    {
+        content: "Wait for the new record to be created",
+        trigger: ".o_kanban_record .o_widget_subtask_kanban_list a:contains(newer subtask)",
+    },
+    {
         trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_list_row:first-child .o_field_project_task_state_selection button",
         content: 'Change the subtask state',
         run: "click",


### PR DESCRIPTION
The tour only fails in saas-17.4 due to the tour not waiting for new record to be created, thus when record is refreshed next step is broken making the tour fail. This is already fixed in 18.0+ in PR https://github.com/odoo/odoo/pull/185691.