### PR TITLE
[FIX] mail: make channel invitation style more visually pleasing

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -13,7 +13,7 @@
             <t t-if="store.self.type === 'partner'">
                 <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 }">
-                    <div t-if="selectablePartners.length === 0" class="small text-muted mx-1 fst-italic">
+                    <div t-if="selectablePartners.length === 0" class="smaller text-muted mx-1 opacity-50">
                         <t t-if="props.thread">No user found that is not already a member of this channel.</t>
                         <t t-else="">No user found.</t>
                     </div>
@@ -50,12 +50,12 @@
                     </button>
                 </t>
                 <div t-if="props.thread?.invitationLink" class="input-group">
-                    <input class="border border-secondary form-control lh-1 px-2 py-0 opacity-75 bg-view" type="text" t-att-value="props.thread.invitationLink" readonly="" t-on-focus="onFocusInvitationLinkInput"/>
-                    <button class="btn btn-primary px-2 py-1" t-on-click="onClickCopy">
+                    <input class="border border-secondary form-control lh-1 px-2 py-0 opacity-50 bg-view smaller" type="text" t-att-value="props.thread.invitationLink" readonly="" t-on-focus="onFocusInvitationLinkInput"/>
+                    <button class="btn btn-primary px-2 o-py-0_5" t-on-click="onClickCopy">
                         <i class="fa fa-copy"/>
                     </button>
                 </div>
-                <div t-if="props.thread?.accessRestrictedToGroupText" class="mt-2 text-muted smaller mx-1" t-esc="props.thread.accessRestrictedToGroupText"/>
+                <div t-if="props.thread?.accessRestrictedToGroupText" class="mt-2 text-muted smaller mx-1 opacity-50" t-esc="props.thread.accessRestrictedToGroupText"/>
             </div>
         </div>
     </t>


### PR DESCRIPTION
This menu is dense of information and user interaction, and without reducing visibility of some information this feels more exhausting than it should.

This commit reduces visibility of textual info text and invite link (smaller, reduced opacity), helping highlighting the most important items: search, suggested / selected items, invite / share link buttons.

Before
<img width="482" alt="Screenshot 2025-04-07 at 16 30 55" src="https://github.com/user-attachments/assets/8ace7532-eb5e-426d-bc4f-d792d1923567" />
After
<img width="481" alt="Screenshot 2025-04-07 at 16 31 56 1" src="https://github.com/user-attachments/assets/54780e64-37fd-4f5f-9dd4-e63fdfce0a1d" />

