### PR TITLE
[FIX] base: fix error message partner form

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -8491,12 +8491,12 @@ msgstr ""
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_partner_form
-msgid "(Same Company Registry"
+msgid "(Same"
 msgstr ""
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_partner_form
-msgid "(Same Tax ID"
+msgid ") and"
 msgstr ""
 
 #. module: base
@@ -38426,7 +38426,7 @@ msgstr ""
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_partner_form
-msgid "and Company Registry"
+msgid "and"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -108,15 +108,21 @@
                     Potential duplicates:
                     <span invisible="not same_vat_partner_id or same_company_registry_partner_id">
                         <field name="same_vat_partner_id" context="{'show_address': False, 'show_vat': False}"/>
-                        (Same Tax ID <field name="vat_label"/>)
+                        (Same <field name="vat_label"/>)
                     </span>
                     <span invisible="same_vat_partner_id or not same_company_registry_partner_id">
                         <field name="same_company_registry_partner_id" context="{'show_address': False, 'show_vat': False}"/>
-                        (Same Company Registry <field name="company_registry_label"/>)
+                        (Same <field name="company_registry_label"/>)
                     </span>
-                    <span invisible="not same_vat_partner_id or not same_company_registry_partner_id">
+                    <span invisible="not (same_vat_partner_id and same_company_registry_partner_id and same_vat_partner_id == same_company_registry_partner_id)">
                         <field name="same_vat_partner_id" context="{'show_address': False, 'show_vat': False}"/>
-                        (Same Tax ID <field name="vat_label"/> and Company Registry <field name="company_registry_label"/>)
+                        (Same <field name="vat_label"/> and <field name="company_registry_label"/>)
+                    </span>
+                    <span invisible="not (same_vat_partner_id and same_company_registry_partner_id and same_vat_partner_id != same_company_registry_partner_id)">
+                        <field name="same_vat_partner_id" context="{'show_address': False, 'show_vat': False}"/>
+                        (Same <field name="vat_label"/>) and
+                        <field name="same_company_registry_partner_id" context="{'show_address': False, 'show_vat': False}"/>
+                        (Same <field name="company_registry_label"/>)
                     </span>
                 </div>
                 <sheet>


### PR DESCRIPTION
[FIX] base: fix error message partner form

This commit will fix two things:
- Currently, the error message if you have a duplicate tax id or a
duplicate company registry in the partner form displays the label of the
concerned field twice. With this commit, we display the label of that
field only once.
From : "Potential duplicates: Partner A (Same Tax ID Tax ID)"
To : "Potential duplicates: Partner A (Same Tax ID)"

- Currently, the error message shows only 1 partner even if the Tax ID
is duplicated with a partner A and the Company Registry is duplicated
with a partner B. With this commit, the partner
with the same Tax ID and the partner with the same Company Registry are
both printed in the error message if they are different.
From : "Potential duplicates: Partner A (Same Tax ID Tax ID and Company
Registry Company Registry)"
To : "Potential duplicates: Partner A (Same Tax ID) and Partner B (Same
Company Registry)"

The choice to not display the value of the field (vat or company
registry) was done because of technical constraints : it would be too
much of a development for an information that's already displayed on the
screen a few lines further on.

task-4668697

runbot : https://runbot.odoo.com/runbot/bundle/saas-18-1-error-message-partner-form-roto-358947


