### PR TITLE
[IMP] mrp: avoid MO updates on lot/serial creation

### DIFF
--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -211,6 +211,9 @@ class TestConsumeComponentCommon(common.TransactionCase):
         i = 1
         if isSerial:
             mrp_productions[i].action_generate_serial()
+            mo_form = Form(mrp_productions[i])
+            mo_form.qty_producing = 1.0
+            mo_form.save()
             i += 1
 
         if isAvailable:
@@ -324,6 +327,9 @@ class TestConsumeComponent(TestConsumeComponentCommon):
                 mo = mo_form.save()
             elif serialTrigger == 2:
                 mo.action_generate_serial()
+                mo_form = Form(mo)
+                mo_form.qty_producing = 1.0
+                mo = mo_form.save()
 
             for mov in mo.move_raw_ids:
                 if mov.has_tracking == "none":
@@ -476,7 +482,7 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         with Form(mo) as mo_form:
             mo_form.lot_producing_id = self.env['stock.lot']
         self.assertRecordValues(mo.move_raw_ids, [
-            {'quantity': 0.0, 'picked': False},
-            {'quantity': 0.0, 'picked': False},
-            {'quantity': 0.0, 'picked': False},
+            {'quantity': 3.0, 'picked': False},
+            {'quantity': 2.0, 'picked': False},
+            {'quantity': 1.0, 'picked': False},
         ])

--- a/addons/mrp/tests/test_smp.py
+++ b/addons/mrp/tests/test_smp.py
@@ -252,6 +252,9 @@ class TestMrpSerialMassProduce(TestMrpCommon):
         self.env['stock.quant']._update_available_quantity(comp1, mo.warehouse_id.lot_stock_id, 5)
         # Generate an SN using the action_generate_serial
         mo.action_generate_serial()
+        mo_form = Form(mo)
+        mo_form.qty_producing = 1.0
+        mo = mo_form.save()
         # In the end mass produce the SN's
         action = mo.action_mass_produce()
         wizard = Form(self.env['mrp.batch.produce'].with_context(**action['context']))

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -194,6 +194,7 @@ class TestTraceability(TestMrpCommon):
             'product_id': product_final.id,
             'name': 'Final_lot_1',
         })
+        mo_form.qty_producing = 1.0
         mo = mo_form.save()
 
         details_operation_form = Form(mo.move_raw_ids[0], view=self.env.ref('stock.view_stock_move_operations'))

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1365,6 +1365,7 @@ class TestSubcontractingTracking(TransactionCase):
             mo = self.env['mrp.production'].browse(action['res_id'])
             mo_form = Form(mo.with_context(**action['context']), view=action['view_id'])
             mo_form.lot_producing_id = serials_finished[i]
+            mo_form.qty_producing = 1.0
             with mo_form.move_line_raw_ids.edit(0) as ml:
                 self.assertEqual(ml.product_id, self.comp1_sn)
                 ml.lot_id = serials_comp1[i]

--- a/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
+++ b/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
@@ -339,6 +339,7 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
             mo = self.env['mrp.production'].browse(action['res_id'])
             mo_form = Form(mo.with_context(**action['context']), view=action['view_id'])
             mo_form.lot_producing_id = serials_finished[i]
+            mo_form.qty_producing = 1.0
             with mo_form.move_line_raw_ids.edit(0) as ml:
                 self.assertEqual(ml.product_id, self.comp1)
                 ml.lot_id = serials_comp1[i]

--- a/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
@@ -555,6 +555,7 @@ class TestSubcontractingDropshippingPortal(TestSubcontractingPortal):
         mo_form = Form(mo.with_context(action['context']), view=action['view_id'])
         # Registering components for the first manufactured product
         mo_form.lot_producing_id = finished_serial
+        mo_form.qty_producing = 1.0
         mo = mo_form.save()
         mo.subcontracting_record_component()
         self.assertRecordValues(mo, [{


### PR DESCRIPTION
Generating a lot or serial number for a manufacturing order no longer updates
the 'Quantity Producing' field. Component reservations and the MO status also
remain unchanged when a lot or serial number is generated.

Following this change, users must manually set the producing quantity, as it
will no longer be updated automatically when a lot or serial number is created.

This ensures that generating a lot/serial numbers does not have unintended side
effects on the MO flow.

Task ID: [4688059](https://www.odoo.com/odoo/project/966/tasks/4688059)
