### PR TITLE
[FIX] point_of_sale: allow searching partner by phone with spaces

### DIFF
--- a/addons/point_of_sale/static/src/app/models/res_partner.js
+++ b/addons/point_of_sale/static/src/app/models/res_partner.js
@@ -17,10 +17,13 @@ export class ResPartner extends Base {
         ];
         return fields
             .map((field) => {
-                if ((field === "phone" || field === "mobile") && this[field]) {
-                    return this[field].split(" ").join("");
+                const value = this[field] || "";
+                if ((field === "phone" || field === "mobile") && value) {
+                    // Include both versions: with and without spaces
+                    const withoutSpaces = value.split(" ").join("");
+                    return `${value} ${withoutSpaces}`;
                 }
-                return this[field] || "";
+                return value;
             })
             .filter(Boolean)
             .join(" ");


### PR DESCRIPTION
Before this commit, it was not possible to find a partner when searching with a phone number that included spaces. This was because the phone number was stored in the search string without spaces, while the user input could included them.

opw-4652338

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
