### PR TITLE
[FIX] stock_account: allow delivery validation for lot valuated products

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -375,7 +375,7 @@ class StockMove(models.Model):
         stock_valuation_layers._validate_accounting_entries()
         stock_valuation_layers._validate_analytic_accounting_entries()
 
-        valued_moves['out'].filtered(lambda m: m.product_id.lot_valuated)._product_price_update_after_done()
+        valued_moves['out'].filtered(lambda m: m.product_id.lot_valuated).sudo()._product_price_update_after_done()
 
         stock_valuation_layers._check_company()
 


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product tracked by lot and lot valuated
- Create a lot for 10 units of that product in stock
- login a user that is not administrator in inventory
- Create and confirm a delivery for 1 units of your product
- Try to validate the delivery
#### > access right error

### Cause of the issue:

During the `_action_done` of the `stock.move` we will need to change the valuated price of the product after done:
https://github.com/odoo/odoo/blob/6beb3ea82d75513803ae78f5bc71024313938a97/addons/stock_account/models/stock_move.py#L378 https://github.com/odoo/odoo/blob/6beb3ea82d75513803ae78f5bc71024313938a97/addons/stock_account/models/stock_move.py#L461-L464 However, only admin inventory users have the read access rights to the `stock.valuation.layer` model.

opw-4680641
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
