### PR TITLE
[FIX] account: prevent reconcile on Bank and Cash accounts

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -16000,6 +16000,15 @@ msgstr ""
 #: code:addons/account/models/account_account.py:0
 #, python-format
 msgid ""
+"You cannot have a Bank and Cash account that is reconcilable. (account code:"
+" %s)"
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/account_account.py:0
+#, python-format
+msgid ""
 "You cannot have a receivable/payable account that is not reconcilable. "
 "(account code: %s)"
 msgstr ""

--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -21,6 +21,8 @@ class AccountAccount(models.Model):
         for account in self:
             if account.account_type in ('asset_receivable', 'liability_payable') and not account.reconcile:
                 raise ValidationError(_('You cannot have a receivable/payable account that is not reconcilable. (account code: %s)', account.code))
+            if account.account_type == 'asset_cash' and account.reconcile:
+                raise ValidationError(_('You cannot have a Bank and Cash account that is reconcilable. (account code: %s)', account.code))
 
     @api.constrains('account_type')
     def _check_account_type_unique_current_year_earning(self):


### PR DESCRIPTION
Currently, it is possible to force the Allow Reconciliation of Bank and Cash accounts, which should not be the case.

Steps to reproduce:
- Go to Chart of Accounts
- Select all accounts and enable the “Allow Reconciliation” toggle
- This bypasses the _compute_reconcile function, allowing even Bank and Cash accounts to be set as reconcile.

opw-4658972