### PR TITLE
[FIX] l10n_ar: add currency_rate field on account move.

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -26,6 +26,8 @@ class AccountMove(models.Model):
         ' identify the type of responsibilities that a person or a legal entity could have and that impacts in the'
         ' type of operations and requirements they need.')
 
+    l10n_ar_currency_rate = fields.Float(copy=False, readonly=True, string="Currency Rate")
+
     # Mostly used on reports
     l10n_ar_afip_concept = fields.Selection(
         compute='_compute_l10n_ar_afip_concept', selection='_get_afip_invoice_concepts', string="AFIP Concept",


### PR DESCRIPTION
PR https://github.com/odoo/enterprise/pull/82924 makes use of the field l10n_ar_currency_rate. But that field is not present in Odoo versions above 17.0

This commit adds it in Odoo.

opw-4708505
