### PR TITLE
[IMP] mail: enable mobile back button to close chat window

### DIFF
--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -13,6 +13,7 @@ import {
 import { describe, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
+import { browser } from "@web/core/browser/browser";
 
 describe.current.tags("mobile");
 defineMailModels();
@@ -65,4 +66,16 @@ test("enter key should create a newline in composer", async () => {
     await insertText(".o-mail-Composer-input", "Other");
     await click(".o-mail-Composer-send");
     await contains(".o-mail-Message-body:has(br)", { textContent: "TestOther" });
+});
+
+test("close chat window using back button on mobile", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    patchUiSize({ size: SIZES.SM });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-ChatWindow");
+    await contains(".o-mail-ChatWindow-command", { text: "General" });
+    browser.dispatchEvent(new PopStateEvent("popstate"));
+    await contains(".o-mail-ChatWindow", { count: 0 });
 });


### PR DESCRIPTION
**Current behavior before PR:**

- The back button on mobile does not close the open chat window.
- Pressing it navigates away from the page instead of closing the chat window.
- Only the "X" button can be used to exit a chat.

**Desired behavior after PR is merged:**

- Pressing the mobile back button will now behave the same as clicking the "X" button.
- It will close the current chat window and prevents unwanted navigation in browser history.

task-[4563827](https://www.odoo.com/odoo/project/1519/tasks/4563827)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
