### PR TITLE
[FIX] point_of_sale: temporarily disable biggest_tax rounding method

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -7392,6 +7392,13 @@ msgstr ""
 #. module: point_of_sale
 #. odoo-python
 #: code:addons/point_of_sale/models/pos_config.py:0
+msgid ""
+"The cash rounding strategy of the point of sale %(pos)s must be: '%(value)s'"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/pos_config.py:0
 msgid "The default pricelist must be included in the available pricelists."
 msgstr ""
 

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -331,6 +331,21 @@ class PosConfig(models.Model):
                 pos_config.pos_session_duration = 0
                 pos_config.current_user_id = False
 
+    @api.constrains('rounding_method')
+    def _check_rounding_method_strategy(self):
+        for config in self:
+            if config.cash_rounding and config.rounding_method.strategy != 'add_invoice_line':
+                selection_value = "Add a rounding line"
+                for key, val in self.env["account.cash.rounding"]._fields["strategy"]._description_selection(config.env):
+                    if key == "add_invoice_line":
+                        selection_value = val
+                        break
+                raise ValidationError(_(
+                    "The cash rounding strategy of the point of sale %(pos)s must be: '%(value)s'",
+                    pos=config.name,
+                    value=selection_value,
+                ))
+
     def _check_profit_loss_cash_journal(self):
         if self.cash_control and self.payment_method_ids:
             for method in self.payment_method_ids:

--- a/addons/point_of_sale/tests/test_pos_cash_rounding.py
+++ b/addons/point_of_sale/tests/test_pos_cash_rounding.py
@@ -249,6 +249,7 @@ class TestPosCashRounding(TestPointOfSaleHttpCommon):
             }])
 
     def test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method(self):
+        self.skipTest('To re-introduce when feature is ready')
         self.main_pos_config.write({
             'rounding_method': self.cash_rounding_biggest_tax.id,
             'cash_rounding': True,
@@ -279,6 +280,7 @@ class TestPosCashRounding(TestPointOfSaleHttpCommon):
             }])
 
     def test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method_pay_by_bank_and_cash(self):
+        self.skipTest('To re-introduce when feature is ready')
         self.main_pos_config.write({
             'rounding_method': self.cash_rounding_biggest_tax.id,
             'cash_rounding': True,
@@ -309,6 +311,7 @@ class TestPosCashRounding(TestPointOfSaleHttpCommon):
             }])
 
     def test_cash_rounding_halfup_biggest_tax_only_round_cash_method(self):
+        self.skipTest('To re-introduce when feature is ready')
         self.main_pos_config.write({
             'rounding_method': self.cash_rounding_biggest_tax.id,
             'cash_rounding': True,
@@ -339,6 +342,7 @@ class TestPosCashRounding(TestPointOfSaleHttpCommon):
             }])
 
     def test_cash_rounding_halfup_biggest_tax_only_round_cash_method_pay_by_bank_and_cash(self):
+        self.skipTest('To re-introduce when feature is ready')
         self.main_pos_config.write({
             'rounding_method': self.cash_rounding_biggest_tax.id,
             'cash_rounding': True,


### PR DESCRIPTION
Currently, when using a cash rounding method with the strategy `Modify tax
amount` on a Pos config, an error message appears upon trying to close the
session.

Steps to reproduce:
-------------------
* Create a cash rounding method with strategy `Modify tax amount`
* Open pos setting and apply the cash rounding method
* Open pos session
* Make an order that will trigger the cash rounding
* Validate the order
* Try closing the session
> Observation: The operation cannot be completed: Missing required account
on accountable line

Why the fix:
------------
Prior to 18.0, the point of sale would only allow rounding methods using
the strategy `add_invoice_line`.
https://github.com/odoo/odoo/blob/786abeb0783461d555c4077b8258490a7aed8c21/addons/point_of_sale/models/pos_config.py#L302-L314

This constraint was removed in this commit to also allow using `biggest_tax`
strategy:
[8fb7e5f#diff-4c6e412c7d8f4df2a05831547e7df93d0b91f510d03b7b3ed0d689a18f5dae44](https://github.com/odoo/odoo/commit/8fb7e5fd304697aebcce085602a5f3a1ecaf757a#diff-4c6e412c7d8f4df2a05831547e7df93d0b91f510d03b7b3ed0d689a18f5dae44)

This is a temporary fix bringing back the constraint has the pos wasns't
fully ready to use it. It will be remove later when the integration is
complete.

opw-[4673618]