### PR TITLE
[FIX] point_of_sale: prevent double confirmation of dialog

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.js
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.js
@@ -52,6 +52,7 @@ export class TextInputPopup extends Component {
 
     onKeydown(ev) {
         if (this.props.rows === 1 && ev.key.toUpperCase() === "ENTER") {
+            ev.stopPropagation();
             this.confirm();
         }
     }


### PR DESCRIPTION
For the `TextInputPopup` component a feature was introduced in 2f5c5c15644412cfb6493c661b2f1b927c8cc7e2 that allows the user to confirm the popup by simply clicking enter.

The problem is that the dialog itself has a hotkey on "CTRL+Enter" that will also confirm the popup.

This means that if a user uses the "CTRL+Enter" hotkey, the popup will be confirmed twice.

Steps to reproduce:
1. In restaurant, click the button to add a new floor
2. Write a name for the floor
3. Click "CTRL+Enter"
4. Observe that 2 floors with the given name were created instead of one.

The fix:
We stop the propagation of the event

Task: 4698289


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
