### PR TITLE
[IMP] sale_project: rename the customer preview stat button

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -55,7 +55,6 @@
                 <field name="privacy_visibility" invisible="1" />
                 <button class="oe_stat_button" type="object" name="action_customer_preview" icon="fa-globe icon" invisible="not partner_id or not allow_billable or privacy_visibility != 'portal' or is_template">
                     <div class="o_field_widget o_stat_info">
-                        <span class="o_stat_text">Customer</span>
                         <span class="o_stat_text">Preview</span>
                     </div>
                 </button>


### PR DESCRIPTION
In this commit:
 - To maintain consistency, the stat button name is renamed from "Customer Preview" to "Preview".

task - 4567479