### PR TITLE
[FIX] point_of_sale: add demo tax group

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_demo.xml
+++ b/addons/point_of_sale/data/point_of_sale_demo.xml
@@ -70,11 +70,15 @@
         </record>
 
         <!-- Taxes -->
+        <record id="pos_taxe_group_0" model="account.tax.group">
+            <field name="name">PoS Taxes</field>
+        </record>
 
         <record id="pos_taxes_0" model="account.tax">
             <field name="name">Default Tax for PoS</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
+            <field name="tax_group_id" ref="pos_taxe_group_0"/>
         </record>
 
         <!-- Products -->


### PR DESCRIPTION
The demo POS tax assumes the presence of a tax group that matches the company and country domains. This is a correct assumption on install because of the post-install [loading](https://github.com/odoo/odoo/blob/ce25577ba6cd6ab178cf05b111aebcf8e1815624/addons/account/demo/account_demo.xml#L31-L35) of the generic_coa in account module, but it is not necessarily true on upgrade, where the loading function is [not called](https://github.com/odoo/odoo/blob/36e6d6ea6792d5e549a7794f111a65fc32decd1c/odoo/tools/convert.py#L276-L278). Upgrading from 16.0 can happen without a coa loaded on the company, leading to the absence of a matching tax group, and the failure of loading the pos demo data.

runbot error 161547

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
