### PR TITLE
[FIX] point_of_sale: prevent error in open session pos order logging

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -48,7 +48,7 @@ class PosOrder(models.Model):
         ], limit=1)
 
         if open_session:
-            _logger.warning('Using open session %s for saving order %s', open_session.name, order['name'])
+            _logger.warning('Using open session %s for uuid number %s', open_session.name, order['uuid'])
             return open_session
 
         raise UserError(_('No open session available. Please open a new session to capture the order.'))


### PR DESCRIPTION
This error occurs when two users scan the same table and place separate orders.

[Steps to Reproduce](https://drive.google.com/file/d/1xW_V2XR0RRihGl8EOEa-5Q_mVRAGRvbh/view?usp=sharing)

- Install the `pos_restaurant module`.
- Set `Self Ordering` to `QR Menu + Ordering` from `settings.`
- Open `Register` and `Create` two new users and log in with them.
- Open `Mobile Menus` for each user. User 1 places an order.
-  User 2 places an order on the same table but `don`t click on pay.`
- Close the POS session and  From User 2, click `Pay`
- Reopen the `POS session` and click `Pay again` from User 2.

KeyError - `name`

This error occurs due to current changes at [1] `name` key is removed from the order but later accessed during logging.

This commit resolves error by accessing the tracking number instead of the Order name.

Link [1]: https://github.com/odoo/odoo/blob/e151c9b25908868ab47c4e9f3faf581dfaac8da5/addons/pos_self_order/controllers/orders.py#L36

Sentry - 6485026613

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
