### PR TITLE
[FIX] stock: correct partner_id search for stock.lot

### DIFF
--- a/addons/stock/views/res_partner_views.xml
+++ b/addons/stock/views/res_partner_views.xml
@@ -43,7 +43,7 @@
                     name="action_view_stock_serial"
                     class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot">
                     <div class="o_stat_info">
-                        <span class="o_stat_text">Serial Numbers</span>
+                        <span class="o_stat_text">Lots/Serial Numbers</span>
                     </div>
                 </button>
             </xpath>


### PR DESCRIPTION
Previous PR: odoo/odoo/pull/184242 improved the SN/Lot traceability, but PR: odoo/odoo#191549 missed refactoring it under the new search method standard. Also note that search is for SNs AND lots, not just for SNs as indicated by the original PR.

Refactoring changed expected passed operator/value and required the method to be completely rewritten.

Additionally, the code has been refactored to:
- significally improve its performance (i.e. less searches) and to avoid potential memory overflows due to original code loading every `stock.lot` record in the db.
- correctly handle the `partner_ids is (not) set` cases

Followup to task: 4199289


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
