### PR TITLE
[FIX] html_editor: add origin to image src on copy

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -217,6 +217,7 @@ export class ClipboardPlugin extends Plugin {
         }
         const dataHtmlElement = this.document.createElement("data");
         dataHtmlElement.append(clonedContents);
+        prependOriginToImages(dataHtmlElement, window.location.origin);
         const odooHtml = dataHtmlElement.innerHTML;
         const odooText = selection.textContent();
         ev.clipboardData.setData("text/plain", odooText);
@@ -750,4 +751,17 @@ export function isHtmlContentSupported(node) {
         node,
         '[data-oe-model]:not([data-oe-field="arch"]):not([data-oe-type="html"]),[data-oe-translation-id]'
     );
+}
+
+/**
+ * Add origin to relative img src.
+ * @param {string} origin
+ */
+function prependOriginToImages(doc, origin) {
+    doc.querySelectorAll("img").forEach((img) => {
+        const src = img.getAttribute("src");
+        if (src && !src.startsWith("http") && !src.startsWith("//")) {
+            img.src = origin + (src.startsWith("/") ? src : "/" + src);
+        }
+    });
 }

--- a/addons/html_editor/static/tests/copy.test.js
+++ b/addons/html_editor/static/tests/copy.test.js
@@ -156,4 +156,16 @@ describe("range not collapsed", () => {
             '<p><a href="http://test.com/">label</a></p>'
         );
     });
+
+    test("should add origin to images urls", async () => {
+        await setupEditor('<p>[<img src="/nice.png">]</p>');
+        const clipboardData = new DataTransfer();
+        await press(["ctrl", "c"], { dataTransfer: clipboardData });
+        expect(clipboardData.getData("text/html")).toBe(
+            `<p><img src="${window.location.origin}/nice.png"></p>`
+        );
+        expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe(
+            `<p><img src="${window.location.origin}/nice.png"></p>`
+        );
+    });
 });


### PR DESCRIPTION
**Problem**:
On copy as HTML, if the content contains images saved on the server, the URLs will not include the origin. When pasted outside of Odoo (for example, in Gmail), the images will not be loaded.

**Solution**:
Add the origin to `img` tag `src` attributes when copying content.

**Steps to reproduce**:
1. Paste an image in the editor.
2. Copy all content (including the image).
3. Paste it elsewhere as HTML (e.g., Gmail).
4. Observe that the HTML is pasted but the image is not loaded.

**opw-4652753**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
