### PR TITLE
[IMP] website: improve popup usability and clarify visibility options

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5891,7 +5891,12 @@ registry.SnippetMove = SnippetOptionWidget.extend(ColumnLayoutMixin, {
                 case "prev": {
                     // Consider only visible elements.
                     let prevEl = this.$target[0].previousElementSibling;
-                    while (prevEl && window.getComputedStyle(prevEl).display === "none") {
+                    while (
+                        prevEl &&
+                        (window.getComputedStyle(prevEl).display === "none" ||
+                         prevEl.classList.contains('s_popup') ||
+                         prevEl.classList.contains('s_popup_close'))
+                    ){
                         prevEl = prevEl.previousElementSibling;
                     }
                     prevEl?.insertAdjacentElement("beforebegin", this.$target[0]);
@@ -5903,7 +5908,12 @@ registry.SnippetMove = SnippetOptionWidget.extend(ColumnLayoutMixin, {
                 case "next": {
                     // Consider only visible elements.
                     let nextEl = this.$target[0].nextElementSibling;
-                    while (nextEl && window.getComputedStyle(nextEl).display === "none") {
+                    while (
+                        nextEl &&
+                        (window.getComputedStyle(nextEl).display === "none" ||
+                         nextEl.classList.contains('s_popup') ||
+                         nextEl.classList.contains('s_popup_close'))
+                    ) {
                         nextEl = nextEl.nextElementSibling;
                     }
                     nextEl?.insertAdjacentElement("afterend", this.$target[0]);
@@ -5986,7 +5996,12 @@ registry.SnippetMove = SnippetOptionWidget.extend(ColumnLayoutMixin, {
             // Consider only visible elements.
             const direction = moveUpOrLeft ? "previousElementSibling" : "nextElementSibling";
             let siblingEl = this.$target[0][direction];
-            while (siblingEl && window.getComputedStyle(siblingEl).display === "none") {
+            while (
+                siblingEl &&
+                (window.getComputedStyle(siblingEl).display === "none" ||
+                 siblingEl.classList.contains('s_popup') ||
+                 siblingEl.classList.contains('s_popup_close'))
+            ) {
                 siblingEl = siblingEl[direction];
             }
             return !!siblingEl;

--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -51,9 +51,9 @@
         <t t-set="extra_popup_options">
             <we-colorpicker string="Close Button Color" data-select-style="true" data-css-property="color" data-color-prefix="text-" data-apply-to=".s_popup_close"/>
             <we-select string="Display" data-attribute-name="display" data-attribute-default-value="always">
-                <we-button data-select-data-attribute="afterDelay" data-name="show_delay">Delay</we-button>
-                <we-button data-select-data-attribute="mouseExit">On Exit</we-button>
-                <we-button data-select-data-attribute="onClick" data-name="onclick_opt">On Click (via link)</we-button>
+                <we-button data-select-data-attribute="afterDelay" data-name="show_delay" title="Automatically opens the pop-up if the user stays on a page longer than the specified time.">Delay</we-button>
+                <we-button data-select-data-attribute="mouseExit" data-name="show_on_exit" title="Pop up appears when a user is about to leave the website.">On Exit</we-button>
+                <we-button data-select-data-attribute="onClick" data-name="onclick_opt" title="Use the link generated to open the pop up.">On Click (via link)</we-button>
             </we-select>
             <we-input string="&#8985; Delay" title="Automatically opens the pop-up if the user stays on a page longer than the specified time." data-select-data-attribute="" data-attribute-name="showAfter" data-unit="s" data-save-unit="ms" data-dependencies="show_delay"/>
             <we-input string="Hide For" title="Once the user closes the popup, it won't be shown again for that period of time." data-select-data-attribute.translate="7 days" data-attribute-name="consentsDuration" data-unit.translate="days" data-dependencies="!onclick_opt"/>

--- a/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
+++ b/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
@@ -45,30 +45,32 @@
                             </ol>
                         </div>
                         <!-- Controls -->
-                        <div class="o_wsale_image_viewer_control position-absolute d-flex align-items-center me-2 h-100 w-100">
+                        <div class="o_wsale_image_viewer_control position-absolute top-0 bottom-0 start-0  d-flex align-items-center my-auto ms-5">
                             <a
-                                class="carousel-control-prev"
+                                class="carousel-control-prev d-flex align-items-center justify-content-center border rounded bg-white text-900 p-2"
                                 t-on-click="previousImage"
                                 title="Previous (Left-Arrow)"
                                 role="button"
+                                style="width: 40px; height: 40px;"
                             >
                                 <i
-                                    class="oi oi-chevron-left border bg-white text-900"
+                                    class="oi oi-chevron-left"
                                     role="img"
                                     aria-label="Previous"
                                     title="Previous"
                                 />
                             </a>
                         </div>
-                        <div class="o_wsale_image_viewer_control position-absolute d-flex align-items-center me-2 h-100 w-100">
+                        <div class="o_wsale_image_viewer_control position-absolute top-0 bottom-0 end-0 d-flex align-items-center my-auto me-5">
                             <a
-                                class="carousel-control-next"
+                                class="carousel-control-next d-flex align-items-center justify-content-center border rounded bg-white text-900 p-2"
                                 t-on-click="nextImage"
                                 title="Next (Right-Arrow)"
                                 role="button"
+                                style="width: 40px; height: 40px;"
                             >
                                 <i
-                                    class="oi oi-chevron-right border bg-white text-900"
+                                    class="oi oi-chevron-right"
                                     role="img"
                                     aria-label="Next"
                                     title="Next"

--- a/addons/website_slides/static/src/js/public/components/category_add_dialog/category_add_dialog.js
+++ b/addons/website_slides/static/src/js/public/components/category_add_dialog/category_add_dialog.js
@@ -1,5 +1,6 @@
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { useAutofocus } from "@web/core/utils/hooks";
+import { onMounted, onWillUnmount } from "@odoo/owl";
 
 export class CategoryAddDialog extends ConfirmationDialog {
     static template = "website_slides.CategoryAddDialog";
@@ -13,6 +14,18 @@ export class CategoryAddDialog extends ConfirmationDialog {
         this.inputRef = useAutofocus();
         this.csrf_token = odoo.csrf_token;
         this.lastInputValue;
+        this.onOutsideClick = (event) => {
+            const isInsideDialog = event.target.closest(".modal-content");
+            if (!isInsideDialog) {
+                this.props.close();
+            }
+        };
+        onMounted(() => {
+            document.addEventListener("click", this.onOutsideClick);
+        });
+        onWillUnmount(() => {
+            document.removeEventListener("click", this.onOutsideClick);
+        });
     }
 
     _confirm() {

--- a/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.js
+++ b/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.js
@@ -45,7 +45,14 @@ export class CourseTagAddDialog extends Component {
         this.state.canCreateTag = tags.can_create;
         this.choices.tagGroupIds = groups.choices;
         this.state.canCreateTagGroup = groups.can_create;
-
+        this.handleClickOutside = (event) => {
+            const isInsideDialog = event.target.closest(".modal-content");
+            const isInsideDropdown = event.target.closest(".dropdown-menu");
+            if (!isInsideDialog && !isInsideDropdown) {
+                this.props.close();
+            }
+        };
+        document.addEventListener("click", this.handleClickOutside);
         if (this.props.defaultTag) {
             // Note: when a default tag is passed to the props we want the tag SelectMenu to behave
             // like a 'readonly' selectMenu dropdown (can see the options but cannot change the selection)

--- a/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_quiz_finish_dialog.js
+++ b/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_quiz_finish_dialog.js
@@ -1,7 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
 import { Dialog } from "@web/core/dialog/dialog";
-import { Component, onMounted, useState } from "@odoo/owl";
+import { Component, onMounted, useState, onWillUnmount } from "@odoo/owl";
 import { SlideXPProgressBar } from "@website_slides/js/public/components/slide_quiz_finish_dialog/slide_xp_progress_bar";
 
 export class SlideQuizFinishDialog extends Component {
@@ -24,7 +24,20 @@ export class SlideQuizFinishDialog extends Component {
             showRankMotivational: false,
         });
         this.title = this.props.quiz.rankProgress.level_up ? _t("Level up!") : _t("Amazing!");
-        onMounted(() => this.animateText());
+        this.onOutsideClick = (event) => {
+            const isInsideDialog = event.target.closest(".modal-content");
+            if (!isInsideDialog) {
+                this.props.close();
+            }
+        };
+        onMounted(() => {
+            document.addEventListener("click", this.onOutsideClick);
+            this.animateText();
+        });
+        onWillUnmount(() => {
+            document.removeEventListener("click", this.onOutsideClick);
+        });
+
     }
 
     //--------------------------------

--- a/addons/website_slides/static/src/js/public/components/slide_share_dialog/slide_share_dialog.js
+++ b/addons/website_slides/static/src/js/public/components/slide_share_dialog/slide_share_dialog.js
@@ -4,7 +4,7 @@ import { CopyButton } from "@web/core/copy_button/copy_button";
 import { Dialog } from "@web/core/dialog/dialog";
 import { EmailSharingInput } from "./email_sharing_input";
 
-import { Component, useRef } from "@odoo/owl";
+import { Component, useRef, onMounted, onWillUnmount} from "@odoo/owl";
 
 export class SlideShareDialog extends Component {
     static template = "website_slides.SlideShareDialog";
@@ -27,6 +27,18 @@ export class SlideShareDialog extends Component {
         this.copyUrlText = _t("Copy Link");
         this.copyEmbedCodeText = _t("Copy Embed Code");
         this.successText = _t("Copied");
+        this.onOutsideClick = (event) => {
+            const isInsideDialog = event.target.closest(".modal-content");
+            if (!isInsideDialog) {
+                this.props.close();
+            }
+        };
+        onMounted(() => {
+            document.addEventListener("click", this.onOutsideClick);
+        });
+        onWillUnmount(() => {
+            document.removeEventListener("click", this.onOutsideClick);
+        });
     }
 
     onSocialShareClick(url) {

--- a/addons/website_slides/static/src/js/public/components/slide_unsubscribe_dialog/slide_unsubscribe_dialog.js
+++ b/addons/website_slides/static/src/js/public/components/slide_unsubscribe_dialog/slide_unsubscribe_dialog.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component, useState, onMounted, onWillUnmount } from "@odoo/owl";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
@@ -23,6 +23,18 @@ export class SlideUnsubscribeDialog extends Component {
         this.isFollower = this.props.isFollower === "True";
         this.updateState("subscription");
         this.isChecked = this.isFollower;
+        this.onOutsideClick = (event) => {
+            const isInsideDialog = event.target.closest(".modal-content");
+            if (!isInsideDialog) {
+                this.props.close();
+            }
+        };
+        onMounted(() => {
+            document.addEventListener("click", this.onOutsideClick);
+        });
+        onWillUnmount(() => {
+            document.removeEventListener("click", this.onOutsideClick);
+        });
     }
 
     updateState(mode) {

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog.js
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog.js
@@ -1,4 +1,4 @@
-import { Component, onMounted, useState } from "@odoo/owl";
+import { Component, onMounted, useState, onWillUnmount} from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { redirect } from "@web/core/utils/urls";
@@ -64,11 +64,22 @@ export class SlideUploadDialog extends Component {
         this.pagesTemplates = this.constructor.pagesTemplates;
         this.slideCategoryData = this.constructor.categoryData;
         this.state = useState({ ...this.constructor.baseSettings });
+        this.onOutsideClick = (event) => {
+            const isInsideDialog = event.target.closest(".modal-content");
+            const isInsideDropdown = event.target.closest(".dropdown-menu");
+            if (!isInsideDialog && !isInsideDropdown) {
+                this.props.close();
+            }
+        };
         onMounted(() => {
             if (this.props.openModal && this.props.openModal in this.slideCategoryData) {
                 // Sets the appropriate category's upload template if one has to be opened on load.
                 this.onClickSlideCategoryIcon(this.props.openModal);
             }
+            document.addEventListener("click", this.onOutsideClick);
+        });
+        onWillUnmount(() => {
+            document.removeEventListener("click", this.onOutsideClick);
         });
     }
 


### PR DESCRIPTION
• Before this commit:
  - Users could only close popups using the X button, which was not always easily noticeable, leading to frustration.
  - The On Exit visibility option caused confusion as users assumed it triggered popups when leaving the page, which was incorrect.

• After this commit:
  - Allows users to close popups by clicking outside them for a more intuitive experience.
  - Adds tooltips to clarify popup visibility options:
    - On Exit: Pop-up appears when a user is about to leave the website.
    - On Click (via link): Use the generated link to open the pop-up.

task-4675456

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
