### PR TITLE
[FIX] spreadsheet: Split cumulative and cumulated_start

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
@@ -41,9 +41,7 @@ export class OdooChart extends AbstractChart {
             ...definition.metaData,
             mode: this.type.replace("odoo_", ""),
             cumulated: definition.cumulative,
-            // if a chart is cumulated, the first data point should take into
-            // account past data, even if a domain on a specific period is applied
-            cumulatedStart: definition.cumulative,
+            cumulatedStart: definition.cumulatedStart,
         };
         this.searchParams = definition.searchParams;
         this.legendPosition = definition.legendPosition;

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
@@ -23,6 +23,7 @@ export class OdooLineChart extends OdooChart {
         this.verticalAxisPosition = definition.verticalAxisPosition;
         this.stacked = definition.stacked;
         this.cumulative = definition.cumulative;
+        this.cumulatedStart = definition.cumulatedStart;
         this.axesDesign = definition.axesDesign;
         this.fillArea = definition.fillArea;
     }
@@ -33,6 +34,7 @@ export class OdooLineChart extends OdooChart {
             verticalAxisPosition: this.verticalAxisPosition,
             stacked: this.stacked,
             cumulative: this.cumulative,
+            cumulatedStart: this.cumulatedStart,
             axesDesign: this.axesDesign,
             fillArea: this.fillArea,
         };

--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
@@ -37,6 +37,7 @@ export class OdooChartUIPlugin extends OdooUIPlugin {
                         if (
                             cmd.definition.type !== chart.type ||
                             chart.cumulative !== cmd.definition.cumulative ||
+                            chart.cumulatedStart !== cmd.definition.cumulatedStart ||
                             dataSource.getInitialDomainString() !==
                                 new Domain(cmd.definition.searchParams.domain).toString()
                         ) {

--- a/addons/spreadsheet/static/src/o_spreadsheet/migration.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/migration.js
@@ -34,6 +34,25 @@ migrationStepRegistry.add("18.1.2", {
     },
 });
 
+migrationStepRegistry.add("18.3.2", {
+    migrate(data) {
+        for (let sheet of data.sheets || []) {
+            for (let figure of sheet.figures || []) {
+                if (
+                    figure.tag === "chart" &&
+                    ["odoo_bar", "odoo_line", "odoo_pie"].includes(figure.data.type) &&
+                    !("cumulatedStart" in figure.data)
+                ) {
+                    const isCumulative = figure.data.cumulative || false;
+                    figure.data.cumulatedStart = isCumulative;
+                    figure.data.metaData.cumulatedStart = isCumulative;
+                }
+            }
+        }
+        return data;
+    },
+});
+
 function migrateOdooData(data) {
     const version = data.odooVersion || 0;
     if (version < 1) {

--- a/addons/spreadsheet/static/tests/migrations/migrations.test.js
+++ b/addons/spreadsheet/static/tests/migrations/migrations.test.js
@@ -221,6 +221,7 @@ test("fieldMatchings are moved from filters to their respective datasources", ()
                         tag: "chart",
                         data: {
                             type: "odoo_bar",
+                            metaData: {}
                         },
                     },
                 ],
@@ -291,6 +292,7 @@ test("fieldMatchings offsets are correctly preserved after migration", () => {
                         tag: "chart",
                         data: {
                             type: "odoo_bar",
+                            metaData: {}
                         },
                     },
                 ],
@@ -533,4 +535,61 @@ test("Pivot sorted columns are migrated (12 to 13)", () => {
         order: "desc",
     });
     expect(migratedData.pivots["2"].sortedColumn).toBe(undefined);
+});
+
+test("Chart cumulatedStart is set to true if cumulative at migration", () => {
+    const data = {
+        version: 18.0,
+        odooVersion: 9,
+        sheets: [
+            {
+                figures: [
+                    {
+                        id: "fig1",
+                        tag: "chart",
+                        data: {
+                            type: "odoo_bar",
+                            metaData: {
+                                cumulatedStart: undefined,
+                                cumulative: true,
+                            },
+                            cumulative: true,
+                        },
+                    },
+                    {
+                        id: "fig2",
+                        tag: "chart",
+                        data: {
+                            type: "odoo_bar",
+                            metaData: {
+                                cumulative: false,
+                            },
+                            cumulative: false,
+                        },
+                    },
+                    {
+                        id: "fig3",
+                        tag: "chart",
+                        data: {
+                            type: "odoo_bar",
+                            metaData: {
+                                cumulative: true,
+                                cumulatedStart: false
+                            },
+                            cumulative: true,
+                            cumulatedStart: false
+                        },
+                    },
+                ],
+            },
+        ],
+    };
+    const migratedData = load(data);
+    const sheet = migratedData.sheets[0];
+    expect(sheet.figures[0].data.metaData.cumulatedStart).toBe(true);
+    expect(sheet.figures[0].data.cumulatedStart).toBe(true);
+    expect(sheet.figures[1].data.metaData.cumulatedStart).toBe(false);
+    expect(sheet.figures[1].data.cumulatedStart).toBe(false);
+    expect(sheet.figures[2].data.metaData.cumulatedStart).toBe(false);
+    expect(sheet.figures[2].data.cumulatedStart).toBe(false);
 });


### PR DESCRIPTION
The option of "cumulatedStart" was incorrectly inferred from the "cumulative" option of an Odoo graph view. However, both options are not specifically linked.

Task-4701303

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
