### PR TITLE
[IMP] website_sale:  simplify checkout by removing /shop/confirm_order

### DIFF
--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -91,7 +91,7 @@
         <record id="website_sale.checkout_step_payment" model="website.checkout.step">
             <field name="name">Payment</field>
             <field name="sequence">999</field>
-            <field name="step_href">/shop/confirm_order</field>
+            <field name="step_href">/shop/payment</field>
             <field name="main_button_label">Confirm</field>
         </record>
 

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -824,3 +824,8 @@ class SaleOrder(models.Model):
 
         if not self.only_services and not self.carrier_id:
             raise ValidationError(_("No shipping method is selected."))
+
+    def _recompute_cart(self):
+        """Recompute taxes and prices for the current cart."""
+        self._recompute_taxes()
+        self._recompute_prices()

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -793,8 +793,8 @@ class Website(models.Model):
         )
         return steps
 
-    def _get_checkout_step_values(self, href=None):
-        href = href or request.httprequest.path
+    def _get_checkout_step_values(self):
+        href = request.httprequest.path
         # /shop/address is associated with the delivery step
         if href == '/shop/address':
             href = '/shop/checkout'

--- a/addons/website_sale/static/src/interactions/tracking.js
+++ b/addons/website_sale/static/src/interactions/tracking.js
@@ -9,7 +9,7 @@ export class Tracking extends Interaction {
         'a[href^="/web/login?redirect"][href*="/shop/checkout"]': {
             't-on-click': this.onCustomerSignin,
         },
-        'a[href="/shop/confirm_order"]': { 't-on-click': this.onOrder },
+        'a[href="/shop/payment"]': { 't-on-click': this.onOrder },
         'button[name="o_payment_submit_button"]': { 't-on-click': this.onOrderPayment },
         _root: {
             't-on-view_item_event': (ev) => this.onViewItem(ev),

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -148,7 +148,7 @@ export function goToCheckout() {
 export function confirmOrder() {
     return {
         content: 'Confirm',
-        trigger: 'a[href^="/shop/confirm_order"]',
+        trigger: 'a[href^="/shop/payment"]',
         run: 'click',
         expectUnloadPage: true,
     };

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2668,7 +2668,7 @@
                                 <a role="button"
                                    name="website_sale_main_button"
                                    class="s_website_form_send btn btn-primary order-lg-3 w-100 w-lg-auto ms-lg-auto"
-                                   href="/shop/confirm_order">
+                                   href="/shop/payment">
                                     Continue checkout
                                     <i class="fa fa-angle-right ms-2 fw-light"/>
                                 </a>
@@ -3145,7 +3145,7 @@
                             not website.is_public_user()) and show_shorter_cart_summary"
                     t-call="payment.express_checkout"
                 />
-                <t t-if="current_website_checkout_step_href == '/shop/confirm_order'">
+                <t t-if="current_website_checkout_step_href == '/shop/payment'">
                     <div t-if="not errors and not website_sale_order.amount_total"
                          name="o_website_sale_free_cart">
                         <form name="o_wsale_confirm_order"

--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -35,13 +35,6 @@ class WebsiteSale(main.WebsiteSale):
                 request.session['successful_code'] = promo
         return request.redirect(post.get('r', '/shop/cart'))
 
-    @route()
-    def shop_payment(self, **post):
-        if order_sudo := request.cart:
-            order_sudo._update_programs_and_rewards()
-            order_sudo._auto_apply_rewards()
-        return super().shop_payment(**post)
-
     @route(['/coupon/<string:code>'], type='http', auth='public', website=True, sitemap=False)
     def activate_coupon(self, code, r='/shop', **kw):
         url_parts = url_parse(r)

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -254,3 +254,9 @@ class SaleOrder(models.Model):
         return super()._cart_find_product_line(*args, **kwargs).filtered(
             lambda sol: not sol.is_reward_line
         )
+
+    def _recompute_cart(self):
+        """Recompute cart with loyalty programs and rewards applied."""
+        self._update_programs_and_rewards()
+        self._auto_apply_rewards()
+        super()._recompute_cart()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Streamlines the eCommerce checkout by removing the /shop/confirm_order route.

Current behavior before PR:
The checkout flow includes a redundant confirmation step (/shop/confirm_order), adding unnecessary complexity and extra user interaction.

Desired behavior after PR is merged:
Checkout proceeds directly from /shop/checkout to /shop/payment..

Related PR:
- Enterprise PR: https://github.com/odoo/enterprise/pull/82952

- Upgrade PR: https://github.com/odoo/upgrade/pull/7699

Affected version - master
Task-4676202


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
