### PR TITLE
[FIX] point_of_sale: prevent cancelled orders from being marked as paid

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -136,7 +136,7 @@ class PosOrder(models.Model):
 
     def _process_saved_order(self, draft):
         self.ensure_one()
-        if not draft:
+        if not draft and self.state != 'cancel':
             try:
                 self.action_pos_order_paid()
             except psycopg2.DatabaseError:


### PR DESCRIPTION
Before this commit, if the state of an order was set to 'cancel' and then the order was synced to the server, it would incorrectly be saved as 'paid'. This could happen in a POS restaurant environment, for example, when releasing a table. As a result, empty orders would appear as paid, which is incorrect.

This behavior was particularly problematic in certain localizations where such empty, paid orders lacked required fiscal data, leading to errors during session closing.

opw-4714877

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
