### PR TITLE
[FIX] account: fix division by zero when importing a PO with != currency

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -971,7 +971,7 @@ class AccountMoveLine(models.Model):
                 include_caba_tags=line.move_id.always_tax_exigible,
                 fixed_multiplicator=sign,
             )
-            rate = line.amount_currency / line.balance if line.balance else line.currency_rate
+            rate = line.amount_currency / line.balance if (line.amount_currency and line.balance) else line.currency_rate
             line.compute_all_tax_dirty = True
             line.compute_all_tax = {
                 frozendict({


### PR DESCRIPTION
Steps to reproduce:
- Install apps accounting, purchase and stock.
- Create a PO with a different currency than the main currency.
- Add a least one PO line.
- Confirm the PO and mark the quantities as received.
- Create a vendor bill and try to link the PO -> Traceback.

Since commit 90158f6, the `balance` of the `account.move.line` is computed before the call to `_compute_all_tax` when importing a PO. Before, it wasn't computed yet and was equal to 0. The line `amount_currency` isn't computed yet at this point, it is always 0.

Since the `rate` is computed as `amount_currency`/`balance`, it is always computed to 0, which then causes a `ZeroDivisionError` in further computations.

[opw-4710499](https://www.odoo.com/odoo/project/967/tasks/4710499)
