### PR TITLE
[FIX] sale: provide `default_author_id` in context when sending mail

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -748,6 +748,7 @@ class SaleOrder(models.Model):
             'default_use_template': bool(mail_template),
             'default_template_id': mail_template.id if mail_template else None,
             'default_composition_mode': 'comment',
+            'default_author_id': (self.user_id or self.company_id).partner_id.id,
             'mark_so_as_sent': True,
             'default_email_layout_xmlid': 'mail.mail_notification_layout_with_responsible_signature',
             'proforma': self.env.context.get('proforma', False),


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Set company email to the same as the admin's;
2. log in as demo user;
3. set up a sales order without a salesperson;
4. send sales order via email.

Issue
-----
Sales order shows as being sent from admin user instead of the company email. The expected behavior for sales orders is that they're sent from the salesperson email if available, else the company's email.

Cause
-----
When sending the email, it has the correct `email_formatted` value, i.e. Company Name <company@email.com>. To get the author however, `mail` uses the `_mail_find_partner_from_emails` method, which normalizes the given emails before searching matching partners.

Without the "Company Name" part, it will also match admin user's email, and because the method prioritizes user emails over partner emails, the company's `partner_id` doesn't even get checked in the lookup.

Solution
--------
Provide a default author_id to the context when sending mail. This way, `mail` won't have to guess one based on the given email.

opw-4690644