### PR TITLE
[IMP] web: Mimic many2one behavior for selection fields in search bar

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -213,8 +213,10 @@ export class SearchBar extends Component {
             // or the properties item itself
             preposition = null;
         }
-
-        if (["selection", "boolean", "tags"].includes(fieldType)) {
+        if (
+            ["boolean", "tags"].includes(fieldType) ||
+            (isFieldProperty && fieldType === "selection")
+        ) {
             const booleanOptions = [
                 [true, _t("Yes")],
                 [false, _t("No")],
@@ -224,7 +226,7 @@ export class SearchBar extends Component {
                 const { selection, tags } = searchItem.propertyFieldDefinition || {};
                 options = selection || tags || booleanOptions;
             } else {
-                options = this.fields[searchItem.fieldName].selection || booleanOptions;
+                options = booleanOptions;
             }
             for (const [value, label] of options) {
                 if (fuzzyTest(trimmedQuery.toLowerCase(), label.toLowerCase())) {
@@ -248,21 +250,18 @@ export class SearchBar extends Component {
         let value;
         try {
             switch (fieldType) {
-                case "date": {
+                case "date":
                     value = serializeDate(parser(trimmedQuery));
                     break;
-                }
-                case "datetime": {
+                case "datetime":
                     value = serializeDateTime(parser(trimmedQuery));
                     break;
-                }
-                case "many2one": {
+                case "selection":
+                case "many2one":
                     value = trimmedQuery;
                     break;
-                }
-                default: {
+                default:
                     value = parser(trimmedQuery);
-                }
             }
         } catch {
             return [];
@@ -286,7 +285,7 @@ export class SearchBar extends Component {
         } else if (fieldType === "properties") {
             item.isParent = true;
             item.unselectable = true;
-        } else if (fieldType === "many2one") {
+        } else if (fieldType === "many2one" || fieldType === "selection") {
             item.isParent = true;
         }
 
@@ -339,38 +338,45 @@ export class SearchBar extends Component {
      */
     async computeSubItems(searchItem, query) {
         const field = this.fields[searchItem.fieldName];
-        let domain = [];
-        if (searchItem.domain) {
-            const domainEvalContext = {
-                ...this.env.searchModel.domainEvalContext,
-                ...field.context,
-            };
-            domain = new Domain(searchItem.domain).toList(domainEvalContext);
-        }
-        const relation =
-            searchItem.type === "field_property"
-                ? searchItem.propertyFieldDefinition.comodel
-                : field.relation;
-
-        let nameSearchOperator;
-        ({ operator: nameSearchOperator, value: query } = manageSearchWithQuotes({
-            operator: "ilike",
-            value: query,
-        }));
-
-        const limitToFetch = this.state.subItemsLimits[searchItem.id] + 1;
-        const options = await this.orm.call(relation, "name_search", [], {
-            domain: domain,
-            operator: nameSearchOperator,
-            context: { ...this.env.searchModel.globalContext, ...field.context },
-            limit: limitToFetch,
-            name: query.trim(),
-        });
-
+        let options = [];
         let showLoadMore = false;
-        if (options.length === limitToFetch) {
-            options.pop();
-            showLoadMore = true;
+        if (searchItem.fieldType === "selection") {
+            options = field.selection.filter(([_, label]) =>
+                fuzzyTest(query.toLowerCase(), label.toLowerCase())
+            );
+        } else {
+            let domain = [];
+            if (searchItem.domain) {
+                const domainEvalContext = {
+                    ...this.env.searchModel.domainEvalContext,
+                    ...field.context,
+                };
+                domain = new Domain(searchItem.domain).toList(domainEvalContext);
+            }
+            const relation =
+                searchItem.type === "field_property"
+                    ? searchItem.propertyFieldDefinition.comodel
+                    : field.relation;
+
+            let nameSearchOperator;
+            ({ operator: nameSearchOperator, value: query } = manageSearchWithQuotes({
+                operator: "ilike",
+                value: query,
+            }));
+
+            const limitToFetch = this.state.subItemsLimits[searchItem.id] + 1;
+            options = await this.orm.call(relation, "name_search", [], {
+                domain: domain,
+                operator: nameSearchOperator,
+                context: { ...this.env.searchModel.globalContext, ...field.context },
+                limit: limitToFetch,
+                name: query.trim(),
+            });
+
+            if (options.length === limitToFetch) {
+                options.pop();
+                showLoadMore = true;
+            }
         }
 
         const subItems = [];
@@ -453,6 +459,7 @@ export class SearchBar extends Component {
 
         const searchItem = this.getSearchItem(item.searchItemId);
         if (
+            (searchItem.fieldType === "selection" && !item.isChild) ||
             (searchItem.type === "field" && searchItem.fieldType === "properties") ||
             (searchItem.type === "field_property" && item.unselectable)
         ) {

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -555,6 +555,59 @@ test("autocompletion with a boolean field", async () => {
     expect(searchBar.env.searchModel.domain).toEqual([["bool", "=", false]]);
 });
 
+test("autocompletion with a selection field", async () => {
+    Partner._fields.selection_field = fields.Selection({
+        string: "Selection Field",
+        selection: [
+            ["abc", "ABC"],
+            ["aef", "AEF"],
+            ["ghi", "GHI"],
+        ],
+    });
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field name="selection_field"/>
+            </search>
+        `,
+    });
+    expect(searchBar.env.searchModel.domain).toEqual([]);
+
+    await editSearch("a");
+    expect(`.o_searchview_autocomplete .o-dropdown-item`).toHaveCount(2);
+    expect(`.o_searchview_autocomplete .o-dropdown-item:first`).toHaveText(
+        "Search Selection Field for: a"
+    );
+    // expand results
+    await contains(".o_searchview_autocomplete .o-dropdown-item:first").click();
+    expect(`.o_searchview_autocomplete .o-dropdown-item`).toHaveCount(4);
+    expect(`.o_searchview_autocomplete .o-dropdown-item:eq(1)`).toHaveText("ABC");
+    expect(`.o_searchview_autocomplete .o-dropdown-item:eq(2)`).toHaveText("AEF");
+    // select "AEF"
+    await contains(`.o_searchview_autocomplete .o-dropdown-item:eq(2)`).click();
+    expect(searchBar.env.searchModel.domain).toEqual([["selection_field", "=", "aef"]]);
+
+    await removeFacet("Selection Field AEF");
+    expect(searchBar.env.searchModel.domain).toEqual([]);
+
+    await editSearch("h");
+    expect(`.o_searchview_autocomplete .o-dropdown-item`).toHaveCount(2);
+    expect(`.o_searchview_autocomplete .o-dropdown-item:first`).toHaveText(
+        "Search Selection Field for: h"
+    );
+    // expand results
+    await contains(".o_searchview_autocomplete .o-dropdown-item:first").click();
+    expect(`.o_searchview_autocomplete .o-dropdown-item`).toHaveCount(3);
+    expect(`.o_searchview_autocomplete .o-dropdown-item:eq(1)`).toHaveText("GHI");
+
+    // select "GHI"
+    await contains(`.o_searchview_autocomplete .o-dropdown-item:eq(1)`).click();
+    expect(searchBar.env.searchModel.domain).toEqual([["selection_field", "=", "ghi"]]);
+});
+
 test("the search value is trimmed to remove unnecessary spaces", async () => {
     const searchBar = await mountWithSearch(SearchBar, {
         resModel: "partner",


### PR DESCRIPTION
This commit updates the autocomplete behavior for selection fields in the search bar. Instead of showing all matches immediately, users now need to confirm that they want to search within a specific selection field—mirroring the existing behavior for many2one fields. This should help reduce the average load of results directly displayed in the dropdown.

The behavior for selection property searches remains unchanged.

task-4700083
