### PR TITLE
[FIX] tools: don't export attributes that aren't translated anyway

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -157,7 +157,7 @@ TRANSLATED_ELEMENTS = {
 TRANSLATED_ATTRS = dict.fromkeys({
     'string', 'add-label', 'help', 'sum', 'avg', 'confirm', 'placeholder', 'alt', 'title', 'aria-label',
     'aria-keyshortcuts', 'aria-placeholder', 'aria-roledescription', 'aria-valuetext',
-    'value_label', 'data-tooltip', 'data-editor-message', 'label',
+    'value_label', 'data-tooltip', 'data-editor-message', 'label', 'cancel-label', 'confirm-label',
 }, lambda e: True)
 
 def translate_attrib_value(node):

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -177,7 +177,17 @@ TRANSLATED_ATTRS.update(
 )
 
 # This should match the list provided to OWL (see translatableAttributes).
-OWL_TRANSLATED_ATTRS = {"alt", "data-tooltip", "label", "placeholder", "title"}
+OWL_TRANSLATED_ATTRS = {
+    "alt",
+    "aria-label",
+    "aria-placeholder",
+    "aria-roledescription",
+    "aria-valuetext",
+    "data-tooltip",
+    "label",
+    "placeholder",
+    "title",
+}
 
 avoid_pattern = re.compile(r"\s*<!DOCTYPE", re.IGNORECASE | re.MULTILINE | re.UNICODE)
 space_pattern = re.compile(r"[\s\uFEFF]*")  # web_editor uses \uFEFF as ZWNBSP

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -153,6 +153,7 @@ TRANSLATED_ELEMENTS = {
 
 # Which attributes must be translated. This is a dict, where the value indicates
 # a condition for a node to have the attribute translatable.
+# ⚠ Note that it implicitly includes their t-attf-* equivalent.
 TRANSLATED_ATTRS = dict.fromkeys({
     'string', 'add-label', 'help', 'sum', 'avg', 'confirm', 'placeholder', 'alt', 'title', 'aria-label',
     'aria-keyshortcuts', 'aria-placeholder', 'aria-roledescription', 'aria-valuetext',
@@ -174,6 +175,9 @@ TRANSLATED_ATTRS.update(
     text=lambda e: (e.tag == 'field' and e.attrib.get('widget', '') == 'url'),
     **{f't-attf-{attr}': cond for attr, cond in TRANSLATED_ATTRS.items()},
 )
+
+# This should match the list provided to OWL (see translatableAttributes).
+OWL_TRANSLATED_ATTRS = {"alt", "data-tooltip", "label", "placeholder", "title"}
 
 avoid_pattern = re.compile(r"\s*<!DOCTYPE", re.IGNORECASE | re.MULTILINE | re.UNICODE)
 space_pattern = re.compile(r"[\s\uFEFF]*")  # web_editor uses \uFEFF as ZWNBSP
@@ -930,7 +934,7 @@ def _extract_translatable_qweb_terms(element, callback):
             # component nodes
             is_component = el.tag[0].isupper() or "t-component" in el.attrib or "t-set-slot" in el.attrib
             for attr in el.attrib:
-                if (not is_component and attr in TRANSLATED_ATTRS) or (is_component and attr.endswith(".translate")):
+                if (not is_component and attr in OWL_TRANSLATED_ATTRS) or (is_component and attr.endswith(".translate")):
                     _push(callback, el.attrib[attr], el.sourceline)
             _extract_translatable_qweb_terms(el, callback)
         _push(callback, el.tail, el.sourceline)


### PR DESCRIPTION
In this PR:
##  [FIX] tools: don't export attributes that aren't translated anyway
PR #162079 made the list of translated attributes shared between QWeb and OWL templates. In hindsight, this was not a good idea, since:

- some attributes are exclusive to QWeb (e.g.: string)
- t-attf- variants of attributes are not translated in OWL
- it does not reflect the list of attributes that OWL actually translates

## [IMP] tools: add missing ARIA attributes to OWL_TRANSLATED_ATTRS
https://github.com/odoo/owl/pull/1679 made human-readable ARIA attributes translated by Owl.
This commit updates OWL_TRANSLATED_ATTRS so that ARIA attributes are also correctly exported for translation, and will therefore be fully translatable when the next version of Owl is released.

## [IMP] tools: make 'confirm-label' and 'cancel-label' translatable
'cancel-label' and 'confirm-label' are missing from the list of attributes to export for translation. This commit adds them to the list.