### PR TITLE
[FIX] hr_org_chart: fix org-chart in employee public view and My profile

### DIFF
--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.js
@@ -58,8 +58,9 @@ export class HrOrgChart extends Component {
         });
 
         useRecordObserver(async (record) => {
-            const newParentId = record.data.parent_id?.[0] || false;
-            const newEmployeeId = record.data.id || false;
+            const newParentId = record.data.parent_id?.[0] || record.data.employee_parent_id?.[0] || false;
+            const newEmployeeId = record.data.employee_ids !== undefined ? record.data.employee_ids.resIds[0] :
+                                        record.resId;
             this.state.employee_id = newEmployeeId;
             if (this.lastParent !== newParentId || this.lastEmployeeId !== newEmployeeId) {
                 await this.fetchEmployeeData(this.state.employee_id, newParentId, true);


### PR DESCRIPTION
Steps to Reproduce:
  - Log in as a user with no special access rights in the employee app.
  - Open any employee and go to the "Work Information" tab.
  - Organization chart is not visible even if the employee has a manager.
  - The same issue occurs under "My Profile."

Cause:
  - in the standard field props `record.data.id` is not available in the hr_org_chart component under the employee public view and `res_user` view, `record.data.parent_id` is not available under the `res.user` view causing the organization chart to fail to load.

Fix:
  - Used `record.resId`  for `hr.employee`, and for `res.user` we will get id from  `record.data.employee_ids.resIds[0]`, and for `res.users` parent_id will be `record.data.employee_parent_id ` ensuring the chart loads correctly

task-4689441

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
