### PR TITLE
[FIX] hr_recruitment : Clean context before creating an employee

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -6,7 +6,7 @@ from markupsafe import Markup
 from odoo import api, fields, models, tools, SUPERUSER_ID
 from odoo.exceptions import AccessError, UserError
 from odoo.osv import expression
-from odoo.tools import Query
+from odoo.tools import clean_context
 from odoo.tools.translate import _
 
 from dateutil.relativedelta import relativedelta
@@ -648,14 +648,14 @@ class Applicant(models.Model):
         if not self.partner_id:
             if not self.partner_name:
                 raise UserError(_('Please provide an applicant name.'))
-            self.partner_id = self.env['res.partner'].create({
+            self.partner_id = self.env['res.partner'].with_context(clean_context(self.env.context)).create({
                 'is_company': False,
                 'name': self.partner_name,
                 'email': self.email_from,
             })
 
         action = self.env['ir.actions.act_window']._for_xml_id('hr.open_view_employee_list')
-        employee = self.env['hr.employee'].create(self._get_employee_create_vals())
+        employee = self.env['hr.employee'].with_context(clean_context(self.env.context)).create(self._get_employee_create_vals())
         action['res_id'] = employee.id
         return action
 


### PR DESCRIPTION
### Steps to reproduce:
	- Navigate to Recruitment > Job Position > Any job position > Job applications (smart button)
	- Create an applicant
	- Set a Recruiter for the applicant
	- Move the stage to 'Contract Signed'
	- Click on 'Create Employee'
	- Notice a validation error that the opertion cannot be completed

### Cause:
This is happening as the 'Job applications' smart button has default value for the user_id in context

https://github.com/odoo/odoo/blob/889f25f1322f00dff7cacad95236d6f045c30d64/addons/hr_recruitment/views/hr_job_views.xml#L207-L211

so when creating an employee it will add the missing fields from defaults and it will get the default value in the context which for an existing user so when creating the employee with this user_id it will trigger the sql constraint

https://github.com/odoo/odoo/blob/889f25f1322f00dff7cacad95236d6f045c30d64/addons/hr/models/hr_employee.py#L145-L148

### Fix:
clean the context before creating the partner and the employee corresponding to this applicant

opw-4629219