### PR TITLE
[FIX] web_editor: make the date clearly visible

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1430,6 +1430,9 @@
                 &::placeholder {
                     color: $o-we-sidebar-content-field-control-item-color;
                 }
+                &.datetimepicker-input.text-primary {
+                    color: inherit !important;
+                }
             }
             span {
                 flex: 0 0 auto;


### PR DESCRIPTION
The text color in the input is purple and not clearly visible with the dark input background.

Steps to reproduce:
-------------------
* Go to edit mode.
* Drag and drop a "countdown" block.
* Open the date picker by clicking the "Due Date" input in the options.
* Click on a date.

> Observation:

Why the fix:
------------
Make it visible

opw-4589158


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
