### PR TITLE
[IMP] web, *: show control panel asap

### DIFF
--- a/addons/calendar/static/src/views/list_view/calendar_list_controller.js
+++ b/addons/calendar/static/src/views/list_view/calendar_list_controller.js
@@ -11,6 +11,13 @@ export class CaledarListController extends ListController {
         this.askRecurrenceUpdatePolicy = useAskRecurrenceUpdatePolicy();
     }
 
+    get modelOptions() {
+        return {
+            ...super.modelOptions,
+            lazy: false,
+        };
+    }
+
     /**
      * Deletes selected records with handling for recurring events.
      */

--- a/addons/calendar/static/src/views/list_view/calendar_list_view.js
+++ b/addons/calendar/static/src/views/list_view/calendar_list_view.js
@@ -9,9 +9,9 @@ export class CalendarListModel extends listView.Model {
     }
 
     /**
-    * @override
-    * Add the calendar view's selected attendees to the list view's domain.
-    */
+     * @override
+     * Add the calendar view's selected attendees to the list view's domain.
+     */
     async load(params = {}) {
         const filters = params?.context?.calendar_filters;
         const emptyDomain = Array.isArray(params?.domain) && params.domain.length == 0;
@@ -22,8 +22,9 @@ export class CalendarListModel extends listView.Model {
                 [[user.userId], filters["user"]]
             );
             // Filter attendees to be shown if 'everybody' filter isn't active.
-            if (!filters["all"])
+            if (!filters["all"]) {
                 params.domain.push(["partner_ids", "in", selectedPartnerIds]);
+            }
         }
         return super.load(params);
     }
@@ -41,4 +42,6 @@ function _mockGetCalendarPartnerIds(params) {
 }
 
 registry.category("views").add("calendar_list_view", CalendarListView);
-registry.category("sample_server").add("get_selected_calendars_partner_ids", _mockGetCalendarPartnerIds);
+registry
+    .category("sample_server")
+    .add("get_selected_calendars_partner_ids", _mockGetCalendarPartnerIds);

--- a/addons/lunch/static/src/views/kanban.js
+++ b/addons/lunch/static/src/views/kanban.js
@@ -3,6 +3,7 @@ import { registry } from '@web/core/registry';
 import { kanbanView } from '@web/views/kanban/kanban_view';
 import { KanbanRecord } from '@web/views/kanban/kanban_record';
 import { KanbanRenderer } from '@web/views/kanban/kanban_renderer';
+import { KanbanController } from '@web/views/kanban/kanban_controller';
 
 import { LunchDashboard } from '../components/lunch_dashboard';
 import { LunchRendererMixin } from '../mixins/lunch_renderer_mixin';
@@ -34,8 +35,18 @@ export class LunchKanbanRenderer extends LunchRendererMixin(KanbanRenderer) {
     }
 }
 
+class LunchKanbanController extends KanbanController {
+    get modelOptions() {
+        return {
+            ...super.modelOptions,
+            lazy: false,
+        };
+    }
+}
+
 registry.category('views').add('lunch_kanban', {
     ...kanbanView,
+    Controller: LunchKanbanController,
     Renderer: LunchKanbanRenderer,
     SearchModel: LunchSearchModel,
 });

--- a/addons/lunch/static/src/views/list.js
+++ b/addons/lunch/static/src/views/list.js
@@ -2,6 +2,7 @@ import { registry } from '@web/core/registry';
 
 import { listView } from '@web/views/list/list_view';
 import { ListRenderer } from '@web/views/list/list_renderer';
+import { ListController } from '@web/views/list/list_controller';
 
 import { LunchDashboard } from '../components/lunch_dashboard';
 import { LunchRendererMixin } from '../mixins/lunch_renderer_mixin';
@@ -29,9 +30,18 @@ export class LunchListRenderer extends LunchRendererMixin(ListRenderer) {
     }
 }
 
+class LunchListController extends ListController {
+    get modelOptions() {
+        return {
+            ...super.modelOptions,
+            lazy: false,
+        };
+    }
+}
 
 registry.category('views').add('lunch_list', {
     ...listView,
+    Controller: LunchListController,
     Renderer: LunchListRenderer,
     SearchModel: LunchSearchModel,
 });

--- a/addons/web/static/src/model/model.js
+++ b/addons/web/static/src/model/model.js
@@ -119,9 +119,6 @@ export function useModel(ModelClass, params, options = {}) {
  * @param {T} ModelClass
  * @param {Object} params
  * @param {Object} [options]
- * @param {Function} [options.onUpdate]
- * @param {Function} [options.onWillStart]
- * @param {Function} [options.onWillStartAfterLoad]
  * @param {Function} [options.lazy=false]
  * @returns {InstanceType<T>}
  */
@@ -142,7 +139,7 @@ export function useModelWithSampleData(ModelClass, params, options = {}) {
 
     const model = new ModelClass(component.env, params, services);
 
-    const onUpdate = options.onUpdate || (() => component.render(true));
+    const onUpdate = () => component.render(true);
     model.bus.addEventListener("update", onUpdate);
     onWillUnmount(() => model.bus.removeEventListener("update", onUpdate));
 
@@ -177,17 +174,8 @@ export function useModelWithSampleData(ModelClass, params, options = {}) {
     }
     const race = new Race();
     const load = (props) => race.add(_load(props));
-    async function initialLoad() {
-        if (options.onWillStart) {
-            await options.onWillStart();
-        }
-        await load(component.props);
-        if (options.onWillStartAfterLoad) {
-            await options.onWillStartAfterLoad();
-        }
-    }
     onWillStart(() => {
-        const prom = initialLoad();
+        const prom = load(component.props);
         if (options.lazy) {
             // in-house error handling as we're out of willStart
             prom.catch((e) => {

--- a/addons/web/static/src/model/record.js
+++ b/addons/web/static/src/model/record.js
@@ -13,7 +13,7 @@ class StandaloneRelationalModel extends RelationalModel {
             const config = this._getNextConfig(this.config, params);
             this.root = this._createRoot(config, data);
             this.config = config;
-            return;
+            return Promise.resolve();
         }
         return super.load(params);
     }
@@ -127,10 +127,11 @@ class _Record extends Component {
         onWillStart(async () => {
             if (this.props.values) {
                 const values = await prepareLoadWithValues(this.props.values);
-                return this.model.load({ values });
+                await this.model.load({ values });
             } else {
-                return this.model.load();
+                await this.model.load();
             }
+            this.model.whenReady.resolve();
         });
         onWillUpdateProps(async (nextProps) => {
             const params = {};

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -70,19 +70,13 @@ export class CalendarController extends Component {
         this.orm = useService("orm");
         this.displayDialog = useUniqueDialog();
 
-        this.model = useModelWithSampleData(
-            this.props.Model,
-            {
-                ...this.props.archInfo,
-                resModel: this.props.resModel,
-                domain: this.props.domain,
-                fields: this.props.fields,
-                date: this.props.state?.date,
-            },
-            {
-                onWillStart: this.onWillStartModel.bind(this),
-            }
-        );
+        this.model = useModelWithSampleData(this.props.Model, {
+            ...this.props.archInfo,
+            resModel: this.props.resModel,
+            domain: this.props.domain,
+            fields: this.props.fields,
+            date: this.props.state?.date,
+        });
 
         useSetupAction({
             getLocalState: () => this.model.exportedState,
@@ -355,8 +349,6 @@ export class CalendarController extends Component {
     deleteRecord(record) {
         this.displayDialog(ConfirmationDialog, this.deleteConfirmationDialogProps(record));
     }
-
-    onWillStartModel() {}
 
     async setDate(move) {
         let date = null;

--- a/addons/web/static/src/views/graph/graph_controller.js
+++ b/addons/web/static/src/views/graph/graph_controller.js
@@ -20,16 +20,22 @@ export class GraphController extends Component {
     };
 
     setup() {
-        this.model = useModelWithSampleData(this.props.Model, this.props.modelParams);
+        this.model = useModelWithSampleData(
+            this.props.Model,
+            this.props.modelParams,
+            this.modelOptions
+        );
 
         useSetupAction({
             rootRef: useRef("root"),
-            getLocalState: () => {
-                return { metaData: this.model.metaData };
-            },
+            getLocalState: () => ({ metaData: this.model.metaData }),
             getContext: () => this.getContext(),
         });
         this.searchBarToggler = useSearchBarToggler();
+    }
+
+    get modelOptions() {
+        return { lazy: !this.env.inDialog && !!this.props.display.controlPanel };
     }
 
     /**

--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -63,7 +63,7 @@
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
-                <t t-if="model.data">
+                <t t-if="model.isReady and model.data">
                     <t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp" t-call="web.ActionHelper">
                         <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
                     </t>
@@ -77,7 +77,7 @@
                     </t>
                     <t t-component="props.Renderer" model="model" buttonTemplate="props.buttonTemplate" />
                 </t>
-                <t t-else="" t-call="web.NoContentHelper">
+                <t t-elif="model.isReady" t-call="web.NoContentHelper">
                     <t t-set="title">Invalid data</t>
                     <t t-set="description">Pie chart cannot mix positive and negative numbers. Try to change your domain to only display positive results</t>
                 </t>

--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -70,7 +70,7 @@ export class GraphModel extends Model {
      * @override
      */
     hasData() {
-        return this.dataPoints.length > 0;
+        return this.dataPoints?.length > 0;
     }
 
     /**

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -306,7 +306,7 @@ export class KanbanController extends Component {
     }
 
     get modelOptions() {
-        return {};
+        return { lazy: !this.env.inDialog && !!this.props.display.controlPanel };
     }
 
     get progressBarAggregateFields() {
@@ -426,23 +426,27 @@ export class KanbanController extends Component {
     }
 
     get canCreate() {
-        const { create, createGroup } = this.props.archInfo.activeActions;
+        return this.props.archInfo.activeActions.create;
+    }
+
+    get isNewButtonDisabled() {
+        const { createGroup } = this.props.archInfo.activeActions;
         const list = this.model.root;
-        if (!create) {
-            return false;
-        }
-        if (list.isGrouped) {
-            if (list.groupByField.type !== "many2one") {
-                return true;
-            }
-            return list.groups.length || !createGroup;
-        }
-        return true;
+        return (
+            this.model.isReady &&
+            list.isGrouped &&
+            list.groupByField.type === "many2one" &&
+            list.groups.length === 0 &&
+            createGroup
+        );
     }
 
     get canQuickCreate() {
         const { activeActions } = this.props.archInfo;
         if (!activeActions.quickCreate) {
+            return false;
+        }
+        if (!this.model.isReady) {
             return false;
         }
 

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -6,7 +6,7 @@
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
                 <t t-set-slot="control-panel-create-button">
                     <t t-if="canCreate and props.showButtons">
-                        <button type="button" class="btn btn-primary o-kanban-button-new" accesskey="c" t-on-click="() => this.createRecord()" data-bounce-button="">
+                        <button type="button" t-att-disabled="isNewButtonDisabled" class="btn btn-primary o-kanban-button-new" accesskey="c" t-on-click="() => this.createRecord()" data-bounce-button="">
                             New
                         </button>
                     </t>
@@ -81,7 +81,7 @@
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-if="!hasSelectedRecords" t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
-                <t t-component="props.Renderer"
+                <t t-component="props.Renderer" t-if="model.isReady"
                     list="model.root"
                     archInfo="props.archInfo"
                     Compiler="props.Compiler"

--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.js
@@ -77,7 +77,10 @@ export class KanbanQuickCreateController extends Component {
         };
         this.model = useState(new this.props.Model(this.env, { config }, modelServices));
 
-        onWillStart(() => this.model.load());
+        onWillStart(async () => {
+            await this.model.load();
+            this.model.whenReady.resolve();
+        });
 
         onMounted(() => {
             this.uiActiveElement = this.uiService.activeElement;

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -85,7 +85,7 @@
                         </t>
                     </div>
                 </t>
-                <t t-component="props.Renderer"
+                <t t-component="props.Renderer" t-if="model.isReady"
                     list="model.root"
                     activeActions="activeActions"
                     archInfo="archInfo"

--- a/addons/web/static/src/views/pivot/pivot_controller.js
+++ b/addons/web/static/src/views/pivot/pivot_controller.js
@@ -20,7 +20,11 @@ export class PivotController extends Component {
     };
 
     setup() {
-        this.model = useModelWithSampleData(this.props.Model, this.props.modelParams);
+        this.model = useModelWithSampleData(
+            this.props.Model,
+            this.props.modelParams,
+            this.modelOptions
+        );
 
         useSetupAction({
             rootRef: useRef("root"),
@@ -32,6 +36,19 @@ export class PivotController extends Component {
         });
         this.searchBarToggler = useSearchBarToggler();
     }
+
+    get displayNoContent() {
+        if (this.props.info.noContentHelp === false) {
+            return false;
+        }
+        const { metaData, useSampleModel } = this.model;
+        return useSampleModel || !this.model.hasData() || !metaData.activeMeasures.length;
+    }
+
+    get modelOptions() {
+        return { lazy: !this.env.inDialog && !!this.props.display.controlPanel };
+    }
+
     /**
      * @returns {Object}
      */

--- a/addons/web/static/src/views/pivot/pivot_controller.xml
+++ b/addons/web/static/src/views/pivot/pivot_controller.xml
@@ -31,19 +31,13 @@
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
-                <t t-set="displayNoContent" t-value="
-                    props.info.noContentHelp !== false and (
-                        !(model.hasData() and model.metaData.activeMeasures.length) or
-                        model.useSampleModel
-                    )"
-                />
-                <t t-if="displayNoContent">
+                <t t-if="model.isReady and displayNoContent">
                     <t t-if="props.info.noContentHelp" t-call="web.ActionHelper">
                         <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
                     </t>
                     <t t-else="" t-call="web.NoContentHelper"/>
                 </t>
-                <t t-component="props.Renderer" model="model" buttonTemplate="props.buttonTemplate"/>
+                <t t-if="model.isReady" t-component="props.Renderer" model="model" buttonTemplate="props.buttonTemplate"/>
             </Layout>
         </div>
     </t>

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -19,7 +19,7 @@ import {
     mockTimeZone,
     runAllTimers,
 } from "@odoo/hoot-mock";
-import { Component, onRendered, onWillRender, onWillStart, xml } from "@odoo/owl";
+import { Component, onRendered, onWillStart, xml } from "@odoo/owl";
 import {
     MockServer,
     contains,
@@ -4908,33 +4908,6 @@ test(`calendar with custom quick create view`, async () => {
     });
     await clickAllDaySlot("2016-12-01");
     expect.verifySteps(["add dialog 2"]);
-});
-
-test(`check onWillStartModel is exectuted`, async () => {
-    class TestCalendarController extends CalendarController {
-        setup() {
-            super.setup();
-            onWillRender(() => {
-                expect.step("render");
-            });
-        }
-        onWillStartModel() {
-            expect.step("onWillStartModel");
-        }
-    }
-
-    registry.category("views").add("test_calendar_view", {
-        ...calendarView,
-        Controller: TestCalendarController,
-    });
-
-    await mountView({
-        resModel: "event",
-        type: "calendar",
-        arch: `<calendar js_class="test_calendar_view" date_start="start" date_stop="stop" all_day="is_all_day" mode="month"/>`,
-        limit: 3,
-    });
-    expect.verifySteps(["onWillStartModel", "render"]);
 });
 
 test(`check apply default record label`, async () => {

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -2883,3 +2883,22 @@ test("limit dataset amount", async () => {
     expect(model.data.datasets).toHaveLength(600);
     expect(model.data.labels).toHaveLength(600);
 });
+
+test.tags("desktop");
+test("graph views make their control panel available directly", async () => {
+    const def = new Deferred();
+    onRpc("formatted_read_group", () => def);
+    await mountView({
+        type: "graph",
+        resModel: "foo",
+        arch: `<graph/>`,
+    });
+
+    expect(".o_graph_view").toHaveCount(1);
+    expect(".o_graph_view .o_control_panel .o_searchview").toHaveCount(1);
+    expect(".o_graph_view .o_graph_renderer").toHaveCount(0);
+
+    def.resolve();
+    await animationFrame();
+    expect(".o_graph_view .o_graph_renderer").toHaveCount(1);
+});

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -3839,3 +3839,26 @@ test("display the field's falsy_value_label for false group, if defined", async 
 
     expect(queryAllTexts("tbody th")).toEqual(["Total", "xpad", "I'm the false group"]);
 });
+
+test.tags("desktop");
+test("pivot views make their control panel available directly", async () => {
+    const def = new Deferred();
+    onRpc("formatted_read_group", () => def);
+    await mountView({
+        type: "pivot",
+        resModel: "partner",
+        arch: `
+            <pivot>
+                <field name="foo" type="row"/>
+            </pivot>`,
+        groupBy: ["product_id"],
+    });
+
+    expect(".o_pivot_view").toHaveCount(1);
+    expect(".o_pivot_view .o_control_panel .o_searchview").toHaveCount(1);
+    expect(".o_pivot_view .o_pivot").toHaveCount(0);
+
+    def.resolve();
+    await animationFrame();
+    expect(".o_pivot_view .o_pivot").toHaveCount(1);
+});

--- a/addons/web/static/tests/webclient/actions/concurrency.test.js
+++ b/addons/web/static/tests/webclient/actions/concurrency.test.js
@@ -35,6 +35,8 @@ const actionRegistry = registry.category("actions");
 class Partner extends models.Model {
     _rec_name = "display_name";
 
+    start = fields.Date();
+
     _records = [
         { id: 1, display_name: "First record" },
         { id: 2, display_name: "Second record" },
@@ -58,6 +60,7 @@ class Partner extends models.Model {
                 </templates>
             </kanban>`,
         "list,false": `<list><field name="display_name"/></list>`,
+        "calendar,false": `<calendar date_start="start"/>`,
         "search,false": `<search/>`,
     };
 }
@@ -88,6 +91,7 @@ defineActions([
         views: [
             [false, "list"],
             [1, "kanban"],
+            [false, "calendar"],
             [false, "form"],
         ],
     },
@@ -205,10 +209,21 @@ test("clicking quickly on breadcrumbs...", async () => {
 
 test.tags("desktop");
 test("execute a new action while loading a lazy-loaded controller", async () => {
-    redirect("/odoo/action-4/2?cids=1");
+    defineActions([
+        {
+            id: 77,
+            type: "ir.actions.act_window",
+            res_model: "partner",
+            views: [
+                [false, "calendar"],
+                [false, "form"],
+            ],
+        },
+    ]);
+    redirect("/odoo/action-77/2?cids=1");
 
     let def;
-    onRpc("partner", "web_search_read", () => def);
+    onRpc("partner", "search_read", () => def);
     stepAllNetworkCalls();
 
     await mountWithCleanup(WebClient);
@@ -232,11 +247,11 @@ test("execute a new action while loading a lazy-loaded controller", async () => 
         "/web/action/load",
         "get_views",
         "web_read",
-        "web_search_read",
-        "has_group",
+        "search_read",
         "/web/action/load",
         "get_views",
         "web_search_read",
+        "has_group",
     ]);
 
     // unblock the switch to Kanban in action 4
@@ -399,14 +414,20 @@ test.tags("desktop");
 test("execute a new action while loading data of default view", async () => {
     const def = new Deferred();
     stepAllNetworkCalls();
-    onRpc("web_search_read", () => def);
+    onRpc("web_read", () => def);
 
     await mountWithCleanup(WebClient);
-    // execute a first action (its 'search_read' RPC is blocked)
-    getService("action").doAction(3);
+    // execute a first action (its 'web_read' RPC is blocked)
+    getService("action").doAction({
+        name: "A Partner",
+        res_model: "partner",
+        res_id: 1,
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+    });
     await animationFrame();
-    expect(".o_list_view").toHaveCount(0, {
-        message: "should not display the list view of action 3",
+    expect(".o_form_view").toHaveCount(0, {
+        message: "should not display the form view",
     });
 
     // execute another action meanwhile (and unlock the RPC)
@@ -416,37 +437,37 @@ test("execute a new action while loading data of default view", async () => {
     expect(".o_kanban_view").toHaveCount(1, {
         message: "should display the kanban view of action 4",
     });
-    expect(".o_list_view").toHaveCount(0, {
-        message: "should not display the list view of action 3",
+    expect(".o_form_view").toHaveCount(0, {
+        message: "should not display the form view",
     });
     expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual(["Partners Action 4"]);
     expect.verifySteps([
         "/web/webclient/translations",
         "/web/webclient/load_menus",
+        "get_views",
+        "web_read",
         "/web/action/load",
         "get_views",
         "web_search_read",
         "has_group",
-        "/web/action/load",
-        "get_views",
-        "web_search_read",
     ]);
 });
 
 test.tags("desktop");
 test("open a record while reloading the list view", async () => {
     let def;
-    onRpc("web_search_read", () => def);
+    onRpc("search_read", () => def);
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(3);
+    expect(".o_calendar_view").toHaveCount(0);
     expect(".o_list_view").toHaveCount(1);
     expect(".o_list_view .o_data_row").toHaveCount(2);
     expect(".o_control_panel .o_list_buttons").toHaveCount(1);
 
     // reload (the search_read RPC will be blocked)
     def = new Deferred();
-    await switchView("list");
+    await switchView("calendar");
     expect(".o_list_view .o_data_row").toHaveCount(2);
     expect(".o_control_panel .o_list_buttons").toHaveCount(1);
 
@@ -460,6 +481,7 @@ test("open a record while reloading the list view", async () => {
     await animationFrame();
     expect(".o_form_view").toHaveCount(1);
     expect(".o_list_view").toHaveCount(0);
+    expect(".o_calendar_view").toHaveCount(0);
     expect(".o_control_panel .o_list_buttons").toHaveCount(0);
 });
 
@@ -595,15 +617,18 @@ test("switching when doing an action -- get_views slow", async () => {
 test.tags("desktop");
 test("switching when doing an action -- search_read slow", async () => {
     const def = new Deferred();
-    const defs = [null, def, null];
-    onRpc("web_search_read", () => defs.shift());
+    onRpc("search_read", () => def);
     stepAllNetworkCalls();
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(3);
     expect(".o_list_view").toHaveCount(1);
 
-    getService("action").doAction(4);
+    getService("action").doAction({
+        type: "ir.actions.act_window",
+        res_model: "partner",
+        views: [[false, "calendar"]],
+    });
     await animationFrame();
     await switchView("kanban");
     def.resolve();
@@ -618,9 +643,8 @@ test("switching when doing an action -- search_read slow", async () => {
         "get_views",
         "web_search_read",
         "has_group",
-        "/web/action/load",
         "get_views",
-        "web_search_read",
+        "search_read",
         "web_search_read",
     ]);
 });

--- a/addons/web/static/tests/webclient/actions/error_handling.test.js
+++ b/addons/web/static/tests/webclient/actions/error_handling.test.js
@@ -172,7 +172,24 @@ test.tags("desktop");
 test("connection lost when coming back to kanban from form", async () => {
     expect.errors(1);
 
-    stepAllNetworkCalls();
+    let offline = false;
+    onRpc(
+        "/*",
+        (req) => {
+            const url = new URL(req.url).pathname;
+            if (!url.startsWith("/web/webclient/translations")) {
+                expect.step(url);
+            }
+            if (url === "/web/webclient/version_info") {
+                // simulate a connection restore
+                return true;
+            }
+            if (offline) {
+                throw new Error(); // simulate a ConnectionLost error
+            }
+        },
+        { pure: true }
+    );
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
@@ -181,38 +198,35 @@ test("connection lost when coming back to kanban from form", async () => {
     await contains(".o_kanban_record").click();
     expect(".o_form_view").toHaveCount(1);
 
-    mockFetch((input) => {
-        expect.step(input);
-        if (input === "/web/webclient/version_info") {
-            // simulate a connection restore at the end of the test, to have no
-            // impact on other tests (see connectionLostNotifRemove)
-            return true;
-        }
-        throw new Error(); // simulate a ConnectionLost error
-    });
+    offline = true;
     await contains(".o_breadcrumb .o_back_button a").click();
     await animationFrame();
-    expect(".o_form_view").toHaveCount(1);
+    expect(".o_form_view").toHaveCount(0);
+    expect(".o_kanban_view").toHaveCount(1);
+    expect(".o_kanban_view .o_kanban_renderer").toHaveCount(0);
     expect(".o_notification").toHaveCount(1);
     expect(".o_notification").toHaveText("Connection lost. Trying to reconnect...");
     expect.verifySteps([
-        "/web/webclient/translations",
         "/web/webclient/load_menus",
         "/web/action/load",
-        "get_views",
-        "web_search_read",
-        "has_group",
-        "web_read",
-        "/web/dataset/call_kw/partner/web_search_read", // from mockFetch
+        "/web/dataset/call_kw/partner/get_views",
+        "/web/dataset/call_kw/partner/web_search_read",
+        "/web/dataset/call_kw/res.users/has_group",
+        "/web/dataset/call_kw/partner/web_read",
+        "/web/dataset/call_kw/partner/web_search_read",
     ]);
     await animationFrame();
     expect.verifySteps([]); // doesn't indefinitely try to reload the list
 
-    // cleanup
     await runAllTimers();
     await animationFrame();
     expect.verifySteps(["/web/webclient/version_info"]);
     expect.verifyErrors([Error]);
+
+    offline = false;
+    await contains(".o_searchview .o_searchview_icon").click();
+    expect(".o_kanban_view .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(2);
+    expect.verifySteps(["/web/dataset/call_kw/partner/web_search_read"]);
 });
 
 test("error on onMounted", async () => {

--- a/addons/web/static/tests/webclient/actions/push_state.test.js
+++ b/addons/web/static/tests/webclient/actions/push_state.test.js
@@ -417,7 +417,7 @@ test(`properly push state`, async () => {
 
 test(`push state after action is loaded, not before`, async () => {
     const def = new Deferred();
-    onRpc("web_search_read", () => def);
+    onRpc("get_views", () => def);
 
     await mountWithCleanup(WebClient);
     expect(browser.location.href).toBe("http://example.com/odoo");


### PR DESCRIPTION
*: calendar, lunch

This commit tweaks the view's common model, and especially the
list, kanban, graph and pivot views such that their control panel
is show directly, without waiting for the data to be loaded. This
allows to interact more quickly with the search view, for instance
to refine the search and hopefully get a result faster, in slow
views/models. This also allows to access the buttons (e.g. "New" or
switch view icons).

This is the default behavior, but this commit disables it in the
calendar and lunch list and kanban views, because they customize
the way their data is fetched (they have more rpcs to do to fetch
their data), so our new strategy doesn't map well with these views.
We could make it could, but it would require to rework those views
a little bit, which isn't the point of this commit.

task-4282605