### PR TITLE
[FIX] base: incorrect phone field alignment

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -237,7 +237,7 @@
                             <label for="name"/>
                             <h1 class="w-75"><field name="name" placeholder="e.g. John Doe" required="1"/></h1>
                             <field name="email" invisible="1"/><!-- needed to update partner's email from on_change_login() -->
-                            <div class="row">
+                            <div class="d-flex flex-wrap">
                                 <div class="col-md-6 me-md-3 ps-0">
                                     <label for="login" string="Email Address"/>
                                     <h2><field name="login" placeholder="e.g. email@yourcompany.com"/></h2>


### PR DESCRIPTION
This PR resolves an issue where the phone field was misaligned on smaller screens, ensuring consistent UI placement across all responsive breakpoints.