### PR TITLE
[IMP] website: prevent indexing of pagination URLs

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -141,8 +141,12 @@
         <meta name="generator" content="Odoo"/>
         <t t-set="website_meta" t-value="seo_object and seo_object.get_website_meta() or {}"/>
         <meta name="default_title" t-att-content="default_title" groups="website.group_website_designer"/>
-        <meta t-if="(main_object and 'website_indexed' in main_object
-        and not main_object.website_indexed) or (website.domain and not website._is_indexable_url(request.httprequest.url_root))" name="robots" content="noindex"/>
+        <t t-set="no_index" t-value="
+            (main_object and 'website_indexed' in main_object and not main_object.website_indexed)
+            or (website.domain and not website._is_indexable_url(request.httprequest.url_root))
+            or (pager and isinstance(pager, dict) and pager.get('page', {}).get('num', 1) != 1)
+        "/>
+        <meta t-if="no_index" name="robots" content="noindex"/>
         <t t-set="seo_object" t-value="seo_object or main_object"/>
         <t t-set="meta_description" t-value="seo_object and 'website_meta_description' in seo_object
             and seo_object.website_meta_description or website_meta_description or website_meta.get('meta_description', '')"/>


### PR DESCRIPTION
This commit ensures that paginated URLs following the pattern /page/x
(e.g., /blog/page/2) are not indexed by search engines. Since these
pages do not represent unique content and should not compete with their
canonical counterparts, preventing their indexing helps maintain better
SEO by avoiding duplicate content issues and preserving the ranking of
primary pages.

task-4563867
