### PR TITLE
[FIX] hw_drivers: parsing response error when no data

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -340,11 +340,11 @@ def load_certificate():
 
     response = json.loads(response.data.decode('utf8'))
     error = response.get('error')
-    if error:
-        _logger.warning("An error received from odoo.com while trying to get the certificate: %s", error)
-    result = json.loads(response.data.decode('utf8'))['result']
-    if not result:
+    if error or not response.get('data') or not json.loads(response.data.decode('utf8')).get('result'):
+        _logger.warning("An error received from odoo.com while trying to get the certificate: %s", error or 'Empty response')
         return "ERR_IOT_HTTPS_LOAD_REQUEST_NO_RESULT"
+
+    result = json.loads(response.data.decode('utf8'))['result']
 
     write_file('odoo-subject.conf', result['subject_cn'])
     if platform.system() == 'Linux':


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
IOT crashes parsing a response from https://www.odoo.com/odoo-enterprise/iot/x509
not containing 'data'

Current behavior before PR:
Crash

Desired behavior after PR is merged:
-
Related internal PR: https://github.com/odoo/internal/pull/3480
opw-4711613
