### PR TITLE
[FIX] point_of_sale: prevent missing error when closing session

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -187,6 +187,10 @@ class PosSession(models.Model):
 
     def delete_opening_control_session(self):
         self.ensure_one()
+        if not self.exists():
+            return {
+                'status': 'success',
+            }
         if self.state != 'opening_control' or len(self.order_ids) > 0:
             raise UserError(_("You can only cancel a session that is in opening control state and has no orders."))
         self.sudo().unlink()


### PR DESCRIPTION
Before this commit, if a POS session was open on two devices and closed on one, a new session would be automatically created and both devices would switch to it. However, if the "Backend" button was clicked on one device—removing the session—then clicking "Backend" on the second device would trigger a missing record error, since the session was already deleted.

opw-4709064

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
