### PR TITLE
[FIX] base: prevent translation error

### DIFF
--- a/odoo/addons/base/i18n/he.po
+++ b/odoo/addons/base/i18n/he.po
@@ -30566,7 +30566,7 @@ msgstr "ערך"
 #. odoo-python
 #: code:addons/base/models/ir_fields.py:0
 msgid "Value '%s' not found in selection field '%%(field)s'"
-msgstr "ערך '%s' לא נמצא בשדה הבחירה '%%'שדה(ות)"
+msgstr "ערך '%s' לא נמצא בשדה הבחירה '%%(field)s'"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_property__value_binary


### PR DESCRIPTION
https://github.com/odoo/odoo/blob/f85e30901a61a6f0b040fe939e7c23bc0503affd/odoo/addons/base/i18n/he.po#L30569

Here, ``'%%(field)s'`` is translated as ``'%%'שדה(ות)`` in Hebrew language.
So, It will lead to the below Traceback.

Error:
``ValueError: unsupported format character ''' (0x27) at index 44``

for solution:
reference from 18.0:
https://github.com/odoo/odoo/blob/0d0c1bc7c075f49a461c66a433e20b431276ff12/odoo/addons/base/i18n/he.po#L38094-L38098

sentry-6500162171

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
