### PR TITLE
[FIX] mail: show all seen indicator once in discuss

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -131,6 +131,8 @@ const threadPatch = {
                         return lastMessageSeenByAllId
                             ? Math.min(lastMessageSeenByAllId, member.seen_message_id.id)
                             : member.seen_message_id.id;
+                    } else {
+                        return lastMessageSeenByAllId;
                     }
                 }, undefined);
             },


### PR DESCRIPTION
Before this commit, the message seen indicator was displayed on many messages when it was seen by everyone.

Steps to reproduce:
- make a DM chat between Mitchell Admin and Marc Demo
- send a dozen messages by Marc
- send a dozen of messages by Mitchell
- mark the conversation as seen by both (focus composer and tab) => Mitchell or Marc sees as many seen indicator as there are messages, instead of just once on the last self-authored message.

This happens due to a typo on computing the field `lastMessageSeenByAllId`: the `reduce` loop could have been `undefined` as the accumulator value, which leads to `Math.min(undefined)` that becomes `NaN`, which is falsy. As a result, no previous to last self message seen by everyone could be found, and all messages were mistakenly considered as messages to display the seen indicator.

This commit fixes the issue by fixing the typo in the reduce, by returning the current accumulator value of the `reduce` function when it's unchanged (self-member).

Task-4689924

Before / After
<img width="258" alt="Screenshot 2025-04-07 at 14 43 06" src="https://github.com/user-attachments/assets/420d44cf-1b5e-4d0a-aa37-43ca17ffa564" /> <img width="248" alt="Screenshot 2025-04-07 at 14 43 35" src="https://github.com/user-attachments/assets/98684bbb-d92d-4d02-bde4-39eb15dcf9b7" />
