### PR TITLE
[IMP] sale_project: task template for service products

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -69,6 +69,7 @@
             'project/static/src/css/project.css',
             'project/static/src/core/web/**/*',
             'project/static/src/utils/**/*',
+            'project/static/src/actions/client_actions.js',
             'project/static/src/components/**/*',
             'project/static/src/views/**/*',
             'project/static/src/js/tours/project.js',

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -776,6 +776,22 @@
             <field name="parent_id" ref="project.project_1_task_16"/>
             <field name="stage_id" ref="project_stage_2"/>
         </record>
+        <record id="project_1_task_18" model="project.task">
+            <field name="name">Template Task</field>
+            <field name="description">This is a template task - WIP</field>
+            <field name="project_id" ref="project.project_project_1"/>
+            <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
+            <field name="is_template">True</field>
+            <field name="active">False</field>
+        </record>
+        <record id="project_1_task_19" model="project.task">
+            <field name="name">Template Task 2</field>
+            <field name="description">Another Template?! - WIP</field>
+            <field name="project_id" ref="project.project_project_1"/>
+            <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
+            <field name="is_template">True</field>
+            <field name="active">False</field>
+        </record>
 
         <!-- Project 2 Tasks-->
         <record id="project_2_task_1" model="project.task">

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -638,6 +638,13 @@ class ProjectProject(models.Model):
                     'to align with the stage\'s company or remove the company designation from the stage', project.stage_id.company_id.name)
                 )
 
+    def get_template_tasks(self):
+        self.ensure_one()
+        return self.env['project.task'].with_context(active_test=False).search_read(
+            [('project_id', '=', self.id), ('is_template', '=', True)],
+            ['id', 'name'],
+        )
+
     # ---------------------------------------------------
     # Mail gateway
     # ---------------------------------------------------

--- a/addons/project/static/src/actions/client_actions.js
+++ b/addons/project/static/src/actions/client_actions.js
@@ -11,7 +11,7 @@ export function displayTemplateNotificationAction(env, action) {
                 name: "Undo",
                 icon: "fa-undo",
                 onClick: async () => {
-                    const res = env.services.orm.call(
+                    const res = await env.services.orm.call(
                         "project.task",
                         "action_undo_convert_to_template",
                         [taskId]

--- a/addons/project/static/src/actions/client_actions.js
+++ b/addons/project/static/src/actions/client_actions.js
@@ -1,0 +1,31 @@
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+
+export function displayTemplateNotificationAction(env, action) {
+    const params = action.params || {};
+    const taskId = params.task_id;
+    env.services.notification.add(_t("Task successfully converted to template."), {
+        type: "success",
+        buttons: [
+            {
+                name: "Undo",
+                icon: "fa-undo",
+                onClick: async () => {
+                    const res = env.services.orm.call(
+                        "project.task",
+                        "action_undo_convert_to_template",
+                        [taskId]
+                    );
+                    if (res) {
+                        env.services.action.doAction(res);
+                    }
+                },
+            },
+        ],
+    });
+    return params.next;
+}
+
+registry
+    .category("actions")
+    .add("project_show_template_notification", displayTemplateNotificationAction);

--- a/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { pick } from "@web/core/utils/objects";
 import { X2ManyField, x2ManyField } from '@web/views/fields/x2many/x2many_field';
 
 import { SubtaskListRenderer } from './subtask_list_renderer';
@@ -8,6 +9,23 @@ export class SubtaskOne2ManyField extends X2ManyField {
         ...X2ManyField.components,
         ListRenderer: SubtaskListRenderer,
     };
+
+    async switchToForm(record, options) {
+        await this.props.record.save();
+        this.action.doAction(
+            {
+                type: "ir.actions.act_window",
+                views: [[false, "form"]],
+                res_id: record.resId,
+                res_model: this.list.resModel,
+                context: pick(this.props.context, "active_test", "default_project_id"),
+            },
+            {
+                props: { resIds: this.list.resIds },
+                newWindow: options.newWindow,
+            }
+        );
+    }
 }
 
 export const subtaskOne2ManyField = {

--- a/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
@@ -18,7 +18,12 @@ export class SubtaskOne2ManyField extends X2ManyField {
                 views: [[false, "form"]],
                 res_id: record.resId,
                 res_model: this.list.resModel,
-                context: pick(this.props.context, "active_test", "default_project_id"),
+                context: pick(
+                    this.props.context,
+                    "active_test",
+                    "default_project_id",
+                    "propagate_not_active"
+                ),
             },
             {
                 props: { resIds: this.list.resIds },

--- a/addons/project/static/src/views/components/project_task_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.js
@@ -38,8 +38,8 @@ export class ProjectTaskTemplateDropdown extends Component {
     }
 
     async createTaskFromTemplate(templateId) {
-        this.action.doAction(
-            this.orm.call("project.task", "action_create_from_template", [templateId])
-        );
+        this.action.switchView("form", {
+            resId: await this.orm.call("project.task", "action_create_from_template", [templateId]),
+        });
     }
 }

--- a/addons/project/static/src/views/components/project_task_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.js
@@ -1,0 +1,45 @@
+import { Component, onWillStart } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+export class ProjectTaskTemplateDropdown extends Component {
+    static template = "project.TemplateDropdown";
+
+    static props = {
+        hotkey: {
+            type: String,
+            optional: true,
+        },
+        newButtonClasses: String,
+        onCreate: Function,
+        // Can be a number, false (in to-do) or undefined
+        projectId: {
+            type: [Number, Boolean],
+            optional: true,
+        },
+    };
+    static defaultProps = {
+        hotkey: "r",
+        projectId: null,
+    };
+
+    setup() {
+        this.action = useService("action");
+        this.orm = useService("orm");
+        onWillStart(this.onWillStart);
+        this.taskTemplates = [];
+    }
+
+    async onWillStart() {
+        if (this.props.projectId) {
+            this.taskTemplates = await this.orm.call("project.project", "get_template_tasks", [
+                this.props.projectId,
+            ]);
+        }
+    }
+
+    async createTaskFromTemplate(templateId) {
+        this.action.doAction(
+            this.orm.call("project.task", "action_create_from_template", [templateId])
+        );
+    }
+}

--- a/addons/project/static/src/views/components/project_task_template_dropdown.xml
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="project.TemplateDropdown">
+        <button t-if="!taskTemplates.length" type="button" t-att-class="props.newButtonClasses" t-att-data-hotkey="props.hotkey" t-on-click.stop="props.onCreate" data-bounce-button="">New</button>
+        <t t-else="">
+            <button type="button" t-attf-class="{{ props.newButtonClasses }} dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" t-att-data-hotkey="props.hotkey" data-bounce-button="">
+                New
+            </button>
+            <ul class="dropdown-menu o-project-form-dropdown-menu">
+                <button type="button" class="btn btn-link dropdown-item o-dropdown-item" t-on-click="props.onCreate">
+                    New Task
+                </button>
+                <div class="dropdown-divider"/>
+                <div class="dropdown-header" style="padding-left: 20px;">Task Templates</div>
+                <t t-foreach="taskTemplates" t-as="template" t-key="template.id">
+                    <button type="button" class="btn btn-link o-dropdown-item dropdown-item" style="padding-left: 32px;" t-on-click="() =&gt; this.createTaskFromTemplate(template.id)" t-out="template.name"/>
+                </t>
+            </ul>
+        </t>
+    </t>
+</templates>

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.js
@@ -6,6 +6,8 @@ import { markup } from '@odoo/owl';
 import { escape } from '@web/core/utils/strings';
 import { FormControllerWithHTMLExpander } from '@resource/views/form_with_html_expander/form_controller_with_html_expander';
 
+import { ProjectTaskTemplateDropdown } from "../components/project_task_template_dropdown";
+
 export const subTaskDeleteConfirmationMessage = _t(
     `Deleting a task will also delete its associated sub-tasks. \
 If you wish to preserve the sub-tasks, make sure to unlink them from their parent task beforehand.
@@ -14,6 +16,12 @@ Are you sure you want to proceed?`
 );
 
 export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
+    static template = "project.ProjectTaskFormView";
+    static components = {
+        ...FormControllerWithHTMLExpander.components,
+        ProjectTaskTemplateDropdown,
+    };
+
     setup() {
         super.setup();
         this.notifications = useService("notification");

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.xml
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.ProjectTaskFormView" t-inherit="resource.FormViewWithHtmlExpander" t-inherit-mode="primary">
+        <button class="btn btn-outline-primary o_form_button_create" position="replace">
+            <ProjectTaskTemplateDropdown projectId="props.context.default_project_id" onCreate="() =&gt; this.create()" newButtonClasses="'btn btn-outline-primary o_form_button_create'"/>
+        </button>
+    </t>
+</templates>

--- a/addons/project/static/src/views/project_task_form/project_task_form_view.scss
+++ b/addons/project/static/src/views/project_task_form/project_task_form_view.scss
@@ -25,3 +25,7 @@
         max-width: initial;
     }
 }
+
+.o-project-form-dropdown-menu {
+    z-index: 1030 !important;
+}

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.js
@@ -1,0 +1,11 @@
+import { KanbanController } from "@web/views/kanban/kanban_controller";
+
+import { ProjectTaskTemplateDropdown } from "../components/project_task_template_dropdown";
+
+export class ProjectTaskKanbanController extends KanbanController {
+    static template = "project.ProjectTaskKanbanView";
+    static components = {
+        ...KanbanController.components,
+        ProjectTaskTemplateDropdown,
+    };
+}

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.ProjectTaskKanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
+        <button class="btn btn-primary o-kanban-button-new" position="replace">
+            <ProjectTaskTemplateDropdown projectId="props.context.default_project_id" onCreate="() =&gt; this.createRecord()" newButtonClasses="'btn btn-primary o-kanban-button-new'"/>
+        </button>
+    </t>
+</templates>

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.js
@@ -1,5 +1,6 @@
 import { registry } from "@web/core/registry";
 import { kanbanView } from '@web/views/kanban/kanban_view';
+import { ProjectTaskKanbanController } from "./project_task_kanban_controller";
 import { ProjectTaskKanbanModel } from "./project_task_kanban_model";
 import { ProjectTaskKanbanRenderer } from './project_task_kanban_renderer';
 
@@ -7,6 +8,7 @@ export const projectTaskKanbanView = {
     ...kanbanView,
     Model: ProjectTaskKanbanModel,
     Renderer: ProjectTaskKanbanRenderer,
+    Controller: ProjectTaskKanbanController,
 };
 
 registry.category('views').add('project_task_kanban', projectTaskKanbanView);

--- a/addons/project/static/src/views/project_task_list/project_task_list_controller.js
+++ b/addons/project/static/src/views/project_task_list/project_task_list_controller.js
@@ -1,7 +1,14 @@
 import { ListController } from "@web/views/list/list_controller";
 import { subTaskDeleteConfirmationMessage } from "@project/views/project_task_form/project_task_form_controller";
 
+import { ProjectTaskTemplateDropdown } from "../components/project_task_template_dropdown";
+
 export class ProjectTaskListController extends ListController {
+    static template = "project.ProjectTaskListView";
+    static components = {
+        ...ListController.components,
+        ProjectTaskTemplateDropdown,
+    };
 
     get deleteConfirmationDialogProps() {
         const deleteConfirmationDialogProps = super.deleteConfirmationDialogProps;

--- a/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
+++ b/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.ProjectTaskListView" t-inherit="web.ListView" t-inherit-mode="primary">
+        <button class="btn btn-primary o_list_button_add" position="replace">
+            <ProjectTaskTemplateDropdown projectId="props.context.default_project_id" onCreate="() = &gt; this.onClickCreate()" newButtonClasses="'btn btn-primary o_list_button_add'"/>
+        </button>
+    </t>
+</templates>

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -30,7 +30,13 @@ export class ProjectProject extends models.Model {
 
     check_access_rights() {
         return Promise.resolve(true);
-    };
+    }
+
+    get_template_tasks(projectId) {
+        return ProjectTask._records.filter(
+            (task) => task.project_id === projectId && task.is_template
+        );
+    }
 }
 
 export class ProjectProjectStage extends models.Model {
@@ -91,6 +97,8 @@ export class ProjectTask extends models.Model {
     depend_on_ids = fields.Many2many({ relation: "project.task" });
     closed_depend_on_count = fields.Integer();
     is_closed = fields.Boolean();
+    active = fields.Boolean({ string: "Active", default: true });
+    is_template = fields.Boolean({ string: "Is Template", default: false });
 
     _records = [
         {

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -1,5 +1,5 @@
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
-import { defineModels, fields, models } from "@web/../tests/web_test_helpers";
+import { defineModels, fields, makeKwArgs, models } from "@web/../tests/web_test_helpers";
 
 export class ProjectProject extends models.Model {
     _name = "project.project";
@@ -33,8 +33,17 @@ export class ProjectProject extends models.Model {
     }
 
     get_template_tasks(projectId) {
-        return ProjectTask._records.filter(
-            (task) => task.project_id === projectId && task.is_template
+        return this.env["project.task"].search_read(
+            [
+                ["project_id", "=", projectId],
+                ["is_template", "=", true],
+            ],
+            ["id", "name"],
+            makeKwArgs({
+                context: {
+                    active_test: false,
+                },
+            })
         );
     }
 }

--- a/addons/project/static/tests/project_task_template_dropdown.test.js
+++ b/addons/project/static/tests/project_task_template_dropdown.test.js
@@ -1,0 +1,118 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { contains, mountView } from "@web/../tests/web_test_helpers";
+
+import { defineProjectModels, ProjectTask } from "./project_models";
+
+defineProjectModels();
+
+function addTemplateTasks() {
+    ProjectTask._records.push(
+        {
+            id: 4,
+            name: "Template Task 1",
+            project_id: 1,
+            stage_id: 1,
+            state: "01_in_progress",
+            active: false,
+            is_template: true,
+        },
+        {
+            id: 5,
+            name: "Template Task 2",
+            project_id: 1,
+            stage_id: 1,
+            state: "01_in_progress",
+            active: false,
+            is_template: true,
+        }
+    );
+}
+
+beforeEach(() => {
+    ProjectTask._views = {
+        form: `
+            <form js_class="project_task_form">
+                <field name="name"/>
+            </form>
+        `,
+        kanban: `
+            <kanban js_class="project_task_kanban">
+                <templates>
+                    <t t-name="card">
+                        <field name="name"/>
+                    </t>
+                </templates>
+            </kanban>
+        `,
+        list: `
+            <list js_class="project_task_list">
+                <field name="name"/>
+            </list>
+        `,
+    };
+});
+
+for (const [viewType, newButtonClass] of [
+    ["form", "o_form_button_create"],
+    ["kanban", "o-kanban-button-new"],
+    ["list", "o_list_button_add"],
+]) {
+    test(`template dropdown in ${viewType} view of a project with no template`, async () => {
+        await mountView({
+            resModel: "project.task",
+            resId: 1,
+            type: viewType,
+            context: {
+                default_project_id: 1,
+            },
+        });
+        expect(`button.${newButtonClass}`).toHaveCount(1, {
+            message: "The “New” button should be displayed",
+        });
+        expect(`button.${newButtonClass}`).not.toHaveClass("dropdown-toggle", {
+            message: "The “New” button should not be a dropdown since there is no template",
+        });
+
+        // Test that we can create a new record without errors
+        await contains(`button.${newButtonClass}`).click();
+    });
+
+    test(`template dropdown in ${viewType} view of a project with one template`, async () => {
+        addTemplateTasks();
+        await mountView({
+            resModel: "project.task",
+            resId: 1,
+            type: viewType,
+            context: {
+                default_project_id: 1,
+            },
+        });
+        expect(`button.${newButtonClass}`).toHaveCount(1, {
+            message: "The “New” button should be displayed",
+        });
+        expect(`button.${newButtonClass}`).toHaveClass("dropdown-toggle", {
+            message: "The “New” button should be a dropdown since there is a template",
+        });
+
+        await contains(`button.${newButtonClass}`).click();
+        expect("button.dropdown-item:contains('New Task')").toHaveCount(1, {
+            message: "The “New Task” button should be in the dropdown",
+        });
+        expect("button.dropdown-item:contains('Template Task 1')").toHaveCount(1, {
+            message: "There should be a button named after the task template",
+        });
+    });
+}
+
+test("template dropdown should not appear when not in the context of a specific project", async () => {
+    addTemplateTasks();
+    await mountView({
+        resModel: "project.task",
+        type: "kanban",
+    });
+
+    expect("button.o-kanban-button-new").not.toHaveClass("dropdown-toggle", {
+        message:
+            "The “New” button should not be a dropdown since there is no project in the context",
+    });
+});

--- a/addons/project/static/tests/tours/project_task_templates_tour.js
+++ b/addons/project/static/tests/tours/project_task_templates_tour.js
@@ -1,0 +1,47 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("project_task_templates_tour", {
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
+            run: "click",
+        },
+        {
+            trigger: '.o_kanban_record span:contains("Project with Task Template")',
+            run: "click",
+            content: "Navigate to the project with a task template",
+        },
+        {
+            trigger: 'div.o_last_breadcrumb_item span:contains("Project with Task Template")',
+            content: "Wit for the kanban view to load",
+        },
+        {
+            trigger: "button.o-kanban-button-new",
+            run: "click",
+        },
+        {
+            trigger: 'ul.dropdown-menu button.dropdown-item:contains("Template")',
+            run: "click",
+            content: "Create a task with the template",
+        },
+        {
+            trigger: 'div[name="name"] .o_input',
+            run: "edit Task",
+        },
+        {
+            trigger: "button.o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
+        {
+            trigger: 'div.note-editable.odoo-editor-editable:contains("Template description")',
+            content: "Check that the created task has copied the description of the template",
+        },
+    ],
+});

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -26,6 +26,8 @@ from . import test_multicompany
 from . import test_personal_stages
 from . import test_task_dependencies
 from . import test_task_follow
+from . import test_task_templates
+from . import test_task_templates_ui
 from . import test_task_tracking
 from . import test_project_report
 from . import test_project_task_quick_create

--- a/addons/project/tests/test_task_templates.py
+++ b/addons/project/tests/test_task_templates.py
@@ -1,5 +1,3 @@
-from odoo import Command
-
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
 
 
@@ -9,7 +7,6 @@ class TestTaskTemplates(TestProjectCommon):
         super().setUpClass()
         cls.project_with_templates = cls.env["project.project"].create({
             "name": "Project with Task Template",
-            "type_ids": [Command.link(cls.env.ref("project.project_project_stage_0").id)],
         })
         cls.template_task = cls.env["project.task"].create({
             "name": "Template",
@@ -17,12 +14,46 @@ class TestTaskTemplates(TestProjectCommon):
             "active": False,
             "is_template": True,
             "description": "Template description",
-            "stage_id": cls.env.ref("project.project_project_stage_0").id,
         })
+        cls.child_task = cls.env["project.task"].create({
+            "name": "Child Task",
+            "parent_id": cls.template_task.id,
+            "active": False,
+            "description": "Child description",
+        })
+
+    def test_create_from_template(self):
+        """
+        Creating a task through the action should result in an active, non template copy
+        """
+        task_id = self.template_task.action_create_from_template()
+        task = self.env["project.task"].browse(task_id)
+        self.assertFalse(task.is_template, "The created task should be a normal task and not a template.")
+        self.assertTrue(task.active, "The created task should not be archived.")
+
+        self.assertEqual(len(task.with_context(active_test=False).child_ids), 1, "The child of the template should be copied too.")
+        child_task = task.with_context(active_test=False).child_ids
+        self.assertTrue(child_task.active, "The child task should be active too.")
+        self.assertFalse(child_task.is_template, "The child task should still not be a template.")
 
     def test_copy_archived_template(self):
         """
         Copying a template should preserve its archived status
         """
         copied_template = self.template_task.copy()
-        self.assertFalse(copied_template.active, "The copied template should also be archived")
+        self.assertFalse(copied_template.active, "The copied template should also be archived.")
+
+        self.assertEqual(len(copied_template.with_context(active_test=False).child_ids), 1, "The child of the template should be copied too.")
+        copied_template_child_task = copied_template.with_context(active_test=False).child_ids
+        self.assertFalse(copied_template_child_task.active, "The child task should be archived.")
+        self.assertFalse(copied_template_child_task.is_template, "The child task should still not be a template.")
+
+    def test_copy_project_with_templates(self):
+        """
+        Copying a project should also copy its task templates
+        """
+        copied_project = self.project_with_templates.copy()
+        task = self.env["project.task"].with_context(active_test=False).search([("project_id", "=", copied_project.id)], order="id asc", limit=1)
+        self.assertTrue(task, "The copied project should contain a copy of the template.")
+        self.assertTrue(task.is_template, "The copied template should still be a template.")
+        self.assertFalse(task.active, "The copied template should still be archived")

--- a/addons/project/tests/test_task_templates.py
+++ b/addons/project/tests/test_task_templates.py
@@ -1,0 +1,28 @@
+from odoo import Command
+
+from odoo.addons.project.tests.test_project_base import TestProjectCommon
+
+
+class TestTaskTemplates(TestProjectCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project_with_templates = cls.env["project.project"].create({
+            "name": "Project with Task Template",
+            "type_ids": [Command.link(cls.env.ref("project.project_project_stage_0").id)],
+        })
+        cls.template_task = cls.env["project.task"].create({
+            "name": "Template",
+            "project_id": cls.project_with_templates.id,
+            "active": False,
+            "is_template": True,
+            "description": "Template description",
+            "stage_id": cls.env.ref("project.project_project_stage_0").id,
+        })
+
+    def test_copy_archived_template(self):
+        """
+        Copying a template should preserve its archived status
+        """
+        copied_template = self.template_task.copy()
+        self.assertFalse(copied_template.active, "The copied template should also be archived")

--- a/addons/project/tests/test_task_templates_ui.py
+++ b/addons/project/tests/test_task_templates_ui.py
@@ -1,0 +1,24 @@
+from odoo import Command
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestTaskTemplatesTour(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project_with_templates = cls.env["project.project"].create({
+            "name": "Project with Task Template",
+            "type_ids": [Command.link(cls.env.ref("project.project_project_stage_0").id)],
+        })
+        cls.template_task = cls.env["project.task"].create({
+            "name": "Template",
+            "project_id": cls.project_with_templates.id,
+            "active": False,
+            "is_template": True,
+            "description": "Template description",
+            "stage_id": cls.env.ref("project.project_project_stage_0").id,
+        })
+
+    def test_task_templates_tour(self):
+        self.start_tour("/odoo", "project_task_templates_tour", login="admin")

--- a/addons/project/views/project_menus.xml
+++ b/addons/project/views/project_menus.xml
@@ -104,6 +104,11 @@
                 action="project_tags_action"
             />
             <menuitem
+                name="Task Templates"
+                id="project_menu_config_task_templates"
+                action="project_task_templates_action"
+            />
+            <menuitem
                 name="Activity Types"
                 id="project_menu_config_activity_type"
                 action="mail_activity_type_action_config_project_types"

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -326,6 +326,7 @@
                     <field name="depend_on_count" invisible="1"/>
                     <field name="closed_depend_on_count" invisible="1"/>
                     <field name="html_field_history_metadata" invisible="1"/>
+                    <field name="is_template" invisible="1"/>
                     <header>
                         <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not project_id and not stage_id"/>
                         <field name="state" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="1"/>
@@ -384,17 +385,18 @@
                         <!-- Dummy tag used to organize buttons -->
                         <span id="end_button_box" invisible="1"/>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or is_template"/>
+                    <widget name="web_ribbon" title="Template" bg_color="text-bg-info" invisible="not is_template"/>
                     <div class="oe_title pe-0">
                         <h1 class="d-flex justify-content-between align-items-center">
                             <div class="d-flex w-100">
                                 <field name="priority" widget="priority_switch" class="me-3"/>
                                 <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
                             </div>
-                            <div class="d-flex justify-content-end o_state_container" invisible="not active">
+                            <div class="d-flex justify-content-end o_state_container" invisible="not active or is_template">
                                 <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                             </div>
-                            <div class="d-flex justify-content-start o_state_container w-100 w-md-50 w-lg-25" invisible="active">
+                            <div class="d-flex justify-content-start o_state_container w-100 w-md-50 w-lg-25" invisible="active and not is_template">
                                 <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                             </div>
                         </h1>
@@ -403,7 +405,7 @@
                         <group>
                             <field name="project_id"
                                 domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
-                                required="parent_id or child_ids"
+                                required="parent_id or child_ids or is_template"
                                 widget="project"/>
                             <field name="milestone_id"
                                 placeholder="e.g. Product Launch"
@@ -455,11 +457,15 @@
                                         'default_parent_id': id,
                                         'default_partner_id': partner_id,
                                         'default_milestone_id': allow_milestones and milestone_id,
+                                        'default_active': not is_template,
+                                        'default_is_template': False,
                                         'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
                                         'closed_X2M_count': closed_subtask_count,
                                    }"
                                    widget="subtasks_one2many">
                                 <list editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
+                                    <field name="active" column_invisible="True"/>
+                                    <field name="is_template" column_invisible="True"/>
                                     <field name="allow_milestones" column_invisible="True"/>
                                     <field name="display_in_project" column_invisible="True" force_save="1"/>
                                     <field name="sequence" widget="handle"/>
@@ -590,6 +596,7 @@
                                placeholder="Private"
                                class="o_project_task_project_field"
                                domain="[('type_ids', 'in', context['default_stage_id'])] if context.get('default_stage_id') else []"
+                               required="is_template"
                         />
                         <field name="user_ids" options="{'no_open': True, 'no_quick_create': True}"
                             widget="many2many_avatar_user"/>
@@ -723,7 +730,7 @@
                     <field name="priority" widget="priority" nolabel="1" width="20px"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
                     <field name="name" string="Title" widget="name_with_subtask_count"/>
-                    <field name="project_id" widget="project" optional="show" options="{'no_open': 1}" readonly="1" column_invisible="context.get('default_project_id')"/>
+                    <field name="project_id" widget="project" optional="show" options="{'no_open': 1}" readonly="1" column_invisible="context.get('default_project_id')" required="is_template"/>
                     <field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}" groups="project.group_project_milestone" optional="hide"/>
                     <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" options="{'no_open': True}"/>
                     <field name="user_ids" optional="show" widget="many2many_avatar_user"/>
@@ -1113,6 +1120,18 @@
             </field>
         </record>
 
+        <record id="action_server_convert_to_template" model="ir.actions.server">
+            <field name="name">Convert to Template</field>
+            <field name="model_id" ref="project.model_project_task"/>
+            <field name="binding_model_id" ref="project.model_project_task"/>
+            <field name="binding_view_types">form</field>
+            <field name="group_ids" eval="[Command.link(ref('project.group_project_manager'))]"/>
+            <field name="state">code</field>
+            <field name="code">
+                action = record.action_convert_to_template()
+            </field>
+        </record>
+
         <!-- Views for 'Tasks' stat button via Contact form -->
         <record id="view_task_form_res_partner" model="ir.ui.view">
             <field name="name">project.task.form.res.partner</field>
@@ -1277,6 +1296,59 @@
             <field name="sequence" eval="70"/>
             <field name="view_mode">graph</field>
             <field name="view_id" ref="project_task_graph_view_project_milestone"/>
+        </record>
+
+        <record id="project_task_templates_list" model="ir.ui.view">
+            <field name="name">project.task.templates.list</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="project_task_view_tree_base"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="//field[not(@name='name') and not(@name='project_id')]" position="attributes">
+                    <attribute name="optional">hide</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="project_task_templates_kanban" model="ir.ui.view">
+            <field name="name">project.task.templates.list</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="view_task_kanban"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <kanban position="attributes">
+                    <attribute name="default_group_by">project_id</attribute>
+                </kanban>
+            </field>
+        </record>
+
+        <record id="project_task_templates_action" model="ir.actions.act_window">
+            <field name="name">Task Templates</field>
+            <field name="res_model">project.task</field>
+            <field name="view_mode">list,kanban,form</field>
+            <field name="domain">[('is_template', '=', True)]</field>
+            <field name="context">{'active_test': False, 'default_is_template': True}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No task templates found. Let's create one!
+                </p>
+                <p>
+                    Save time by using task templates with pre-filled details.<br/>
+                    Standardize workflows and ensure consistency across tasks.
+                </p>
+            </field>
+        </record>
+
+        <record id="project_task_templates_action_list" model="ir.actions.act_window.view">
+            <field name="act_window_id" ref="project_task_templates_action"/>
+            <field name="view_mode">list</field>
+            <field name="view_id" ref="project.project_task_templates_list"/>
+        </record>
+
+        <record id="project_task_templates_action_kanban" model="ir.actions.act_window.view">
+            <field name="act_window_id" ref="project_task_templates_action"/>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="project.project_task_templates_kanban"/>
         </record>
 
 </odoo>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -457,10 +457,11 @@
                                         'default_parent_id': id,
                                         'default_partner_id': partner_id,
                                         'default_milestone_id': allow_milestones and milestone_id,
-                                        'default_active': not is_template,
+                                        'default_active': not is_template and not context.get('propagate_not_active'),
                                         'default_is_template': False,
                                         'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
                                         'closed_X2M_count': closed_subtask_count,
+                                        'propagate_not_active': is_template or context.get('propagate_not_active'),
                                    }"
                                    widget="subtasks_one2many">
                                 <list editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
@@ -1304,9 +1305,9 @@
             <field name="inherit_id" ref="project_task_view_tree_base"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <xpath expr="//field[not(@name='name') and not(@name='project_id')]" position="attributes">
-                    <attribute name="optional">hide</attribute>
-                </xpath>
+                <field name="project_id" position="attributes">
+                    <attribute name="readonly">False</attribute>
+                </field>
             </field>
         </record>
 

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -746,6 +746,7 @@
             <field name="arch" type="xml">
                 <list position="attributes">
                     <attribute name="multi_edit">1</attribute>
+                    <attribute name="js_class">project_task_list</attribute>
                 </list>
                 <field name="date_deadline" position="after">
                     <field name="activity_ids" string="Next Activity" widget="list_activity" optional="show"/>
@@ -778,7 +779,6 @@
             <field name="priority">2</field>
             <field name="arch" type="xml">
                 <list position="attributes">
-                    <attribute name="js_class">project_task_list</attribute>
                     <attribute name="default_group_by">stage_id</attribute>
                 </list>
             </field>

--- a/addons/sale_project/models/product_template.py
+++ b/addons/sale_project/models/product_template.py
@@ -36,6 +36,10 @@ class ProductTemplate(models.Model):
     project_template_id = fields.Many2one(
         'project.project', 'Project Template', company_dependent=True, copy=True,
     )
+    task_template_id = fields.Many2one(
+        'project.task', 'Task Template', domain="[('is_template', '=', True), ('active', '=', False), ('project_id', 'in', [project_id, project_template_id])]",
+        company_dependent=True, copy=True,
+    )
     service_policy = fields.Selection('_selection_service_policy', string="Service Invoicing Policy", compute_sudo=True, compute='_compute_service_policy', inverse='_inverse_service_policy', tracking=True)
     service_type = fields.Selection(selection_add=[
         ('milestones', 'Project Milestones'),
@@ -124,6 +128,10 @@ class ProductTemplate(models.Model):
             self.project_template_id = False
         elif self.service_tracking in ['task_in_project', 'project_only']:
             self.project_id = False
+
+    @api.onchange('project_id', 'project_template_id')
+    def _onchange_project_fields(self):
+        self.task_template_id = False
 
     def write(self, vals):
         if 'type' in vals and vals['type'] != 'service':

--- a/addons/sale_project/views/product_views.xml
+++ b/addons/sale_project/views/product_views.xml
@@ -21,6 +21,24 @@
                     <label for='project_template_id'/>
                 </div>
                 <field name="project_template_id" context="{'active_test': False, 'default_allow_billable': True}" invisible="service_tracking not in ['task_in_project', 'project_only']" nolabel="1" placeholder="Empty project"/>
+                <div class="o_td_label d-inline-flex"
+                    invisible="not project_id and (service_tracking != 'task_in_project' or not project_template_id)">
+                    <label for="task_template_id" />
+                </div>
+                <!-- Editable field for project users -->
+                <field name="task_template_id"
+                    groups="project.group_project_user"
+                    context="{'default_active': False, 'default_is_template': True, 'default_project_id': project_id or project_template_id}"
+                    invisible="not project_id and (service_tracking != 'task_in_project' or not project_template_id)"
+                    nolabel="1"
+                    placeholder="Empty Task template" />
+                <!-- Read-only field for non-project users -->
+                <field name="task_template_id"
+                    groups="!project.group_project_user"
+                    options="{'no_open': True, 'no_create_edit': True, 'no_create': True}"
+                    invisible="not project_id and (service_tracking != 'task_in_project' or not project_template_id)"
+                    nolabel="1"
+                    placeholder="Empty Task template" />
                 <field name="service_policy"
                     string="Invoicing Policy"
                     invisible="type != 'service' or sale_ok == False"


### PR DESCRIPTION
- Task Template field is added to the Product Template.
- Selection is limited to Service products with 'Create on Order' set
  to `Task` or `Project & Task` when any project is selected.
- The existing behavior is maintained when no template is selected.

task-4369824




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
