### PR TITLE
[FIX] point_of_sale: prevent removal of unsynced orders from pendingOrders

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1296,7 +1296,8 @@ export class PosStore extends Reactive {
                     .forEach((order) => (order.session_id = this.session));
             }
 
-            this.clearPendingOrder();
+            // Remove only synced orders from the pending orders
+            orders.forEach((o) => this.removePendingOrder(o));
             return newData["pos.order"];
         } catch (error) {
             if (options.throw) {


### PR DESCRIPTION
In `syncAllOrders`, we can specify which orders should be synced using options.
This means that not all pending orders need to be synced at once. 
However, `clearPendingOrder` currently removes all pending orders, 
even those that haven't been synced, leading to order loss.

This commit ensures that only synced orders are removed from pendingOrders.

Task: 4702408
