### PR TITLE
[FIX] website_payment: prevent error when clicking on donate button

### DIFF
--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -35,6 +35,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
 
     @http.route('/donation/transaction/<minimum_amount>', type='json', auth='public', website=True, sitemap=False)
     def donation_transaction(self, amount, currency_id, partner_id, access_token, minimum_amount=0, **kwargs):
+        if not amount:
+            raise ValidationError(_('Please select or enter an amount'))
         if float(amount) < float(minimum_amount):
             raise ValidationError(_('Donation amount must be at least %.2f.', float(minimum_amount)))
         use_public_partner = request.env.user._is_public() or not partner_id

--- a/addons/website_payment/i18n/website_payment.pot
+++ b/addons/website_payment/i18n/website_payment.pot
@@ -405,6 +405,8 @@ msgstr ""
 
 #. module: website_payment
 #. odoo-javascript
+#. odoo-python
+#: code:addons/website_payment/controllers/portal.py:0
 #: code:addons/website_payment/static/src/snippets/s_donation/000.js:0
 #, python-format
 msgid "Please select or enter an amount"


### PR DESCRIPTION
When user clicks on the donate button without the amount,
A traceback will appear.

Steps to reproduce the error:
- Install ``website_payment`` and activate demo payment provider
- Go to Website > Drag and drop the donation button > Save
- Click on Donate Now > Click on custom amount box > Don't add any amount
- Click on Donate button

Traceback:
```
File "/home/odoo/src/odoo/addons/website_payment/controllers/portal.py", line 38, in donation_transaction
    if float(amount) < float(minimum_amount):
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

https://github.com/odoo/odoo/blob/f31a8d64d8447c516a2793705fb0b2d640289e85/addons/website_payment/controllers/portal.py#L38
Here, when user clicks on donate button without amount,
``amount`` will be None, so ``float(amount)`` will lead to the above Traceback.

sentry-6498712345

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
