### PR TITLE
[FIX] point_of_sale: update archived products when opening pos

### DIFF
--- a/addons/point_of_sale/models/pos_load_mixin.py
+++ b/addons/point_of_sale/models/pos_load_mixin.py
@@ -28,3 +28,6 @@ class PosLoadMixin(models.AbstractModel):
         if last_server_date and domain is not False and limited_loading:
             domain = AND([domain, [('write_date', '>', last_server_date)]])
         return domain
+
+    def _unrelevant_records(self):
+        return self.filtered(lambda record: not record.active).ids

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -200,6 +200,13 @@ class PosSession(models.Model):
 
         return response
 
+    def filter_local_data(self, models_to_filter):
+        response = {}
+        for model, ids in models_to_filter.items():
+            response[model] = self.env[model].browse(ids)._unrelevant_records()
+
+        return response
+
     def delete_opening_control_session(self):
         self.ensure_one()
         if not self.exists():

--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -83,6 +83,10 @@ export class DataServiceOptions {
         return ["pos.session", "res.users", "res.company"];
     }
 
+    get cleanupModels() {
+        return ["product.template"];
+    }
+
     get prohibitedAutoLoadedFields() {
         return {
             "res.partner": ["property_product_pricelist"],

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -240,8 +240,21 @@ export class PosData extends Reactive {
                     }
                 );
 
-                for (const [model, values] of Object.entries(data)) {
+                const local_records_to_filter = {};
+                for (const model of this.opts.cleanupModels) {
                     const local = localData[model] || [];
+                    if (local.length > 0) {
+                        local_records_to_filter[model] = local.map((r) => r.id);
+                    }
+                }
+
+                const data_to_remove = await this.orm.call("pos.session", "filter_local_data", [
+                    odoo.pos_session_id,
+                    local_records_to_filter,
+                ]);
+
+                for (const [model, values] of Object.entries(data)) {
+                    let local = localData[model] || [];
 
                     if (this.opts.uniqueModels.includes(model) && values.length > 0) {
                         this.indexedDB.delete(
@@ -250,6 +263,11 @@ export class PosData extends Reactive {
                         );
                         localData[model] = values;
                     } else {
+                        if (data_to_remove[model] && data_to_remove[model].length > 0) {
+                            const remove_ids = data_to_remove[model];
+                            local = local.filter((r) => !remove_ids.includes(r.id));
+                            this.indexedDB.delete(model, remove_ids);
+                        }
                         localData[model] = local.concat(values);
                     }
                 }

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -13,6 +13,8 @@ import * as ProductConfiguratorPopup from "@point_of_sale/../tests/pos/tours/uti
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
+import * as Utils from "@point_of_sale/../tests/pos/tours/utils/common";
+import * as BackendUtils from "@point_of_sale/../tests/pos/tours/utils/backend_utils";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
     steps: () =>
@@ -700,6 +702,35 @@ registry.category("web_tour.tours").add("test_fiscal_position_tax_group_labels",
                 content: "Make sure receipt tax label is correct and correspond to the orderline",
                 trigger: ".pos-receipt-taxes:contains('Tax Group 2')",
             },
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_remove_archived_product_from_cache", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("A Test Product"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            Chrome.clickMenuOption("Close Register"),
+            Dialog.confirm("Close Register"),
+            Utils.selectButton("Backend"),
+            BackendUtils.openProductForm("A Test Product"),
+            {
+                trigger: `.fa-cog`,
+                run: "click",
+            },
+            {
+                trigger: ".dropdown-item:contains('Archive')",
+                run: "click",
+            },
+            Utils.selectButton("Archive"),
+            BackendUtils.openShopSession("Shop"),
+            Dialog.confirm("Open Register"),
+            ProductScreen.productIsDisplayed("A Test Product").map(negateStep),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/utils/backend_utils.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/backend_utils.js
@@ -15,11 +15,44 @@ export function editShopConfiguration(shop) {
     ];
 }
 
-export function saveShopConfiguration() {
+export function openShopSession(shop) {
+    return [
+        {
+            trigger: ".o_main_navbar .o-dropdown-item:contains('Dashboard')",
+            run: "click",
+        },
+        {
+            trigger: `.o_kanban_record:contains(${shop}) .btn-primary`,
+            run: "click",
+        },
+    ];
+}
+
+export function saveConfiguration() {
     return [
         {
             trigger: ".o_form_button_save",
             run: "click",
+        },
+    ];
+}
+
+export function openProductForm(name) {
+    return [
+        {
+            trigger: ".o_main_navbar span:contains('Products')",
+            run: "click",
+        },
+        {
+            trigger: ".dropdown-item:contains('Products')",
+            run: "click",
+        },
+        {
+            trigger: `.o_kanban_record:contains("${name}")`,
+            run: "click",
+        },
+        {
+            trigger: `.o_form_renderer`,
         },
     ];
 }

--- a/addons/point_of_sale/static/tests/unit/data_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/data_service.test.js
@@ -1,5 +1,11 @@
 import { expect, test } from "@odoo/hoot";
-import { defineModels, getService, makeMockEnv, models } from "@web/../tests/web_test_helpers";
+import {
+    defineModels,
+    getService,
+    makeMockEnv,
+    models,
+    onRpc,
+} from "@web/../tests/web_test_helpers";
 import { RPCError } from "@web/core/network/rpc";
 
 class PosSession extends models.ServerModel {
@@ -125,6 +131,7 @@ class ResPartner extends models.ServerModel {
 }
 test("don't retry sending data to the server if the reason that caused the failure is not a network error", async () => {
     defineModels({ PosSession, ResPartner });
+    onRpc("pos.session", "filter_local_data", () => ({}));
     await makeMockEnv();
 
     await expect(

--- a/addons/point_of_sale/tests/test_pos_cash_rounding.py
+++ b/addons/point_of_sale/tests/test_pos_cash_rounding.py
@@ -449,3 +449,17 @@ class TestPosCashRounding(TestPointOfSaleHttpCommon):
             'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
         })
         self.start_pos_tour('test_cash_rounding_up_with_change')
+
+    def test_remove_archived_product_from_cache(self):
+        self.env['product.product'].create({
+            'is_storable': True,
+            'name': 'A Test Product',
+            'available_in_pos': True,
+            'list_price': 1,
+        })
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_remove_archived_product_from_cache",
+            login="pos_admin"
+        )

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -166,7 +166,7 @@ registry.category("web_tour.tours").add("test_change_on_rights_reflected_directl
                 trigger: ".o_tag:contains('Pos Employee1') .o_delete",
                 run: "click",
             },
-            BackendUtils.saveShopConfiguration(),
+            BackendUtils.saveConfiguration(),
             {
                 trigger: ".o_main_navbar .o-dropdown-item:contains('Dashboard')",
                 run: "click",


### PR DESCRIPTION
Currently, when archiving products, they will still appear in the pos session.

Steps to reproduce:
-------------------
* Open a shop and close it (to store products in cache)
* Archive any product from the previous shop
* Open the shop again
> Observation: The product is still visible in the product screen.

Why the fix:
------------
Compared to previous versions, we are now caching products for performance issue. Currently, when opening a shop, all products that we modified after the last modification date of the config parameters are loaded to the pos.

This is done to reflect any change like the product price, and more. However, only active product were loaded. This meant that every product that was archived were not loaded and the information was not sent to the backend.

opw-4657471