### PR TITLE
[IMP] pos_loyalty, *: make gift card/eWallet reward lines editable

### DIFF
--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -331,4 +331,5 @@ class LoyaltyReward(models.Model):
             'sale_ok': False,
             'purchase_ok': False,
             'lst_price': 0,
+            'taxes_id': False,
         } for reward in self]

--- a/addons/pos_loyalty/__manifest__.py
+++ b/addons/pos_loyalty/__manifest__.py
@@ -18,6 +18,7 @@
         'views/res_config_settings_view.xml',
         'views/loyalty_program_views.xml',
         'views/res_partner_views.xml',
+        'views/pos_order_views.xml',
     ],
     'demo': [
         'data/pos_loyalty_demo.xml',

--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -10,12 +10,6 @@ class LoyaltyReward(models.Model):
     _name = 'loyalty.reward'
     _inherit = ['loyalty.reward', 'pos.load.mixin']
 
-    def _get_discount_product_values(self):
-        res = super()._get_discount_product_values()
-        for vals in res:
-            vals.update({'taxes_id': False})
-        return res
-
     @api.model
     def _load_pos_data_domain(self, data, config):
         return [('program_id', 'in', config._get_program_ids().ids)]

--- a/addons/pos_loyalty/static/src/app/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order_line.js
@@ -82,4 +82,15 @@ patch(PosOrderline.prototype, {
             "fst-italic": this.is_reward_line,
         };
     },
+    getPriceChange(price) {
+        const ProductPrice = this.models["decimal.precision"].find(
+            (dp) => dp.name === "Product Price"
+        );
+        const parsed_price = !isNaN(price)
+            ? price
+            : isNaN(parseFloat(price))
+            ? 0
+            : parseFloat("" + price);
+        return ProductPrice.round(parsed_price || 0);
+    },
 });

--- a/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
@@ -172,3 +172,39 @@ registry.category("web_tour.tours").add("EWalletLoyaltyHistory", {
             PosLoyalty.finalizeOrder("Cash", "0"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_editable_ewallet_reward_line", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            // Topup 100$ for E wallet Partner
+            ProductScreen.addOrderline("Top-up eWallet", "1", "100"),
+            PosLoyalty.orderTotalIs("100.00"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.clickPartner("E wallet Partner"),
+            PosLoyalty.finalizeOrder("Cash", "100"),
+
+            // Use eWallet for 50$ payment
+            ProductScreen.clickDisplayedProduct("Test Product A"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.clickPartner("E wallet Partner"),
+            PosLoyalty.eWalletButtonState({
+                highlighted: true,
+                text: getEWalletText("Pay"),
+                click: true,
+            }),
+            PosLoyalty.orderTotalIs("0.00"),
+            ProductScreen.clickLine("eWallet"),
+            ProductScreen.clickNumpad("Qty"),
+            ProductScreen.clickNumpad("⌫"),
+            ProductScreen.selectedOrderlineHasDirect("eWallet", "0", "0.0"),
+            PosLoyalty.orderTotalIs("100.00"),
+            ProductScreen.clickNumpad("Price"),
+            ProductScreen.clickNumpad("5"),
+            ProductScreen.clickNumpad("0"),
+            PosLoyalty.orderTotalIs("50.00"),
+            PosLoyalty.finalizeOrder("Cash", "50"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -215,3 +215,26 @@ registry.category("web_tour.tours").add("EmptyProductScreenTour", {
             ProductScreen.loadSampleButtonIsThere(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_editable_gift_card_reward_line", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Test Product A"),
+            PosLoyalty.orderTotalIs("100.00"),
+            PosLoyalty.enterCode("test-card-0005"),
+            Dialog.confirm(),
+            PosLoyalty.orderTotalIs("0.00"),
+            ProductScreen.clickLine("Gift Card"),
+            ProductScreen.clickNumpad("Qty"),
+            ProductScreen.clickNumpad("⌫"),
+            ProductScreen.selectedOrderlineHasDirect("Gift Card", "0", "0.0"),
+            PosLoyalty.orderTotalIs("100.00"),
+            ProductScreen.clickNumpad("Price"),
+            ProductScreen.clickNumpad("5"),
+            ProductScreen.clickNumpad("0"),
+            PosLoyalty.orderTotalIs("50.00"),
+            PosLoyalty.finalizeOrder("Cash", "50"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/views/pos_order_views.xml
+++ b/addons/pos_loyalty/views/pos_order_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pos_form_inherit_pos_loyalty" model="ir.ui.view">
+        <field name="name">pos.order.form.inherit.pos.loyalty</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                <button name="action_open_loyalty_cards"
+                        context="{'program_type': 'gift_card'}"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-gift"
+                        invisible="not gift_card_count">
+                    <field name="gift_card_count" widget="statinfo" string="Gift Cards"/>
+                </button>
+                <button name="action_open_loyalty_cards"
+                        context="{'program_type': 'ewallet'}"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-credit-card"
+                        invisible="not ewallet_count">
+                    <field name="ewallet_count" widget="statinfo" string="eWallet"/>
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/sale_loyalty/models/loyalty_reward.py
+++ b/addons/sale_loyalty/models/loyalty_reward.py
@@ -10,7 +10,6 @@ class LoyaltyReward(models.Model):
         res = super()._get_discount_product_values()
         for vals in res:
             vals.update({
-                'taxes_id': False,
                 'supplier_taxes_id': False,
                 'invoice_policy': 'order',
             })


### PR DESCRIPTION
*: loyalty, sale_loyalty

Before this commit:
==========
- Reward lines for gift cards and eWallets were not editable.
- The reward amount was automatically calculated based on the order amount, preventing users from manually adjusting it.
- Users were unable to track sold or redeemed gift cards and eWallet usage from the POS order form view.
- Taxes are added for the gift card program's reward.

After this commit:
==========
- Gift card and eWallet reward lines are now editable.
- Users can manually set or modify the reward amount as needed.
- POS order form view now includes Gift Card and eWallet state buttons, enabling better tracking of issued and redeemed rewards.
- Taxes are removed for all reward products.
- Gift card and eWallet reward lines will work as normal product order lines and will be removed after double backspace.

task-4678835