### PR TITLE
[IMP] website_sale: Variant preview on Product cards

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -509,7 +509,7 @@
                 </field>
                 <field name="uom_ids" position="attributes">
                     <attribute name="context">{'product_id': id}</attribute>
-                </field> 
+                </field>
             </field>
         </record>
 

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -484,6 +484,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'float_round': float_round,
             'shop_path': SHOP_PATH,
             'product_query_string': self._get_product_query_string(**post),
+            'previewed_attribute_values': lazy(products._get_previewed_attribute_values),
         }
         if filter_by_price_enabled:
             values['min_price'] = min_price or available_min_price

--- a/addons/website_sale/models/product_attribute.py
+++ b/addons/website_sale/models/product_attribute.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductAttribute(models.Model):
@@ -10,3 +10,25 @@ class ProductAttribute(models.Model):
         selection=[('visible', "Visible"), ('hidden', "Hidden")],
         default='visible',
     )
+    preview_variants = fields.Selection(
+        string="On Product Cards",
+        selection=[
+            ('visible', "Visible"),
+            ('hidden', "Hidden"),
+            ('hover', "Hover"),
+        ],
+        default='hidden',
+        help="Instantly created variants are available for selection from your /shop page.",
+    )
+    is_thumbnail_visible = fields.Boolean(
+        string="Show Thumbnails",
+        help="Use product variant images instead of the attribute values displays."
+    )
+
+    @api.onchange('create_variant', 'display_type')
+    def _onchange_disable_preview_variants(self):
+        """ The option to preview variants is only available for instantly created single variants.
+        """
+        if self.create_variant != 'always' or self.display_type == 'multi':
+            self.preview_variants = 'hidden'
+            self.is_thumbnail_visible = False

--- a/addons/website_sale/static/src/interactions/product/product_variant_preview.js
+++ b/addons/website_sale/static/src/interactions/product/product_variant_preview.js
@@ -1,0 +1,101 @@
+import { Interaction } from '@web/public/interaction';
+import { registry } from '@web/core/registry';
+
+export class ProductVariantPreview extends Interaction {
+    static selector = '.o_wsale_attribute_previewer';
+    dynamicContent = {
+        _window: {
+            't-on-resize': this.debounced(this._updateVariantPreview, 250),
+        },
+    };
+
+    setup() {
+        this.ptavs = this.el.querySelectorAll('.o_product_variant_preview');
+        this.hiddenCountSpan = this.el.querySelector('span[name="hidden_ptavs_count"]');
+        this.ptavCount = this.ptavs.length + Number(this.el.dataset.hiddenPtavCount ?? 0);
+        this.displayedPTAVCount = 0;
+        // Class `gap-1` on parent adds 4px margin for each ptav.
+        this.margin = 4;
+        this._updateVariantPreview();
+    }
+
+    /**
+     * Hide all attribute values from view to be able to recompute correctly how many elements are
+     * to be shown.
+     *
+     * @private
+     *
+     * @returns {void}
+     */
+    _resetDisplay() {
+        for (const child of this.el.children) {
+            child.classList.add('d-none');
+        }
+    }
+
+    /**
+     * Updates the span to include the correct number of hidden PTAVs and return the
+     * new width of the element.
+     *
+     * @returns {Number}
+     */
+    _updateAndGetHiddenPTAVsWidth() {
+        const hiddenPTAVCount = this.ptavCount - this.displayedPTAVCount;
+        this.hiddenCountSpan.firstElementChild.textContent = `+${hiddenPTAVCount}`;
+        this.hiddenCountSpan.classList.remove('d-none');
+        return this.hiddenCountSpan.offsetWidth + this.margin * 2;
+    }
+
+    /**
+     * Update the count of hidden PTAVs with the correct number and make it visible.
+     *
+     * @private
+     * @param {Element} currentPTAV
+     * @param {Number} remainingSpace
+     *
+     * @returns {void}
+     */
+    _showHiddenPTAVsElement(currentPTAV, remainingSpace) {
+        let hiddenCountSpanWidth = this._updateAndGetHiddenPTAVsWidth();
+        while (currentPTAV && hiddenCountSpanWidth >= remainingSpace) {
+            const currentPTAVWidth = currentPTAV.offsetWidth;
+            currentPTAV.classList.add("d-none");
+            this.displayedPTAVCount--;
+            hiddenCountSpanWidth = this._updateAndGetHiddenPTAVsWidth();
+            remainingSpace += currentPTAVWidth;
+            currentPTAV = currentPTAV.previousElementSibling;
+        }
+    }
+
+    /**
+     * For each ptav check if there is enough space to add on the parent element and update the
+     * hidden PTAVs count accordingly, with the truncated elements from the backend.
+     *
+     * @private
+     *
+     * @returns {void}
+     */
+    _updateVariantPreview() {
+        this._resetDisplay();
+        const containerWidth = this.el.offsetWidth;
+        let usedWidth = 0;
+        this.displayedPTAVCount = 0;
+        for (const ptav of this.ptavs) {
+            // Remove d-none to be able to get width.
+            ptav.classList.remove('d-none');
+            usedWidth += ptav.offsetWidth + this.margin;
+            this.displayedPTAVCount++;
+            const remainingSpace = containerWidth - usedWidth;
+            const isLastPTAV = ptav === this.ptavs[this.ptavs.length - 1];
+            const hasHiddenPtavs = isLastPTAV && this.ptavCount > this.displayedPTAVCount;
+            if (usedWidth >= containerWidth || hasHiddenPtavs) {
+                this._showHiddenPTAVsElement(ptav, remainingSpace);
+                break;
+            }
+        }
+    }
+}
+
+registry
+    .category('public.interactions')
+    .add('website_sale.product_variant_preview', ProductVariantPreview);

--- a/addons/website_sale/static/src/interactions/product/product_variant_preview_hover.js
+++ b/addons/website_sale/static/src/interactions/product/product_variant_preview_hover.js
@@ -1,0 +1,84 @@
+import { Interaction } from '@web/public/interaction';
+import { registry } from '@web/core/registry';
+
+export class ProductVariantPreviewImageHover extends Interaction {
+    static selector = '.oe_product_cart';
+    dynamicContent = {
+        '.o_product_variant_preview': {
+            't-on-mouseenter': this._mouseEnter,
+            't-on-mouseleave': this._mouseLeave,
+            't-on-click': this._onClick,
+        },
+    };
+
+    setup() {
+        this.productImg = this.el.querySelector('.oe_product_image_img_wrapper img');
+        this.originalImgSrc = this.productImg.getAttribute('src');
+    }
+
+    /**
+     * Display the variant image on hover.
+     *
+     * @private
+     * @param {Event} ev
+     *
+     * @returns {void}
+     */
+    _mouseEnter(ev) {
+        if (!this.env.isSmall) {
+            const variantImageSrc = ev.target.dataset.variantImage;
+            if (!variantImageSrc) {
+                return;
+            }
+            this._setImgSrc(variantImageSrc);
+        }
+    }
+
+    /**
+     * Reset the product image when mouse no longer hovers on the ptav.
+     *
+     * @private
+     *
+     * @returns {void}
+     */
+    _mouseLeave() {
+        if (!this.env.isSmall) {
+            this._setImgSrc(this.originalImgSrc);
+        }
+    }
+
+    /**
+     * Set the image source of the product to the given image source
+     *
+     * @param {string} imageSrc
+     */
+    _setImgSrc(imageSrc) {
+        this.productImg.src = imageSrc;
+    }
+
+    /**
+     * On mobile, when ptav is clicked simulate on hover behavior and change product image
+     * to variant image.
+     * The href of product card is changed to match that of the selected variant.
+     *
+     * @param {Event} ev
+     * @returns
+     */
+    _onClick(ev) {
+        if (this.env.isSmall) {
+            ev.preventDefault();
+            const targetElement = ev.target.closest('.o_product_variant_preview');
+            const productCard = ev.target.closest('.oe_product_cart');
+            productCard.querySelector('.oe_product_image_link').href = targetElement.href;
+            const variantImageSrc = targetElement.dataset.variantImage;
+            if (!variantImageSrc) {
+                return;
+            }
+            this._setImgSrc(variantImageSrc);
+        }
+    }
+}
+
+registry
+    .category('public.interactions')
+    .add('website_sale.product_variant_preview_image_hover', ProductVariantPreviewImageHover);

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -39,10 +39,11 @@ $input-border-color: $gray-400;
         --o-wsale-card-border-width: 1px;
         --o-wsale-card-border-radius: #{$card-border-radius};
         --o-wsale-card-info-padding: #{map-get($spacers, 2)};
-        --o-wsale-card-info-grow: 1;
+        --o-wsale-card-info-text-grow: 1;
         --o-wsale-card-bg: #{$card-bg};
         --o-wsale-card-color: #{adjust-color-to-background($body-color, $card-bg)};
         --o-wsale-card-text-muted: #{adjust-color-to-background($text-muted, $card-bg, mute-color($color-contrast-light), mute-color($color-contrast-dark))};
+        --o-wsale-card-attribute-previewer-thumbnail-border-radius: #{$border-radius-sm};
 
         $-br-top: calc(#{$card-border-radius} - 1px);
         --o-wsale-card-thumb-border-radius: #{$-br-top} #{$-br-top} 0 0;
@@ -53,11 +54,12 @@ $input-border-color: $gray-400;
         --o-wsale-card-thumb-border-radius: #{$o-wsale-products-layout-grid-gutter-width * .5};
         --o-wsale-card-thumb-shadow: 0 13px 27px -5px #{scale-color(map-get($theme-colors, 'primary'), $alpha: -90%)},
                                      0 8px 16px -8px rgba(0, 0, 0, .28);
+        --o-wsale-card-attribute-previewer-thumbnail-border-radius: #{$border-radius-sm};
     }
     &.o_wsale_design_grid {
         --o-wsale-card-border-width: 0 #{$border-width $border-width} 0;
         --o-wsale-card-info-padding: #{map-get($spacers, 2)};
-        --o-wsale-card-info-grow: 1;
+        --o-wsale-card-info-text-grow: 1;
         --o-wsale-card-padding: calc(var(--o-wsale-products-grid-gap-y) * 0.5) calc(var(--o-wsale-products-grid-gap, 16px) * 0.5);
         --o-wsale-topbar-padding-left: #{$container-padding-x * 0.5};
         --o-wsale-topbar-padding-right: calc(var(--o-wsale-container-fluid-padding-xl, var(--gutter-x)) * 0.5);
@@ -385,11 +387,67 @@ $input-border-color: $gray-400;
 
     .o_wsale_product_information {
         flex-direction: var(--o-wsale-card-info-flex-direction, column);
+        align-items: var(--o-wsale-card-info-flex-align-items);
+        gap: var(--o-wsale-card-info-gap);
+        margin: var(--o-wsale-card-info-marign);
         padding: var(--o-wsale-card-info-padding, #{map-get($spacers, 2)} 0);
     }
 
     .o_wsale_product_information_text {
-        flex-grow: var(--o-wsale-card-info-grow);
+        flex-grow: var(--o-wsale-card-info-text-grow);
+
+        .o_wsale_attribute_previewer {
+            width: var(--o-wsale-card-attribute-previewer-width, 100%);
+            justify-content: var(--o-wsale-card-attribute-previewer-justify-content);
+            padding: var(--o-wsale-card-attribute-previewer-padding, 0 #{map-get($spacers, 2)});
+            order: var(--o-wsale-card-attribute-previewer-order);
+
+            a.o_product_variant_preview {
+                &:has(.btn) {
+                    max-width: 40%;
+                }
+
+                &:has(.css_attribute_preview_thumbnail) {
+                    width: 14%;
+                    min-width: 2.6rem;
+
+                    * {
+                        width: 100%;
+                        height: 100%;
+                    }
+                }
+            }
+            // Only visible in /shop page
+            .css_attribute_preview_thumbnail {
+            border: $border-width solid $border-color;
+            border-radius: var(--o-wsale-card-attribute-previewer-thumbnail-border-radius, 0);
+            aspect-ratio: var(--o-wsale-card-thumb-aspect-ratio, 1/1);
+            transition: border-color 0.05s ease-in-out;
+
+                &:hover {
+                    border-color: map-get($theme-colors, "primary");
+                }
+            }
+
+            .css_attribute_color {
+            height: 1.75rem;
+            width: 1.75rem;
+            }
+
+            .btn {
+            border: $border-width solid $border-color;
+
+                &:hover {
+                    border-color: map-get($theme-colors, "primary");
+                }
+            }
+
+            @include media-breakpoint-up(md) {
+                &.show_on_hover {
+                    max-height: 0;
+                }
+            }
+        }
     }
 
     .oe_subdescription div {
@@ -408,12 +466,16 @@ $input-border-color: $gray-400;
 
     // Container for Price and Buttons
     .o_wsale_product_sub {
-        flex-direction: var(--o-wsale-card-sub-flex-direction, row);
+        width: var(--o-wsale-card-sub-width);
         align-items: var(--o-wsale-card-sub-align-items, end);
         flex-wrap: var(--o-wsale-card-sub-wrap, wrap);
+        order: var(--o-wsale-card-sub-order);
     }
 
     .o_wsale_product_btn {
+        margin: var(--o-wsale-card-btn-margin, #{map-get($spacers, 2)});
+        flex-direction: var(--o-wsale-card-btn-flex-direction, column);
+
         .btn {
             padding-left: .9rem;
             padding-right: .9rem;
@@ -429,11 +491,20 @@ $input-border-color: $gray-400;
         &:empty {
             display: none !important;
         }
+
+        @include media-breakpoint-down(md) {
+            --o-wsale-card-btn-flex-direction: row;
+        }
     }
 
     .o_product_link {
         @include o-position-absolute(0, 0, 0, 0);
         z-index: 1;
+    }
+
+    &:hover .show_on_hover {
+        max-height: 100px !important;
+        transition: max-height 0.2s ease-in-out;
     }
 }
 
@@ -468,7 +539,8 @@ body:not(.editor_enable) #category_header {
 
         .oe_product:not(.oe_product_size_stretch) {
             .o_wsale_product_btn {
-                @include o-position-absolute(auto, auto, calc(100% + #{map-get($spacers, 2)}), map-get($spacers, 2));
+                @include o-position-absolute(0, 0, auto, auto);
+
                 z-index: 2;
             }
 
@@ -487,6 +559,7 @@ body:not(.editor_enable) #category_header {
                 calc(100cqw / var(--o-wsale-ppr)) - calc(var(--o-wsale-products-grid-gap) / 2)
             );
             --o-wsale-card-padding: #{0 0 $o-wsale-products-layout-grid-gutter-width};
+            --o-wsale-card-attribute-previewer-padding: 0;
 
             .oe_subdescription div {
                 -webkit-line-clamp: initial;
@@ -501,7 +574,7 @@ body:not(.editor_enable) #category_header {
         }
 
         &.o_wsale_context_thumb_cover .oe_product.oe_product_size_stretch {
-            --o-wsale-card-info-grow: 1;
+            --o-wsale-card-info-text-grow: 1;
 
             .o_wsale_product_information {
                 height: 100%;
@@ -557,6 +630,14 @@ body:not(.editor_enable) #category_header {
         }
     }
 
+    .o_wsale_product_btn_list {
+        display: none !important;
+    }
+
+    & .oe_product:not(.oe_product_size_stretch) .o_wsale_attribute_previewer {
+        @include o-position-absolute(auto, 0, 100%, auto);
+    }
+
     .o_wsale_products_grid_table {
         @include media-breakpoint-up(lg) {
             @include desktop-setup();
@@ -590,12 +671,64 @@ body:not(.editor_enable) #category_header {
     .oe_product {
         --o-wsale-card-flex-direction: row;
         --o-wsale-card-flex-align-items: start;
+        --o-wsale-card-info-flex-direction: row;
+        --o-wsale-card-info-flex-align-items: center;
+        --o-wsale-card-info-marign: auto 0;
+        --o-wsale-card-info-gap: #{map-get($spacers, 3)};
         --o-wsale-card-info-padding: 0 #{map-get($spacers, 3)};
-        --o-wsale-card-info-grow: 1;
+        --o-wsale-card-info-text-grow: 1;
+        --o-wsale-card-sub-order: 3;
+        --o-wsale-card-attribute-previewer-width: 14vw;
+        --o-wsale-card-attribute-previewer-justify-content: start;
+        --o-wsale-card-attribute-previewer-padding: 0;
+        --o-wsale-card-attribute-previewer-order: 2;
         --o-wsale-card-thumb-size: calc(100px * var(--o-wsale-card-thumb-aspect-ratio, 1));
+        --o-wsale-card-btn-flex-direction: row;
+        --o-wsale-card-btn-margin: 0;
 
         grid-column: span $grid-columns;
         grid-row: span 1;
+    }
+
+    .product_price {
+        > span, > del {
+            display: block;
+            text-align: end;
+        }
+
+        @include media-breakpoint-up(md) {
+            min-width: MAX(12ch, 16cqw);
+        }
+    }
+
+    .o_wsale_attribute_previewer {
+        position: relative;
+    }
+
+    .o_wsale_product_btn_catalog {
+        display: none !important;
+    }
+
+    @include media-breakpoint-down(lg) {
+        .oe_product_cart {
+            --o-wsale-card-info-flex-direction: column;
+            --o-wsale-card-info-flex-align-items: start;
+            --o-wsale-card-info-gap: #{map-get($spacers, 2)};
+            --o-wsale-card-info-padding: 0 0 0 #{map-get($spacers, 2)};
+            --o-wsale-card-sub-width: 100%;
+            --o-wsale-card-attribute-previewer-width: 50vw;
+        }
+
+        .product_price {
+            > span, > del {
+                display: block;
+                text-align: start;
+            }
+        }
+    }
+
+    & .oe_product:hover .show_on_hover{
+        opacity: 1;
     }
 
     &:where(:not(.o_wsale_design_grid)) {
@@ -648,14 +781,13 @@ body:not(.editor_enable) #category_header {
         .oe_product_cart {
             --o-wsale-card-flex-align-items: stretch;
             --o-wsale-card-info-padding: #{map-get($spacers, 2) ($container-padding-x * 0.5) map-get($spacers, 2) map-get($spacers, 2)};
-            --o-wsale-card-sub-flex-direction: row-reverse;
+            --o-wsale-card-info-marign: 0;
             --o-wsale-card-sub-wrap: nowrap;
             --o-wsale-card-sub-align-items: start;
-            --o-wsale-card-info-grow: 0;
+            --o-wsale-card-info-flex-align-items: auto;
 
             @include media-breakpoint-up(lg) {
                 --o-wsale-card-thumb-size: calc(126px * var(--o-wsale-card-thumb-aspect-ratio, 1));
-                --o-wsale-card-info-flex-direction: row;
                 --o-wsale-card-info-padding: 0 calc(var(--o-wsale-container-fluid-padding-xl, #{$container-padding-x}) * 0.5);
                 --o-wsale-card-sub-align-items: center;
 
@@ -672,27 +804,24 @@ body:not(.editor_enable) #category_header {
 
                 .o_wsale_product_sub {
                     position: relative;
+                }
 
-                    .product_price {
-                        min-width: MAX(12ch, 16cqw);
-
-                        > span, > del {
-                            display: block;
-                            text-align: center;
-                        }
+                .product_price {
+                    > span, > del {
+                        text-align: center;
                     }
+                }
 
-                    .product_price, .o_wsale_product_btn {
-                        --_line-gap: #{map-get($spacers, 3)};
+                .product_price, .o_wsale_product_btn {
+                    --_line-gap: #{map-get($spacers, 3)};
 
-                        padding-left: var(--_line-gap);
+                    padding-left: var(--_line-gap);
 
-                        &:before {
-                            @include o-position-absolute(0, auto, 0);
-                            transform: translateX(calc(var(--_line-gap) * -1));
-                            border-left: $border-width solid $border-color;
-                            content: "";
-                        }
+                    &:before {
+                        @include o-position-absolute(0, auto, 0);
+                        transform: translateX(calc(var(--_line-gap) * -1));
+                        border-left: $border-width solid $border-color;
+                        content: "";
                     }
                 }
             }

--- a/addons/website_sale/views/product_attribute_views.xml
+++ b/addons/website_sale/views/product_attribute_views.xml
@@ -14,6 +14,18 @@
                         widget="radio"
                         options="{'horizontal': True}"
                     />
+                    <field
+                        name="preview_variants"
+                        widget="radio"
+                        options="{'horizontal': True}"
+                        readonly="create_variant != 'always' or display_type == 'multi'"
+                    />
+                    <field
+                        name="is_thumbnail_visible"
+                        widget="boolean_toggle"
+                        readonly="create_variant != 'always' or display_type == 'multi'"
+                        invisible="preview_variants == 'hidden'"
+                    />
                 </group>
             </group>
         </field>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -208,6 +208,83 @@
         </t>
     </template>
 
+    <template id="product_variant_preview">
+        <t
+            t-set="product_ptavs_data"
+            t-value="previewed_attribute_values[product.id]"
+        />
+        <t t-if="product_ptavs_data">
+            <t
+                t-set="product_ptavs"
+                t-value="product_ptavs_data.get('ptavs_data')"
+            />
+            <div
+                t-attf-class="o_wsale_attribute_previewer d-flex align-items-center gap-1 flex-nowrap z-1 overflow-hidden {{
+                    'show_on_hover' if product_ptavs[0]['ptav'].attribute_id.preview_variants == 'hover' and layout_mode != 'list' else ''
+                }}"
+                t-att-data-hidden-ptav-count="product_ptavs_data.get('hidden_ptavs_count')"
+            >
+                <t t-foreach="product_ptavs" t-as="previewed_ptav">
+                    <t t-set="ptav" t-value="previewed_ptav['ptav']"/>
+                    <t t-set="selected_attribute_value"
+                        t-value="ptav.product_attribute_value_id.id"/>
+                    <t
+                        t-set="variant_href"
+                        t-value="product_href.split('#')[0] + '#attribute_values=%s' % (selected_attribute_value)"
+                    />
+                    <a
+                        class="o_product_variant_preview my-2 d-none"
+                        t-att-data-variant-image="previewed_ptav['variant_image_url']"
+                        t-att-href="variant_href"
+                    >
+                        <div
+                            t-if="ptav.attribute_id.is_thumbnail_visible"
+                            class="d-flex"
+                        >
+                            <label
+                                class="css_attribute_preview_thumbnail cursor-pointer d-block"
+                                t-att-style="'background:url(%s); background-size:cover; background-position: center center;' % previewed_ptav['variant_image_url']"
+                                t-att-title="ptav.name"
+                            />
+                        </div>
+                        <div
+                            t-elif="ptav.display_type == 'color'"
+                            class="d-flex"
+                        >
+                            <t
+                                t-if="ptav.product_attribute_value_id.image"
+                                t-set="background_style"
+                                t-value="'background:url(/web/image/product.attribute.value/%s/image); background-size:cover;' % ptav.product_attribute_value_id.id"
+                            />
+                            <t
+                                t-elif="not ptav.is_custom"
+                                t-set="background_style"
+                                t-value="'background: ' + str(ptav.html_color or ptav.name)"
+                            />
+                            <label
+                                t-att-style="background_style"
+                                class="css_attribute_color cursor-pointer d-block"
+                                t-att-title="ptav.name"
+                            />
+                        </div>
+                        <span
+                            t-else=""
+                            t-attf-class="{{'' if ppr == 2 and layout_mode != 'list' else 'btn-sm'}} btn bg-body w-100 text-body text-truncate"
+                            t-out="ptav.name"
+                        />
+                    </a>
+                </t>
+                <span name="hidden_ptavs_count" class="d-none ms-1 small">
+                    <a t-att-href="product_href"/>
+                </span>
+            </div>
+        </t>
+    </template>
+
+    <template id="website_sale.shop_product_buttons">
+        <t name="buttons_container"/>
+    </template>
+
     <template id="products_item" name="Products item">
         <form
             class="oe_product_cart h-100 d-flex"
@@ -264,10 +341,11 @@
                             Unpublished
                         </a>
                     </h6>
+
+                    <t t-call="website_sale.product_variant_preview" />
                 </div>
-                <div class="o_wsale_product_sub d-flex justify-content-between gap-2">
+                <div class="o_wsale_product_sub d-flex align-items-center justify-content-between flex-nowrap gap-3">
                     <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
-                    <div class="o_wsale_product_btn d-flex gap-2"/>
                     <div class="product_price">
                         <span class="h6 mb-0"
                               t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale"
@@ -282,8 +360,18 @@
                             </del>
                         </t>
                     </div>
+                    <div
+                        t-if="layout_mode == 'list'"
+                        class="o_wsale_product_btn o_wsale_product_btn_list d-flex gap-2"
+                        t-call="website_sale.shop_product_buttons"
+                    />
                 </div>
             </div>
+            <div
+                t-if="layout_mode != 'list'"
+                class="o_wsale_product_btn o_wsale_product_btn_catalog d-flex gap-2"
+                t-call="website_sale.shop_product_buttons"
+            />
         </form>
     </template>
 
@@ -298,8 +386,13 @@
         </xpath>
     </template>
 
-    <template id="products_add_to_cart" inherit_id="website_sale.products_item" active="False" name="Add to Cart">
-        <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
+    <template
+        id="products_add_to_cart"
+        inherit_id="website_sale.shop_product_buttons"
+        active="False"
+        name="Add to Cart"
+    >
+        <t name="buttons_container" position="inside">
             <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
             <input name="product_id" t-att-value="product_variant_id" type="hidden"/>
             <input name="product_template_id" t-att-value="product.id" type="hidden"/>
@@ -317,7 +410,7 @@
                     <span class="fa fa-shopping-cart"/>
                 </a>
             </t>
-        </xpath>
+        </t>
     </template>
 
     <template id="pricelist_list" name="Pricelists Dropdown">

--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -104,7 +104,7 @@
 
                     <t t-elif="attribute.display_type == 'color'">
                         <ul t-att-data-attribute_id="attribute.id" t-attf-class="list-inline o_wsale_product_attribute #{'d-none' if single_and_custom else ''}">
-                            <li t-foreach="ptavs" t-as="ptav" class="list-inline-item me-1">
+                            <li t-foreach="ptavs" t-as="ptav" class="list-inline-item me-1 mb-2">
                                 <t t-set="img_style"
                                    t-value="'background:url(/web/image/product.template.attribute.value/%s/image); background-size:cover;' % ptav.id if ptav.image else ''"
                                 />

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="add_to_compare" inherit_id="website_sale.products_item" name="Comparison List" priority="22">
-        <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
+    <template
+        id="website_sale_comparison.add_to_compare"
+        inherit_id="website_sale.shop_product_buttons"
+        name="Comparison List"
+        priority="22"
+    >
+        <t name="buttons_container" position="inside">
             <t t-set="attrib_categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
             <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
             <button
                 t-if="product_variant_id and attrib_categories"
                 type="button"
                 role="button"
-                class="d-none d-md-inline-block btn btn-light o_add_compare"
+                class="btn btn-light o_add_compare"
                 title="Compare"
                 aria-label="Compare"
                 t-att-data-product-product-id="product_variant_id"
@@ -17,7 +22,7 @@
             >
                 <span class="fa fa-exchange"/>
             </button>
-        </xpath>
+        </t>
     </template>
 
     <template id="product_add_to_compare" name='Add to comparison in product page' inherit_id="website_sale.product" priority="8">

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="add_to_wishlist" inherit_id="website_sale.products_item" name="Wishlist Button" priority="20">
-        <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
+    <template
+        id="website_sale_wishlist.add_to_wishlist"
+        inherit_id="website_sale.shop_product_buttons"
+        name="Wishlist Button"
+        priority="20"
+    >
+        <t name="buttons_container" position="inside">
             <t t-set="in_wish" t-value="product in products_in_wishlist"/>
             <t t-set="product_variant_id" t-value="in_wish or product._get_first_possible_variant_id()"/>
             <button
@@ -18,7 +23,7 @@
             >
                 <span class="fa fa-heart" role="img" aria-label="Add to wishlist"/>
             </button>
-        </xpath>
+        </t>
     </template>
 
     <template id="product_cart_lines" inherit_id="website_sale.cart_lines" active="True">


### PR DESCRIPTION
If you sell product variants and if you have different images set on each variant, it is currently not possible to display a preview of these images from your /shop page (e.g.: variants in different colors). Only product templates are displayed in /shop, and the user must go to the product page to see the existing variants.

The aim of this PR is to add the option to view the variants on the product cards in /shop

task-3603625

Demo refactor see also: https://github.com/odoo/enterprise/pull/83390

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
