### PR TITLE
[FIX] mail: discuss app slightly darker in dark theme

### DIFF
--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -1,5 +1,5 @@
 .o-mail-discussSidebarBgColor {
-    background-color: $o-webclient-background-color;
+    background-color: mix($white, $o-webclient-background-color, 15%);
 }
 
 a.o_mail_redirect, a.o_channel_redirect {

--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -1,10 +1,9 @@
 .o-mail-Discuss {
-    --mail-Discuss-coreBgColor: #{mix($body-bg, $gray-200, 75%)};
     --mail-Discuss-headerActionsGroupBorderOpacity: .1;
 }
 
 .o-mail-Discuss-header {
-    background-color: $o-webclient-background-color;
+    background-color: mix($white, $o-webclient-background-color, 15%);
 }
 
 .o-mail-Discuss-headerActions button {
@@ -23,10 +22,10 @@
 .o_web_client:has(.o-mail-Discuss) {
 
     .o_main_navbar {
-        background-color: unset;
+        background-color: mix($white, $o-webclient-background-color, 15%);
     }
 
     .o_control_panel {
-        background-color: unset;
+        background-color: mix($white, $o-webclient-background-color, 15%);
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -5,11 +5,7 @@
 }
 
 .o-mail-Discuss-core {
-    background-color: var(--mail-Discuss-coreBgColor, $body-bg);
-}
-
-.o-mail-Discuss-threadContainerHeader {
-    background-color: var(--mail-Discuss-coreBgColor, $body-bg);
+    background-color: $body-bg;
 }
 
 .o-mail-Discuss-selfAvatar {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
@@ -1,4 +1,4 @@
 .o-mail-DiscussSidebar-item {
-    --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-200, $gray-300, 25%)};
+    --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-200, $gray-300)};
     --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .25)};
 }


### PR DESCRIPTION
Before this color, the bg color of conversation in discuss app in dark theme was lighter than bg color of chat window.

This made reading conversation slightly harder in discuss app compared to chat window, due to reduced contrast.

This commit fixes the issue by darkening the bg color of discuss app conversation by reusing the body color like in chat window and white theme.

The left / top / right / control / systray panels were using the body bg color, therefore to keep same separation with the conversation bg, their color have been slightly adjusted by being a bit darker. Active item bg is also slightly darker for improved readability.

Before
![Screenshot 2025-04-06 at 18 56 19](https://github.com/user-attachments/assets/872b787b-cfe5-4361-99f3-9a216d83a224)

After
![Screenshot 2025-04-06 at 19 02 07](https://github.com/user-attachments/assets/02f74df9-e698-402f-ac2d-35f4cc423f01)

