### PR TITLE
[FIX] http.py: fix a typo in documentation

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -76,7 +76,7 @@ Request._serve_nodb
 Request._serve_db
   Handle all requests that are not static when it is possible to connect
   to a database. It opens a registry on the database and then delegates
-  most of the effort the the ``ir.http`` abstract model. This model acts
+  most of the effort to the ``ir.http`` abstract model. This model acts
   as a module-aware middleware, its implementation in ``base`` is merely
   more than just delegating to Dispatcher.
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: a small typo in the http.py file's documentation

Current behavior before PR: creating a small confusion for the reader of the Request._serve_db section in odoo/http.py file's documentation

Desired behavior after PR is merged: typo fix




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
