### PR TITLE
[FIX] point_of_sale: Fix runbot test that relies on demo data

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -611,12 +611,12 @@ registry.category("web_tour.tours").add("test_product_create_update_from_fronten
                 "Test Frontend Product",
                 "710535977349",
                 "20.0",
-                "Chairs"
+                "Chair Test"
             ),
             Dialog.confirm(),
 
             // Click on the category button for "Chairs" to verify the product's addition.
-            ProductScreen.clickSubcategory("Chairs"),
+            ProductScreen.clickSubcategory("Chair Test"),
             ProductScreen.clickDisplayedProduct("Test Frontend Product"),
             inLeftSide([
                 ...ProductScreen.selectedOrderlineHasDirect("Test Frontend Product", "1", "20.0"),
@@ -636,7 +636,7 @@ registry.category("web_tour.tours").add("test_product_create_update_from_fronten
                 "50.0"
             ),
             Dialog.confirm(),
-            ProductScreen.clickSubcategory("Chairs"),
+            ProductScreen.clickSubcategory("Chair Test"),
             ProductScreen.clickDisplayedProduct("Test Frontend Product Edited"),
             inLeftSide([
                 ...ProductScreen.selectedOrderlineHasDirect(

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1833,6 +1833,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.pos_admin.write({
             'groups_id': [Command.link(self.env.ref('base.group_system').id)],
         })
+        self.pos_cat_chair_test.write({'sequence': 1})
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour('/pos/ui?config_id=%d' % self.main_pos_config.id, 'test_product_create_update_from_frontend', login='pos_admin')
 


### PR DESCRIPTION
Change used category in test from `Chairs` which is demo data to `Chair Test`

runbot error: 162925, 162923

