### PR TITLE
[FIX] account: customer's default invoice template as only attachment

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -62,7 +62,7 @@
     </p>
 </div>
             </field>
-            <field name="report_template_ids" eval="[(4, ref('account.account_invoices'))]"/>
+            <field name="report_template_ids" eval="[]"/>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="auto_delete" eval="True"/>
         </record>
@@ -135,7 +135,7 @@
     </p>
 </div>
             </field>
-            <field name="report_template_ids" eval="[(4, ref('account.account_invoices'))]"/>
+            <field name="report_template_ids" eval="[]"/>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="auto_delete" eval="True"/>
         </record>

--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -198,7 +198,20 @@ class AccountMoveSend(models.AbstractModel):
 
     @api.model
     def _get_placeholder_mail_template_dynamic_attachments_data(self, move, mail_template, pdf_report=None):
-        invoice_template = pdf_report or self._get_default_pdf_report_id(move)
+        """
+        This method returns the placeholder data for the dynamic attachments.
+        :param move:            The current move we are generating documents for.
+        :param mail_template:   The mail template used to get dynamic attachments for the move.
+        :param pdf_report:      The 'ir.actions.report' used for the move.
+                                Usually it will be the generic 'account.account_invoices' but the user can customize it
+                                from the Send Wizard interface.
+        :return:                A list of dictionary, one for each placeholder.
+        """
+        # The Send wizard will generate a legal PDF based on a specific ir.actions.report.
+        # In case the report selected to do so is also added in dynamic attachments of the mail template, we need to
+        # filter them out to avoid duplicated placeholders, since they are already added in the
+        # _get_placeholder_mail_attachments_data method.
+        invoice_template = (pdf_report or self._get_default_pdf_report_id(move)) + self.env.ref('account.account_invoices')
         extra_mail_templates = mail_template.report_template_ids - invoice_template
         filename = move._get_invoice_report_filename()
         return [


### PR DESCRIPTION
[FIX] account: customer's default invoice template as only attachment

Currently, when the user define an invoice template other than the
standard 'account.account_invoices', both the standard report and the
one defined by the user are attached to the mail when he hits the Send &
Print. We want the template chosen by the user to be the one sent &
printed.

The fix is to remove the default accounting action report from the
dynamic attachments : before, we were just removing the default action
report used for the current move. But e.g. if the partner had a default
report set in the field invoice_template_pdf_report_id, the default
report for the move was this one, and so we weren't removing the
accounting default one. This was causing the duplicate placeholder
because the default accounting report placeholder is already processed
in another method.

Also, we remove the configuration that sets the
'account.account_invoices' report as a default dynamic attachment.

Task-4681142
Runbot : https://runbot.odoo.com/runbot/bundle/18-0-invoice-report-per-partner-roto-361127
