### PR TITLE
[IMP] tests: make the test cursor lock timeout configurable

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -329,6 +329,7 @@ class BaseCase(case.TestCase):
 
     _registry_patched = False
     _registry_readonly_enabled = True
+    test_cursor_lock_timeout: int = 20
 
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)

--- a/odoo/tests/test_cursor.py
+++ b/odoo/tests/test_cursor.py
@@ -42,8 +42,9 @@ class TestCursor(BaseCursor):
         current_test = odoo.modules.module.current_test
         assert current_test, 'Test Cursor without active test ?'
         current_test.assertCanOpenTestCursor()
-        if not self._lock.acquire(timeout=20):
-            raise Exception('Unable to acquire lock for test cursor after 20s')
+        lock_timeout = current_test.test_cursor_lock_timeout
+        if not self._lock.acquire(timeout=lock_timeout):
+            raise Exception(f'Unable to acquire lock for test cursor after {lock_timeout}s')
         try:
             # Check after acquiring in case current_test has changed.
             # This can happen if the request was hanging between two tests.


### PR DESCRIPTION
Make it possible to change the test cursor lock timeout through environment variables.
Scraper tests require a longer timeout than the short one we initially put as the logic is done through controllers.

