### PR TITLE
[FIX] web: fix page no wrapping issue in PDF report footers with Montserrat Font

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -528,7 +528,7 @@
                 <div class="flex-grow-1 text-start me-2" t-field="company.report_footer"/>
                 <div class="text-end text-muted">
                     <div t-if="report_type == 'pdf' and display_name_in_footer" t-out="o.name">(document name)</div>
-                    <div t-if="report_type == 'pdf'">Page <span class="page"/> / <span class="topage"/></div>
+                    <div t-if="report_type == 'pdf'" class="text-nowrap">Page <span class="page"/> / <span class="topage"/></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Steps to reproduce:
1. Go to Settings > Configure your document layout> Select Text as Montserrat
2. Preview Document > open downloaded file

Issue:
The issue is when printing reports using the ‘Montserrat’ text font with ‘A4’ paper format in the ‘Configure Document Layout’ section of the general settings.
 The word "Páge" does not align correctly in a single line with "X/X" at the
 bottom right of the report. However, it prints correctly when using the other
fonts.

Solution:
Applied Bootstrap's text-nowrap class to prevent pagination text from breaking onto separate lines when using the Montserrat font. This addresses the issue where "<span class="page"/>" and "<span class="topage"/>" components were displaying on different lines in PDF reports.

opw-4654332


Before FIX:
![image](https://github.com/user-attachments/assets/8624b3c9-fa1f-4c80-8cdc-fec3c63b563a)

After FIX:
![image](https://github.com/user-attachments/assets/76a39e3a-f3ff-4636-bcb9-56d4e3027a0f)

