### PR TITLE
[FIX] hr_attendance, resource : Check leaves for flexible emp when detecting absence

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -364,8 +364,13 @@ class HrAttendance(models.Model):
                             work_duration += (local_check_out - local_check_in).total_seconds() / 3600.0
                         # In case of fully flexible employee, no overtime is computed
                         if not emp.is_fully_flexible:
-                            overtime_duration = work_duration - emp.resource_id.calendar_id.hours_per_day
-                            overtime_duration_real = overtime_duration
+                            # If the attendance is for absence but the employee is on a leave
+                            if float_is_zero(work_duration, 2) and not working_times:
+                                overtime_duration = work_duration
+                                overtime_duration_real = overtime_duration
+                            else:
+                                overtime_duration = work_duration - emp.resource_id.calendar_id.hours_per_day
+                                overtime_duration_real = overtime_duration
 
                     # The employee usually doesn't work on that day
                     elif not working_times[attendance_date]:

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -63,6 +63,10 @@ class TestHrAttendanceOvertime(TransactionCase):
             'tz': 'UTC',
             'resource_calendar_id': cls.calendar_flex_40h.id,
         })
+        cls.new_employee = cls.env['hr.employee'].create({
+            'name': 'Ninja',
+            'company_id': cls.company.id,
+        })
 
     def test_overtime_company_settings(self):
         self.company.write({
@@ -528,6 +532,14 @@ class TestHrAttendanceOvertime(TransactionCase):
             'check_out': datetime(2024, 2, 1, 17, 0)
         })
 
+        self.env['resource.calendar.leaves'].create({
+            'name': 'scheduled leave',
+            'date_from': datetime(2024, 1, 31, 00),
+            'date_to': datetime(2024, 1, 31, 23, 59),
+            'resource_id': self.flexible_employee.resource_id.id,
+            'time_type': 'leave',
+        })
+
         self.assertAlmostEqual(self.employee.total_overtime, 0, 2)
         self.assertAlmostEqual(self.other_employee.total_overtime, 0, 2)
         self.assertAlmostEqual(self.jpn_employee.total_overtime, 0, 2)
@@ -543,6 +555,9 @@ class TestHrAttendanceOvertime(TransactionCase):
 
         # Employee Checked in yesterday, no absence found
         self.assertAlmostEqual(self.employee.total_overtime, 0, 2)
+
+        # Employee on leave yesterday, no absence found
+        self.assertAlmostEqual(self.flexible_employee.total_overtime, 0, 2)
 
         # Other company with setting disabled
         self.assertAlmostEqual(self.europe_employee.total_overtime, 0, 2)

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -327,10 +327,6 @@ class ResourceCalendar(models.Model):
             tz: (start_dt.astimezone(tz), end_dt.astimezone(tz))
             for tz in resources_per_tz.keys()
         }
-        # Use the outer bounds from the requested timezones
-        for tz, bounds in bounds_per_tz.items():
-            start = min(start, bounds[0].replace(tzinfo=utc))
-            end = max(end, bounds[1].replace(tzinfo=utc))
         # Generate once with utc as timezone
         days = rrule(DAILY, start.date(), until=end.date(), byweekday=weekdays)
         ResourceCalendarAttendance = self.env['resource.calendar.attendance']
@@ -391,7 +387,7 @@ class ResourceCalendar(models.Model):
         """Hook method to handle flexible leave intervals. Can be overridden in other modules."""
         tz = dt0.tzinfo  # Get the timezone information from dt0
         dt0 = datetime.combine(dt0.date(), time.min).replace(tzinfo=tz)
-        dt1 = datetime.combine(dt1.date(), time.max).replace(tzinfo=tz)
+        dt1 = datetime.combine(dt1.date() + relativedelta(days=1), time.min).replace(tzinfo=tz)
         return dt0, dt1
 
     def _leave_intervals(self, start_dt, end_dt, resource=None, domain=None, tz=None):


### PR DESCRIPTION
### Steps to reproduce:
	- Enable Absence Management from general settings
	- Create a leave for the previous day for a flexible employee
	- Run the 'Detect Absences for employees' cron job
	- Navigate to the attendance gantt view
	- Notice a negative attendance created for the employee on the day of his leave

### Cause:
This is happening because when checking the expected attendances for a flexible employee there is a difference between the end of the attendance interval (e.g. 2025-04-03 00:00:00 UTC) and the of the leave interval (e.g. 2025-04-02 23:59:59.9999 Europe/Burssels). This difference considered to be an expected attendance. Also when checking the attendances to calculate working hours and overtime duration we take the attendance created to cover the absence into account and assume that it is working hours

https://github.com/odoo/odoo/blob/6beb3ea82d75513803ae78f5bc71024313938a97/addons/hr_attendance/models/hr_attendance.py#L357-L366

### Fix:
We are now setting the end datetime of the attendance interval to be the end of the day in the user's timezone not in UTC. Also set the end of the leave interval to be the minimum time of the next day instead of the max time in the same day of the leave. Also when calculating the overtime duration for flexible employee we check if it is a very small amount of time.

opw-4545023