### PR TITLE
[FIX] mail,hr: fix avatar popover missing information

### DIFF
--- a/addons/hr/__init__.py
+++ b/addons/hr/__init__.py
@@ -3,6 +3,7 @@
 
 from . import models
 from . import wizard
+from . import controllers
 from . import populate
 
 

--- a/addons/hr/controllers/__init__.py
+++ b/addons/hr/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import avatar_card

--- a/addons/hr/controllers/avatar_card.py
+++ b/addons/hr/controllers/avatar_card.py
@@ -1,0 +1,53 @@
+from odoo import http
+from odoo.http import request
+from odoo.addons.mail.controllers.avatar_card import AvatarCardController
+
+USER_TO_EMPLOYEE_FIELDS = {
+    "work_phone": "work_phone",
+    "work_email": "work_email",
+    "job_title": "job_title",
+    "department_id": "department_id",
+    "employee_parent_id": "parent_id",
+}
+
+
+class EmployeeAvatarCardController(AvatarCardController):
+
+    def _get_user_fields(self):
+        fields = super()._get_user_fields()
+        fields.extend(
+            [
+                *self._get_user_employee_mapping().keys(),
+                "employee_ids",
+            ]
+        )
+        return fields
+
+    def _get_user_employee_mapping(self):
+        return USER_TO_EMPLOYEE_FIELDS
+
+    def _get_default_employee_multi_company(self, user_id):
+        user_to_employee_fields = self._get_user_employee_mapping()
+        employees = request.env["hr.employee"].search_read(
+                domain=[("user_id", "=", user_id)],
+                fields=list(user_to_employee_fields.values()),
+                limit=1,
+            )
+        return employees[0] if employees else False
+
+    def _employee_to_user_mapping(self, employee_mapping, user_mapping):
+        user_to_employee_fields = self._get_user_employee_mapping()
+        for field_user, field_employee in user_to_employee_fields.items():
+            user_mapping[field_user] = employee_mapping[field_employee]
+        user_mapping["employee_ids"] = [employee_mapping["id"]]
+
+    @http.route()
+    def mail_avatar_card_get_user_info(self, user_id):
+        user = super().mail_avatar_card_get_user_info(user_id)
+        if user.get("employee_ids"):
+            return user
+        employee_multi_company = self._get_default_employee_multi_company(user_id)
+        if not employee_multi_company:
+            return user
+        self._employee_to_user_mapping(employee_multi_company, user)
+        return user

--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
@@ -7,7 +7,7 @@ import { useService } from "@web/core/utils/hooks";
 export const patchAvatarCardPopover = {
     setup() {
         super.setup();
-        this.userInfoTemplate = "hr.avatarCardUserInfos",
+        this.userInfoTemplate = "hr.avatarCardUserInfos";
         this.actionService = useService("action");
     },
     get fieldNames(){
@@ -30,7 +30,7 @@ export const patchAvatarCardPopover = {
     async onClickViewEmployee(){
         const employeeId = this.user.employee_ids[0];
         const action = await this.orm.call('hr.employee', 'get_formview_action', [employeeId]);
-        this.actionService.doAction(action); 
+        this.actionService.doAction(action);
     }
 };
 

--- a/addons/hr/static/tests/helpers/mock_server/controllers/discuss.js
+++ b/addons/hr/static/tests/helpers/mock_server/controllers/discuss.js
@@ -1,0 +1,29 @@
+/* @odoo-module */
+
+import { patch } from "@web/core/utils/patch";
+import { MockServer } from "@web/../tests/helpers/mock_server";
+
+patch(MockServer.prototype, {
+    async _performRPC(route, args) {
+        if (route === "/mail/avatar_card/get_user_info") {
+            const user_info = await super._performRPC(route, args);
+            const { user_id } = args;
+            const user = this.pyEnv["res.users"].searchRead([["id", "=", user_id]])[0];
+            user_info.job_title = user.job_title;
+            user_info.department_id = user.department_id;
+            user_info.work_phone = user.work_phone;
+            user_info.work_email = user.work_email;
+            const employee = this.pyEnv["hr.employee"].searchRead([["user_id", "=", user_id]])[0];
+            if (employee) {
+                user_info.work_phone = employee.work_phone;
+                user_info.work_email = employee.work_email;
+                user_info.job_title = employee.job_title;
+                user_info.department_id = employee.department_id;
+                user_info.employee_parent_id = employee.parent_id;
+                user_info.employee_ids = [employee.id];
+            }
+            return user_info;
+        }
+        return super._performRPC(route, args);
+    }
+})

--- a/addons/hr/static/tests/web/m2x_avatar_user_tests.js
+++ b/addons/hr/static/tests/web/m2x_avatar_user_tests.js
@@ -63,23 +63,7 @@ QUnit.module("M2XAvatarUser", ({ beforeEach }) => {
             job_title: "sub manager",
             department_id: departmentId,
         });
-        const mockRPC = (route, args) => {
-            if(route === "/web/dataset/call_kw/res.users/read"){
-                assert.deepEqual(args.args[1], [
-                "name", 
-                "email", 
-                "phone", 
-                "im_status",
-                "share",
-                "work_phone",
-                "work_email",
-                "job_title",
-                "department_id",
-                "employee_parent_id",
-                "employee_ids"]);
-                assert.step("user read");
-            }
-        };
+
         const avatarUserId = pyEnv["m2x.avatar.user"].create({ user_id: userId });
         const views = {
             "m2x.avatar.user,false,kanban": `
@@ -93,7 +77,7 @@ QUnit.module("M2XAvatarUser", ({ beforeEach }) => {
                         </templates>
                     </kanban>`,
         };
-        const { openView } = await start({ serverData: { views }, mockRPC });
+        const { openView } = await start({ serverData: { views }});
         await openView({
             res_model: "m2x.avatar.user",
             res_id: avatarUserId,
@@ -108,7 +92,7 @@ QUnit.module("M2XAvatarUser", ({ beforeEach }) => {
         });
         // Open card
         await click(document, ".o_m2o_avatar > img");
-        assert.verifySteps(["setTimeout of 250ms", "user read"]);
+        assert.verifySteps(["setTimeout of 250ms"]);
         assert.containsOnce(target, ".o_avatar_card");
         assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_card_user_infos > *")), ['Mario', 'sub manager', 'Managemment', 'Mario@odoo.pro', '+585555555']);
         // Close card

--- a/addons/hr/tests/__init__.py
+++ b/addons/hr/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_avatar_card
 from . import test_hr_employee
 from . import test_channel
 from . import test_self_user_access

--- a/addons/hr/tests/test_avatar_card.py
+++ b/addons/hr/tests/test_avatar_card.py
@@ -1,0 +1,70 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+
+
+class TestAvatarCardMultiCompanies(HttpCaseWithUserDemo):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._mc_enabled = True
+        cls.company_1 = cls.env["res.company"].search([("name", "=", "YourCompany")], limit=1)
+        cls.company_2 = cls.env["res.company"].create(
+            {
+                "name": "Test Company 2",
+            }
+        )
+        cls.user_1 = cls.env["res.users"].create(
+            {
+                "name": "Test User 1",
+                "login": "test_user_1",
+            }
+        )
+        cls.user_2 = cls.env["res.users"].create(
+            {
+                "name": "Test User 2",
+                "login": "test_user_2",
+            }
+        )
+        cls.user_admin.write(
+            {
+                "company_ids": [(4, cls.company_1.id), (4, cls.company_2.id)],
+            }
+        )
+        cls.employee_1 = cls.env["hr.employee"].create(
+            {
+                "name": "Test Employee 1",
+                "user_id": cls.user_1.id,
+                "company_id": cls.company_1.id,
+                "work_email": "test_employee_1@test.com",
+            }
+        )
+
+        cls.employee_2 = cls.env["hr.employee"].create(
+            {
+                "name": "Test Employee 2",
+                "user_id": cls.user_2.id,
+                "company_id": cls.company_2.id,
+                "work_email": "test_employee_2@test.com",
+            }
+        )
+
+    def test_avatar_card_multi_company_takes_default_company(self):
+        self.authenticate("admin", "admin")
+        response = self.make_jsonrpc_request(
+            "/mail/avatar_card/get_user_info", {"user_id": self.user_1.id}
+        )
+        self.assertEqual(
+            response["work_email"],
+            "test_employee_1@test.com"
+        )
+
+    def test_avatar_card_multi_company_takes_other_company(self):
+        self.authenticate("admin", "admin")
+        response = self.make_jsonrpc_request(
+            "/mail/avatar_card/get_user_info", {"user_id": self.user_2.id}
+        )
+        self.assertEqual(
+            response["work_email"],
+            "test_employee_2@test.com"
+        )

--- a/addons/mail/controllers/__init__.py
+++ b/addons/mail/controllers/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import attachment
+from . import avatar_card
 from . import google_translate
 from . import guest
 from . import link_preview

--- a/addons/mail/controllers/avatar_card.py
+++ b/addons/mail/controllers/avatar_card.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from werkzeug.exceptions import NotFound
+
+from odoo import http
+from odoo.http import request
+
+
+class AvatarCardController(http.Controller):
+    def _get_user_fields(self):
+        return ["name", "email", "phone", "im_status", "share"]
+
+    @http.route("/mail/avatar_card/get_user_info", methods=["POST"], type="json", auth="user")
+    def mail_avatar_card_get_user_info(self, user_id):
+        fields = self._get_user_fields()
+        user = request.env["res.users"].search_read(
+            domain=[("id", "=", user_id)],
+            fields=fields,
+            limit=1,
+        )
+        if not user:
+            raise NotFound()
+        return user[0]

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -15,15 +15,17 @@ export class AvatarCardPopover extends Component {
     setup() {
         this.orm = useService("orm");
         this.openChat = useOpenChat("res.users");
+        this.rpc = useService("rpc");
         onWillStart(async () => {
-            [this.user] = await this.orm.read("res.users", [this.props.id], this.fieldNames);
+            this.user = await this.rpc("/mail/avatar_card/get_user_info", {
+                user_id: this.props.id,
+            });
         });
     }
 
     get fieldNames() {
         return ["name", "email", "phone", "im_status", "share"];
     }
-
     get email() {
         return this.user.email;
     }

--- a/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
@@ -197,6 +197,16 @@ patch(MockServer.prototype, {
         if (route === "/discuss/gif/favorites") {
             return [[]];
         }
+        if (route === "/mail/avatar_card/get_user_info") {
+            const { user_id } = args;
+            const user = this.pyEnv["res.users"].searchRead([["id", "=", user_id]])[0];
+            return {
+                id: user.id,
+                name: user.name,
+                email: user.email,
+                phone: user.phone,
+            }
+        }
         return super._performRPC(route, args);
     },
     /**

--- a/addons/mail/static/tests/web/fields/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/web/fields/m2x_avatar_user_tests.js
@@ -413,12 +413,6 @@ QUnit.test("avatar card preview", async (assert) => {
         phone: "+78786987",
         im_status: "online",
     });
-    const mockRPC = (route, args) => {
-        if (route === "/web/dataset/call_kw/res.users/read") {
-            assert.deepEqual(args.args[1], ["name", "email", "phone", "im_status", "share"]);
-            assert.step("user read");
-        }
-    };
     const avatarUserId = pyEnv["m2x.avatar.user"].create({ user_id: userId });
     const views = {
         "m2x.avatar.user,false,kanban": `
@@ -432,7 +426,7 @@ QUnit.test("avatar card preview", async (assert) => {
                     </templates>
                 </kanban>`,
     };
-    const { openView } = await start({ serverData: { views }, mockRPC });
+    const { openView } = await start({ serverData: { views }});
     await openView({
         res_model: "m2x.avatar.user",
         res_id: avatarUserId,
@@ -451,7 +445,7 @@ QUnit.test("avatar card preview", async (assert) => {
     await contains(".o_card_user_infos > span", { text: "Mario" });
     await contains(".o_card_user_infos > a", { text: "Mario@odoo.test" });
     await contains(".o_card_user_infos > a", { text: "+78786987" });
-    assert.verifySteps(["setTimeout of 250ms", "user read"]);
+    assert.verifySteps(["setTimeout of 250ms"]);
     // Close card
     await click(".o_action_manager");
     await contains(".o_avatar_card", { count: 0 });


### PR DESCRIPTION
Before this commit the employee information was not displayed in the
avatar popover when the user was in another company. Only the partner
information was available.

Steps to reproduce:
- Install hr, mail, project
- Create user A with employee B in company A
- Create user B with employee B in company B
- Assign both users to the same task
- click on the avatar

This is due to the special way the employe is linked to the user
(`employee_ids` in `res.users`) with a domain keeping the default
employee in the same company.

It was fixed by creating an rpc call that get the information directly
from the `res.users` and `hr.employee` models, therefore still enforcing
the ACLs on those models.

task-4648745

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
