### PR TITLE
[FIX] product_matrix: settings warning

### DIFF
--- a/addons/product_matrix/__manifest__.py
+++ b/addons/product_matrix/__manifest__.py
@@ -11,6 +11,7 @@ Please refer to Sale Matrix or Purchase Matrix for the use of this module.
     'depends': ['account'],
     # Account dependency for section_and_note widget.
     'data': [
+        'data/res_groups.xml',
         'views/matrix_templates.xml',
     ],
     'demo': [

--- a/addons/product_matrix/data/res_groups.xml
+++ b/addons/product_matrix/data/res_groups.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="base.group_user" model="res.groups">
+        <field name="implied_ids" eval="[Command.link(ref('product.group_product_variant'))]"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
If you install `sale_product_matrix` module without enabling variants, opening the settings will show a warning saying:
"Disabling this option will also uninstall the following modules: Sale Matrix"

To ensure this doesn't happen, installing the matrix will automatically enable the variants feature.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
