### PR TITLE
[FIX] hr_calendar: Assign default calendar for resources without one

### DIFF
--- a/addons/hr_calendar/models/res_partner.py
+++ b/addons/hr_calendar/models/res_partner.py
@@ -52,11 +52,11 @@ class Partner(models.Model):
         calendar_periods_by_employee = employees._get_calendar_periods(start_period, stop_period)
         for employee, calendar_periods in calendar_periods_by_employee.items():
             for (start, stop, calendar) in calendar_periods:
+                calendar = calendar or self.env.company.resource_calendar_id  # No calendar if fully flexible
                 resources_by_calendar[calendar] += employee.resource_id
 
         # Compute all work intervals per calendar
         for calendar, resources in resources_by_calendar.items():
-            calendar = calendar or self.env.company.resource_calendar_id # No calendar if fully flexible
             work_intervals = calendar._work_intervals_batch(start_period, stop_period, resources=resources, tz=timezone(calendar.tz))
             del work_intervals[False]
             # Merge all employees intervals to avoid to compute it multiples times

--- a/addons/test_hr_contract_calendar/tests/common.py
+++ b/addons/test_hr_contract_calendar/tests/common.py
@@ -73,7 +73,8 @@ class TestHrContractCalendarCommon(common.TransactionCase):
                 ],
             },
         ])
-        cls.partnerA, cls.partnerB, cls.partnerC, cls.partnerD, cls.partnerE = cls.env['res.partner'].create([
+        cls.partnerA, cls.partnerB, cls.partnerC, cls.partnerD, cls.partnerE,\
+        cls.partnerF, cls.partnerG = cls.env['res.partner'].create([
             {
                 'name': "Partner A",
             },
@@ -89,10 +90,17 @@ class TestHrContractCalendarCommon(common.TransactionCase):
             {
                 'name': "Partner E",
             },
+            {
+                'name': 'Partner F',
+            },
+            {
+                'name': 'Partner G',
+            },
         ])
 
         cls.employeeA, cls.employeeB, cls.employeeB_company_B,\
-        cls.employeeC, cls.employeeD, cls.employeeE = cls.env['hr.employee'].create([
+        cls.employeeC, cls.employeeD, cls.employeeE,\
+        cls.employeeF, cls.employeeG = cls.env['hr.employee'].create([
             {
                 'name': "Partner A - Calendar 35h",
                 'tz': "Europe/Brussels",
@@ -129,9 +137,23 @@ class TestHrContractCalendarCommon(common.TransactionCase):
                 'work_contact_id': cls.partnerE.id,
                 'company_id': cls.company_A.id,
             },
+            {
+                'name': 'Partner F - Fully Flexible',
+                'tz': "Europe/Brussels",
+                'resource_calendar_id': False,
+                'work_contact_id': cls.partnerF.id,
+                'company_id': cls.company_A.id,
+            },
+            {
+                'name': 'Partner G - Default Calendar',
+                'tz': "Europe/Brussels",
+                'resource_calendar_id': cls.company_A.resource_calendar_id.id,
+                'work_contact_id': cls.partnerG.id,
+                'company_id': cls.company_A.id,
+            },
         ])
         cls.contractA, cls.contractB, cls.contractB_company_B,\
-        cls.contractC, cls.contractD = cls.env['hr.contract'].create([
+        cls.contractC, cls.contractD, cls.contractF, cls.contractG = cls.env['hr.contract'].create([
             {
                 'date_start': datetime(2023, 12, 1),
                 'name': 'Contract Employee A start december',
@@ -176,6 +198,24 @@ class TestHrContractCalendarCommon(common.TransactionCase):
                 'wage': 5000.0,
                 'employee_id': cls.employeeD.id,
                 'state': 'close',
+                'company_id': cls.company_A.id,
+            },
+            {
+                'date_start': datetime(2023, 12, 1),
+                'name': 'Test contract F',
+                'resource_calendar_id': False,
+                'wage': 5000.0,
+                'employee_id': cls.employeeF.id,
+                'state': 'open',
+                'company_id': cls.company_A.id,
+            },
+            {
+                'date_start': datetime(2023, 12, 1),
+                'name': 'Test contract G',
+                'resource_calendar_id': cls.company_A.resource_calendar_id.id,
+                'wage': 5000.0,
+                'employee_id': cls.employeeG.id,
+                'state': 'open',
                 'company_id': cls.company_A.id,
             },
         ])


### PR DESCRIPTION
## Issue

When an employee has a flexible (unset) working calendar, and another employee has the default calendar (`Standard 40 hours/week`), scheduling a meeting involving both results in a `KeyError`:

```python
  File "/home/odoo/src/odoo/18.0/addons/hr_calendar/models/res_partner.py", line 78, in _get_schedule
    calendar_interval = interval_by_calendar[calendar][employee.resource_id.id]
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: <number>
```

## Root Cause

Odoo uses the Standard 40 hours/week calendar (resource.resource_calendar_std) as a fallback for flexible (unset) calendars. However, when grouping resources by their calendars, resources without a calendar are included in a separate group. 
Later, when Odoo computes work intervals per calendar, it assigns the default calendar to resource.resource(). If another user already uses the same calendar, the group duplication results in one being overwritten during iteration—causing the KeyError.

## Fix
Before grouping resources by calendar, explicitly assign the default calendar (resource.resource_calendar_std) to any resource that lacks a calendar. This ensures all resources are grouped correctly, avoiding duplication and key errors.

## Impacted versions:
18.0 and later

## Steps to Reproduce
### Pre-requisites:

- Install `hr_contract`, `calendar` apps.

### Steps:
1. Create **Employee 1**:
    - Set **Working hours** to **Flexible** (unset)
    - Create a **Contract**:
        - Set **Working hours** to **Flexible** (unset)

2. Create **Employee 2**:
    - Set **Working hours** to **Standard 40 hours/week**
    - Create a **Contract**:
        - Set **Working hours** to **Standard 40 hours/week**
        - Ensure the XML ID is `resource.resource_calendar_std`

3. Open the **Calendar** app.
4. Create a **new Event**.
5. Add both employees as **attendees**.

## Current Behavior  
The system raises a `KeyError` and does not allow the event to be saved.

## Expected Behavior
The event is saved successfully with both attendees.

### Task
OPW-[4699028](https://www.odoo.com/odoo/my-tasks/4699028)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
