### PR TITLE
[FIX] spreadsheet: Split cumulative and cumulated_start

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
@@ -43,9 +43,10 @@ export class OdooChart extends AbstractChart {
             ...definition.metaData,
             mode: this.type.replace("odoo_", ""),
             cumulated: definition.cumulative,
-            // if a chart is cumulated, the first data point should take into
-            // account past data, even if a domain on a specific period is applied
-            cumulatedStart: definition.cumulative,
+            cumulatedStart:
+                "cumulatedStart" in definition
+                    ? definition.cumulatedStart
+                    : definition.cumulative,
         };
         this.searchParams = definition.searchParams;
         this.legendPosition = definition.legendPosition;


### PR DESCRIPTION
The option of "cumulatedStart" was incorrectly infered from the "cumulative" option of an Odoo graph view. However, both options are not specifically linked.

Task-4701303

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
