### PR TITLE
[FIX] web: fix error message for missing parent in property fields

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -595,6 +595,17 @@ export class PropertiesField extends Component {
     }
 
     async onPropertyCreate() {
+        if (!this.definitionRecordId) {
+            this.notification.add(
+                _t(
+                    "You must set the '%s' field to create a property field.",
+                    this.props.record.fields[this.definitionRecordField].string
+                ),
+                { type: "warning" }
+            );
+            return;
+        }
+
         if (!this.state.canChangeDefinition || !(await this.checkDefinitionWriteAccess())) {
             this.notification.add(
                 _t("You need edit access on the parent document to update these property fields"),

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -2681,3 +2681,48 @@ test("properties: split, moving property from 1st group to 2nd", async () => {
         ],
     ]);
 });
+
+test("properties: no parent document set", async () => {
+    onRpc("has_access", () => true);
+
+    const formView = await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="company_id"/>
+                        <field name="properties"/>
+                    </group>
+                </sheet>
+            </form>`,
+        actionMenus: {},
+    });
+
+    patchWithCleanup(formView.env.services.notification, {
+        add: (message, options) => {
+            expect.step("notification");
+            expect(message).toBe(
+                "You must set the 'Company' field to create a property field."
+            );
+            expect(options.type).toBe("warning");
+        },
+    });
+
+    expect(".o_field_properties").toHaveCount(1, { message: "The field must be in the view" });
+
+    await toggleActionMenu();
+
+    expect(".o-dropdown--menu span:contains(Add Properties)").toHaveCount(1, {
+        message: "Show Add Properties btn in cog menu",
+    });
+
+    await toggleMenuItem("Add Properties");
+
+    expect.verifySteps(["notification"]);
+
+    expect(".o_field_properties:first-child .o_field_property_open_popover").toHaveCount(0, {
+        message: "The edit definition button must not be in the view",
+    });
+});


### PR DESCRIPTION
Issue:
------------------------------------------
- When using property fields (e.g., products since 18.1 where categories are optional), users trying to add a property field without a parent document receive a generic warning:
"You need edit access on the parent document to update these property fields".

- This message is misleading and does not explain the actual dependency.

How to reproduce:
------------------------------------------
1. Create or edit a record (e.g., product) without setting its parent (e.g., category).
2. Try to add a property field.

Cause of the issue:
------------------------------------------
- In `checkDefinitionWriteAccess`, when `definitionRecordId` is missing, the method returns `false`, triggering a generic access-rights warning.

Solution:
------------------------------------------
- Added a check at the beginning of `onPropertyCreate` verify if `definitionRecordId` exists.
- If missing, following error is raised using the parent field label: "You must set the '%s' field to create a property field."

task-4589393