### PR TITLE
[FIX] stock_account: set children product categories in AVCO

### DIFF
--- a/addons/stock_account/data/stock_account_demo.xml
+++ b/addons/stock_account/data/stock_account_demo.xml
@@ -4,6 +4,13 @@
         <record id="product.product_category_furniture" model="product.category">
             <field name="property_cost_method">average</field>
         </record>
+        <record id="product.product_category_office" model="product.category">
+            <field name="property_cost_method">average</field>
+        </record>
+        <record id="product.product_category_outdoor_furniture" model="product.category">
+            <field name="property_cost_method">average</field>
+        </record>
+
         <record id="product.product_category_construction" model="product.category">
             <field name="property_cost_method">fifo</field>
         </record>


### PR DESCRIPTION
Since the parent category 'Furniture' is in AVCO, its children should be too.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
