### PR TITLE
[FIX] purchase: Prevent division by zero in average cost

### DIFF
--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -159,7 +159,7 @@ class PurchaseReport(models.Model):
         if aggregate_spec != 'price_average:avg':
             return super()._read_group_select(aggregate_spec, query)
         return SQL(
-            'SUM(%(f_price)s * %(f_qty)s) / SUM(%(f_qty)s)',
+            'SUM(%(f_price)s * %(f_qty)s) / NULLIF(SUM(%(f_qty)s), 0.0)',
             f_qty=self._field_to_sql(self._table, 'qty_ordered', query),
             f_price=self._field_to_sql(self._table, 'price_average', query),
         )


### PR DESCRIPTION
When a purchase order is created with a positive and negative quantity of the same product but different unit prices, the read_group runs into a division by zero error as the `SUM('purchase_report'.'qty_ordered')` is zero.

To prevent this exception, we NULL the denominator if it's 0.

**Example PO that would cause issues when adding "Average Cost" as a measure in the purchase report:**
![image](https://github.com/user-attachments/assets/12d9875c-3b51-4d87-b6ff-19a2752d36a0)

opw-4684787