### PR TITLE
[FIX] l10n_sa_edi: Attachment access right error when generating invoice

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -491,7 +491,7 @@ class AccountEdiFormat(models.Model):
         if self.code != 'sa_zatca' or edi_document.move_id.country_code != 'SA':
             return
 
-        attachment = edi_document.attachment_id
+        attachment = edi_document.sudo().attachment_id
         if not attachment or not attachment.datas:
             _logger.warning(f"No attachment found for invoice {edi_document.move_id.name}")
             return


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
As a result of the following commit 9a6b8fec280ccf63b14d3fdafdd39f534c54c646 normal users attempting to print invoices in SA company where the invocie has been ZATCA verified, are getting errors if they have insufficient access rights; for instance a normal user who has POS User access and Accounting/Billing is unable to generate PoS orders as they are forced to have the invoice checkbox set in the `l10n_sa_pos` and when the invoice is generated it is giving the following Traceback.

Current behavior before PR:
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/api.py", line 1013, in get
    cache_value = field_cache[record._ids[0]]
KeyError: 415613

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/fields.py", line 1161, in _get_
    value = env.cache.get(record, self)
  File "/home/odoo/src/odoo/odoo/api.py", line 1020, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'account.edi.document(415613,).attachment_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/fields.py", line 1187, in _get_
    recs._fetch_field(self)
  File "/home/odoo/src/odoo/odoo/models.py", line 3230, in _fetch_field
    self.check_field_access_rights('read', [field.name])
  File "/home/odoo/src/odoo/odoo/models.py", line 2986, in check_field_access_rights
    raise AccessError(_(
odoo.exceptions.AccessError: The requested operation can not be completed due to security restrictions.

Document type: Electronic Document for an account.move (account.edi.document)
Operation: read
User: 40
Fields:
•⁠  ⁠attachment_id (allowed for groups 'Administration / Settings')
```


Desired behavior after PR is merged:
To Fix the issue and sudo() the access to the edi attachment



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr