### PR TITLE
[FIX] stock, mrp: enable lot tracking for the demo data 'Drawer'

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -488,10 +488,6 @@
             <field name="image_1920" type="base64" file="mrp/static/img/product_product_drawer_case_black.png"/>
         </record>
 
-        <record id="product.product_product_27" model="product.product">
-            <field name="tracking">lot</field>
-        </record>
-
         <record id="lot_product_27_0" model="stock.lot">
             <field name="name">0000000000030</field>
             <field name="product_id" ref="product.product_product_27"/>

--- a/addons/stock/data/stock_demo.xml
+++ b/addons/stock/data/stock_demo.xml
@@ -5,6 +5,11 @@
         <record id="base.user_demo" model="res.users">
             <field eval="[(3, ref('group_stock_manager')), (4, ref('group_stock_user'))]" name="groups_id"/>
         </record>
+
+        <record id="product.product_product_27" model="product.product">
+            <field name="tracking">lot</field>
+        </record>
+
          <record id="lot_product_27" model="stock.lot">
             <field name="name">0000000000029</field>
             <field name="product_id" ref="product.product_product_27"/>


### PR DESCRIPTION
The demo product 'Drawer' was initially configured to be tracked by quantity, 
but a lot was incorrectly created, and the stock quant was subsequently created 
for the 'Drawer' with lot.

Steps to reproduce
===============
- Install the 'stock' module with demo data.
- Navigate to Inventory > Products > Products and search for 'Drawer'.
- Observe that 'Drawer' is set to track by quantity (Tracking field).
- Check Inventory > Operations > Physical Inventory and locate the 
  stock quant for 'Drawer'.
- Note that a lot exists and is linked to the product 'Drawer', despite 
  the quantity tracking setting.

This commit modifies the demo data to enable lot tracking for the product, 
aligning its configuration with the existing lot and stock quant data for consistency.

