### PR TITLE
[FIX] mrp: resolve byproduct uom widget

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -131,7 +131,7 @@
                                     <field name="sequence" widget="handle"/>
                                     <field name="product_id" context="{'default_is_storable': True}"/>
                                     <field name="product_qty"/>
-                                    <field name="product_uom_id" groups="uom.group_uom" options="{'product_field': 'product_qty'}" widget="many2one_uom"/>
+                                    <field name="product_uom_id" groups="uom.group_uom" options="{'quantity_field': 'product_qty'}" widget="many2one_uom"/>
                                     <field name="cost_share" optional="hide"/>
                                     <field name="allowed_operation_ids" column_invisible="True"/>
                                     <field name="operation_id" groups="mrp.group_mrp_routings" options="{'no_quick_create':True,'no_create_edit':True}"/>


### PR DESCRIPTION
Currently, a console log warning appears when adding a byproduct in 
the BOM. Additionally, the uom widget doesn't function as expected.

Steps to Reproduce
==================
- Enable byproducts for the manufacturing operation.
- Navigate to Manufacturing > Products > Bill of Materials.
- Open an existing demo BOM or create a new BOM product.
- Add a byproduct and observe the console log warning.

Issue
=====
In the mrp_bom view, the byproduct list uses the many2one_uom widget.
However, the quantity_field was not passed, leading to the console
log warning.

This commit ensures the quantity_field is correctly passed and resolves
the warning. Additionally, the uom widget is now properly displayed.

Task: [4714266](https://www.odoo.com/odoo/project.task/4714266)