### PR TITLE
[FIX] account_check_printing: add default value to unposted check number

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -249,7 +249,8 @@ class AccountPayment(models.Model):
         self.ensure_one()
 
         def prepare_vals(invoice, partials=None, current_amount=0):
-            number = ' - '.join([invoice.name, invoice.ref] if invoice.ref else [invoice.name])
+            invoice_name = invoice.name or '/'
+            number = ' - '.join([invoice_name, invoice.ref] if invoice.ref else [invoice_name])
 
             if invoice.is_outbound() or invoice.move_type == 'in_receipt':
                 invoice_sign = 1


### PR DESCRIPTION
**Steps to reproduce:**
- Create new bill and save it manually (still in draft, with no name)
- Select bill from the list view and press `Pay` button
- Select check payment method
- On the new payment page press `Print Check` button
- Press `Print` button on the pop-up

**Issue:**
As task-id 3979071 (https://github.com/odoo/odoo/commit/3ccdd62bb9ce2f623e31f2e82aa1d5b35afe9d95) allowed payment on draft invoices, bills with unset name were throwing an error when printing check payment.

**Fix:**
Added '/' as default value of the invoice name for check payment which have unposted bills.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4662760)  
opw-4662760