### PR TITLE
[FIX] hr_attendance: set default company language in attendance kiosk URL

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -111,7 +111,7 @@ class HrAttendance(http.Controller):
                         'kiosk_mode': kiosk_mode,
                         'from_trial_mode': from_trial_mode,
                         'barcode_source': company.attendance_barcode_source,
-                        'lang': py_to_js_locale(company.partner_id.lang or company.env.lang),
+                        'lang': py_to_js_locale(request.lang.code),
                         'server_version_info': version_info.get('server_version_info'),
                     },
                 }

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -42,7 +42,12 @@ class ResCompany(models.Model):
     @api.depends("attendance_kiosk_key")
     def _compute_attendance_kiosk_url(self):
         for company in self:
-            company.attendance_kiosk_url = url_join(self.env['res.company'].get_base_url(), '/hr_attendance/%s' % company.attendance_kiosk_key)
+            lang = company.partner_id.lang or company.env.lang
+            lang_string = f'/{lang}' if lang else ''
+            company.attendance_kiosk_url = url_join(
+                self.env['res.company'].get_base_url(),
+                f'{lang_string}/hr_attendance/{company.attendance_kiosk_key}'
+            )
 
     # ---------------------------------------------------------
     # ORM Overrides


### PR DESCRIPTION
**Steps to reproduce:**
- Enable multiple languages
- Set Company contact language to the language you want by default in the kiosk
- Set another language for the user
- Go to Attendance app then Kiosk Mode
- Kiosk will be displayed using the company language
- There is no way to change the language for the user (but the URL still accept `.../LANG_CODE/hr_attendance/...`)

**Issue:**
Kiosk language is computed after url routing, this means the user has no way to change it manually if needed.
Changing the URL directly results in inconsistent behaviour (valid /fr/ URL with arabic content for example).

**Fix:**
Updated the kiosk URL computation to default to the company's (or user's) language before the URL routing is done.
This ensures that the kiosk button directs users to the company's default language page while allowing manual URL modification to switch to other allowed languages.

opw-4659403

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
