### PR TITLE
[FIX] account: _read_group_select division by zero error

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -162,7 +162,7 @@ class AccountInvoiceReport(models.Model):
         if aggregate_spec != 'price_average:avg':
             return super()._read_group_select(aggregate_spec, query)
         return SQL(
-            'SUM(%(f_price)s) / SUM(%(f_qty)s)',
+            'SUM(%(f_price)s) / NULLIF(SUM(%(f_qty)s), 0.0)',
             f_qty=self._field_to_sql(self._table, 'quantity', query),
             f_price=self._field_to_sql(self._table, 'price_subtotal', query),
         )


### PR DESCRIPTION
Steps to reproduce:
    - Install accounting with demo data
    - Go to Reporting, Invoice Analysis in pivot view
    - Select Average Price

Issue:
    The _read_group_select method is overridden to correctly calculate the average price of products (see https://github.com/odoo/odoo/commit/29d9ea0d40c5f89c5636e80c68977358af5f77b4). But if the sum of quantities is zero, then we divide by zero.