### PR TITLE
[FIX] mail, portal_rating: double composer when putting comment

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -259,6 +259,10 @@ export class Message extends Component {
         return _t("Expand");
     }
 
+    get isEditing() {
+        return this.props.message.composer;
+    }
+
     get message() {
         return this.props.message;
     }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -57,13 +57,13 @@
                                    'flex-row-reverse': isAlignedRight,
                                    }"
                         >
-                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': props.message.composer, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
-                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': props.message.composer }">
+                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
+                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': isEditing }">
                                     <t t-if="message.message_type === 'notification' and message.richBody" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
-                                    <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or props.message.composer or message.edited))">
-                                        <MessageLinkPreviewList t-if="!props.message.composer and message.linkPreviewSquash" messageLinkPreviews="message.message_link_preview_ids"/>
+                                    <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or isEditing or message.edited))">
+                                        <MessageLinkPreviewList t-if="!isEditing and message.linkPreviewSquash" messageLinkPreviews="message.message_link_preview_ids"/>
                                         <t t-else="">
-                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': props.message.composer }">
+                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': isEditing }">
                                                 <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',
@@ -72,16 +72,16 @@
                                                 <MessageInReply t-if="message.parentMessage" message="message" onClick="props.onParentMessageClick"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.is_note,
-                                                            'fs-1': !props.message.composer and !env.inChatter and message.onlyEmojis,
+                                                            'fs-1': !isEditing and !env.inChatter and message.onlyEmojis,
                                                             'mb-0': !message.is_note,
-                                                            'py-2': !message.is_note and !props.message.composer,
-                                                            'pt-2 pb-1': !message.is_note and props.message.composer,
+                                                            'py-2': !message.is_note and !isEditing,
+                                                            'pt-2 pb-1': !message.is_note and isEditing,
                                                             'o-note': message.is_note,
-                                                            'align-self-start rounded-end-3 rounded-bottom-3': !props.message.composer and !message.is_note,
-                                                            'flex-grow-1': props.message.composer,
+                                                            'align-self-start rounded-end-3 rounded-bottom-3': !isEditing and !message.is_note,
+                                                            'flex-grow-1': isEditing,
                                                             }" t-ref="body">
                                                     <i t-if="message.isEmpty" class="text-muted opacity-75" t-out="message.inlineBody"/>
-                                                    <Composer t-elif="props.message.composer" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
+                                                    <Composer t-elif="isEditing" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
                                                     <t t-else="">
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
@@ -126,7 +126,7 @@
 </t>
 
 <t t-name="mail.Message.actions">
-    <div t-if="props.hasActions and message.hasActions and !props.message.composer" class="o-mail-Message-actions d-print-none"
+    <div t-if="props.hasActions and message.hasActions and !isEditing" class="o-mail-Message-actions d-print-none"
         t-att-class="{
             'start-0': isAlignedRight,
             'mx-1': !isMobileOS,

--- a/addons/portal_rating/static/src/chatter/frontend/message_patch.js
+++ b/addons/portal_rating/static/src/chatter/frontend/message_patch.js
@@ -10,6 +10,10 @@ patch(Message.prototype, {
         this.state.editRating = false;
     },
 
+    get isEditing() {
+        return !this.state.editRating && this.props.message.composer;
+    },
+
     get ratingValue() {
         return this.message.rating_id?.rating || this.message.rating_value;
     },


### PR DESCRIPTION
Since odoo/odoo#202366 editing a message relies on the JS models and the editing
 state of the message is no longer needed. Putting comments to the portal
 chatter messages is almost the same flow as editing a message. Both open a
 composer on the message. So we need to know that the composer is open because
 the user is editing the message or commenting on the message. Currently, both
 composers open at the same time when the comment button is clicked.

task-4709990


