### PR TITLE
[18.0][FIX] mail: don't log fields deletion message on deleted model

### DIFF
--- a/addons/mail/models/ir_model_fields.py
+++ b/addons/mail/models/ir_model_fields.py
@@ -45,6 +45,9 @@ class IrModelField(models.Model):
             )
             field_to_trackings = groupby(tracking_values, lambda track: track.field_id)
             for field, trackings in field_to_trackings:
+                if field.model_id.model not in self.env:
+                    # Model is already deleted
+                    continue
                 self.env['mail.tracking.value'].concat(*trackings).write({
                     'field_info': {
                         'desc': field.field_description,


### PR DESCRIPTION
Fixes
```
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 2647, in _process_end
    self._process_end_unlink_record(record)
  File "/home/odoo/src/odoo/addons/website/models/ir_model_data.py", line 35, in _process_end_unlink_record
    return super()._process_end_unlink_record(record)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 2576, in _process_end_unlink_record
    record.unlink()
  File "/home/odoo/src/odoo/addons/mail/models/ir_model_fields.py", line 52, in unlink
    'sequence': self.env[field.model_id.model]._mail_track_get_field_sequence(field.name),
                ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/api.py", line 612, in __getitem__
    return self.registry[model_name](self, (), ())
           ~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/modules/registry.py", line 240, in __getitem__
    return self.models[model_name]
           ~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'my.custom.model'
```

To reproduce:

* add a model with a tracked field to a module
* create a record and update field value to create a tracking message
* remove the model from the module and update the module

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
