### PR TITLE
[IMP] portal: allow the user to choose their preferred language for emails

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -714,10 +714,9 @@ class CustomerPortal(Controller):
         # Validate the lang
         if 'lang' in address_values:
             ResLang = request.env['res.lang']
-            try:
-                lang_id = int(address_values.get('lang'))
-            except Exception:
-                lang_id = None
+            lang_id = int(lang_value) if isinstance(lang_value, int) or (
+                        isinstance(lang_value, str) and lang_value.isdigit()) else None
+
             supported_langs = ResLang._get_frontend().values()
 
             if not any(lang.id == lang_id for lang in supported_langs):

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -714,6 +714,8 @@ class CustomerPortal(Controller):
         # Validate the lang
         if 'lang' in address_values:
             ResLang = request.env['res.lang']
+
+            lang_value = address_values.get('lang')
             lang_id = int(lang_value) if isinstance(lang_value, int) or (
                         isinstance(lang_value, str) and lang_value.isdigit()) else None
 

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -716,7 +716,7 @@ class CustomerPortal(Controller):
             ResLang = request.env['res.lang']
             try:
                 lang_id = int(address_values.get('lang'))
-            except Exception as e:
+            except Exception:
                 lang_id = None
             supported_langs = ResLang._get_frontend().values()
 

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -711,6 +711,21 @@ class CustomerPortal(Controller):
                 invalid_fields.add('vat')
                 error_messages.append(exception.args[0])
 
+        # Validate the lang
+        if 'lang' in address_values:
+            ResLang = request.env['res.lang']
+            try:
+                lang_id = int(address_values.get('lang'))
+            except Exception as e:
+                lang_id = None
+            supported_langs = ResLang._get_frontend().values()
+
+            if not any(lang.id == lang_id for lang in supported_langs):
+                invalid_fields.add('lang')
+                error_messages.append(_('Invalid Language! Please enter a valid language.'))
+            else:
+                address_values.update({'lang': ResLang.search([('id', '=', lang_id)]).code})
+
         # Build the set of required fields from the address form's requirements.
         required_field_set = {f for f in required_fields.split(',') if f}
 

--- a/addons/portal/models/res_partner.py
+++ b/addons/portal/models/res_partner.py
@@ -14,7 +14,7 @@ class ResPartner(models.Model):
         """
         return {
             'name', 'phone', 'email', 'street', 'street2', 'city', 'state_id', 'country_id', 'zip',
-            'zipcode', 'vat', 'company_name',
+            'zipcode', 'vat', 'company_name', 'lang'
         }
 
     def _can_edit_name(self):

--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -333,6 +333,28 @@
                 />
             </select>
         </div>
+        <div class="w-100"/>
+        <t t-set="language_selector_visible" t-value="len(frontend_languages) &gt; 1"/>
+        <div t-if="language_selector_visible" id="div_lang" class="col-lg-6 mb-2">
+            <label class="col-form-label" for="o_lang">
+                Language
+            </label>
+            <select
+                id="o_lang"
+                name="lang"
+                class="form-select"
+            >
+                <option value="">Language...</option>
+                <option
+                    t-foreach="frontend_languages.values()"
+                    t-as="lg"
+                    t-att-value="lg.id"
+                    t-att-selected="lg.code == partner_sudo.lang"
+                    t-att-code="lg.code"
+                    t-out="lg.name"
+                />
+            </select>
+        </div>
         <input
             type="hidden"
             name="csrf_token"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Users currently do not have the option to select their preferred language for receiving emails, which limits personalization.

Current behavior before PR:
- All users receive emails in the language they registered with for the first time, without an option to change it.

Desired behavior after PR is merged:
- Users can select their preferred language in the **Portal My Account** settings. 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
