### PR TITLE
[FIX] payment_paypal: only add email if it exists

### DIFF
--- a/addons/payment_paypal/models/payment_transaction.py
+++ b/addons/payment_paypal/models/payment_transaction.py
@@ -98,8 +98,13 @@ class PaymentTransaction(models.Model):
                 },
             },
         }
+        # PayPal does not accept None set to fields and to avoid users getting errors when email
+        # is not set on company we will add it conditionally since its not a required field.
         if self.partner_email:
             payload['payment_source']['paypal']['email_address'] = self.partner_email
+
+        if company_email := self.provider_id.company_id.email:
+            payload['purchase_units'][0]['payee']['display_data']['business_email'] = company_email
 
         return payload
 


### PR DESCRIPTION
Since paypal does not allow empty fields to be sent, its better to add email only if it exists.

Some customers find it confusing that paypal integration fails without proper feedback that the issue comes from the empty email in their company form.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
