### PR TITLE
[FIX] pos_self_order: fix categories name wrapping

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.scss
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.scss
@@ -18,7 +18,7 @@
         }
 
         .category-name {
-            word-break: break-all;
+            overflow-wrap: break-word;
         }
     }
 }


### PR DESCRIPTION
Before this commit, the text wrapping in the product categories sometimes resulted in ugly breaks in the middle of words where not needed.

Steps to reproduce
-----
1. Configure a category with spaces in Point of Sale > Configuration > PoS Product Categories For example, a category named "Special Menu"
2. Open a self-ordering kiosk, the "Special Menu" will be displayed as "Special M" + "enu"

Cause
-----
The styling `word-break: break-all;` was added to this element in #140095 to avoid overlapping category names. However `break-all` always breaks in the exact place needed, often resulting in breaks in the middle of words.

Solution
-----
Use `overflow-wrap: break-word;` instead which will break between words if possible and only break in the middle of a word if needed.

opw-4642999