### PR TITLE
[FIX] stock{,_barcode}: mutex barcode model validations

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1129,6 +1129,7 @@ class Picking(models.Model):
         self.package_level_ids.filtered(lambda p: not p.move_ids).unlink()
 
     def button_validate(self):
+        self = self.filtered(lambda p: p.state != 'done')
         draft_picking = self.filtered(lambda p: p.state == 'draft')
         draft_picking.action_confirm()
         for move in draft_picking.move_ids:


### PR DESCRIPTION
### Issue:

Spamming the validation button in the barcode app can end up performing the operation on an already processed record and raise an invalid operation.

### Steps to reproduce:

- Create and confirm a delivery for 1 unit of a storable product.
- In the barcode app, scan 1 unit
- Spam the validate button
#### > An invalid operation is raised: You can not validate a transfer if no quantities are reserved.

### Cause of the issue:

Spamming the validate button will launch concurrent calls of the `validate` method. However, if the record has already been processed by a call of the validate method, the next call might be performed on an updated record that should not be able to be validated.

opw-4599862
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
