### PR TITLE
[FIX] web_editor: prevent oe-tabs selection overflow

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -271,6 +271,7 @@ function sanitizeNode(node, root) {
         }
         if (isEditorTab(tabPreviousSibling)) {
             node.style.width = '40px';
+            node.style.tabSize = '40px';
         } else {
             const editable = closestElement(node, '.odoo-editor-editable');
             if (editable?.firstElementChild) {
@@ -282,6 +283,7 @@ function sanitizeNode(node, root) {
                 if (nodeRect.width && referenceRect.width) {
                     const width = (nodeRect.left - referenceRect.left) % 40;
                     node.style.width = (40 - width) + 'px';
+                    node.style.tabSize = (40 - width) + 'px';
                 }
             }
         }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/tabs.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/tabs.test.js
@@ -15,7 +15,7 @@ describe('Tabs', () => {
     const oeTab =  (size, contenteditable = true) => (
         `<span class="oe-tabs"` +
             (contenteditable ? '' : ' contenteditable="false"') +
-            (size ?` style="width: ${size}px;"` : '') +
+            (size ?` style="width: ${size}px; tab-size: ${size}px;"` : '') +
         `>\u0009</span>\u200B`
     );
     describe('insert tabulation', () => {


### PR DESCRIPTION
Problem:
The inner content (text) of `oe-tabs` can be larger than the `span`
itself, causing the selection to visually overflow outside the tab.

Solution:
Set `tab-size` to match `width` for `oe-tabs` to prevent the
selection overflow.

Steps to reproduce:
1. Add a tab between some text in the editor.
2. Select only the tab.
3. Notice that the selection (blue highlight) visually overflows
   outside the tab.

opw-4711458

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
