### PR TITLE
[FIX] sale_project: set project on purchase order

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -453,6 +453,6 @@ class SaleOrderLine(models.Model):
 
     def _prepare_procurement_values(self, group_id=False):
         values = super()._prepare_procurement_values(group_id=group_id)
-        if self.project_id:
+        if self.project_id or self.order_id.project_id:
             values['project_id'] = self.order_id.project_id.id
         return values


### PR DESCRIPTION
###  Steps to Reproduce:
  - Create Product 1:
    - Type: Goods
    - Routes: Dropship and Buy
- Create Product 2:
    - Type: Service
    - Create on Order: Project & Task
- Create Sale Order and Confirm
- Open Purchase Order
- Check Project

### Issue:
 When the product's route is set to Dropship the project was not being set on the purchase order.

### Fix:
  This commit ensures that the project associated with the sale order is now correctly set on the purchase order.

###  Technical Issue:
  There is no direct bridge module between sale_project and stock_dropshipping, so we are setting the project_id from sale_project module.

task-4690044