### PR TITLE
[FIX] html_editor: prevent file boxes from being editable by portal users

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/core/file/static_file.xml
+++ b/addons/html_editor/static/src/others/embedded_components/core/file/static_file.xml
@@ -7,7 +7,7 @@
                 t-att-title="fileModel.filename" t-att-data-mimetype="fileModel.mimetype"/>
             <!-- file name -->
             <span class="o_file_name_container mx-2">
-                <a class="o_link_readonly" t-att-href="fileModel.downloadUrl"
+                <a class="o_link_readonly o-contenteditable-true" t-att-href="fileModel.downloadUrl"
                     t-out="fileModel.filename"
                     contenteditable="true"/>
             </span>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/file_blueprint.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/file_blueprint.xml
@@ -1,6 +1,6 @@
 <templates>
     <t t-name="html_editor.EmbeddedFileBlueprint">
         <span t-att-data-embedded-props="embeddedProps" data-embedded="file"
-            data-oe-protected="true" contenteditable="false" class="o_file_box"/>
+            data-oe-protected="true" contenteditable="false" class="o_file_box o-contenteditable-false"/>
     </t>
 </templates>


### PR DESCRIPTION
**Problem**:
File boxes contain elements with `contenteditable=true`. Once saved, portal users can edit them even when the editor is disabled.

**Solution**:
Use the new mechanism introduced in
[69fb021](https://github.com/odoo/odoo/pull/201139/commits/69fb0216dee2bbea407ca6f3c3ef9f1cc71a2f6b), by adding `o-contenteditable-true` and `o-contenteditable-false` classes to file banners.

**Steps to reproduce**:
1. Navigate to **Sales > Product**.
2. Open any product.
3. In the **Sales** tab, add a **banner** to "Ecommerce Description".
4. Save and click **Go to Website**.
   - **Issue**: The banner remains editable, even when the editor is disabled.

**opw-4597744**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
