### PR TITLE
[IMP] web,*: calendar: do not display "Edit" if can't edit

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
@@ -17,11 +17,6 @@
     </t>
 
     <t t-name="calendar.AttendeeCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary">
-        <xpath expr="//t[@t-if='isEventEditable']" position="after">
-            <t t-elif="isEventViewable">
-                <a href="#" class="btn btn-primary o_cw_popover_edit" t-on-click="onEditEvent">View</a>
-            </t>
-        </xpath>
         <xpath expr="//t[@t-if='isEventDeletable']" position="after">
             <a t-if="isEventArchivable and isEventDetailsVisible" href="#" class="btn btn-secondary o_cw_popover_archive_g" t-on-click="onClickArchive">Delete</a>
             <t t-if="displayAttendeeAnswerChoice">

--- a/addons/hr_homeworking_calendar/static/src/calendar/common/popover/calendar_common_popover.xml
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/popover/calendar_common_popover.xml
@@ -28,7 +28,7 @@
             </div>
             <div class="o_cw_body">
                 <t t-call="{{ constructor.subTemplates.body }}" />
-                <div class="card-footer border-top d-flex gap-1" t-att-class="{ 'o_footer_shrink': !hasFooter }">
+                <div t-if="hasFooter" class="card-footer border-top d-flex gap-1">
                     <t t-call="{{ constructor.subTemplates.footer }}" />
                 </div>
             </div>

--- a/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.xml
+++ b/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
     <t t-name="project.ProjectCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary">
-        <xpath expr="//t[@t-if='isEventEditable']" position="after">
+        <xpath expr="//t[@t-if='isEventDeletable']" position="before">
             <a href="#" class="btn btn-secondary" t-on-click="onClickViewTasks">View Tasks</a>
         </xpath>
     </t>

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.js
@@ -45,13 +45,16 @@ export class CalendarCommonPopover extends Component {
         return this.props.model.activeFields;
     }
     get isEventEditable() {
-        return true;
+        return this.props.model.canEdit;
     }
     get isEventDeletable() {
         return this.props.model.canDelete;
     }
+    get isEventViewable() {
+        return true;
+    }
     get hasFooter() {
-        return this.isEventEditable || this.isEventDeletable;
+        return this.isEventEditable || this.isEventDeletable || this.isEventViewable;
     }
 
     isInvisible(fieldNode, record) {

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
@@ -18,10 +18,6 @@ $o-cw-popup-avatar-size: 16px;
         background: none;
     }
 
-    .o_footer_shrink {
-        padding-top: 0px;
-        padding-bottom: 0px;
-    }
     .o_cw_popover_close {
         cursor: pointer;
     }

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -24,7 +24,7 @@
         </div>
         <div class="o_cw_body">
             <t t-call="{{ constructor.subTemplates.body }}" />
-            <div class="card-footer d-flex gap-1 border-top" t-att-class="{ 'o_footer_shrink': !hasFooter }">
+            <div t-if="hasFooter" class="card-footer d-flex gap-1 border-top">
                 <t t-call="{{ constructor.subTemplates.footer }}" />
             </div>
         </div>
@@ -67,8 +67,11 @@
     </t>
 
     <t t-name="web.CalendarCommonPopover.footer">
-        <t t-if="isEventEditable">
-            <a href="#" class="btn btn-primary o_cw_popover_edit" t-on-click="onEditEvent">Edit</a>
+        <t t-if="isEventEditable or isEventViewable">
+            <a href="#" class="btn btn-primary o_cw_popover_edit" t-on-click="onEditEvent">
+                <t t-if="isEventEditable">Edit</t>
+                <t t-else="">View</t>
+            </a>
         </t>
         <t t-if="isEventDeletable">
             <a href="#" class="btn btn-secondary o_cw_popover_delete" t-on-click="onDeleteEvent">Delete</a>


### PR DESCRIPTION
*calendar, hr_homeworking_calendar,project

In calendar views, clicking on an event opens the popover. In that popover, there's an "Edit" button allowing to open the event in a form view. That "Edit" button is there even if the user doesn't have edit access rights on the model. This commits labels it "View" in that situation.

task-4606641

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
