### PR TITLE
[FIX] point_of_sale: fix runbot error

### DIFF
--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -303,7 +303,6 @@ def setup_pos_combo_items(self):
             "list_price": 40,
             "name": "Custom Attr Combo",
             "type": "combo",
-            "categ_id": self.env.ref("product.product_category_2").id,
             "combo_ids": custom_combo.ids,
         }
     )


### PR DESCRIPTION
Fix tests that were using unexisting category in runbot. Removing the category from the product since categ_id isn't necessary in PoS tests.

runbot error: 162900

