### PR TITLE
[FIX] pdf: fix signature generation time difference

### DIFF
--- a/odoo/addons/base/tests/test_signature.py
+++ b/odoo/addons/base/tests/test_signature.py
@@ -58,10 +58,11 @@ class TestSignature(TransactionCase):
         cls.pdf_path =  "base/tests/minimal.pdf"
 
     def test_odoo_pdf_signer(self):
+        fixed_time = datetime.datetime.now(datetime.timezone.utc)
         with file_open(self.pdf_path, "rb") as stream:
             out_stream = io.BytesIO()
             with patch.object(PdfSigner, "_load_key_and_certificate", return_value=(self.private_key, self.certificate)):
-                signer = PdfSigner(stream, self.env)
+                signer = PdfSigner(stream, self.env, signing_time=fixed_time)
                 out_stream = signer.sign_pdf()
                 if not out_stream:
                     self.skipTest("Could not load the PdfSigner class properly")
@@ -102,7 +103,7 @@ class TestSignature(TransactionCase):
                 }),
                 cms.CMSAttribute({
                     'type': 'signing_time',
-                    'values': [cms.Time({'utc_time': core.UTCTime(datetime.datetime.now(datetime.timezone.utc))})]
+                    'values': [cms.Time({'utc_time': core.UTCTime(fixed_time)})]
                 }),
                 cms.CMSAttribute({
                     'type': 'cms_algorithm_protection',

--- a/odoo/tools/pdf/signature.py
+++ b/odoo/tools/pdf/signature.py
@@ -42,7 +42,8 @@ class PdfSigner:
     for the structure of the signature in a PDF.
     """
 
-    def __init__(self, stream: io.BytesIO, company: Optional[ResCompany] = None) -> None:
+    def __init__(self, stream: io.BytesIO, company: Optional[ResCompany] = None, signing_time=None) -> None:
+        self.signing_time = signing_time
         self.company = company
         if not 'clone_document_from_reader' in dir(PdfWriter):
             _logger.info("PDF signature is supported by Python 3.12 and above")
@@ -295,7 +296,7 @@ class PdfSigner:
             }),
             cms.CMSAttribute({
                 'type': 'signing_time',
-                'values': [cms.Time({'utc_time': core.UTCTime(datetime.datetime.now(datetime.timezone.utc))})]
+                'values': [cms.Time({'utc_time': core.UTCTime(self.signing_time or datetime.datetime.now(datetime.timezone.utc))})]
             }),
             cms.CMSAttribute({
                 'type': 'cms_algorithm_protection',


### PR DESCRIPTION
so that the expected and actual signature match
the signing time needs to match too , any slight delay between the date generation
would fail the test


build_error-134224

