### PR TITLE
[FIX] stock_account: make return moves to refund be default

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -125,7 +125,7 @@ class StockPicking(models.Model):
             # for moves with qty. done and not already linked to a SO line.
             if not sale_order or move.sale_line_id or not move.picked or not (
                 (move.location_dest_id.usage in ['customer', 'transit'] and not move.move_dest_ids)
-                or (move.location_id.usage == 'customer' and move.to_refund)
+                or (not move.location_id.warehouse_id and move.to_refund)
             ):
                 continue
             product = move.product_id

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -20,6 +20,16 @@ class StockMove(models.Model):
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'stock_move_id')
     analytic_account_line_ids = fields.Many2many('account.analytic.line', copy=False)
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get('picking_id'):
+                continue
+            picking = self.env['stock.picking'].browse(vals['picking_id'])
+            if picking.return_id and 'to_refund' not in vals:
+                vals['to_refund'] = True
+        return super().create(vals_list)
+
     def _inverse_picked(self):
         super()._inverse_picked()
         self._account_analytic_entry_move()


### PR DESCRIPTION
This commit makes the `to_refund` field `True` by default for stock move in case of return. The value is True for product coming from the return wizard but not for extra product added later in the picking. In `stock_barcode` there is even not return wizard.

Task: 4680813

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
