### PR TITLE
[FIX] point_of_sale: ensure screen switch when skip preview is disabled

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -361,7 +361,7 @@ export class PaymentScreen extends Component {
         // Always show the next screen regardless of error since pos has to
         // continue working even offline.
         let nextScreen = this.nextScreen;
-        let switchScreen = false;
+        let switchScreen = true;
 
         if (
             nextScreen === "ReceiptScreen" &&
@@ -385,8 +385,6 @@ export class PaymentScreen extends Component {
                     }
                 }
             }
-        } else {
-            switchScreen = true;
         }
 
         if (switchScreen) {


### PR DESCRIPTION
Before this commit, when automatic receipt printing was enabled, a POS printer was configured, and the "Skip Preview" option was not enabled, the POS remained on the Payment screen after order validation instead of switching to the Receipt screen.

opw-4656023

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
