### PR TITLE
[IMP] tests: catch potential concurrent cr errors.

### DIFF
--- a/odoo/addons/base/tests/test_http_case.py
+++ b/odoo/addons/base/tests/test_http_case.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import HttpCase, tagged, ChromeBrowser
-from odoo.tools import config, logging
+import threading
 from unittest.mock import patch
+
+from odoo.http import Controller, request, route
+from odoo.tests.common import ChromeBrowser, HttpCase, tagged
+from odoo.tools import config, logging
+
+_logger = logging.getLogger(__name__)
+
 
 @tagged('-at_install', 'post_install')
 class TestHttpCase(HttpCase):
@@ -88,3 +94,57 @@ class TestChromeBrowser(HttpCase):
         code = "setTimeout(() => console.log('test successful'), 2000); setInterval(() => document.body.innerText = (new Date()).getTime(), 100);"
         self.browser._wait_code_ok(code, 10)
         self.browser._save_screencast()
+
+
+class TestRequestRemaining(HttpCase):
+    # This test case tries to reproduce the case where a request is lost between two test and is execute during the secone one.
+    #
+    # - Test A browser js finishes with a pending request
+    # - _wait_remaining_requests misses the request since the thread may not be totally spawned (or correctly named)
+    # - Test B starts and a SELECT is executed
+    # - The request is executed and makes a concurrent fetchall
+    # - The test B tries to fetchall and fails since the cursor is already used by the request
+    #
+    # Note that similar cases can also consume savepoint, make the main cursor readonly, ...
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.thread_a = None
+        # this lock is used to ensure the request is executed after test b starts
+        cls.main_lock = threading.Lock()
+        cls.main_lock.acquire()
+
+    def test_requests_a(self):
+        class Dummycontroller(Controller):
+            @route('/web/concurrent', type='http', auth='public', sitemap=False)
+            def wait(c, **params):
+                self.assertEqual(request.env.cr.__class__.__name__, 'TestCursor')
+                request.env.cr.execute('SELECT 1')
+                request.env.cr.fetchall()
+                # not that the previous queries are not really needed since the http stack will check the registry
+                # but this makes the test more clear and robust
+                _logger.info('B finish')
+
+        self.env.registry.clear_caches()
+        self.addCleanup(self.env.registry.clear_caches)
+
+        def late_request_thread():
+            # In some rare case the request may arrive after _wait_remaining_requests.
+            # this thread is trying to reproduce this case.
+            _logger.info('Waiting for B to start')
+            if self.main_lock.acquire(timeout=10):
+                self.url_open("/web/concurrent", timeout=10)
+            else:
+                _logger.error('Something went wrong and thread was not able to aquire lock')
+        TestRequestRemaining.thread_a = threading.Thread(target=late_request_thread)
+        self.thread_a.start()
+
+    def test_requests_b(self):
+        self.env.cr.execute('SELECT 1')
+        with self.assertLogs('odoo.tests.common', level="ERROR") as lc:
+            self.main_lock.release()
+            _logger.info('B started, waiting for A to finish')
+            self.thread_a.join()
+        self.assertEqual(lc.output, ['ERROR:odoo.tests.common:Request with path /web/concurrent has been ignored during test as it it does not contain the test_cursor cookie or it is expired. (required "/base/tests/test_http_case.py:TestRequestRemaining.test_requests_b", got "/base/tests/test_http_case.py:TestRequestRemaining.test_requests_a")'])
+        self.env.cr.fetchall()

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -848,7 +848,7 @@ class Registry(Mapping):
         """
         if self.test_cr is not None:
             # in test mode we use a proxy object that uses 'self.test_cr' underneath
-            return TestCursor(self.test_cr, self.test_lock)
+            return TestCursor(self.test_cr, self.test_lock, current_test=odoo.modules.module.current_test)
         return self._db.cursor()
 
 

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -516,8 +516,11 @@ class TestCursor(BaseCursor):
         +------------------------+---------------------------------------------------+
     """
     _cursors_stack = []
-    def __init__(self, cursor, lock):
+
+    def __init__(self, cursor, lock, current_test=None):
         assert isinstance(cursor, BaseCursor)
+        self.current_test = current_test
+        self._check('__init__')
         super().__init__()
         self._now = None
         self._closed = False
@@ -529,6 +532,10 @@ class TestCursor(BaseCursor):
         # in order to simulate commit and rollback, the cursor maintains a
         # savepoint at its last commit, the savepoint is created lazily
         self._savepoint = self._cursor.savepoint(flush=False)
+
+    def _check(self, operation):
+        if self.current_test:
+            self.current_test.check_test_cursor(operation)
 
     def execute(self, *args, **kwargs):
         if not self._savepoint:
@@ -554,6 +561,7 @@ class TestCursor(BaseCursor):
 
     def commit(self):
         """ Perform an SQL `COMMIT` """
+        self._check('commit')
         self.flush()
         if self._savepoint:
             self._savepoint.close(rollback=False)
@@ -565,6 +573,7 @@ class TestCursor(BaseCursor):
 
     def rollback(self):
         """ Perform an SQL `ROLLBACK` """
+        self._check('rollback')
         self.clear()
         self.postcommit.clear()
         self.prerollback.run()
@@ -573,6 +582,7 @@ class TestCursor(BaseCursor):
         self.postrollback.run()
 
     def __getattr__(self, name):
+        self._check(name)
         return getattr(self._cursor, name)
 
     def now(self):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -53,6 +53,8 @@ import odoo
 from odoo import api
 from odoo.models import BaseModel
 from odoo.exceptions import AccessError
+from odoo.http import BadRequest
+from odoo.modules import module
 from odoo.modules.registry import Registry
 from odoo.osv import expression
 from odoo.osv.expression import normalize_domain, TRUE_LEAF, FALSE_LEAF
@@ -91,6 +93,7 @@ ADMIN_USER_ID = odoo.SUPERUSER_ID
 CHECK_BROWSER_SLEEP = 0.1 # seconds
 CHECK_BROWSER_ITERATIONS = 100
 BROWSER_WAIT = CHECK_BROWSER_SLEEP * CHECK_BROWSER_ITERATIONS # seconds
+TEST_CURSOR_COOKIE_NAME = 'test_request_key'
 
 def get_db_name():
     db = odoo.tools.config['db_name']
@@ -666,6 +669,45 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
         p = patch('requests.Session.request', Mock(spec_set=[]))
         self.addCleanup(p.stop)
         return p.start()
+
+    def setUp(self):
+        super().setUp()
+        self.http_request_key = self.canonical_tag
+
+        def reset_http_key():
+            self.http_request_key = None
+        self.addCleanup(reset_http_key)  # this should avoid to have a request executing during teardown
+
+    def check_test_cursor(self, operation):
+        if odoo.modules.module.current_test != self:
+            message = f"Trying to open a test cursor for {self.canonical_tag} while already in a test {odoo.modules.module.current_test.canonical_tag}"
+            _logger.error(message)
+            raise BadRequest(message)
+        request = odoo.http.request
+        if not request:
+            return
+        if not self.http_request_key:
+            message = f'Using a test cursor without http_request_key, most likely between two tests on request {request.httprequest.path} in {module.current_test.canonical_tag}'
+            _logger.error(message)
+            raise BadRequest(message)
+        http_request_key = request.httprequest.cookies.get(TEST_CURSOR_COOKIE_NAME)
+        if not http_request_key:
+            if operation == '__init__':  # main difference with master, don't fail if no cookie is defined_check
+                message = f'Opening a test cursor without specified test on request {request.httprequest.path} in {module.current_test.canonical_tag}'
+                _logger.info(message)
+            return
+        http_request_required_key = self.http_request_key
+        if http_request_key != http_request_required_key:
+            expected = http_request_required_key
+            _logger.error(
+                'Request with path %s has been ignored during test as it '
+                'it does not contain the test_cursor cookie or it is expired.'
+                ' (required "%s", got "%s")',
+                request.httprequest.path, expected, http_request_key
+            )
+            raise BadRequest(
+                'Request ignored during test as it does not contain the required cookie.'
+            )
 
 savepoint_seq = itertools.count()
 
@@ -1670,6 +1712,7 @@ class HttpCase(TransactionCase):
         self.xmlrpc_object = xmlrpclib.ServerProxy(self.xmlrpc_url + 'object', transport=Transport(self.cr))
         # setup an url opener helper
         self.opener = Opener(self.cr)
+        self.opener.cookies[TEST_CURSOR_COOKIE_NAME] = self.canonical_tag
 
     def parse_http_location(self, location):
         """ Parse a Location http header typically found in 201/3xx
@@ -1787,9 +1830,11 @@ class HttpCase(TransactionCase):
         # completely) or clear-ing session.cookies.
         self.opener = Opener(self.cr)
         self.opener.cookies['session_id'] = session.sid
+        self.opener.cookies[TEST_CURSOR_COOKIE_NAME] = self.http_request_key
         if self.browser:
             self._logger.info('Setting session cookie in browser')
             self.browser.set_cookie('session_id', session.sid, '/', HOST)
+            self.browser.set_cookie(TEST_CURSOR_COOKIE_NAME, self.http_request_key, '/', HOST)
 
         return session
 
@@ -1827,6 +1872,7 @@ class HttpCase(TransactionCase):
             self.browser._chrome_without_limit([self.browser.executable, debug_front_end])
             time.sleep(3)
         try:
+            self.http_request_key = self.canonical_tag + '_browser_js'
             self.authenticate(login, login)
             # Flush and clear the current transaction.  This is useful in case
             # we make requests to the server, as these requests are made with
@@ -1884,6 +1930,8 @@ class HttpCase(TransactionCase):
             self.browser.delete_cookie('session_id', domain=HOST)
             self.browser.clear()
             self._wait_remaining_requests()
+            self.http_request_key = self.canonical_tag
+            self.opener.cookies[TEST_CURSOR_COOKIE_NAME] = self.http_request_key
 
     @classmethod
     def base_url(cls):


### PR DESCRIPTION
Partial backport of #202835

Nicer strategy for stable to avoid braking all existing clients tests

This should catch most case without introducing a lock and a mandatory allowance of the request.

- If the cookie is present, check if it is valid (request opening cursor in next test)
- Check if the test cursor was opened in the same test as the execute/rollback (request started in previous test executing in next)
- custom expected cookie for browser js to avoid allowing a request after wait_remaining_requests

All message could be silenced to kill the transaction without braking the test if it is a better strategy. 


Some design choices:
 - current_test is passed to Testcursor to avoid to add an import to odoo modules in sql_db, only impacts test logic. Parameter is optional. 
 - test cursor checks current_test before each operation (execute, commit, rollback). 
 - http_request_key is the test itself (between setup and cleanup), only exception is for browser js to avoid request executing during the end of the test (once browser is closed). It is the most common case.
 
