### PR TITLE
[IMP] resource_mail: remove color field from resource

### DIFF
--- a/addons/resource_mail/models/resource_resource.py
+++ b/addons/resource_mail/models/resource_resource.py
@@ -2,19 +2,25 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from random import randint
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResourceResource(models.Model):
     _inherit = 'resource.resource'
 
-    def _default_color(self):
-        return randint(1, 11)
-
-    color = fields.Integer(default=_default_color)
+    role_color = fields.Integer(string='Role Color', compute='_compute_role_color', store=False)
     im_status = fields.Char(related='user_id.im_status')
 
     def get_avatar_card_data(self, fields):
         return self.env['resource.resource'].search_read(
             domain=[('id', 'in', self.ids)],
         )
+
+    @api.depends("role_ids")
+    def _compute_role_color(self):
+        for slot in self:
+            if slot.role_ids:
+                slot.role_color = slot.role_ids[0].color
+            else:
+                # fallback to prevent not having color in dark mode (dont use 0)
+                slot.role_color = 1

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -24,7 +24,7 @@ export class AvatarResourceMany2XAutocomplete extends Many2XAutocomplete {
         return this.orm.call(
             this.props.resModel,
             "search_read",
-            [this.getDomain(request), ["id", "display_name", "resource_type", "color"]],
+            [this.getDomain(request), ["id", "display_name", "resource_type", "role_color"]],
             {
                 context: this.props.context,
                 limit: this.props.searchLimit + 1,
@@ -69,7 +69,7 @@ const WithResourceFieldMixin = (T) => class ResourceFieldMixin extends T {
         return {
             ...super.getTagProps(...arguments),
             icon: record.data.resource_type === "user" ? null : "fa-wrench",
-            colorIndex: record.data.color,
+            colorIndex: record.data.role_color,
             img: record.data.resource_type === "user"
                 ? `/web/image/${this.relation}/${record.resId}/avatar_128`
                 : null,
@@ -90,7 +90,7 @@ const resourceFieldMixin = {
                 ],
             },
             {
-                name: "color",
+                name: "role_color",
                 type: "integer",
             },
         ];

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
@@ -3,7 +3,7 @@
     <t t-name="resource_mail.Many2ManyAvatarResourceField.option" t-inherit="web.Many2ManyTagsAvatarField.option">
         <xpath expr="//span[hasclass('o_avatar_many2x_autocomplete')]/img" position="before">
             <i t-if="autoCompleteItemScope.record.resource_type === 'material'" class="o_material_resource fa fa-wrench rounded text-center me-2
-            d-flex align-items-center justify-content-center" t-attf-class="o_colorlist_item_color_{{ autoCompleteItemScope.record.color }}"/>
+            d-flex align-items-center justify-content-center" t-attf-class="o_colorlist_item_color_{{ autoCompleteItemScope.record.role_color }}"/>
         </xpath>
         <xpath expr="//span[hasclass('o_avatar_many2x_autocomplete')]/img" position="attributes">
             <attribute name="t-if" add="&amp;&amp; autoCompleteItemScope.record.resource_type !== 'material'" separator=" "/>


### PR DESCRIPTION
Before this commit:
- The color field was visible in Resources > Materials kanban and list views.
- The color field was also displayed in the Many2ManyAvatarUserTagsList widget.

After this commit:
- The color field has been removed from all materials-related views, including the materials widget.

Task id: [4678837](https://www.odoo.com/odoo/project/4105/tasks/4678837)