### PR TITLE
[PERF] mrp: Speedup _compute_move_finished_ids

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -764,6 +764,7 @@ class MrpProduction(models.Model):
 
     @api.depends('product_id', 'bom_id', 'product_qty', 'product_uom_id', 'location_dest_id', 'date_finished', 'move_dest_ids')
     def _compute_move_finished_ids(self):
+        production_with_move_finished_ids_to_unlink_ids = OrderedSet()
         for production in self:
             if production.state != 'draft':
                 updated_values = {}
@@ -776,9 +777,15 @@ class MrpProduction(models.Model):
                         Command.update(m.id, updated_values) for m in production.move_finished_ids
                     ]
                 continue
-            # delete to remove existing moves from database and clear to remove new records
-            production.move_finished_ids = [Command.delete(m) for m in production.move_finished_ids.ids]
-            production.move_finished_ids = [Command.clear()]
+            production_with_move_finished_ids_to_unlink_ids.add(production.id)
+
+        production_with_move_finished_ids_to_unlink = self.browse(production_with_move_finished_ids_to_unlink_ids)
+
+        # delete to remove existing moves from database and clear to remove new records
+        production_with_move_finished_ids_to_unlink.move_finished_ids = [Command.delete(m) for m in production_with_move_finished_ids_to_unlink.move_finished_ids.ids]
+        production_with_move_finished_ids_to_unlink.move_finished_ids = [Command.clear()]
+
+        for production in production_with_move_finished_ids_to_unlink:
             if production.product_id:
                 production._create_update_move_finished()
             else:


### PR DESCRIPTION
### Description:

When confirming a sale order with products on MTO, it can trigger the method _run_manufacture to generate the manufacturing order linked to it. However, this part can take a long time to be processed because of the multiple compute stored triggered on the way (mostly from the field `move_finished_ids`).

### Fix:

To speed this up, we can extract the deletion of the previous finished moves so the ORM can batch delete in `_compute_move_finished_ids`.

### Benchmark:

| # of lines with MTO | Before  | After  |
|---------------------|---------|--------|
|  20                 |    3:48 |   2:48 |
|  10                 |    1:45 |   1:18 |

### Reference:

opw-4629884