### PR TITLE
[FIX] stock: reserve only full packages for stock moves

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1635,7 +1635,7 @@ Please change the quantity done or the rounding precision in your settings.""",
             owner_id = self.env['res.partner']
 
         quants = self.env['stock.quant']._get_reserve_quantity(
-            self.product_id, location_id, need, uom_id=self.product_uom,
+            self.product_id, location_id, need, uom_id=self.packaging_uom_id or self.product_uom,
             lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict)
 
         taken_quantity = 0

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -875,6 +875,8 @@ class StockQuant(models.Model):
         # will take care of changing the UOM to the UOM of the product.
         if not strict and uom_id and product_id.uom_id != uom_id:
             quantity_move_uom = product_id.uom_id._compute_quantity(quantity, uom_id, rounding_method='DOWN')
+            if product_id.categ_id.packaging_reserve_method == 'full':
+                quantity_move_uom //= 1
             quantity = uom_id._compute_quantity(quantity_move_uom, product_id.uom_id, rounding_method='HALF-UP')
 
         if product_id.tracking == 'serial':


### PR DESCRIPTION
Issue
-----
Deliveries reserve up to the on hand quantity of products, even when the product is in a category for which only full packages should be reserved.

Steps to reproduce
-----
- Install Inventory, Sales apps
- Enable packages in the settings
- Create a Product Category
  - Reserve Only Full Packagings
- Create a product
  - Tracked by quantity
  - In the Sales tab, add the "Pack of 6" packaging
  - Update the on hand quantity to 10
- Create a new Sale Order for 2 packs of 6 of the product & confirm it
- Open the linked Delivery
- Open the linked Delivery

-> The reserved quantity is 10 instead of 6

Cause
-----
Packagings have been removed in 18.1, we now only use UoMs. When cleaning up for the change, the specific use case with the "Reserve Only Full Packagings" field in product.category has been overlooked and the condition handling it in
stock.quant's `_get_reserve_quantity` method was removed because it relied on packagings.

We cannot rely on the packaging's `_check_qty` method to compute the quantity, but since the packaging uom is now a field of the move, we can just use it instead of the default product uom when calling `_get_reserve_quantity`.

We can then just apply flooring to the packaging uom when needed.

-----
Ticket:
opw-4595779
