### PR TITLE
[FIX] point_of_sale: reset single qty combo

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.js
@@ -125,16 +125,16 @@ export class ComboConfiguratorPopup extends Component {
         }
     }
 
-    resetComboQuantities(comboId) {
-        for (const itemId in this.state.qty[comboId]) {
-            this.state.qty[comboId][itemId] = 0;
+    resetSingleQtyMaxCombo(combo) {
+        if (combo.qty_max === 1) {
+            for (const itemId in this.state.qty[combo.id]) {
+                this.state.qty[combo.id][itemId] = 0;
+            }
         }
     }
 
     async onClickSimpleProduct(combo_item, combo) {
-        if (combo.qty_max === 1) {
-            this.resetComboQuantities(combo.id);
-        }
+        this.resetSingleQtyMaxCombo(combo);
         if (this.totalQuantityForCombo(combo.id) < combo.qty_max) {
             this.state.qty[combo.id][combo_item.id] += 1;
         }
@@ -148,7 +148,7 @@ export class ComboConfiguratorPopup extends Component {
             } else {
                 const payload = await this.pos.openConfigurator(product.product_tmpl_id);
                 if (payload) {
-                    this.resetComboQuantities(combo.id);
+                    this.resetSingleQtyMaxCombo(combo);
                     this.state.configuration[combo_item.id] = payload;
                     this.state.qty[combo.id][combo_item.id] = 1;
                 }


### PR DESCRIPTION
- Fix issue that was reseting combo choice quantities (for configurable product), when selecting an other choice in the combo.
- When clicking a combo choice, reset combo quantity only for combos with `qty_max === 1`, otherwise keep the quantities defined for each combo choice.

task-id: 4642341



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
