### PR TITLE
[FIX] sale_timesheet : Prevent linking not-invoiced timesheet to invoice

### DIFF
--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -77,6 +77,8 @@ class AccountMove(models.Model):
         """
         for line in self.filtered(lambda i: i.move_type == 'out_invoice' and i.state == 'draft').invoice_line_ids:
             sale_line_delivery = line.sale_line_ids.filtered(lambda sol: sol.product_id.invoice_policy == 'delivery' and sol.product_id.service_type == 'timesheet')
+            if not start_date and not end_date:
+                start_date, end_date = self._get_range_dates(sale_line_delivery.order_id)
             if sale_line_delivery:
                 domain = line._timesheet_domain_get_invoiced_lines(sale_line_delivery)
                 if start_date:
@@ -85,3 +87,8 @@ class AccountMove(models.Model):
                     domain = expression.AND([domain, [('date', '<=', end_date)]])
                 timesheets = self.env['account.analytic.line'].sudo().search(domain)
                 timesheets.write({'timesheet_invoice_id': line.move_id.id})
+
+    def _get_range_dates(self):
+        # A method that will be overridden in sale_subscription_timesheet
+        # to set the start and end dates for the subscription period
+        return None, None


### PR DESCRIPTION
### Steps to reproduce:
	- Create a recurring service (product) with invoicing policy set as 'Based on Timesheets'
	- Create a subscription using the created product
	- Create a task and link it to this subscription order
	- Timesheet 3 line in the task one in the past one on the same date of creation and one in the future.
	- Create an invoice for this order
	- Notice the quantity has been invoiced is the present timesheet line only
	- Notice that the 3 timesheet lines have all been validated

### Cause:
This is happening because when trying to link the lines to the invoice we consider the timesheets within the date range that the user might have set in the create invoice wizard.
https://github.com/odoo/odoo/blob/9a4ec08b9a6b07470747923d09adcf51f7e4cd6a/addons/sale_timesheet/wizard/sale_make_invoice_advance.py#L33-L51 https://github.com/odoo/odoo/blob/9a4ec08b9a6b07470747923d09adcf51f7e4cd6a/addons/sale_timesheet/models/sale_order.py#L153

### Fix:
In subscription we can use the last and next invoice dates if the user hasn't set a period for the invoice.

opw-4523727