### PR TITLE
[FIX] mail: non admin users can edit roles

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -77,7 +77,7 @@ class ResUsers(models.Model):
 
     @api.depends_context("uid")
     def _compute_can_edit_role(self):
-        self.can_edit_role = self.env["res.role"].has_access("write")
+        self.can_edit_role = self.env["res.role"].sudo(False).has_access("write")
 
     # ------------------------------------------------------------
     # CRUD


### PR DESCRIPTION
Before this PR:

Non-admin users could edit their roles from the user settings menu. This was due to a patch in `res.users` which was causing the compute to be called with sudo.

After this PR:

Only Admin users can edit roles.

Task-4690344

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
