### PR TITLE
[FIX] website_sale: handle non-existent category ID

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -665,8 +665,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def _prepare_product_values(self, product, category, search, **kwargs):
         ProductCategory = request.env['product.public.category']
         product_markup_data = [product._to_markup_data(request.website)]
-        if category:
-            category = ProductCategory.browse(int(category)).exists()
+        if category := ProductCategory.browse(category and int(category)).exists():
             # Add breadcrumb's SEO data.
             product_markup_data.append(self._prepare_breadcrumb_markup_data(
                 request.website.get_base_url(), category, product.name


### PR DESCRIPTION
Currently, an error occurs when the category ID is manually changed in the website URL.

Steps to Reproduce:
---
- Install the `website_sale` application
- Website > Shop > Select any category > Open any product
- Change category ID in URL(eg: category=91)

Traceback:
---
ValueError: Cannot slug non-existent record product.public.category()

At [1], an error occurs when adding a manual category ID because it does not exist in the `product.public.category` model, resulting in an empty return when browsing it.

[1]- https://github.com/odoo/odoo/blob/74aa68d159b0708b09495956d23d51e3acef9bb5/addons/website_sale/controllers/main.py#L669

sentry-6407561181

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
