### PR TITLE
[FIX] mail sanitize: allow 'object-fit' in sanitizer

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -84,7 +84,7 @@ class _Cleaner(clean.Cleaner):
     _style_whitelist = [
         'font-size', 'font-family', 'font-weight', 'font-style', 'background-color', 'color', 'text-align',
         'line-height', 'letter-spacing', 'text-transform', 'text-decoration', 'text-decoration', 'opacity',
-        'float', 'vertical-align', 'display',
+        'float', 'vertical-align', 'display', 'object-fit',
         'padding', 'padding-top', 'padding-left', 'padding-bottom', 'padding-right',
         'margin', 'margin-top', 'margin-left', 'margin-bottom', 'margin-right',
         'white-space',


### PR DESCRIPTION
The 'object-fit' CSS property is currently not whitelisted in the sanitizer, leading to images not being displayed correctly in mails.

opw-4655989