### PR TITLE
[FIX] core: fix domain read_group groupby many2many.

### DIFF
--- a/odoo/addons/test_read_group/tests/test_m2m_grouping.py
+++ b/odoo/addons/test_read_group/tests/test_m2m_grouping.py
@@ -108,7 +108,7 @@ class TestM2MGrouping(TransactionCaseWithUserDemo):
                 'user_ids': False,
                 'user_ids_count': 1,
                 'name': unordered(["Donkey Kong"]),
-                '__domain': [('user_ids', 'not in', [self.users[0].id, self.users[1].id])],
+                '__domain': [('user_ids', 'not any', [(1, '=', 1)])],
             },
         ])
 
@@ -172,7 +172,7 @@ class TestM2MGrouping(TransactionCaseWithUserDemo):
                 'user_ids': False,
                 'user_ids_count': 1,
                 'name': unordered(["Donkey Kong"]),
-                '__domain': [('user_ids', 'not in', [self.users[0].id, self.users[1].id])],
+                '__domain': [('user_ids', 'not any', [(1, '=', 1)])],
             },
         ])
 
@@ -217,7 +217,7 @@ class TestM2MGrouping(TransactionCaseWithUserDemo):
                 'user_ids': False,
                 'user_ids_count': 2,
                 'name': unordered(["Luigi's Mansion", 'Donkey Kong']),
-                '__domain': [('user_ids', 'not in', self.users[0].ids)],
+                '__domain': [('user_ids', 'not any', [(1, '=', 1)])],
             },
         ])
 
@@ -249,7 +249,7 @@ class TestM2MGrouping(TransactionCaseWithUserDemo):
             {   # tasks of no one
                 'user_ids': False,
                 'user_ids_count': 1,
-                '__domain': [('user_ids', 'not in', [self.users[1].id, self.users[0].id])],
+                '__domain': [('user_ids', 'not any', [(1, '=', 1)])],
             },
             {   # tasks of Luigi
                 'user_ids': (self.users[1].id, 'Luigi'),

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2495,10 +2495,7 @@ class BaseModel(metaclass=MetaModel):
                     value = value.id
 
                 if not value and field.type == 'many2many':
-                    other_values = [other_row[group][0] if isinstance(other_row[group], tuple)
-                                    else other_row[group].id if isinstance(other_row[group], BaseModel)
-                                    else other_row[group] for other_row in rows_dict if other_row[group]]
-                    additional_domain = [(field_name, 'not in', other_values)]
+                    additional_domain = [(field_name, 'not any', [])]
                 else:
                     additional_domain = [(field_name, '=', value)]
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/143233, when we group by a many2many, the `__domain` of the Falsy group for records that don't have any many2many values) is expressed with `[('many2many', 'not in', <other group values>)]`. We did this because the ORM bypasses the 'ir.rule' for checking this type of domain: `[('many2many', '=', False)]` and changing this semantic is impossible in stable (and even hard to change in master).

Unfortunately, this fix is not correct when the read_group() limit is reached. In fact, the right part of the domain doesn't contain ids of many2many, which are filtered out by the limit.

Instead, use `[('many2many', 'not any', [])]` as the domain for the False group. Note that this may decrease the performance of the generated search because it will have to check ir.rule in the comodel and will generate more complex queries.

opw-4577443

