### PR TITLE
[FIX] web_editor: remove dynamic _t usage and escape banner title

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -42,6 +42,7 @@ import {
     onWillUpdateProps,
     markup,
     status,
+    htmlEscape,
 } from "@odoo/owl";
 import { isCSSColor } from '@web/core/utils/colors';
 import { EmojiPicker } from '@web/core/emoji_picker/emoji_picker';
@@ -2437,7 +2438,7 @@ export class Wysiwyg extends Component {
             callback: () => {
                 const bannerElement = parseHTML(this.odooEditor.document, `
                     <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" role="status" data-oe-protected="true">
-                        <i class="fs-4 fa ${iconClass} mb-3" aria-label="${_t(title)}"></i>
+                        <i class="fs-4 fa ${iconClass} mb-3" aria-label="${htmlEscape(title)}"></i>
                         <div class="w-100 px-3" data-oe-protected="false">
                             <p><br></p>
                         </div>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- The `_t` call was used with  non-static string (title), which breaks translation extraction since only static strings can be exported to .pot files.
- Additionally, the title was directly injected into the DOM without escaping posing an XSS (Cross-Site Scripting) risk.

### Desired behavior after PR is merged:

- The `_t` call is removed, as  title passed to `_getBannerCommand` is already a translated static string. The value is now also passed through `htmlEscape()` before being used in the aria-label attribute, preventing any injected HTML from being rendered or executed.

task-4639885

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
