### PR TITLE
[FIX] mail: remove xml declaration in case that exists in the response

### DIFF
--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -78,11 +78,22 @@ class TestLinkPreview(MailCommon):
         content = b""""""
         return self._patched_get_html(None, content)
 
+    def _patch_with_xml_declaration(self, *args, **kwargs):
+        content = b"""<?xml version="1.0" encoding="UTF-8"?>
+        <html>
+        <head>
+        <title>Test title</title>
+        </head>
+        </html>
+        """
+        return self._patched_get_html("text/html", content)
+
     def test_get_link_preview_from_url(self):
         test_cases = [
             (self._patch_with_og_properties, self.source_url),
             (self._patch_without_og_properties, self.source_url),
             (self._patch_with_image_mimetype, self.og_image),
+            (self._patch_with_xml_declaration, self.source_url)
         ]
         expected_values = [
             {
@@ -108,6 +119,15 @@ class TestLinkPreview(MailCommon):
                 'og_image': self.og_image,
                 'source_url': self.og_image,
             },
+            {
+                'og_description': None,
+                'og_image': None,
+                'og_mimetype': None,
+                'og_title': self.title,
+                'og_type': None,
+                'og_site_name': None,
+                'source_url': self.source_url,
+            }
         ]
         session = requests.Session()
         for (get_patch, url), expected in zip(test_cases, expected_values):

--- a/addons/mail/tools/link_preview.py
+++ b/addons/mail/tools/link_preview.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import re
 from lxml import html
 import chardet
 import requests
@@ -73,7 +73,14 @@ def get_link_preview_from_html(url, response):
     except (UnicodeDecodeError, TypeError) as e:
         decoded_content = content.decode("utf-8", errors="ignore")
 
-    tree = html.fromstring(decoded_content)
+    try:
+        tree = html.fromstring(decoded_content)
+    except ValueError:
+        decoded_content = re.sub(
+            r"^<\?xml[^>]+\?>\s*", "", decoded_content, flags=re.IGNORECASE
+        )
+        tree = html.fromstring(decoded_content)
+
     og_title = tree.xpath('//meta[@property="og:title"]/@content')
     if og_title:
         og_title = og_title[0]


### PR DESCRIPTION
## Details:

The function get_link_preview_from_html is a common tool used in many modules, one of them documents.

When you add a link on a workspace that response with a content with a xml declaration (ex. "<!--?xml version="1.0" encoding="UTF-8"?-->"), this will raise the next ValueError:

"Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration."

At the moment that the string is being parsed as a html element, this string has been cleaned, to avoid the issue, we can only remove this xml declaration because this element is only being used to extract information about the page.

## Impacted versions:

18.0 and later

## Steps to reproduce:
1. Go to Documents App
2. Add a link in any workspace with xml declaration (ex. https://www.buffalo.jp/s3/guide/crmm/userguide/99/en/pc_index.html)

## Current behavior:
Raise Value Error "Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration."

## Expected behavior:
Link should be saved.

### Task
OPW-4675813