### PR TITLE
[FIX] pos_loyalty: separates e-wallet payments

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -71,7 +71,9 @@ patch(PaymentScreen.prototype, {
      * @override
      */
     async _postPushOrderResolve(order, server_ids) {
-        const orders = this.pos.models["pos.order"].readMany(server_ids).filter((o) => o.is_paid());
+        const orders = this.pos.models["pos.order"]
+            .readMany(server_ids)
+            .filter((o) => o.is_paid() && o.finalized);
         for (const order of orders) {
             await this._postProcessLoyalty(order);
         }

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -1,6 +1,7 @@
 import * as PartnerList from "@point_of_sale/../tests/tours/utils/partner_list_util";
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as combo from "@point_of_sale/../tests/tours/utils/combo_popup_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
@@ -285,6 +286,8 @@ registry.category("web_tour.tours").add("PosLoyaltyMultipleOrders", {
             ProductScreen.addOrderline("Whiteboard Pen", "2"),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
 
             // Order2: Finalize a different order.
             Chrome.clickMenuOption("Orders"),


### PR DESCRIPTION
## Version:
17.4
Fixed in 18.0+ by SBEL via https://github.com/odoo/odoo/pull/204942

## Issue:
When two orders are open simultaneously, each using an eWallet payment, finalizing one order causes the second order's wallet amount to be incorrectly withdrawn as well.

## Steps to reproduce:
- Create an eWallet via `Point of Sale / Products / Gift cards & eWallet`:
  - Set a random name and select `eWallet` as `Program Type`;
  - Click on the `Generate eWallet` button;
  - In the `Customers` field, select 2 customers;
  - Change the value to 100$;
- Open any register via the `Point of Sale` app:
  - On the first order:
    - Add any product;
    - Via the `Customer` button, select one of the 2 customers having an eWallet;
    - Click on the `eWallet Pay` button;
  - Open a new order *(via the `Orders` button from the top right corner menu)*:
    - Add any product;
    - Via the `Customer` button, select the second customers having an eWallet;
    - Click on the `eWallet Pay` button;
    - Click on the `Payment` button:
    - Validate the payment *(the due amount should be equal to 0)*;
- Access the eWallet program via `Point of Sale / Products / Gift cards & eWallet`:
  - Display all wallets by clicking on the `eWallets` smart button;
  - Both customers have less than 100$ even though only one order has been finalized.

## Cause:
When processing a payment, all open orders are checked *(offline feature)* to ensure that paid orders are stored in the database (ref: 6e63f8731c03d9f4deef67604ca879e3d0716366).

The commit 51eb875e7c1c89818e44a8c52c88a77c09c5de75 ensures the loyalty program isn't computed twice when orders were processed offline and applies only to open paid orders.

However, the `is_paid` method does not verify whether the order is finalized — it only checks if the due amount is non-positive. As an open order with an eWallet payment still has `draft` status but a $0 due amount, the loyalty program is incorrectly computed for it, and the order remains open.

## Fix:
Backporting https://github.com/odoo-dev/odoo/commit/a5c92b3a4f41bf8969578e5870a8576ebf829718 in saas-17.4 context.

opw-4557586