### PR TITLE
[FIX] mail: store update cycle more robust to crash

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -835,14 +835,15 @@ export class Composer extends Component {
 
     restoreContent() {
         const composer = toRaw(this.props.composer);
+        let config;
         try {
-            const config = JSON.parse(browser.localStorage.getItem(composer.localId));
-            if (config.text) {
-                composer.emailAddSignature = config.emailAddSignature;
-                composer.text = config.text;
-            }
+            config = JSON.parse(browser.localStorage.getItem(composer.localId));
         } catch {
             browser.localStorage.removeItem(composer.localId);
+        }
+        if (config && config.text) {
+            composer.emailAddSignature = config.emailAddSignature;
+            composer.text = config.text;
         }
     }
 }

--- a/addons/mail/static/src/discuss/message_pin/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/message_pin/common/thread_model_patch.js
@@ -34,15 +34,16 @@ patch(Thread.prototype, {
             return;
         }
         this.pinnedMessagesState = "loading";
+        let data;
         try {
-            const data = await rpc("/discuss/channel/pinned_messages", {
+            data = await rpc("/discuss/channel/pinned_messages", {
                 channel_id: this.id,
             });
-            this.store.insert(data, { html: true });
-            this.pinnedMessagesState = "loaded";
         } catch (e) {
             this.pinnedMessagesState = "error";
             throw e;
         }
+        this.store.insert(data, { html: true });
+        this.pinnedMessagesState = "loaded";
     },
 });

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -28,6 +28,7 @@ export class StoreInternal extends RecordInternal {
     RD_QUEUE = new Map(); // record-deletes
     /** @type {Map<Record, true>} */
     RHD_QUEUE = new Map(); // record-hard-deletes
+    ERRORS = [];
     UPDATE = 0;
 
     /**


### PR DESCRIPTION
When store is updated, during the update cycle there's many moments some business code is invoked:

- compute/sort field methods
- onUpdate on fields
- onAdd on fields
- onDelete on fields
- Record.onChange on fields
- any setter on JS record

Lazy fields can also trigger all of the above implicitly.

When mistakes happens in business code and result in crash, usually business code also crashes and this is disruptive enough to continue. However some business code are suspiciously written and want to put crashes into silent. In any cases, the store data insertion is not in a good state.

Before this commit, these crashes prevented the store to flush. In other words, any side-effect of updating store data was never executed after business code crash. This is a problem, because the store is basically non-working, therefore apps that rely heavily on the store show critical bugs, like being unable to mark a Discuss conversation as read.

This commit makes any crash in business code during update cycle resets the flush state of store. Only partial data is inserted in store and some data is lost like before, but at least if some other code tries to insert some other data in store, the store is still able to flush.

opw-4688250