### PR TITLE
[FIX] account, point_of_sale: remove pos_manager group from account

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -267,7 +267,6 @@ class AccountTestInvoicingCommon(ProductCommon):
                     # This is a consequence of moving groups from data to demo data: https://github.com/odoo/odoo/pull/198078
                     'group_hr_manager', # hr
                     'group_mrp_manager', # mrp
-                    'group_pos_manager', # point_of_sale
                     'group_purchase_manager', # purchase
                     'group_stock_manager', # stock
                     # enterprise groups

--- a/addons/point_of_sale/models/account_journal.py
+++ b/addons/point_of_sale/models/account_journal.py
@@ -17,7 +17,7 @@ class AccountJournal(models.Model):
             raise ValidationError(_("This journal is associated with a payment method. You cannot modify its type"))
 
     def _check_no_active_payments(self):
-        hanging_journal_entries = self.env['pos.payment'].search(
+        hanging_journal_entries = self.env['pos.payment'].sudo().search(
         [
             ('payment_method_id', 'in', self.pos_payment_method_ids.ids),
             ('session_id.state', '=', 'opened')

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -21,7 +21,7 @@ class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
+        cls.env.user.group_ids |= cls.env.ref('point_of_sale.group_pos_manager')
         cls.company_data_2 = cls.setup_other_company()
 
         cls.company_data['company'].write({
@@ -150,6 +150,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env.user.group_ids |= cls.env.ref('point_of_sale.group_pos_manager')
 
         cls.company_data['company'].write({
             'point_of_sale_update_stock_quantities': 'real',

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -11,6 +11,7 @@ class TestAngloSaxonCommon(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env.user.group_ids |= cls.env.ref('point_of_sale.group_pos_manager')
         cls.PosMakePayment = cls.env['pos.make.payment']
         cls.PosOrder = cls.env['pos.order']
         cls.Statement = cls.env['account.bank.statement']

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -28,7 +28,7 @@ class TestUi(TestPointOfSaleHttpCommon, OnlinePaymentCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
+        cls.env.user.group_ids |= cls.env.ref('point_of_sale.group_pos_manager')
         # Code from addons/account_payment/tests/common.py:
         Method_get_payment_method_information = AccountPaymentMethod._get_payment_method_information
 

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -108,7 +108,7 @@ class SaleOrderLine(models.Model):
     def _compute_qty_delivered(self):
         super()._compute_qty_delivered()
         for sale_line in self:
-            pos_lines = sale_line.pos_order_line_ids.filtered(lambda order_line: order_line.order_id.state not in ['cancel', 'draft'])
+            pos_lines = sale_line.sudo().pos_order_line_ids.filtered(lambda order_line: order_line.order_id.state not in ['cancel', 'draft'])
             if all(picking.state == 'done' for picking in pos_lines.order_id.picking_ids):
                 sale_line.qty_delivered += sum((self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in pos_lines if sale_line.product_id.type != 'service'), 0)
 
@@ -116,7 +116,7 @@ class SaleOrderLine(models.Model):
     def _compute_qty_invoiced(self):
         super()._compute_qty_invoiced()
         for sale_line in self:
-            pos_lines = sale_line.pos_order_line_ids.filtered(lambda order_line: order_line.order_id.state not in ['cancel', 'draft'])
+            pos_lines = sale_line.sudo().pos_order_line_ids.filtered(lambda order_line: order_line.order_id.state not in ['cancel', 'draft'])
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in pos_lines], 0)
 
     def _get_sale_order_fields(self):
@@ -175,7 +175,7 @@ class SaleOrderLine(models.Model):
     def _compute_untaxed_amount_invoiced(self):
         super()._compute_untaxed_amount_invoiced()
         for line in self:
-            line.untaxed_amount_invoiced += sum(line.pos_order_line_ids.mapped('price_subtotal'))
+            line.untaxed_amount_invoiced += sum(line.sudo().pos_order_line_ids.mapped('price_subtotal'))
 
     def _get_downpayment_line_price_unit(self, invoices):
         return super()._get_downpayment_line_price_unit(invoices) + sum(


### PR DESCRIPTION
The `group_pos_manager` was previously reintroduced in `AccountTestInvoicingCommon` due to demo data changes. However, this group is unrelated to the `account` module and may mask real permission issues in tests.

This commit removes the group from the common test setup and adds it explicitly in the relevant PoS test cases where needed.

Also updated PoS-related model logic to use `sudo()` where necessary to avoid access rights issues in test environments.

See also: odoo/enterprise#83129

Task [link](https://www.odoo.com/odoo/project/1737/tasks/4678172)
task-4678172


