### PR TITLE
[FIX] account: fixed fields in tax_report read_group

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -164,9 +164,9 @@ class AccountInvoiceReport(models.Model):
             for data in res:
                 data['price_average'] = data['price_subtotal'] / data['quantity'] if data['quantity'] else 0
 
-                if 'quantity' not in fields:
+                if 'quantity:sum' not in fields:
                     del data['quantity']
-                if 'price_subtotal' not in fields:
+                if 'price_subtotal:sum' not in fields:
                     del data['price_subtotal']
 
         return res

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -196,7 +196,7 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
 
         report = self.env['account.invoice.report'].read_group(
             [('product_id', '=', product.id)],
-            ['price_subtotal', 'quantity', 'price_average:avg'],
+            ['price_subtotal:sum', 'quantity:sum', 'price_average:avg'],
             [],
         )
         self.assertEqual(report[0]['quantity'], 35)
@@ -210,3 +210,15 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             [],
         )
         self.assertEqual(round(report[0]['price_average'], 2), 4.71)
+
+        def _apply_combination_on_report_pivot(combination):
+            report = self.env['account.invoice.report'].read_group(
+                [],
+                combination,
+                [],
+            )
+            for field in combination:
+                self.assertTrue(field.split(':')[0] in report[0])
+
+        _apply_combination_on_report_pivot(['price_average:avg', 'price_subtotal:sum'])
+        _apply_combination_on_report_pivot(['price_average:avg', 'quantity:sum'])


### PR DESCRIPTION
Steps to reproduce:
- Install accounting
- Go to Reporting, Invoice Analysis in pivot view
- Select Untaxed amount and Average price
- Or (Select Product Quantity and Average Price)

Issue:
If the `average_price` is selected, the `untaxed_amount` becomes empty and not read, and it is the same case for the `product_quantity`. In pivot view, the frontend sends the fields to the backend in this format field_name:agg https://github.com/odoo/odoo/blob/36e6d6ea6792d5e549a7794f111a65fc32decd1c/addons/web/static/src/views/pivot/pivot_model.js#L1142-L1143

In [d741788](https://github.com/odoo/odoo/commit/d7417883062e14c4a0a58978463f181b3811d19d), read_group is overridden to correctly handle the `average_price`, and uses both the `untaxed_amount` and the `product_quantity` to compute it. If the `untaxed_amount` and `product_quantity` weren’t in the original fields sent from the frontend by the user, they are removed from the result data. But the problem they are named incorrectly in the if conditions, and because of the format sent from the frontend, the if condition will always succeed (because the name in the fields array is not the same as the one checked in the if condition) leading to the removal of both `untaxed_amount` and `product_quantity` from the result whenever selecting the `average_price`.

opw-4644004

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
