### PR TITLE
[FIX] {sale_,}stock: propagate move cancellations in pull chain

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1868,7 +1868,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             if move.propagate_cancel:
                 # only cancel the next move if all my siblings are also cancelled
                 if all(state == 'cancel' for state in siblings_states):
-                    move.move_dest_ids.filtered(lambda m: m.state != 'done' and m.location_dest_id == m.move_dest_ids.location_id)._action_cancel()
+                    move.move_dest_ids.filtered(lambda m: m.state != 'done' and move.location_dest_id == m.location_id)._action_cancel()
                     if cancel_moves_origin:
                         move.move_orig_ids.sudo().filtered(lambda m: m.state != 'done')._action_cancel()
             else:

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1175,9 +1175,10 @@ Please change the quantity done or the rounding precision of your unit of measur
                     pos_move.product_uom_qty = 0
                     moves_to_cancel |= pos_move
 
+        # We are using propagate to False in order to not cancel destination moves merged in moves[0]
+        (moves_to_unlink | moves_to_cancel)._clean_merged()
+
         if moves_to_unlink:
-            # We are using propagate to False in order to not cancel destination moves merged in moves[0]
-            moves_to_unlink._clean_merged()
             moves_to_unlink._action_cancel()
             moves_to_unlink.sudo().unlink()
 

--- a/addons/stock/tests/test_old_rules.py
+++ b/addons/stock/tests/test_old_rules.py
@@ -647,3 +647,39 @@ class TestOldRules(TestStockCommon):
         move2._action_confirm()
         self.assertEqual(picking_pick.partner_id.id, False)
         self.assertEqual(picking_pick.origin, False)
+
+    def test_propagate_cancel_in_pull_setup(self):
+        """
+        Check the cancellation propagation in pull set ups.
+        """
+        # create a procurement group
+        procurement_group0 = self.env['procurement.group'].create({})
+        product1 = self.env['product.product'].create({
+            'name': 'test_procurement_cancel_propagation',
+            'is_storable': True,
+        })
+        pick_pack_ship_route = self.warehouse_3_steps.delivery_route_id
+        pick_rule = pick_pack_ship_route.rule_ids.filtered(lambda rule: rule.picking_type_id == self.warehouse_3_steps.pick_type_id)
+        pack_rule = pick_pack_ship_route.rule_ids.filtered(lambda rule:  rule.picking_type_id == self.warehouse_3_steps.pack_type_id)
+        (pick_rule | pack_rule).propagate_cancel = True
+        ship_rule = pick_pack_ship_route.rule_ids - (pick_rule | pack_rule)
+        self.env['procurement.group'].run([
+            procurement_group0.Procurement(
+                product1,
+                1.0,
+                product1.uom_id,
+                ship_rule.location_dest_id,
+                'test_mtso_mts_1',
+                'test_mtso_mts_1',
+                self.warehouse_3_steps.company_id,
+                {
+                    'warehouse_id': self.warehouse_3_steps,
+                    'group_id': procurement_group0,
+                }
+            ),
+        ])
+        move_chain = self.env['stock.move'].search([('product_id', '=', product1.id)])
+        self.assertEqual(len(move_chain), 3)
+        pick_move = move_chain.filtered(lambda m: m.picking_type_id == self.warehouse_3_steps.pick_type_id)
+        pick_move.picking_id.action_cancel()
+        self.assertEqual(move_chain.mapped('state'), ['cancel', 'cancel', 'cancel'])


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable Multi-Steps Rules
- Inventory > Configuration > Warehouse Management > Warehouses
- Put your warehouse in delivery in 2 steps and modify the rules to be in the old pull set up Stock 1-> Output 2-> Customer.
- Enable the "Cancel next move" option of the pick rule.
- Create an SO for 1 unit of a storable product
> This should generate both a pick and a ship move.
- Cancel the pick move
#### > The ship move was not cancelled

### Cause of the issue:

While the moves of the chain are correctly linked and the `move_dest_ids` of the pick move is planed to be cancelled, it does not satisfy the filtering condition of moves that should be cancelled because as it is at the end of the chain it does not have a `move_dest_id` it self: https://github.com/odoo/odoo/blob/eb43cdbfeb3d141283dbd9274fae45bf0bf641db/addons/stock/models/stock_move.py#L1966-L1968 IMO, the condition on the locations should be set between the move we are cancelling and the move we plan to cancel rather than on next step of the chain that might not even exist.

Note (fix sale_stock):

The forward port of commit 853d9c46fc506564c5c40a2ce7cd14507109a923 has not been merged in 17.2 since its issue was not reproducible in that version. This is because the propagate cancel option was not working properly since the push pull refactor. To merge our change we therefore need to reintroduce the associated `sale_stock` fix.

opw-4689175
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
