### PR TITLE
[IMP] hr_timesheet: ensure accurate worked hours calculation in timesheet

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models
 from odoo.exceptions import RedirectWarning, ValidationError
-from odoo.tools import SQL
+from odoo.tools import SQL, float_round
 from odoo.tools.translate import _
 
 
@@ -24,7 +24,7 @@ class ProjectProject(models.Model):
 
     timesheet_ids = fields.One2many('account.analytic.line', 'project_id', 'Associated Timesheets', export_string_translation=False)
     timesheet_encode_uom_id = fields.Many2one('uom.uom', compute='_compute_timesheet_encode_uom_id', export_string_translation=False)
-    total_timesheet_time = fields.Integer(
+    total_timesheet_time = fields.Float(
         compute='_compute_total_timesheet_time', groups='hr_timesheet.group_hr_timesheet_user',
         string="Total amount of time (in the proper unit) recorded in the project, rounded to the unit.", export_string_translation=False)
     encode_uom_in_days = fields.Boolean(compute='_compute_encode_uom_in_days', export_string_translation=False)
@@ -128,7 +128,7 @@ class ProjectProject(models.Model):
                 total_time += unit_amount * (1.0 if project.encode_uom_in_days else factor)
             # Now convert to the proper unit of measure set in the settings
             total_time /= project.timesheet_encode_uom_id.factor
-            project.total_timesheet_time = int(round(total_time))
+            project.total_timesheet_time = float_round(total_time, precision_digits=2)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_timesheet/tests/test_project_project.py
+++ b/addons/hr_timesheet/tests/test_project_project.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.tests import TransactionCase, tagged
 
 
@@ -61,3 +62,32 @@ class TestProjectProject(TransactionCase):
         }])
         self.assertEqual(project1.account_id, analytic_account, 'Project 1 should have the default analytic account')
         self.assertEqual(project2.account_id, analytic_account, 'Project 2 should have the default analytic account')
+
+    def test_compute_total_timesheet_time(self):
+        employee = self.env['hr.employee'].create({
+             'name': 'Test Employee',
+        })
+
+        project = self.env['project.project'].create({
+            'name': 'Test Project',
+            'allocated_hours': 1.0,
+        })
+
+        self.env['project.task'].create({
+            'name': 'Test Task',
+            'project_id': project.id,
+            'timesheet_ids': [
+                Command.create({
+                    'name': '/',
+                    'employee_id': employee.id,
+                    'unit_amount': 0.5,
+                }),
+                Command.create({
+                    'name': '/',
+                    'employee_id': employee.id,
+                    'unit_amount': 0.25,
+                }),
+            ],
+        })
+
+        self.assertEqual(project.total_timesheet_time, 0.75, 'The total timesheet time should be 0.75 (00:45) hours.')


### PR DESCRIPTION
Previously, timesheet incorrectly displayed remaining time due to rounding issues.

For example, if 1 hour was allocated and 30 minutes were logged, it showed `+1:00` instead of the correct `+00:30`.

Now, worked hours reflect the exact logged duration without unintended rounding.

Task Id: 4216964