### PR TITLE
[FIX] purchase: show bill of a commercial partner in purchase matching 

### DIFF
--- a/addons/purchase/models/purchase_bill_line_match.py
+++ b/addons/purchase/models/purchase_bill_line_match.py
@@ -106,7 +106,7 @@ class PurchaseBillLineMatch(models.Model):
                    NULL as pol_id,
                    aml.id as aml_id,
                    aml.company_id as company_id,
-                   aml.partner_id as partner_id,
+                   am.partner_id as partner_id,
                    aml.product_id as product_id,
                    aml.quantity as line_qty,
                    aml.product_uom_id as line_uom_id,


### PR DESCRIPTION
When you have a bill with a partner that is not a company itself and has a parent company, its commercial_partner_id will be that of the parent company. This leads to the account move line having a different partner_id than the potential matching purchase order line, therefore not showing up in the purchase matching view.

task - 4656238