### PR TITLE
[FIX] hr_attendance: restrict employee visibility to manager

### DIFF
--- a/addons/hr_attendance/tests/test_hr_attendance_constraints.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_constraints.py
@@ -77,3 +77,32 @@ class TestHrAttendance(TransactionCase):
         lang.time_format = "%H:%M:%S"
         attendance_id._compute_display_name()
         self.assertEqual(attendance_id.display_name, "01:00 (08:00:00-09:00:00)")
+
+    def test_attendance_list_limited_to_managed_employees(self):
+        manager_user = self.env['res.users'].create({
+            'name': 'Manager User',
+            'login': 'manager_user',
+            'email': 'manager@example.com',
+            'groups_id': [(6, 0, [self.env.ref('base.group_user').id])],
+        })
+        managed_employee = self.env['hr.employee'].create({
+            'name': 'Managed Employee',
+            'attendance_manager_id': manager_user.id,
+        })
+        unmanaged_employee = self.env['hr.employee'].create({
+            'name': 'Unmanaged Employee',
+        })
+        self.env['hr.attendance'].create({
+            'employee_id': managed_employee.id,
+            'check_in': '2025-04-07 08:00:00',
+            'check_out': '2025-04-07 17:00:00',
+        })
+        self.env['hr.attendance'].create({
+            'employee_id': unmanaged_employee.id,
+            'check_in': '2025-04-07 09:00:00',
+            'check_out': '2025-04-07 18:00:00',
+        })
+        attendances = self.env['hr.attendance'].with_user(manager_user).with_context(allowed_company_ids=manager_user.company_ids.ids).search([])
+        employee_ids = attendances.mapped('employee_id').ids
+        self.assertIn(managed_employee.id, employee_ids, "Managed employee's attendance should be visible in the list")
+        self.assertNotIn(unmanaged_employee.id, employee_ids, "Unmanaged employee's attendance should not be visible")


### PR DESCRIPTION
### Issue:
- In the Attendance Gantt view, users can see all employees in the company, including those they are not allowed to manage or view.
- While access rules prevent users from seeing attendance records for these employees, the employees' names still appear in the Gantt view as group headers.
- This creates a misleading user experience and potentially exposes restricted information (employee names).

### Steps To Reproduce:
1. Log in as Marc Demo.
2. Open the attendance App.
3. Observe that all employees are shown as group headers.

### Solution:
- Since Odoo 18.0, the `employee_id` field in `hr.attendance` was given a `group_expand='_read_group_employee_id'`. this method returns all employees in the allowed companies, without checking if the user actually manages them.
- We updated the `group_expand` method `_read_group_employee_id` to restrict the list of employees shown in the Gantt view.
Now, users will only see employees for whom they are set as the `attendance_manager_id`, unless they belong to the HR Officer group or are superusers, in which case they continue to see all employees.
- This ensures that group headers in the Gantt view match the user's actual access rights.

opw-4570867

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
