### PR TITLE
[FIX] mail: no 'Today at' for messages posted recently

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -208,9 +208,7 @@ export class Message extends Record {
     get dateSimpleWithDay() {
         const userLocale = { locale: user.lang };
         if (this.datetime.hasSame(DateTime.now(), "day")) {
-            return _t("Today at %(time)s", {
-                time: this.datetime.toLocaleString(DateTime.TIME_SIMPLE, userLocale),
-            });
+            return this.datetime.toLocaleString(DateTime.TIME_SIMPLE, userLocale);
         }
         if (this.datetime.hasSame(DateTime.now().minus({ day: 1 }), "day")) {
             return _t("Yesterday at %(time)s", {

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -52,7 +52,7 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Message:contains(today at)",
+            trigger: ".o-mail-Message",
             content: _t("Hover on your message and mark as todo"),
             tooltipPosition: "top",
             run: "hover && click .o-mail-Message [title='Mark as Todo']",


### PR DESCRIPTION
Before this commit, message that were posted today relative to current user all had "Today at HH:mm".

All other messages posted in the past have "Yesterday at HH:mm" or "Month Day at HH:mm" format. Therefore we could just display "HH:mm" and deduce easily these are messages from today.

The main benefit of removing "Today at" is to reduce the length of message header. This shorten for recent messages, which contribute to a big chunk of messages.

This also matches with messaging menu that displays the timestamp for recent notifications with just "HH:mm".

Before / After
<img width="403" alt="Screenshot 2025-04-06 at 20 32 05" src="https://github.com/user-attachments/assets/7146b629-8de4-4b0f-8a0a-451ed759b2bf" /> <img width="391" alt="Screenshot 2025-04-06 at 20 32 22" src="https://github.com/user-attachments/assets/2b16cefc-e6d6-4153-912a-cdb3796f2316" />

