### PR TITLE
[IMP] project: add 'Task Created' message in chatter when copying a task

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -880,6 +880,8 @@ class ProjectTask(models.Model):
         )).copy(default=default)
 
         self._resolve_copied_dependencies(copied_tasks)
+        log_message = _("Task Created")
+        copied_tasks._message_log_batch(bodies={task.id: log_message for task in copied_tasks})
 
         return copied_tasks
 

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -543,3 +543,13 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
             self.flush_tracking()
         # check that no mail was received for the assignee of the task
         self.assertNotSentEmail(self.user_projectuser.email_formatted)
+
+    def test_copy_task_logs_chatter(self):
+        """Test that copying a task logs a message in the chatter."""
+        copied_task = self.task_1.copy()
+
+        # Ensure only one message is logged in chatter
+        self.assertEqual(
+            'Task Created', copied_task.message_ids[0].preview,
+            "Expected 'Task Created' message not found in copied task's chatter."
+        )


### PR DESCRIPTION
Previously, copying a task didn’t show the 'Task Created' message in the chatter. Now, `Task Created` message is added during the copy. No user notifications are sent, so there’s no effect on performance.


Performance Impact:
--------------
- Minimal impact observed on duplication performance.

  **- Without chatter log:**
    • 25 tasks (1 subtask each): 937 queries
    • 256 tasks (4 subtasks each): 9133 queries
    • 1296 tasks (6 subtasks each): 45636 queries

  **- With chatter log:**
    • 25 tasks (1 subtask each): 938 queries
    • 256 tasks (4 subtasks each): 9136 queries
    • 1296 tasks (6 subtasks each): 45649 queries

Task-4702377