### PR TITLE
[FIX] web: compiler: tolerate but ignore t-translation attrs

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -208,5 +208,4 @@ KanbanCompiler.OWL_DIRECTIVE_WHITELIST = [
     "t-key",
     "t-att.*",
     "t-call",
-    "t-translation",
 ];

--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -268,6 +268,9 @@ export class ViewCompiler {
             return createTextNode(node.nodeValue);
         }
 
+        if (node.hasAttribute("t-translation")) {
+            node.removeAttribute("t-translation");
+        }
         this.validateNode(node);
         let invisible;
         if (evalInvisible) {

--- a/addons/web/static/tests/views/form/form_compiler.test.js
+++ b/addons/web/static/tests/views/form/form_compiler.test.js
@@ -405,7 +405,7 @@ test("invisible is correctly computed with another t-if", () => {
     expect(compileTemplate(arch)).toHaveOuterHTML(expected);
 });
 
-test("keep nosheet style if a sheet is part of a nested form", (assert) => {
+test("keep nosheet style if a sheet is part of a nested form", () => {
     const arch = `
         <form>
             <field name="move_line_ids" field_id="move_line_ids">
@@ -432,4 +432,24 @@ test("keep nosheet style if a sheet is part of a nested form", (assert) => {
         </div>
     </t>`;
     expect(compileTemplate(arch)).toHaveOuterHTML(expected);
+});
+
+test("form with t-translation directive", () => {
+    patchWithCleanup(console, { warn: (message) => expect.step(message) });
+    const arch = `
+        <form>
+            <div t-translation="off">Hello</div>
+        </form>`;
+
+    const expected = `<t t-translation="off">
+        <div
+            class="o_form_renderer o_form_nosheet"
+            t-att-class="__comp__.props.class"
+            t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}"
+            t-ref="compiled_view_root">
+                <div> Hello </div>
+        </div>
+    </t>`;
+    expect(compileTemplate(arch)).toHaveOuterHTML(expected);
+    expect.verifySteps([]); // should no log any warning
 });


### PR DESCRIPTION
Form and kanban view archs are compiled into owl templates. Those archs are translated server-side, before being sent to the client. They can contain `t-translation` directives (typically ="off" to disable translations). This tells the view processing in python not to translate the subtree.

In the js compilers, that attribute is listed among the tolerated attributes for kanban archs, but not for forms. However, the cases are similar, so their should be not differences between the two.

Moreover, since [1], compiled templates are wrapped into a
```xml
<t t-translation="off"/>
```
node, s.t. terms aren't translated twice (once in python, and once in js, by owl).

Instead of tolerating the `t-translation` directive in form view, this commit ignores it in all view compilers. This directive indeed makes sense, so it is valid to use it in kanban and form archs (then used by the view processing in python). But the view compilers in js must ignore it, so we simply remove it.

[1] odoo/odoo#158759
Fixes runbot error-134670

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
