### PR TITLE
[FIX] l10n_in_*: Fix regex to correctly compute distance

### DIFF
--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -196,8 +196,8 @@ class AccountEdiFormat(models.Model):
 
     def _l10n_in_edi_ewaybill_handle_zero_distance_alert_if_present(self, invoice, response):
         if invoice.l10n_in_distance == 0 and (alert := response.get("data", {}).get('alert')):
-            pattern = r", Distance between these two pincodes is \d+, "
-            if re.fullmatch(pattern, alert) and (distance := int(re.search(r'\d+', alert).group())) > 0:
+            pattern = r"Distance between these two pincodes is (\d+)"
+            if (match := re.search(pattern, alert)) and (distance := int(match.group(1))) > 0:
                 invoice.l10n_in_distance = distance
 
     def _l10n_in_edi_ewaybill_irn_post_invoice_edi(self, invoices):

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_distance.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_distance.py
@@ -8,9 +8,16 @@ from odoo.tests import tagged
 
 @tagged("post_install_l10n", "post_install", "-at_install")
 class TestEdiEwaybillJson(TestEdiJson):
+    """
+    Test cases for validating the extraction of distance values from
+    E-Waybill API responses and updating invoice fields accordingly.
+    """
 
     @contextmanager
-    def mockEwaybillGateway(self):
+    def mockEwaybillGateway1(self):
+        """
+        Mock gateway returning multiple alerts.
+        """
 
         def _l10n_in_edi_ewaybill_generate(self, company, json_payload={}):
             return {
@@ -27,20 +34,62 @@ class TestEdiEwaybillJson(TestEdiJson):
         with patch.object(AccountEdiFormat, "_l10n_in_edi_ewaybill_generate", side_effect=_l10n_in_edi_ewaybill_generate):
             yield
 
+    @contextmanager
+    def mockEwaybillGateway2(self):
+        """
+        Mock gateway returning a single alert.
+        """
+
+        def _l10n_in_edi_ewaybill_generate(self, company, json_payload={}):
+            return {
+                "status_cd": "1",
+                "status_desc": "EWAYBILL request succeeds",
+                "data": {
+                    "ewayBillNo": 123456789012,
+                    "ewayBillDate": "08/04/2025 11:41:15 AM",
+                    "validUpto": "08/04/2025 11:41:15 AM",
+                    "alert": "Distance between these two pincodes is 222",
+                }
+            }
+
+        with patch.object(AccountEdiFormat, "_l10n_in_edi_ewaybill_generate", side_effect=_l10n_in_edi_ewaybill_generate):
+            yield
+
     def test_edi_distance(self):
-        self.invoice.write(
-            {
-                "l10n_in_type_id": self.env.ref(
-                    "l10n_in_edi_ewaybill.type_tax_invoice_sub_type_supply"
-                ),
+        # Sub-test: Extract `Distance` when multiple alerts in response
+        with self.subTest(scenario="Extract distance when multiple alerts in response"):
+            expected_distance = 118
+            copy_invoice = self.invoice.copy()
+            copy_invoice.write({
+                "l10n_in_type_id": self.env.ref("l10n_in_edi_ewaybill.type_tax_invoice_sub_type_supply").id,
                 "l10n_in_distance": 0,
                 "l10n_in_mode": "1",
                 "l10n_in_vehicle_no": "GJ11AA1234",
                 "l10n_in_vehicle_type": "R",
-            }
-        )
-        with self.mockEwaybillGateway():
-            self.invoice.l10n_in_edi_ewaybill_send()
-            self.invoice.action_process_edi_web_services(with_commit=False)
-        expected_distance = 118
-        self.assertEqual(self.invoice.l10n_in_distance, expected_distance)
+            })
+            copy_invoice.action_post()
+
+            # Simulate E-Waybill API response and process it
+            with self.mockEwaybillGateway1():
+                copy_invoice.l10n_in_edi_ewaybill_send()
+                copy_invoice.action_process_edi_web_services(with_commit=False)
+            self.assertEqual(copy_invoice.l10n_in_distance, expected_distance)
+
+        # Sub-test: Extract `Distance` when single alert in response
+        with self.subTest(scenario="Extract distance when single alert in response"):
+            expected_distance = 222
+            copy_invoice = self.invoice.copy()
+            copy_invoice.write({
+                "l10n_in_type_id": self.env.ref("l10n_in_edi_ewaybill.type_tax_invoice_sub_type_supply").id,
+                "l10n_in_distance": 0,
+                "l10n_in_mode": "1",
+                "l10n_in_vehicle_no": "GJ11AA1234",
+                "l10n_in_vehicle_type": "R",
+            })
+            copy_invoice.action_post()
+
+            # Simulate E-Waybill API response and process it
+            with self.mockEwaybillGateway2():
+                copy_invoice.l10n_in_edi_ewaybill_send()
+                copy_invoice.action_process_edi_web_services(with_commit=False)
+            self.assertEqual(copy_invoice.l10n_in_distance, expected_distance)

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -408,8 +408,8 @@ class Ewaybill(models.Model):
 
     def _l10n_in_ewaybill_stock_handle_zero_distance_alert_if_present(self, response):
         if self.distance == 0 and (alert := response.get('data').get('alert')):
-            pattern = r", Distance between these two pincodes is \d+, "
-            if re.fullmatch(pattern, alert) and (dist := int(re.search(r'\d+', alert).group())) > 0:
+            pattern = r"Distance between these two pincodes is (\d+)"
+            if (match := re.search(pattern, alert)) and (dist := int(match.group(1))) > 0:
                 self.distance = dist
 
     def _generate_ewaybill_direct(self):

--- a/addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py
+++ b/addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py
@@ -185,16 +185,36 @@ class TestStockEwaybill(AccountTestInvoicingCommon):
             'transportation_doc_no': 123456789,
             'transportation_doc_date': '2024-04-26'
         })
-        expected_distance = 118
-        response = {
-            'status_cd': '1',
-            'status_desc': 'EWAYBILL request succeeds',
-            'data': {
-                'ewayBillNo': 123456789012,
-                'ewayBillDate': '26/02/2024 12:09:43 PM',
-                'validUpto': '27/02/2024 12:09:43 PM',
-                "alert": ", Distance between these two pincodes is 118, "
+
+        # Sub-test: Extract `Distance` when multiple alerts in response
+        with self.subTest(scenario="Extract distance when multiple alerts in response"):
+            expected_distance = 118
+            response = {
+                'status_cd': '1',
+                'status_desc': 'EWAYBILL request succeeds',
+                'data': {
+                    'ewayBillNo': 123456789012,
+                    'ewayBillDate': '26/02/2024 12:09:43 PM',
+                    'validUpto': '27/02/2024 12:09:43 PM',
+                    'alert': ', Distance between these two pincodes is 118, '
+                }
             }
-        }
-        ewaybill._l10n_in_ewaybill_stock_handle_zero_distance_alert_if_present(response)
-        self.assertEqual(ewaybill.distance, expected_distance)
+            ewaybill._l10n_in_ewaybill_stock_handle_zero_distance_alert_if_present(response)
+            self.assertEqual(ewaybill.distance, expected_distance)
+
+        # Sub-test: Extract `Distance` when single alert in response
+        with self.subTest(scenario="Extract distance when single alert in response"):
+            ewaybill.distance = 0
+            expected_distance = 222
+            response = {
+                'status_cd': '1',
+                'status_desc': 'EWAYBILL request succeeds',
+                'data': {
+                    'ewayBillNo': 987654321012,
+                    'ewayBillDate': '08/04/2025 11:04:04 AM',
+                    'validUpto': '09/04/2025 11:04:04 AM',
+                    'alert': 'Distance between these two pincodes is 222'
+                }
+            }
+            ewaybill._l10n_in_ewaybill_stock_handle_zero_distance_alert_if_present(response)
+            self.assertEqual(ewaybill.distance, expected_distance)


### PR DESCRIPTION
* applies to: `l10n_in_edi_ewaybill`, `l10n_in_ewaybill_stock`

* Before this commit: When there were multiple alerts, the code handled all alert messages correctly and calculated the `distance` as expected. However, when there was only a single alert related to distance, the process would get stuck.

* After this commit: The code now also handles cases with a single distance-related alert message, ensuring proper detection and processing in all scenarios.

> No Task ID


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
