### PR TITLE
[FIX] {sale_,}loyalty: ensure gift card email has a sender

### DIFF
--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -80,6 +80,12 @@ class LoyaltyCard(models.Model):
         self.ensure_one()
         return self.partner_id
 
+    def _get_mail_author(self):
+        self.ensure_one()
+        return (
+            self.env.user._is_internal() and self.env.user or self.company_id or self.env.company
+        ).partner_id
+
     def _get_signature(self):
         """To be overriden"""
         self.ensure_one()
@@ -130,7 +136,18 @@ class LoyaltyCard(models.Model):
             if not create_comm_per_program[coupon.program_id] or not coupon._get_mail_partner():
                 continue
             for comm in create_comm_per_program[coupon.program_id]:
-                comm.mail_template_id.send_mail(res_id=coupon.id, force_send=force_send, email_layout_xmlid='mail.mail_notification_light')
+                mail_template = comm.mail_template_id
+                email_values = {}
+                if not mail_template.email_from:
+                    # provide author_id & email_from values to ensure the email gets sent
+                    author = coupon._get_mail_author()
+                    email_values.update(author_id=author.id, email_from=author.email_formatted)
+                mail_template.send_mail(
+                    res_id=coupon.id,
+                    force_send=force_send,
+                    email_layout_xmlid='mail.mail_notification_light',
+                    email_values=email_values,
+                )
 
     def _send_points_reach_communication(self, points_changes):
         """

--- a/addons/sale_loyalty/models/loyalty_card.py
+++ b/addons/sale_loyalty/models/loyalty_card.py
@@ -19,6 +19,13 @@ class LoyaltyCard(models.Model):
     def _get_mail_partner(self):
         return super()._get_mail_partner() or self.order_id.partner_id
 
+    def _get_mail_author(self):
+        """Default author is the order's salesperson if set, otherwise the order's company."""
+        if not self.order_id:
+            return super()._get_mail_author()
+        self.ensure_one()
+        return (self.order_id.user_id or self.order_id.company_id).partner_id
+
     def _get_signature(self):
         return self.order_id.user_id.signature or super()._get_signature()
 

--- a/addons/sale_loyalty/tests/test_buy_gift_card.py
+++ b/addons/sale_loyalty/tests/test_buy_gift_card.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
+
 from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
 from odoo.tests.common import tagged
 
@@ -34,3 +36,44 @@ class TestBuyGiftCard(TestSaleCouponCommon):
         order.order_line[1].product_uom_qty = 1
         order._update_programs_and_rewards()
         self.assertEqual(len(order._get_reward_coupons()), 1)
+
+    def test_gift_card_email_sender(self):
+        """Ensure that sending gift card emails have a sender.
+        Either the order's salesman if available, otherwise the order's company.
+        """
+        mail_template = self.env['mail.template'].create({
+            'name': "Gift Card Mail",
+            'model_id': self.env.ref('loyalty.model_loyalty_card').id,
+            'auto_delete': False,
+        })
+        self.program_gift_card.communication_plan_ids = [Command.create({
+            'trigger': 'create',
+            'mail_template_id': mail_template.id,
+        })]
+        order = self.empty_order
+        salesman = order.user_id.partner_id.ensure_one()
+        salesman.email = "sales@company.co"
+        company = order.company_id.partner_id
+        company.email = "noreply@company.co"
+        order.write({
+            'order_line': [Command.create({'product_id': self.product_gift_card.id})],
+        })
+        order._update_programs_and_rewards()
+        order._auto_apply_rewards()
+
+        # Create an order without salesman to test company-based fallback
+        orders = order + order.copy({'user_id': None})
+
+        # Clear out the mailbox before sending mail
+        self.env['mail.mail'].search([]).sudo().unlink()
+
+        # Confirm order as Public User to trigger loyalty mail
+        public_user = self.env.ref('base.public_user')
+        orders.with_context({}).with_user(public_user).sudo().action_confirm()
+
+        mails = self.env['mail.mail'].search([])
+        self.assertEqual(len(mails), 2)
+        salesman_mail = mails.filtered(lambda m: m.author_id == salesman).ensure_one()
+        company_mail = mails.filtered(lambda m: m.author_id == company).ensure_one()
+        self.assertEqual(salesman_mail.email_from, salesman.email_formatted)
+        self.assertEqual(company_mail.email_from, company.email_formatted)


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Install `website_sale_loyalty` with default configuration;
2. add a payment provider;
3. as a public user, buy a gift card via eCommerce.

Issue
-----
No email is sent with the gift card's code to the provided email address.

Cause
-----
The email template doesn't have an `email_from` field added. Without this value, it falls back on the current user, but because we're Public User, this also doesn't have an `email` value.

Additionally, if the order gets confirmed as a portal user, the email will be sent from the client's email address.

Solution
--------
Add a `_get_mail_author` hook to `loyalty.card`, which can be used when an email template lacks an `email_from` value.

Mail author precedence for cards without an order:
- current internal user > card's company > current company

Mail author precedence for cards with an order:
- salesperson > order's company


opw-4687107