### PR TITLE
[MERGE][IMP] product,account,sale,*: tests improvements

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -269,9 +269,7 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_hr_manager', # hr
                     'group_mrp_manager', # mrp
                     'group_pos_manager', # point_of_sale
-                    'group_product_manager', # product
                     'group_purchase_manager', # purchase
-                    'group_sale_manager', # sales_team
                     'group_stock_manager', # stock
                     # enterprise groups
                     'group_hr_payroll_manager', # hr_payroll
@@ -279,7 +277,12 @@ class AccountTestInvoicingCommon(ProductCommon):
                 ))
             ]).mapped('res_id')
         )
-        return groups | cls.env.ref('account.group_account_manager') | cls.env.ref('account.group_account_user')
+        return (
+            groups
+            | cls.quick_ref('account.group_account_manager')
+            | cls.quick_ref('account.group_account_user')
+            | cls.quick_ref('base.group_system')  # company creation during setups
+        )
 
     @classmethod
     def setup_other_currency(cls, code, **kwargs):

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -44,27 +44,28 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
             'available_in_pos': True,
         })
 
-        sale_order = self.env['sale.order'].create({
-            'partner_id': self.partner_a.id,
-            'order_line': [Command.create({
-                'product_id': self.product_a.id,
-                'product_uom_qty': 10,
-                'price_unit': 10,
-                'tax_ids': intracom_tax,
-            })],
-        })
+        sale_orders = self.env['sale.order'].sudo().create([
+            {
+                'partner_id': self.partner_a.id,
+                'order_line': [Command.create({
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 10,
+                    'price_unit': 10,
+                    'tax_ids': intracom_tax,
+                })],
+            },
+            {
+                'partner_id': self.partner_a.id,
+                'order_line': [Command.create({
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 20,
+                    'price_unit': 20,
+                    'tax_ids': False,
+                })],
+            }
+        ])
 
-        sale_order.action_confirm()
-        sale_order2 = self.env['sale.order'].create({
-            'partner_id': self.partner_a.id,
-            'order_line': [Command.create({
-                'product_id': self.product_a.id,
-                'product_uom_qty': 20,
-                'price_unit': 20,
-                'tax_ids': False,
-            })],
-        })
-        sale_order2.action_confirm()
+        sale_orders.action_confirm()
         self.main_pos_config.open_ui()
         self.start_pos_tour('PosSettleOrderIsInvoice', login="accountman")
 
@@ -108,7 +109,7 @@ class TestPoSSaleL10NBeNormalCompany(TestPointOfSaleHttpCommon):
             'available_in_pos': True,
         })
 
-        self.env['sale.order'].create({
+        self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [Command.create({
                 'product_id': self.product_a.id,

--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -167,7 +167,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
             'price': 1,
         })
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [(0, 0, {
                 'product_id': final_product.id,
@@ -251,7 +251,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
             'property_valuation': 'real_time',
         })
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_b.id,
             'order_line': [(0, 0, {
                 'price_unit': 900,

--- a/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
@@ -45,7 +45,7 @@ class TestSubcontractingDropshippingFlows(TestMrpSubcontractingCommon):
         })
 
         # Create a receipt picking from the subcontractor
-        so_form = Form(self.env['sale.order'])
+        so_form = Form(self.env['sale.order'].sudo())
         so_form.partner_id = partner
         so_form.warehouse_id = warehouse
         with so_form.order_line.new() as line:

--- a/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
@@ -41,7 +41,7 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
             ],
         })
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.customer.id,
             'picking_policy': 'direct',
             'order_line': [
@@ -90,7 +90,7 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
             ],
         })
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.customer.id,
             'picking_policy': 'direct',
             'order_line': [
@@ -148,7 +148,7 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
             ],
         })
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.customer.id,
             'picking_policy': 'direct',
             'order_line': [
@@ -233,7 +233,7 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
             ],
         })
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.customer.id,
             'picking_policy': 'direct',
             'order_line': [
@@ -272,7 +272,7 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
             ],
         })
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.customer.id,
             'picking_policy': 'direct',
             'order_line': [

--- a/addons/pos_repair/tests/test_frontend.py
+++ b/addons/pos_repair/tests/test_frontend.py
@@ -29,7 +29,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.repair1._action_repair_confirm()
         self.repair1.action_repair_start()
         self.repair1.action_repair_end()
-        self.repair1.action_create_sale_order()
+        self.repair1.sudo().action_create_sale_order()
         self.assertEqual(len(self.product_1.stock_move_ids.ids), 2, "There should be 2 stock moves for the product created by the repair order")
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosRepairSettleOrder', login="pos_user")

--- a/addons/pos_sale/tests/test_pos_sale_lot.py
+++ b/addons/pos_sale/tests/test_pos_sale_lot.py
@@ -47,7 +47,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
 
         partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': partner_test.id,
             'order_line': [(0, 0, {
                 'product_id': self.product.id,

--- a/addons/pos_sale/tests/test_pos_sale_report.py
+++ b/addons/pos_sale/tests/test_pos_sale_report.py
@@ -95,7 +95,7 @@ class TestPoSSaleReport(TestPoSCommon):
 
     def test_different_shipping_address(self):
         product_0 = self.create_product('Product 0', self.categ_basic, 0.0, 0.0)
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.customer.id,
             'partner_shipping_id': self.other_customer.id,
             'order_line': [(0, 0, {

--- a/addons/pos_sale_loyalty/tests/test_pos_sale_loyalty.py
+++ b/addons/pos_sale_loyalty/tests/test_pos_sale_loyalty.py
@@ -31,7 +31,7 @@ class TestPoSSaleLoyalty(TestPointOfSaleHttpCommon):
                 }),
             ],
         })
-        self.env['sale.order'].create({
+        self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [(0, 0, {
                 'product_id': self.desk_organizer.product_variant_id.id,

--- a/addons/product/tests/common.py
+++ b/addons/product/tests/common.py
@@ -37,7 +37,7 @@ class ProductCommon(UomCommon):
     @classmethod
     def get_default_groups(cls):
         groups = super().get_default_groups()
-        return groups | cls.quick_ref('base.group_system')
+        return groups | cls.quick_ref('product.group_product_manager')
 
     @classmethod
     def _enable_pricelists(cls):

--- a/addons/product/tests/test_pricelist_auto_creation.py
+++ b/addons/product/tests/test_pricelist_auto_creation.py
@@ -8,7 +8,7 @@ class TestPricelistAutoCreation(ProductCommon):
 
     @classmethod
     def setUpClass(cls):
-        res = super().setUpClass()
+        super().setUpClass()
 
         # Only one currency enabled and used on companies (multi-curr disabled)
         cls.currency_euro = cls._enable_currency('EUR')
@@ -18,10 +18,8 @@ class TestPricelistAutoCreation(ProductCommon):
 
         # Disabled pricelists feature
         cls.group_user = cls.env.ref('base.group_user').sudo()
-        cls.group_product_pricelist = cls.env.ref('product.group_product_pricelist')
         cls.group_user._remove_group(cls.group_product_pricelist)
         cls.env['product.pricelist'].search([]).unlink()
-        return res
 
     def test_inactive_curr_set_on_company(self):
         """Make sure that when setting an inactive currency on a company, the activation of the

--- a/addons/repair/tests/test_anglo_saxon_valuation.py
+++ b/addons/repair/tests/test_anglo_saxon_valuation.py
@@ -65,7 +65,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         ro.action_repair_start()
         ro.action_repair_end()
 
-        ro.action_create_sale_order()
+        ro.sudo().action_create_sale_order()
         so = ro.sale_order_id
         so.action_confirm()
         self.assertEqual(so.order_line.qty_to_invoice, 1)

--- a/addons/sale/tests/common.py
+++ b/addons/sale/tests/common.py
@@ -201,6 +201,11 @@ class TestSaleCommon(AccountTestInvoicingCommon):
 
         return company_data
 
+    @classmethod
+    def get_default_groups(cls):
+        groups = super().get_default_groups()
+        return groups | cls.quick_ref('sales_team.group_sale_manager')
+
 
 class TestTaxCommonSale(TestTaxCommon):
 

--- a/addons/sale/tests/common.py
+++ b/addons/sale/tests/common.py
@@ -210,6 +210,11 @@ class TestSaleCommon(AccountTestInvoicingCommon):
 class TestTaxCommonSale(TestTaxCommon):
 
     @classmethod
+    def get_default_groups(cls):
+        groups = super().get_default_groups()
+        return groups | cls.quick_ref('sales_team.group_sale_manager')
+
+    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.foreign_currency_pricelist = cls.env['product.pricelist'].create({
@@ -223,7 +228,7 @@ class TestTaxCommonSale(TestTaxCommon):
         currency = document['currency']
         self._ensure_rate(currency, order_date, document['rate'])
         self.foreign_currency_pricelist.currency_id = currency
-        order = self.env['sale.order'].create({
+        return self.env['sale.order'].create({
             'date_order': order_date,
             'currency_id': currency.id,
             'partner_id': self.partner_a.id,
@@ -240,7 +245,6 @@ class TestTaxCommonSale(TestTaxCommon):
                 for i, base_line in enumerate(document['lines'])
             ],
         })
-        return order
 
     def assert_sale_order_tax_totals_summary(self, sale_order, expected_values, soft_checking=False):
         self._assert_tax_totals_summary(sale_order.tax_totals, expected_values, soft_checking=soft_checking)

--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -1,13 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tests import freeze_time, tagged
 
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.sale.tests.common import TestSaleCommon
 
 
 @freeze_time('2022-01-01')
 @tagged('post_install', '-at_install')
-class TestAccruedSaleOrders(AccountTestInvoicingCommon):
+class TestAccruedSaleOrders(TestSaleCommon):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/sale/tests/test_sale_product_attribute_value_config.py
+++ b/addons/sale/tests/test_sale_product_attribute_value_config.py
@@ -1,73 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields
 from odoo.tests import tagged
 
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.product.tests.test_product_attribute_value_config import (
     TestProductAttributeValueCommon,
 )
-
-
-@tagged("post_install", "-at_install")
-class TestSaleProductAttributeValueCommon(AccountTestInvoicingCommon, TestProductAttributeValueCommon):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.computer.company_id = cls.env.company
-        cls.computer = cls.computer.with_env(cls.env)
-        cls.env['product.pricelist'].sudo().search([]).action_archive()
-        cls.pricelist = cls.env['product.pricelist'].create({'name': 'Base Pricelist'})
-
-    @classmethod
-    def _setup_currency(cls, currency_ratio=2):
-        """Get or create a currency. This makes the test non-reliant on demo.
-
-        With an easy currency rate, for a simple 2 ratio in the following tests.
-        """
-        from_currency = cls.computer.currency_id
-        cls._set_or_create_rate_today(from_currency, rate=1)
-
-        to_currency = cls._get_or_create_currency("my currency", "C")
-        cls._set_or_create_rate_today(to_currency, currency_ratio)
-        return to_currency
-
-    @classmethod
-    def _set_or_create_rate_today(cls, currency, rate):
-        """Get or create a currency rate for today. This makes the test
-        non-reliant on demo data."""
-        name = fields.Date.today()
-        currency_id = currency.id
-        company_id = cls.env.company.id
-
-        CurrencyRate = cls.env['res.currency.rate']
-
-        currency_rate = CurrencyRate.search([
-            ('company_id', '=', company_id),
-            ('currency_id', '=', currency_id),
-            ('name', '=', name),
-        ])
-
-        if currency_rate:
-            currency_rate.rate = rate
-        else:
-            CurrencyRate.create({
-                'company_id': company_id,
-                'currency_id': currency_id,
-                'name': name,
-                'rate': rate,
-            })
-
-    @classmethod
-    def _get_or_create_currency(cls, name, symbol):
-        """Get or create a currency based on name. This makes the test
-        non-reliant on demo data."""
-        currency = cls.env['res.currency'].search([('name', '=', name)])
-        return currency or currency.create({
-            'name': name,
-            'symbol': symbol,
-        })
 
 
 @tagged('post_install', '-at_install')

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -838,7 +838,7 @@ class TestSaleToInvoice(TestSaleCommon):
         orders = so1 | so2 | so3
         orders.action_confirm()
         # Create the invoicing wizard and invoice all of them at once
-        wiz = self.env['sale.advance.payment.inv'].with_context(active_ids=orders.ids, open_invoices=True).create({})
+        wiz = self.env['sale.advance.payment.inv'].with_context(active_ids=orders.ids).create({})
         res = wiz.create_invoices()
         # Check that exactly 2 invoices are generated
         self.assertEqual(

--- a/addons/sale_expense_margin/tests/test_so_expense_purchase_price.py
+++ b/addons/sale_expense_margin/tests/test_so_expense_purchase_price.py
@@ -1,7 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import Command
-from odoo.addons.hr_expense.tests.common import TestExpenseCommon
+
+from odoo.fields import Command
 from odoo.tests import tagged
+
+from odoo.addons.hr_expense.tests.common import TestExpenseCommon
+
 
 @tagged('-at_install', 'post_install')
 class TestExpenseMargin(TestExpenseCommon):
@@ -14,7 +17,10 @@ class TestExpenseMargin(TestExpenseCommon):
         product_with_no_cost.write({'expense_policy': 'sales_price'})
 
         # create SO line and confirm SO (with only one line)
-        sale_order = self.env['sale.order'].with_context(mail_notrack=True, mail_create_nolog=True).create({
+        sale_order = self.env['sale.order'].with_context(
+            mail_notrack=True,
+            mail_create_nolog=True,
+        ).sudo().create({
             'partner_id': self.partner_a.id,
             'partner_invoice_id': self.partner_a.id,
             'partner_shipping_id': self.partner_a.id,

--- a/addons/sale_management/tests/test_sale_ui.py
+++ b/addons/sale_management/tests/test_sale_ui.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.fields import Command
 from odoo.tests.common import HttpCase, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -8,30 +9,33 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 @tagged('post_install', '-at_install')
 class TestUi(AccountTestInvoicingCommon, HttpCase):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.agrolait = cls.env['res.partner'].create({'name': 'Agrolait', 'email': 'agro@lait.be'})
+
     def test_01_sale_tour(self):
         self.env.ref('base.user_admin').write({
             'email': 'mitchell.admin@example.com',
         })
-        self.env['res.partner'].create({'name': 'Agrolait', 'email': 'agro@lait.be'})
         self.start_tour("/odoo", 'sale_tour', login="admin")
 
     def test_04_portal_sale_signature_without_name_tour(self):
         """The goal of this test is to make sure the portal user can sign SO even witout a name."""
+        self.agrolait.name = ""
 
-        portal_user_partner = self.env['res.partner'].create({'name': 'Agrolait', 'email': 'agro@lait.be'})
-        # create a SO to be signed
-        portal_user_partner.name = ""
-        sales_order = self.env['sale.order'].create({
+        sales_order = self.env['sale.order'].sudo().create({
             'name': 'test SO',
-            'partner_id': portal_user_partner.id,
+            'partner_id': self.agrolait.id,
             'state': 'sent',
             'require_payment': False,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product.id,
+                })
+            ]
         })
-        self.env['sale.order.line'].create({
-            'order_id': sales_order.id,
-            'product_id': self.env['product.product'].create({'name': 'A product'}).id,
-        })
-
         action = sales_order.action_preview_sale_order()
 
         self.start_tour(action['url'], 'sale_signature_without_name', login="admin")

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -3,25 +3,24 @@
 
 from odoo.tests import Form, tagged
 
+from odoo.addons.sale.tests.common import TestSaleCommon
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
 
 
 @tagged('post_install', '-at_install')
-class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
+class TestSaleMRPAngloSaxonValuation(TestSaleCommon, ValuationReconciliationTestCommon):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
         cls.env.user.company_id.anglo_saxon_accounting = True
-        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
 
     @classmethod
-    def _create_product(cls, **kwargs):
-        return super()._create_product(
-            categ_id=cls.stock_account_product_categ.id if kwargs.get('is_storable') else cls.env.ref('product.product_category_goods').id,
-            **kwargs
-        )
+    def _create_product(cls, **create_vals):
+        if create_vals.get('is_storable'):
+            create_vals['categ_id'] = cls.stock_account_product_categ.id
+        return super()._create_product(**create_vals)
 
     def test_sale_mrp_kit_bom_cogs(self):
         """Check invoice COGS aml after selling and delivering a product

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -1,22 +1,25 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
-from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
-from odoo.tests import common, Form
 from odoo.exceptions import UserError
-from odoo.tools import mute_logger, float_compare
-from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
+from odoo.tests import Form, common
+from odoo.tools import float_compare, mute_logger
+
+from odoo.addons.sale.tests.common import TestSaleCommon
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import (
+    ValuationReconciliationTestCommon,
+)
 
 
 # these tests create accounting entries, and therefore need a chart of accounts
-class TestSaleMrpFlowCommon(ValuationReconciliationTestCommon):
+class TestSaleMrpFlowCommon(ValuationReconciliationTestCommon, TestSaleCommon):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
         # Required for `uom_id` to be visible in the view
-        cls.env.user.group_ids += cls.env.ref('uom.group_uom')
+        cls._enable_uom()
         cls.env.ref('stock.route_warehouse0_mto').active = True
 
         # Useful models
@@ -26,10 +29,8 @@ class TestSaleMrpFlowCommon(ValuationReconciliationTestCommon):
         cls.Quant = cls.env['stock.quant']
         cls.ProductCategory = cls.env['product.category']
 
-        cls.uom_kg = cls.env.ref('uom.product_uom_kgm')
-        cls.uom_gm = cls.env.ref('uom.product_uom_gram')
-        cls.uom_unit = cls.env.ref('uom.product_uom_unit')
-        cls.uom_dozen = cls.env.ref('uom.product_uom_dozen')
+        cls.uom_kg = cls.uom_kgm
+        cls.uom_gm = cls.uom_gram
         cls.uom_ten = cls.UoM.create({
             'name': 'Test-Ten',
             'relative_factor': 10,

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -1,11 +1,12 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import Form, TransactionCase, tagged
+from odoo.tests import Form, tagged
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
 @tagged('post_install', '-at_install')
-class TestSaleMrpKitBom(TransactionCase):
+class TestSaleMrpKitBom(BaseCommon):
 
     @classmethod
     def setUpClass(cls):
@@ -13,6 +14,7 @@ class TestSaleMrpKitBom(TransactionCase):
         cls.env.ref('base.user_admin').write({
             'email': 'mitchell.admin@example.com',
         })
+        cls.env.user.group_ids += cls.quick_ref('product.group_product_variant')
 
     def _create_product(self, name, storable, price):
         return self.env['product.product'].create({

--- a/addons/sale_mrp/tests/test_sale_mrp_report.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_report.py
@@ -1,15 +1,14 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.tests import common
-
+from odoo.fields import Command
+from odoo.tests import tagged
 from odoo.tools import html2plaintext
 
+from odoo.addons.sale.tests.common import TestSaleCommon
 
-@common.tagged('post_install', '-at_install')
-class TestSaleMrpInvoices(AccountTestInvoicingCommon):
+
+@tagged('post_install', '-at_install')
+class TestSaleMrpInvoices(TestSaleCommon):
 
     @classmethod
     def setUpClass(cls):
@@ -40,7 +39,6 @@ class TestSaleMrpInvoices(AccountTestInvoicingCommon):
                 'product_qty': 1,
             })]
         })
-        cls.partner = cls.env['res.partner'].create({'name': 'Test Partner'})
 
     def test_deliver_and_invoice_tracked_components(self):
         """

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1,9 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command, fields
-from odoo.tests import Form, tagged
-from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
 from odoo.exceptions import UserError
+from odoo.tests import Form, tagged
+
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import (
+    ValuationReconciliationTestCommon,
+)
 
 
 @tagged('post_install', '-at_install')
@@ -29,7 +32,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         }).action_apply_inventory()
 
     def _so_and_confirm_two_units(self):
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -478,7 +481,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         product.list_price = 100
         product.standard_price = 50
 
-        so = self.env['sale.order'].create({
+        so = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'partner_invoice_id': self.partner_a.id,
             'partner_shipping_id': self.partner_a.id,
@@ -915,7 +918,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         in_move_1._action_done()
 
         # Create and confirm a sale order for 2@12
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1004,7 +1007,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         in_move_2._action_done()
 
         # sale 1@20, deliver, invoice
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1022,7 +1025,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         invoice.action_post()
 
         # sale 6@20, deliver, invoice
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1066,7 +1069,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         in_move_1._action_done()
 
         # Create and confirm a sale order for 10@12
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1145,7 +1148,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         return_pick._action_done()
 
         # Create, confirm and deliver a sale order for 1@12 (SO2)
-        so_2 = self.env['sale.order'].create({
+        so_2 = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1238,7 +1241,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         })
 
         # Create, confirm and deliver a sale order for 12@1.5 without reception with std_price = 2.0 (SO1)
-        so_1 = self.env['sale.order'].create({
+        so_1 = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1298,7 +1301,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         in_move_1._action_done()
 
         # Create, confirm and deliver a sale order for 12@1.5 with reception (50 * 1.0, 50 * 0.0)(SO2)
-        so_2 = self.env['sale.order'].create({
+        so_2 = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1365,7 +1368,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         in_moves._action_done()
 
         # Sell 3 units
-        so = self.env['sale.order'].create({
+        so = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1457,7 +1460,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         in_moves._action_done()
 
         # Sell 3 units
-        so = self.env['sale.order'].create({
+        so = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1507,9 +1510,10 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         return_picking.button_validate()
 
         # Create a new invoice for the returned product
-        ctx = {'active_model': 'sale.order', 'active_ids': so.ids}
-        create_invoice_wizard = self.env['sale.advance.payment.inv'].with_context(ctx).create({'advance_payment_method': 'delivered'})
-        create_invoice_wizard.create_invoices()
+        self.env['sale.advance.payment.inv'].with_context({
+            'active_model': 'sale.order',
+            'active_ids': so.ids,
+        }).sudo().create({}).create_invoices()
         reverse_invoice = so.invoice_ids[-1]
         with Form(reverse_invoice) as reverse_invoice_form:
             with reverse_invoice_form.invoice_line_ids.edit(0) as line:
@@ -1543,7 +1547,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         in_moves.write({'quantity': 1, 'picked': True})
         in_moves._action_done()
 
-        so = self.env['sale.order'].create({
+        so = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1631,7 +1635,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         in_moves.write({'quantity': 1, 'picked': True})
         in_moves._action_done()
 
-        so = self.env['sale.order'].create({
+        so = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1708,7 +1712,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         }).action_apply_inventory()
 
         # Create a SO with a product invoiced on delivered quantity
-        so = self.env['sale.order'].create({
+        so = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [
                 (0, 0, {
@@ -1722,12 +1726,12 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         so.action_confirm()
 
         # Do a 100% down payment
-        down_payment = self.env['sale.advance.payment.inv'].create({
+        self.env['sale.advance.payment.inv'].sudo().create({
             'advance_payment_method': 'percentage',
             'amount': 100,
             'sale_order_ids': so.ids,
-        })
-        down_payment.create_invoices()
+        }).create_invoices()
+
         # Invoice the delivered part from the down payment
         down_payment_invoices = so.invoice_ids
         down_payment_invoices.action_post()
@@ -1737,8 +1741,10 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         so.picking_ids.move_ids.picked = True
         Form.from_action(self.env, so.picking_ids.button_validate()).save().process()
 
-        invoice_wizard = self.env['sale.advance.payment.inv'].with_context(active_ids=so.ids, open_invoices=True).create({})
-        invoice_wizard.create_invoices()
+        self.env['sale.advance.payment.inv'].with_context(
+            active_ids=so.ids,
+            open_invoices=True
+        ).sudo().create({}).create_invoices()
         credit_note = so.invoice_ids.filtered(lambda i: i.state != 'posted')
         self.assertEqual(len(credit_note), 1)
         self.assertEqual(len(credit_note.invoice_line_ids.filtered(lambda line: line.display_type == 'product')), 2)
@@ -1751,8 +1757,9 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         backorder.move_ids.picked = True
         backorder.button_validate()
 
-        invoice_wizard = self.env['sale.advance.payment.inv'].with_context(active_ids=so.ids, open_invoices=True).create({})
-        invoice_wizard.create_invoices()
+        self.env['sale.advance.payment.inv'].with_context(
+            active_ids=so.ids, open_invoices=True
+        ).sudo().create({}).create_invoices()
 
         invoice = so.invoice_ids.filtered(lambda i: i.state != 'posted')
         invoice.action_post()
@@ -1796,7 +1803,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         in_move.picked = True
         in_move._action_done()
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'order_line': [Command.create({
                 'product_id': product.id,
@@ -1816,10 +1823,9 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         backorder_delivery = sale_order.picking_ids.filtered(lambda p: p.state != 'done')
         backorder_delivery.move_ids.quantity = 2
         backorder_delivery.button_validate()
-        invoice_wizard = self.env['sale.advance.payment.inv'].with_context(
+        self.env['sale.advance.payment.inv'].with_context(
             active_ids=sale_order.ids, open_invoices=True
-        ).create({})
-        invoice_wizard.create_invoices()
+        ).sudo().create({}).create_invoices()
 
         invoice = sale_order.invoice_ids
         qty_ten_invoice_line = invoice.invoice_line_ids.filtered(lambda l: l.quantity == 10)
@@ -1827,10 +1833,9 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         invoice.invoice_date = fields.Date.today()
         invoice.action_post()
         product.standard_price = 50
-        invoice_wizard = self.env['sale.advance.payment.inv'].with_context(
+        self.env['sale.advance.payment.inv'].with_context(
             active_ids=sale_order.ids, open_invoices=True
-        ).create({})
-        invoice_wizard.create_invoices()
+        ).sudo().create({}).create_invoices()
         invoice2 = sale_order.invoice_ids.filtered(lambda i: i.state != 'posted')
         invoice2.invoice_date = fields.Date.today()
         invoice2.action_post()

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1743,7 +1743,6 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
 
         self.env['sale.advance.payment.inv'].with_context(
             active_ids=so.ids,
-            open_invoices=True
         ).sudo().create({}).create_invoices()
         credit_note = so.invoice_ids.filtered(lambda i: i.state != 'posted')
         self.assertEqual(len(credit_note), 1)
@@ -1758,7 +1757,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         backorder.button_validate()
 
         self.env['sale.advance.payment.inv'].with_context(
-            active_ids=so.ids, open_invoices=True
+            active_ids=so.ids,
         ).sudo().create({}).create_invoices()
 
         invoice = so.invoice_ids.filtered(lambda i: i.state != 'posted')
@@ -1824,7 +1823,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         backorder_delivery.move_ids.quantity = 2
         backorder_delivery.button_validate()
         self.env['sale.advance.payment.inv'].with_context(
-            active_ids=sale_order.ids, open_invoices=True
+            active_ids=sale_order.ids,
         ).sudo().create({}).create_invoices()
 
         invoice = sale_order.invoice_ids
@@ -1834,7 +1833,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         invoice.action_post()
         product.standard_price = 50
         self.env['sale.advance.payment.inv'].with_context(
-            active_ids=sale_order.ids, open_invoices=True
+            active_ids=sale_order.ids,
         ).sudo().create({}).create_invoices()
         invoice2 = sale_order.invoice_ids.filtered(lambda i: i.state != 'posted')
         invoice2.invoice_date = fields.Date.today()

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -15,7 +15,7 @@ class TestValuationReconciliationCommon(ValuationReconciliationTestCommon):
         cls.test_product_delivery.invoice_policy = 'delivery'
 
     def _create_sale(self, product, date, quantity=1.0):
-        rslt = self.env['sale.order'].create({
+        order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'currency_id': self.other_currency.id,
             'order_line': [
@@ -28,8 +28,8 @@ class TestValuationReconciliationCommon(ValuationReconciliationTestCommon):
                 })],
             'date_order': date,
         })
-        rslt.action_confirm()
-        return rslt
+        order.action_confirm()
+        return order
 
     def _create_invoice_for_so(self, sale_order, product, date, quantity=1.0):
         rslt = self.env['account.move'].create({
@@ -186,7 +186,7 @@ class TestValuationReconciliation(TestValuationReconciliationCommon):
         categ_2.property_stock_account_output_categ_id = account_2
         product_2.categ_id = categ_2
         # Create out_svls
-        so = self.env['sale.order'].create({
+        so = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,
             'currency_id': self.other_currency.id,
             'order_line': [
@@ -274,7 +274,7 @@ class TestValuationReconciliation(TestValuationReconciliationCommon):
 
         products = [self.test_product_delivery, self.test_product_delivery_2]
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'name': "sale order product 2",
             'company_id': self.env.company.id,
             'partner_id': self.partner_a.id
@@ -349,13 +349,11 @@ class TestValuationReconciliation(TestValuationReconciliationCommon):
             'state': 'done'
         })
 
-        sale_order_line_1 = self.env['sale.order.line'].create({
+        sale_order_line_1 = self.env['sale.order.line'].sudo().create({
             'product_id': products[0].id,
             'order_id': sale_order.id,
             'move_ids': sm_1
         })
-
-        sm_1.sale_line_id = sale_order_line_1.id
 
         sm_2 = self.env['stock.move'].create({
             'name': products[1].name,
@@ -369,13 +367,11 @@ class TestValuationReconciliation(TestValuationReconciliationCommon):
             'state': 'done'
         })
 
-        sale_order_line_2 = self.env['sale.order.line'].create({
+        sale_order_line_2 = self.env['sale.order.line'].sudo().create({
             'product_id': products[1].id,
             'order_id': sale_order.id,
             'move_ids': sm_2
         })
-
-        sm_2.sale_line_id = sale_order_line_2.id
 
         invoice_1.invoice_line_ids.sale_line_ids = sale_order_line_1 | sale_order_line_2
 

--- a/addons/sale_stock/tests/test_sale_order_dates.py
+++ b/addons/sale_stock/tests/test_sale_order_dates.py
@@ -1,10 +1,14 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
 from datetime import timedelta
+
 from odoo import fields
-from odoo.tests import common, tagged
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import (
+    ValuationReconciliationTestCommon,
+)
 
 
 @tagged('post_install', '-at_install')
@@ -37,13 +41,13 @@ class TestSaleExpectedDate(ValuationReconciliationTestCommon):
         self.env['stock.quant']._update_available_quantity(product_B, self.company_data['default_warehouse'].lot_stock_id, 10)
         self.env['stock.quant']._update_available_quantity(product_C, self.company_data['default_warehouse'].lot_stock_id, 10)
 
-        sale_order = self.env['sale.order'].create({
+        sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.env['res.partner'].create({'name': 'A Customer'}).id,
             'picking_policy': 'direct',
             'order_line': [
-                (0, 0, {'name': product_A.name, 'product_id': product_A.id, 'customer_lead': product_A.sale_delay, 'product_uom_qty': 5}),
-                (0, 0, {'name': product_B.name, 'product_id': product_B.id, 'customer_lead': product_B.sale_delay, 'product_uom_qty': 5}),
-                (0, 0, {'name': product_C.name, 'product_id': product_C.id, 'customer_lead': product_C.sale_delay, 'product_uom_qty': 5})
+                Command.create({'product_id': product_A.id, 'product_uom_qty': 5}),
+                Command.create({'product_id': product_B.id, 'product_uom_qty': 5}),
+                Command.create({'product_id': product_C.id, 'product_uom_qty': 5})
             ],
         })
 
@@ -91,17 +95,17 @@ class TestSaleExpectedDate(ValuationReconciliationTestCommon):
 
         # In order to test the Commitment Date feature in Sales Orders in Odoo,
         # I copy a demo Sales Order with committed Date on 2010-07-12
-        new_order = self.env['sale.order'].create({
+        new_order = self.env['sale.order'].sudo().create({
             'partner_id': self.env['res.partner'].create({'name': 'A Partner'}).id,
-            'order_line': [(0, 0, {
-                'name': "A product",
-                'product_id': self.env['product.product'].create({
-                    'name': 'A product',
-                    'is_storable': True,
-                }).id,
-                'product_uom_qty': 1,
-                'price_unit': 750,
-            })],
+            'order_line': [
+                Command.create({
+                    'product_id': self.env['product.product'].create({
+                        'name': 'A product',
+                        'is_storable': True,
+                    }).id,
+                    'price_unit': 750,
+                })
+            ],
             'commitment_date': '2010-07-12',
         })
         # I confirm the Sales Order.

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -153,7 +153,7 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
             'advance_payment_method': 'percentage',
             'amount': 5.0,
         })
-        act = adv_wiz.with_context(open_invoices=True).create_invoices()
+        act = adv_wiz.create_invoices()
         inv = self.env['account.move'].browse(act['res_id'])
         self.assertEqual(inv.amount_untaxed, self.so.amount_untaxed * 5.0 / 100.0, 'Sale Stock: deposit invoice is wrong')
         self.assertEqual(self.so.invoice_status, 'to invoice', 'Sale Stock: so should be to invoice after invoicing deposit')
@@ -236,7 +236,7 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         adv_wiz = self.env['sale.advance.payment.inv'].with_context(active_ids=[self.so.id]).create({
             'advance_payment_method': 'delivered',
         })
-        adv_wiz.with_context(open_invoices=True).create_invoices()
+        adv_wiz.create_invoices()
         self.inv_2 = self.so.invoice_ids.filtered(lambda r: r.state == 'draft')
         self.assertAlmostEqual(self.inv_2.invoice_line_ids.sorted()[0].quantity, 2.0, msg='Sale Stock: refund quantity on the invoice should be 2.0 instead of "%s".' % self.inv_2.invoice_line_ids.sorted()[0].quantity)
         self.assertEqual(self.so.invoice_status, 'no', 'Sale Stock: so invoice_status should be "no" instead of "%s" after invoicing the return' % self.so.invoice_status)
@@ -1388,7 +1388,7 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
             'amount': 5.0,
         })
 
-        act = adv_wiz.with_context(open_invoices=True).create_invoices()
+        act = adv_wiz.create_invoices()
         invoice = self.env['account.move'].browse(act['res_id'])
 
         self.assertEqual(invoice.invoice_incoterm_id.id, incoterm.id)

--- a/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
+++ b/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
@@ -1,32 +1,33 @@
-# -*- coding: utf-8 -*-
-from odoo import fields, Command
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.tests import tagged, Form
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields
 from odoo.exceptions import UserError
+from odoo.fields import Command
+from odoo.tests import Form, tagged
+
+from odoo.addons.sale.tests.common import TestSaleCommon
 
 
 @tagged('post_install', '-at_install')
-class TestAccruedStockSaleOrders(AccountTestInvoicingCommon):
+class TestAccruedStockSaleOrders(TestSaleCommon):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        uom_unit = cls.env.ref('uom.product_uom_unit')
-        cls.product_order = cls.env['product.product'].create({
+
+        product = cls.env['product.product'].create({
             'name': "Product",
             'list_price': 30.0,
             'type': 'consu',
-            'uom_id': uom_unit.id,
+            'uom_id': cls.uom_unit.id,
             'invoice_policy': 'delivery',
         })
         cls.sale_order = cls.env['sale.order'].with_context(tracking_disable=True).create({
             'partner_id': cls.partner_a.id,
             'order_line': [
                 Command.create({
-                    'name': cls.product_order.name,
-                    'product_id': cls.product_order.id,
+                    'product_id': product.id,
                     'product_uom_qty': 10.0,
-                    'price_unit': cls.product_order.list_price,
                     'tax_ids': False,
                 })
             ]

--- a/addons/sales_team/tests/common.py
+++ b/addons/sales_team/tests/common.py
@@ -41,6 +41,11 @@ class SalesTeamCommon(BaseCommon):
             ('id', '!=', cls.sale_team.id),
         ]).action_archive()
 
+    @classmethod
+    def get_default_groups(cls):
+        groups = super().get_default_groups()
+        return groups | cls.quick_ref('sales_team.group_sale_manager')
+
 
 class TestSalesCommon(TransactionCase):
 

--- a/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
+++ b/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
@@ -3,9 +3,9 @@
 
 from freezegun import freeze_time
 
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.tests import tagged
 from odoo import fields
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
 class ValuationReconciliationTestCommon(AccountTestInvoicingCommon):
@@ -29,21 +29,19 @@ class ValuationReconciliationTestCommon(AccountTestInvoicingCommon):
             'property_stock_account_output_categ_id': cls.company_data['default_account_stock_out'].id,
         })
 
-        uom_unit = cls.env.ref('uom.product_uom_unit')
-
         cls.test_product_order = cls.env['product.product'].create({
             'name': "Test product template invoiced on order",
             'standard_price': 42.0,
             'is_storable': True,
             'categ_id': cls.stock_account_product_categ.id,
-            'uom_id': uom_unit.id,
+            'uom_id': cls.uom_unit.id,
         })
         cls.test_product_delivery = cls.env['product.product'].create({
             'name': 'Test product template invoiced on delivery',
             'standard_price': 42.0,
             'is_storable': True,
             'categ_id': cls.stock_account_product_categ.id,
-            'uom_id': uom_unit.id,
+            'uom_id': cls.uom_unit.id,
         })
 
         cls.res_users_stock_user = cls.env['res.users'].create({
@@ -51,7 +49,7 @@ class ValuationReconciliationTestCommon(AccountTestInvoicingCommon):
             'login': "su",
             'email': "stockuser@yourcompany.com",
             'group_ids': [(6, 0, [cls.env.ref('stock.group_stock_user').id])],
-            })
+        })
 
     @classmethod
     def collect_company_accounting_data(cls, company):

--- a/addons/stock_delivery/tests/test_delivery_stock_move.py
+++ b/addons/stock_delivery/tests/test_delivery_stock_move.py
@@ -1,11 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import Form, tagged
+
+from odoo.addons.sale.tests.common import TestSaleCommon
 
 
 @tagged('post_install', '-at_install')
-class StockMoveInvoice(AccountTestInvoicingCommon):
+class TestStockMoveInvoice(TestSaleCommon):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
+++ b/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
@@ -11,6 +11,11 @@ from odoo.addons.account_edi_ubl_cii.tests.test_ubl_cii import TestAccountEdiUbl
 class TestOrderEdiUbl(TestAccountEdiUblCii):
 
     @classmethod
+    def get_default_groups(cls):
+        groups = super().get_default_groups()
+        return groups | cls.quick_ref('sales_team.group_sale_manager')
+
+    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.purchase_company = cls.company_data_2['company']

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -3,14 +3,15 @@
 from odoo.fields import Command
 from odoo.tests import tagged
 
-from odoo.addons.sale.tests.test_sale_product_attribute_value_config import (
-    TestSaleProductAttributeValueCommon,
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.product.tests.test_product_attribute_value_config import (
+    TestProductAttributeValueCommon,
 )
 from odoo.addons.website_sale.tests.common import MockRequest
 
 
 @tagged('post_install', '-at_install', 'product_attribute')
-class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCommon):
+class TestWebsiteSaleProductAttributeValueConfig(AccountTestInvoicingCommon, TestProductAttributeValueCommon):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/website_sale/tests/test_website_sale_product_filters.py
+++ b/addons/website_sale/tests/test_website_sale_product_filters.py
@@ -3,14 +3,14 @@
 from odoo import Command
 from odoo.tests import tagged
 
-from odoo.addons.sale.tests.test_sale_product_attribute_value_config import (
-    TestSaleProductAttributeValueCommon,
+from odoo.addons.product.tests.test_product_attribute_value_config import (
+    TestProductAttributeValueCommon,
 )
 from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
-class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestSaleProductAttributeValueCommon):
+class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestProductAttributeValueCommon):
 
     @classmethod
     def setUpClass(cls):
@@ -61,20 +61,19 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestSaleProductAttributeV
         })
 
         # Computer alternatives
-        cls.windows_pc = cls.product_a.with_env(cls.env).product_tmpl_id
-        cls.windows_pc.write({
-            'name': "Windows PC",
-            'company_id': False,
-            'alternative_product_ids': cls.computer.ids,
-            'website_published': True,
-        })
-        cls.mac = cls.product_b.with_env(cls.env).product_tmpl_id
-        cls.mac.write({
-            'name': "Mac",
-            'company_id': False,
-            'alternative_product_ids': (cls.computer + cls.windows_pc).ids,
-            'website_published': True,
-        })
+        cls.windows_pc = cls._create_product(
+            name='Windows PC',
+            lst_price=1000.0,
+            standard_price=800.0,
+            alternative_product_ids=[Command.set(cls.computer.ids)],
+        ).product_tmpl_id
+        cls.mac = cls._create_product(
+            name='Mac',
+            uom_id=cls.uom_dozen.id,
+            lst_price=200.0,
+            standard_price=160.0,
+            alternative_product_ids=[Command.link(cls.computer.id), Command.link(cls.windows_pc.id)]
+        ).product_tmpl_id
 
         # More generic products to get the number of product templates to 17
         generics = cls.env['product.template'].create([{

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -7,16 +7,14 @@ from odoo.exceptions import ValidationError
 from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 
-from odoo.addons.sale.tests.test_sale_product_attribute_value_config import (
-    TestSaleProductAttributeValueCommon,
-)
+from odoo.addons.sale.tests.common import TestSaleCommon
 from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 from odoo.addons.website_sale_loyalty.controllers.cart import Cart
 from odoo.addons.website_sale_loyalty.controllers.main import WebsiteSale
 
 
 @tagged('post_install', '-at_install')
-class WebsiteSaleLoyaltyTestUi(TestSaleProductAttributeValueCommon, HttpCase):
+class WebsiteSaleLoyaltyTestUi(TestSaleCommon, HttpCase):
 
     @classmethod
     def setUpClass(cls):
@@ -35,6 +33,7 @@ class WebsiteSaleLoyaltyTestUi(TestSaleProductAttributeValueCommon, HttpCase):
         })
         cls.env.ref('base.user_admin').sudo().partner_id.company_id = cls.env.company
         cls.env.ref('website.default_website').company_id = cls.env.company
+        cls.public_category = cls.env['product.public.category'].create({'name': 'Public Category'})
 
     def test_01_admin_shop_sale_loyalty_tour(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
@@ -48,16 +47,13 @@ class WebsiteSaleLoyaltyTestUi(TestSaleProductAttributeValueCommon, HttpCase):
         })
         transfer_provider._transfer_ensure_pending_msg_is_set()
 
-        # pre enable "Show # found" option to avoid race condition...
-        public_category = self.env['product.public.category'].create({'name': 'Public Category'})
-
         large_cabinet = self.env['product.product'].create({
             'name': 'Small Cabinet',
             'list_price': 320.0,
             'type': 'consu',
             'is_published': True,
             'sale_ok': True,
-            'public_categ_ids': [(4, public_category.id)],
+            'public_categ_ids': [(4, self.public_category.id)],
             'taxes_id': False,
         })
 
@@ -144,16 +140,13 @@ class WebsiteSaleLoyaltyTestUi(TestSaleProductAttributeValueCommon, HttpCase):
         self.start_tour("/", 'shop_sale_loyalty', login="admin")
 
     def test_02_admin_shop_gift_card_tour(self):
-        # pre enable "Show # found" option to avoid race condition...
-        public_category = self.env['product.public.category'].create({'name': 'Public Category'})
-
         gift_card = self.env['product.product'].create({
             'name': 'TEST - Gift Card',
             'list_price': 50,
             'type': 'service',
             'is_published': True,
             'sale_ok': True,
-            'public_categ_ids': [(4, public_category.id)],
+            'public_categ_ids': [(4, self.public_category.id)],
             'taxes_id': False,
         })
         self.env['product.product'].create({
@@ -162,7 +155,7 @@ class WebsiteSaleLoyaltyTestUi(TestSaleProductAttributeValueCommon, HttpCase):
             'type': 'consu',
             'is_published': True,
             'sale_ok': True,
-            'public_categ_ids': [(4, public_category.id)],
+            'public_categ_ids': [(4, self.public_category.id)],
             'taxes_id': False,
         })
         # Disable any other program
@@ -219,14 +212,13 @@ class WebsiteSaleLoyaltyTestUi(TestSaleProductAttributeValueCommon, HttpCase):
         self.assertEqual(len(gift_card_program.coupon_ids.filtered('points')), 1, 'There should be two coupons, one with points, one without')
 
     def test_03_admin_shop_ewallet_tour(self):
-        public_category = self.env['product.public.category'].create({'name': 'Public Category'})
         self.env['product.product'].create({
             'name': "TEST - Gift Card",
             'list_price': 50,
             'type': 'service',
             'is_published': True,
             'sale_ok': True,
-            'public_categ_ids': [(4, public_category.id)],
+            'public_categ_ids': [(4, self.public_category.id)],
             'taxes_id': False,
         })
         # Disable any other program

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
@@ -3,14 +3,16 @@
 
 from odoo.tests import tagged
 
-from odoo.addons.sale.tests.test_sale_product_attribute_value_config import TestSaleProductAttributeValueCommon
+from odoo.addons.product.tests.test_product_attribute_value_config import (
+    TestProductAttributeValueCommon,
+)
 from odoo.addons.website_sale.tests.common import MockRequest
 from odoo.addons.website_sale_stock.tests.common import WebsiteSaleStockCommon
 
 
 @tagged('post_install', '-at_install')
 class TestWebsiteSaleStockProductWarehouse(
-    TestSaleProductAttributeValueCommon, WebsiteSaleStockCommon
+    TestProductAttributeValueCommon, WebsiteSaleStockCommon
 ):
 
     @classmethod

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -32,6 +32,8 @@ class BaseCommon(TransactionCase):
         if independent_user:
             cls.env = cls.env(user=independent_user)
             cls.user = cls.env.user
+        else:
+            cls.env.user.group_ids += cls.get_default_groups()
 
         independent_company = cls.setup_independent_company()
         if independent_company:
@@ -62,7 +64,7 @@ class BaseCommon(TransactionCase):
     @classmethod
     def setup_other_currency(cls, code, **kwargs):
         rates = kwargs.pop('rates', [])
-        currency = cls.env['res.currency'].with_context(active_test=False).search([('name', '=', code)], limit=1)
+        currency = cls._enable_currency(code)
         currency.rate_ids.unlink()
         currency.write({
             'active': True,
@@ -96,7 +98,8 @@ class BaseCommon(TransactionCase):
     @classmethod
     def _enable_currency(cls, currency_code):
         currency = cls.env['res.currency'].with_context(active_test=False).search(
-            [('name', '=', currency_code.upper())]
+            [('name', '=', currency_code.upper())],
+            limit=1,
         )
         currency.action_unarchive()
         return currency


### PR DESCRIPTION
Administrators groups have been recently removed from the default groups when creating a database, they're only added when demo data is installed.  Tests have been adapted quickly, by adding all those groups in the core `AccountTestInvoicingCommon`, because he doesn't rely on the administrator to run the test setups (when all other tests do), but on a newly made test user `accountman`.

This PR removes two of those generic groups from the `AccountTestInvoicingCommon` default groups, moving them to more specific descendants of the class, and fixes the broken tests as well.

When possible to easily integrate the test class in the existing tests architecture (with the right parent), this approach is used, otherwise a sudo or an override of `default_groups` is added.

task-4677987

