### PR TITLE
[IMP] website: enable website logo access from media manager

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -277,6 +277,7 @@ class Website(models.CachedModel):
                 vals['user_id'] = company._get_public_user().id if company else self.env.ref('base.public_user').id
 
         websites = super().create(vals_list)
+        websites._ensure_logo_media_attachment()
         websites.company_id._compute_website_id()
         for website in websites:
             website._bootstrap_homepage()
@@ -327,6 +328,9 @@ class Website(models.CachedModel):
 
         result = super(Website, self - public_user_to_change_websites).write(values)
 
+        if 'logo' in values:
+            self._ensure_logo_media_attachment()
+
         if any(key in values for key in ["cdn_activated", "cdn_url", "cdn_filters", "domain"]):
             # invalidate the caches from static node at compile time
             if any(self._ids):
@@ -340,6 +344,35 @@ class Website(models.CachedModel):
             self._ensure_default_website_consistency()
 
         return result
+
+    def _ensure_logo_media_attachment(self):
+        """ Clone the bound logo as a media-library attachment so it shows up
+        in the media manager, which hides res_field rows. """
+        Attachment = self.env['ir.attachment']
+        default_logo_checksum = Attachment._compute_checksum(self._default_logo())
+        bounds = Attachment.search([
+            ('res_model', '=', 'website'),
+            ('res_field', '=', 'logo'),
+            ('res_id', 'in', self.ids),
+            ('checksum', '!=', default_logo_checksum),
+        ])
+        if not bounds:
+            return
+        mirrored = {
+            (res_id, checksum)
+            for res_id, checksum in Attachment._read_group(
+                [
+                    ('res_model', '=', 'website'),
+                    ('res_field', '=', False),
+                    ('res_id', 'in', self.ids),
+                    ('checksum', 'in', bounds.mapped('checksum')),
+                ],
+                groupby=['res_id', 'checksum'],
+            )
+        }
+        bounds.filtered(
+            lambda b: (b.res_id, b.checksum) not in mirrored,
+        ).copy({'res_field': False})
 
     @api.model
     def _handle_create_write(self, vals):
@@ -857,11 +890,8 @@ class Website(models.CachedModel):
         company = website.company_id
         attachment = self.env['ir.attachment'].browse(logo_attachment_id).exists() if logo_attachment_id else False
         if attachment:
-            attachment.write({
-                'res_model': 'website',
-                'res_field': 'logo',
-                'res_id': website.id,
-            })
+            website.logo = BinaryBytes(attachment.raw)
+            attachment.unlink()
         elif not company.uses_default_logo:
             website.logo = BinaryBytes(company.logo.content)
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -755,16 +755,9 @@ class Website(models.CachedModel):
         logo_attachment_id = kwargs.get('logo_attachment_id')
         company = website.company_id
         if logo_attachment_id:
-            attachment = self.env['ir.attachment'].browse(logo_attachment_id).exists()
-            if attachment:
-                website.logo = attachment.raw
-                website_logo_attachments = self.env['ir.attachment'].search([
-                    ('res_model', '=', 'website'),
-                    ('res_field', '=', 'logo'),
-                    ('res_id', '=', website.id),
-                ], order='id')
-                website_logo_attachments[1:].unlink()
-                attachment.unlink()
+            attachment = self.env['ir.attachment'].browse(logo_attachment_id)
+            website.logo = attachment.raw
+            attachment.unlink()
         elif not logo_attachment_id and not company.uses_default_logo:
             website.logo = company.logo.decode('utf-8')
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -755,12 +755,16 @@ class Website(models.CachedModel):
         logo_attachment_id = kwargs.get('logo_attachment_id')
         company = website.company_id
         if logo_attachment_id:
-            attachment = self.env['ir.attachment'].browse(logo_attachment_id)
-            attachment.write({
-                'res_model': 'website',
-                'res_field': 'logo',
-                'res_id': website.id,
-            })
+            attachment = self.env['ir.attachment'].browse(logo_attachment_id).exists()
+            if attachment:
+                website.logo = attachment.raw
+                website_logo_attachments = self.env['ir.attachment'].search([
+                    ('res_model', '=', 'website'),
+                    ('res_field', '=', 'logo'),
+                    ('res_id', '=', website.id),
+                ], order='id')
+                website_logo_attachments[1:].unlink()
+                attachment.unlink()
         elif not logo_attachment_id and not company.uses_default_logo:
             website.logo = company.logo.decode('utf-8')
 

--- a/addons/website/static/src/components/media_dialog/image_selector.js
+++ b/addons/website/static/src/components/media_dialog/image_selector.js
@@ -1,4 +1,6 @@
+import { Domain } from "@web/core/domain";
 import { patch } from "@web/core/utils/patch";
+import { IMAGE_MIMETYPES } from "@html_editor/main/media/media_dialog/file_selector";
 import { ImageSelector as HtmlImageSelector } from "@html_editor/main/media/media_dialog/image_selector";
 
 patch(HtmlImageSelector.prototype, {
@@ -6,7 +8,27 @@ patch(HtmlImageSelector.prototype, {
         const domain = super.attachmentsDomain;
         domain.push("|", ["url", "=", false], "!", ["url", "=like", "/web/image/website.%"]);
         domain.push(["key", "=", false]);
-        return domain;
+
+        const websiteId = this.env.services.website?.currentWebsiteId;
+        if (!websiteId) {
+            return domain;
+        }
+
+        // A website logo exists as two attachments: the clean copy the user
+        // uploaded and the one bound to the logo field (blurry, because it's
+        // rendered downscaled). Show the clean copy in the media manager hide
+        // the blurry bound one.
+        const regular = Domain.and([
+            domain,
+            ["|", ["res_model", "!=", "website"], ["res_field", "=", false]],
+        ]);
+        const websiteUploads = Domain.and([
+            [["res_model", "=", "website"]],
+            [["res_id", "=", websiteId]],
+            [["res_field", "=", false]],
+            [["mimetype", "in", IMAGE_MIMETYPES]],
+        ]);
+        return Domain.or([websiteUploads, regular]).toList();
     },
 });
 

--- a/addons/website/static/src/components/media_dialog/image_selector.js
+++ b/addons/website/static/src/components/media_dialog/image_selector.js
@@ -4,6 +4,17 @@ import { ImageSelector as HtmlImageSelector } from "@html_editor/main/media/medi
 patch(HtmlImageSelector.prototype, {
     get attachmentsDomain() {
         const domain = super.attachmentsDomain;
+        if (this.env.services.website.currentWebsite) {
+            // Add website logos to media manager
+            domain.unshift(
+                "|",
+                "&",
+                "&",
+                ["res_model", "=", "website"],
+                ["res_id", "=", this.env.services.website.currentWebsiteId],
+                ["res_field", "=", "logo"]
+            );
+        }
         domain.push("|", ["url", "=", false], "!", ["url", "=like", "/web/image/website.%"]);
         domain.push(["key", "=", false]);
         return domain;

--- a/addons/website/static/src/components/media_dialog/image_selector.js
+++ b/addons/website/static/src/components/media_dialog/image_selector.js
@@ -4,16 +4,21 @@ import { ImageSelector as HtmlImageSelector } from "@html_editor/main/media/medi
 patch(HtmlImageSelector.prototype, {
     get attachmentsDomain() {
         const domain = super.attachmentsDomain;
-        if (this.env.services.website.currentWebsite) {
-            // Add website logos to media manager
-            domain.unshift(
-                "|",
-                "&",
-                "&",
-                ["res_model", "=", "website"],
-                ["res_id", "=", this.env.services.website.currentWebsiteId],
-                ["res_field", "=", "logo"]
-            );
+        if (this.env.services.website?.currentWebsiteId) {
+            const websiteId = this.env.services.website.currentWebsiteId;
+            if (this.props.resModel !== "website") {
+                // Add website logos to media manager
+                domain.unshift(
+                    "|",
+                    "&",
+                    "&",
+                    ["res_model", "=", "website"],
+                    ["res_id", "=", websiteId],
+                    ["res_field", "=", "logo"]
+                );
+            } else {
+                domain.push("!", "&", ["res_model", "=", "website"], ["res_field", "!=", "logo"]);
+            }
         }
         domain.push("|", ["url", "=", false], "!", ["url", "=like", "/web/image/website.%"]);
         domain.push(["key", "=", false]);

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -14,6 +14,7 @@ import {
     setInputRange,
 } from "@odoo/hoot-dom";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { IMAGE_MIMETYPES } from "@html_editor/main/media/media_dialog/file_selector";
 import {
     defineWebsiteModels,
     setupWebsiteBuilder,
@@ -64,6 +65,40 @@ test("Double click on image and replace it", async () => {
     expect(".o_select_media_dialog").toHaveCount(0);
     expect(":iframe img").toHaveClass("o_modified_image_to_save");
     expect(".options-container[data-container-title='Image']").toHaveCount(1);
+});
+
+test("media dialog requests website logo attachments", async () => {
+    onRpc("ir.attachment", "search_read", ({ kwargs = {} }) => {
+        expect(kwargs.domain.slice(0, 8)).toEqual([
+            "|",
+            "&",
+            ["res_model", "=", "website"],
+            "&",
+            ["res_id", "=", 1],
+            "&",
+            ["res_field", "=", false],
+            ["mimetype", "in", IMAGE_MIMETYPES],
+        ]);
+        return [
+            {
+                id: 1,
+                name: "logo",
+                mimetype: "image/png",
+                image_src: "/web/image/website/1/logo",
+                access_token: false,
+                public: true,
+            },
+        ];
+    });
+
+    await setupWebsiteBuilder(`<div><img class=a_nice_img src='${dummyBase64Img}'></div>`);
+    await dblclick(":iframe img.a_nice_img");
+    await waitFor(".o_select_media_dialog");
+
+    expect(".o_select_media_dialog .o_existing_attachment_cell img").toHaveAttribute(
+        "data-src",
+        "/web/image/website/1/logo?height=256"
+    );
 });
 
 test("simple click on Image", async () => {

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -66,6 +66,38 @@ test("Double click on image and replace it", async () => {
     expect(".options-container[data-container-title='Image']").toHaveCount(1);
 });
 
+test("Media dialog requests website logo attachments", async () => {
+    onRpc("ir.attachment", "search_read", ({ kwargs = {} }) => {
+        expect(kwargs.domain.slice(0, 6)).toEqual([
+            "|",
+            "&",
+            "&",
+            ["res_model", "=", "website"],
+            ["res_id", "=", 1],
+            ["res_field", "=", "logo"],
+        ]);
+        return [
+            {
+                id: 1,
+                name: "logo",
+                mimetype: "image/png",
+                image_src: "/web/image/website/1/logo",
+                access_token: false,
+                public: true,
+            },
+        ];
+    });
+
+    await setupWebsiteBuilder(`<div><img class=a_nice_img src='${dummyBase64Img}'></div>`);
+    await dblclick(":iframe img.a_nice_img");
+    await waitFor(".o_select_media_dialog");
+
+    expect(".o_select_media_dialog .o_existing_attachment_cell img").toHaveAttribute(
+        "data-src",
+        "/web/image/website/1/logo?height=256"
+    );
+});
+
 test("simple click on Image", async () => {
     await setupWebsiteBuilder(`<div><img class=a_nice_img src='${dummyBase64Img}'></div>`);
     await click(":iframe img.a_nice_img");

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -40,6 +40,7 @@ from . import test_views_inherit_module_update
 from . import test_website_default_website
 from . import test_website_favicon
 from . import test_website_form_editor
+from . import test_website_logo
 from . import test_website_reset_password
 from . import test_website_visitor
 from . import test_website_technical_page

--- a/addons/website/tests/test_website_logo.py
+++ b/addons/website/tests/test_website_logo.py
@@ -1,0 +1,64 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+from odoo.tools import BinaryBytes
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteLogo(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.logo_v1 = BinaryBytes(b'fake-logo-bytes-v1')
+        cls.logo_v2 = BinaryBytes(b'fake-logo-bytes-v2')
+        cls.website = cls.env['website'].create({
+            'name': 'Test Site',
+            'logo': cls.logo_v1,
+        })
+
+    def _bound_logo(self, website):
+        return self.env['ir.attachment'].search([
+            ('res_model', '=', 'website'),
+            ('res_field', '=', 'logo'),
+            ('res_id', '=', website.id),
+        ])
+
+    def _media_logos(self, website):
+        return self.env['ir.attachment'].search([
+            ('res_model', '=', 'website'),
+            ('res_field', '=', False),
+            ('res_id', '=', website.id),
+        ])
+
+    def test_default_logo_not_mirrored(self):
+        # create new website, since we want default logo to be set and tested
+        website = self.env['website'].create({'name': 'Default Logo Site'})
+        self.assertTrue(self._bound_logo(website), "bound logo expected for default")
+        self.assertFalse(
+            self._media_logos(website),
+            "default placeholder must not produce a media-library row",
+        )
+
+    def test_custom_logo_mirrored(self):
+        bound = self._bound_logo(self.website)
+        mirrors = self._media_logos(self.website)
+        self.assertEqual(len(mirrors), 1, "exactly one media-library row expected")
+        self.assertEqual(mirrors.checksum, bound.checksum)
+        self.assertEqual(bytes(mirrors.raw), bytes(bound.raw))
+
+    def test_no_duplicate_on_same_bytes_write(self):
+        self.website.logo = self.logo_v1
+        self.assertEqual(len(self._media_logos(self.website)), 1)
+
+    def test_replace_logo_keeps_previous(self):
+        self.website.logo = self.logo_v2
+        bound = self._bound_logo(self.website)
+        mirrors = self._media_logos(self.website)
+        self.assertEqual(len(mirrors), 2)
+        self.assertIn(bound.checksum, mirrors.mapped('checksum'))
+        self.assertEqual(
+            {bytes(r) for r in mirrors.mapped('raw')},
+            {b'fake-logo-bytes-v1', b'fake-logo-bytes-v2'},
+        )


### PR DESCRIPTION
Before this commit:
The website logo was only visible and selectable when opening the media
manager from the header logo. Accessing it from other media managers
(e.g., footer, snippets) was not possible.

After this commit:
Website logos can now be accessed and selected from any media manager,
making it easier to reuse the logo across the website.

task-4681194