### PR TITLE
[FIX] website_sale: show zero-priced alternative products

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -176,8 +176,6 @@ class WebsiteSnippetFilter(models.Model):
             excluded_products |= current_template.product_variant_ids
             included_products = current_template.alternative_product_ids.product_variant_ids
             products = included_products - excluded_products
-            if website.prevent_zero_price_sale:
-                products = products.filtered(lambda p: p._get_contextual_price())
             if products:
                 domain = expression.AND([
                     domain,


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Configure website to prevent sale of zero-priced products;
2. add a zero-priced product as an alternative product to a product;
3. open the product in eCommerce.

Issue
-----
The alternative products block with the zero-priced product isn't shown.

Cause
-----
The `_get_products_alternative_products` method filters out zero-priced products out of its end result. It is the only snippet filter to do this.

Solution
--------
Don't filter out zero-priced products, as users may still want those products to be visible, even if not available for sale.

opw-4443410