### PR TITLE
[IMP] hw_*: use iot route wrapper

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -16,15 +16,13 @@ from odoo import http, tools
 
 from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.main import iot_devices, manager
-from odoo.addons.hw_drivers.tools import helpers
-from odoo.addons.hw_drivers.tools import route
+from odoo.addons.hw_drivers.tools import helpers, route
 
 _logger = logging.getLogger(__name__)
 
 
 class DriverController(http.Controller):
-    @route.protect
-    @http.route('/hw_drivers/action', type='jsonrpc', auth='none', cors='*', csrf=False, save_session=False)
+    @route.iot_route('/hw_drivers/action', type='jsonrpc', cors='*', csrf=False, sign=True)
     def action(self, session_id, device_identifier, data):
         """
         This route is called when we want to make a action with device (take picture, printing,...)
@@ -49,7 +47,7 @@ class DriverController(http.Controller):
             return True
         return False
 
-    @http.route('/hw_drivers/check_certificate', type='http', auth='none', cors='*', csrf=False, save_session=False)
+    @route.iot_route('/hw_drivers/check_certificate', type='http', cors='*', csrf=False)
     def check_certificate(self):
         """
         This route is called when we want to check if certificate is up-to-date
@@ -57,8 +55,7 @@ class DriverController(http.Controller):
         """
         helpers.get_certificate_status()
 
-    @route.protect
-    @http.route('/hw_drivers/event', type='jsonrpc', auth='none', cors='*', csrf=False, save_session=False)
+    @route.iot_route('/hw_drivers/event', type='jsonrpc', cors='*', csrf=False, sign=True)
     def event(self, listener):
         """
         listener is a dict in witch there are a sessions_id and a dict of device_identifier to listen
@@ -81,7 +78,7 @@ class DriverController(http.Controller):
             req['result']['session_id'] = req['session_id']
             return req['result']
 
-    @http.route('/hw_drivers/download_logs', type='http', auth='none', cors='*', csrf=False, save_session=False)
+    @route.iot_route('/hw_drivers/download_logs', type='http', cors='*', csrf=False)
     def download_logs(self):
         """
         Downloads the log file

--- a/addons/hw_drivers/controllers/proxy.py
+++ b/addons/hw_drivers/controllers/proxy.py
@@ -2,19 +2,20 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http
+from odoo.addons.hw_drivers.tools import route
 
 proxy_drivers = {}
 
 class ProxyController(http.Controller):
-    @http.route('/hw_proxy/hello', type='http', auth='none', cors='*')
+    @route.iot_route('/hw_proxy/hello', type='http', cors='*')
     def hello(self):
         return "ping"
 
-    @http.route('/hw_proxy/handshake', type='jsonrpc', auth='none', cors='*')
+    @route.iot_route('/hw_proxy/handshake', type='jsonrpc', cors='*')
     def handshake(self):
         return True
 
-    @http.route('/hw_proxy/status_json', type='jsonrpc', auth='none', cors='*')
+    @route.iot_route('/hw_proxy/status_json', type='jsonrpc', cors='*')
     def status_json(self):
         statuses = {}
         for driver in proxy_drivers:

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -13,7 +13,7 @@ from odoo import http
 from odoo.addons.hw_drivers.browser import Browser, BrowserState
 from odoo.addons.hw_drivers.driver import Driver
 from odoo.addons.hw_drivers.main import iot_devices
-from odoo.addons.hw_drivers.tools import helpers, wifi
+from odoo.addons.hw_drivers.tools import helpers, route
 from odoo.addons.hw_drivers.tools.helpers import Orientation
 from odoo.tools.misc import file_path
 
@@ -122,7 +122,7 @@ class DisplayDriver(Driver):
 
 
 class DisplayController(http.Controller):
-    @http.route('/hw_proxy/customer_facing_display', type='jsonrpc', auth='none', cors='*')
+    @route.iot_route('/hw_proxy/customer_facing_display', type='jsonrpc', cors='*')
     def customer_facing_display(self, action, pos_id=None, access_token=None, data=None):
         display = self.ensure_display()
         if action in ['open', 'open_kiosk']:

--- a/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
@@ -21,7 +21,7 @@ from odoo.addons.hw_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.hw_drivers.driver import Driver
 from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.main import iot_devices
-from odoo.addons.hw_drivers.tools import helpers
+from odoo.addons.hw_drivers.tools import helpers, route
 
 _logger = logging.getLogger(__name__)
 xlib = ctypes.cdll.LoadLibrary('libX11.so.6')
@@ -375,7 +375,7 @@ proxy_drivers['scanner'] = KeyboardUSBDriver
 
 
 class KeyboardUSBController(http.Controller):
-    @http.route('/hw_proxy/scanner', type='jsonrpc', auth='none', cors='*')
+    @route.iot_route('/hw_proxy/scanner', type='jsonrpc', cors='*')
     def get_barcode(self):
         scanners = [iot_devices[d] for d in iot_devices if iot_devices[d].device_type == "scanner"]
         if scanners:

--- a/addons/hw_drivers/iot_handlers/drivers/L10nEGDrivers.py
+++ b/addons/hw_drivers/iot_handlers/drivers/L10nEGDrivers.py
@@ -10,6 +10,7 @@ from passlib.context import CryptContext
 
 from odoo import http
 from odoo.tools.config import config
+from odoo.addons.hw_drivers.tools import route
 
 _logger = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class EtaUsbController(http.Controller):
             return False
         return crypt_context.verify(access_token, stored_hash)
 
-    @http.route('/hw_l10n_eg_eta/certificate', type='http', auth='none', cors='*', csrf=False, save_session=False, methods=['POST'])
+    @route.iot_route('/hw_l10n_eg_eta/certificate', type='http', cors='*', csrf=False, methods=['POST'])
     def eta_certificate(self, pin, access_token):
         """Gets the certificate from the token and returns it to the main odoo instance so that we can prepare the
         cades-bes object on the main odoo instance rather than this middleware
@@ -53,7 +54,7 @@ class EtaUsbController(http.Controller):
             session.logout()
             session.closeSession()
 
-    @http.route('/hw_l10n_eg_eta/sign', type='http', auth='none', cors='*', csrf=False, save_session=False, methods=['POST'])
+    @route.iot_route('/hw_l10n_eg_eta/sign', type='http', cors='*', csrf=False, methods=['POST'])
     def eta_sign(self, pin, access_token, invoices):
         """Check if the access_token is valid and sign the invoices accessing the usb key with the pin.
 

--- a/addons/hw_drivers/iot_handlers/drivers/L10nKeEDISerialDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/L10nKeEDISerialDriver.py
@@ -11,6 +11,7 @@ from functools import reduce
 from odoo import http
 from odoo.addons.hw_drivers.iot_handlers.drivers.SerialBaseDriver import SerialDriver, SerialProtocol, serial_connection
 from odoo.addons.hw_drivers.main import iot_devices
+from odoo.addons.hw_drivers.tools import route
 
 _logger = logging.getLogger(__name__)
 
@@ -226,7 +227,7 @@ class TremolG03Driver(SerialDriver):
 
 class TremolG03Controller(http.Controller):
 
-    @http.route('/hw_proxy/l10n_ke_cu_send', type='http', auth='none', cors='*', csrf=False, save_session=False, methods=['POST'])
+    @route.iot_route('/hw_proxy/l10n_ke_cu_send', type='http', cors='*', csrf=False, methods=['POST'])
     def l10n_ke_cu_send(self, messages, company_vat):
         """ Posts the messages sent to this endpoint to the fiscal device connected to the server
 

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -18,7 +18,7 @@ from odoo.addons.hw_drivers.driver import Driver
 from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.iot_handlers.interfaces.PrinterInterface_L import PPDs, conn, cups_lock
 from odoo.addons.hw_drivers.main import iot_devices
-from odoo.addons.hw_drivers.tools import helpers, wifi
+from odoo.addons.hw_drivers.tools import helpers, wifi, route
 from odoo.addons.hw_drivers.websocket_client import send_to_controller
 
 _logger = logging.getLogger(__name__)
@@ -471,7 +471,7 @@ class PrinterDriver(Driver):
 
 class PrinterController(http.Controller):
 
-    @http.route('/hw_proxy/default_printer_action', type='jsonrpc', auth='none', cors='*')
+    @route.iot_route('/hw_proxy/default_printer_action', type='jsonrpc', cors='*')
     def default_printer_action(self, data):
         printer = next((d for d in iot_devices if iot_devices[d].device_type == 'printer' and iot_devices[d].device_connection == 'direct'), None)
         if printer:

--- a/addons/hw_drivers/tools/__init__.py
+++ b/addons/hw_drivers/tools/__init__.py
@@ -1,2 +1,3 @@
 from . import helpers
 from . import wifi
+from . import route

--- a/addons/hw_drivers/tools/route.py
+++ b/addons/hw_drivers/tools/route.py
@@ -4,6 +4,7 @@ import logging
 from odoo.addons.iot_base.tools.payload_signature import verify_hmac_signature
 from odoo.addons.hw_drivers.tools import helpers
 from odoo.http import request
+from odoo import http
 from werkzeug.exceptions import Forbidden
 
 _logger = logging.getLogger(__name__)
@@ -30,3 +31,25 @@ def protect(endpoint):
 
         return endpoint(*args, **kwargs)
     return protect_wrapper
+
+
+def iot_route(route=None, sign=False, **kwargs):
+    """A wrapper for the http.route function that sets useful defaults for IoT:
+      - `auth = 'none'`
+      - `save_session = False`
+
+    It also adds the `sign` parameter, which if `True` wraps the route with `@route.protect`.
+
+    Both auth and sessions are useless on IoT since we have no DB and no users.
+    """
+    if 'auth' not in kwargs:
+        kwargs['auth'] = 'none'
+    if 'save_session' not in kwargs:
+        kwargs['save_session'] = False
+
+    http_decorator = http.route(route, **kwargs)
+
+    def decorator(endpoint):
+        return protect(http_decorator(endpoint)) if sign else http_decorator(endpoint)
+
+    return decorator

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -46,15 +46,15 @@ class IotBoxOwlHomePage(http.Controller):
         super().__init__()
         self.updating = threading.Lock()
 
-    @http.route('/', auth='none', type='http')
+    @route.iot_route('/', type='http')
     def index(self):
         return http.Stream.from_path("hw_posbox_homepage/views/index.html").get_response(content_security_policy=CONTENT_SECURITY_POLICY)
 
-    @http.route('/logs', auth='none', type='http')
+    @route.iot_route('/logs', type='http')
     def logs_page(self):
         return http.Stream.from_path("hw_posbox_homepage/views/logs.html").get_response(content_security_policy=CONTENT_SECURITY_POLICY)
 
-    @http.route('/status', auth='none', type='http')
+    @route.iot_route('/status', type='http')
     def status_page(self):
         return http.Stream.from_path("hw_posbox_homepage/views/status_display.html").get_response(content_security_policy=CONTENT_SECURITY_POLICY)
 
@@ -62,7 +62,7 @@ class IotBoxOwlHomePage(http.Controller):
     # GET methods                                                #
     # -> Always use json.dumps() to return a JSON response       #
     # ---------------------------------------------------------- #
-    @http.route('/hw_posbox_homepage/restart_odoo_service', auth='none', type='http', cors='*')
+    @route.iot_route('/hw_posbox_homepage/restart_odoo_service', type='http', cors='*')
     def odoo_service_restart(self):
         helpers.odoo_restart(0)
         return json.dumps({
@@ -70,7 +70,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Odoo service restarted',
         })
 
-    @http.route('/hw_posbox_homepage/iot_logs', auth='none', type='http', cors='*')
+    @route.iot_route('/hw_posbox_homepage/iot_logs', type='http', cors='*')
     def get_iot_logs(self):
         logs_path = "/var/log/odoo/odoo-server.log" if platform.system() == 'Linux' else Path().absolute().parent.joinpath('odoo.log')
         with open(logs_path, encoding="utf-8") as file:
@@ -79,7 +79,7 @@ class IotBoxOwlHomePage(http.Controller):
                 'logs': file.read(),
             })
 
-    @http.route('/hw_posbox_homepage/six_payment_terminal_clear', auth='none', type='http', cors='*')
+    @route.iot_route('/hw_posbox_homepage/six_payment_terminal_clear', type='http', cors='*')
     def clear_six_terminal(self):
         helpers.update_conf({'six_payment_terminal': ''})
         return json.dumps({
@@ -87,7 +87,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Successfully cleared Six Payment Terminal',
         })
 
-    @http.route('/hw_posbox_homepage/clear_credential', auth='none', type='http', cors='*')
+    @route.iot_route('/hw_posbox_homepage/clear_credential', type='http', cors='*')
     def clear_credential(self):
         helpers.update_conf({
             'db_uuid': '',
@@ -99,7 +99,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Successfully cleared credentials',
         })
 
-    @http.route('/hw_posbox_homepage/wifi_clear', auth='none', type='http', cors='*')
+    @route.iot_route('/hw_posbox_homepage/wifi_clear', type='http', cors='*')
     def clear_wifi_configuration(self):
         helpers.update_conf({'wifi_ssid': '', 'wifi_password': ''})
         wifi.disconnect()
@@ -108,7 +108,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Successfully disconnected from wifi',
         })
 
-    @http.route('/hw_posbox_homepage/server_clear', auth='none', type='http', cors='*')
+    @route.iot_route('/hw_posbox_homepage/server_clear', type='http', cors='*')
     def clear_server_configuration(self):
         helpers.disconnect_from_server()
         close_server_log_sender_handler()
@@ -117,14 +117,14 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Successfully disconnected from server',
         })
 
-    @http.route('/hw_posbox_homepage/ping', auth='none', type='http', cors='*')
+    @route.iot_route('/hw_posbox_homepage/ping', type='http', cors='*')
     def ping(self):
         return json.dumps({
             'status': 'success',
             'message': 'pong',
         })
 
-    @http.route('/hw_posbox_homepage/data', auth="none", type="http", cors='*')
+    @route.iot_route('/hw_posbox_homepage/data', type="http", cors='*')
     def get_homepage_data(self):
         network_interfaces = []
         if platform.system() == 'Linux':
@@ -183,14 +183,14 @@ class IotBoxOwlHomePage(http.Controller):
             'qr_code_url' : network_qr_codes.get('qr_url'),
         })
 
-    @http.route('/hw_posbox_homepage/wifi', auth="none", type="http", cors='*')
+    @route.iot_route('/hw_posbox_homepage/wifi', type="http", cors='*')
     def get_available_wifi(self):
         return json.dumps({
             'currentWiFi': wifi.get_current(),
             'availableWiFi': wifi.get_available_ssids(),
         })
 
-    @http.route('/hw_posbox_homepage/version_info', auth="none", type="http", cors='*')
+    @route.iot_route('/hw_posbox_homepage/version_info', type="http", cors='*')
     def get_version_info(self):
         git = ["git", "--work-tree=/home/pi/odoo/", "--git-dir=/home/pi/odoo/.git"]
         # Check branch name and last commit hash on IoT Box
@@ -219,7 +219,7 @@ class IotBoxOwlHomePage(http.Controller):
             'currentCommitHash': current_commit,
         })
 
-    @http.route('/hw_posbox_homepage/log_levels', auth="none", type="http", cors='*')
+    @route.iot_route('/hw_posbox_homepage/log_levels', type="http", cors='*')
     def log_levels(self):
         drivers_list = helpers.list_file_by_os(
             file_path('hw_drivers/iot_handlers/drivers'))
@@ -240,7 +240,7 @@ class IotBoxOwlHomePage(http.Controller):
             'interfaces_logger_info': self._get_iot_handlers_logger(interfaces_list, 'interfaces'),
         })
 
-    @http.route('/hw_posbox_homepage/load_iot_handlers', auth="none", type="http", cors='*')
+    @route.iot_route('/hw_posbox_homepage/load_iot_handlers', type="http", cors='*')
     def load_iot_handlers(self):
         helpers.download_iot_handlers(False)
         helpers.odoo_restart(0)
@@ -253,7 +253,7 @@ class IotBoxOwlHomePage(http.Controller):
     # POST methods                                               #
     # -> Never use json.dumps() it will be done automatically    #
     # ---------------------------------------------------------- #
-    @http.route('/hw_posbox_homepage/six_payment_terminal_add', auth="none", type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/six_payment_terminal_add', type="jsonrpc", methods=['POST'], cors='*')
     def add_six_terminal(self, terminal_id):
         if terminal_id.isdigit():
             helpers.update_conf({'six_payment_terminal': terminal_id})
@@ -265,7 +265,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Successfully saved Six Payment Terminal',
         }
 
-    @http.route('/hw_posbox_homepage/save_credential', auth="none", type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/save_credential', type="jsonrpc", methods=['POST'], cors='*')
     def save_credential(self, db_uuid, enterprise_code):
         helpers.update_conf({
             'db_uuid': db_uuid,
@@ -277,7 +277,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Successfully saved credentials',
         }
 
-    @http.route('/hw_posbox_homepage/update_wifi', auth="none", type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/update_wifi', type="jsonrpc", methods=['POST'], cors='*')
     def update_wifi(self, essid, password):
         if wifi.reconnect(essid, password, force_update=True):
             helpers.update_conf({'wifi_ssid': essid, 'wifi_password': password})
@@ -299,14 +299,13 @@ class IotBoxOwlHomePage(http.Controller):
 
         return res_payload
 
-    @route.protect
-    @http.route('/hw_posbox_homepage/generate_password', auth="none", type="jsonrpc", methods=["POST"], cors='*')
+    @route.iot_route('/hw_posbox_homepage/generate_password', type="jsonrpc", methods=["POST"], cors='*', sign=True)
     def generate_password(self):
         return {
             'password': helpers.generate_password(),
         }
 
-    @http.route('/hw_posbox_homepage/enable_ngrok', auth="none", type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/enable_ngrok', type="jsonrpc", methods=['POST'], cors='*')
     def enable_remote_connection(self, auth_token):
         if subprocess.call(['pgrep', 'ngrok']) == 1:
             subprocess.Popen(['sudo', 'systemd-run', 'ngrok', 'tcp', '--authtoken', auth_token, '--log', '/tmp/ngrok.log', '22'])
@@ -317,7 +316,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Ngrok tunnel is now enabled',
         }
 
-    @http.route('/hw_posbox_homepage/update_hostname', auth="none", type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/update_hostname', type="jsonrpc", methods=['POST'], cors='*')
     def update_hostname(self, hostname):
         """Update the hostname of the IoT Box.
 
@@ -350,8 +349,7 @@ class IotBoxOwlHomePage(http.Controller):
                     'message': 'Failed to update hostname, please try again.',
                 }
 
-
-    @http.route('/hw_posbox_homepage/connect_to_server', auth="none", type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/connect_to_server', type="jsonrpc", methods=['POST'], cors='*')
     def connect_to_odoo_server(self, token):
         if token:
             try:
@@ -383,7 +381,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Successfully connected to db, IoT will restart to update the configuration.',
         }
 
-    @http.route('/hw_posbox_homepage/log_levels_update', auth="none", type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/log_levels_update', type="jsonrpc", methods=['POST'], cors='*')
     def update_log_level(self, name, value):
         if not name.startswith(IOT_LOGGING_PREFIX) and name != 'log-to-server':
             return {
@@ -414,7 +412,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Logger level updated',
         }
 
-    @http.route('/hw_posbox_homepage/update_git_tree', auth="none", type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/update_git_tree', type="jsonrpc", methods=['POST'], cors='*')
     def update_git_tree(self):
         helpers.check_git_branch()
         return {

--- a/addons/hw_posbox_homepage/controllers/main.py
+++ b/addons/hw_posbox_homepage/controllers/main.py
@@ -5,9 +5,8 @@ import os
 import subprocess
 import threading
 
-from odoo import http
 from odoo.http import Response
-from odoo.addons.hw_drivers.tools import helpers
+from odoo.addons.hw_drivers.tools import helpers, route
 from odoo.addons.web.controllers.home import Home
 
 _logger = logging.getLogger(__name__)
@@ -21,18 +20,18 @@ class IoTboxHomepage(Home):
     def clean_partition(self):
         subprocess.check_call(['sudo', 'bash', '-c', '. /home/pi/odoo/addons/iot_box_image/configuration/upgrade.sh; cleanup'])
 
-    @http.route('/hw_proxy/perform_upgrade', type='http', auth='none')
+    @route.iot_route('/hw_proxy/perform_upgrade', type='http')
     def perform_upgrade(self):
         self.updating.acquire()
         os.system('/home/pi/odoo/addons/iot_box_image/configuration/checkout.sh')
         self.updating.release()
         return 'SUCCESS'
 
-    @http.route('/hw_proxy/get_version', type='http', auth='none')
+    @route.iot_route('/hw_proxy/get_version', type='http')
     def check_version(self):
         return helpers.get_version()
 
-    @http.route('/hw_proxy/perform_flashing_create_partition', type='http', auth='none')
+    @route.iot_route('/hw_proxy/perform_flashing_create_partition', type='http')
     def perform_flashing_create_partition(self):
         try:
             response = subprocess.check_output(['sudo', 'bash', '-c', '. /home/pi/odoo/addons/iot_box_image/configuration/upgrade.sh; create_partition']).decode().split('\n')[-2]
@@ -45,7 +44,7 @@ class IoTboxHomepage(Home):
             _logger.exception("Flashing create partition failed")
             return Response(str(e), status=500)
 
-    @http.route('/hw_proxy/perform_flashing_download_raspios', type='http', auth='none')
+    @route.iot_route('/hw_proxy/perform_flashing_download_raspios', type='http')
     def perform_flashing_download_raspios(self):
         try:
             response = subprocess.check_output(['sudo', 'bash', '-c', '. /home/pi/odoo/addons/iot_box_image/configuration/upgrade.sh; download_raspios']).decode().split('\n')[-2]
@@ -59,7 +58,7 @@ class IoTboxHomepage(Home):
             _logger.exception("Flashing download raspios failed")
             return Response(str(e), status=500)
 
-    @http.route('/hw_proxy/perform_flashing_copy_raspios', type='http', auth='none')
+    @route.iot_route('/hw_proxy/perform_flashing_copy_raspios', type='http')
     def perform_flashing_copy_raspios(self):
         try:
             response = subprocess.check_output(['sudo', 'bash', '-c', '. /home/pi/odoo/addons/iot_box_image/configuration/upgrade.sh; copy_raspios']).decode().split('\n')[-2]


### PR DESCRIPTION
Before this commit, for routes defined on the IoT box, we had to
manually set `auth='none'` and `save_session=False` for every route.
While forgetting to set `save_session=False` is okay, it is what causes
the many DEBUG logs referred to in task-4587619.

After this commit, there is an `iot_route` decorator that wraps the
existing `http.route`, defaulting `auth` and `save_session` to the
correct values. It also allows setting `sign=True` to automatically
wrap the route with `@route.protect`.

task-4587619

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
