### PR TITLE
[IMP] web: Mouse cursor selects dropdown/autocomplete items only on mousemove

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -64,6 +64,7 @@ export class AutoComplete extends Component {
         this.nextOptionId = 0;
         this.sources = [];
         this.inEdition = false;
+        this.mouseSelectionActive = false;
 
         this.state = useState({
             navigationRev: 0,
@@ -100,6 +101,7 @@ export class AutoComplete extends Component {
 
         useExternalListener(window, "scroll", this.externalClose, true);
         useExternalListener(window, "pointerdown", this.externalClose, true);
+        useExternalListener(window, "mousemove", () => this.mouseSelectionActive = true, true);
 
         this.hotkey = useService("hotkey");
         this.hotkeysToRemove = [];
@@ -173,6 +175,7 @@ export class AutoComplete extends Component {
     close() {
         this.state.open = false;
         this.state.activeSourceOption = null;
+        this.mouseSelectionActive = false;
     }
 
     cancel() {
@@ -434,6 +437,10 @@ export class AutoComplete extends Component {
     }
 
     onOptionMouseEnter(indices) {
+        if (!this.mouseSelectionActive) {
+            return;
+        }
+
         const [sourceIndex, optionIndex] = indices;
         if (this.sources[sourceIndex].options[optionIndex]?.unselectable) {
             this.state.activeSourceOption = null;

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -25,14 +25,17 @@ class NavigationItem {
      */
     target = undefined;
 
-    constructor({ index, el, setActiveItem, options }) {
+    constructor({ index, el, navigator, options }) {
         this.index = index;
 
         /**@private */
         this._options = options;
 
-        /**@private*/
-        this._setActiveItem = setActiveItem;
+        /**
+         * @private
+         * @type {Navigator}
+        */
+        this._navigator = navigator;
 
         this.el = el;
         if (this._options.shouldFocusChildInput) {
@@ -43,15 +46,15 @@ class NavigationItem {
         }
 
         const onFocus = () => this.setActive(false);
-        const onMouseEnter = () => this._onMouseEnter();
+        const onMouseMove = () => this._onMouseMove();
 
         this.target.addEventListener("focus", onFocus);
-        this.target.addEventListener("mouseenter", onMouseEnter);
+        this.target.addEventListener("mousemove", onMouseMove);
 
         /**@private*/
         this._removeListeners = () => {
             this.target.removeEventListener("focus", onFocus);
-            this.target.removeEventListener("mouseenter", onMouseEnter);
+            this.target.removeEventListener("mousemove", onMouseMove);
         };
     }
 
@@ -62,7 +65,7 @@ class NavigationItem {
 
     setActive(focus = true) {
         scrollTo(this.target);
-        this._setActiveItem(this.index);
+        this._navigator._setActiveItem(this.index);
         this.target.classList.add(ACTIVE_ELEMENT_CLASS);
 
         if (focus && !this._options.virtualFocus) {
@@ -81,9 +84,11 @@ class NavigationItem {
     /**
      * @private
      */
-    _onMouseEnter() {
-        this.setActive(false);
-        this._options.onMouseEnter?.(this);
+    _onMouseMove() {
+        if (this._navigator.activeItem !== this) {
+            this.setActive(false);
+            this._options.onMouseEnter?.(this);
+        }
     }
 }
 
@@ -270,7 +275,7 @@ export class Navigator {
                 index: i,
                 el: elements[i],
                 options: this._options,
-                setActiveItem: (index) => this._setActiveItem(index),
+                navigator: this,
             });
 
             if (i >= this.items.length) {

--- a/addons/web/static/tests/core/autocomplete.test.js
+++ b/addons/web/static/tests/core/autocomplete.test.js
@@ -906,3 +906,48 @@ test("unselectable options are... not selectable", async () => {
     expect(`.o-autocomplete--input`).toBeFocused();
     expect.verifySteps(["selected: selectable"]);
 });
+
+test("items are selected only when the mouse moves, not just on enter", async () => {
+    class Parent extends Component {
+        static template = xml`
+            <AutoComplete value="''" sources="[source]" onSelect.bind="onSelect"/>
+        `;
+        static props = ["*"];
+        static components = { AutoComplete };
+        get source() {
+            return {
+                options: [
+                    { label: "one" },
+                    { label: "two" },
+                    { label: "three" },
+                ],
+            };
+        }
+        onSelect(option) {}
+    }
+
+    // In this test we use custom events to prevent unwanted mouseenter/mousemove events
+
+    await mountWithCleanup(Parent);
+    queryOne(`.o-autocomplete input`).focus();
+    queryOne(`.o-autocomplete input`).click();
+    await animationFrame();
+
+    expect(".o-autocomplete--dropdown-item:nth-child(1) .dropdown-item").toHaveClass("ui-state-active");
+
+    queryOne(".o-autocomplete--dropdown-item:nth-child(2)").dispatchEvent(new MouseEvent("mouseenter"));
+    await animationFrame();
+    // mouseenter should be ignored
+    expect(".o-autocomplete--dropdown-item:nth-child(2) .dropdown-item").not.toHaveClass("ui-state-active");
+
+    await press("arrowdown");
+    await animationFrame();
+    expect(".o-autocomplete--dropdown-item:nth-child(2) .dropdown-item").toHaveClass("ui-state-active");
+
+    queryOne(".o-autocomplete--dropdown-item:nth-child(3)").dispatchEvent(new MouseEvent("mousemove"));
+    queryOne(".o-autocomplete--dropdown-item:nth-child(3)").dispatchEvent(new MouseEvent("mouseenter"));
+    await animationFrame();
+    // mousemove should not be ignored
+    expect(".o-autocomplete--dropdown-item:nth-child(2) .dropdown-item").not.toHaveClass("ui-state-active");
+    expect(".o-autocomplete--dropdown-item:nth-child(3) .dropdown-item").toHaveClass("ui-state-active");
+});


### PR DESCRIPTION
The mouse cursor automaticaly selects dropdown and autocomplete items if the mouse is on top of the item when the menu opens, this is not expected.

After this commit, the mouse cursor only select items if it moves.

Task: 4687065

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
