### PR TITLE
[FIX] purchase_stock: applying discounts on backorders of PO

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -63,7 +63,7 @@ class StockMove(models.Model):
                 if invoice_line.move_id.state != 'posted':
                     continue
                 # Discount applied on bill prior to reception
-                if invoice_line.discount and not move_layer:
+                if invoice_line.discount:
                     price_unit = invoice_line.price_subtotal / invoice_line.quantity
                 else:
                     price_unit = invoice_line.price_unit


### PR DESCRIPTION
Steps to reproduce:
- Create a product with costing method `AVCO` and control policy based `ordered quantities`
- Create a purchase order on this product with amount 2
- Create a bill to this PO with discount on the POL
- Post the bill
- Change the quantity received in the reception to 1 instead of 2
- Create a backorder with the remaining amount

Current Behaviour:
The valuation of the original reception has the discount applied on The valuation of the second reception doesn’t have the discount applied, instead is the remaining of the total amount and the discounted cost of first reception

Issue:
In ab9d2a4ed56, a fix was introduced to apply the discount on the main reception, but the condition is not handling the case of a move that is a backorder of the original one and their processed orders already have valuations.
https://github.com/odoo/odoo/blob/bbff98ff34ecf1412a675581df483681a75b007b/addons/purchase_stock/models/stock_move.py#L65-L69 The backorder will have the valuations from the originals hence `move_layer` will be true and the discount is not going to be applied.

opw-4659587

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
