### PR TITLE
[IMP] l10n_in: add `l10n_in_code` in UoM

### DIFF
--- a/addons/l10n_in/data/uom_data.xml
+++ b/addons/l10n_in/data/uom_data.xml
@@ -81,4 +81,7 @@
     <record id="uom.product_uom_cubic_foot" model="uom.uom">
         <field name="l10n_in_code">OTH-OTHERS</field>
     </record>
+    <record id="uom.product_uom_milliliter" model="uom.uom">
+        <field name="l10n_in_code">MLT-MILILITRE</field>
+    </record>
 </odoo>


### PR DESCRIPTION
Purpose
=======
Odoo 18.1 introduced a new unit of measure: "Milliliter (ml)"
in the uom.uom model.

This commit adds `l10n_in_code` for this unit in l10n_in:
- "Milliliter (ml)" with code "MLT-MILILITRE"

(https://einvoice1.gst.gov.in/Others/MasterCodes) (select UQC Codes)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
