### PR TITLE
[FIX] account_debit_note: access to debit note wizard

### DIFF
--- a/addons/account_debit_note/models/account_move.py
+++ b/addons/account_debit_note/models/account_move.py
@@ -30,5 +30,5 @@ class AccountMove(models.Model):
         }
 
     def action_debit_note(self):
-        action = self.env.ref('account_debit_note.action_view_account_move_debit').read()[0]
+        action = self.env.ref('account_debit_note.action_view_account_move_debit')._get_action_dict()
         return action


### PR DESCRIPTION
Steps to reproduce:
- Log in with User without Administration Rights
- Open a Credit note
- Actions > Debit note

Issue: Access Error will raise

opw-4659611
