### PR TITLE
[FIX] mail_group: prevent traceback on missing quote element

### DIFF
--- a/addons/mail_group/static/src/interactions/mail_group_message.js
+++ b/addons/mail_group/static/src/interactions/mail_group_message.js
@@ -20,15 +20,19 @@ export class MailGroupMessage extends Interaction {
 
     setup() {
         this.isShown = true;
+    }
 
+    start() {
         // By default hide the mention of the previous email for which we reply
         // And add a button "Read more" to show the mention of the parent email
         const quoted = this.el.querySelector(".card-body *[data-o-mail-quote]");
-        const readMore = document.createElement("button");
-        readMore.classList.add("btn btn-light btn-sm ms-1");
-        readMore.innerText = ". . .";
-        quoted.insertBefore(readMore);
-        readMore.addEventListener("click", () => quoted.classList.toggle("visible"));
+        if (quoted) {
+            const readMore = document.createElement("button");
+            readMore.classList.add("btn", "btn-light", "btn-sm", "ms-1");
+            readMore.innerText = ". . .";
+            this.insert(readMore, quoted, "beforebegin");
+            this.addListener(readMore, "click", () => quoted.classList.toggle("visible"));
+        }
     }
 
     /**


### PR DESCRIPTION
Problem:
After this commit:
https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba#diff-4c88f379fa12efc16e2a3e4063f0dc4f7cf41affe8aedcc15e47ccf7c3306087

- `".card-body *[data-o-mail-quote]"` might not exist, causing a traceback on `quoted.insertBefore`.
- `classList.add` does not accept space-separated classes, causing another traceback.

Solution:
- Add `readMore` only if `".card-body *[data-o-mail-quote]"` exists.
- Pass classes separately in `classList.add`.

Steps to reproduce:
1. Go to `/groups` (e.g., `http://localhost:8069/groups`).
2. Open any group.
3. Traceback occurs.

opw-4703771

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
