### PR TITLE
[FIX] html_editor: traceback issue when clicking at the start of a link

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -427,12 +427,14 @@ export class LinkPlugin extends Plugin {
 
                 // Handle selection movement.
                 if (isCursorAtStartOfLink || isCursorAtEndOfLink) {
-                    const block = closestBlock(linkElement);
-                    const linkIndex = [...block.childNodes].indexOf(linkElement);
+                    const [targetNode, targetOffset] = isCursorAtStartOfLink
+                        ? leftPos(linkElement)
+                        : rightPos(linkElement);
                     this.dependencies.selection.setSelection({
-                        anchorNode: block,
-                        anchorOffset: isCursorAtStartOfLink ? linkIndex - 1 : linkIndex + 2,
+                        anchorNode: targetNode,
+                        anchorOffset: isCursorAtStartOfLink ? targetOffset - 1 : targetOffset + 1,
                     });
+                    return;
                 }
             }
         }

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -91,6 +91,20 @@ describe("should position the cursor outside the link", () => {
         expect(getContent(el)).toBe('<p>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</p>');
     });
 
+    test("clicking at the start of the link when format is applied on link", async () => {
+        const { el } = await setupEditor('<p><strong><a href="#/">test</a></strong></p>');
+        expect(getContent(el)).toBe('<p><strong>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>');
+
+        const aElement = queryOne("p a");
+        await pointerDown(el);
+        // Simulate the selection with mousedown
+        setSelection({ anchorNode: aElement.childNodes[0], anchorOffset: 0 });
+        expect(getContent(el)).toBe('<p><strong>\ufeff<a href="#/">[]\ufefftest\ufeff</a>\ufeff</strong></p>');
+        await animationFrame(); // selection change
+        await pointerUp(el);
+        expect(getContent(el)).toBe('<p><strong>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>');
+    });
+
     test("clicking at the end of the link", async () => {
         const { el } = await setupEditor('<p><a href="#/">test</a></p>');
         expect(getContent(el)).toBe('<p>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</p>');


### PR DESCRIPTION
**Current behavior before PR:**

- Clicking at the start of a link which has some format applied on it would trigger a traceback error.

**Desired behavior after PR is merged:**

- Now, Clicking at the start of the formatted link will now correctly display the cursor before the link.

task:4699778