### PR TITLE
[IMP] orm: cached check_access

### DIFF
--- a/addons/survey/tests/test_certification_flow.py
+++ b/addons/survey/tests/test_certification_flow.py
@@ -117,12 +117,12 @@ class TestCertificationFlow(common.TestSurveyCommon, MockEmail, HttpCase):
             self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token, button_submit='previous')
             self._answer_question(q03, "Just kidding, I don't like it...", answer_token, csrf_token)
             self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token,
-                                  submit_query_count=43, access_page_query_count=24)
+                                  submit_query_count=43, access_page_query_count=25)
             q05_answers = q05.suggested_answer_ids.ids[0:2] + [q05.suggested_answer_ids.ids[3]]
             self._answer_question(q05, q05_answers, answer_token, csrf_token,
-                                  submit_query_count=28, access_page_query_count=24)
+                                  submit_query_count=29, access_page_query_count=25)
             self._answer_question(q06, q06.suggested_answer_ids.ids[0], answer_token, csrf_token,
-                                  submit_query_count=108, access_page_query_count=24)
+                                  submit_query_count=108, access_page_query_count=25)
 
         user_inputs.invalidate_recordset()
         # Check that certification is successfully passed

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -54,6 +54,7 @@ class TestActivityRights(TestActivityCommon):
 
         # If user has no access to the record, should return activity view instead
         with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_no_access):
+            self.env.transaction.clear_access_cache()
             self.assertFalse(self.test_record.with_user(self.user_employee).has_access('read'))
 
             action = test_activity.with_user(self.user_employee).action_open_document()

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -90,6 +90,7 @@ class TestMailMail(MailCommon):
 
         with patch.object(self.env.registry['ir.attachment'], '_check_access', _patched_check_access):
             # Sanity check
+            self.env.transaction.clear_access_cache()
             self.assertEqual(mail.restricted_attachment_count, 2)
             self.assertEqual(len(mail.unrestricted_attachment_ids), 2)
             self.assertEqual(mail.unrestricted_attachment_ids.mapped('name'), ['file 1', 'file 3'])

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1152,7 +1152,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=41, employee=42):
+        with self.assertQueryCount(admin=42, employee=42):
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -1202,7 +1202,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
 
-        with self.assertQueryCount(admin=57, employee=57):
+        with self.assertQueryCount(admin=58, employee=58):
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -1239,7 +1239,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=62, employee=63):
+        with self.assertQueryCount(admin=64, employee=64):
             rec.write({
                 'name': 'Test2',
                 'container_id': container_id,
@@ -1272,7 +1272,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(admin=32, employee=33):
+        with self.assertQueryCount(admin=34, employee=34):
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -182,6 +182,7 @@ class IrRule(models.Model):
 
     def unlink(self):
         res = super(IrRule, self).unlink()
+        self.env.transaction.clear_access_cache()
         self.env.registry.clear_cache()
         return res
 
@@ -190,6 +191,7 @@ class IrRule(models.Model):
         res = super(IrRule, self).create(vals_list)
         # DLE P33: tests
         self.env.flush_all()
+        self.env.transaction.clear_access_cache()
         self.env.registry.clear_cache()
         return res
 
@@ -200,6 +202,7 @@ class IrRule(models.Model):
         # - odoo/addons/test_access_rights/tests/test_ir_rules.py
         # - odoo/addons/base/tests/test_orm.py (/home/dle/src/odoo/master-nochange-fp/odoo/addons/base/tests/test_orm.py)
         self.env.flush_all()
+        self.env.transaction.clear_access_cache()
         self.env.registry.clear_cache()
         return res
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -580,7 +580,7 @@ class ResUsers(models.Model):
         users = super().create(vals_list)
         setting_vals = []
         for user in users:
-            if not user.res_users_settings_ids and user._is_internal():
+            if not user.sudo().res_users_settings_ids and user._is_internal():
                 setting_vals.append({'user_id': user.id})
             # if partner is global we keep it that way
             if user.partner_id.company_id:
@@ -623,6 +623,8 @@ class ResUsers(models.Model):
                     user.partner_id.write({'company_id': user.company_id.id})
 
         if 'company_id' in vals or 'company_ids' in vals:
+            # Access cache depends on the company, clear it
+            self.env.transaction.clear_access_cache()
             # Reset lazy properties `company` & `companies` on all envs,
             # This is unlikely in a business code to change the company of a user and then do business stuff
             # but in case it happens this is handled.

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -1481,7 +1481,7 @@ class PropertiesCase(TestPropertiesMixin):
         self.env['ir.rule'].sudo().create({
             'name': 'test_rule_tags',
             'model_id': self.env['ir.model']._get('test_orm.multi.tag').id,
-            'domain_force': [('name', 'not in', tags[5:].mapped('name'))],
+            'domain_force': [('id', 'not in', tags[5:].ids)],
             'perm_read': True,
             'perm_create': True,
             'perm_write': True,


### PR DESCRIPTION
Build a cache of accessible records. We cache _read_ (not and _write_) operations in the transaction cache, so that if we have checked permissions to a record once, we don't check them again. It is needed if we want to be able to check permissions at each field access, but can already improve performance when checks are done multiple times.

In most cases, we can populate the _read_ cache after searching for records because by design we know that records returned by searches are readable. If we stumble upon a record for which we don't know the access, we cache the access for its prefetch set.

task-3483964
odoo/enterprise#82964