### PR TITLE
[FIX] product: prevent uploading empty file

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -2250,6 +2250,12 @@ msgstr ""
 #. module: product
 #. odoo-javascript
 #: code:addons/product/static/src/js/product_document_kanban/upload_button/upload_button.js:0
+msgid "Oops! '%(fileName)s' didn’t upload since it is empty."
+msgstr ""
+
+#. module: product
+#. odoo-javascript
+#: code:addons/product/static/src/js/product_document_kanban/upload_button/upload_button.js:0
 msgid "Oops! '%(fileName)s' didn’t upload since its format isn’t allowed."
 msgstr ""
 


### PR DESCRIPTION
Currently, a error is encountered on uploading an empty file in a `PDF Quote Builder` .

**Steps to reproduce:**
-  Install `Sales`
- `Sales>Configuration>Settings`
-  Under `Quotations & Orders>PDF Quote builder>Headers/Footers`, upload an empty file or try this [demo_file](https://drive.google.com/file/d/1NePURnYY3EK63vXM_uz8weJZwDbUbHfc/view?usp=sharing)

**Error:**
`EmptyFileError: Cannot read an empty file`

**Root Cause:**
The error occurred because the system attempts to read the uploaded file at [1] triggered by [2].
If the uploaded file is empty, it raises an `EmptyFileError`.

[1] - https://github.com/py-pdf/pypdf/blob/5735cb742a45a503e8eb7e409067f7c3d4cb9158/PyPDF2/pdf.py#L1691

[2] - https://github.com/odoo/odoo/blob/9463bfeb58fb40176ecf1131bac6627a1627d02c/odoo/tools/pdf/_pypdf2_1.py#L18

This commit ensures that users cannot upload empty files.

sentry-6519503224,6519471276