### PR TITLE
[FIX] mail: temp msg bubble size is same as actual msg size

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -53,7 +53,7 @@
                                 </span>
                             </div>
                             <t t-if="isAlignedRight" t-call="mail.Message.notification"/>
-                            <t t-if="message.is_note and !message.isPending" t-call="mail.Message.actions"/>
+                            <t t-if="message.is_note" t-call="mail.Message.actions"/>
                         </div>
                         <div
                             class="o-mail-Message-contentContainer position-relative d-flex"
@@ -110,7 +110,7 @@
                                             </div>
                                         </t>
                                     </t>
-                                    <t t-if="!message.is_note and !message.isPending and message.hasTextContent and !env.inChatWindow" t-call="mail.Message.actions"/>
+                                    <t t-if="!message.is_note and message.hasTextContent and !env.inChatWindow" t-call="mail.Message.actions"/>
                                 </div>
                                 <AttachmentList
                                     t-if="message.attachment_ids.length > 0"
@@ -120,7 +120,7 @@
                                     messageSearch="props.messageSearch"/>
                                 <LinkPreviewList t-if="message.linkPreviews.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="props.message.editable"/>
                             </div>
-                            <t t-if="!message.is_note and !message.isPending and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>
+                            <t t-if="!message.is_note and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>
                         </div>
                         <MessageReactions message="message" openReactionMenu="openReactionMenu" t-if="message.reactions.length"/>
                     </div>
@@ -179,6 +179,11 @@
                         </t>
                     </Dropdown>
                 </div>
+                <t t-foreach="Array.from({ length: quickActionCount - quickActions.length - 1 })" t-as="emptyQuickAction" t-key="emptyQuickAction_index">
+                    <button class="btn border-0 px-1 py-0 rounded-0 opacity-0 pe-none">
+                        <i class="fa-lg fa fa-question"/>
+                    </button>
+                </t>
             </div>
         </t>
     </div>


### PR DESCRIPTION
Before this commit, when posting a message in chat window, the new message being posted had its size flicker momentarily.

This happens because when posting a new message, the message list contains a temporary message with the content momentarily and soon replaced by the genuine message from server data.

The genuine message shows quick actions like "Add a reaction", which the temporary message has not. Since these quick actions take some horizontal place, the temporary message was bigger on width than an actual message, which results to this flickering when the message takes more than 1 line.

This commit fixes the issue by allocating some space when a message has less (or no) available quick actions, so that their size matches with genuine message that have quick actions.

Before / After
![before](https://github.com/user-attachments/assets/73ad5051-153f-4294-95cf-225a1b4d749e) ![after](https://github.com/user-attachments/assets/09ad2eb0-67f4-4813-aade-8883990b525a)
