### PR TITLE
[FIX] surveys: multiple label spelling corrections

### DIFF
--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -51,7 +51,7 @@ class SurveyUserInput(models.Model):
     predefined_question_ids = fields.Many2many('survey.question', string='Predefined Questions', readonly=True)
     scoring_percentage = fields.Float("Score (%)", compute="_compute_scoring_values", store=True, compute_sudo=True)  # stored for perf reasons
     scoring_total = fields.Float("Total Score", compute="_compute_scoring_values", store=True, compute_sudo=True, digits=(10, 2))  # stored for perf reasons
-    scoring_success = fields.Boolean('Quizz Passed', compute='_compute_scoring_success', store=True, compute_sudo=True)  # stored for perf reasons
+    scoring_success = fields.Boolean('Quiz Passed', compute='_compute_scoring_success', store=True, compute_sudo=True)  # stored for perf reasons
     survey_first_submitted = fields.Boolean(string='Survey First Submitted')
     # live sessions
     is_session_answer = fields.Boolean('Is in a Session', help="Is that user input part of a survey session or not.")

--- a/addons/survey/static/src/js/tours/survey_tour.js
+++ b/addons/survey/static/src/js/tours/survey_tour.js
@@ -64,7 +64,7 @@ registry.category("web_tour.tours").add('survey_tour', {
     run: "click",
 }, {
     trigger: 'button[name=action_survey_user_input_completed]',
-    content: _t("Here, you can overview all the participations."),
+    content: _t("Here, you can view the participants."),
     tooltipPosition: 'bottom',
     run: "click",
 }, {

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -44,7 +44,7 @@
                             type="object"
                             class="oe_stat_button"
                             icon="fa-check-square-o">
-                            <field string="Participations" name="answer_done_count" widget="statinfo"/>
+                            <field string="Participants" name="answer_done_count" widget="statinfo"/>
                         </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -17,7 +17,7 @@
                 <filter string="In Progress" name="in_progress" domain="[('state', '=', 'in_progress')]"/>
                 <filter name="completed" string="Completed" domain="[('state', '=', 'done')]"/>
                 <separator/>
-                <filter string="Quizz passed" name="scoring_success" domain="[('scoring_success','=', True)]"/>
+                <filter string="Quiz passed" name="scoring_success" domain="[('scoring_success','=', True)]"/>
                 <separator/>
                 <filter string="Tests Only" name="test" domain="[('test_entry','=', True)]"/>
                 <filter string="Exclude Tests" name="not_test" domain="[('test_entry','=', False)]"/>
@@ -68,7 +68,7 @@
                             <label for="attempts_number" string="Attempt n°" invisible="not is_attempts_limited or test_entry or state != 'done'"/>
                             <div invisible="not is_attempts_limited or test_entry or state != 'done'" class="d-inline-flex">
                                 <field name="attempts_number" nolabel="1"/>
-                                 / 
+                                 /
                                 <field name="attempts_limit" nolabel="1"/>
                             </div>
                             <field name="test_entry" groups="base.group_no_one"/>
@@ -151,7 +151,7 @@
     </record>
 
     <record model="ir.actions.act_window" id="action_survey_user_input">
-        <field name="name">Participations</field>
+        <field name="name">Participants</field>
         <field name="res_model">survey.user_input</field>
         <field name="domain">[('survey_id.survey_type', 'in', ('assessment', 'custom', 'live_session', 'survey'))]</field>
         <field name="view_mode">list,kanban,form</field>
@@ -239,7 +239,7 @@
         </field>
     </record>
 
-    <menuitem name="Participations"
+    <menuitem name="Participants"
         id="menu_survey_type_form1"
         action="action_survey_user_input"
         parent="menu_surveys"


### PR DESCRIPTION
**Surveys app misspellings on main menu item, dashboard name, breadcrumbs, and column label**

Impacted versions:
 
 - 16.0+ (confirmed on Runbot, however the PR target is 18.0+ to only be applied on the latest stable release)
 
Steps to reproduce:
 
 1. Open any Community Runbot (or deploy Odoo locally)
 2. Navigate to the **Surveys** app to view misspelling across multiple app views.
 
Current behavior --> Expected behavior
 
- "Participations" is not a word --> It should be "Participants" 
- "Quizz" is misspelled --> It should be "Quiz"

Proposed changes highlighted in green [here on the screenshots](https://imgur.com/a/0vM48R0).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
