### PR TITLE
[FIX] account: correctly display terms and condition on invoice report

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -182,7 +182,7 @@
                             </tbody>
                         </table>
                         <div>
-                            <div id="right-elements" t-attf-class="#{'col-5' if report_type != 'html' else 'col-12 col-md-5'} ms-5 d-inline-block float-end">
+                            <div id="right-elements" t-attf-class="#{'col-5 mt-5' if report_type == 'pdf' else 'col-12 col-md-5'} ms-5 d-inline-block float-end">
                                 <div id="total" class="clearfix row mt-n3">
                                     <div class="ms-auto">
                                         <table class="o_total_table table table-borderless avoid-page-break-inside">
@@ -236,7 +236,7 @@
                                     <div class="oe_structure"/>
                                 </t>
                             </div>
-                            <div id="payment_term" class="clearfix overflow-hidden">
+                            <div id="payment_term" class="clearfix">
                                 <div class="justify-text">
                                     <p t-if="not is_html_empty(o.fiscal_position_id.note)" name="note" class="mb-2">
                                         <span t-field="o.fiscal_position_id.note"/>


### PR DESCRIPTION
**Issue**
The "Terms and Conditions" section in the invoice report only takes up half of the page, leaving unnecessary blank space on the other half.

**Steps to Reproduce:**
1. Install the Accounting app.
2. Navigate to Accounting > Customers > Invoices.
3. Create or open an invoice.
4. Add a multiline text in the "Terms and Conditions" field.
5. Confirm and print the invoice report.
6. Observe that the content only fills half the available width.

**Expected Behavior:**
The "Terms and Conditions" text should utilize the full width of the report layout if needed, especially for multiline entries.

**Actual Behavior:**
The text is constrained to half the page, reducing readability and leaving unused space.

**Root Cause**

The issue was introduced by PR #193399, which added the `overflow-auto` class to address a display bug from ticket 4416845. However, this class was applied too broadly, affecting the layout of the "Terms and Conditions" block.

**Fix**
To address this issue, a class is added specifically to the terms and conditions div to control its display.

opw-4698250

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
