### PR TITLE
[FIX] web: prevent kanban record dropdown menu overlap header while scrolling

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -238,7 +238,6 @@
 
         .o_dropdown_kanban {
             visibility: hidden;
-            z-index: 1;
 
             @include media-breakpoint-down(md) {
                 visibility: visible;


### PR DESCRIPTION
Before this commit:
When scrolling, the Kanban record drop-down menu overlap Kanban header.

After this commit:
The Kanban record drop-down menu should not overlap with the Kanban header while scrolling.

Task-4686607
