### PR TITLE
[FIX] product: give docs value to the report data for pricelist report

### DIFF
--- a/addons/product/report/product_pricelist_report.py
+++ b/addons/product/report/product_pricelist_report.py
@@ -41,6 +41,7 @@ class ProductPricelistReport(models.AbstractModel):
             'pricelist': pricelist,
             'products': products_data,
             'quantities': quantities,
+            'docs': pricelist,
         }
 
     def _get_product_data(self, is_product_tmpl, product, pricelist, quantities):


### PR DESCRIPTION
Steps to reproduce:

1) Install sales, l10n_din5008_sale and enable pricelist from settings 
2) Change the document layout to `DIN 5008` from settings
3) Open the pricelist from sales and print the pricelist report with a product

Issue:-

Pricelist report gets printed with "Invoice" title

Cause:-

This is because in the `DIN 5008` report, we print the invoice title by default if there are no `docs` or `object` values.

https://github.com/odoo/odoo/blob/c80db0e6ff96ed4d8a00f01817694a4edcca6c64/addons/l10n_din5008/report/din5008_report.xml#L93

Solution:
Provide the docs value to the pricelist report values.

opw-4680444

