### PR TITLE
[FIX] mail: don't log fields deletion message on deleted model

### DIFF
--- a/addons/mail/models/ir_model_fields.py
+++ b/addons/mail/models/ir_model_fields.py
@@ -45,6 +45,9 @@ class IrModelField(models.Model):
             )
             field_to_trackings = groupby(tracking_values, lambda track: track.field_id)
             for field, trackings in field_to_trackings:
+                if field.model_id.model not in self.env:
+                    # Model is already deleted
+                    continue
                 self.env['mail.tracking.value'].concat(*trackings).write({
                     'field_info': {
                         'desc': field.field_description,

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -891,6 +891,31 @@ class TestTrackingInternals(MailCommon):
         )
 
     @users('employee')
+    def test_unlinked_model(self):
+        """ Fields from obsolete models with tracking values can be unlinked without error. """
+        record = self.record.with_env(self.env)
+        record.write({'email_from': 'new_value'})  # create a tracking value
+        self.flush_tracking()
+        self.assertTracking(
+            record.message_ids[0],
+            [('email_from', 'char', False, 'new_value')],
+            strict=True,
+        )
+
+        fields_to_remove = self.env['ir.model.fields'].sudo().search([
+            ('model', '=', 'mail.test.ticket'),
+        ])
+
+        # Simulate a registry without the model, which is what we have if we
+        # update a module with the model code removed
+        model = self.env.registry.models.pop('mail.test.ticket')
+        try:
+            fields_to_remove.with_context(_force_unlink=True).unlink()
+        finally:
+            # Restore model to prevent registry errors after test
+            self.env.registry.models['mail.test.ticket'] = model
+
+    @users('employee')
     def test_unlinked_field(self):
         """ Check that removing a field removes its tracking values. """
         record = self.record.with_env(self.env)


### PR DESCRIPTION
Fixes
```
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 2647, in _process_end
    self._process_end_unlink_record(record)
  File "/home/odoo/src/odoo/addons/website/models/ir_model_data.py", line 35, in _process_end_unlink_record
    return super()._process_end_unlink_record(record)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 2576, in _process_end_unlink_record
    record.unlink()
  File "/home/odoo/src/odoo/addons/mail/models/ir_model_fields.py", line 52, in unlink
    'sequence': self.env[field.model_id.model]._mail_track_get_field_sequence(field.name),
                ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/api.py", line 612, in __getitem__
    return self.registry[model_name](self, (), ())
           ~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/modules/registry.py", line 240, in __getitem__
    return self.models[model_name]
           ~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'my.custom.model'
```

To reproduce:

* add a model with a tracked field to a module
* create a record and update field value to create a tracking message
* remove the model from the module and update the module


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
