### PR TITLE
[IMP] website, *: add pretty url for menu items

### DIFF
--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -203,6 +203,7 @@
     <record id="action_delivery_carrier_form" model="ir.actions.act_window">
         <field name="name">Delivery Methods</field>
         <field name="res_model">delivery.carrier</field>
+        <field name="path">delivery-methods</field>
         <field name="view_mode">list,form</field>
         <field name="context">{'search_default_group_by_provider': True}</field>
         <field name="help" type="html">

--- a/addons/delivery/views/delivery_zip_prefix_views.xml
+++ b/addons/delivery/views/delivery_zip_prefix_views.xml
@@ -4,6 +4,7 @@
     <record id="action_delivery_zip_prefix_list" model="ir.actions.act_window">
         <field name="name">Zip Prefix</field>
         <field name="res_model">delivery.zip.prefix</field>
+        <field name="path">zip-prefix</field>
         <field name="view_mode">list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/gamification/views/gamification_badge_views.xml
+++ b/addons/gamification/views/gamification_badge_views.xml
@@ -16,6 +16,7 @@
     <record id="badge_list_action" model="ir.actions.act_window">
         <field name="name">Badges</field>
         <field name="res_model">gamification.badge</field>
+        <field name="path">badges</field>
         <field name="view_mode">kanban,list,form</field>
         <field name="search_view_id" ref="gamification_badge_view_search"/>
         <field name="help" type="html">

--- a/addons/gamification/views/gamification_karma_rank_views.xml
+++ b/addons/gamification/views/gamification_karma_rank_views.xml
@@ -6,6 +6,7 @@
         <record id="gamification_karma_ranks_action" model="ir.actions.act_window">
             <field name="name">Ranks</field>
             <field name="res_model">gamification.karma.rank</field>
+            <field name="path">ranks</field>
             <field name="view_mode">list,form</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -197,6 +197,7 @@
     <record id="loyalty_program_discount_loyalty_action" model="ir.actions.act_window">
         <field name="name">Discount &amp; Loyalty</field>
         <field name="res_model">loyalty.program</field>
+        <field name="path">discount-loyalty</field>
         <field name="view_mode">list,form</field>
         <field name="domain">[('program_type', 'not in', ('gift_card', 'ewallet'))]</field>
         <field name="help" type="html">
@@ -240,6 +241,7 @@
     <record id="loyalty_program_gift_ewallet_action" model="ir.actions.act_window">
         <field name="name">Gift cards &amp; eWallet</field>
         <field name="res_model">loyalty.program</field>
+        <field name="path">gift-cards-ewallet</field>
         <field name="view_mode">list,form</field>
         <field name="context">{'menu_type': 'gift_ewallet', 'default_program_type': 'gift_card'}</field>
         <field name="domain">[('program_type', 'in', ('gift_card', 'ewallet'))]</field>

--- a/addons/mail_group/views/mail_group_moderation_views.xml
+++ b/addons/mail_group/views/mail_group_moderation_views.xml
@@ -35,6 +35,7 @@
     <record id="mail_group_moderation_action" model="ir.actions.act_window">
         <field name="name">Moderation</field>
         <field name="res_model">mail.group.moderation</field>
+        <field name="path">mail-moderation</field>
         <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="mail_group_moderation_view_search"/>
     </record>

--- a/addons/mail_group/views/mail_group_views.xml
+++ b/addons/mail_group/views/mail_group_views.xml
@@ -183,6 +183,7 @@
     <record id="mail_group_action" model="ir.actions.act_window">
         <field name="name">Mail Groups</field>
         <field name="res_model">mail.group</field>
+        <field name="path">mail-groups</field>
         <field name="view_mode">kanban,list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">Create a Mail Group</p>

--- a/addons/payment/views/payment_token_views.xml
+++ b/addons/payment/views/payment_token_views.xml
@@ -67,6 +67,7 @@
     <record id="action_payment_token" model="ir.actions.act_window">
         <field name="name">Payment Tokens</field>
         <field name="res_model">payment.token</field>
+        <field name="path">payment-tokens</field>
         <field name="view_mode">list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -149,6 +149,7 @@
     <record id="action_payment_transaction" model="ir.actions.act_window">
         <field name="name">Payment Transactions</field>
         <field name="res_model">payment.transaction</field>
+        <field name="path">payment-transactions</field>
         <field name="view_mode">list,kanban,form,graph,pivot</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_neutral_face">

--- a/addons/product/views/product_attribute_views.xml
+++ b/addons/product/views/product_attribute_views.xml
@@ -97,6 +97,7 @@
     <record id="attribute_action" model="ir.actions.act_window">
         <field name="name">Attributes</field>
         <field name="res_model">product.attribute</field>
+        <field name="path">attributes</field>
         <field name="view_mode">list,form</field>
     </record>
 

--- a/addons/product/views/product_combo_views.xml
+++ b/addons/product/views/product_combo_views.xml
@@ -63,6 +63,7 @@
     <record id="product.product_combo_action" model="ir.actions.act_window">
         <field name="name">Combo Choices</field>
         <field name="res_model">product.combo</field>
+        <field name="path">combo-choices</field>
         <field name="view_mode">list,form</field>
     </record>
 </odoo>

--- a/addons/product/views/product_tag_views.xml
+++ b/addons/product/views/product_tag_views.xml
@@ -48,6 +48,7 @@
     <record id="product_tag_action" model="ir.actions.act_window">
         <field name="name">Product Tags</field>
         <field name="res_model">product.tag</field>
+        <field name="path">product-tags</field>
         <field name="view_mode">list,form</field>
         <field name="view_id" eval="False"/>
         <field name="context">{'create': True}</field>

--- a/addons/test_website/views/test_model_views.xml
+++ b/addons/test_website/views/test_model_views.xml
@@ -46,6 +46,7 @@
     <field name="name">Test Model</field>
     <field name="type">ir.actions.act_window</field>
     <field name="res_model">test.model</field>
+    <field name="path">test-model</field>
     <field name="view_id" eval="False"/>
 </record>
 

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -182,6 +182,7 @@
 <record id="action_website_pages_list" model="ir.actions.act_window">
     <field name="name">Website Pages</field>
     <field name="res_model">website.page</field>
+    <field name="path">website-pages</field>
     <field name="view_mode">list,kanban</field>
     <field name="view_ids" eval="[(5, 0, 0),
         (0, 0, {'view_mode': 'list', 'view_id': ref('website_pages_tree_view')}),

--- a/addons/website/views/website_rewrite.xml
+++ b/addons/website/views/website_rewrite.xml
@@ -54,6 +54,7 @@
         <record id="action_website_rewrite_list" model="ir.actions.act_window">
             <field name="name">Rewrite</field>
             <field name="res_model">website.rewrite</field>
+            <field name="path">website-rewrite</field>
             <field name="view_id" eval="False"/>
         </record>
 

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -83,6 +83,7 @@
         <record id="action_website_list" model="ir.actions.act_window">
             <field name="name">Websites</field>
             <field name="res_model">website</field>
+            <field name="path">websites</field>
             <field name="view_mode">list,form</field>
             <field name="view_id" ref="view_website_tree"/>
             <field name="target">current</field>
@@ -167,6 +168,7 @@
         <record id="action_website_menu" model="ir.actions.act_window">
             <field name="name">Website Menu</field>
             <field name="res_model">website.menu</field>
+            <field name="path">website-menu</field>
             <field name="view_mode">list,form</field>
             <field name="context">{'search_default_group_by_website_id':1}</field>
             <field name="view_id" ref="menu_tree"/>
@@ -201,6 +203,7 @@
         ==================================================================== -->
         <record id="backend_dashboard" model="ir.actions.client">
             <field name="name">Analytics</field>
+            <field name="path">website-analytics</field>
             <field name="tag">backend_dashboard</field>
         </record>
 

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -303,6 +303,7 @@
     <record id="website_visitor_view_action" model="ir.actions.act_window">
         <field name="name">Page Views</field>
         <field name="res_model">website.track</field>
+        <field name="path">website-page-views</field>
         <field name="view_mode">list</field>
         <field name="context">{'search_default_type_url': 1, 'create': False, 'edit': False, 'copy': False}</field>
         <field name="view_ids" eval="[(5, 0, 0),

--- a/addons/website_blog/views/website_blog_views.xml
+++ b/addons/website_blog/views/website_blog_views.xml
@@ -47,6 +47,7 @@
         <record id="action_blog_blog" model="ir.actions.act_window">
             <field name="name">Blogs</field>
             <field name="res_model">blog.blog</field>
+            <field name="path">blogs</field>
             <field name="view_mode">list,form</field>
         </record>
 
@@ -84,6 +85,7 @@
         <record id="action_tags" model="ir.actions.act_window">
             <field name="name">Blog Tags</field>
             <field name="res_model">blog.tag</field>
+            <field name="path">blog-tags</field>
             <field name="view_mode">list,form</field>
             <field name="view_id" ref="blog_tag_tree"/>
         </record>
@@ -115,6 +117,7 @@
         <record id="action_tag_category" model="ir.actions.act_window">
             <field name="name">Tag Category</field>
             <field name="res_model">blog.tag.category</field>
+            <field name="path">blog-tag-categories</field>
             <field name="view_mode">list,form</field>
             <field name="view_id" ref="blog_tag_category_tree"/>
         </record>

--- a/addons/website_blog/views/website_pages_views.xml
+++ b/addons/website_blog/views/website_pages_views.xml
@@ -121,6 +121,7 @@
 <record id="action_blog_post" model="ir.actions.act_window">
     <field name="name">Blog Post Pages</field>
     <field name="res_model">blog.post</field>
+    <field name="path">blog-post-pages</field>
     <field name="view_mode">list,kanban,form</field>
     <field name="view_ids" eval="[(5, 0, 0),
         (0, 0, {'view_mode': 'list', 'view_id': ref('view_blog_post_list')}),

--- a/addons/website_event/views/website_pages_views.xml
+++ b/addons/website_event/views/website_pages_views.xml
@@ -79,6 +79,7 @@
 <record id="action_event_pages_list" model="ir.actions.act_window">
     <field name="name">Event Pages</field>
     <field name="res_model">event.event</field>
+    <field name="path">event-pages</field>
     <field name="view_mode">list,kanban</field>
     <field name="view_ids" eval="[(5, 0, 0),
         (0, 0, {'view_mode': 'list', 'view_id': ref('event_pages_tree_view')}),

--- a/addons/website_forum/views/forum_forum_views.xml
+++ b/addons/website_forum/views/forum_forum_views.xml
@@ -163,6 +163,7 @@
         <record id="forum_forum_action" model="ir.actions.act_window">
             <field name="name">Forums</field>
             <field name="res_model">forum.forum</field>
+            <field name="path">forums</field>
             <field name="view_mode">list,form</field>
         </record>
 

--- a/addons/website_forum/views/forum_post_reason_views.xml
+++ b/addons/website_forum/views/forum_post_reason_views.xml
@@ -15,6 +15,7 @@
     <record id="forum_post_reason_action" model="ir.actions.act_window">
         <field name="name">Post Close Reason</field>
         <field name="res_model">forum.post.reason</field>
+        <field name="path">forum-close-reasons</field>
         <field name="view_mode">list</field>
     </record>
 </data></odoo>

--- a/addons/website_forum/views/forum_post_views.xml
+++ b/addons/website_forum/views/forum_post_views.xml
@@ -158,6 +158,7 @@
 <record id="forum_post_action" model="ir.actions.act_window">
     <field name="name">Forum Post Pages</field>
     <field name="res_model">forum.post</field>
+    <field name="path">forum-post-pages</field>
     <field name="view_mode">list,kanban,graph</field>
     <field name="view_ids" eval="[(5, 0, 0),
         (0, 0, {'view_mode': 'list', 'view_id': ref('forum_post_view_tree')}),

--- a/addons/website_forum/views/forum_tag_views.xml
+++ b/addons/website_forum/views/forum_tag_views.xml
@@ -33,6 +33,7 @@
     <record id="forum_tag_action" model="ir.actions.act_window">
         <field name="name">Forum Tags</field>
         <field name="res_model">forum.tag</field>
+        <field name="path">forum-tags</field>
         <field name="view_mode">list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/website_hr_recruitment/views/website_pages_views.xml
+++ b/addons/website_hr_recruitment/views/website_pages_views.xml
@@ -46,6 +46,7 @@
 <record id="action_job_pages_list" model="ir.actions.act_window">
     <field name="name">Job Pages</field>
     <field name="res_model">hr.job</field>
+    <field name="path">job-pages</field>
     <field name="view_mode">list,kanban,form</field>
     <field name="view_ids" eval="[(5, 0, 0),
         (0, 0, {'view_mode': 'list', 'view_id': ref('job_pages_tree_view')}),

--- a/addons/website_sale/report/sale_report_views.xml
+++ b/addons/website_sale/report/sale_report_views.xml
@@ -75,6 +75,7 @@
     <record id="sale_report_action_dashboard" model="ir.actions.act_window">
         <field name="name">Online Sales Analysis</field>
         <field name="res_model">sale.report</field>
+        <field name="path">online-sales-analysis</field>
         <field name="view_mode">pivot,graph</field>
         <field name="domain">[('website_id', '!=', False)]</field>
         <field name="context">{'search_default_confirmed': 1}</field>

--- a/addons/website_sale/views/product_public_category_views.xml
+++ b/addons/website_sale/views/product_public_category_views.xml
@@ -43,6 +43,7 @@
     <record id="product_public_category_action" model="ir.actions.act_window">
         <field name="name">eCommerce Categories</field>
         <field name="res_model">product.public.category</field>
+        <field name="path">ecommerce-categories</field>
         <field name="view_mode">list,form</field>
         <field name="view_id" eval="False"/>
         <field name="help" type="html">

--- a/addons/website_sale/views/product_ribbon_views.xml
+++ b/addons/website_sale/views/product_ribbon_views.xml
@@ -55,6 +55,7 @@
     <record id="product_ribbon_action" model="ir.actions.act_window">
         <field name="name">Product Ribbons</field>
         <field name="res_model">product.ribbon</field>
+        <field name="path">product-ribbons</field>
         <field name="view_mode">list,form</field>
         <field name="context">{'create': True}</field>
         <field name="help" type="html">

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -93,6 +93,7 @@
     <record id="product_template_action_website" model="ir.actions.act_window">
         <field name="name">Products</field>
         <field name="res_model">product.template</field>
+        <field name="path">ecommerce-products</field>
         <field name="view_mode">kanban,list,form,activity</field>
         <field name="view_id"/>
         <field name="search_view_id" ref="product_template_search_view_website"/>

--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -43,6 +43,7 @@
     <record id="action_orders_ecommerce" model="ir.actions.act_window">
         <field name="name">Orders</field>
         <field name="res_model">sale.order</field>
+        <field name="path">ecommerce-orders</field>
         <field name="view_mode">list,form,kanban,activity</field>
         <field name="domain">[]</field>
         <field name="context">{'show_sale': True, 'search_default_order_confirmed': 1, 'search_default_from_website': 1}</field>
@@ -113,6 +114,7 @@
     <record id="action_view_unpaid_quotation_tree" model="ir.actions.act_window">
         <field name="name">Unpaid Orders</field>
         <field name="res_model">sale.order</field>
+        <field name="path">ecommerce-unpaid-orders</field>
         <field name="view_mode">list,kanban,form,activity</field>
         <field name="domain">[('state', '=', 'sent'), ('website_id', '!=', False)]</field>
         <field name="context">{'show_sale': True, 'create': False}</field>
@@ -130,6 +132,7 @@
     <record id="action_view_abandoned_tree" model="ir.actions.act_window">
         <field name="name">Abandoned Carts</field>
         <field name="res_model">sale.order</field>
+        <field name="path">ecommerce-abandoned-carts</field>
         <field name="view_mode">list,kanban,form,activity</field>
         <field name="domain">[('is_abandoned_cart', '=', 1)]</field>
         <field name="context" eval="{'show_sale': True, 'create': False, 'public_partner_id': ref('base.public_partner'), 'search_default_recovery_email': True}"/>

--- a/addons/website_sale/views/website_pages_views.xml
+++ b/addons/website_sale/views/website_pages_views.xml
@@ -72,6 +72,7 @@
     <record id="action_product_pages_list" model="ir.actions.act_window">
         <field name="name">Product Pages</field>
         <field name="res_model">product.template</field>
+        <field name="path">product-pages</field>
         <field name="view_mode">list,kanban</field>
         <field name="view_id" ref="product_pages_tree_view"/>
         <field name="view_ids" eval="[Command.clear(),

--- a/addons/website_sale_comparison/views/website_sale_comparison_view.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_view.xml
@@ -16,6 +16,7 @@
     <record id="product_attribute_category_action" model="ir.actions.act_window">
         <field name="name">Attribute Categories</field>
         <field name="res_model">product.attribute.category</field>
+        <field name="path">attribute-categories</field>
         <field name="view_mode">list</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/website_slides/views/website_pages_views.xml
+++ b/addons/website_slides/views/website_pages_views.xml
@@ -60,6 +60,7 @@
 <record id="action_slide_channel_pages_list" model="ir.actions.act_window">
     <field name="name">Course Pages</field>
     <field name="res_model">slide.channel</field>
+    <field name="path">course-pages</field>
     <field name="view_mode">list,kanban,form</field>
     <field name="view_ids" eval="[(5, 0, 0),
         (0, 0, {'view_mode': 'list', 'view_id': ref('slide_channel_pages_tree_view')}),

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -426,6 +426,7 @@
         <record id="action_partner_customer_form" model="ir.actions.act_window">
             <field name="name">Customers</field>
             <field name="res_model">res.partner</field>
+            <field name="path">ecommerce-customers</field>
             <field name="view_mode">list,kanban,form</field>
             <field name="domain">[]</field>
             <field name="context">{'res_partner_search_mode': 'customer', 'default_is_company': True}</field>


### PR DESCRIPTION
`*` = base, delivery, gamification, loyalty, mail_group, payment, product,
test_website, website_blog, website_event, website_forum,
website_hr_recruitment, website_sale, website_sale_comparison,
website_slides

Previously, menu item URLs for actions were not user-friendly or
readable.

Since we now support pretty URLs, this commit updates the above
modules to use clean, readable URLs for their menu items.

Enterprise PR: odoo/enterprise#83149

task-4700261