### PR TITLE
[IMP] mail, test_mail_full: assign correct company to attachments

### DIFF
--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -65,6 +65,15 @@ class AttachmentController(http.Controller):
                     "res_model": "mail.compose.message",
                 }
             )
+        attachment_company_id = False
+        if "company_id" in thread and thread.company_id:
+            attachment_company_id = thread.company_id.id
+        else:
+            cids = request.cookies.get('cids')
+            if cids:
+                attachment_company_id = int(cids.split('-')[0])
+        if attachment_company_id:
+            vals["company_id"] = attachment_company_id
         if request.env.user.share:
             # Only generate the access token if absolutely necessary (= not for internal user).
             vals["access_token"] = request.env["ir.attachment"]._generate_access_token()

--- a/addons/test_mail_full/models/test_mail_models_mail.py
+++ b/addons/test_mail_full/models/test_mail_models_mail.py
@@ -121,3 +121,11 @@ class MailTestRatingThreadRead(models.Model):
     _inherit = ["mail.test.rating.thread"]
     _order = "name asc, id asc"
     _mail_post_access = "read"
+
+
+class MailTestAttachmentCompany(models.Model):
+    _name = 'mail.test.attachment.company'
+    _description = "Model for testing attachment company"
+    _inherit = 'mail.thread'
+
+    company_id = fields.Many2one("res.company")

--- a/addons/test_mail_full/security/ir.model.access.csv
+++ b/addons/test_mail_full/security/ir.model.access.csv
@@ -10,3 +10,4 @@ access_mail_test_rating_thread_portal,mail.test.rating.thread.portal,model_mail_
 access_mail_test_rating_thread_user,mail.test.rating.thread.user,model_mail_test_rating_thread,base.group_user,1,1,1,1
 access_mail_test_rating_thread_read_portal,mail.test.rating.thread.read.portal,model_mail_test_rating_thread_read,base.group_portal,1,0,0,0
 access_mail_test_rating_thread_read_user,mail.test.rating.thread.read.user,model_mail_test_rating_thread_read,base.group_user,1,1,1,1
+access_mail_test_attachment_company_user,mail.test.attachment.company.user,model_mail_test_attachment_company,base.group_user,1,1,1,1

--- a/addons/test_mail_full/tests/test_controller_attachment.py
+++ b/addons/test_mail_full/tests/test_controller_attachment.py
@@ -35,3 +35,19 @@ class TestPortalAttachmentController(MailControllerAttachmentCommon):
                 (self.user_admin, True, sign),
             ),
         )
+
+    def test_mail_attachment_company(self):
+        self.authenticate(self.user_admin.login, self.user_admin.login)
+        record = self.env['mail.test.attachment.company'].create({})
+
+        self.env.user.company_ids = self.company_2 | self.company_3
+        self.opener.cookies['cids'] = f'{self.company_2.id}-{self.company_3.id}'
+
+        attachment_id = self._upload_attachment(record, {})
+        attachment = self.env['ir.attachment'].sudo().browse(attachment_id)
+        self.assertEqual(attachment.company_id, self.company_2, "Attachment should be assigned to company_2")
+
+        record.company_id = self.company_3
+        attachment_id = self._upload_attachment(record, {})
+        attachment = self.env['ir.attachment'].sudo().browse(attachment_id)
+        self.assertEqual(attachment.company_id, self.company_3, "Attachment should be assigned to company_3")


### PR DESCRIPTION
Issue:
In a multi-company environment, when an attachment is uploaded, the resulting ir.attachment record incorrectly sets the company_id to the current user's default company. This occurs regardless of the active company or the company associated with the record the attachment is linked to.

Steps to reproduce:
In a multi-company setup, activate only Company B. Open any chatter and attach a file.
Navigate to Settings > Technical > Data Structure > Attachments.

Current behaviour:
The created attachment has its company_id set to the user's default company, rather than the currently active company, or the company of the record, even when the record has a company_id field. This behavior introduces inconsistencies in data visibility, particularly when attachments appear to belong to a company different from the one associated with the related business record.

Behaviour After Fix:
If the related record (i.e., the model the attachment is linked to) contains a company_id field, its value will be used as the attachment's company_id otherwise, the attachment's company_id will be set to the currently active company's id.

This logic ensures proper alignment between attachments and their related business records and also maintaining consistency in multi-company scenarios.

task-4563173

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
