### PR TITLE
[IMP] stock: add custom search filter for 'Last Count Date'

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -2,6 +2,7 @@
 import heapq
 import logging
 from collections import namedtuple
+import operator as py_operator
 
 from ast import literal_eval
 from collections import defaultdict
@@ -14,6 +15,15 @@ from odoo.fields import Domain
 from odoo.tools import SQL
 
 _logger = logging.getLogger(__name__)
+
+PY_OPERATORS = {
+    '>': py_operator.gt,
+    '<': py_operator.lt,
+    '>=': py_operator.ge,
+    '<=': py_operator.le,
+    '=': py_operator.eq,
+    '!=': py_operator.ne,
+}
 
 
 class StockQuant(models.Model):
@@ -110,7 +120,7 @@ class StockQuant(models.Model):
     inventory_date = fields.Date(
         'Scheduled', compute='_compute_inventory_date', store=True, readonly=False,
         help="Next date the On Hand Quantity should be counted.")
-    last_count_date = fields.Date(compute='_compute_last_count_date', help='Last time the Quantity was Updated')
+    last_count_date = fields.Date(compute='_compute_last_count_date', search='_search_last_count_date', help='Last time the Quantity was Updated')
     inventory_quantity_set = fields.Boolean(store=True, compute='_compute_inventory_quantity_set', readonly=False)
     is_outdated = fields.Boolean('Quantity has been moved since last count', compute='_compute_is_outdated', search='_search_is_outdated')
     user_id = fields.Many2one(
@@ -176,6 +186,44 @@ class StockQuant(models.Model):
             _update_dict(date_by_quant, (location_dest_id, result_package_id, product_id, lot_id, owner_id), move_line_date)
         for quant in self:
             quant.last_count_date = date_by_quant.get((quant.location_id.id, quant.package_id.id, quant.product_id.id, quant.lot_id.id, quant.owner_id.id))
+
+    def _search_last_count_date(self, operator, value):
+        op = PY_OPERATORS.get(operator)
+        if not op:
+            return NotImplemented
+        domain = Domain([('state', '=', 'done'), ('is_inventory', '=', True)])
+        groups = self.env['stock.move.line']._read_group(
+            domain=domain,
+            groupby=['product_id', 'lot_id', 'package_id', 'owner_id', 'result_package_id', 'location_id', 'location_dest_id'],
+            aggregates=['date:max'],
+        )
+
+        def date_compare(max_dt, operator, value):
+            max_date = max_dt.date()
+            return PY_OPERATORS[operator](max_date, value)
+
+        product_ids = self.env['product.product']
+        lot_ids = self.env['stock.lot']
+        owner_ids = self.env['res.partner']
+        location_ids = self.env['stock.location']
+        package_ids = self.env['stock.package']
+        for product, lot, package, owner, result_package, location, location_dest, max_date in groups:
+            if not date_compare(max_date, operator, value):
+                continue
+            product_ids |= product
+            lot_ids |= lot
+            owner_ids |= owner
+            location_ids |= location | location_dest
+            package_ids |= package | result_package
+
+        quant_domain = Domain.AND([
+            Domain('product_id', 'in', product_ids.ids),
+            Domain('lot_id', 'in', lot_ids.ids + [False]),
+            Domain('owner_id', 'in', owner_ids.ids + [False]),
+            Domain('location_id', 'in', location_ids.ids),
+            Domain('package_id', 'in', package_ids.ids + [False]),
+        ])
+        return quant_domain
 
     def _search(self, domain, *args, **kwargs):
         domain = Domain(domain).map_conditions(

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1418,6 +1418,53 @@ class TestStockQuant(TestStockCommon):
         )
         self.assertEqual(quant.inventory_quantity, 0)
 
+    def test_quants_search_last_count_date(self):
+        """Test that the 'last_count_date' filter works correctly on stock quants with different operators.
+        """
+        self.product_consu.is_storable = True
+        products = [self.product_consu, self.product_lot, self.product_serial]
+        lots = [False, None, None]
+        for id, (name, product) in enumerate([('LOT-001', self.product_lot), ('SN-001', self.product_serial)]):
+            lots[id + 1] = self.env['stock.lot'].create({
+                'name': name,
+                'product_id': product.id,
+            })
+        dates = [datetime.today() + timedelta(days=1), datetime.today() - timedelta(days=1), datetime.today()]
+
+        self.env['stock.quant']._update_available_quantity(self.product_consu, self.shelf_2, 1, lot_id=lots[0])
+        self.env['stock.quant']._update_available_quantity(self.product_lot, self.shelf_2, 1, lot_id=lots[1])
+        self.env['stock.quant']._update_available_quantity(self.product_serial, self.shelf_2, 1, lot_id=lots[2])
+
+        for i in range(len(products)):
+            move = self.env['stock.move'].create({
+                'product_id': products[i].id,
+                'product_uom_qty': 1,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.shelf_2.id,
+                'is_inventory': True,
+            })
+
+            move._action_confirm()
+            move._action_assign()
+            move.picked = True
+            move._action_done()
+            move.move_line_ids.write({
+                'date': dates[i],
+            })
+
+        self.env.cr.flush()
+        today = datetime.today().date()
+        result_eq = self.env['stock.quant'].search_count([('last_count_date', '=', today)])
+        self.assertEqual(result_eq, 1)
+        result_lt = self.env['stock.quant'].search_count([('last_count_date', '<', today)])
+        self.assertEqual(result_lt, 1)
+        result_gt = self.env['stock.quant'].search_count([('last_count_date', '>', today)])
+        self.assertEqual(result_gt, 1)
+        result_gt_eq = self.env['stock.quant'].search_count([('last_count_date', '>=', today)])
+        self.assertEqual(result_gt_eq, 2)
+        result_lt_eq = self.env['stock.quant'].search_count([('last_count_date', '<=', today)])
+        self.assertEqual(result_lt_eq, 2)
+
 
 class TestStockQuantRemovalStrategy(TestStockCommon):
 

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -24,6 +24,7 @@
                 <field name="storage_category_id" groups="stock.group_stock_multi_locations" />
                 <field name="user_id"/>
                 <field name="inventory_date"/>
+                <field name="last_count_date"/>
                 <field name="product_categ_id"/>
                 <field name="product_tmpl_id"/>
                 <field name="package_id" groups="stock.group_tracking_lot"/>


### PR DESCRIPTION
- Currently, The last_count_date field did not support any custom search
  filters.As a result, users were unable to filter inventory records based on
  when products were last counted, making it difficult to identify products
  counted within a specific time period.
- Now, a custom search filter is introduced on the last_count_date field in
  quants.
- This allows users to filter products based on when they were last counted,
  either on a specific date or within a given time range.
- This custom filter helps users easily retrieve all products that were counted
  within any particular time period.

Task Id: 4649810