### PR TITLE
[FIX] hr_expense: Fix double button_box

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -171,8 +171,6 @@
                             invisible="not split_expense_origin_id"
                             string="Split"
                         />
-                    </div>
-                    <div class="oe_button_box" name="button_box">
                         <button name="action_open_account_move"
                             class="oe_stat_button"
                             icon="fa-bars"


### PR DESCRIPTION
This fixes a bug introduced by aac7a41
where the button_box element is declared twice and does not allow both buttons to be shown at the same time

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
