### PR TITLE
[IMP] portal: improve address management for portal users

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -764,9 +764,9 @@ class ResPartner(models.Model):
         )
         return bool(invoice)
 
-    def _can_edit_name(self):
-        """ Can't edit `name` if there is (non draft) issued invoices. """
-        return super()._can_edit_name() and not self._has_invoice(
+    def _can_edit_country(self):
+        """ Can't edit `country_id` if there is (non draft) issued invoices. """
+        return super()._can_edit_country() and not self._has_invoice(
             [('partner_id', '=', self.id)]
         )
 

--- a/addons/portal/models/res_partner.py
+++ b/addons/portal/models/res_partner.py
@@ -18,8 +18,7 @@ class ResPartner(models.Model):
             'zipcode', 'vat', 'company_name',
         }
 
-    def _can_edit_name(self):
-        """ Name can be changed more often than the VAT """
+    def _can_edit_country(self):
         self.ensure_one()
         return True
 

--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -92,11 +92,22 @@
                     t-out="contact"
                     t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True)"
                 />
+                <t t-set="icon_classes" t-value="'fa text-primary fs-5 position-absolute mt-1 '"/>
                 <div class="mt-3 mx-1">
                     <i
                         t-if="is_user_address"
-                        class="fa fa-id-card text-primary fs-5 position-absolute mt-1"
+                        t-att-class=" icon_classes + 'fa-id-card'"
                         title="Your Account Address"
+                    />
+                    <i
+                        t-elif="contact.type=='delivery'"
+                        t-att-class=" icon_classes + 'fa-solid fa-truck'"
+                        title="Delivery Address"
+                    />
+                    <i
+                        t-elif="contact.type=='invoice'"
+                        t-att-class=" icon_classes + 'fa-file-text'"
+                        title="Billing Address"
                     />
                     <div t-if="can_be_edited" class="text-end">
                         <t
@@ -183,7 +194,7 @@
                         type="text"
                         name="company_name"
                         t-att-value="current_partner.commercial_company_name"
-                        t-att-readonly="'1' if (not is_commercial_address or vat_warning) else None"
+                        t-att-readonly="'1' if not is_main_address else None"
                         class="form-control"
                     />
                 </div>
@@ -199,24 +210,27 @@
                         t-att-readonly="'1' if (not is_commercial_address or vat_warning) else None"
                         class="form-control"
                     />
+                    <!-- Even on new addresses, first tell the customer if their VAT cannot be changed,
+                        then tell them to update it elsewhere if it can be. -->
+                    <div
+                        t-if="not is_commercial_address and commercial_partner.is_company and is_main_address"
+                        class="col-12 d-none d-lg-block mb-1"
+                    >
+                        <small class="form-text text-muted">
+                            The VAT number can only be updated on the company account.
+                        </small>
+                    </div>
+                    <div t-elif="vat_warning and is_main_address" class="col-12 d-none d-lg-block mb-1">
+                        <small class="form-text text-muted">
+                            Changing VAT number is not allowed once document(s) have
+                            been issued for your account. Please contact us directly for this
+                            operation.
+                        </small>
+                    </div>
                 </div>
-                <!-- Even on new addresses, first tell the customer if their VAT/Company cannot be changed,
-                    then tell them to update it elsewhere if it can be. -->
-                <div t-if="vat_warning" class="col-12 d-none d-lg-block mb-1">
+                <div t-if="not (is_commercial_address or is_main_address)" class="col-12 d-none d-lg-block mb-1">
                     <small class="form-text text-muted">
-                        Changing company name or VAT number is not allowed once document(s) have
-                        been issued for your account. Please contact us directly for this
-                        operation.
-                    </small>
-                </div>
-                <div t-elif="not is_commercial_address" class="col-12 d-none d-lg-block mb-1">
-                    <small class="form-text text-muted">
-                        <t t-if="commercial_partner.is_company">
-                            The company name and VAT number can only be updated on the company account.
-                        </t>
-                        <t t-else="">
-                            The company name and VAT number can only be updated on your main account.
-                        </t>
+                        The company name and VAT number can only be updated on your main account.
                         <t t-if="commercial_address_update_url">
                             If you want to modify it, update
                             <a t-att-href="commercial_address_update_url">your account details</a>.
@@ -296,7 +310,7 @@
             <select
                 id="o_country_id"
                 name="country_id"
-                class="form-select"
+                t-att-class="'pe-none opacity-50 form-select' if not can_edit_country else 'form-select'"
             >
                 <option value="">Country...</option>
                 <option
@@ -308,6 +322,13 @@
                     t-out="c.name"
                 />
             </select>
+            <div t-if="not can_edit_country" class="col-12 d-none d-lg-block mb-1">
+                <small class="form-text text-muted">
+                    Changing country is not allowed once document(s) have
+                    been issued for your account. Please contact us directly for this
+                    operation.
+                </small>
+            </div>
         </div>
         <div
             id="div_state"

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -64,9 +64,9 @@ class ResPartner(models.Model):
         )
         return bool(sale_order)
 
-    def _can_edit_name(self):
-        """ Can't edit `name` if there is (non draft) issued SO. """
-        return super()._can_edit_name() and not self._has_order(
+    def _can_edit_country(self):
+        """ Can't edit `country_id` if there is (non draft) issued SO. """
+        return super()._can_edit_country() and not self._has_order(
             [
                 ('partner_invoice_id', '=', self.id),
                 ('partner_id', '=', self.id),

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -563,9 +563,9 @@ class TestCheckoutAddress(WebsiteSaleCommon):
         })
         partner_1, _partner_2, _partner_3 = partner_company.child_ids
         self.assertTrue(partner_company.can_edit_vat())
-        self.assertTrue(partner_company._can_edit_name())
+        self.assertTrue(partner_company._can_edit_country())
         self.assertTrue(all(not p.can_edit_vat() for p in partner_company.child_ids))
-        self.assertTrue(all(p._can_edit_name() for p in partner_company.child_ids))
+        self.assertTrue(all(p._can_edit_country() for p in partner_company.child_ids))
 
         dumb_product = self.env['product.product'].create({'name': 'test'})
         invoice = self.env['account.move'].create({
@@ -581,8 +581,8 @@ class TestCheckoutAddress(WebsiteSaleCommon):
 
         self.assertEqual(invoice.state, 'posted')
         self.assertFalse(partner_company.can_edit_vat())
-        self.assertFalse(partner_company._can_edit_name())
-        self.assertTrue(all(p._can_edit_name() for p in partner_company.child_ids))
+        self.assertFalse(partner_company._can_edit_country())
+        self.assertTrue(all(p._can_edit_country() for p in partner_company.child_ids))
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
             'partner_id': partner_1.id,
@@ -593,7 +593,7 @@ class TestCheckoutAddress(WebsiteSaleCommon):
             ],
         })
         invoice.action_post()
-        self.assertFalse(partner_1._can_edit_name())
+        self.assertFalse(partner_1._can_edit_country())
 
     def test_11_payment_term_when_address_change(self):
         """Make sure the expected payment terms are set on ecommerce orders"""


### PR DESCRIPTION
Multiple changes to the addresses creation or updates (portal or ecommerce checkout flows):

* Forbid country updates when address was already used on SO/invoices
* Allow company name edition on main customer address, updating the parent company if there is any
* Always allow name edition regardless of linked SO/invoices
* Display main account address last in the delivery/billing address choices
* If there is any billing address, 'Use same as delivery address' is not pre-selected anymore.
* other display improvements (better help messages, icons for delivery/billing addresses, ...)

task-4669485

