### PR TITLE
[FIX] point_of_sale: scale not displaying price

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -32,7 +32,7 @@ export class ProductTemplate extends Base {
         const config = this.models["pos.config"].getFirst();
         const productTemplate = this instanceof ProductTemplate ? this : this.product_tmpl_id;
         const basePrice = this?.lst_price || productTemplate.getPrice(pricelist, 1);
-        const priceUnit = price === undefined ? basePrice : price;
+        const priceUnit = price || price === 0 ? price : basePrice;
         const currency = config.currency_id;
         const extraValues = { currency_id: currency };
 


### PR DESCRIPTION
See https://github.com/odoo/enterprise/pull/82873 for the updated test.

In commit 9e84f87, some refactoring was made to tax calculation in order to make it easier to override. However, a bug was introduced in the `prepareProductBaseLineForTaxesComputationExtraValues` of the product template model, where the default `false` value would be incorrectly used, leading to a price of 0.

Steps to reproduce:
- Configure a scale in the POS
- Add a weighed product, e.g. the demo 'Flour' product
- In the scale popup, observe that the price per unit (and therefore total price) is 0.00

task-4702650

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
