### PR TITLE
[FIX] purchase: correct typo in translation

### DIFF
--- a/addons/purchase/i18n/fr.po
+++ b/addons/purchase/i18n/fr.po
@@ -549,7 +549,7 @@ msgstr "<strong>Prix unitaire</strong>"
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.report_purchaseorder_document
 msgid "<strong>Your Order Reference</strong>"
-msgstr "<strong>YVotre référence de commande</strong>"
+msgstr "<strong>Votre référence de commande</strong>"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase


### PR DESCRIPTION
Small typo in .po file 'YVotre' => 'Votre'

Steps to reproduce:
-------------------
* Create an RFQ
* Add a vendor with french contact language
* Add a vendor reference
* Print the pruchase order
> Observation:

Why the fix:
------------
Typo

opw-4677629

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
