### PR TITLE
18.0 visible product external

### DIFF
--- a/custom_addons/visible_product_external_id/README.md
+++ b/custom_addons/visible_product_external_id/README.md
@@ -1,0 +1,42 @@
+# Visible Product External ID
+
+This module adds a visible External IDs field to product forms and views in Odoo.
+
+## Purpose
+
+When importing/exporting data between Odoo and external systems, it's often necessary to reference the External ID of products. However, by default, Odoo doesn't show the External ID in the interface, making it difficult to know which identifier to use when creating data that references products.
+
+This module solves that problem by displaying the External ID as a read-only field on product forms and list views.
+
+## Features
+
+- Shows the External ID as a read-only field on product template forms
+- Shows the External ID as a read-only field on product variant forms
+- Adds External ID to product list views (optional column)
+- Makes External ID searchable in product search views
+
+## Installation
+
+1. Place the `visible_product_external_id` module in your Odoo addons directory
+2. Update the addons list: Settings -> Technical -> Modules -> Update Apps List
+3. Install the module: Apps -> search for "Visible Product External ID" -> Install
+
+## Usage
+
+Once installed, the External ID will be visible:
+
+1. In product forms, next to the Internal Reference field
+2. In product list views as an optional column
+3. In product search, allowing you to search by External ID
+
+## Benefits
+
+- Upload BoM using external ID to reference line items
+- Eliminate the need to export products just to obtain their External IDs
+- Make it easier to identify which products are being referenced in imported/exported data
+
+## Technical Notes
+
+- The module uses a computed field to retrieve the External ID from the `ir.model.data` table
+- For products with multiple External IDs, they are concatenated into a comma separated string
+- The field is read-only as External IDs should be managed via data import/export or developer tools 

--- a/custom_addons/visible_product_external_id/__init__.py
+++ b/custom_addons/visible_product_external_id/__init__.py
@@ -1,0 +1,1 @@
+from . import models 

--- a/custom_addons/visible_product_external_id/__manifest__.py
+++ b/custom_addons/visible_product_external_id/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': 'Visible Product External ID',
+    'version': '1.0',
+    'category': 'Inventory',
+    'summary': 'Display Visible External ID on products',
+    'description': """
+        This module adds the ability to see the External ID directly on product forms.
+        External IDs are useful for integration with third-party systems.
+    """,
+    'depends': ['product'],
+    'data': [
+        'views/product_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+    'license': 'LGPL-3',
+} 

--- a/custom_addons/visible_product_external_id/models/__init__.py
+++ b/custom_addons/visible_product_external_id/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template 

--- a/custom_addons/visible_product_external_id/models/product_template.py
+++ b/custom_addons/visible_product_external_id/models/product_template.py
@@ -1,0 +1,66 @@
+from odoo import api, fields, models
+
+
+class ExternalIdMixin(models.AbstractModel):
+    """Mixin to add external ID functionality to models."""
+    _name = 'external.id.mixin'
+    _description = 'External ID Mixin'
+
+    external_id = fields.Char(
+        string='External ID(s)',
+        compute='_compute_external_id',
+        help="All external IDs as comma-separated string",
+        readonly=True,
+        store=False,
+        search='_search_external_id'
+    )
+
+    @api.depends()
+    def _compute_external_id(self):
+        """Compute the external ID field for the record."""
+        all_external_ids = self.env['ir.model.data'].search([
+            ('model', '=', self._name),
+            ('res_id', 'in', self.ids)
+        ])
+        
+        record_to_external_ids = {}
+        for ext_id in all_external_ids:
+            if ext_id.res_id not in record_to_external_ids:
+                record_to_external_ids[ext_id.res_id] = []
+            record_to_external_ids[ext_id.res_id].append(ext_id)
+        
+        for record in self:
+            ext_ids = record_to_external_ids.get(record.id, [])
+            if ext_ids:
+                ext_id_list = [ext_id.name for ext_id in ext_ids]
+                record.external_id = ", ".join(ext_id_list)
+            else:
+                # Unexpected, but handle just in case
+                record.external_id = False
+
+    @api.model
+    def _search_external_id(self, operator, value):
+        """Search for records by their external ID."""
+        if not value:
+            return [('id', '=', False)]
+        
+        domain = [
+            ('model', '=', self._name),
+            ('name', 'ilike', value)
+        ]
+        external_ids = self.env['ir.model.data'].search(domain)
+        
+        if not external_ids:
+            return [('id', '=', False)]
+            
+        return [('id', 'in', external_ids.mapped('res_id'))]
+
+
+class ProductTemplate(models.Model):
+    _inherit = ['product.template', 'external.id.mixin']
+    _name = 'product.template'
+
+
+class ProductProduct(models.Model):
+    _inherit = ['product.product', 'external.id.mixin']
+    _name = 'product.product'

--- a/custom_addons/visible_product_external_id/tests/__init__.py
+++ b/custom_addons/visible_product_external_id/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_visible_product_external_id 

--- a/custom_addons/visible_product_external_id/tests/test_visible_product_external_id.py
+++ b/custom_addons/visible_product_external_id/tests/test_visible_product_external_id.py
@@ -1,0 +1,124 @@
+from odoo.tests.common import TransactionCase
+from odoo.tests import Form
+from odoo.tools import mute_logger
+
+
+class TestVisibleProductExternalId(TransactionCase):
+    """Tests for the visible_product_external_id module."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test data."""
+        super().setUpClass()
+        cls.product_template = cls.env['product.template'].create({
+            'name': 'Test Product Template',
+            'default_code': 'TPT-001',
+        })
+        
+        cls.product_variant = cls.env['product.product'].create({
+            'name': 'Test Product Variant',
+            'default_code': 'TPV-001',
+        })
+        
+        cls.env['ir.model.data'].create({
+            'name': 'test_product_template',
+            'module': 'visible_product_external_id',
+            'model': 'product.template',
+            'res_id': cls.product_template.id,
+        })
+        
+        cls.env['ir.model.data'].create({
+            'name': 'test_product_variant',
+            'module': 'visible_product_external_id',
+            'model': 'product.product',
+            'res_id': cls.product_variant.id,
+        })
+        
+        cls.env['ir.model.data'].create({
+            'name': 'test_product_template_alt',
+            'module': 'visible_product_external_id',
+            'model': 'product.template',
+            'res_id': cls.product_template.id,
+        })
+
+        cls.product_without_id = cls.env['product.template'].create({
+            'name': 'Product Without External ID',
+            'default_code': 'PWI-001',
+        })
+
+    def test_product_template_external_id(self):
+        """Test that external IDs are correctly computed for product templates."""
+        self.product_template.env.cache.invalidate()
+        
+        expected_ids = "test_product_template, test_product_template_alt"
+        actual_ids = ", ".join(sorted(self.product_template.external_id.split(", ")))
+        
+        self.assertEqual(
+            actual_ids, 
+            expected_ids,
+            "External IDs should be correctly computed for product templates"
+        )
+
+    def test_product_variant_external_id(self):
+        """Test that external IDs are correctly computed for product variants."""
+        self.product_variant.env.cache.invalidate()
+        
+        self.assertEqual(
+            self.product_variant.external_id,
+            "test_product_variant",
+            "External IDs should be correctly computed for product variants"
+        )
+        
+    def test_no_external_id(self):
+        """Test that products without external IDs return False."""
+        self.assertFalse(
+            self.product_without_id.external_id,
+            "Products without external IDs should have external_id field set to False"
+        )
+    
+    def test_product_template_form_view(self):
+        """Test that the product template form view loads correctly and contains the external_id field."""
+        with Form(self.product_template) as form:
+            self.assertIn("external_id", form._values)
+            expected_ids = "test_product_template, test_product_template_alt"
+            actual_ids = ", ".join(sorted(form._values["external_id"].split(", ")))
+            self.assertEqual(actual_ids, expected_ids)
+
+    def test_product_variant_form_view(self):
+        """Test that the product variant form view loads correctly and contains the external_id field."""
+        with Form(self.product_variant) as form:
+            self.assertIn("external_id", form._values)
+            self.assertEqual(form._values["external_id"], "test_product_variant")
+        
+    def test_search_by_external_id(self):
+        """Test searching by external ID substring."""
+        products = self.env['product.template'].search([
+            ('external_id', 'ilike', 'test_product_template')
+        ])
+        self.assertEqual(len(products), 1)
+        self.assertEqual(products, self.product_template)
+        
+        variants = self.env['product.product'].search([
+            ('external_id', 'ilike', 'test_product_variant')
+        ])
+        self.assertEqual(len(variants), 1)
+        self.assertEqual(variants, self.product_variant)
+        
+    def test_search_no_results(self):
+        """Test searching with no results."""
+        products = self.env['product.template'].search([
+            ('external_id', 'ilike', 'non_existent_id')
+        ])
+        self.assertEqual(len(products), 0)
+        
+    def test_search_empty_value(self):
+        """Test searching with empty value."""
+        products = self.env['product.template'].search([
+            ('external_id', 'ilike', '')
+        ])
+        self.assertEqual(len(products), 0)
+        
+        products = self.env['product.template'].search([
+            ('external_id', '=', False)
+        ])
+        self.assertEqual(len(products), 0)

--- a/custom_addons/visible_product_external_id/views/product_views.xml
+++ b/custom_addons/visible_product_external_id/views/product_views.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- ======================= -->
+    <!-- PRODUCT TEMPLATE VIEWS -->
+    <!-- ======================= -->
+    
+    <!-- Product template form view -->
+    <record id="product_template_form_view_inherit_visible_external_id" model="ir.ui.view">
+        <field name="name">product.template.form.inherit.visible.external.id</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <!-- Add external_id field at the top of the General Information tab -->
+            <xpath expr="//page[@name='general_information']//field[@name='type']" position="before">
+                <field name="external_id" readonly="1" string="External ID(s)"/>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Product template tree/list view -->
+    <record id="product_template_tree_view_inherit_visible_external_id" model="ir.ui.view">
+        <field name="name">product.template.tree.inherit.visible.external.id</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_tree_view"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="external_id" optional="show" string="External ID(s)"/>
+            </field>
+        </field>
+    </record>
+
+    <!-- Product template search view -->
+    <record id="product_template_search_view_inherit_visible_external_id" model="ir.ui.view">
+        <field name="name">product.template.search.inherit.visible.external.id</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_search_view"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="external_id" string="External ID(s)"/>
+            </field>
+        </field>
+    </record>
+
+    <!-- ======================= -->
+    <!-- PRODUCT VARIANT VIEWS -->
+    <!-- ======================= -->
+    
+    <!-- Product variant form view -->
+    <record id="product_product_form_view_inherit_visible_external_id" model="ir.ui.view">
+        <field name="name">product.product.form.inherit.visible.external.id</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <!-- Add external_id field at the top of the General Information tab -->
+            <xpath expr="//page[@name='general_information']//field[@name='type']" position="before">
+                <field name="external_id" readonly="1" string="External ID(s)"/>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Product variant tree/list view -->
+    <record id="product_product_tree_view_inherit_visible_external_id" model="ir.ui.view">
+        <field name="name">product.product.tree.inherit.visible.external.id</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_product_tree_view"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="external_id" optional="show" string="External ID(s)"/>
+            </field>
+        </field>
+    </record>
+
+    <!-- Product variant search view -->
+    <record id="product_product_search_view_inherit_visible_external_id" model="ir.ui.view">
+        <field name="name">product.product.search.inherit.visible.external.id</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_search_form_view"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="external_id" string="External ID(s)"/>
+            </field>
+        </field>
+    </record>
+</odoo> 

--- a/doc/cla/corporate/podium-automation.md
+++ b/doc/cla/corporate/podium-automation.md
@@ -1,0 +1,16 @@
+United States, 2025-04-07
+
+Podium Automation agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Gordon Noble gordon.m.noble@gmail.com https://github.com/gordonnoble
+
+List of contributors:
+
+Gordon Noble gordon.m.noble@gmail.com https://github.com/gordonnoble
+


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:
Our organization would like to manage the external ID of products (i.e. during product CSV upload) because this lets us later upload BoMs and inventory adjustments that reference this external ID. This avoid an extra step of first finding products in Odoo, downloading them to get their auto-generated external ID, and then re-uploading.

# Current behavior before PR:
External ID is hidden from the user

# Desired behavior after PR is merged:
1. External ID is present on the product list page
2. External ID can be used for searching products
3. External ID is present on the General Information tab of the product form page

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
