### PR TITLE
[IMP] purchase_stock: add test for bill autocomplete

### DIFF
--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -784,3 +784,41 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         stock_move.quantity = 1.0
         picking.button_validate()
         self.assertEqual(picking.move_ids.location_dest_id, sub_location)
+
+    def test_foreign_bill_autocomplete_with_payment_term(self):
+        """ Test the bill auto-complete with a PO having a payment term in a foreign currency """
+        currency = self.env['res.currency'].create({
+            'name': "Test",
+            'symbol': 'T',
+            'rounding': 0.01,
+            'rate_ids': [
+                Command.create({'name': '2025-01-01', 'rate': 1.5}),
+            ],
+        })
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': currency.id,
+            'payment_term_id': self.pay_terms_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product_id_1.id,
+                'price_unit': 100.0,
+                'taxes_id': [Command.set(self.tax_purchase_a.ids)],
+            })],
+        })
+        po.button_confirm()
+
+        picking = po.picking_ids[0]
+        picking.move_line_ids.quantity = 1.0
+        picking.move_ids.picked = True
+        picking.button_validate()
+
+        move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-po.id)
+        invoice = move_form.save()
+
+        self.assertEqual(invoice.currency_id, currency)
+        self.assertEqual(invoice.invoice_payment_term_id, self.pay_terms_a)
+
+        line = invoice.invoice_line_ids[0]
+        self.assertEqual(line.amount_currency, 100.0)
+        self.assertEqual(line.balance, 66.67)


### PR DESCRIPTION
The issue was introduced by:
https://github.com/odoo/odoo/commit/90158f647ba610b31499555641c9db8450b49c4c

The issue has been fixed by:
https://github.com/odoo/odoo/commit/b1666c61bbc9d7e7b920483e168c6048ecde011c

This commit is adding a test for it.

**Steps to reproduce:**
- Install Accounting and purchase_stock
- Activate a foreign currency (e.g. Euro)
- Create a PO:
  * Vendor: [any]
  * Currency: EUR
  * Product: [any with a Unit Price and a tax]
  * Payment Terms: [any] (e.g. 15 Days)
- Confirm the PO
- Validate the receipt order
- Go to "Accounting / Vendors / Bills"
- Create a new bill
- In "Auto-Complete" field, select the created PO

**Issue:**
A traceback is raised due to a division by zero.

**Cause:**
The bill and its lines are created from some information coming
from the PO.
In the computation of the needed terms of the bill, a computation
of the taxes is called on the lines (i.e. _compute_all_tax).
During that computation, the rate is computed as followed:

(*) rate = line.amount_currency / line.balance if line.balance else line.currency_rate

and later, rate is used as followed:

'balance': tax['amount'] / rate

When "purchase_stock" module is not installed, there is no issue
because "_prepare_account_move_line" method from "purchase.order.
line" model doesn't initialized "amount_currency" nor "balance".
Therefore, the result of (*) falls back on "line.currency_rate"
which is not zero.

However, when "purchase_stock" module is installed, "balance" is
initialized in "_prepare_account_move_line" but not "amount_currency",
leading a result of 0 for (*).

opw-4681735