### PR TITLE
[FIX] mrp: calculate workorder workcenter costs as intervals

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -8,6 +8,7 @@ import json
 
 from odoo import api, fields, models, _, SUPERUSER_ID
 from odoo.exceptions import UserError, ValidationError
+from odoo.addons.resource.models.utils import Intervals, sum_intervals
 from odoo.tools import float_compare, float_round, format_datetime
 
 
@@ -554,9 +555,10 @@ class MrpWorkorder(models.Model):
 
     def _cal_cost(self):
         total = 0
-        for wo in self:
-            duration = sum(wo.time_ids.mapped('duration'))
-            total += (duration / 60.0) * wo.workcenter_id.costs_hour
+        for workorder in self:
+            intervals = Intervals([[t.date_start, t.date_end, t] for t in workorder.time_ids])
+            duration = sum_intervals(intervals)
+            total += duration * workorder.workcenter_id.costs_hour
         return total
 
     @api.model


### PR DESCRIPTION
**Current behavior**
Having multiple employees on a workorder with overlapping work
intervals will result in an inaccurate valuation value.

**Expected behavior:**
Accurate valuation.

**Steps to reproduce:**
1. Create a BOM with an operation (workorder) for a finished
product which is valuated

2. Create an MO for that BOM, assign multiple employees on the
workorder with various (overlapping) working intervals

3. Process the MO -> look at the valuation generated -> its
value is too high (because it counted the overlapping work
intervals)

**Cause of the issue**
A workorder's resource intervals are currently just naively
summed.

**Fix**
Use the `Intervals` class to find the union of all resources in
a workorder.

opw-4430375