### PR TITLE
[IMP] orm: put field cache API on fields

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3224,9 +3224,9 @@ class MailThread(models.AbstractModel):
         if not recipients_data:
             return recipients_data
         # cache data fetched by manual query to avoid extra queries when reading user.partner_id
-        for r in filter(lambda r: r["uid"], recipients_data):
-            user = self.env["res.users"].browse(r["uid"])
-            self.env.cache.insert_missing(user, user._fields["partner_id"], [r["id"]])
+        uid2pid = {r['uid']: r['id'] for r in recipients_data if r['uid']}
+        users = self.env['res.users'].browse(uid2pid)
+        users._fields['partner_id']._insert_cache(users, uid2pid.values())
         # if scheduled for later: add in queue instead of generating notifications
         scheduled_date = self._is_notification_scheduled(kwargs.pop('scheduled_date', None))
         if scheduled_date:

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -1447,7 +1447,6 @@ class Base(models.AbstractModel):
         self.env.flush_all()
 
         env = self.env
-        cache = env.cache
         first_call = not field_names
 
         if not (self and self._name == 'res.users'):
@@ -1500,11 +1499,9 @@ class Base(models.AbstractModel):
                 new_lines = lines.browse(map(NewId, line_ids))
                 for field_name in sub_fields_spec:
                     field = lines._fields[field_name]
-                    line_values = [
-                        field.convert_to_cache(line[field_name], new_line, validate=False)
-                        for new_line, line in zip(new_lines, lines)
-                    ]
-                    cache.update(new_lines, field, line_values)
+                    for new_line, line in zip(new_lines, lines):
+                        line_value = field.convert_to_cache(line[field_name], new_line, validate=False)
+                        field._update_cache(new_line, line_value)
 
         # Isolate changed values, to handle inconsistent data sent from the
         # client side: when a form view contains two one2many fields that

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -504,7 +504,6 @@ class IrModuleModule(models.Model):
 
         # use the translation dic of the generic to translate the specific
         self.env.cr.flush()
-        cache = self.env.cache
         View = self.env['ir.ui.view']
         field = self.env['ir.ui.view']._fields['arch_db']
         # assume there are not too many records
@@ -538,7 +537,7 @@ class IrModuleModule(models.Model):
             for lang in langs_update:
                 specific_arch_db[lang] = field.translate(
                     lambda term: specific_translation_dictionary.get(term, {lang: None})[lang], specific_arch_db_en)
-            cache.update_raw(View.browse(specific_id), field, [specific_arch_db], dirty=True)
+            field._update_cache(View.with_context(prefetch_langs=True).browse(specific_id), specific_arch_db, dirty=True)
 
         default_menu = self.env.ref('website.main_menu', raise_if_not_found=False)
         if not default_menu:

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -237,11 +237,8 @@ class Website(models.Model):
                 # don't add child menu if parent is forbidden
                 if menu.parent_id and menu.parent_id in menus:
                     children[menu.parent_id] += (menu.id,)
-            menus.env.cache.update(
-                menus.browse(child.id for child in children),
-                menus._fields['child_id'],
-                children.values(),
-            )
+            for menu, child_items in children.items():
+                menu._fields['child_id']._update_cache(menu, child_items)
 
             # prefetch every website.page and ir.ui.view at once
             menus.mapped('is_visible')

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -920,7 +920,7 @@ class IrModelFields(models.Model):
             model = self.env.get(record.model)
             field = model and model._fields.get(record.name)
             if field:
-                self.env.cache.clear_dirty_field(field)
+                self.env._field_dirty.pop(field)
         # remove fields from registry, and check that views are not broken
         fields = [pop_field(self.env[record.model], record.name) for record in records]
         domain = Domain.OR([('arch_db', 'like', record.name)] for record in records)

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -682,8 +682,8 @@ actual arch.
         views = self.browse(row[0] for row in rows)
 
         # optimization: fill in cache of inherit_id and mode
-        self.env.cache.update(views, self._fields['inherit_id'], [row[1] for row in rows])
-        self.env.cache.update(views, self._fields['mode'], [row[2] for row in rows])
+        self._fields['inherit_id']._insert_cache(views, [row[1] for row in rows])
+        self._fields['mode']._insert_cache(views, [row[2] for row in rows])
 
         # During an upgrade, we can only use the views that have been
         # fully upgraded already.

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -704,7 +704,7 @@ class TestAPI(SavepointCaseWithUserDemo):
         with self.subTest("Should allow cross-group prefetching"):
             byfn = (p0 | p1 | p2).grouped('function')
             self.env.invalidate_all(flush=False)
-            self.assertFalse(self.env.cache._data, "ensure the cache is empty")
+            self.assertFalse(self.env.transaction.field_data, "ensure the cache is empty")
             self.assertEqual(byfn['guest'].mapped('name'), ['bob', 'rhod'])
             # name should have been prefetched by previous statement (on guest
             # group), so should be nothing here

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -4181,7 +4181,7 @@ class TestMany2oneReference(TransactionExpressionCase):
         reference.res_model = record._name
 
         # the model field 'res_model' is not in database yet
-        self.assertTrue(self.env.cache.has_dirty_fields(reference, [type(reference).res_model]))
+        self.assertIn(record.id, self.env._field_dirty[reference._fields['res_model']])
 
         # searching on the one2many should flush the field 'res_model'
         records = record.search([('model_ids.create_date', '!=', False)])

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -28,11 +28,6 @@ class Boolean(Field[bool]):
     def convert_to_column(self, value, record, values=None, validate=True):
         return bool(value)
 
-    def convert_to_column_update(self, value, record):
-        if self.company_dependent:
-            value = {k: bool(v) for k, v in value.items()}
-        return super().convert_to_column_update(value, record)
-
     def convert_to_cache(self, value, record, validate=True):
         return bool(value)
 

--- a/odoo/orm/fields_temporal.py
+++ b/odoo/orm/fields_temporal.py
@@ -4,7 +4,6 @@ import typing
 from datetime import date, datetime, time
 
 import pytz
-from psycopg2.extras import Json as PsycopgJson
 
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DATE_FORMAT
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT as DATETIME_FORMAT
@@ -48,11 +47,6 @@ class BaseDate(Field[T | typing.Literal[False]], typing.Generic[T]):
         granularity = READ_GROUP_NUMBER_GRANULARITY[property_name]
         sql_expr = SQL('date_part(%s, %s)', granularity, sql_expr)
         return sql_expr
-
-    def convert_to_column_update(self, value, record):
-        if self.company_dependent:
-            return PsycopgJson({k: self.convert_to_column(v, record) for k, v in value.items()})
-        return super().convert_to_column_update(value, record)
 
     def convert_to_column(self, value, record, values=None, validate=True):
         # we can write date/datetime directly using psycopg


### PR DESCRIPTION
Moving the cache management to fields so that they can independently customize the behaviour over how the cache is structured.

The data of the transaction is now available on the `Transaction` object. The `Cache` object stays, but most of its low-level methods are deprecated and it is just manipulating the data of the transaction through the fields.
The `Environment` gains a few lazy properties to be able to quickly access the cache while doing a minimum amount of calls.
`Field` has now generic methods to manipulate the cache and sub-classes can overwrite them.

Some performance improvements (some operations are similar in time). Results are quite volatile, but most common operations are 5-25% faster).
| operation | before | after |
| --------| --| --|
| read partner.name | 450ns | 330ns |
| read user.partner_id | 660ns | 570ns |
| read 3 users.partner_id | 1.7us | 1.2us |
| read 3 users.bank_ids | 2.9us | 2.4us |

task-4139371

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
