### PR TITLE
[FIX] website_event: incorrect drop zone message on new event pages

### DIFF
--- a/addons/website_event/models/website.py
+++ b/addons/website_event/models/website.py
@@ -57,6 +57,7 @@ class Website(models.Model):
                     wrap = tree.xpath('//div[@id="wrap"]')[0]
                     content_container = content_container[0]
                     content_container.attrib.pop('t-att-data-editor-sub-message', None)
+                    content_container.attrib.pop('data-editor-sub-message.translate', None)
                     content_container.attrib.pop('id', None)
 
                     if sections_arch:


### PR DESCRIPTION
The drop zone message `Following content will appear on all events.` should not
appear on newly created custom event pages, as it's misleading.

This issue was previously resolved, but a recent change to the translate attribute
of drop zone messages (https://github.com/odoo/odoo/pull/201511) reintroduced the bug.

We now ensure the translate attribute is removed when creating a new page to
prevent this message from showing incorrectly.

Task-3661323
