### PR TITLE
[IMP] sale,*: light improvements

### DIFF
--- a/addons/pos_loyalty/data/pos_loyalty_demo.xml
+++ b/addons/pos_loyalty/data/pos_loyalty_demo.xml
@@ -79,13 +79,13 @@
 
     <record id="loyalty_program_rule" model="loyalty.rule">
         <field name="reward_point_mode">money</field>
-        <field name="reward_point_amount">10</field>
+        <field name="reward_point_amount">1</field>
         <field name="program_id" ref="pos_loyalty.loyalty_program"/>
     </record>
 
     <record id="loyalty_program_reward" model="loyalty.reward">
         <field name="reward_type">product</field>
-        <field name="required_points">5</field>
+        <field name="required_points">50</field>
         <field name="reward_product_id" ref="pos_loyalty.simple_pen"/>
         <field name="program_id" ref="pos_loyalty.loyalty_program"/>
     </record>

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -18,7 +18,7 @@ class ProductTemplate(models.Model):
         help="Manually set quantities on order: Invoice based on the manually entered quantity, without creating an analytic account.\n"
              "Timesheets on contract: Invoice based on the tracked hours on the related timesheet.\n"
              "Create a task and track hours: Create a task on the sales order validation and track the work hours.")
-    sale_line_warn_msg = fields.Text(string="Message for Sales Order Line")
+    sale_line_warn_msg = fields.Text(string="Sales Order Line Warning")
     expense_policy = fields.Selection(
         selection=[
             ('no', "No"),

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -61,6 +61,15 @@
                     <strong>Expiration</strong>
                     <div t-field="doc.validity_date">2023-12-31</div>
                 </div>
+                <div t-if="doc.commitment_date" class="col" name="delivery_date">
+                    <strong>Delivery Date</strong>
+                    <div
+                        t-field="doc.commitment_date"
+                        t-options="{'widget': 'date'}"
+                    >
+                        2023-12-31
+                    </div>
+                </div>
                 <div t-if="doc.user_id.name" class="col">
                     <strong>Salesperson</strong>
                     <div t-field="doc.user_id">Mitchell Admin</div>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -806,7 +806,18 @@
                                 name="action_open_discount_wizard"
                                 type="object"
                                 class="btn btn-secondary"
-                                groups="sale.group_discount_per_so_line"/>
+                                groups="sale.group_discount_per_so_line"
+                                invisible="locked or state == 'cancel'"
+                            />
+                            <button
+                                string="Discounts"
+                                name="action_open_discount_wizard"
+                                type="object"
+                                class="btn btn-secondary"
+                                groups="sale.group_discount_per_so_line"
+                                disabled="1"
+                                invisible="not (locked or state == 'cancel')"
+                            />
                         </div>
                         <group name="note_group" col="6" class="mt-2 mt-md-0">
                             <group colspan="4" class="order-1 order-lg-0">

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -101,7 +101,7 @@
                             <span class='d-block d-md-none'>Ref.</span>
                         </th>
                         <th class="text-end">Order Date</th>
-                        <th class="text-end">Total</th>
+                        <th name="order_total" class="text-end">Total</th>
                     </tr>
                 </thead>
                 <t t-foreach="orders" t-as="order">
@@ -111,7 +111,9 @@
                             <span t-field="order.date_order" t-options="{'widget': 'date'}"/>&amp;nbsp;
                             <span class='d-none d-md-inline' t-field="order.date_order" t-options="{'time_only': True}"/>
                         </td>
-                        <td class="text-end"><span t-field="order.amount_total"/></td>
+                        <td name="order_amount_total" class="text-end">
+                            <span t-field="order.amount_total"/>
+                        </td>
                     </tr>
                 </t>
             </t>
@@ -604,6 +606,15 @@
                             <tr t-if="sale_order.client_order_ref">
                                 <th class="ps-0 pb-0">Your Reference:</th>
                                 <td class="w-100 pb-0 text-wrap"><span t-field="sale_order.client_order_ref"/></td>
+                            </tr>
+                            <tr t-if="sale_order.commitment_date">
+                                <th class="ps-0 pb-0">Delivery Date:</th>
+                                <td class="w-100 pb-0 text-wrap">
+                                    <span
+                                        t-field="sale_order.commitment_date"
+                                        t-options="{'widget': 'date'}"
+                                    />
+                                </td>
                             </tr>
                         </tbody>
                     </table>

--- a/addons/sale_loyalty/views/sale_order_views.xml
+++ b/addons/sale_loyalty/views/sale_order_views.xml
@@ -19,15 +19,38 @@
                 </button>
             </div>
             <button name="action_open_discount_wizard" position="before">
-                <button name="%(sale_loyalty.sale_loyalty_coupon_wizard_action)d"
-                        type="action"
-                        string="Coupon Code"
-                        class="btn btn-secondary"/>
-                <button name="action_open_reward_wizard"
-                        type="object"
-                        string="Reward"
-                        help="Update current promotional lines and select new rewards if applicable."
-                        class="btn btn-secondary"/>
+                <button
+                    string="Coupon Code"
+                    name="%(sale_loyalty.sale_loyalty_coupon_wizard_action)d"
+                    type="action"
+                    class="btn btn-secondary"
+                    invisible="locked or state == 'cancel'"
+                />
+                <button
+                    string="Coupon Code"
+                    name="%(sale_loyalty.sale_loyalty_coupon_wizard_action)d"
+                    type="action"
+                    class="btn btn-secondary"
+                    disabled="1"
+                    invisible="not (locked or state == 'cancel')"
+                />
+                <button
+                    string="Reward"
+                    name="action_open_reward_wizard"
+                    type="object"
+                    class="btn btn-secondary"
+                    help="Update current promotional lines and select new rewards if applicable."
+                    invisible="locked or state == 'cancel'"
+                />
+                <button
+                    string="Reward"
+                    name="action_open_reward_wizard"
+                    type="object"
+                    class="btn btn-secondary"
+                    help="Update current promotional lines and select new rewards if applicable."
+                    disabled="1"
+                    invisible="not (locked or state == 'cancel')"
+                />
             </button>
             <xpath expr="//list//field[@name='product_uom_qty']" position="before">
                 <field name="is_reward_line" column_invisible="True"/>

--- a/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
+++ b/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
@@ -34,7 +34,7 @@
                                 icon="fa-arrow-right"
                             />
                             <a
-                                href="https://www.youtube.com/watch?v=M_95g8_dhGk"
+                                href="https://www.youtube.com/watch?v=SIvlo2JFU_U"
                                 target="_blank"
                                 invisible="not quotation_document_ids"
                             >
@@ -42,7 +42,7 @@
                             </a>
                             <iframe
                                 title="Quote Builder Demo Video"
-                                src="https://www.youtube.com/embed/M_95g8_dhGk"
+                                src="https://www.youtube.com/embed/SIvlo2JFU_U?start=195"
                                 class="mt-2"
                                 style="height: 30rem;"
                                 invisible="quotation_document_ids"

--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="sale_order_portal_content_inherit_sale_stock"
+    <template
+        id="sale_stock.sale_order_portal_content_inherit_sale_stock"
         name="Orders Shipping Followup"
-        inherit_id="sale.sale_order_portal_content">
+        inherit_id="sale.sale_order_portal_content"
+    >
         <tbody id="sale_info_table" position="inside">
             <tr t-if="sale_order.incoterm">
                 <th class="pb-0">Incoterm:</th>
@@ -104,6 +106,50 @@
                 </t>
             </div>
         </div>
+    </template>
+
+    <template
+        id="sale_stock.portal_my_orders"
+        name="Portal Orders Shipping Status Column"
+        inherit_id="sale.portal_my_orders"
+    >
+        <th name="order_total" position="before">
+            <th class="text-end" name="order_delivery">Shipping Status</th>
+        </th>
+        <td name="order_amount_total" position="before">
+            <td class="text-end" name="order_delivery_status">
+                <span
+                    t-if="order.delivery_status == 'pending'"
+                    class="badge rounded-pill text-bg-warning"
+                >
+                    Not Delivered
+                </span>
+                <span
+                    t-elif="order.delivery_status == 'started'"
+                    class="badge rounded-pill text-bg-primary"
+                >
+                    Started
+                </span>
+                <span
+                    t-elif="order.delivery_status == 'partial'"
+                    class="badge rounded-pill text-bg-info"
+                >
+                    Partially Delivered
+                </span>
+                <span
+                    t-elif="order.delivery_status == 'full'"
+                    class="badge rounded-pill text-bg-success"
+                >
+                    Delivered
+                </span>
+                <span
+                    t-else=""
+                    class="badge rounded-pill text-bg-danger"
+                >
+                    Not Available
+                </span>
+            </td>
+        </td>
     </template>
 
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Improvements to Sales module and portal view.

Current behavior before PR:
- Delivery date always shown in PDF  
- Old demo reward for Simple Pen  
- Sales warning field had a label  
- Static quote builder video timestamp  
- No Shipping Status in SO portal

Desired behavior after PR is merged: 
- Show delivery date in PDF only if set  
- Update Simple Pen reward to 1 per $50  
- Remove label from sales warning field  
- Use dynamic timestamp for quote video  
- Show Shipping Status in SO portal view

See also:

- Enterprise PR: https://github.com/odoo/enterprise/pull/82886

Task-4402920
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
