### PR TITLE
[FIX] mail: show 'Mark as Unread' button in mobile view

### DIFF
--- a/addons/mail/static/src/discuss/core/common/message_actions.js
+++ b/addons/mail/static/src/discuss/core/common/message_actions.js
@@ -14,7 +14,7 @@ messageActionsRegistry.add("set-new-message-separator", {
         return (
             thread &&
             thread.selfMember &&
-            component.isOriginThread &&
+            thread.eq(component.message.thread) &&
             !component.message.hasNewMessageSeparator
         );
     },


### PR DESCRIPTION
Before this commit,
The 'Mark as Unread' button was missing in the mobile view because 
the `set-new-message-separator` action relied on `component.isOriginThread`.
`isOriginThread` property exists on the `Message` component but not on 
`MessageActionMenuMobile`, which is used in mobile view.

This commit fixes the issue by removing the dependency on `isOriginThread` from 
`message-actions` and instead introducing an inline condition.

As a result, the 'Mark as Unread' button now displays correctly on mobile.

task-[4686591](https://www.odoo.com/odoo/project/1519/tasks/4686591)