### PR TITLE
[FIX] hr_holidays: prevent officer from validating his leave requests

### DIFF
--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -100,9 +100,9 @@ A user without any rights on Time Off will be able to see the application, creat
         <field name="name">Time Off All Approver read</field>
         <field name="model_id" ref="model_hr_leave"/>
         <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="perm_write" eval="True"/>
-        <field name="perm_create" eval="True"/>
-        <field name="perm_unlink" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
         <field name="groups" eval="[(4, ref('hr_holidays.group_hr_holidays_user'))]"/>
     </record>
 


### PR DESCRIPTION
After this commit, the Time Off officer will no longer be able to validate their leave request, while still being able to manage all other requests.

task-471198

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
