### PR TITLE
[FIX] hr:tests: fix 'many2one widget in list view' race condition

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee.test.js
+++ b/addons/hr/static/tests/m2x_avatar_employee.test.js
@@ -387,7 +387,6 @@ test("many2one widget in list view", async () => {
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
-    expect(".o-mail-ChatWindow").toHaveCount(2);
     await waitFor(".o-mail-ChatWindow-header:contains('Yoshi')");
 });
 


### PR DESCRIPTION
This test was failing because it asserts a new chat window spawn, but this was asserting synchronously with `expect()` rather than asynchronously with `waitFor()`.

This made the test fail non-deterministically, as the spawn of chat window is not guaranteed to be exactly next animation frame of a click.

This is fixed by removing the `expect()` assertion on 2 chat windows, which is not really necessary as there's already an asynchronous assertion of the chat window with its header name on these test. Asserting presence of exactly 2 chat windows on UI is not supported with `waitFor`, so replacing with `waitFor('.o-mail-ChatWindow')` is useless because the 1st chat window is already open.

runbot-162712