### PR TITLE
[FIX] stock: bypass picking validation for already validated pickings

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1129,6 +1129,7 @@ class Picking(models.Model):
         self.package_level_ids.filtered(lambda p: not p.move_ids).unlink()
 
     def button_validate(self):
+        self = self.filtered(lambda p: p.state != 'done')
         draft_picking = self.filtered(lambda p: p.state == 'draft')
         draft_picking.action_confirm()
         for move in draft_picking.move_ids:

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2605,6 +2605,36 @@ class TestSinglePicking(TestStockCommon):
             ('Shell 2', 'LOT004', 2.0),
         ])
 
+    def test_validate_picking_twice(self):
+        """
+        Check that validating an already validated picking bypasses the call.
+        """
+        picking = self.env['stock.picking'].create({
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+            'picking_type_id': self.picking_type_out,
+            'move_ids': [
+                Command.create({
+                    'name': 'Lovely Move',
+                    'product_id': self.productA.id,
+                    'product_uom_qty': 50,
+                    'location_id': self.stock_location,
+                    'location_dest_id': self.customer_location,
+                    'product_uom': self.productA.uom_id.id,
+                }),
+            ],
+        })
+        picking.button_validate()
+        self.assertEqual(picking.state, 'done')
+        self.assertRecordValues(picking.move_ids, [
+            {'quantity': 50.0, 'state': 'done'}
+        ])
+        picking.button_validate()
+        self.assertEqual(picking.state, 'done')
+        self.assertRecordValues(picking.move_ids, [
+            {'quantity': 50.0, 'state': 'done'}
+        ])
+
 
 class TestStockUOM(TestStockCommon):
     @classmethod


### PR DESCRIPTION
### Issue:

Spamming the validation button in the barcode app can end up performing the operation on an already processed record and raise an invalid operation.

### Steps to reproduce:

- Create and confirm a delivery for 1 unit of a storable product.
- In the barcode app, scan 1 unit
- Spam the validate button
#### > An invalid operation is raised: You can not validate a transfer if no quantities are reserved.

### Cause of the issue:

Spamming the validate button will launch concurrent calls of the `validate` method. However, if the record has already been processed by a call of the validate method, the next call might be performed on an updated record that should not be able to be validated.

opw-4599862
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
