### PR TITLE
[IMP] domains: allow for custom domains

### DIFF
--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -262,6 +262,20 @@ class Domain:
         return operator in NEGATIVE_CONDITION_OPERATORS
 
     @staticmethod
+    def custom(
+        *,
+        to_sql: Callable[[BaseModel, str, Query], SQL],
+        predicate: Callable[[BaseModel], bool] | None = None,
+    ) -> DomainCustom:
+        """Create a custom domain.
+
+        :param to_sql: callable(model, alias, query) that returns the SQL
+        :param predicate: callable(record) that checks whether a record is kept
+                          when filtering
+        """
+        return DomainCustom(to_sql, predicate)
+
+    @staticmethod
     def AND(items: Iterable) -> Domain:
         """Build the conjuction of domains: (item1 AND item2 AND ...)"""
         return DomainAnd.apply(Domain(item) for item in items)
@@ -693,6 +707,52 @@ class DomainOr(DomainNary):
         return or_predicate
 
 
+class DomainCustom(Domain):
+    """Domain condition that generates directly SQL and possibly a ``filtered`` predicate."""
+    __slots__ = ('_filtered', '_sql')
+
+    def __new__(
+        cls,
+        sql: Callable[[BaseModel, str, Query], SQL],
+        filtered: Callable[[BaseModel], bool] | None = None,
+    ):
+        """Create a new domain.
+
+        :param to_sql: callable(model, alias, query) that implements ``_to_sql``
+                       which is used to generate the query for searching
+        :param predicate: callable(record) that checks whether a record is kept
+                          when filtering (``Model.filtered``)
+        """
+        self = object.__new__(cls)
+        self._sql = sql
+        self._filtered = filtered
+        self._opt_level = OptimizationLevel.FULL
+        return self
+
+    def _as_predicate(self, records):
+        if self._filtered is not None:
+            return self._filtered
+        # by default, run the SQL query
+        query = records._search(DomainCondition('id', 'in', records.ids) & self, order='id')
+        return DomainCondition('id', 'any', query)._as_predicate(records)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, DomainCustom)
+            and self._sql == other._sql
+            and self._filtered == other._filtered
+        )
+
+    def __hash__(self):
+        return hash(self._sql)
+
+    def __iter__(self):
+        yield self
+
+    def _to_sql(self, model: BaseModel, alias: str, query: Query) -> SQL:
+        return self._sql(model, alias, query)
+
+
 class DomainCondition(Domain):
     """Domain condition on field: (field, operator, value)
 
@@ -749,7 +809,7 @@ class DomainCondition(Domain):
         elif isinstance(value, (Domain, Query)) and operator not in ('any', 'not any', 'in', 'not in'):
             # accept SQL object in the right part for simple operators
             # use case: compare 2 fields
-            # TODO we should remove support for SQL for these other operators, add DomainSQLCondition
+            # TODO we should remove support for SQL for these other operators, add DomainCustom
             _logger.warning("The domain condition %r should use the 'any' or 'not any' operator.", (self.field_expr, self.operator, self.value))
         if value is not self.value:
             return DomainCondition(self.field_expr, operator, value)
@@ -1059,10 +1119,11 @@ def _optimize_nary_sort_key(domain: Domain) -> tuple[str, str, str]:
         else:
             order = positive_op
         return domain.field_expr, order, operator
-    else:
+    elif hasattr(domain, 'OPERATOR') and isinstance(domain.OPERATOR, str):
         # in python; '~' > any letter
-        assert hasattr(domain, 'OPERATOR') and isinstance(domain.OPERATOR, str)
         return '~', '', domain.OPERATOR
+    else:
+        return '~', '~', domain.__class__.__name__
 
 
 def nary_optimization(optimization: MergeOptimization):

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1049,7 +1049,12 @@ class DomainCondition(Domain):
         return func if positive_operator == operator else lambda rec: not func(rec)
 
     def _to_sql(self, model: BaseModel, alias: str, query: Query) -> SQL:
-        return model._condition_to_sql(alias, self.field_expr, self.operator, self.value, query)
+        field_expr, operator, value = self.field_expr, self.operator, self.value
+        assert operator in STANDARD_CONDITION_OPERATORS, \
+            f"Invalid operator {operator!r} for SQL in domain term {(field_expr, operator, value)!r}"
+
+        field = model._fields[parse_field_expr(field_expr)[0]]
+        return field.condition_to_sql(field_expr, operator, value, model, alias, query)
 
 
 # --------------------------------------------------

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1284,8 +1284,8 @@ class Field(typing.Generic[T]):
                 return v
 
         # support for SQL value
-        # TODO deprecate this usage
         if operator in SQL_OPERATORS and isinstance(value, SQL):
+            warnings.warn("Since 19.0, use Domain.custom(to_sql=lambda model, alias, query: SQL(...))", DeprecationWarning)
             return SQL("%s%s%s", sql_field, SQL_OPERATORS[operator], value)
 
         # nullability

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -59,7 +59,6 @@ from odoo.tools.lru import LRU
 from odoo.tools.misc import ReversedIterable, exception_to_unicode, unquote
 from odoo.tools.translate import _, LazyTranslate
 
-from . import domains
 from . import decorators as api
 from .commands import Command
 from .domains import Domain, NEGATIVE_CONDITION_OPERATORS
@@ -2720,22 +2719,6 @@ class BaseModel(metaclass=MetaModel):
 
         # if the key is not present in the dict, fallback to false instead of none
         return SQL("COALESCE(%s, 'false')", sql_property)
-
-    def _condition_to_sql(self, alias: str, field_expr: str, operator: str, value, query: Query) -> SQL:
-        """ Return an :class:`SQL` object that represents the domain condition
-        given by the triple ``(field_expr, operator, value)`` with the given
-        table alias, and in the context of the given query.
-
-        The method is also responsible for checking that the field is accessible
-        for reading, and should include metadata in the result object to make
-        sure that the necessary fields are flushed before executing the final
-        SQL query.
-        """
-        assert operator in domains.STANDARD_CONDITION_OPERATORS, \
-            f"Invalid operator {operator!r} for SQL in domain term {(field_expr, operator, value)!r}"
-
-        field = self._fields[parse_field_expr(field_expr)[0]]
-        return field.condition_to_sql(field_expr, operator, value, self, alias, query)
 
     @api.model
     def get_property_definition(self, full_name: str) -> dict:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A new type of custom domain that allows to inject arbitrary SQL into the domain.

Current behavior before PR:
When needed to inject custom SQL into a domain, there are multiple possibilities:
1. use `[('id', 'in', SQL(...))]` - which needs a subquery
2. use `[('some_field', '>', SQL(...))]` - where you hope that the alias of the compared column is the same as what is expected
3. overwrite _condition_to_sql which is very low-level and called after domain optimizations

Desired behavior after PR is merged:
A new domain type that generates a SQL given a model, alias and query.

odoo/enterprise#87802

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
