### PR TITLE
[FIX] website: fix link popover arrow color

### DIFF
--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -310,17 +310,24 @@ body.editor_enable {
         i:not(.js_edit_menu > i) {
             color: rgba(0, 0, 0, 0.9);
         }
-        &.bs-popover-top > .popover-arrow::after {
+        &.bs-popover-auto[data-popper-placement^=top] > .popover-arrow::after {
             border-top-color: $o-we-popover-bg;
         }
-        &.bs-popover-end > .popover-arrow::after {
+        &.bs-popover-auto[data-popper-placement^=right] > .popover-arrow::after {
             border-right-color: $o-we-popover-bg;
         }
-        &.bs-popover-bottom > .popover-arrow::after {
+        &.bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow::after {
             border-bottom-color: $o-we-popover-bg;
         }
-        &.bs-popover-start > .popover-arrow::after {
+        &.bs-popover-auto[data-popper-placement^=left] > .popover-arrow::after {
             border-left-color: $o-we-popover-bg;
         }
+    }
+}
+
+// tooltip
+body.editor_enable {
+     .tooltip .tooltip-inner {
+        color: white !important;
     }
 }


### PR DESCRIPTION
Steps to reproduce the issue:

- Enter Website edit mode.
- Click on the "Theme" tab.
- Pick a black color for the website background (4th color button).
- Click on a link in the website navbar to make the link popover appear.
- Bug: The popover arrow is black.

Bug introduced by this commit [1], where popover colors were updated to match the website's theme. It was fixed since version 17.0 by this commit [2]. But during the forward-port to saas-17.4, the fix no longer works because of the upgrade to Bootstrap 5.3 done in this commit [3].

In this commit, we adapt the CSS code introduced by commit [2], so that it fixes the arrow color in the same way as it does in 17.0.

[1]: https://github.com/odoo/odoo/commit/0d96be06faf8aad1a92183bd2b6371253980c7e6
[2]: https://github.com/odoo/odoo/commit/bf59d2aba488931ba89512d5d6489ecb48ef2aa3
[3]: https://github.com/odoo/odoo/commit/058212e12b5079eba870bde9775fe98f27928935

task-4422810