### PR TITLE
[FIX] web_editor: fix background image handling in media manager

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -893,27 +893,29 @@ const Wysiwyg = Widget.extend({
                     // id parameters.
                     return;
                 }
+                let newAttachmentSrc = isBackground ? el.dataset.bgSrc : el.getAttribute('src');
+                const isImageAlreadySaved = !newAttachmentSrc || !newAttachmentSrc.startsWith("data:");
                 // Frequent media changes or page reloads may trigger a save request  
                 // without removing the `o_modified_image_to_save` class, causing a traceback  
                 // on the next save since the element loses its base64 `src`.  
                 // If the image isn't already saved, a new copy is created.
-                let newAttachmentSrc = el.getAttribute('src');
-                const isImageAlreadySaved = !newAttachmentSrc || !newAttachmentSrc.startsWith("data:");
-                if (!isImageAlreadySaved) {
-                    // Modifying an image always creates a copy of the original, even if
-                    // it was modified previously, as the other modified image may be used
-                    // elsewhere if the snippet was duplicated or was saved as a custom one.
-                    newAttachmentSrc = await this._rpc({
-                        route: `/web_editor/modify_image/${encodeURIComponent(el.dataset.originalId)}`,
-                        params: {
-                            res_model: resModel,
-                            res_id: parseInt(resId),
-                            data: (isBackground ? el.dataset.bgSrc : el.getAttribute('src')).split(',')[1],
-                            mimetype: (isBackground ? el.dataset.mimetype : el.getAttribute('src').split(":")[1].split(";")[0]),
-                            name: (el.dataset.fileName ? el.dataset.fileName : null),
-                        },
-                    });
+                if (isImageAlreadySaved) {
+                    el.classList.remove('o_modified_image_to_save');
+                    return;
                 }
+                // Modifying an image always creates a copy of the original, even if
+                // it was modified previously, as the other modified image may be used
+                // elsewhere if the snippet was duplicated or was saved as a custom one.
+                newAttachmentSrc = await this._rpc({
+                    route: `/web_editor/modify_image/${encodeURIComponent(el.dataset.originalId)}`,
+                    params: {
+                        res_model: resModel,
+                        res_id: parseInt(resId),
+                        data: (isBackground ? el.dataset.bgSrc : el.getAttribute('src')).split(',')[1],
+                        mimetype: (isBackground ? el.dataset.mimetype : el.getAttribute('src').split(":")[1].split(";")[0]),
+                        name: (el.dataset.fileName ? el.dataset.fileName : null),
+                    },
+                });
                 el.classList.remove('o_modified_image_to_save');
                 if (isBackground) {
                     const parts = weUtils.backgroundImageCssToParts($(el).css('background-image'));


### PR DESCRIPTION
**Problem**:
Commit [f523cb8](https://github.com/odoo/odoo/commit/f523cb85174687856d2c93fbc3c2f52a307f6761) did not properly handle background images, leading to issues when retrieving the correct attachment source.

**Solution**:
Use `el.dataset.bgSrc` to get the correct attachment source for background images.

**Steps to reproduce**:
1. Add a "Banner" block.
2. Update the image.
3. Save.
   - **Issue**: image lost.

**opw-4686236**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
