### PR TITLE
[FIX] mail, im_livechat: avoid duplicate username in pinned message

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -928,7 +928,7 @@ class DiscussChannel(models.Model):
             notification = Markup(notification_text) % {
                 'user_pinned_a_message_to_this_channel': Markup('<a href="#" data-oe-type="highlight" data-oe-id="%s">%s</a>') % (
                     message_id,
-                    _('%(user_name)s pinned a message to this channel.', user_name=self.env.user.display_name),
+                    _('%(user_name)s pinned a message to this channel.', user_name=self.self_member_id._get_html_link_title()),
                 ),
                 'see_all_pins': _('See all pinned messages.'),
             }


### PR DESCRIPTION
**Current behavior before PR:**

When a user pinned a message in livechat, both the regular username and the livechat username were shown, resulting in a duplicate display. This happened because the notification message used `username` directly, while `livechat_username` was separately injected in the template, leading to redundancy ([here](https://github.com/odoo/odoo/blob/f4c42ee65c8ec0511e1d5fd6063680328da365e8/addons/mail/static/src/core/common/notification_message.xml#L10C33-L10C34)).

**Desired behavior after PR is merged:**

Pinned notification message now show the livechat username if available.

**Task**-4715349

before / after
![image](https://github.com/user-attachments/assets/e0767bec-fe4f-4e15-864a-decddf302982)
![image](https://github.com/user-attachments/assets/09ba665b-5103-49b8-883a-82eadb1d428b)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
