### PR TITLE
[FIX] mail: set default value for 'newWindow' in openRecord method  

### DIFF
--- a/addons/mail/static/src/views/web/activity/activity_controller.js
+++ b/addons/mail/static/src/views/web/activity/activity_controller.js
@@ -125,7 +125,7 @@ export class ActivityController extends Component {
         this.model.orm.call(this.props.resModel, "activity_send_mail", [resIds, templateID], {});
     }
 
-    async openRecord(record, { newWindow }) {
+    async openRecord(record, { newWindow } = {}) {
         const activeIds = this.model.root.records.map((datapoint) => datapoint.resId);
         this.props.selectRecord(record.resId, { activeIds, newWindow });
     }


### PR DESCRIPTION
Steps to Reproduce:
-  Open the industry fsm app and navigate to the activity view.
-  Click on any task to open its form view.

Issue:  
- A traceback error occurs when opening a task on large screens because
  'newWindow' is undefined.  

Fix:  
- Set a default empty objec in openRecord to ensure 'newWindow' is always defined.  

[Issue](https://github.com/odoo/enterprise/commit/2bd4b62d828cc0a283bcbf12eccd918c2d8076b6)

task-4664793