### PR TITLE
[IMP] website_sale: redirect to `/shop` when wishlist is empty

### DIFF
--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -1,4 +1,5 @@
 import { rpc, RPCError } from "@web/core/network/rpc";
+import { redirect } from "@web/core/utils/urls";
 import publicWidget from "@web/legacy/js/public/public_widget";
 import VariantMixin from "@website_sale/js/sale_variant_mixin";
 import wSaleUtils from "@website_sale/js/website_sale_utils";
@@ -157,6 +158,8 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
                 deferred_redirect.then(function () {
                     self._redirectNoWish();
                 });
+            } else {
+                self._redirectNoWish('/shop');
             }
         }
         this._updateWishlistView();
@@ -191,8 +194,8 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
     /**
      * @private
      */
-    _redirectNoWish: function () {
-        window.location.href = '/shop/cart';
+    _redirectNoWish(redirect_url='/shop/cart') {
+        redirect(redirect_url);
     },
 
 

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -24,11 +24,6 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             run: "click",
         },
         {
-            content: "go back to the store",
-            trigger: "a[href='/shop']",
-            run: "click",
-        },
-        {
             content: "hover card && click on add to wishlist",
             trigger: ".o_wsale_product_grid_wrapper:contains(desk)",
             run: "hover && click .o_add_wishlist",
@@ -424,11 +419,6 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         {
             content: "Remove the product from the wishlist",
             trigger: '.o_wish_rm',
-            run: "click",
-        },
-        {
-            content: "Go to '/shop",
-            trigger: 'header#top a[href="/shop"]',
             run: "click",
         },
         {


### PR DESCRIPTION
Before this commit:
- Removing the final item from the wishlist does not trigger a redirect, leaving the user on an empty page.

After this commit:
- Redirect the user to the `/shop` page when the last wishlist item is removed, improving the overall user experience.

Affected version-master
Task-4495968

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
