### PR TITLE
[IMP] mail: improved behaviour for counter and new msg separator

### DIFF
--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -141,13 +141,6 @@ patch(Thread.prototype, {
         return message;
     },
 
-    get showUnreadBanner() {
-        if (this.chatbot && !this.chatbot.currentStep?.operatorFound) {
-            return false;
-        }
-        return super.showUnreadBanner;
-    },
-
     get composerDisabled() {
         const step = this.chatbot?.currentStep;
         if (this.chatbot?.forwarded && this.livechat_active) {

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -115,14 +115,14 @@ class ChannelController(http.Controller):
 
     @http.route("/discuss/channel/mark_as_read", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
-    def discuss_channel_mark_as_read(self, channel_id, last_message_id, sync=False):
+    def discuss_channel_mark_as_read(self, channel_id, last_message_id):
         member = request.env["discuss.channel.member"].search([
             ("channel_id", "=", channel_id),
             ("is_self", "=", True),
         ])
         if not member:
             return  # ignore if the member left in the meantime
-        member._mark_as_read(last_message_id, sync=sync)
+        member._mark_as_read(last_message_id)
 
     @http.route("/discuss/channel/set_new_message_separator", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
@@ -133,7 +133,7 @@ class ChannelController(http.Controller):
         ])
         if not member:
             raise NotFound()
-        return member._set_new_message_separator(message_id, sync=True)
+        return member._set_new_message_separator(message_id)
 
     @http.route("/discuss/channel/notify_typing", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -839,7 +839,7 @@ class DiscussChannel(models.Model):
             ("channel_id", "=", self.id), ("is_self", "=", True)
         ])) and message.is_current_user_or_guest_author:
             current_channel_member._set_last_seen_message(message, notify=False)
-            current_channel_member._set_new_message_separator(message.id + 1, sync=True)
+            current_channel_member._set_new_message_separator(message.id + 1)
         return super()._message_post_after_hook(message, msg_vals)
 
     def _check_can_update_message_content(self, message):

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -493,14 +493,12 @@ class DiscussChannelMember(models.Model):
                 self.channel_id._web_push_send_notification(devices, private_key, public_key, payload_by_lang=payload_by_lang)
         return members
 
-    def _mark_as_read(self, last_message_id, sync=False):
+    def _mark_as_read(self, last_message_id):
         """
         Mark channel as read by updating the seen message id of the current
         member as well as its new message separator.
 
         :param last_message_id: the id of the message to be marked as read.
-        :param sync: wether the new message separator and the unread counter in
-            the UX will sync to their server values.
         """
         self.ensure_one()
         domain = [
@@ -512,7 +510,7 @@ class DiscussChannelMember(models.Model):
         if not last_message:
             return
         self._set_last_seen_message(last_message)
-        self._set_new_message_separator(last_message.id + 1, sync=sync)
+        self._set_new_message_separator(last_message.id + 1)
 
     def _set_last_seen_message(self, message, notify=True):
         """
@@ -542,13 +540,10 @@ class DiscussChannelMember(models.Model):
             ],
         )
 
-    def _set_new_message_separator(self, message_id, sync=False):
+    def _set_new_message_separator(self, message_id):
         """
         :param message_id: id of the message above which the new message
             separator should be displayed.
-        :param sync: whether the new message separator and the unread counter
-            in the UX will sync to their server values.
-
         """
         self.ensure_one()
         if message_id == self.new_message_separator:
@@ -564,7 +559,6 @@ class DiscussChannelMember(models.Model):
                 {"message_unread_counter_bus_id": bus_last_id},
                 "new_message_separator",
                 *self.env["discuss.channel.member"]._to_store_persona([]),
-                {"syncUnread": sync},
             ],
         )
 

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -804,7 +804,13 @@ export class Composer extends Component {
     onFocusin() {
         const composer = toRaw(this.props.composer);
         composer.isFocused = true;
-        composer.thread?.markAsRead({ sync: false });
+        if (
+            composer.thread?.scrollTop === "bottom" &&
+            !composer.thread.scrollUnread &&
+            !composer.thread.markedAsUnread
+        ) {
+            composer.thread?.markAsRead();
+        }
     }
 
     onFocusout(ev) {

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -32,7 +32,18 @@ export class Composer extends Record {
     };
     /** @type {boolean} */
     forceCursorMove;
-    isFocused = false;
+    isFocused = fields.Attr(false, {
+        /** @this {import("models").Composer} */
+        onUpdate() {
+            if (this.thread) {
+                if (this.isFocused) {
+                    this.thread.isFocusedCounter++;
+                } else {
+                    this.thread.isFocusedCounter--;
+                }
+            }
+        },
+    });
     autofocus = 0;
     replyToMessage = fields.One("mail.message");
 }

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Thread">
-    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto bg-inherit" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-2': !env.inChatter and !props.isInChatWindow }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1">
+    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto bg-inherit" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-2': !env.inChatter and !props.isInChatWindow }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1" t-on-focusout="onFocusout">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1 bg-inherit" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>
@@ -20,8 +20,8 @@
                         <DateSection date="msg.dateDay" className="'pt-2 px-2'"/>
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
-                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bold z-1 px-2">
-                        <div class="o-mail-Thread-newMessageLine flex-grow-1 border border-danger opacity-100 shadow-sm"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase shadow-sm">New</span>
+                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread) and (prevMsg or props.thread.markedAsUnread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bold z-1 px-2">
+                        <div class="o-mail-Thread-newMessageLine flex-grow-1 border border-danger opacity-100 shadow-sm my-1"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase shadow-sm">New</span>
                     </div>
                     <NotificationMessage t-if="msg.isNotification and !msg.notificationHidden" message="msg" thread="props.thread" registerMessageRef="registerMessageRef" />
                     <Message

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -6,7 +6,6 @@ import { rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 import { Deferred } from "@web/core/utils/concurrency";
-import { isMobileOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef SuggestedRecipient
@@ -165,6 +164,10 @@ export class Thread extends Record {
         },
     });
     isDisplayedOnUpdate() {}
+    get isFocused() {
+        return this.isFocusedCounter !== 0;
+    }
+    isFocusedCounter = 0;
     isLoadingAttachments = false;
     isLoadedDeferred = new Deferred();
     isLoaded = fields.Attr(false, {
@@ -732,9 +735,6 @@ export class Thread extends Record {
             assignDefined({ thread: this }, { fromMessagingMenu, bypassCompact })
         );
         cw.open({ focus: focus });
-        if (isMobileOS()) {
-            this.markAsRead();
-        }
         return cw;
     }
 

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -108,8 +108,10 @@ export class DiscussCoreCommon {
             if (message.isSelfAuthored) {
                 channel.onNewSelfMessage(message);
             } else {
+                if (channel.isDisplayed && channel.selfMember?.new_message_separator_ui === 0) {
+                    channel.selfMember.new_message_separator_ui = message.id;
+                }
                 if (!channel.isDisplayed && channel.selfMember) {
-                    channel.selfMember.syncUnread = true;
                     channel.scrollUnread = true;
                 }
                 if (
@@ -134,9 +136,10 @@ export class DiscussCoreCommon {
             !message.isSelfAuthored &&
             channel.composer.isFocused &&
             this.store.self.type === "partner" &&
-            channel.newestPersistentMessage?.eq(channel.newestMessage)
+            channel.newestPersistentMessage?.eq(channel.newestMessage) &&
+            !channel.markedAsUnread
         ) {
-            channel.markAsRead({ sync: false });
+            channel.markAsRead();
         }
         this.env.bus.trigger("discuss.channel/new_message", { channel, message, silent });
         const authorMember = channel.channel_member_ids.find(({ persona }) =>

--- a/addons/mail/static/src/discuss/core/common/message_actions.js
+++ b/addons/mail/static/src/discuss/core/common/message_actions.js
@@ -23,6 +23,12 @@ messageActionsRegistry.add("set-new-message-separator", {
     /** @param {import("@mail/core/common/message").Message} component */
     onClick: (component) => {
         const message = toRaw(component.message);
+        const selfMember = message.thread?.selfMember;
+        if (selfMember) {
+            selfMember.new_message_separator = message.id;
+            selfMember.new_message_separator_ui = selfMember.new_message_separator;
+        }
+        message.thread.markedAsUnread = true;
         rpc("/discuss/channel/set_new_message_separator", {
             channel_id: message.thread.id,
             message_id: message.id,

--- a/addons/mail/static/src/discuss/core/common/thread_patch.xml
+++ b/addons/mail/static/src/discuss/core/common/thread_patch.xml
@@ -5,7 +5,7 @@
             <span t-if="!env.inChatter and props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm smaller fw-bolder rounded-bottom-3 rounded-top-0">
                 <t t-set="alertClass" t-value="'alert alert-warning m-0 border-start-0 o-mail-Thread-bannerHover rounded-top-0 rounded-bottom-3 py-1'"/>
                 <span t-attf-class="{{ alertClass }} flex-grow-1" style="border-bottom-right-radius: 0 !important" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
-                <span t-attf-class="{{ alertClass }}" style="border-bottom-left-radius: 0 !important" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-square"/></span>
+                <span t-attf-class="{{ alertClass }}" style="border-bottom-left-radius: 0 !important" t-on-click="() => props.thread.markAsRead()">Mark as Read<i class="ms-2 fa fa-check-square"/></span>
             </span>
         </xpath>
     </t>

--- a/addons/mail/static/src/discuss/core/public_web/messaging_menu_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/messaging_menu_patch.js
@@ -7,7 +7,7 @@ patch(MessagingMenu.prototype, {
     markAsRead(thread) {
         super.markAsRead(...arguments);
         if (thread.model === "discuss.channel") {
-            thread.markAsRead({ sync: true });
+            thread.markAsRead();
         }
     },
 });

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -420,7 +420,7 @@ registerRoute("/discuss/channel/mark_as_read", discuss_channel_mark_as_read);
 async function discuss_channel_mark_as_read(request) {
     /** @type {import("mock_models").DiscussChannel} */
     const DiscussChannelMember = this.env["discuss.channel.member"];
-    const { channel_id, last_message_id, sync } = await parseRequestParams(request);
+    const { channel_id, last_message_id } = await parseRequestParams(request);
     const [partner, guest] = this.env["res.partner"]._get_current_persona();
     const [memberId] = this.env["discuss.channel.member"].search([
         ["channel_id", "=", channel_id],
@@ -429,7 +429,7 @@ async function discuss_channel_mark_as_read(request) {
     if (!memberId) {
         return; // ignore if the member left in the meantime
     }
-    return DiscussChannelMember._mark_as_read([memberId], last_message_id, sync);
+    return DiscussChannelMember._mark_as_read([memberId], last_message_id);
 }
 
 registerRoute(

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -831,7 +831,7 @@ export class DiscussChannel extends models.ServerModel {
         kwargs.message_type ||= "notification";
         const [channel] = this.browse(id);
         this.write([id], {
-            last_interest_dt: serializeDateTime(today()),
+            last_interest_dt: serializeDateTime(DateTime.now()),
         });
         if (kwargs.special_mentions?.includes("everyone")) {
             kwargs["partner_ids"] = DiscussChannelMember._filter([

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -135,14 +135,12 @@ export class DiscussChannelMember extends models.ServerModel {
     /**
      * @param {number[]} ids
      * @param {number} last_message_id
-     * @param {boolean} [sync]
      */
-    _mark_as_read(ids, last_message_id, sync) {
+    _mark_as_read(ids, last_message_id) {
         const kwargs = getKwArgs(arguments, "ids", "last_message_id", "sync");
         ids = kwargs.ids;
         delete kwargs.ids;
         last_message_id = kwargs.last_message_id;
-        sync = kwargs.sync ?? false;
         const [member] = this.browse(ids);
         if (!member) {
             return;
@@ -157,8 +155,7 @@ export class DiscussChannelMember extends models.ServerModel {
         this._set_last_seen_message([member.id], last_message_id);
         this.env["discuss.channel.member"]._set_new_message_separator(
             [member.id],
-            last_message_id + 1,
-            sync
+            last_message_id + 1
         );
     }
 
@@ -216,14 +213,12 @@ export class DiscussChannelMember extends models.ServerModel {
     /**
      * @param {number[]} ids
      * @param {number} message_id
-     * @param {boolean} sync
      */
-    _set_new_message_separator(ids, message_id, sync) {
+    _set_new_message_separator(ids, message_id) {
         const kwargs = getKwArgs(arguments, "ids", "message_id", "sync");
         ids = kwargs.ids;
         delete kwargs.ids;
         message_id = kwargs.message_id;
-        sync = kwargs.sync ?? false;
 
         /** @type {import("mock_models").DiscussChannelMember} */
         const DiscussChannelMember = this.env["discuss.channel.member"];
@@ -252,7 +247,7 @@ export class DiscussChannelMember extends models.ServerModel {
                     },
                 })
             )
-                .add("discuss.channel.member", { id: member.id, syncUnread: sync })
+                .add("discuss.channel.member", { id: member.id })
                 .get_result()
         );
     }

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -314,7 +314,8 @@ test("mark channel as fetched when a new message is loaded", async () => {
     );
     await contains(".o-mail-Message");
     await waitForSteps(["rpc:channel_fetch"]);
-    await contains(".o-mail-Thread-newMessage:contains('New')");
+    await contains(".o-mail-ChatWindow .badge:contains(1)");
+    await contains(".o-mail-Message:contains('Hello!')");
     await focus(".o-mail-Composer-input");
     await waitForSteps(["rpc:mark_as_read"]);
 });

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -430,7 +430,6 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 "message_unread_counter_bus_id": 0,
                                 "new_message_separator": msg_1.id + 1,
                                 "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
-                                "syncUnread": False,
                                 "thread": {
                                     "id": chat.id,
                                     "model": "discuss.channel",

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -112,7 +112,6 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member.partner_id.id,
                                     "type": "partner"
                                 },
-                                "syncUnread": True,
                                 "thread": { "id": channel.id, "model": "discuss.channel" }
                             }
                         ]


### PR DESCRIPTION
This commit improves behaviour of new message counter, msg separator and unread message banner in discuss conversation.

Before this commit, all these conditions were made with special fields `syncUnread` and passing `sync` param to mark_as_read rpc, so that the server acknowledges by providing the new_message_separator value.

This solution is very prone to race condition and the code is far too complicated and result to many misses, leading to end-user to manually click on mark as read very often and/or come back to conversation and/or page reload to have proper counters.

This commit improves by making the implementation much simpler by being fully client-side and more imperative. There's no more `sync` param acknowledgement, and instead the UI versions of counter and separator are mostly the same as the server values but soften in JS for UI concerns, i.e. don't increase counter if it becomes immediately decreased, or new message separator is a bit more persistent to not jump between messages all the time.

This implementation also improve behaviour of auto mark as read: before this commit, focus on composer was a hard requirement for this auto-mark as read. Now, soft-focus on thread is good enough, and scrolling to bottom with focus on either composer or thread is enough to mark the conversation as read.

This commit also makes these new improvements on new message separator:
- new message separator was always displayed on opening new conversation with only new messages. Now this is not displayed because all messages are new anyway. It displays a new message separator however when a new message is posted just after conversation is being displayed
- new message separator is shown above 1st message of conversation only when conversation is explicitly marked as unread from this message

Task-4448873

https://github.com/odoo/enterprise/pull/83240