### PR TITLE
[FIX] sale_project: add milestone button check for project access rights

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -18,7 +18,7 @@ class SaleOrder(models.Model):
     visible_project = fields.Boolean('Display project', compute='_compute_visible_project', readonly=True)
     project_id = fields.Many2one('project.project', 'Project',
         help='Select a non billable project on which tasks can be created.')
-    project_ids = fields.Many2many('project.project', compute="_compute_project_ids", string='Projects', copy=False, groups="project.group_project_user", help="Projects used in this sales order.")
+    project_ids = fields.Many2many('project.project', compute="_compute_project_ids", string='Projects', copy=False, groups="project.group_project_user,project.group_project_milestone", help="Projects used in this sales order.")
     project_count = fields.Integer(string='Number of Projects', compute='_compute_project_ids', groups='project.group_project_user')
     milestone_count = fields.Integer(compute='_compute_milestone_count')
     is_product_milestone = fields.Boolean(compute='_compute_is_product_milestone')

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -878,3 +878,16 @@ class TestSaleProject(TestSaleProjectCommon):
             'sale_line_id': sale_order_line.id,
         })
         self.assertEqual(sale_order.state, 'sale')
+
+    def test_sale_order_milestone_with_no_project_rights(self):
+        milestone_user = new_test_user(
+            self.env, groups='project.group_project_milestone,sales_team.group_sale_salesman',
+            login='Milestone user', name='Milestone user',
+        )
+
+        group_project_user = self.env.ref('project.group_project_user').id
+        self.assertNotIn(group_project_user, milestone_user.groups_id.ids)
+
+        sale_order_form = Form(self.env['sale.order'].with_user(milestone_user), view='sale_project.view_order_form_inherit_sale_project')
+        project_ids = sale_order_form._view['fields'].get('project_ids')
+        self.assertTrue(project_ids, "'project_ids' field should be present for milestone users in the sale order form")


### PR DESCRIPTION
**Steps to reproduce:**
- Create product as service based on milestone
- Set user rights as:
    - Sales/Sales : User: Own documents Only
    - Services/Project: None
- Make sale order and save it

**Issue:**
Milestone button `invisible` field in the sale order view was throwing an error due to `project_ids` not being defined
for users with `project.group_project_milestone` enabled but not `project.group_project_user`.

**Fix:**
Added `project.group_project_milestone` group to `project_ids` field.

opw-4563845

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
