### PR TITLE
[FIX] calendar: fix error when previewing a mail template

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -113,7 +113,7 @@ class CalendarAttendee(models.Model):
         # simplify computation, we have no other choice than relying on it
         return {
             attendee.id: {
-                'partner_ids': attendee.partner_id.ids,
+                'partners': attendee.partner_id,
                 'email_to_lst': [],
                 'email_cc_lst': [],
             } for attendee in self


### PR DESCRIPTION
When a user previews the mail template for Calendar Attendee Information,
A traceback will appear.

Steps to reproduce the error:
- Install ``calendar``
- Now go to Email Templates >
 Open email template (Applies to: ``Calendar Attendee Information``)
- Click Preview

Traceback:
```
File "/home/odoo/src/odoo/saas-18.2/addons/mail/models/models.py", line 300, in _message_get_default_recipients
    all_emails += defaults['partners'].mapped('email_normalized')
KeyError: 'partners'
```
https://github.com/odoo/odoo/blob/09099ab477bd871c67205388d96172280cd714a5/addons/mail/models/models.py#L300 Here, ``partners`` key is accessed but at [1] key is ``partner_ids``,
So, it will lead to the above traceback.

1-https://github.com/odoo/odoo/blob/09099ab477bd871c67205388d96172280cd714a5/addons/calendar/models/calendar_attendee.py#L116

sentry-6505820998

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
