### PR TITLE
[FIX] point_of_sale: Fix notes on preparation tickets

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1563,6 +1563,23 @@ export class PosStore extends WithLazyGetterTrap {
                     return;
                 }
 
+                // Printers need to directly have the note text.
+                // Colors are not taken into account like in preparation display.
+                for (const changeItem of [
+                    ...orderChange.new,
+                    ...orderChange.cancelled,
+                    ...orderChange.noteUpdate,
+                ]) {
+                    if (changeItem.note) {
+                        try {
+                            const note = JSON.parse(changeItem.note);
+                            changeItem.note = note.map((n) => n.text).join(", ");
+                        } catch {
+                            changeItem.note = "";
+                        }
+                    }
+                }
+
                 this.printChanges(order, orderChange, reprint);
             } catch (e) {
                 console.info("Failed in printing the changes in the order", e);


### PR DESCRIPTION
Note variable on orderline was recently changed, now it's an object containing the text and colorIndex.

For the preparation display is fine because it used both of them, but for the ticket note we only need the text.

This commit fixes data send to the ticket method to only give the text.

taskId: 4711623

