### PR TITLE
[FIX] mail: no upload file action on comment composer

### DIFF
--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -103,9 +103,11 @@ composerActionsRegistry
     .add("upload-files", {
         condition: (component) => {
             const thread = component.thread ?? component.message?.thread;
-            return !(
-                thread?.channel_type === "whatsapp" &&
-                component.props.composer.attachments.length > 0
+            return (
+                !(
+                    thread?.channel_type === "whatsapp" &&
+                    component.props.composer.attachments.length > 0
+                ) && !component.props.composer.portalComment
             );
         },
         icon: "fa fa-paperclip",


### PR DESCRIPTION
The upload file action is available in the comment composer, but it's not relevant to what this composer is expected to do, and it doesn't work there. This PR removes that action from the comment composer.

part of task-4712487

