### PR TITLE
[FIX] l10n_uk: Prevent Forced Creation of Accounts, Taxes, and Fiscal Positions During Upgrade

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -265,8 +265,8 @@ class AccountChartTemplate(models.AbstractModel):
                 template_data.pop(prop)
         data.pop('account.reconcile.model', None)
         if 'res.company' in data:
+            data['res.company'][company.id].clear()
             data['res.company'][company.id].setdefault('anglo_saxon_accounting', company.anglo_saxon_accounting)
-
         for xmlid, journal_data in list(data.get('account.journal', {}).items()):
             if self.ref(xmlid, raise_if_not_found=False):
                 del data['account.journal'][xmlid]
@@ -452,7 +452,7 @@ class AccountChartTemplate(models.AbstractModel):
         e.g. the account codes' width must be standardized to the code_digits applied.
         The fiscal country code must be put in place before taxes are generated.
         """
-        if 'account_fiscal_country_id' in data['res.company'][company.id]:
+        if 'account_fiscal_country_id' in data.get('res.company', {}).get(company.id, {}):
             fiscal_country = self.ref(data['res.company'][company.id]['account_fiscal_country_id'])
         else:
             fiscal_country = company.account_fiscal_country_id

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -373,8 +373,6 @@ class TestChartTemplate(AccountTestInvoicingCommon):
         * Update all the references to the old taxes to the new ones.
           - Fiscal positions: The previous mappings won't be deleted but the new ones will be created.
                               This ensures that reports still work.
-          - Company: The default sales/purchase taxes should be updated. It should only impact the creation
-                     of new products so it is probably not going to be an issue.
         * If such a tax was part of a group, a new group must be created and the old one removed from the template.
 
         The procedure for the users, when they are ready, is:
@@ -416,8 +414,6 @@ class TestChartTemplate(AccountTestInvoicingCommon):
             {'tax_src_id': tax_1.id, 'tax_dest_id': tax_2.id},
             {'tax_src_id': tax_3.id, 'tax_dest_id': tax_2.id},
         ])
-        self.assertEqual(self.company.account_sale_tax_id, tax_3)
-
         # On a new company you would never see the old tax.
         # In case users need it, they can duplicate the new one and change the rate.
         new_company = self.env['res.company'].create({'name': 'New Company'})
@@ -708,6 +704,8 @@ class TestChartTemplate(AccountTestInvoicingCommon):
             return data
 
         company = self.company
+        # force first load since company data is removed on reload
+        company.chart_template = False
 
         with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=local_get_data, autospec=True):
             # hard fail the loading if the context key is set to ensure `test_all_l10n` works as expected

--- a/addons/l10n_ch/migrations/11.1/end-migrate_update_taxes.py
+++ b/addons/l10n_ch/migrations/11.1/end-migrate_update_taxes.py
@@ -18,4 +18,4 @@ def migrate(cr, version):
                     # set the child to it's parent's value
                     child.type_tax_use = tax.type_tax_use
 
-        env['account.chart.template'].try_loading('ch', company)
+        env['account.chart.template'].try_loading('ch', company, force_create=False)

--- a/addons/l10n_cl/migrations/3.1/end-migrate_update_taxes.py
+++ b/addons/l10n_cl/migrations/3.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'cl')], order="parent_path"):
-        env['account.chart.template'].try_loading('cl', company)
+        env['account.chart.template'].try_loading('cl', company, force_create=False)

--- a/addons/l10n_cz/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_cz/migrations/1.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'cz')], order="parent_path"):
-        env['account.chart.template'].try_loading('cz', company)
+        env['account.chart.template'].try_loading('cz', company, force_create=False)

--- a/addons/l10n_dk/migrations/1.2/end-migrate.py
+++ b/addons/l10n_dk/migrations/1.2/end-migrate.py
@@ -4,4 +4,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'dk')], order="parent_path"):
-        env['account.chart.template'].try_loading('dk', company)
+        env['account.chart.template'].try_loading('dk', company, force_create=False)

--- a/addons/l10n_ee/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_ee/migrations/1.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'ee')], order="parent_path"):
-        env['account.chart.template'].try_loading('ee', company)
+        env['account.chart.template'].try_loading('ee', company, force_create=False)

--- a/addons/l10n_ee/migrations/1.2/end-migrate_update_taxes.py
+++ b/addons/l10n_ee/migrations/1.2/end-migrate_update_taxes.py
@@ -4,4 +4,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'ee')], order="parent_path"):
-        env['account.chart.template'].try_loading('ee', company)
+        env['account.chart.template'].try_loading('ee', company, force_create=False)

--- a/addons/l10n_es/migrations/5.3/end-migrate_update_taxes.py
+++ b/addons/l10n_es/migrations/5.3/end-migrate_update_taxes.py
@@ -23,4 +23,4 @@ def migrate(cr, version):
             ('model', '=', 'account.tax'),
         ]).mapped('res_id')
         env['account.tax'].browse(tax_ids).active = False
-        env['account.chart.template'].try_loading(company.chart_template, company)
+        env['account.chart.template'].try_loading(company.chart_template, company, force_create=False)

--- a/addons/l10n_es/migrations/5.4/end-migrate.py
+++ b/addons/l10n_es/migrations/5.4/end-migrate.py
@@ -4,4 +4,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', 'like', r'es\_%')], order="parent_path"):
-        env['account.chart.template'].try_loading(company.chart_template, company)
+        env['account.chart.template'].try_loading(company.chart_template, company, force_create=False)

--- a/addons/l10n_fi/migrations/13.0.2/end-migrate_update_taxes.py
+++ b/addons/l10n_fi/migrations/13.0.2/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'fi')], order="parent_path"):
-        env['account.chart.template'].try_loading('fi', company)
+        env['account.chart.template'].try_loading('fi', company, force_create=False)

--- a/addons/l10n_fr_account/migrations/2.1/end-migrate_update_taxes.py
+++ b/addons/l10n_fr_account/migrations/2.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'fr')], order="parent_path"):
-        env['account.chart.template'].try_loading('fr', company)
+        env['account.chart.template'].try_loading('fr', company, force_create=False)

--- a/addons/l10n_id/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_id/migrations/1.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'id')], order="parent_path"):
-        env['account.chart.template'].try_loading('id', company)
+        env['account.chart.template'].try_loading('id', company, force_create=False)

--- a/addons/l10n_il/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_il/migrations/1.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'il')]):
-        env['account.chart.template'].try_loading('il', company)
+        env['account.chart.template'].try_loading('il', company, force_create=False)

--- a/addons/l10n_it/migrations/0.6/end-migrate_update_taxes.py
+++ b/addons/l10n_it/migrations/0.6/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'it')], order="parent_path"):
-        env['account.chart.template'].try_loading('it', company)
+        env['account.chart.template'].try_loading('it', company, force_create=False)

--- a/addons/l10n_lu/migrations/2.1/end-migrate_update_taxes.py
+++ b/addons/l10n_lu/migrations/2.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'lu')], order="parent_path"):
-        env['account.chart.template'].try_loading('lu', company)
+        env['account.chart.template'].try_loading('lu', company, force_create=False)

--- a/addons/l10n_lu/migrations/2.2/end-migrate_update_taxes.py
+++ b/addons/l10n_lu/migrations/2.2/end-migrate_update_taxes.py
@@ -4,4 +4,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'lu')], order="parent_path"):
-        env['account.chart.template'].try_loading('lu', company)
+        env['account.chart.template'].try_loading('lu', company, force_create=False)

--- a/addons/l10n_mx/migrations/2.2/end-migrate.py
+++ b/addons/l10n_mx/migrations/2.2/end-migrate.py
@@ -4,4 +4,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'mx')], order="parent_path"):
-        env['account.chart.template'].try_loading('mx', company)
+        env['account.chart.template'].try_loading('mx', company, force_create=False)

--- a/addons/l10n_my/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_my/migrations/1.1/end-migrate_update_taxes.py
@@ -6,4 +6,4 @@ def migrate(cr, version):
     """ Update taxes for existing companies, in order to apply the new tags to them. """
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'my')], order="parent_path"):
-        env['account.chart.template'].try_loading('my', company)
+        env['account.chart.template'].try_loading('my', company, force_create=False)

--- a/addons/l10n_no/migrations/2.1/end-migrate_update_taxes.py
+++ b/addons/l10n_no/migrations/2.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'no')], order="parent_path"):
-        env['account.chart.template'].try_loading('no', company)
+        env['account.chart.template'].try_loading('no', company, force_create=False)

--- a/addons/l10n_ph/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_ph/migrations/1.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'ph')], order="parent_path"):
-        env['account.chart.template'].try_loading('ph', company)
+        env['account.chart.template'].try_loading('ph', company, force_create=False)

--- a/addons/l10n_pk/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_pk/migrations/1.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'pk')], order="parent_path"):
-        env['account.chart.template'].try_loading('pk', company)
+        env['account.chart.template'].try_loading('pk', company, force_create=False)

--- a/addons/l10n_se/migrations/1.1/end-migrate.py
+++ b/addons/l10n_se/migrations/1.1/end-migrate.py
@@ -4,4 +4,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'se')], order="parent_path"):
-        env['account.chart.template'].try_loading('se', company)
+        env['account.chart.template'].try_loading('se', company, force_create=False)

--- a/addons/l10n_sg/migrations/2.1/end-migrate_update_tax.py
+++ b/addons/l10n_sg/migrations/2.1/end-migrate_update_tax.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'sg')], order="parent_path"):
-        env['account.chart.template'].try_loading('sg', company)
+        env['account.chart.template'].try_loading('sg', company, force_create=False)

--- a/addons/l10n_sg/migrations/2.2/end-migrate_update_taxes.py
+++ b/addons/l10n_sg/migrations/2.2/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'sg')], order="parent_path"):
-        env['account.chart.template'].try_loading('sg', company)
+        env['account.chart.template'].try_loading('sg', company, force_create=False)

--- a/addons/l10n_tr/migrations/1.1/end-migrate_update_taxes.py
+++ b/addons/l10n_tr/migrations/1.1/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'tr')], order="parent_path"):
-        env['account.chart.template'].try_loading('tr', company)
+        env['account.chart.template'].try_loading('tr', company, force_create=False)

--- a/addons/l10n_tr/migrations/1.2/end-migrate_update_package.py
+++ b/addons/l10n_tr/migrations/1.2/end-migrate_update_package.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'tr')], order="parent_path"):
-        env['account.chart.template'].try_loading('tr', company)
+        env['account.chart.template'].try_loading('tr', company, force_create=False)

--- a/addons/l10n_tr/migrations/1.3/end-migrate_update_taxes.py
+++ b/addons/l10n_tr/migrations/1.3/end-migrate_update_taxes.py
@@ -5,4 +5,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'tr')], order="parent_path"):
-        env['account.chart.template'].try_loading('tr', company)
+        env['account.chart.template'].try_loading('tr', company, force_create=False)

--- a/addons/l10n_uk/migrations/1.1/end-migrate.py
+++ b/addons/l10n_uk/migrations/1.1/end-migrate.py
@@ -4,4 +4,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'uk')], order="parent_path"):
-        env['account.chart.template'].try_loading('uk', company)
+        env['account.chart.template'].try_loading('uk', company, force_create=False)

--- a/addons/l10n_vn/migrations/2.0.3/end-migrate_update_taxes.py
+++ b/addons/l10n_vn/migrations/2.0.3/end-migrate_update_taxes.py
@@ -4,4 +4,4 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'vn')], order="parent_path"):
-        env['account.chart.template'].try_loading('vn', company)
+        env['account.chart.template'].try_loading('vn', company, force_create=False)


### PR DESCRIPTION

- Updated UK localization template handling to avoid automatic recreation of accounts, taxes, and fiscal positions when upgrading.
- Added `force_create = "0"` parameter to `try_loading` to ensure that existing configurations are retained and no new records are created unless explicitly required.
- Fixed a similar issue for all impacted localizations, following the discussion in the previous task (https://www.odoo.com/odoo/project/967/tasks/4556250).

task-4712602

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
