### PR TITLE
[IMP] account_payment: allow online registering payment on draft invoices

### DIFF
--- a/addons/account_payment/models/account_move.py
+++ b/addons/account_payment/models/account_move.py
@@ -62,7 +62,7 @@ class AccountMove(models.Model):
         )
         return enabled_feature and bool(
             (self.amount_residual or not transactions)
-            and self.state == 'posted'
+            and self.state in ['posted', 'draft']
             and self.payment_state in ('not_paid', 'in_payment', 'partial')
             and not self.currency_id.is_zero(self.amount_residual)
             and self.amount_total


### PR DESCRIPTION
In this PR:
- Added support to generate payment links for draft invoices using the "Generate Payment Link" action.
- The invoice should be automatically posted upon payment receipt.

Task-4664363