### PR TITLE
[FIX] account: exchange rounding reco issue

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1888,8 +1888,6 @@ class AccountMoveLine(models.Model):
             return currency._get_conversion_rate(aml.company_currency_id, currency, aml.company_id, exchange_rate_date)
 
         def get_accounting_rate(aml, currency):
-            if forced_rate := self._context.get('forced_rate_from_register_payment'):
-                return forced_rate
             balance = aml._get_reconciliation_aml_field_value('balance', shadowed_aml_values)
             amount_currency = aml._get_reconciliation_aml_field_value('amount_currency', shadowed_aml_values)
             if not aml.company_currency_id.is_zero(balance) and not currency.is_zero(amount_currency):
@@ -2033,6 +2031,20 @@ class AccountMoveLine(models.Model):
         debit_fully_matched = compare_amounts <= 0
         credit_fully_matched = compare_amounts >= 0
 
+        def get_amount_range_after_rate(currency_from, currency_to, amount, rate):
+            # Suppose balance=1000, rate=12.
+            # 1000.0 could be the result of a rounding of [999.995, 1000.0049999999999].
+            # Let's say the target currency could be [999.995 * 12, 1000.005 * 12] = [11999.94, 12000.06]
+            # instead of just 120000.
+            if not rate:
+                return 0.0, 0.0, 0.0
+            half_rounding = currency_from.rounding / 2
+            return (
+                currency_to.round((amount - half_rounding) * rate),
+                currency_to.round(amount * rate),
+                currency_to.round((amount + half_rounding) * rate),
+            )
+
         # ==== Computation of partial amounts ====
         if recon_currency == company_currency:
             if exchange_line_mode:
@@ -2067,17 +2079,59 @@ class AccountMoveLine(models.Model):
                 credit_rate = credit_recon_values['rate']
 
             # Compute the partial amount expressed in foreign currency.
-            if debit_rate:
-                partial_debit_amount = company_currency.round(min_recon_amount / debit_rate)
-                partial_debit_amount = min(partial_debit_amount, remaining_debit_amount)
-            else:
-                partial_debit_amount = 0.0
-            if credit_rate:
-                partial_credit_amount = company_currency.round(min_recon_amount / credit_rate)
-                partial_credit_amount = min(partial_credit_amount, -remaining_credit_amount)
-            else:
-                partial_credit_amount = 0.0
+            partial_debit_amount_range = get_amount_range_after_rate(
+                currency_from=debit_currency,
+                currency_to=company_currency,
+                amount=min_recon_amount,
+                rate=(1 / debit_rate) if debit_rate else 0.0,
+            )
+            partial_debit_amount = partial_debit_amount_range[1]
+            partial_debit_amount = min(partial_debit_amount, remaining_debit_amount)
+            partial_credit_amount_range = get_amount_range_after_rate(
+                currency_from=credit_currency,
+                currency_to=company_currency,
+                amount=min_recon_amount,
+                rate=(1 / credit_rate) if credit_rate else 0.0,
+            )
+            partial_credit_amount = partial_credit_amount_range[1]
+            partial_credit_amount = min(partial_credit_amount, -remaining_credit_amount)
             partial_amount = min(partial_debit_amount, partial_credit_amount)
+
+            # Prevent exchange differences if amounts are close enough to be a rounding issue
+            # after applying the exchange rate and then, rounding amounts to store them into
+            # the monetary fields.
+            # Suppose 2 lines:
+            # l1: balance=377554.0, amount_currency=20000.0
+            # l2: balance=-5314.62, amount_currency=-281.53
+            # ... computing min_recon_amount = min(20000.0, 281.53) = 281.53 in foreign currency to reconcile.
+            # The equivalent of 281.53 for l1 in company currency is 5314.64 that could be the result of rounding any value
+            # between [5314.54, 5314.7300000000005]
+            # ... considering the rate of 0.05297255491929631 and the rounding applied to reach this value.
+            # For l2, it will be 5314.62 in the range [5314.53, 5314.71].
+            #
+            # ---------
+            # | 5314.73         ---------       <- max amount
+            # |                 5314.71  |
+            # |                          |
+            # | 5314.64                  |
+            # |                 5314.62  |      Every number between the min and the max are considered as valid to be the partial amount.
+            # |                          |      Depending on the one we choose, we can avoid to create an exchange difference entry or
+            # |                          |      we could also prevent to let an unnecessary open residual amount.
+            # | 5314.54                  |
+            # ---------         5314.53  |      <- min amount
+            #                   ---------
+            if (
+                company_currency.compare_amounts(partial_debit_amount, partial_credit_amount_range[2]) <= 0
+                and company_currency.compare_amounts(partial_debit_amount, partial_credit_amount_range[0]) >= 0
+                and company_currency.compare_amounts(partial_credit_amount, partial_debit_amount_range[2]) <= 0
+                and company_currency.compare_amounts(partial_credit_amount, partial_debit_amount_range[0]) >= 0
+            ):
+                if debit_fully_matched:
+                    partial_amount = remaining_debit_amount
+                else:
+                    partial_amount = -remaining_credit_amount
+                partial_debit_amount = partial_amount
+                partial_credit_amount = partial_amount
 
             # Compute the partial amount expressed in foreign currency.
             # Take care to handle the case when a line expressed in company currency is mimicking the foreign

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -1895,6 +1895,174 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
         self.assertTrue(all([line.full_reconcile_id for line in reversed_lines]))
 
+    def test_reconcile_foreign_currency_rounding_issue(self):
+        comp_curr = self.company_data['currency']
+        foreign_currency = self.env['res.currency'].create({
+            'name': "Bread",
+            'symbol': '🍞',
+            'rounding': 0.01,
+            'rate_ids': [
+                Command.create({'name': '2019-06-01', 'rate': 0.052972554919}),
+            ],
+        })
+
+        non_rec_pay_account = self.company_data['default_account_revenue'].copy()
+        non_rec_pay_account.reconcile = True
+        self.assertFalse(non_rec_pay_account.account_type in ('asset_receivable', 'liability_payable'))
+        rec_pay_account = self.company_data['default_account_receivable'].copy()
+        self.assertTrue(rec_pay_account.reconcile)
+        self.assertTrue(rec_pay_account.account_type in ('asset_receivable', 'liability_payable'))
+
+        # Check that the reconciliation works independently of
+        # - whether the foreign amount is debit or credit
+        # - the account type (payable / receivable)
+        for sign, reco_account in [
+            (-1, non_rec_pay_account),
+            (1, non_rec_pay_account),
+            (-1, rec_pay_account),
+            (1, rec_pay_account),
+        ]:
+            with self.subTest(sub_test_name=f'sign: {sign}, reco_account: {reco_account.name}'):
+                line_1 = self.create_line_for_reconciliation(
+                    balance=sign * 377554.0,
+                    amount_currency=sign * 20000.0,
+                    currency=foreign_currency,
+                    move_date='2019-06-01',
+                    account_1=reco_account,
+                )
+                line_2 = self.create_line_for_reconciliation(
+                    balance=-sign * 372239.38,
+                    amount_currency=-sign * 372239.38,
+                    currency=comp_curr,
+                    move_date='2019-06-01',
+                    account_1=reco_account,
+                )
+                line_3 = self.create_line_for_reconciliation(
+                    balance=-sign * 5314.62,
+                    amount_currency=-sign * 281.53,
+                    currency=foreign_currency,
+                    move_date='2019-06-01',
+                    account_1=reco_account,
+                )
+                amls = line_1 + line_2 + line_3
+                amls.reconcile()
+
+                full_reconcile = amls.full_reconcile_id
+                self.assertTrue(full_reconcile)
+                self.assertTrue(all(line.full_reconcile_id == full_reconcile for line in amls))
+                self.assertRecordValues(
+                    amls,
+                    [{'amount_residual': 0.0, 'amount_residual_currency': 0.0, 'reconciled': True}] * len(amls),
+                )
+
+                partials = self._get_partials(amls)
+                if sign == 1:
+                    expected_partials = [
+                        {
+                            'amount': 5314.62,
+                            'debit_amount_currency': 281.53,
+                            'credit_amount_currency': 281.53,
+                            'debit_move_id': line_1.id,
+                            'credit_move_id': line_3.id,
+                        },
+                        {
+                            'amount': 372239.38,
+                            'debit_amount_currency': 19718.47,
+                            'credit_amount_currency': 372239.38,
+                            'debit_move_id': line_1.id,
+                            'credit_move_id': line_2.id,
+                        },
+                    ]
+                else:
+                    expected_partials = [
+                        {
+                            'amount': 5314.62,
+                            'debit_amount_currency': 281.53,
+                            'credit_amount_currency': 281.53,
+                            'debit_move_id': line_3.id,
+                            'credit_move_id': line_1.id,
+                        },
+                        {
+                            'amount': 372239.38,
+                            'debit_amount_currency': 372239.38,
+                            'credit_amount_currency': 19718.47,
+                            'debit_move_id': line_2.id,
+                            'credit_move_id': line_1.id,
+                        },
+                    ]
+                self.assertRecordValues(partials.sorted('amount'), expected_partials)
+
+    def test_reconcile_partial_exchange_rounding_issue(self):
+        comp_curr = self.company_data['currency']
+        foreign_currency = self.env['res.currency'].create({
+            'name': "Bread",
+            'symbol': '🍞',
+            'rounding': 0.01,
+            'rate_ids': [
+                Command.create({'name': '2019-06-01', 'rate': 0.052972554919}),
+            ],
+        })
+
+        non_rec_pay_account = self.company_data['default_account_revenue'].copy()
+        non_rec_pay_account.reconcile = True
+        self.assertFalse(non_rec_pay_account.account_type in ('asset_receivable', 'liability_payable'))
+        rec_pay_account = self.company_data['default_account_receivable'].copy()
+        self.assertTrue(rec_pay_account.reconcile)
+        self.assertTrue(rec_pay_account.account_type in ('asset_receivable', 'liability_payable'))
+
+        # Check that the reconciliation works independently of
+        # - whether the foreign amount is debit or credit
+        # - the account type (payable / receivable)
+        for sign, reco_account in [
+            (-1, non_rec_pay_account),
+            (1, non_rec_pay_account),
+            (-1, rec_pay_account),
+            (1, rec_pay_account),
+        ]:
+            with self.subTest(sub_test_name=f'sign: {sign}, reco_account: {reco_account.name}'):
+                line_1 = self.create_line_for_reconciliation(
+                    balance=sign * 377554.0,
+                    amount_currency=sign * 20000.0,
+                    currency=foreign_currency,
+                    move_date='2019-06-01',
+                    account_1=reco_account,
+                )
+                line_2 = self.create_line_for_reconciliation(
+                    balance=-sign * 372239.38,
+                    amount_currency=-sign * 372239.38,
+                    currency=comp_curr,
+                    move_date='2019-06-01',
+                    account_1=reco_account,
+                )
+                amls = line_1 + line_2
+                amls.reconcile()
+
+                full_reconcile = amls.full_reconcile_id
+                self.assertFalse(full_reconcile)
+
+                partials = self._get_partials(amls)
+                if sign == 1:
+                    expected_partials = [
+                        {
+                            'amount': 372239.38,
+                            'debit_amount_currency': 19718.47,
+                            'credit_amount_currency': 372239.38,
+                            'debit_move_id': line_1.id,
+                            'credit_move_id': line_2.id,
+                        },
+                    ]
+                else:
+                    expected_partials = [
+                        {
+                            'amount': 372239.38,
+                            'debit_amount_currency': 372239.38,
+                            'credit_amount_currency': 19718.47,
+                            'debit_move_id': line_2.id,
+                            'credit_move_id': line_1.id,
+                        },
+                    ]
+                self.assertRecordValues(partials.sorted('amount'), expected_partials)
+
     def test_reconcile_special_mexican_workflow_1(self):
         comp_curr = self.company_data['currency']
         foreign_curr = self.env['res.currency'].create({


### PR DESCRIPTION
Currently the reconciliation may create unnecessary exchange difference entries or have unnecessary residual amounts.
This can happen in case we try to reconcile lines with multiple currencies.

Consider e.g. the following case (c.f. the added test cases in the code):
company currency: EUR
foreign currency: USD
rate: 1 EUR = 18.8777 USD (1 USD = 0.052972554919 EUR)
rounding: Both EUR and USD are rounded to 2 decimal places (to 0.01)

Lines to reconicle:
line0 |   20000.00 USD |  377554.00 EUR
line1 | -372239.38 EUR | -372239.38 EUR

Perfect write-off line for a full reconciliation (w/o exchange difference or remaining residuals)
line2 |    -281.53 USD |   -5314.62 EUR

Since
EUR: 377554.00 + -372239.38 = 5314.62
USD: 200000.00 + USD.round(-372239.38 * 0.052972554919) = 200000.00 + USD.round(-19718.47100006451) = 281.53

Note the actually used exchange rates during the reconciliation are not necessarily the ones from the currencies.
They could also be (re)computed from the lines.

Note that the "reconciliation currency" may be choosen differently in the following cases
- the reconciled account is a payable (`liability_payable`) or receivable (`asset_receivable`) account
- the reconciled account has another type

In the code see
- `recon_currency` in `_prepare_reconciliation_single_partial`
- `is_rec_pay_account` in `_prepare_move_line_residual_amounts`

#### Problem (1); receivable / payable account & partial reconciliation
In this case we reconcile line0 and line1 and the account on the lines is either a payable or a receivable account.

The following happens
1. Due to the account type we try to match the foreign currency (USD) amounts.
   line1: 20000.00 USD
   line2: 19718.47 USD (= USD.round(-372239.38 * ≈0.052972554919) = USD.round(-19718.47100006451))
   USD: 19718.47 (= min(20000.00, 19718.47))
2. Use the exchange rate (from line0) to compute the value in EUR (company currency)
   EUR: 372239.36 (= EUR.round(19718.47 * ≈18.8777) = EUR.round(372239.36111900007))
3. We still have a residual of 0.02 EUR on line1.
   But since line2 was fully matched in step 1 we create an exchange difference entry
   (to cover for the residual in company currency)

Issue:
We could have matched 372239.38 EUR on both lines since the difference (0.02 EUR) is just a rounding error.
Here 372239.38 EUR represents the full remaining amount in company currency on line1.
Then there would have been no residual (and thus no need for an exchange difference entry)

#### Problem (2); other account type & try full reconciliation with correct write-off line
In this case we reconcile line0 and line1 and line2 and the account on the lines is neither payable nor receivable.

First the reconciliation will reconcile line0 and line2 (roughly speaking since they have the same foreign currency).
1. Since both are in foreign currency we try to match these amounts first:
   USD: 281.53 (= min(20000.00, 281.53))
2. We then use the exchange rate to compute the value in EUR (company currency)
   line0, EUR: 5314.64 (= EUR.round(281.53 * ≈18.8777) = EUR.round(5314.638881))
   line2, EUR: 5314.62 (281.53 converted via the "custom" rate on line2)
3. We now have the following residuals
   line0 (residuals) |   19718.47 USD |  372239.36 EUR
   line2 (residuals) |       0.00 USD |       0.00 EUR
   We substracted 5314.64 EUR from line0 but only 5314.62 EUR from line2.
4. To account for the difference we create an exchange difference entry

We could have matched 5314.62 EUR on both lines (since the difference is just a rounding error)
This way we could void the exchange difference entry.
And we would also have a "correct" residual on line0.
The residuals on line0 will cause the full reconciliation to fail (see below).

Next the reconciliation will match line1 with the residuals of line0
The following happens.
1. We try to match company currency amounts first (due to the account type)
   line0, EUR: 372239.36
   line1, EUR: 372239.38
   EUR: 372239.36 = min(372239.38, 372239.36)
2. Compute the amounts in currency
   line0, USD:  19718.47 (= USD.round(372239.36 * ≈0.052972554919))
   line1, EUR: 372239.36 (= 372239.36 * 1)
3. We now have the following residuals
   line0 (residuals) |       0.00 USD |       0.02 EUR
   line1 (residuals) |       0.00 USD |       0.00 EUR
4. The reconciliation ends without creating an exchange difference entry

#### Solution

Problem (1)
In case the remaining amount (in company currency) could be fully matched if not for rounding issues
we will just match the full remaining amount.

Problem (2)
We match the company currency amounts of the individual lines to a common value if they are the same up to exchange rounding issues.

#### References

opw-4438542