### PR TITLE
[FIX] web: tests - separate container env

### DIFF
--- a/addons/web/static/tests/_framework/view_test_helpers.js
+++ b/addons/web/static/tests/_framework/view_test_helpers.js
@@ -4,10 +4,10 @@ import { animationFrame, Deferred, tick } from "@odoo/hoot-mock";
 import { Component, onMounted, useSubEnv, xml } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { MainComponentsContainer } from "@web/core/main_components_container";
-import { View, getDefaultConfig } from "@web/views/view";
+import { View } from "@web/views/view";
 import { mountWithCleanup } from "./component_test_helpers";
 import { contains } from "./dom_test_helpers";
-import { getMockEnv, getService, makeMockEnv } from "./env_test_helpers";
+import { getService } from "./env_test_helpers";
 import { MockServer } from "./mock_server/mock_server";
 
 /**
@@ -200,20 +200,15 @@ export function fieldInput(name, options) {
  * @param {MountViewParams} params
  */
 export async function mountViewInDialog(params) {
-    const config = { ...getDefaultConfig(), ...params.config };
-    const container = await mountWithCleanup(MainComponentsContainer, {
-        env: params.env || getMockEnv() || (await makeMockEnv()),
-    });
-
+    const container = await mountWithCleanup(MainComponentsContainer, { env: params.env });
     const deferred = new Deferred();
     getService("dialog").add(ViewDialog, {
-        viewEnv: { config },
+        viewEnv: { config: params.config },
         viewProps: parseViewProps(params),
         onMounted() {
             deferred.resolve();
         },
     });
-
     await deferred;
     return container;
 }
@@ -227,9 +222,9 @@ export async function mountView(params, target = null) {
     actionManagerEl.classList.add("o_action_manager");
     (target ?? getFixture()).append(actionManagerEl);
     after(() => actionManagerEl.remove());
-    const config = { ...getDefaultConfig(), ...params.config };
     return mountWithCleanup(View, {
-        env: params.env || getMockEnv() || (await makeMockEnv({ config })),
+        env: params.env,
+        componentEnv: { config: params.config },
         props: parseViewProps(params),
         target: actionManagerEl,
     });


### PR DESCRIPTION
Before this commit, in the `mountWithCleanup` test helper, the same `env` object was passed to both the given component and the main component container.

This is wrong as in some cases, the env given to the given component should include sub-env specific information, like the `config` key given to the `View` component (that shouldn't be given to the container).

This commit ensures that these `env` objects can be configured separately.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
