### PR TITLE
[FIX] mail: restrict role mentions to partners having access

### DIFF
--- a/addons/mail/controllers/discuss/thread.py
+++ b/addons/mail/controllers/discuss/thread.py
@@ -1,13 +1,20 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.http import request
 from odoo.addons.mail.controllers.thread import ThreadController
 
 
 class DiscussThreadController(ThreadController):
     def _filter_message_post_partners(self, thread, partners):
-        if thread._name == "discuss.channel":
-            domain = [("channel_id", "=", thread.id), ("partner_id", "in", partners.ids)]
-            # sudo: discuss.channel.member - filtering partners that are members is acceptable
-            return request.env["discuss.channel.member"].sudo().search(domain).partner_id
-        return super()._filter_message_post_partners(thread, partners)
+        if thread._name != "discuss.channel":
+            return super()._filter_message_post_partners(thread, partners)
+        if thread.channel_type == "channel":
+            if group := ((thread.parent_channel_id or thread).group_public_id):
+                domain = [("id", "in", partners.ids), ("user_ids.all_group_ids", "in", group.ids)]
+                # sudo: res.partner - filtering partners that have the correct group is acceptable.
+                partners = self.env["res.partner"].sudo().search(domain)
+            # Non-internal users can only mention members of the channel which is handled below.
+            if self.env.user._is_internal():
+                return partners
+        domain = [("channel_id", "=", thread.id), ("partner_id", "in", partners.ids)]
+        # sudo: discuss.channel.member - filtering partners that are members is acceptable
+        return self.env["discuss.channel.member"].sudo().search(domain).partner_id

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -376,6 +376,7 @@ export class Composer extends Component {
                             return {
                                 label: suggestion.name,
                                 role: suggestion,
+                                thread: this.thread,
                                 optionTemplate: "mail.Composer.suggestionRole",
                                 classList: "o-mail-Composer-suggestion",
                             };

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -210,7 +210,10 @@
 
     <t t-name="mail.Composer.suggestionRole">
         <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate" t-esc="option.label"/>
-        <em class="text-600 text-truncate align-self-center">Notify users with this role</em>
+        <em class="text-600 text-truncate align-self-center">
+            <t t-if="option.thread?.channel_type === 'channel'">Notify users with this role who have permission to view this channel</t>
+            <t t-else="">Notify users with this role</t>
+        </em>
     </t>
 
     <t t-name="mail.Composer.suggestionThread">

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -11,6 +11,7 @@ from . import test_discuss_channel_member
 from . import test_discuss_mail_presence
 from . import test_discuss_message_update_controller
 from . import test_discuss_reaction_controller
+from . import test_discuss_res_role
 from . import test_discuss_sub_channels
 from . import test_discuss_thread_controller
 from . import test_message_controller

--- a/addons/mail/tests/discuss/test_discuss_res_role.py
+++ b/addons/mail/tests/discuss/test_discuss_res_role.py
@@ -1,0 +1,57 @@
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.mail.tests.test_res_role import TestResRole
+from odoo.tests.common import tagged
+
+
+@tagged("-at_install", "post_install")
+class TestDiscussResRole(TestResRole):
+    def test_only_mention_by_role_when_channel_is_accessible(self):
+        self.authenticate("admin", "admin")
+        role = self.env["res.role"].create({"name": "rd-Discuss"})
+        for idx, test_case in enumerate([
+            # channel_type, channel_grp, user_grp, is_member, mentionned
+            ("channel", None, "base.group_user", False, True),
+            ("channel", None, "base.group_user", True, True),
+            ("channel", "base.group_system", "base.group_user", False, False),
+            ("channel", "base.group_system", "base.group_system", True, True),
+            ("group", None, "base.group_user", False, False),
+            ("group", None, "base.group_user", True, True),
+        ]):
+            channel_type, channel_grp, user_grp, is_member, mentionned = test_case
+            with self.subTest(
+                channel_type=channel_type,
+                channel_grp=channel_grp,
+                user_grp=user_grp,
+                is_member=is_member,
+                notified=mentionned,
+            ):
+                channel = self.env["discuss.channel"].create(
+                    {
+                        "name": f"channel_{channel_grp}_{user_grp}_{mentionned}",
+                        "channel_type": channel_type,
+                        "group_public_id": self.env.ref(channel_grp).id if channel_grp else None,
+                    }
+                )
+                user = mail_new_test_user(
+                    self.env, login=f"user_{user_grp}_{idx}", role_ids=role.ids, groups=user_grp
+                )
+                if is_member:
+                    channel.add_members(partner_ids=user.partner_id.ids)
+                data = self.make_jsonrpc_request(
+                    "/mail/message/post",
+                    {
+                        "thread_model": "discuss.channel",
+                        "thread_id": channel.id,
+                        "post_data": {
+                            "body": "irrelevant",
+                            "message_type": "comment",
+                            "role_ids": role.ids,
+                            "subtype_xmlid": "mail.mt_note",
+                        },
+                    },
+                )
+                formatted_partner = {"id": user.partner_id.id, "type": "partner"}
+                if mentionned:
+                    self.assertIn(formatted_partner, data["mail.message"][0]["recipients"])
+                else:
+                    self.assertNotIn(formatted_partner, data["mail.message"][0]["recipients"])

--- a/addons/project/controllers/thread.py
+++ b/addons/project/controllers/thread.py
@@ -7,7 +7,7 @@ from odoo.addons.mail.controllers import thread
 
 class ThreadController(thread.ThreadController):
     def _filter_message_post_partners(self, thread, partners):
-        if thread._name == "project.task":
+        if thread._name == "project.task" and not self.env.user._is_internal():
             domain = [
                 ("res_model", "=", "project.task"),
                 ("res_id", "=", thread.id),


### PR DESCRIPTION
Before this PR, mentionning a role would notify every partners linked to this role, regardless of whether they can access the channel or not.

This PR solves the issue by filtering partners that can actually access the channel (i.e. having the correct group when the channel type is "channel", being member otherwise).

task-4680858

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
