### PR TITLE
[FIX] web: only trim string values in set defaults debug menu

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -282,7 +282,10 @@ class SetDefaultDialog extends Component {
                 return option[0] === value;
             })[1];
         }
-        if (displayed.length > 60) {
+        if (
+            (typeof displayed === "string" || displayed instanceof String) &&
+            displayed.length > 60
+        ) {
             displayed = displayed.slice(0, 57) + "...";
         }
         return [value, displayed];

--- a/addons/web/static/tests/core/debug/debug_manager_tests.js
+++ b/addons/web/static/tests/core/debug/debug_manager_tests.js
@@ -823,6 +823,7 @@ QUnit.module("DebugMenu", (hooks) => {
         registry.category("debug").category("form").add("setDefaults", setDefaults);
 
         const serverData = getActionManagerServerData();
+        serverData.models.partner.fields.description = { string: "Description", type: "html" };
         serverData.actions[1234] = {
             id: 1234,
             xml_id: "action_1234",
@@ -833,7 +834,17 @@ QUnit.module("DebugMenu", (hooks) => {
             views: [[18, "form"]],
         };
         const fooValue = "12".repeat(250);
+        serverData.views["partner,18,form"] = `
+            <form>
+                <group>
+                    <field name="display_name"/>
+                    <field name="description"/>
+                    <field name="foo"/>
+                </group>
+            </form>
+        `;
         serverData.models.partner.records[0].foo = fooValue;
+        serverData.models.partner.records[0].description = fooValue;
         const mockRPC = async (route, args) => {
             if (args.method === "check_access_rights") {
                 return Promise.resolve(true);
@@ -860,6 +871,8 @@ QUnit.module("DebugMenu", (hooks) => {
             "": "",
             display_name: "Display Name = First record",
             foo: "Foo = 121212121212121212121212121212121212121212121212121212121...",
+            description:
+                "Description = 121212121212121212121212121212121212121212121212121212121...",
         });
 
         select.value = "foo";


### PR DESCRIPTION
Steps to reproduce
==================

- In 18, go to a view with an always invisible many2one field
- Enable debug mode
- In the debug menu, click on "Set defaults"

=> Cannot read properties of undefined (reading 'length')

Cause of the issue
==================

We only fetch the display name for many2one that are not always invisible

https://github.com/odoo/odoo/blob/6a1c38a83a1a9108ae4cbfe36bf787bef02de063/addons/web/static/src/model/relational_model/utils.js#L383-L384

In that case, `displayed` will be undefined.

a0732ec87edbb7fee6ebc76ea093bc8a52fd3fad didn't check if displayed was defined. It also checked the length of non-string values. While it doesn't cause an error, it doesn't make sense.

A comparison of `typeof displayed === "string"` is not enough, because we also need to handle Markup elements.

opw-4572496