### PR TITLE
[FIX] stock: add description to DTE guide

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -52,7 +52,7 @@ class StockMove(models.Model):
         'move_id', 'template_attribute_value_id',
         string="Never attribute Values"
     )
-    description_picking = fields.Text('Description of Picking')
+    description_picking = fields.Text('Description of Picking', readonly=False, store=True, compute='_compute_description_picking')
     product_qty = fields.Float(
         'Real Quantity', compute='_compute_product_qty', inverse='_set_product_qty',
         digits=0, store=True, compute_sudo=True,
@@ -2494,3 +2494,8 @@ Please change the quantity done or the rounding precision of your unit of measur
         return self.location_dest_id.usage in ('customer', 'supplier') or (
             self.location_dest_id.usage == 'transit' and not self.location_dest_id.company_id
         )
+
+    @api.depends('description_picking')
+    def _compute_description_picking(self):
+        for move in self:
+            move.description_picking = move.product_id.description_picking


### PR DESCRIPTION
When generating a 'Delivery Guide SII DTE 52 (CL)' the picking description was not always displayed.

Steps to reproduce:
-------------------
* Install l10n_cl_edi_stock
* In Sales app, make a new quotation
* Add a product and confirm
* Click on the Delivery smart button
* Click on the gear icon > Print > Delivery Guide SII DTE 52 (CL)

> Observation:

Why the fix:
------------
We now use the picking description of the line, which inherits from the product's picking description. This improves clarity, makes the line's description more useful, and preserves the original behavior. 
Enterprise pr: https://github.com/odoo/enterprise/pull/81920

opw-4596901

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
