### PR TITLE
[FIX] web: prevent traceback when opening "Set Default Values"

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -309,7 +309,7 @@ class SetDefaultDialog extends Component {
                 return option[0] === value;
             })[1];
         }
-        if (displayed.length > 60) {
+        if (displayed?.length > 60) {
             displayed = displayed.slice(0, 57) + "...";
         }
         return [value, displayed];


### PR DESCRIPTION
Problem:
When trying to open the "Set Default Values" modal, a traceback occurs if the record contains an invisible field, due to `displayed` being `undefined`.

Solution:
Safely check the length of `displayed` before using it.

Steps to reproduce:
1. Open CRM.
2. Open any record.
3. Enable Debug Mode.
4. Click "Set Default Values".
5. Observe the traceback.

opw-4707774

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
