### PR TITLE
[IMP] l10n_us_account: remove duplicated data section

### DIFF
--- a/addons/l10n_us_account/__manifest__.py
+++ b/addons/l10n_us_account/__manifest__.py
@@ -12,11 +12,9 @@
     'depends': ['l10n_us', 'account'],
     'data': [
         'views/res_bank_views.xml',
+        'data/uom_data.xml',
     ],
     'installable': True,
     'auto_install': ['account'],
     'license': 'LGPL-3',
-    'data': [
-        'data/uom_data.xml',
-    ],
 }


### PR DESCRIPTION
A second 'data' key was accidentally added to the manifest in bc50e7abf23b09e89128d0823793cfd9da50287e.
