### PR TITLE
[PERF] stock: improve perf of reordering via the list button

### DIFF
--- a/addons/stock/static/src/views/stock_orderpoint_list_controller.js
+++ b/addons/stock/static/src/views/stock_orderpoint_list_controller.js
@@ -20,8 +20,19 @@ export class StockOrderpointListController extends ListController {
         if (action) {
             await this.actionService.doAction(action);
         }
-        return this.actionService.doAction('stock.action_replenishment', {
-            stackPosition: 'replaceCurrentAction',
+        return this.actionService.doAction({
+            name: "Replenishment",
+            type: "ir.actions.act_window",
+            res_model: "stock.warehouse.orderpoint",
+            view_id: "stock.action_orderpoint_replenish",
+            target: "main",
+            views:[[false,'list']],
+            context : {
+                search_default_filter_to_reorder: true,
+                search_default_filter_not_snoozed: true,
+                default_trigger: 'manual',
+                searchpanel_default_trigger: 'manual',
+            },
         });
     }
 


### PR DESCRIPTION
Considering that there is a large number of `stock.warehouse.orderpoints` records, products, and locations; the `action_replenishment` action on Replenishments is slow. Inside the list view, if one or multiple orderpoints are selected and the 'Order' list button is clicked, method `action_replenish` gets called and subsequently, the `action_replenishment` action is called again-- going through the slow process again.

Solution -->

Edit the onClickOrder function to call the action `action_orderpoint_replenish` instead. This avoids redoing the the expensive `_get_orderpoint_action` method. this change essentially changes the behavior of the 'Order' button to mimic the 'Order Once' button.

Benchmarks -->

Assume that the time taken for `_get_orderpoint_action` is `A` and the time taken for `action_replenish` and to render the view is `B`.

For the list button action 'Order' on orderpoints -->

| Before | After |
|--------|--------|
| (A+B) seconds | B seconds |

Notes -->

`action_replenishment` is a server action that eventually calls `_get_orderpoint_action`, which returns the `action_orderpoint_replenish` window action that opens the tree view for `stock.warehouse.orderpoint`.

opw-4597143

