### PR TITLE
[IMP] web: allow multiple match on dynamicSelectors

### DIFF
--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -209,8 +209,12 @@ export class Colibri {
     getNodes(sel) {
         const selectors = this.interaction.dynamicSelectors;
         if (sel in selectors) {
-            const elem = selectors[sel]();
-            return elem ? [elem] : [];
+            const elems = selectors[sel]();
+            if (elems) {
+                return elems[Symbol.iterator] ? elems : [elems];
+            } else {
+                return [];
+            }
         }
         return this.interaction.el.querySelectorAll(sel);
     }

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -376,6 +376,28 @@ describe("using selectors", () => {
         );
         expect("span").toHaveAttribute("animal", "colibri");
     });
+
+    test("dynamic selector can return multiple nodes", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicSelectors = {
+                _myselector: () => this.el.querySelectorAll(".my-selector"),
+            };
+            dynamicContent = {
+                _myselector: { "t-att-animal": () => "colibri" },
+            };
+        }
+        await startInteraction(
+            Test,
+            `
+            <div class="test">
+                <span class="my-selector">coucou</span>
+                <span class="my-selector">coucou</span>
+                <span class="my-selector">coucou</span>
+            </div>`
+        );
+        expect(queryAll("span")).toHaveAttribute("animal", "colibri");
+    });
 });
 
 describe("removing listeners", () => {


### PR DESCRIPTION
In interactions, `dynamicSelectors` only accepted single-match. There is no technical reason for that limitation, so this commit allows to return arrays of elements (or array-like, like a NodeList).