### PR TITLE
[FIX] test_lint: be more resilient to weird setups

### DIFF
--- a/odoo/addons/test_lint/tests/test_pylint.py
+++ b/odoo/addons/test_lint/tests/test_pylint.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import platform
+import sys
 from os.path import join
 
 try:
@@ -76,7 +77,8 @@ class TestPyLint(TransactionCase):
             ]),
         ]
 
-        pypath = HERE + os.pathsep + os.environ.get('PYTHONPATH', '')
+        stdlib_prefixes = tuple({sys.prefix, sys.base_prefix, sys.exec_prefix, sys.base_exec_prefix})
+        pypath = os.pathsep.join([HERE, *(p for p in sys.path if not p.startswith(stdlib_prefixes))])
         env = {
             **os.environ,
             "PYTHONPATH": pypath,


### PR DESCRIPTION
Because #203874 needed to manipulate Odoo imports, it had to be able to import Odoo. Turns out there are setups where the root of the community repository is on `sys.path` but not in `PYTHONPATH` which can lead the pylint invocation to be confused and not have `odoo` be reachable from the `PYTHONPATH`, thus crashing the plugins' loading.

Thus to run pylint we need not the `PYTHONPATH` but the `sys.path`. Which is not ideal because that'll contain the paths to the site and standard library of the python running the test, which might be different than the python running pylint.

To limit the risks of contamination, strip out any path starting with one of the `sys.$CATEGORY_prefix` entries.
