### PR TITLE
[FIX] sale_project: set sale order on tasks for non-billable projects

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -910,12 +910,9 @@ class ProjectTask(models.Model):
             return search_on_comodel
         return sales_orders
 
-    @api.depends('sale_line_id', 'project_id', 'partner_id.commercial_partner_id', 'allow_billable')
+    @api.depends('sale_line_id', 'project_id', 'partner_id.commercial_partner_id')
     def _compute_sale_order_id(self):
         for task in self:
-            if not task.allow_billable:
-                task.sale_order_id = False
-                continue
             sale_order = (
                 task.sale_line_id.order_id
                 or task.project_id.sale_order_id

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -891,3 +891,22 @@ class TestSaleProject(TestSaleProjectCommon):
         sale_order_form = Form(self.env['sale.order'].with_user(milestone_user), view='sale_project.view_order_form_inherit_sale_project')
         project_ids = sale_order_form._view['fields'].get('project_ids')
         self.assertTrue(project_ids, "'project_ids' field should be present for milestone users in the sale order form")
+
+    def test_non_billable_task_sale_order_id(self):
+        project = self.env['project.project'].create({
+            "name": "Test Task's Smart Button",
+            "allow_billable": False,
+        })
+        prod = self.env['product.product'].create({
+            'name': 'elct',
+            'type': 'service',
+            'service_tracking': 'task_global_project',
+            'project_id': project.id
+        })
+        partner = self.env['res.partner'].create({'name': 'Val Kilmer'})
+        so = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'order_line': [(0, 0, {'product_id': prod.id, 'product_uom_qty': 1})]
+        })
+        so.action_confirm()
+        self.assertEqual(len(so.tasks_ids[0].sale_order_id), 1)


### PR DESCRIPTION
When billing is disabled for a project, tasks created for service products in a sale order do not have their `sale_order_id` set. This is because the `_compute_sale_order_id` method explicitly skips assigning a sale order when `allow_billable` is False.

Current behavior before PR:
There is no smart button linking back to the sale order on the task since len(sale_order_id) == 0

Desired behavior after PR is merged:
The sale_order_id is still set when the task.allow_billable == False. 

Steps to reproduce:
1.) Create a project with the Billing config disabled
2.) Create a service product that creates a task on order within the project from step 1

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
