### PR TITLE
[FIX] hr_attendance : Set Extra hours to zero when refuse overtime

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -162,8 +162,10 @@ class HrAttendance(models.Model):
         with_validation = self - no_validation
 
         for attendance in with_validation:
-            if attendance.overtime_status not in ['approved', 'refused']:
+            if attendance.overtime_status == 'to_approve':
                 attendance.validated_overtime_hours = attendance.overtime_hours
+            elif attendance.overtime_status == 'refused':
+                attendance.validated_overtime_hours = 0
 
         for attendance in no_validation:
             attendance.validated_overtime_hours = attendance.overtime_hours

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -581,3 +581,20 @@ class TestHrAttendanceOvertime(TransactionCase):
             'check_out': datetime(2023, 1, 4, 9, 0)
         })
         self.assertEqual(attendance.overtime_hours, 0, 'There should be no overtime for the fully flexible resource.')
+
+    def test_refuse_timeoff(self):
+        self.company.write({
+            "attendance_overtime_validation": "by_manager"
+        })
+
+        attendance = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2023, 1, 2, 8, 0),
+            'check_out': datetime(2023, 1, 3, 16, 0)
+        })
+
+        self.assertEqual(attendance.validated_overtime_hours, 23)
+        self.assertEqual(attendance.overtime_hours, attendance.validated_overtime_hours)
+
+        attendance.action_refuse_overtime()
+        self.assertEqual(attendance.validated_overtime_hours, 0)


### PR DESCRIPTION
### Steps to reproduce:
	- Go to settings, set the overtime of an attendance to be validated by a manager
	- Go to attendance, create an attendance with an overtime
	- Worked Extra Hours and Extra Hours are the same
	- Refuse the overtime - Extra Hours is not 0

### Cause:
This is happening because when computing the overtime validated hours we are just setting it equals to the worked extra hours value when the status of the attendance is to_approve but when it got refused we don't re-compute the value.

https://github.com/odoo/odoo/blob/0d0c1bc7c075f49a461c66a433e20b431276ff12/addons/hr_attendance/models/hr_attendance.py#L164-L166

### Fix:
We are overriding the value for the validated overtime hours now when it got refused and set it equals to 0

opw-4675268