### PR TITLE
[FIX] account: Error computing placeholder without date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -912,7 +912,7 @@ class AccountMove(models.Model):
     @api.depends('date', 'journal_id', 'move_type', 'name', 'posted_before', 'sequence_number', 'sequence_prefix', 'state')
     def _compute_name_placeholder(self):
         for move in self:
-            if (not move.name or move.name == '/') and not move._get_last_sequence():
+            if (not move.name or move.name == '/') and self.date and not move._get_last_sequence():
                 sequence_format_string, sequence_format_values = move._get_next_sequence_format()
                 sequence_format_values['seq'] = sequence_format_values['seq'] + 1
                 move.name_placeholder = sequence_format_string.format(**sequence_format_values)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When creating a new journal entry, clearing the date field causes an error because the system tries to compute the placeholder name field using the date, which is missing.

Current behavior before PR:
An error is raised when the date field is cleared while creating a journal entry, as the computation of the name field relies on the date field being present.

Desired behavior after PR is merged:
The system will check if the date field is present before computing the name field. If the date field is missing, a default value will be used, or a clear validation error will be displayed to the user.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
