### PR TITLE
[IMP] mail: prettier 'is typing' IM status

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -1,6 +1,6 @@
 import { ImStatus } from "@mail/core/common/im_status";
 
-import { Component, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, useEffect, useRef, useState, useSubEnv } from "@odoo/owl";
 
 import { useChildRef, useService } from "@web/core/utils/hooks";
 import { useHover } from "@mail/utils/common/hooks";
@@ -67,6 +67,7 @@ export class ChatBubble extends Component {
             },
             () => [this.thread.importantCounter]
         );
+        useSubEnv({ inChatBubble: true });
     }
 
     /** @returns {import("models").Thread} */

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -7,7 +7,10 @@
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent">
                 <t t-set-slot="pre_icon">
-                    <i class="fa fa-circle position-absolute text-300" style="font-size: 18px; right: 1px; bottom: 0px; z-index: -1;"/>
+                    <i style="font-size: 18px; right: -2px; bottom: -2px; z-index: -1;" t-att-class="{
+                        'bg-success rounded-pill position-absolute': thread?.correspondent?.isTyping,
+                        'fa fa-circle position-absolute text-300': !thread?.correspondent?.isTyping,
+                    }"/>
                 </t>
             </ImStatus>
             <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border'"/>

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -82,6 +82,10 @@ export class ChatWindow extends Component {
         return this.props.chatWindow.thread;
     }
 
+    get showImStatus() {
+        return this.thread?.channel_type === "chat" && this.thread.correspondent;
+    }
+
     get style() {
         const maxHeight = !this.ui.isSmall ? "max-height: 95vh;" : "";
         const textDirection = localization.direction;

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -14,6 +14,9 @@
     &.o-quick {
         opacity: 15%;
     }
+    &.o-actionsMenu {
+        background-color: inherit !important;
+    }
     &:not(.o-actionsMenu) {
         padding: map-get($spacers, 1) / 2;
     }
@@ -54,6 +57,11 @@
         height: $o-mail-Avatar-sizeSmall;
         width: $o-mail-Avatar-sizeSmall;
     }
+}
+
+.o-mail-ChatWindow-imStatus {
+    bottom: -2px;
+    right: -2px;
 }
 
 .o-mail-ChatWindow-typing {

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -14,10 +14,10 @@
     >
         <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1 border-bottom border-secondary" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and !props.chatWindow.actionsDisabled }">
             <t t-if="hasActionsMenu">
-                <div class="d-flex text-truncate">
+                <div class="d-flex text-truncate bg-inherit">
                     <Dropdown position="ui.isSmall ? 'bottom-end' : 'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0 bg-100 border-secondary'">
                         <button
-                            class="o-mail-ChatWindow-command o-actionsMenu btn rounded-0 d-flex align-items-center px-2 py-1 my-0 w-100 rounded-end-0"
+                            class="o-mail-ChatWindow-command o-actionsMenu btn rounded-0 d-flex align-items-center px-2 py-1 my-0 w-100 rounded-end-0 bg-inherit"
                             t-att-class="{ 'rounded-top-3': !ui.isSmall, 'o-active': state.actionsMenuOpened, 'o-hover': actionsMenuButtonHover.isHover and !parentChannelHover.isHover }"
                             t-att-disabled="state.editingName or props.chatWindow.actionsDisabled"
                             t-att-title="actionsMenuTitleText"
@@ -104,7 +104,7 @@
                 <t t-elif="thread">
                     <Thread isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage"/>
                     <div t-if="thread.hasOtherMembersTyping" class="d-flex bg-inherit position-relative">
-                        <div class="o-mail-ChatWindow-typing d-flex px-2 position-absolute bottom-0 start-0 w-100 bg-inherit align-items-center">
+                        <div class="o-mail-ChatWindow-typing d-flex px-3 position-absolute bottom-0 start-0 w-100 bg-inherit align-items-center">
                             <Typing channel="thread" size="'medium'"/>
                         </div>
                     </div>
@@ -127,7 +127,7 @@
 </t>
 
 <t t-name="mail.ChatWindow.headerContent">
-    <div class="o-mail-ChatWindow-threadAvatar my-0 me-1" t-att-class="{
+    <div class="o-mail-ChatWindow-threadAvatar position-relative bg-inherit my-0 me-1" t-att-class="{
         'py-1': !thread or threadActions.actions.length gt 3,
         'py-2': thread and threadActions.actions.length lte 3,
         'ms-1': thread,
@@ -135,12 +135,12 @@
         'ps-2': !hasActionsMenu,
     }">
         <img t-if="thread" class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
+        <ImStatus t-if="showImStatus" className="'o-mail-ChatWindow-imStatus position-absolute'" member="thread.correspondent"/>
     </div>
     <t t-if="thread?.parent_channel_id">
         <span class="fw-bold small ms-1 p-1 opacity-75 opacity-100-hover cursor-pointer o-hover-text-underline rounded fs-6" t-esc="thread.parent_channel_id.displayName" title="Open Channel" t-ref="parentChannel" t-on-click.stop="() => this.thread.parent_channel_id.open({ focus: true })"/>
         <i class="fa fa-chevron-right o-xsmaller ms-1 text-muted opacity-50"/>
     </t>
-    <ThreadIcon t-if="thread?.channel_type === 'chat' and thread.correspondent" thread="thread"/>
     <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatWindow-country border'"/>
     <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent mx-1 my-0 py-1" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="{ 'fs-4': ui.isSmall, 'fs-5': !ui.isSmall }"/>
 </t>

--- a/addons/mail/static/src/core/common/im_status.scss
+++ b/addons/mail/static/src/core/common/im_status.scss
@@ -1,14 +1,12 @@
 
 .o-mail-ImStatus {
-    width: $font-size-lg;
-    height: $font-size-lg;
 
-    &.o-md {
-        width: $font-size-base;
-        height: $font-size-base;
+    i {
+        padding-left: 1px;
+        padding-right: 1px;
     }
 
-    &.o-sm {
+    &.o-sm i {
         width: $font-size-sm;
         height: $font-size-sm;
     }

--- a/addons/mail/static/src/core/common/im_status.xml
+++ b/addons/mail/static/src/core/common/im_status.xml
@@ -2,9 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.ImStatus">
-        <div class="o-mail-ImStatus d-flex justify-content-center flex-shrink-0 align-items-center rounded-circle bg-inherit" t-attf-class="{{ props.className }}" t-att-style="props.style" t-att-class="{
+        <div class="o-mail-ImStatus d-flex justify-content-center flex-shrink-0 align-items-center bg-inherit" t-attf-class="{{ props.className }}" t-att-style="props.style" t-att-class="{
             'o-md': props.size === 'md' or props.size === 'medium',
             'o-sm': props.size === 'sm' or props.size === 'small',
+            'rounded-circle': !props.member?.isTyping,
+            'rounded-pill': props.member?.isTyping,
         }">
             <span class="d-flex flex-column" t-att-class="{
                 'smaller': props.size === 'md' or props.size === 'medium',
@@ -19,7 +21,11 @@
                         <i t-elif="persona.im_status === 'bot'" class="fa fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
                         <i t-else="" class="fa fa-fw fa-question-circle opacity-75" title="No IM status available"/>
                     </t>
-                    <Typing t-if="props.member?.isTyping" member="props.member" channel="props.member.threadAsTyping" size="'medium'" displayText="false" />
+                    <div t-if="props.member?.isTyping" class="rounded-pill" style="padding: 1px;" t-att-class="{ 'bg-300': env.inChatBubble, 'bg-inherit': !env.inChatBubble }">
+                        <div class="bg-success rounded-pill" style="padding: 3px;">
+                            <Typing member="props.member" channel="props.member.threadAsTyping" size="'md'" displayText="false" />
+                        </div>
+                    </div>
                 </t>
             </span>
         </div>

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -52,6 +52,11 @@
     width: 24px;
 }
 
+.o-mail-Discuss-headerImStatus {
+    bottom: -2px;
+    right: -2px;
+}
+
 .o-mail-Discuss-panelContainer {
     --border-opacity: .5;
 }

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -8,7 +8,7 @@
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
             <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
-                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center ms-1 me-2 my-1">
+                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center ms-1 me-2 my-1 bg-inherit">
                         <img class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="!thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
@@ -17,12 +17,12 @@
                                 </a>
                             </t>
                         </FileUploader>
+                        <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'o-mail-Discuss-headerImStatus position-absolute'" member="thread.correspondent"/>
                     </div>
                     <t t-else="">
                         <ThreadIcon className="'mx-2 align-self-center fs-2 my-2 opacity-75'" size="'large'" thread="thread"/>
                     </t>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-Discuss-headerCountry border'"/>
-                    <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'me-1'" member="thread.correspondent" />
                     <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-2">
                         <div t-if="thread.parent_channel_id" class="d-flex align-items-center gap-1 ms-1">
                             <span class="fw-bolder cursor-pointer opacity-75 opacity-100-hover o-hover-text-underline" t-esc="thread.parent_channel_id.displayName" t-on-click="() => this.thread.parent_channel_id.open({ focus: true })"/>

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -39,7 +39,7 @@
                         <span t-else="" t-out="message?.previewText" t-att-class="{ 'opacity-75': message?.isEmpty }"/>
                     </t>
                     <t t-set-slot="icon">
-                        <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" member="thread.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
+                        <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" member="thread.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ' + (thread.correspondent.isTyping ? 'ms-n2' : 'ms-n1')"/>
                         <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-NotificationItem-country position-absolute border'"/>
                     </t>
                     <t t-if="message" t-set-slot="body-icon">

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -38,7 +38,7 @@
         <div class="o-discuss-ChannelMember d-flex align-items-center p-1 bg-inherit rounded" t-att-class="{ 'cursor-pointer': canOpenChatWith(member), 'o-offline': offline }" t-on-click.stop="(ev) => this.onClickAvatar(ev, member)">
             <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex flex-shrink-0">
                 <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="member.persona.avatarUrl"/>
-                <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
+                <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ' + (member.isTyping ? 'ms-n2' : 'ms-n1')" size="'md'"/>
             </div>
             <div t-ref="displayName" class="d-flex overflow-hidden flex-column">
                 <span class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name" t-att-title="member.name"/>

--- a/addons/mail/static/src/discuss/typing/common/primary_variables.scss
+++ b/addons/mail/static/src/discuss/typing/common/primary_variables.scss
@@ -1,2 +1,0 @@
-$o-discuss-Typing-medium: 5px !default;
-$o-discuss-Typing-small: 3px !default;

--- a/addons/mail/static/src/discuss/typing/common/thread_icon_patch.xml
+++ b/addons/mail/static/src/discuss/typing/common/thread_icon_patch.xml
@@ -2,7 +2,11 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ThreadIcon" t-inherit-mode="extension">
         <xpath expr="//t[@name='chat']" position="replace">
-            <Typing t-if="props.thread.hasOtherMembersTyping" channel="props.thread" size="props.size" displayText="false"/>
+            <div t-if="props.thread.hasOtherMembersTyping" class="bg-inherit rounded-pill" style="padding: 1px;">
+                <div class="bg-success rounded-pill" style="padding: 3px;">
+                    <Typing member="props.member" channel="props.thread" size="props.size" displayText="false" />
+                </div>
+            </div>
             <t t-else="">$0</t>
         </xpath>
     </t>

--- a/addons/mail/static/src/discuss/typing/common/typing.scss
+++ b/addons/mail/static/src/discuss/typing/common/typing.scss
@@ -1,14 +1,19 @@
 .o-discuss-Typing-dot {
     animation: o_mail_Typing_animation 1.5s linear infinite;
+    background-color: $gray-500;
+
+    .o-mail-ImStatus &, .o-mail-ThreadIcon & {
+        background-color: #fff;
+    }
 
     &.o-sizeMedium {
-        width: $o-discuss-Typing-medium;
-        height: $o-discuss-Typing-medium;
+        width: 5px;
+        height: 5px;
     }
 
     &.o-sizeSmall {
-        width: $o-discuss-Typing-small;
-        height: $o-discuss-Typing-small;
+        width: 4px;
+        height: 4px;
     }
 
     &.o-discuss-Typing-dot2 {
@@ -18,6 +23,10 @@
     &.o-discuss-Typing-dot3 {
         animation-delay: -1.2s;
     }
+}
+
+.o-discuss-Typing-icon {
+    gap: 1px;
 }
 
 @keyframes o_mail_Typing_animation {

--- a/addons/mail/static/src/discuss/typing/common/typing.xml
+++ b/addons/mail/static/src/discuss/typing/common/typing.xml
@@ -4,30 +4,24 @@
     <t t-name="discuss.Typing">
         <t t-if="props.member ? props.member.isTyping : props.channel.hasOtherMembersTyping">
             <div class="o-discuss-Typing-icon d-flex align-items-center bg-inherit" t-attf-class="{{ className }}" t-att-title="text">
-                <span class="o-discuss-Typing-dot d-flex flex-shrink-0 rounded-pill bg-500"
-                      t-att-class="{
-                             'o-sizeMedium': props.size === 'medium',
-                             'o-sizeSmall': props.size === 'small',
-                             }"
-                />
+                <span class="o-discuss-Typing-dot d-flex flex-shrink-0 rounded-pill" t-att-class="{
+                    'o-sizeMedium': ['medium', 'md'].includes(props.size),
+                    'o-sizeSmall': ['small', 'sm'].includes(props.size),
+                }"/>
                 <span class="flex-grow-1 flex-shrink-0"/>
-                <span class="o-discuss-Typing-dot o-discuss-Typing-dot2 d-flex flex-shrink-0 rounded-pill bg-500"
-                      t-att-class="{
-                             'o-sizeMedium': props.size === 'medium',
-                             'o-sizeSmall': props.size === 'small',
-                             }"
-                />
+                <span class="o-discuss-Typing-dot o-discuss-Typing-dot2 d-flex flex-shrink-0 rounded-pill" t-att-class="{
+                    'o-sizeMedium': ['medium', 'md'].includes(props.size),
+                    'o-sizeSmall': ['small', 'sm'].includes(props.size),
+                }"/>
                 <span class="flex-grow-1 flex-shrink-0"/>
-                <span class="o-discuss-Typing-dot o-discuss-Typing-dot3 d-flex flex-shrink-0 rounded-pill bg-500"
-                      t-att-class="{
-                             'o-sizeMedium': props.size === 'medium',
-                             'o-sizeSmall': props.size === 'small',
-                             }"
-                />
+                <span class="o-discuss-Typing-dot o-discuss-Typing-dot3 d-flex flex-shrink-0 rounded-pill" t-att-class="{
+                    'o-sizeMedium': ['medium', 'md'].includes(props.size),
+                    'o-sizeSmall': ['small', 'sm'].includes(props.size),
+                }"/>
             </div>
             <t t-if="props.displayText">
                 <span class="ms-1"/>
-                <span class="text-truncate smaller" t-out="text"/>
+                <span class="text-truncate smaller text-muted" t-out="text"/>
             </t>
         </t>
     </t>


### PR DESCRIPTION
- bigger and more spacing between dot animation of "is typing"
- IM status and thread icon of is typing has online bg color
- IM status on discuss & chat window header is now on avatar

Before
![before](https://github.com/user-attachments/assets/fdf843f4-8a37-4d42-9488-2ee59f290ffc)

After
![after](https://github.com/user-attachments/assets/52064fe0-a2ff-4c13-835c-593214d38d13)
