### PR TITLE
[FIX] point_of_sale: prevent error when pay order in different config

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -96,6 +96,10 @@ class PosOrder(models.Model):
         else:
             pos_order = existing_order
 
+            # If the order is belonging to another session, it must be moved to the current session first
+            if order.get('session_id') and order['session_id'] != pos_order.session_id.id:
+                pos_order.write({'session_id': order['session_id']})
+
             # Save lines and payments before to avoid exception if a line is deleted
             # when vals change the state to 'paid'
             for field in ['lines', 'payment_ids']:


### PR DESCRIPTION
Before this commit, validating an order that belonged to a different PoS configuration could result in an error if the selected payment method was not available in the current configuration. This prevented the order from being successfully validated.

opw-4687658

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
