### PR TITLE
[IMP] web: TreeEditor: set/not set operators for boolean fields

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -17,7 +17,7 @@ export function getDomainDisplayedOperators(fieldDef) {
     const hierarchyOperators = fieldDef.allow_hierachy_operators ? ["child_of", "parent_of"] : [];
     switch (type) {
         case "boolean":
-            return ["is", "is_not"];
+            return ["set", "not_set"];
         case "selection":
             return ["=", "!=", "in", "not in", "set", "not_set"];
         case "char":
@@ -37,7 +37,20 @@ export function getDomainDisplayedOperators(fieldDef) {
             ];
         case "date":
         case "datetime":
-            return ["=", "!=", ">", ">=", "<", "<=", "between", "is_not_between", "within", "is_not_within", "set", "not_set"];
+            return [
+                "=",
+                "!=",
+                ">",
+                ">=",
+                "<",
+                "<=",
+                "between",
+                "is_not_between",
+                "within",
+                "is_not_within",
+                "set",
+                "not_set",
+            ];
         case "integer":
         case "float":
         case "monetary":

--- a/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
+++ b/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
@@ -13,8 +13,6 @@ const EXPRESSION_VALID_OPERATORS = [
     "!=",
     "set",
     "not_set",
-    "is",
-    "is_not",
 ];
 
 export function getExpressionDisplayedOperators(fieldDef) {

--- a/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
@@ -29,10 +29,8 @@ const OPERATOR_DESCRIPTIONS = {
     parent_of: _t("parent of"),
 
     // virtual operators (replace = and != in some cases)
-    is: _t("is"),
-    is_not: _t("is not"),
-    set: _t("is set"),
-    not_set: _t("is not set"),
+    set: _t("set"),
+    not_set: _t("not set"),
 
     starts_with: _t("starts with"),
     ends_with: _t("ends with"),

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -117,7 +117,8 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
             return {
                 component: null,
                 extractProps: null,
-                isSupported: (value) => value === false,
+                isSupported: (value) =>
+                    value === false || (fieldDef.type === "boolean" && value === true),
                 defaultValue: () => false,
             };
         case "=like":
@@ -279,20 +280,6 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "html":
         case "text":
             return STRING_EDITOR;
-        case "boolean": {
-            if (["is", "is_not"].includes(operator)) {
-                const options = [
-                    [true, _t("set")],
-                    [false, _t("not set")],
-                ];
-                return makeSelectEditor(options, params);
-            }
-            const options = [
-                [true, _t("True")],
-                [false, _t("False")],
-            ];
-            return makeSelectEditor(options, params);
-        }
         case "many2one": {
             if (["=", "!="].includes(operator)) {
                 return {

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -187,25 +187,16 @@ function _getConditionDescription(node, getFieldDef, getPathDescription, display
     if (["set", "not_set"].includes(operator)) {
         return description;
     }
-    if (["is", "is_not"].includes(operator)) {
-        description.valueDescription = {
-            values: [value ? _t("set") : _t("not set")],
-            join: "",
-            addParenthesis: false,
-        };
-        return description;
-    }
 
     const coModeldisplayNames = displayNames[getResModel(fieldDef)];
     const dis = disambiguate(value, coModeldisplayNames);
-    const values =
-        ["within", "is_not_within"].includes(operator)
-            ? [value[0], Within.options.find((option) => option[0] === value[1])[1]]
-            : (Array.isArray(value) ? value : [value])
-                  .slice(0, 21)
-                  .map((val, index) =>
-                      index < 20 ? formatValue(val, dis, fieldDef, coModeldisplayNames) : "..."
-                  );
+    const values = ["within", "is_not_within"].includes(operator)
+        ? [value[0], Within.options.find((option) => option[0] === value[1])[1]]
+        : (Array.isArray(value) ? value : [value])
+              .slice(0, 21)
+              .map((val, index) =>
+                  index < 20 ? formatValue(val, dis, fieldDef, coModeldisplayNames) : "..."
+              );
     let join;
     let addParenthesis = Array.isArray(value);
     switch (operator) {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -117,14 +117,13 @@ test("creating a domain from scratch", async () => {
     await contains(
         ".o_model_field_selector_popover .o_model_field_selector_popover_item_name"
     ).click();
-    expect(SELECTORS.debugArea).toHaveCount(1);
-    expect(SELECTORS.debugArea).toHaveValue(`[("bar", "=", True)]`);
+    expect(SELECTORS.debugArea).toHaveValue(`[("bar", "!=", False)]`);
 
     // There should be a "+" button to add a domain part; clicking on it
     // should add the default "('id', '=', 1)" domain
     expect(SELECTORS.buttonAddNewRule).toHaveCount(1);
     await clickOnButtonAddNewRule();
-    expect(SELECTORS.debugArea).toHaveValue(`["&", ("bar", "=", True), ("bar", "=", True)]`);
+    expect(SELECTORS.debugArea).toHaveValue(`["&", ("bar", "!=", False), ("bar", "!=", False)]`);
 
     // There should be two "Add branch" buttons to add a domain "branch"; clicking on
     // the first one, should add this group with defaults "('id', '=', 1)"
@@ -132,7 +131,7 @@ test("creating a domain from scratch", async () => {
     expect(SELECTORS.buttonAddBranch).toHaveCount(2);
     await clickOnButtonAddBranch();
     expect(SELECTORS.debugArea).toHaveValue(
-        `["&", "&", ("bar", "=", True), "|", ("id", "=", 1), ("id", "=", 1), ("bar", "=", True)]`
+        `["&", "&", ("bar", "!=", False), "|", ("id", "=", 1), ("id", "=", 1), ("bar", "!=", False)]`
     );
 
     // There should be five buttons to remove domain part; clicking on
@@ -141,7 +140,7 @@ test("creating a domain from scratch", async () => {
     expect(SELECTORS.buttonDeleteNode).toHaveCount(5);
     await clickOnButtonDeleteNode(-1);
     await clickOnButtonDeleteNode(-1);
-    expect(SELECTORS.debugArea).toHaveValue(`["&", ("bar", "=", True), ("id", "=", 1)]`);
+    expect(SELECTORS.debugArea).toHaveValue(`["&", ("bar", "!=", False), ("id", "=", 1)]`);
 });
 
 test("building a domain with a datetime", async () => {
@@ -174,7 +173,7 @@ test("building a domain with an invalid path", async () => {
     await makeDomainSelector({
         domain: `[("fooooooo", "=", "abc")]`,
         update(domain) {
-            expect(domain).toBe(`[("bar", "=", True)]`);
+            expect(domain).toBe(`[("bar", "!=", False)]`);
         },
     });
 
@@ -188,8 +187,7 @@ test("building a domain with an invalid path", async () => {
     await openModelFieldSelectorPopover();
     await contains(".o_model_field_selector_popover_item_name").click();
     expect(getCurrentPath()).toBe("Bar");
-    expect(getCurrentOperator()).toBe("is");
-    expect(getCurrentValue()).toBe("set");
+    expect(getCurrentOperator()).toBe("set");
 });
 
 test("building a domain with an invalid path (2)", async () => {
@@ -394,10 +392,10 @@ test("cache fields_get", async () => {
     expect.verifySteps(["fields_get"]);
 });
 
-test("selection field with operator change from 'is set' to '='", async () => {
+test("selection field with operator change from 'set' to '='", async () => {
     await makeDomainSelector({ domain: `[['state', '!=', False]]` });
     expect(getCurrentPath()).toBe("State");
-    expect(getCurrentOperator()).toBe("is set");
+    expect(getCurrentOperator()).toBe("set");
 
     await selectOperator("=");
     expect(getCurrentPath()).toBe("State");
@@ -996,18 +994,18 @@ test("support properties", async () => {
     expectedDomain = `[("properties.xpad_prop_1", "=", False)]`;
     await contains(".o_model_field_selector_popover_item[data-name='xpad_prop_1'] button").click();
     expect(getCurrentPath()).toBe("Properties > M2O");
-    expect(getOperatorOptions()).toEqual(["is equal", "is not equal", "is set", "is not set"]);
+    expect(getOperatorOptions()).toEqual(["is equal", "is not equal", "set", "not set"]);
 
     const toTests = [
         {
             name: "xphone_prop_1",
-            domain: `[("properties.xphone_prop_1", "=", True)]`,
-            options: ["is", "is not"],
+            domain: `[("properties.xphone_prop_1", "!=", False)]`,
+            options: ["set", "not set"],
         },
         {
             name: "xphone_prop_2",
             domain: `[("properties.xphone_prop_2", "=", False)]`,
-            options: ["is equal", "is not equal", "is set", "is not set"],
+            options: ["is equal", "is not equal", "set", "not set"],
         },
         {
             name: "xphone_prop_3",
@@ -1019,8 +1017,8 @@ test("support properties", async () => {
                 "does not contain",
                 "is in",
                 "is not in",
-                "is set",
-                "is not set",
+                "set",
+                "not set",
                 "starts with",
                 "ends with",
             ],
@@ -1038,8 +1036,8 @@ test("support properties", async () => {
                 "is between",
                 "contains",
                 "does not contain",
-                "is set",
-                "is not set",
+                "set",
+                "not set",
             ],
         },
         {
@@ -1056,19 +1054,19 @@ test("support properties", async () => {
                 "is not between",
                 "is within",
                 "is not within",
-                "is set",
-                "is not set",
+                "set",
+                "not set",
             ],
         },
         {
             name: "xphone_prop_6",
             domain: `[("properties.xphone_prop_6", "in", "")]`,
-            options: ["is in", "is not in", "is set", "is not set"],
+            options: ["is in", "is not in", "set", "not set"],
         },
         {
             name: "xphone_prop_7",
             domain: `[("properties.xphone_prop_7", "in", [])]`,
-            options: ["is in", "is not in", "is set", "is not set"],
+            options: ["is in", "is not in", "set", "not set"],
         },
     ];
 
@@ -1118,7 +1116,7 @@ test("support properties (mode readonly)", async () => {
     const toTest = [
         {
             domain: `[("properties.xphone_prop_1", "=", False)]`,
-            result: "Properties ➔ Boolean is not set",
+            result: "Properties ➔ Boolean not set",
         },
         {
             domain: `[("properties.xphone_prop_2", "=", "abc")]`,
@@ -1209,9 +1207,9 @@ test("treat false and true like False and True", async () => {
         domain: `[("bar","=",false)]`,
         readonly: true,
     });
-    expect(getConditionText()).toBe(`Bar is not set`);
+    expect(getConditionText()).toBe(`Bar not set`);
     await parent.set(`[("bar","=",true)]`);
-    expect(getConditionText()).toBe(`Bar is set`);
+    expect(getConditionText()).toBe(`Bar set`);
 });
 
 test("Edit the value for field char and an operator in", async () => {
@@ -1316,10 +1314,10 @@ test("boolean field (readonly)", async () => {
         domain: `[]`,
     });
     const toTest = [
-        { domain: `[("bar", "=", True)]`, text: "Bar is set" },
-        { domain: `[("bar", "=", False)]`, text: "Bar is not set" },
-        { domain: `[("bar", "!=", True)]`, text: "Bar is not set" },
-        { domain: `[("bar", "!=", False)]`, text: "Bar is not not set" },
+        { domain: `[("bar", "=", True)]`, text: "Bar set" },
+        { domain: `[("bar", "=", False)]`, text: "Bar not set" },
+        { domain: `[("bar", "!=", True)]`, text: "Bar not set" },
+        { domain: `[("bar", "!=", False)]`, text: "Bar set" },
     ];
     for (const { domain, text } of toTest) {
         await parent.set(domain);
@@ -1334,9 +1332,9 @@ test("integer field (readonly)", async () => {
     });
     const toTest = [
         { domain: `[("int", "=", True)]`, text: `Int is equal true` },
-        { domain: `[("int", "=", False)]`, text: `Int is not set` },
+        { domain: `[("int", "=", False)]`, text: `Int not set` },
         { domain: `[("int", "!=", True)]`, text: `Int is not equal true` },
-        { domain: `[("int", "!=", False)]`, text: `Int is set` },
+        { domain: `[("int", "!=", False)]`, text: `Int set` },
         { domain: `[("int", "=", 1)]`, text: `Int is equal 1` },
         { domain: `[("int", "!=", 1)]`, text: `Int is not equal 1` },
         { domain: `[("int", "<", 1)]`, text: `Int is lower 1` },
@@ -1395,8 +1393,8 @@ test("char field (readonly)", async () => {
         domain: `[]`,
     });
     const toTest = [
-        { domain: `[("foo", "=", False)]`, text: `Foo is not set` },
-        { domain: `[("foo", "!=", False)]`, text: `Foo is set` },
+        { domain: `[("foo", "=", False)]`, text: `Foo not set` },
+        { domain: `[("foo", "!=", False)]`, text: `Foo set` },
         { domain: `[("foo", "=", "abc")]`, text: `Foo is equal abc` },
         { domain: `[("foo", "=", expr)]`, text: `Foo is equal expr` },
         { domain: `[("foo", "!=", "abc")]`, text: `Foo is not equal abc` },
@@ -1417,8 +1415,8 @@ test("selection field (readonly)", async () => {
         domain: `[]`,
     });
     const toTest = [
-        { domain: `[("state", "=", False)]`, text: `State is not set` },
-        { domain: `[("state", "!=", False)]`, text: `State is set` },
+        { domain: `[("state", "=", False)]`, text: `State not set` },
+        { domain: `[("state", "!=", False)]`, text: `State set` },
         { domain: `[("state", "=", "abc")]`, text: `State is equal ABC` },
         { domain: `[("state", "=", expr)]`, text: `State is equal expr` },
         { domain: `[("state", "!=", "abc")]`, text: `State is not equal ABC` },
@@ -1466,11 +1464,11 @@ test("selection property (readonly)", async () => {
     const toTest = [
         {
             domain: `[("properties.selection_prop", "=", false)]`,
-            text: `Properties ➔ Selection is not set`,
+            text: `Properties ➔ Selection not set`,
         },
         {
             domain: `[("properties.selection_prop", "!=", false)]`,
-            text: `Properties ➔ Selection is set`,
+            text: `Properties ➔ Selection set`,
         },
         {
             domain: `[("properties.selection_prop", "=", "abc")]`,
@@ -1560,8 +1558,8 @@ test("many2one field operators (edit)", async () => {
         "is not equal",
         "contains",
         "does not contain",
-        "is set",
-        "is not set",
+        "set",
+        "not set",
         "starts with",
         "ends with",
         "matches",
@@ -1733,12 +1731,12 @@ test("many2many field and operator set/not set (edit)", async () => {
 
     await selectOperator("not_set");
 
-    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentOperator()).toBe("not set");
     expect(".o_ds_value_cell").toHaveCount(0);
     expect.verifySteps([`[("product_id", "=", False)]`]);
 
     await selectOperator("set");
-    expect(getCurrentOperator()).toBe("is set");
+    expect(getCurrentOperator()).toBe("set");
     expect(".o_ds_value_cell").toHaveCount(0);
     expect.verifySteps([`[("product_id", "!=", False)]`]);
 
@@ -1760,15 +1758,15 @@ test("many2many field: clone a set/not set condition", async () => {
     expect.verifySteps([]);
 
     await selectOperator("not_set");
-    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentOperator()).toBe("not set");
     expect(".o_ds_value_cell").toHaveCount(0);
     expect.verifySteps([`[("product_id", "=", False)]`]);
     expect(SELECTORS.condition).toHaveCount(1);
 
     await clickOnButtonAddNewRule();
     expect(SELECTORS.condition).toHaveCount(2);
-    expect(getCurrentOperator()).toBe("is not set");
-    expect(getCurrentOperator(1)).toBe("is not set");
+    expect(getCurrentOperator()).toBe("not set");
+    expect(getCurrentOperator(1)).toBe("not set");
     expect.verifySteps([`["&", ("product_id", "=", False), ("product_id", "=", False)]`]);
 });
 
@@ -1784,8 +1782,8 @@ test("x2many field operators (edit)", async () => {
         "is not equal",
         "contains",
         "does not contain",
-        "is set",
-        "is not set",
+        "set",
+        "not set",
         "starts with",
         "ends with",
         "match",
@@ -1916,12 +1914,12 @@ test("many2many field: operator set/not set (edit)", async () => {
             expect.step(domain);
         },
     });
-    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentOperator()).toBe("not set");
     expect(".o_ds_value_cell").toHaveCount(0);
     expect.verifySteps([]);
 
     await selectOperator("set");
-    expect(getCurrentOperator()).toBe("is set");
+    expect(getCurrentOperator()).toBe("set");
     expect(".o_ds_value_cell").toHaveCount(0);
     expect.verifySteps([`[("product_ids", "!=", False)]`]);
 });
@@ -2000,7 +1998,7 @@ test("Include archived not shown when model doesn't have the active field", asyn
     expect('.form-switch label:contains("Include archived")').toHaveCount(0);
 });
 
-test("date/datetime edition: switch !=/is set", async () => {
+test("date/datetime edition: switch !=/set", async () => {
     mockDate("2023-04-20 17:00:00", 0);
     await makeDomainSelector({
         isDebugMode: true,
@@ -2014,7 +2012,7 @@ test("date/datetime edition: switch !=/is set", async () => {
     expect(getCurrentValue()).toBe("05/20/2023");
 
     await selectOperator("set");
-    expect(getCurrentOperator()).toBe("is set");
+    expect(getCurrentOperator()).toBe("set");
     expect(".o_datetime_input").toHaveCount(0);
     expect.verifySteps([`[("date", "!=", False)]`]);
 
@@ -2037,7 +2035,7 @@ test("date/datetime edition: switch is_set to other operators", async () => {
     await selectOperator("set");
     expect(".o_datetime_input").toHaveCount(0);
     expect(getCurrentValue()).toBe(null);
-    expect(getCurrentOperator()).toBe("is set");
+    expect(getCurrentOperator()).toBe("set");
     expect.verifySteps(['[("datetime", "!=", False)]']);
 
     await selectOperator("between");
@@ -2054,7 +2052,7 @@ test("date/datetime edition: switch is_set to other operators", async () => {
     await selectOperator("not_set");
     expect(".o_datetime_input").toHaveCount(0);
     expect(getCurrentValue()).toBe(null);
-    expect(getCurrentOperator()).toBe("is not set");
+    expect(getCurrentOperator()).toBe("not set");
     expect.verifySteps(['[("datetime", "=", False)]']);
 
     await selectOperator(">=");
@@ -2231,7 +2229,7 @@ test(`any/not any operator (readonly)`, async () => {
         },
         {
             domain: `[("product_id", "any", ["|", ("name", "in", [37,41] ), ("bar", "=", True)] )]`,
-            text: `Match\nall\nof the following rules:\nProduct\nmatches\nany\nof:\nProduct Name\nis in\n(\n37\n,\n41\n)\nProduct Bar\nis\nset`,
+            text: `Match\nall\nof the following rules:\nProduct\nmatches\nany\nof:\nProduct Name\nis in\n(\n37\n,\n41\n)\nProduct Bar\nset`,
         },
         {
             domain: `[("product_id", "any", ["&", ("name", "in", ["JD7", "KDB"]), ("team_id", "not any", ["&", ("id", "=", 17), ("name", "ilike", "mancity")])])]`,
@@ -2453,8 +2451,8 @@ test("Hierarchical operators", async () => {
         "does not contain",
         "child of",
         "parent of",
-        "is set",
-        "is not set",
+        "set",
+        "not set",
         "starts with",
         "ends with",
         "matches",
@@ -2489,14 +2487,14 @@ test("Hierarchical operators", async () => {
             "is not equal",
             "contains",
             "does not contain",
-            "is set",
-            "is not set",
+            "set",
+            "not set",
             "starts with",
             "ends with",
             "matches",
             "matches none of",
         ],
-        { message: "no hierarchical operator if allow_hierachy_operators is set to false" }
+        { message: "no hierarchical operator if allow_hierachy_operators set to false" }
     );
 });
 
@@ -2510,14 +2508,12 @@ test("preserve virtual operators in sub domains", async () => {
     });
     expect(getCurrentOperator()).toBe("matches");
     expect(getCurrentOperator(1)).toBe("matches");
-    expect(getCurrentOperator(2)).toBe("is");
-    expect(getCurrentOperator(3)).toBe("is not set");
+    expect(getCurrentOperator(2)).toBe("not set");
+    expect(getCurrentOperator(3)).toBe("not set");
 
     await contains(".o_tree_editor:eq(1) a:contains('New Rule'):eq(1)").click();
-    expect(getCurrentOperator()).toBe("matches");
-    expect(getCurrentOperator(1)).toBe("matches");
-    expect(getCurrentOperator(2)).toBe("is");
-    expect(getCurrentOperator(3)).toBe("is not set");
+    expect(getCurrentOperator(2)).toBe("not set");
+    expect(getCurrentOperator(3)).toBe("not set");
     expect(getCurrentOperator(4)).toBe("is equal");
     expect.verifySteps([
         `[("product_id", "any", ["&", ("team_id", "any", ["&", ("active", "=", False), ("name", "=", False)]), ("id", "=", 1)])]`,
@@ -2526,8 +2522,8 @@ test("preserve virtual operators in sub domains", async () => {
     await clickOnButtonDeleteNode(4);
     expect(getCurrentOperator()).toBe("matches");
     expect(getCurrentOperator(1)).toBe("matches");
-    expect(getCurrentOperator(2)).toBe("is");
-    expect(getCurrentOperator(3)).toBe("is not set");
+    expect(getCurrentOperator(2)).toBe("not set");
+    expect(getCurrentOperator(3)).toBe("not set");
     expect.verifySteps([
         `[("product_id", "any", [("team_id", "any", ["&", ("active", "=", False), ("name", "=", False)])])]`,
     ]);

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -182,7 +182,7 @@ test("change path, operator and value", async () => {
     await makeExpressionEditor({ expression: `bar != "blabla"` });
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Bar", "is not", "blabla"] },
+        { level: 1, value: ["Bar", "is not equal", "blabla"] },
     ]);
     const tree = getTreeEditorContent({ node: true });
     await openModelFieldSelectorPopover();
@@ -215,12 +215,12 @@ test("rendering of a valid fieldName in fields", async () => {
     const parent = await makeExpressionEditor({ fieldFilters: ["foo"] });
 
     const toTests = [
-        { expr: `foo`, condition: ["Foo", "is set"] },
+        { expr: `foo`, condition: ["Foo", "set"] },
         { expr: `foo == "a"`, condition: ["Foo", "is equal", "a"] },
         { expr: `foo != "a"`, condition: ["Foo", "is not equal", "a"] },
         // { expr: `foo is "a"`, complexCondition: `foo is "a"` },
         // { expr: `foo is not "a"`, complexCondition: `foo is not "a"` },
-        { expr: `not foo`, condition: ["Foo", "is not set"] },
+        { expr: `not foo`, condition: ["Foo", "not set"] },
         { expr: `foo + "a"`, complexCondition: `foo + "a"` },
     ];
 
@@ -298,7 +298,7 @@ test("rendering of connectors", async () => {
         { level: 1, value: "all" },
         { level: 2, value: "expr" },
         { level: 2, value: ["Foo", "is equal", "abc"] },
-        { level: 1, value: ["Bar", "is", "not set"] },
+        { level: 1, value: ["Bar", "not set"] },
     ]);
 });
 
@@ -358,13 +358,13 @@ test("allow selection of boolean field", async () => {
     await makeExpressionEditor({ expression: "id" });
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Id", "is set"] },
+        { level: 1, value: ["Id", "set"] },
     ]);
     await openModelFieldSelectorPopover();
     await contains(".o_model_field_selector_popover_item_name").click();
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Bar", "is", "set"] },
+        { level: 1, value: ["Bar", "set"] },
     ]);
 });
 
@@ -393,7 +393,7 @@ test("no field of type properties in model field selector", async () => {
     });
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Properties", "is set"] },
+        { level: 1, value: ["Properties", "set"] },
     ]);
     expect(isNotSupportedPath()).toBe(true);
     await clearNotSupported();
@@ -414,12 +414,12 @@ test("no special fields in fields", async () => {
     });
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Bar", "is not", "not set"] },
+        { level: 1, value: ["Bar", "set"] },
     ]);
     await addNewRule();
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Bar", "is not", "not set"] },
+        { level: 1, value: ["Bar", "set"] },
         { level: 1, value: ["Foo", "is equal", ""] },
     ]);
     expect.verifySteps([`bar and foo == ""`]);
@@ -440,8 +440,8 @@ test("between operator", async () => {
         "is lower",
         "is lower or equal",
         "is between",
-        "is set",
-        "is not set",
+        "set",
+        "not set",
     ]);
     expect.verifySteps([]);
     await selectOperator("between");

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1543,7 +1543,7 @@ test("facets display with any / not any operator (check brackets)", async functi
         searchViewId: false,
         searchViewArch: `
             <search>
-                <filter isDebugMode="true" name="filter" string="Filter" domain="['|', ('company', 'any', [('bar', 'any', [('bool', 'is', False)]), ('bar', 'any', [('bool', 'is', True)])]), ('bar', '=', false)]"/>
+                <filter isDebugMode="true" name="filter" string="Filter" domain="['|', ('company', 'any', [('bar', 'any', [('bool', '=', False)]), ('bar', 'any', [('bool', '=', True)])]), ('bar', '=', false)]"/>
             </search>
         `,
         context: {
@@ -1558,7 +1558,7 @@ test("facets display with any / not any operator (check brackets)", async functi
 
     await contains(".modal footer button").click();
     expect(getFacetTexts()).toEqual([
-        "Company matches ( Bar matches ( Bool is not set ) and Bar matches ( Bool is set ) ) or Bar is equal false",
+        "Company matches ( Bar matches ( Bool not set ) and Bar matches ( Bool set ) ) or Bar is equal false",
     ]);
     expect.verifySteps([`/web/domain/validate`]);
 });

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -7,7 +7,6 @@ import {
     getCurrentPath,
     openModelFieldSelectorPopover,
     selectOperator,
-    selectValue,
 } from "@web/../tests/core/tree_editor/condition_tree_editor_test_helpers";
 import {
     contains,
@@ -797,7 +796,7 @@ test("consistent display of ! in debug mode", async () => {
     expect(searchBar.env.searchModel.domain).toEqual(["!", "|", ["foo", "=", 1], ["id", "=", 2]]);
 });
 
-test("display of is (not) (not) set in facets", async () => {
+test("display of (not) set in facets", async () => {
     Foo._fields.boolean = fields.Boolean();
     onRpc("/web/domain/validate", () => true);
     const searchBar = await mountWithSearch(SearchBar, {
@@ -813,39 +812,27 @@ test("display of is (not) (not) set in facets", async () => {
     await openAddCustomFilterDialog();
     await selectOperator("not_set");
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Id is not set"]);
+    expect(getFacetTexts()).toEqual(["Id not set"]);
     expect(searchBar.env.searchModel.domain).toEqual([["id", "=", false]]);
 
     await contains(".o_searchview_facet_label").click();
     await selectOperator("set");
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Id is set"]);
+    expect(getFacetTexts()).toEqual(["Id set"]);
     expect(searchBar.env.searchModel.domain).toEqual([["id", "!=", false]]);
 
     await contains(".o_searchview_facet_label").click();
     await openModelFieldSelectorPopover();
     await contains(".o_model_field_selector_popover_item_name:contains(Boolean)").click();
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Boolean is set"]);
-    expect(searchBar.env.searchModel.domain).toEqual([["boolean", "=", true]]);
-
-    await contains(".o_searchview_facet_label").click();
-    await selectValue(false);
-    await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Boolean is not set"]);
-    expect(searchBar.env.searchModel.domain).toEqual([["boolean", "=", false]]);
-
-    await contains(".o_searchview_facet_label").click();
-    await selectOperator("is_not");
-    await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Boolean is not not set"]);
+    expect(getFacetTexts()).toEqual(["Boolean set"]);
     expect(searchBar.env.searchModel.domain).toEqual([["boolean", "!=", false]]);
 
     await contains(".o_searchview_facet_label").click();
-    await selectValue(true);
+    await selectOperator("not_set");
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Boolean is not set"]);
-    expect(searchBar.env.searchModel.domain).toEqual([["boolean", "!=", true]]);
+    expect(getFacetTexts()).toEqual(["Boolean not set"]);
+    expect(searchBar.env.searchModel.domain).toEqual([["boolean", "=", false]]);
 });
 
 test("Add a custom filter: notification on invalid domain", async () => {


### PR DESCRIPTION
We make the boolean fields use the operators set/not_set like the other fields. We find this better than have two special operators is/is_not with strange things like "boolean is not not set" displayed in the ui. We take the opportunity to change the labels of set/not_set to be simply set/not set.
