### PR TITLE
[IMP] profiler: Commit the profile after a set entry count

### DIFF
--- a/addons/web/static/src/core/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/core/debug/profiling/profiling_item.xml
@@ -34,6 +34,10 @@
                                 <option value="1" t-att-selected="interval === '1'">1</option>
                             </select>
                         </div>
+                        <div class="input-group input-group-sm mt-2">
+                            <div class="input-group-text">Entry Count</div>
+                            <input type="number" class="form-control" t-on-click.stop.prevent="" t-on-change="(ev) => this.changeParam('entry_count_limit', ev)" t-att-value="profiling.state.params.entry_count_limit || '0'" placeholder="None"/>
+                        </div>
                         <span t-if="profiling.isCollectorEnabled('sql') || profiling.isCollectorEnabled('traces_async')" class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="(ev) => this.toggleParam('execution_context_qweb', ev)">
                             <input type="checkbox" class="form-check-input" id="profile_execution_context_qweb"
                                 t-att-checked="!!profiling.state.params.execution_context_qweb"/>

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -113,13 +113,20 @@ class Collector:
 
     def add(self, entry=None, frame=None):
         """ Add an entry (dict) to this collector. """
-        # todo add entry count limit
         self._entries.append({
             'stack': self._get_stack_trace(frame),
             'exec_context': getattr(self.profiler.init_thread, 'exec_context', ()),
             'start': real_time(),
             **(entry or {}),
         })
+
+    def progress(self, entry=None, frame=None):
+        """ Checks if the limits were met and add to the entries"""
+        if self.profiler.entry_count_limit \
+            and self.profiler.entry_count() >= self.profiler.entry_count_limit:
+            self.profiler.end()
+
+        self.add(entry=entry, frame=frame)
 
     def _get_stack_trace(self, frame=None):
         """ Return the stack trace to be included in a given entry. """
@@ -156,7 +163,7 @@ class SQLCollector(Collector):
         self.profiler.init_thread.query_hooks.remove(self.hook)
 
     def hook(self, cr, query, params, query_start, query_time):
-        self.add({
+        self.progress({
             'query': str(query),
             'full_query': str(cr._format(query, params)),
             'start': query_start,
@@ -192,7 +199,7 @@ class PeriodicCollector(Collector):
                 # is incorrectly attributed to the last frame.
                 self._entries[-1]['stack'].append(('profiling', 0, '⚠ Profiler freezed for %s s' % duration, ''))
                 self.last_frame = None  # skip duplicate detection for the next frame.
-            self.add()
+            self.progress()
             last_time = real_time()
             time.sleep(self.frame_interval)
 
@@ -206,14 +213,14 @@ class PeriodicCollector(Collector):
         init_thread = self.profiler.init_thread
         if not hasattr(init_thread, 'profile_hooks'):
             init_thread.profile_hooks = []
-        init_thread.profile_hooks.append(self.add)
+        init_thread.profile_hooks.append(self.progress)
 
         self.__thread.start()
 
     def stop(self):
         self.active = False
         self.__thread.join()
-        self.profiler.init_thread.profile_hooks.remove(self.add)
+        self.profiler.init_thread.profile_hooks.remove(self.progress)
 
     def add(self, entry=None, frame=None):
         """ Add an entry (dict) to this collector. """
@@ -249,7 +256,7 @@ class SyncCollector(Collector):
         if event == 'call' and _frame.f_back:
             # we need the parent frame to determine the line number of the call
             entry['parent_frame'] = _format_frame(_frame.f_back)
-        self.add(entry, frame=_frame)
+        self.progress(entry, frame=_frame)
         return self.hook
 
     def _get_stack_trace(self, frame=None):
@@ -530,6 +537,8 @@ class Profiler:
         self.filecache = {}
         self.params = params or {}  # custom parameters usable by collectors
         self.profile_id = None
+        self.entry_count_limit = int(self.params.get("entry_count_limit", 0))   # the limit could be set using a smarter way
+        self.done = False
 
         if db is ...:
             # determine database from current thread
@@ -584,6 +593,12 @@ class Profiler:
         return self
 
     def __exit__(self, *args):
+        self.end()
+
+    def end(self):
+        if self.done:
+            return
+        self.done = True
         try:
             for collector in self.collectors:
                 collector.stop()


### PR DESCRIPTION
This is used in the event a request is timing out or has an out of memory issue. This would cause the profile to be committed to the database before the request gets terminated.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
