### PR TITLE
[FIX] spreadsheet: fix crash on oob number in date

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
@@ -58,6 +58,21 @@ const odooNumberDateAdapter = {
     },
 };
 
+function boundedOdooNumberDateAdapter(lower, upper) {
+    return {
+        normalizeServerValue(groupBy, field, readGroupResult) {
+            return Number(readGroupResult[groupBy]);
+        },
+        increment(normalizedValue, step) {
+            const value = normalizedValue + step
+            if (value < lower || upper < value){
+                return undefined
+            }
+            return value
+        },
+    };    
+}
+
 const odooDayAdapter = {
     normalizeServerValue(groupBy, field, readGroupResult) {
         const serverDayValue = getGroupStartingDay(field, groupBy, readGroupResult);
@@ -230,11 +245,11 @@ pivotTimeAdapterRegistry.add("quarter", falseHandlerDecorator(odooQuarterAdapter
 
 extendSpreadsheetAdapter("day", odooDayAdapter);
 extendSpreadsheetAdapter("year", odooNumberDateAdapter);
-extendSpreadsheetAdapter("day_of_month", odooNumberDateAdapter);
+extendSpreadsheetAdapter("day_of_month", boundedOdooNumberDateAdapter(1, 31));
 extendSpreadsheetAdapter("day", odooDayAdapter);
-extendSpreadsheetAdapter("iso_week_number", odooNumberDateAdapter);
-extendSpreadsheetAdapter("month_number", odooNumberDateAdapter);
-extendSpreadsheetAdapter("quarter_number", odooNumberDateAdapter);
+extendSpreadsheetAdapter("iso_week_number", boundedOdooNumberDateAdapter(0, 54));
+extendSpreadsheetAdapter("month_number", boundedOdooNumberDateAdapter(1, 12));
+extendSpreadsheetAdapter("quarter_number", boundedOdooNumberDateAdapter(1, 4));
 
 /**
  * When grouping by a time field, return


### PR DESCRIPTION
Issue :
Given a pivot grouped by date with anything else than year as aggregate (I tried with week, quarter and month), Given the pivot is exploded
When I autofill the date cells and the date passes from one year to another, it crashes hard

New behaviour:
For bounded date fields, the autofill loop around when reaching the upper bound.

Task: 4700703

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
