### PR TITLE
[16.0][FIX] account: Incorrect display of the payment date field (AccountPaymentPopOver)

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -86,7 +86,7 @@
                         </tr>
                         <tr>
                             <td><strong>Date: </strong></td>
-                            <td><t t-esc="props.date"/></td>
+                            <td><t t-esc="props.formattedDate"/></td>
                         </tr>
                         <tr>
                             <td><strong>Journal: </strong></td>


### PR DESCRIPTION
Incorrect display of the payment date field (AccountPaymentPopOver)

Related to https://github.com/odoo/odoo/pull/202258

**Before**
![antes](https://github.com/user-attachments/assets/920f6422-c754-4fad-9809-862c3ff97488)

**After**
![despues](https://github.com/user-attachments/assets/ea95e4a3-6bd6-4cce-b8da-d3d16cc63f84)

Please @pedrobaeza can you review it?

@Tecnativa TT55826

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
