### PR TITLE
[FIX] stock:  Prevent error in Product Routes Report if Source Location is empty

### DIFF
--- a/addons/stock/report/report_stock_rule.py
+++ b/addons/stock/report/report_stock_rule.py
@@ -60,9 +60,10 @@ class ReportStockRule(models.AbstractModel):
                     idx = locations_names.index(rule_loc['destination'].display_name)
                     tpl = (rule, 'destination', route_color, )
                     res[idx] = tpl
-                    idx = locations_names.index(rule_loc['source'].display_name)
-                    tpl = (rule, 'origin', route_color, )
-                    res[idx] = tpl
+                    if rule_loc['source']:
+                        idx = locations_names.index(rule_loc['source'].display_name)
+                        tpl = (rule, 'origin', route_color)
+                        res[idx] = tpl
                     route_lines.append(res)
         return {
             'docs': product,


### PR DESCRIPTION
This error occurs when users view the Product Routes Report. 

Steps to Reproduce:
 - Install the `mrp` modules.
 - Open `Products`.
 - In the Inventory tab, enable `Manufacture` in Routes.
 - Clear the `Production Location` field.
 - Click View `Diagram` in Routes.

ValueError: False is not in list

This error occurs because, in `Warehouse > Routes`, when a rule is created with the Manufacture action, the Source Location field is not required. However, when generating the Product Routes Report, the system attempts to access this field even if it is empty, resulting in an error.

This commit ensures the Product Routes Report view correctly

Sentry-6487434464

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
