### PR TITLE
[FIX] mail, account, sms: various followup for many2many tags email

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5488,6 +5488,7 @@ class AccountMove(models.Model):
         self.ensure_one()
 
         report_action = self.action_send_and_print()
+        report_action['context'].update({'allow_partners_without_mail': True})
         if self.env.is_admin() and not self.env.company.external_report_layout_id and not self.env.context.get('discard_logo_check'):
             report_action = self.env['ir.actions.report']._action_configure_external_report_layout(report_action, "account.action_base_document_layout_configurator")
             report_action['context']['default_from_invoice'] = self.move_type == 'out_invoice'

--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -183,7 +183,7 @@ class AccountMoveSend(models.AbstractModel):
             partner_to = self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'partner_to')
             partner_ids = mail_template._parse_partner_to(partner_to)
             partners |= self.env['res.partner'].sudo().browse(partner_ids).exists()
-        return partners.filtered('email')
+        return partners if self.env.context.get('allow_partners_without_mail') else partners.filtered('email')
 
     # -------------------------------------------------------------------------
     # ATTACHMENTS

--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -127,12 +127,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "edit Test Customer",
     },
     {
-        isActive: ["auto"],
-        trigger: ".ui-menu-item a:contains('Test Customer')",
-        content: _t("Select first partner"),
-        run: "click",
-    },
-    {
         trigger: ".o-mail-RecipientsInputTagsListPopover input",
         content: markup(_t("Write here <b>your own email address</b> to test the flow.")),
         run: "edit customer@example.com",

--- a/addons/mail/static/src/core/web/recipients_input.js
+++ b/addons/mail/static/src/core/web/recipients_input.js
@@ -96,10 +96,10 @@ export class RecipientsInput extends Component {
                             id: match.id,
                             label: match.email
                                 ? _t("%(partner_name)s <%(partner_email)s>", {
-                                      partner_name: match.name,
+                                      partner_name: match.name || _t("Unnamed"),
                                       partner_email: match.email,
                                   })
-                                : match.name,
+                                : match.name || _t("Unnamed"),
                             onSelectOption: () => {
                                 this.insertAdditionalRecipient({
                                     email: match.email,
@@ -177,7 +177,7 @@ export class RecipientsInput extends Component {
             const title = _t(
                 recipient.email ? "%(partner_name)s <%(partner_email)s>" : "%(partner_name)s",
                 {
-                    partner_name: recipient.name,
+                    partner_name: recipient.name || _t("Unnamed"),
                     partner_email: recipient.email,
                 }
             );
@@ -185,8 +185,8 @@ export class RecipientsInput extends Component {
                 id: uniqueId("tag_"),
                 resId: recipient.partner_id,
                 canEdit: true,
-                text: recipient.name || recipient.email,
-                name: recipient.name,
+                text: recipient.name || recipient.email || _t("Unnamed"),
+                name: recipient.name || _t("Unnamed"),
                 email: recipient.email,
                 title,
                 onClick: (ev) => {

--- a/addons/mail/static/src/core/web/recipients_popover.js
+++ b/addons/mail/static/src/core/web/recipients_popover.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
 import { Component, onWillStart } from "@odoo/owl";
@@ -20,6 +21,10 @@ export class RecipientsPopover extends Component {
         onWillStart(async () => {
             [this.partner] = await this.orm.read("res.partner", [this.props.id], this.fieldNames);
         });
+    }
+
+    get name() {
+        return this.partner.name || _t("Unnamed");
     }
 
     get phone() {

--- a/addons/mail/static/src/core/web/recipients_popover.xml
+++ b/addons/mail/static/src/core/web/recipients_popover.xml
@@ -7,11 +7,11 @@
                     <span class="o_avatar pt-1 position-relative o_card_avatar bg-inherit">
                         <img t-if="props.id"
                             t-attf-src="/web/image/res.partner/{{props.id}}/avatar_128"
-                            class="rounded"
+                            class="rounded object-fit-contain"
                         />
                     </span>
                     <div class="d-flex flex-column o_card_user_infos overflow-hidden">
-                        <span class="fw-bold" t-out="partner.name"/>
+                        <span class="fw-bold" t-out="name"/>
                         <a t-if="email" t-attf-href="mailto:{{email}}" t-att-title="email" class="text-truncate">
                             <i class="fa fa-fw fa-envelope me-1"/><t t-out="email"/>
                         </a>

--- a/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
+++ b/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
@@ -87,7 +87,7 @@ export class FieldMany2ManyTagsEmail extends Many2ManyTagsField {
      */
     getTagProps(record) {
         return {...super.getTagProps(record),
-            text: record.data.name,
+            text: record.data.name || record.data.email || _t("Unnamed"),
             onClick: (ev) => this.onTagClick(ev, record),
         };
     }

--- a/addons/sms/static/src/thread/message_patch.js
+++ b/addons/sms/static/src/thread/message_patch.js
@@ -1,8 +1,38 @@
+import { _t } from "@web/core/l10n/translation";
+import { user } from "@web/core/user";
 import { Message } from "@mail/core/common/message";
 
 import { patch } from "@web/core/utils/patch";
 
 patch(Message.prototype, {
+    async onClickNotification(ev) {
+        const hasAccountFailure = this.message.notification_ids.some(
+            (notification) => notification.isFailure && notification.failure_type === "sms_acc"
+        );
+        if (
+            this.message.message_type === "sms" &&
+            hasAccountFailure &&
+            (await user.hasGroup("base.group_system"))
+        ) {
+            const [accountId] = await this.env.services.orm.call("iap.account", "get", [], {
+                service_name: "sms",
+                force_create: false,
+            });
+            if (accountId) {
+                this.env.services.action.doAction({
+                    type: "ir.actions.act_window",
+                    name: _t("SMS Account"),
+                    target: "current",
+                    res_model: "iap.account",
+                    res_id: accountId,
+                    views: [[false, "form"]],
+                });
+                return;
+            }
+        }
+
+        super.onClickNotification(ev);
+    },
     onClickFailure() {
         if (this.message.message_type === "sms") {
             this.env.services.action.doAction("sms.sms_resend_action", {


### PR DESCRIPTION
1. Display email of the recipients if email is given otherwise
fallback to `Unnamed`.

  Steps to reproduce 
  1. Create a contact with no name.
  2. Open the chatter from any document.
  3. Try to send a message to the contact without name.

  -> Tag without name will be shown

  From [Commit 1], we added a possibility to show partner's information or enter
  missing email address with [Commit 2]. In the case when partner didn't have
  name set, tags's text was shown blank.

  After this commit, tags of widget many2many_tags_email having no name will
  show email if given otherwise "Unnamed".

2. Account
   Account send invoice wizard will allow partners without email as the opened
   wizard will ask for the email.

3. SMS
  If sending sms fails because of account unregistered, we will redirect the user
  on click of the red SMS button to the IAP SMS account if user can access,
  otherwise the normal popover is shown as usual.

[Commit 1]: https://github.com/odoo/odoo/commit/abdb7654e463c7b20b7e0d16e0b9cb76863cbdeb
[Commit 2]: https://github.com/odoo/odoo/commit/2bbf118e60d793bea98078810a282fe45e896403

Task-4711346