### PR TITLE
[FIX] stock: bypass procurement on backorder of mto moves

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1517,3 +1517,40 @@ class TestReorderingRule(TransactionCase):
         self.assertRecordValues(self.env['purchase.order'].search([('company_id', '=', company_b.id), ('partner_id', '=', self.partner.id)], limit=1).order_line, [{
             'product_id': product.id, 'product_uom_qty': 10,
         }])
+
+    def test_backorder_mto_buy(self):
+        """
+        Check that purchase order created to fullfill an mto buy demand are
+        well behaved with respect to backorder deliveries.
+        """
+        buy_product = self.product_01
+        mto_route = self.env.ref('stock.route_warehouse0_mto')
+        mto_route.active = True
+        buy_product.route_ids |= mto_route
+        pg = self.env["procurement.group"].create({'name': 'Test mto buy procurement'})
+        self.env["procurement.group"].run(
+            [pg.Procurement(
+                buy_product, 100, buy_product.uom_id,
+                self.env.ref('stock.stock_location_customers'), "Test mto buy", "/",
+                self.env.company,
+                {
+                    "warehouse_id": self.env.ref('stock.warehouse0'),
+                    "group_id": pg,
+                },
+            )])
+        po_line = self.env["purchase.order.line"].search([("product_id", "=", buy_product.id)], limit=1)
+        self.assertEqual(po_line.product_uom_qty, 100)
+        delivery = po_line.move_dest_ids.picking_id
+        # Deliver only 30 units and backorder the rest
+        delivery.move_ids.quantity = 30
+        backorder_wizard_dict = delivery.button_validate()
+        backorder_wizard_form = Form.from_action(self.env, backorder_wizard_dict)
+        backorder_wizard_form.save().process()
+        # Check that the bakorder is still mto
+        self.assertRecordValues(delivery.backorder_ids.move_ids, [{
+            'product_uom_qty': 70, 'procure_method': 'make_to_order',
+        }])
+        # Check that the backorder belongs to the same procurement group
+        self.assertEqual(delivery.backorder_ids.group_id, delivery.group_id)
+        # Check that the PO was not updated not a new PO created
+        self.assertEqual(self.env["purchase.order.line"].search([("product_id", "=", buy_product.id)]).product_qty, 100)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1502,7 +1502,7 @@ Please change the quantity done or the rounding precision of your unit of measur
 
         # create procurements for make to order moves
         procurement_requests = []
-        move_create_proc = self.browse(move_create_proc)
+        move_create_proc = self.browse(move_create_proc) if not self.env.context.get('bypass_procurement_creation', False) else self.env['stock.move']
         quantities = move_create_proc._prepare_procurement_qty()
         for move, quantity in zip(move_create_proc, quantities):
             values = move._prepare_procurement_values()
@@ -2071,7 +2071,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         backorder_moves = self.env['stock.move'].create(backorder_moves_vals)
         # The backorder moves are not yet in their own picking. We do not want to check entire packs for those
         # ones as it could messed up the result_package_id of the moves being currently validated
-        backorder_moves.with_context(bypass_entire_pack=True)._action_confirm(merge=False)
+        backorder_moves.with_context(bypass_entire_pack=True, bypass_procurement_creation=True)._action_confirm(merge=False)
         return backorder_moves
 
     @api.ondelete(at_uninstall=False)


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable Multi-Step routes
- Unarchive the MTO route
- Create a storable product using the MTO and buy route
- Create and confirm a sale order for 100 units of that product
- Validate the delivery for only 30 units and backorder the rest
#### > The purchase order demand was updated to 170 units

### Cause of the issue:

Since the refactoring a72382063ee662010729d983fbf6fb6305b8adf2 the rule of the MTO route is purely MTO. Furthermore, the moves creating and running a procurement are added depending solely on their `procure_method` during the `_action_confirm`:
https://github.com/odoo/odoo/blob/1dd360658222c0afeb268a5c8cf435defddf55d1/addons/stock/models/stock_move.py#L1485-L1496 https://github.com/odoo/odoo/blob/1dd360658222c0afeb268a5c8cf435defddf55d1/addons/stock/models/stock_move.py#L1503-L1513 In our use case, the delivery move is therefore created as `mto` and then creates and run a procurments creating the PO during its confirmation. However, when it is backordered, the backorder move is also created and confirmed as `mto` by the `_create_backorder` call:
https://github.com/odoo/odoo/blob/02a370a7a34a42f2bc9f668eee756fb466db8722/addons/stock/models/stock_move.py#L2071-L2075 It will therefore also automatically create and run a procurment that will in turn modify the current PO.

opw-4633920

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
