### PR TITLE
[FIX] stock_account: adapt stock valuation with tracked inventory adjustment

### DIFF
--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -31,9 +31,6 @@ class StockMoveLine(models.Model):
             for move_line in self:
                 move_id = vals.get('move_id', move_line.move_id.id)
                 analytic_move_to_recompute.add(move_id)
-        if 'quantity' in vals:
-            for move_line in self:
-                move_line._update_svl_quantity(vals['quantity'] - move_line.quantity)
         new_lot = False
         if 'lot_id' in vals:
             new_lot = vals.get('lot_id')
@@ -44,6 +41,10 @@ class StockMoveLine(models.Model):
             # remove quantity of old lot
             for move_line in self:
                 move_line._update_svl_quantity(-move_line.quantity)
+        elif 'quantity' in vals:
+            # directly updates the right quantity if no lot change
+            for move_line in self:
+                move_line._update_svl_quantity(vals['quantity'] - move_line.quantity)
         if 'location_id' in vals or 'location_dest_id' in vals:
             for move_line in self:
                 if move_line.state != 'done':


### PR DESCRIPTION
### Steps to reproduce:
- Create a storable product tracked by lot and avco valuated.
- Put 10 units of that product in stock withtout set lot.
- On the stock quant, click on history
- Modify the inventory adjustment move to set a quantity of 3 and a lot.
- Inventory > Reporting > Valuation
#### > Stock valuation layer inconsistency: +10, -10, -7, +3 > the -7 should not be there

### Cause of the issue:

If you change the quantity of a move line you will automatically reconcile the quantity difference because of these lines: https://github.com/odoo/odoo/blob/6f3f89f55ab67d39b2487fdf8220747f568b7eb0/addons/stock_account/models/stock_move_line.py#L34-L36 However, if you change the lot of your move line you already plan to conter balance the entire quantity of the previous lot because of these lines:
https://github.com/odoo/odoo/blob/6f3f89f55ab67d39b2487fdf8220747f568b7eb0/addons/stock_account/models/stock_move_line.py#L37-L46 In partciular, the first reconciliation should not be performed in case we change both the quantity and the lot of the move line.

opw-4685988
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
