### PR TITLE
[FIX] point_of_sale: pricelist combo price computation

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -527,7 +527,7 @@ export class PosOrder extends Base {
             );
         }
         const combo_children_lines = this.lines.filter(
-            (line) => line.price_type === "original" && line.combo_parent_id
+            (line) => line.price_type === "automatic" && line.combo_parent_id
         );
         combo_children_lines.forEach((line) => {
             line.set_unit_price(

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -761,6 +761,7 @@ export class PosStore extends Reactive {
                     ]),
                     combo_item_id: comboItem.combo_item_id,
                     price_unit: comboItem.price_unit,
+                    price_type: "automatic",
                     order_id: order,
                     qty: 1,
                     attribute_value_ids: comboItem.attribute_value_ids?.map((attr) => [

--- a/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
@@ -146,3 +146,30 @@ registry.category("web_tour.tours").add("ProductComboChangeFP", {
             ProductScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("ProductComboChangePricelist", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            Dialog.confirm(),
+            inLeftSide([
+                ...ProductScreen.orderLineHas("Combo Product 2", "1.0", "6.67"),
+                ...ProductScreen.orderLineHas("Combo Product 4", "1.0", "14.66"),
+                ...ProductScreen.orderLineHas("Combo Product 6", "1.0", "26.00"),
+            ]),
+            ProductScreen.totalAmountIs("47.33"),
+            ProductScreen.clickPriceList("sale 10%"),
+            inLeftSide([
+                ...ProductScreen.orderLineHas("Combo Product 2", "1.0", "6.00"),
+                ...ProductScreen.orderLineHas("Combo Product 4", "1.0", "13.20"),
+                ...ProductScreen.orderLineHas("Combo Product 6", "1.0", "23.40"),
+            ]),
+            ProductScreen.totalAmountIs("42.60"),
+            ProductScreen.isShown(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1486,6 +1486,29 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductComboChangeFP', login="pos_user")
 
+    def test_product_combo_change_pricelist(self):
+        """
+        Verify than when we change the pricelist, the combo price is updated
+        """
+        setup_product_combo_items(self)
+
+        sale_10_pl = self.env['product.pricelist'].create({
+            'name': 'sale 10%',
+        })
+        self.env['product.pricelist.item'].create({
+            'pricelist_id': sale_10_pl.id,
+            'base': 'pricelist',
+            'compute_price': 'percentage',
+            'applied_on': '3_global',
+            'percent_price': 10,
+        })
+
+        self.main_pos_config.write({
+            'available_pricelist_ids': [(4, sale_10_pl.id)],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductComboChangePricelist', login="pos_user")
+
     def test_cash_rounding_payment(self):
         """Verify than an error popup is shown if the payment value is more precise than the rounding method"""
         rounding_method = self.env['account.cash.rounding'].create({


### PR DESCRIPTION
- Fix issue where combo price were not recomputed when changing the pricelist of the order.
- The issue was due to the fact that in the `pos_order.set_pricelist()` method we were only recopute the combo line that have a `price_type === "original"`, and that the combo line `price_type` was undefined.
Now when a adding a combo product to the cart, all of its lines have a `price_type` set to `automatic` initially, and inside `pos_order.set_pricelist()` we now recompute the price of the combo line that have a `price_type === "automatic"`.

Steps to reproduct:
- Create pricelists and add it to pos config
- Open PoS
- Add combo product to cart
- Change pricelist
- => Price is not recomputed based on the pricelist as it should

task-id: 4707663



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
