### PR TITLE
[FIX] hr_expanse: do not create CABA moves on Exchange Difference journal

### DIFF
--- a/addons/hr_expense/models/account_move_line.py
+++ b/addons/hr_expense/models/account_move_line.py
@@ -17,7 +17,7 @@ class AccountMoveLine(models.Model):
     def reconcile(self):
         # OVERRIDE
         not_paid_expenses = self.move_id.expense_sheet_id.expense_line_ids.filtered(lambda expense: expense.state != 'done')
-        res = super().reconcile()
+        res = super().with_context(no_cash_basis=True).reconcile()
         # Do not update expense or expense sheet states when reversing journal entries
         not_paid_expense_sheets = not_paid_expenses.sheet_id.filtered(lambda sheet: sheet.account_move_id.payment_state != 'reversed')
         paid_expenses = not_paid_expenses.filtered(lambda expense: expense.currency_id.is_zero(expense.amount_residual))

--- a/doc/cla/individual/quijoquim.md
+++ b/doc/cla/individual/quijoquim.md
@@ -1,0 +1,9 @@
+Spain, 2025-04-06
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Quijo Quim  36902634+QuiJoQuim@users.noreply.github.com https://github.com/QuiJoQuim


### PR DESCRIPTION
It is a similar case to the one described in :
commit [[2f62d5c](https://github.com/odoo/odoo/commit/2f62d5c0d78371be70586c79cb2b5931e733b042)](https://github.com/odoo/odoo/commit/2f62d5c0d78371be70586c79cb2b5931e733b042)

When an expense is reversed, account_moves are being generated in the exchange differences because they are not matched correctly. The solution applied is the same as the aforementioned commit.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Created extra CABA lines on Exchange Difference journal


Desired behavior after PR is merged:

Do not create erroneous moves

---

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](https://github.com/odoo/odoo/compare/www.odoo.com/submit-pr)