### PR TITLE
[FIX] server: preserve order of server-wide modules for consistent loading

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1268,7 +1268,8 @@ class WorkerCron(Worker):
 server = None
 
 def load_server_wide_modules():
-    server_wide_modules = {'base', 'web'} | set(odoo.conf.server_wide_modules)
+    server_wide_modules = list(odoo.conf.server_wide_modules)
+    server_wide_modules.extend(m for m in ('base', 'web') if m not in server_wide_modules)
     for m in server_wide_modules:
         try:
             odoo.modules.module.load_openerp_module(m)


### PR DESCRIPTION
Avoid using a set when loading server-wide modules to ensure a deterministic and consistent module loading order. This change ensures 'base' and 'web' are always loaded in that specific order, improving predictability.
