### PR TITLE
[FIX] tests: allow test-file with dashes

### DIFF
--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -212,6 +212,9 @@ class TestSelector(TransactionCase):
         self.assertEqual({(None, 'module', None, None, None), }, tags.include)  # all in module
         self.assertEqual({('standard', None, None, None, None), }, tags.exclude)  # exept standard ones
 
+        tags = TagsSelector('*/some-paths/with-dash/addons/account/test/test_file.py')  # a filepath with dashes
+        self.assertEqual({(None, None, None, None, '/some-paths/with-dash/addons/account/test/test_file.py'), }, tags.include)
+
         tags = TagsSelector('/some/absolute/path/v.3/module.py')
         self.assertEqual({('standard', None, None, None, '/some/absolute/path/v.3/module.py'), }, tags.include)  # all in module
 
@@ -375,7 +378,7 @@ class TestSelectorSelection(TransactionCase):
 
         # absolute path case (used by test-file)
         tags = TagsSelector(__file__)
-        self.assertTrue(tags.check(no_tags_obj), 'Test should its absolute file path')
+        self.assertTrue(tags.check(no_tags_obj), 'Test should match its absolute file path')
 
     def test_selector_parser_parameters(self):
         tags = ','.join([

--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -12,7 +12,7 @@ class TagsSelector(object):
                                 ^
                                 ([+-]?)                     # operator_re
                                 (\*|\w*)                    # tag_re
-                                (\/[\w\/\.]+.py)?           # file_re
+                                (\/[\w\/\.-]+.py)?           # file_re
                                 (?:\/(\w+))?                # module_re
                                 (?::(\w*))?                 # test_class_re
                                 (?:\.(\w*))?                # test_method_re


### PR DESCRIPTION
Before this commit a file containing dashes wouldn't work with test-tags

Backport of odoo/odoo#196774