### PR TITLE
[FIX] pos_loyalty: only grant points for paid orders

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -76,7 +76,9 @@ patch(PaymentScreen.prototype, {
      * @override
      */
     async _postPushOrderResolve(order, server_ids) {
-        const orders = this.pos.models["pos.order"].readMany(server_ids).filter((o) => o.is_paid());
+        const orders = this.pos.models["pos.order"]
+            .readMany(server_ids)
+            .filter((o) => !["draft", "cancel"].includes(o.state));
         for (const order of orders) {
             await this._postProcessLoyalty(order);
         }

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -1,6 +1,7 @@
 import * as PartnerList from "@point_of_sale/../tests/tours/utils/partner_list_util";
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as combo from "@point_of_sale/../tests/tours/utils/combo_popup_util";
@@ -280,6 +281,8 @@ registry.category("web_tour.tours").add("PosLoyaltyMultipleOrders", {
             ProductScreen.addOrderline("Whiteboard Pen", "2"),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
 
             // Order2: Finalize a different order.
             Chrome.createFloatingOrder(),


### PR DESCRIPTION
Recently, we've face an issue when multiple orders were opened. When one of them was paid, loyalty points were applied for all other opened orders.

A fix has been applied to correct the situation:
https://github.com/odoo/odoo/commit/2dcad5f32693471588bbe605601d3346b14196be

Afterward it appears that the fix does not get rid of the problem 100% of the time. When there are more than 1 order on the payment screen with payment lines covering the total amount, and when one of them is finalized, the other orders are also getting points applied.

Why the fix:
------------
The fix mentionned above uses `is_paid()` as a filter to select which orders should get points applied. It seems like `is_paid` is intended to be used to know if the payment lines cover the order amount before the order is truly finalized.

https://github.com/odoo/odoo/blob/8be96595ce5795df25b9b7dbea14a0f8c75a804c/addons/point_of_sale/static/src/app/models/pos_order.js#L905-L911

We change the condition to be based on the state of the order instead.

opw-4677541