### PR TITLE
[FIX] web: prevent error with extremely vertical logos in document layout

### DIFF
--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -2,6 +2,7 @@
 import markupsafe
 import os
 from markupsafe import Markup
+from math import ceil
 
 from odoo import api, fields, models, tools
 
@@ -217,7 +218,7 @@ class BaseDocumentLayout(models.TransientModel):
             return False, False
 
         base_w, base_h = image.size
-        w = int(50 * base_w / base_h)
+        w = ceil(50 * base_w / base_h)
         h = 50
 
         # Converts to RGBA (if already RGBA, this is a noop)


### PR DESCRIPTION
This error occurs when a user attempts to `Configure Document Layout` in settings using a large vertically-oriented image.

Steps to Reproduce:

 - Install the `web` module.
 - Go to `Settings`.
 - In the `companies` section, under Your Company, click on `Update Info`.
 - Upload an image with dimensions width = 8 and height = 901.
 - Go back, and in the Companies section, click `Configure Document Layout`.

ValueError: height and width must be > 0

This error is due to the current logic in `base_document_layout.py`, where the width (w) is computed using int(50 * base_w / base_h). For highly vertical images (e.g., width = 8, height = 901), this calculation results in w = 0, which subsequently causes a ValueError when passed to the resize() function.

This commit resolves the error by using `math.ceil` to compute the width (w) instead of int, ensuring that the value is never zero, even for extremely vertical images.

Sentry-6516888945

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
