### PR TITLE
[FIX] point_of_sale: broken ship later date format on payment screen

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -7,6 +7,7 @@ import { roundCurrency } from "@point_of_sale/app/models/utils/currency";
 import { computeComboItems } from "./utils/compute_combo_items";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 import { localization } from "@web/core/l10n/localization";
+import { formatDate } from "@web/core/l10n/dates";
 
 const formatCurrency = registry.subRegistries.formatters.content.monetary[1];
 const { DateTime } = luxon;
@@ -949,7 +950,7 @@ export class PosOrder extends Base {
     }
     //FIXME remove this
     getShippingDate() {
-        return this.shipping_date;
+        return formatDate(this.shipping_date);
     }
 
     getHasRefundLines() {


### PR DESCRIPTION
Before this commit:
==================
The `Ship Later` date was displayed in an incorrect or broken format on the payment screen.

After this commit:
====================
The `Ship Later` date is now displayed in the correct and readable format, consistent with how it appeared before the bug.

Task: 4702375
