### PR TITLE
[IMP] web: add button style props on the widget CopyClipboardButtonField

### DIFF
--- a/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.xml
+++ b/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.xml
@@ -2,14 +2,14 @@
 <templates xml:space="preserve">
     <t t-name="FieldMany2ManyTagsEmailTagsList" t-inherit="web.TagsList" t-inherit-mode="primary">
         <xpath expr="//span[hasclass('o_tag')]" position="replace">
-            <div t-attf-class="badge rounded-pill dropdown o_tag o_tag_color_0 #{tag.email.indexOf('@') &lt; 0 ? 'o_tag_error' : ''}"
+            <div t-attf-class="badge rounded-pill align-items-center dropdown o_tag o_tag_color_0 #{tag.email.indexOf('@') &lt; 0 ? 'o_tag_error' : ''}"
                  t-att-data-color="tag.colorIndex"
                  t-att-data-index="tag_index"
                  t-att-data-id="tag.id"
                  t-att-title="tag.text"
                  t-on-click="(ev) => tag.onClick and tag.onClick(ev)" t-ref="{{tagEquals(tag, state.tagToUpdate) ? 'tagToUpdate' : `tag_${tag_index}`}}">
                 <span class="o_badge_text" t-att-title="tag.email"><t t-esc="tag.text"/></span>
-                <a t-if="!readonly &amp;&amp; tag.onDelete" t-on-click.stop.prevent="tag.onDelete" href="#" class="fa fa-times o_delete" title="Delete" aria-label="Delete"/>
+                <a t-if="!readonly &amp;&amp; tag.onDelete" t-on-click.stop.prevent="tag.onDelete" href="#" class="fa fa-times o_delete ms-1" title="Delete" aria-label="Delete"/>
             </div>
         </xpath>
     </t>

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
@@ -45,9 +45,17 @@ class CopyClipboardField extends Component {
 export class CopyClipboardButtonField extends CopyClipboardField {
     static template = "web.CopyClipboardButtonField";
     static components = { CopyButton };
+    static props = {
+        ...CopyClipboardField.props,
+        btnClass: { type: String, optional: true },
+    };
+    static defaultProps = {
+        ...CopyClipboardField.defaultProps,
+        btnClass: "primary",
+    };
 
     get copyButtonClassName() {
-        return `o_btn_${this.type}_copy btn-primary rounded-2`;
+        return `o_btn_${this.type}_copy btn-${this.props.btnClass} rounded-2`;
     }
 }
 
@@ -79,7 +87,10 @@ function extractProps({ string, attrs }) {
 export const copyClipboardButtonField = {
     component: CopyClipboardButtonField,
     displayName: _t("Copy to Clipboard"),
-    extractProps,
+    extractProps: (fieldInfo) => ({
+        ...extractProps(fieldInfo),
+        btnClass: fieldInfo.options.btn_class,
+    }),
 };
 
 registry.category("fields").add("CopyClipboardButton", copyClipboardButtonField);

--- a/addons/web/static/tests/views/fields/copy_clipboard_field.test.js
+++ b/addons/web/static/tests/views/fields/copy_clipboard_field.test.js
@@ -125,10 +125,31 @@ test("CopyClipboardButtonField in form view", async () => {
 
     expect(".o_field_widget[name=char_field] input").toHaveCount(0);
     expect(".o_clipboard_button.o_btn_char_copy").toHaveCount(1);
+    expect(".o_clipboard_button.o_btn_char_copy").toHaveClass("btn-primary");
+    expect(".o_clipboard_button.o_btn_char_copy").not.toHaveClass("btn-secondary");
 
     await contains(".o_clipboard_button.o_btn_char_copy").click();
 
     expect.verifySteps(["char value"]);
+});
+
+test("CopyClipboardButtonField with a secondary style", async () => {
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        resId: 1,
+        arch: `
+            <form>
+                <group>
+                    <field name="char_field" widget="CopyClipboardButton" options="{'btn_class': 'secondary'}"/>
+                </group>
+            </form>`,
+    });
+
+    expect(".o_field_widget[name=char_field] input").toHaveCount(0);
+    expect(".o_clipboard_button.o_btn_char_copy").toHaveCount(1);
+    expect(".o_clipboard_button.o_btn_char_copy").not.toHaveClass("btn-primary");
+    expect(".o_clipboard_button.o_btn_char_copy").toHaveClass("btn-secondary");
 });
 
 test("CopyClipboardButtonField can be disabled", async () => {


### PR DESCRIPTION
We add a style props on the widget CopyClipboardButtonField allowing to use that widget not only as a primary button but also as a secondary button (or maybe other style if needed).

[IMP] mail: add space between the cross and the label in the tag email widget

We improve slightly the layout of the widget many2many_tags_email by adding some space between the label and the cross and by centering the cross vertically.

Task-4545482