### PR TITLE
[FIX] account: prevent TypeError when calculating days left

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5596,9 +5596,9 @@ class AccountMove(models.Model):
             next_amount_to_pay = self.amount_residual
             next_payment_reference = self.name
             next_due_date = epd_installment['date_maturity']
-            discount_date = epd_installment['line'].discount_date
+            discount_date = epd_installment['line'].discount_date or fields.Date.context_today(self)
             discount_amount_currency = epd_installment['discount_amount_currency']
-            days_left = (discount_date - fields.Date.context_today(self)).days  # should never be lower than 0 since epd is valid
+            days_left = max(0, (discount_date - fields.Date.context_today(self)).days)  # should never be lower than 0 since epd is valid
             if days_left > 0:
                 discount_msg = _(
                     "Discount of %(amount)s if paid within %(days)s days",

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -397,7 +397,8 @@ class AccountMoveLine(models.Model):
     discount_date = fields.Date(
         string='Discount Date',
         store=True,
-        help='Last date at which the discounted amount must be paid in order for the Early Payment Discount to be granted'
+        help='Last date at which the discounted amount must be paid in order for the Early Payment Discount to be granted',
+        readonly=True
     )
     # Discounted amount to pay when the early payment discount is applied
     discount_amount_currency = fields.Monetary(


### PR DESCRIPTION
When manually changing the `discount_date` field to null in an invoice related to a customer with an Early price discount payment term, the customer will face a type error on the website when accessing their invoices.

**Steps to reproduce:**

* Install the accountant module
* Create a new invoice for the current user as a customer (e.g., Mitchel Admin).
* Set `2/7 Net 30` in payment terms and add any product.
* Go to Journal Items and make Discount Date visible if not already visible.
* Under the account field `121000 Account Receivable` remove the discount date
  and confirm the invoice.
* Open portal View (/my) and click on Your Invoices >>> Error occurs.

`TypeError: unsupported operand type(s) for -: 'bool' and 'datetime.date'`

**Solution:**
We use if else blocks to check if `discount_date` exists for the `days_left calculation`; if it exists,
do the calculation as usual if `discount_date` is in future. Otherwise, set `days_left` to zero and continue the function as usual.

Sentry-6395559503

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
