### PR TITLE
[IMP] web: allow multiple match on dynamicSelectors

### DIFF
--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -209,8 +209,15 @@ export class Colibri {
     getNodes(sel) {
         const selectors = this.interaction.dynamicSelectors;
         if (sel in selectors) {
-            const elem = selectors[sel]();
-            return elem ? [elem] : [];
+            const elems = selectors[sel]();
+            if (elems) {
+                if (elems.nodeName && ["FORM", "SELECT"].includes(elems.nodeName)) {
+                    return [elems];
+                }
+                return elems[Symbol.iterator] ? elems : [elems];
+            } else {
+                return [];
+            }
         }
         return this.interaction.el.querySelectorAll(sel);
     }

--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -343,7 +343,12 @@ export class Interaction {
      * @returns {Function} removes the listeners
      */
     addListener(target, event, fn, options) {
-        const nodes = target[Symbol.iterator] ? target : [target];
+        let nodes;
+        if (target.nodeName && ["FORM", "SELECT"].includes(target.nodeName)) {
+            nodes = [target];
+        } else {
+            nodes = target[Symbol.iterator] ? target : [target];
+        }
         const [ev, handler, opts] = this.__colibri__.addListener(nodes, event, fn, options);
         return () => nodes.forEach((node) => node.removeEventListener(ev, handler, opts));
     }

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -376,6 +376,50 @@ describe("using selectors", () => {
         );
         expect("span").toHaveAttribute("animal", "colibri");
     });
+
+    test("dynamic selector can return multiple nodes", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicSelectors = {
+                _myselector: () => this.el.querySelectorAll(".my-selector"),
+            };
+            dynamicContent = {
+                _myselector: { "t-att-animal": () => "colibri" },
+            };
+        }
+        await startInteraction(
+            Test,
+            `
+            <div class="test">
+                <span class="my-selector">coucou</span>
+                <span class="my-selector">coucou</span>
+                <span class="my-selector">coucou</span>
+            </div>`
+        );
+        expect(queryAll("span")).toHaveAttribute("animal", "colibri");
+    });
+
+    test("dynamicSelector on form element is applied on form, not on controls", async () => {
+        // <form> and <select> elements are iterable. Make sure that listeners
+        // and dynamic attributes are applied on the element, not its children.
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                _root: { "t-att-animal": () => "colibri" },
+            };
+        }
+        await startInteraction(
+            Test,
+            `
+            <form class="test">
+                <input type="text">coucou</input>
+                <button type="button"/>Submit</button>
+            </form>`
+        );
+        expect(".test").toHaveAttribute("animal", "colibri");
+        expect(".test input").not.toHaveAttribute("animal");
+        expect(".test button").not.toHaveAttribute("animal");
+    });
 });
 
 describe("removing listeners", () => {

--- a/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
@@ -173,10 +173,6 @@ export class DynamicSnippet extends Interaction {
                     delete carouselEl.dataset.bsRide;
                     delete carouselEl.dataset.bsInterval;
                 }
-                window.Carousel.getInstance(carouselEl)?.dispose();
-                if (!this.withSample) {
-                    window.Carousel.getOrCreateInstance(carouselEl);
-                }
             });
         }, 0);
     }


### PR DESCRIPTION
In interactions, `dynamicSelectors` only accepted single-match. There is no technical reason for that limitation, so this commit allows to return arrays of elements (or array-like, like a NodeList).
