### PR TITLE
[FIX] uom: avoid traceback with archived product and many2one_uom widget

### DIFF
--- a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
+++ b/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
@@ -49,7 +49,8 @@ export class Many2XUomTagsAutocomplete extends Many2XAutocomplete {
 
     async updateReferenceUnit(props = this.props) {
         if (props.productModel && props.productId) {
-            const product = await this.orm.searchRead(props.productModel, [["id", "=", props.productId]], ["uom_id"]);
+            const context = { "active_test" : false };
+            const product = await this.orm.searchRead(props.productModel, [["id", "=", props.productId]], ["uom_id"], { context });
             this.referenceUnit = (await this.orm.searchRead("uom.uom", [["id", "=", product[0].uom_id[0]]], ["name", "factor", "parent_path", "rounding"]))[0];
         }
     }


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product
- Archive it
- Refresh the page

**Problem:**
A traceback is triggered:
`TypeError: Cannot read properties of undefined (reading 'uom_id')`

This happens because, during setup, the updateReferenceUnit function is called:
 https://github.com/odoo/odoo/blob/9fb46cdbc553e7ac91aeccf9779af37c018a7327/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js#L38

In this function, a "search_read" is performed to fetch the product:
 https://github.com/odoo/odoo/blob/9fb46cdbc553e7ac91aeccf9779af37c018a7327/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js#L43

However, by default, the search only looks for non-archived products. As a result, the archived product isn't found, and the code still tries to access its uom, which leads to an error:
 https://github.com/odoo/odoo/blob/9fb46cdbc553e7ac91aeccf9779af37c018a7327/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js#L44

opw-4701779
