### PR TITLE
[FIX] mail:  remove link preview when deleting a message

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4746,7 +4746,7 @@ class MailThread(models.AbstractModel):
         message._bus_send_store(message, res)
 
     def _clean_empty_message(self, message):
-        pass
+        message.link_preview_ids._unlink_and_notify()
 
     def _get_store_message_update_extra_fields(self):
         return []

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -2024,3 +2024,28 @@ test("deleted message should not have translate feature", async () => {
         await contains(".dropdown-item:contains('Translate')", { count: 0 });
     }
 });
+
+test("should delete link preview along with message", async () => {
+    const pyEnv = await startServer();
+    const linkPreviewId = pyEnv["mail.link.preview"].create({
+        og_title: "Delete Test Link",
+        og_description: "Should be removed with the message.",
+        og_type: "article",
+        source_url: "https://www.odoo.com",
+    });
+    const channelId = pyEnv["discuss.channel"].create({ name: "DeletePreviewTest" });
+    pyEnv["mail.message"].create({
+        body: "<a href='https://www.odoo.com'>https://www.odoo.com</a>",
+        link_preview_ids: [linkPreviewId],
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-LinkPreviewCard");
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message-moreMenu [title='Delete']");
+    await click("button:contains('Confirm')");
+    await contains(".o-mail-LinkPreviewCard", { count: 0 });
+});

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -695,6 +695,8 @@ async function mail_message_update_content(request) {
     const BusBus = this.env["bus.bus"];
     /** @type {import("mock_models").IrAttachment} */
     const IrAttachment = this.env["ir.attachment"];
+    /** @type {import("mock_models").MailLinkPreview} */
+    const MailLinkPreview = this.env["mail.link.preview"];
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
 
@@ -722,6 +724,9 @@ async function mail_message_update_content(request) {
         );
         msg_values.attachment_ids = attachment_ids;
     }
+    if (body === "") {
+        MailLinkPreview.unlink(message.link_preview_ids);
+    }
     if (!body && attachment_ids.length === 0) {
         msg_values.partner_ids = false;
         msg_values.parent_id = false;
@@ -738,6 +743,7 @@ async function mail_message_update_content(request) {
                 this.env["res.partner"].browse(message.partner_ids),
                 makeKwArgs({ fields: ["avatar_128", "name"] })
             ),
+            link_preview_ids: message.link_preview_ids,
             parentMessage: mailDataHelpers.Store.one(MailMessage.browse(message.parent_id)),
         }).get_result()
     );

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -232,3 +232,18 @@ class TestLinkPreview(MailCommon):
                         [("message_id", "=", message.id)]
                     )
                     self.assertEqual(link_preview_count, counter)
+
+    def test_link_preview_delete_with_message(self):
+        with patch.object(requests.Session, "get", self._patch_with_og_properties), patch.object(
+            requests.Session, "head", self._patch_head_html
+        ):
+            message = self.test_partner.message_post(
+                body=Markup('<a href="%s">Test link</a>') % self.source_url,
+                message_type="comment"
+            )
+            self.env["mail.link.preview"]._create_from_message_and_notify(message)
+            preview = message.link_preview_ids
+            self.assertTrue(preview)
+            self.assertEqual(preview.source_url, self.source_url)
+            self.test_partner._message_update_content(message, body="")
+            self.assertFalse(message.link_preview_ids)

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -77,7 +77,7 @@ class TestMessageValues(MailCommon):
         # Completely emptied now
         note_subtype.sudo().write({'description': ''})
         self.assertEqual(message.sudo()._filter_empty(), message)
-        record._message_update_content(message, '', [])
+        record._message_update_content(message.sudo(), '', [])
         self.assertEqual(message.notified_partner_ids, self.partner_admin)  # message still notified (albeit content is removed)
         self.assertEqual(message.starred_partner_ids, self.partner_admin)  # starred messages stay (albeit content is removed)
 


### PR DESCRIPTION
**Specifications:**
- Ensure link preview is removed when deleting a message.

**Purpose:**
- Previously, deleting a message with a link preview did not remove the preview, requiring manual intervention.
- This fix ensures that when a message containing a link preview is deleted, its associated preview is also removed automatically, improving user experience.

task-4678962

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
