### PR TITLE
[FIX] l10n_in: synchronize fiscal position with GST warning

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -100,3 +100,5 @@ class ResPartner(models.Model):
         self.ensure_one()
         state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', self.vat[:2])], limit=1)
         self.state_id = state_id
+        if self.ref_company_ids:
+            self.ref_company_ids._update_l10n_in_fiscal_position()


### PR DESCRIPTION
Before this commit:
- Changing the state via the GST warning did not update the fiscal position.

After this commit:
- Changing the state via the GST warning correctly update the fiscal position.

Task-4681566