### PR TITLE
[IMP] mrp: open stock quant for update kits-components on-hand qty

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -365,7 +365,6 @@ class ProductProduct(models.Model):
             components |= self.env['product.product'].concat(*[l[0].product_id for l in bom_sub_lines])
         res = super(ProductProduct, components).action_open_quants()
         if bom_kits:
-            res['context']['single_product'] = False
             res['context'].pop('default_product_tmpl_id', None)
         return res
 

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -61,6 +61,9 @@ class ProductTemplate(models.Model):
                 template.show_on_hand_qty_status_button = template.product_variant_count <= 1
                 template.show_forecasted_qty_status_button = False
 
+    def _should_open_product_quants(self):
+        return super()._should_open_product_quants() or self.is_kits
+
     def _compute_used_in_bom_count(self):
         for template in self:
             template.used_in_bom_count = self.env['mrp.bom'].search_count(

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -133,10 +133,7 @@ class ProductProduct(models.Model):
     @api.depends('product_tmpl_id')
     def _compute_show_qty_update_button(self):
         for product in self:
-            product.show_qty_update_button = (
-                product.product_tmpl_id._should_open_product_quants()
-                or product.tracking != 'none'
-            )
+            product.show_qty_update_button = product.product_tmpl_id._should_open_product_quants()
 
     @api.depends('barcode')
     def _compute_valid_ean(self):
@@ -894,7 +891,6 @@ class ProductTemplate(models.Model):
             product.show_qty_update_button = (
                 product._should_open_product_quants()
                 or product.product_variant_count > 1
-                or product.tracking != 'none'
             )
 
     @api.depends(


### PR DESCRIPTION
1.There was no option for update the on-hand qty of the `components` for a product
which has a `bom type` of `kit` and none of the following options are active.

Update button visible for the cases like:
- Product has more than 1 variants.
- Product has tracking of `lot` or `Serial`.
- Enable Storage Locations.
- Enable Consignment.

Currently, if user tries to update the quantity of that product it will give
`user error`: "You should update the components quantity instead of directly
updating the quantity of the kit product."

2.When a kit product has only one component, updating the qty allows the user to
  modify the qty of any product instead of restricting it to the component only.

With this commit :
--------------------------
Now user can update the `on-hand qty` of the `components` for a product which
has a `bom type` of `kit` from `update button`. which opens the stock quant list
view and displaying its quants of the components.

for single-component kits, when updating the product quantity in the
stock quant view, the component is now automatically `preselected` and made
`read-only`, ensuring that only the correct component's quantity
can be updated.

Task ID: [4600627](https://www.odoo.com/odoo/project/966/tasks/4600627)