### PR TITLE
[FIX] point_of_sale: display products in subcategories

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -345,8 +345,7 @@ export class ProductScreen extends Component {
         if (limit_categories && iface_available_categ_ids.length > 0) {
             const productIds = new Set([]);
             for (const categ of iface_available_categ_ids) {
-                const categoryProducts =
-                    this.pos.models["product.product"].getBy("pos_categ_ids", categ.id) || [];
+                const categoryProducts = this.getProductsByCategory(categ);
                 for (const p of categoryProducts) {
                     productIds.add(p.id);
                 }


### PR DESCRIPTION
Before this commit, when the "restricted categories" setting was enabled, products belonging to subcategories of the allowed categories were not shown on the POS screen when no category was selected.

opw-4700812

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
