### PR TITLE
[FIX] account: fix statement line date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -799,7 +799,7 @@ class AccountMove(models.Model):
     @api.depends('invoice_date', 'company_id')
     def _compute_date(self):
         for move in self:
-            if not move.invoice_date:
+            if not move.invoice_date or not move.is_invoice():
                 if not move.date:
                     move.date = fields.Date.context_today(self)
                 continue

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -1450,3 +1450,13 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
         reversed_move = self.env['account.move'].browse(reversal['res_id'])
 
         self.assertEqual(reversed_move.partner_id, partner)
+
+    def test_bank_transaction_creation_with_default_journal_entry_date(self):
+        invoice_date_field = self.env['ir.model.fields'].search([('model', '=', 'account.move'), ('name', '=', 'invoice_date')], limit=1)
+        self.env['ir.default'].create({
+            'field_id': invoice_date_field.id,
+            'json_value': '"2023-10-16"',
+        })
+
+        transaction = self.create_bank_transaction(1, '2020-01-10', journal=self.bank_journal_1)
+        assert transaction.date == transaction.move_id.date == fields.Date.from_string('2020-01-10')


### PR DESCRIPTION
The date used in statement lines is invalid when lines
are created via bank synchronization, and the user has
configured a default date for the Invoice/Bill Date field.

Steps to reproduce:
- Set a default value for the Invoice/Bill Date field.
- Connect to Demo Bank and import the test statement line.
- Check the statement line date; it will use the default
  Invoice/Bill Date value instead of the correct one.

The issue comes from the fact that during the 
`st_line.move_id.write(to_write)`, the date field gets considered 'dirty'
by the ORM (unless it is explicitly set in the vals), and when the
`account.move.line` tries to set-up its date, which is related to the
move, the compute method for the date is triggered as the field was
flagged as dirty.

opw-4662209