### PR TITLE
[FIX] discuss: prevent peer negotiations for removed peers

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -15,6 +15,11 @@ import { memoize } from "@web/core/utils/functions";
 import { url } from "@web/core/utils/urls";
 import { callActionsRegistry } from "./call_actions";
 
+let sequence = 1;
+const getSequence = () => {
+    return sequence++;
+};
+
 /**
  *
  * @param {EventTarget} target
@@ -681,6 +686,24 @@ export class Rtc extends Record {
             return;
         }
         switch (name) {
+            case "broadcast":
+                {
+                    const {
+                        senderId,
+                        message: { sequence },
+                    } = payload;
+                    if (!sequence) {
+                        return;
+                    }
+                    const session = await this.store.RtcSession.getWhenReady(senderId);
+                    if (!session) {
+                        return;
+                    }
+                    if (!session.sequence || session.sequence < sequence) {
+                        session.sequence = sequence;
+                    }
+                }
+                return;
             case "connection_change":
                 {
                     const { id, state } = payload;
@@ -718,12 +741,19 @@ export class Rtc extends Record {
                 return;
             case "track":
                 {
-                    const { sessionId, type, track, active } = payload;
+                    const { sessionId, type, track, active, sequence } = payload;
                     const session = await this.store.RtcSession.getWhenReady(sessionId);
                     if (!session || !this.state.channel) {
                         this.log(
                             this.selfSession,
                             `track received for unknown session ${sessionId} (${this.state.connectionType})`
+                        );
+                        return;
+                    }
+                    if (sequence && sequence < session.sequence) {
+                        this.log(
+                            session,
+                            `track received for old sequence ${sequence} (${this.state.connectionType})`
                         );
                         return;
                     }
@@ -750,6 +780,7 @@ export class Rtc extends Record {
             case this.SFU_CLIENT_STATE.AUTHENTICATED:
                 // if we are hot-swapping connection type, we clear the p2p as late as possible
                 this.p2pService.removeALlPeers();
+                this.sfuClient.broadcast({ sequence: getSequence() });
                 break;
             case this.SFU_CLIENT_STATE.CONNECTED:
                 browser.clearTimeout(this.sfuTimeout);
@@ -822,12 +853,13 @@ export class Rtc extends Record {
         if (this.state.channel.rtcSessions.length === 0) {
             return;
         }
+        const sequence = getSequence();
         for (const session of this.state.channel.rtcSessions) {
             if (session.eq(this.selfSession)) {
                 continue;
             }
             this.log(session, "init call", { step: "init call" });
-            this.p2pService.addPeer(session.id);
+            this.p2pService.addPeer(session.id, { sequence });
         }
     }
 
@@ -1547,6 +1579,14 @@ export const rtcService = {
     start(env, services) {
         const rtc = env.services["mail.store"].rtc;
         rtc.p2pService = services["discuss.p2p"];
+        rtc.p2pService.acceptOffer = async (id, sequence) => {
+            const session = await this.store.RtcSession.getWhenReady(Number(id));
+            /**
+             * We only accept offers for new connections (higher sequence),
+             * or offers that renegotiate an existing connection (same sequence).
+             */
+            return sequence >= session?.sequence;
+        };
         services["bus_service"].subscribe(
             "discuss.channel.rtc.session/sfu_hot_swap",
             async ({ serverInfo }) => {

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -107,6 +107,14 @@ export class RtcSession extends Record {
     videoStreams = new Map();
     /** @type {string} */
     mainVideoStreamType;
+    /**
+     * Represents the sequence of the last valid connection with that session. This can be used to
+     * compare connection attempts (if they follow the last valid connection) and to validate information
+     * (if they match the sequence).
+     *
+     *  @type {number}
+     */
+    sequence = 0;
     // RTC stats
     connectionState;
     localCandidateType;

--- a/addons/mail/static/tests/discuss/call/peer_to_peer.test.js
+++ b/addons/mail/static/tests/discuss/call/peer_to_peer.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { advanceTime } from "@odoo/hoot-mock";
 import { browser } from "@web/core/browser/browser";
-import { onRpc, mountWebClient } from "@web/../tests/web_test_helpers";
+import { onRpc, mountWebClient, asyncStep, waitForSteps } from "@web/../tests/web_test_helpers";
 import {
     assertSteps,
     defineMailModels,
@@ -168,6 +168,9 @@ test("can broadcast arbitrary messages (dataChannel)", async () => {
     const network = new Network();
     const user1 = network.register(1);
     const user2 = network.register(2);
+    user2.p2p.connect(user2.id, channelId);
+    user1.p2p.connect(user1.id, channelId);
+    await user1.p2p.addPeer(user2.id);
     user1.inbox = [];
     const pongPromise = new Promise((resolve) => {
         user1.p2p.addEventListener("update", ({ detail: { name, payload } }) => {
@@ -179,20 +182,37 @@ test("can broadcast arbitrary messages (dataChannel)", async () => {
     });
     user2.inbox = [];
     user2.p2p.addEventListener("update", ({ detail: { name, payload } }) => {
-        if (name === UPDATE_EVENT.BROADCAST) {
+        if (name === UPDATE_EVENT.BROADCAST && payload.message === "ping") {
             user2.inbox.push(payload);
             user2.p2p.broadcast("pong");
         }
     });
-
-    user2.p2p.connect(user2.id, channelId);
-    user1.p2p.connect(user1.id, channelId);
-    await user1.p2p.addPeer(user2.id);
     user1.p2p.broadcast("ping");
     await pongPromise;
     expect(user2.inbox[0].senderId).toBe(user1.id);
     expect(user2.inbox[0].message).toBe("ping");
     expect(user1.inbox[0].senderId).toBe(user2.id);
     expect(user1.inbox[0].message).toBe("pong");
+    network.close();
+});
+
+test("can reject arbitrary offers", async () => {
+    await mountWebClient();
+    const channelId = 1;
+    const network = new Network();
+    const user1 = network.register(1);
+    const user2 = network.register(2);
+    user2.p2p.connect(user2.id, channelId);
+    user1.p2p.connect(user1.id, channelId);
+    user2.p2p._emitLog = (id, message) => {
+        if (message === "offer rejected") {
+            asyncStep("offer rejected");
+        }
+    };
+    user2.p2p.acceptOffer = (id, sequence) => {
+        return id !== user1.id || sequence > 20;
+    };
+    user1.p2p.addPeer(user2.id, { sequence: 19 });
+    await waitForSteps(["offer rejected"]);
     network.close();
 });


### PR DESCRIPTION
Before this commit, and since the addition of the SFU fallback feature,
it was possible that a peer was removed while being created or
connected, this could lead to a race condition where we no longer need
the peer but some negotiations are still being made.

This commit fixes this issue by stopping the negotiation if the
peer no longer exist when the promises are resolved.

Another race condition could lead to receiving a track from the
failed peer-to-peer connection (as tracks are generated when
transceiver are created, before we know if the connection is stable),
while we already have a track from the SFU.

This commit fixes this issue by:

1) Awaiting that the p2p connection is ready before emitting the tracks,
which ensures that the API only provides valid tracks (when usable).
2) Adding a concept of sequence to prevent race conditions between
connections and tracks.