### PR TITLE
[IMP] project_todo: add task quick create shortcuts

### DIFF
--- a/addons/project_todo/data/todo_template.xml
+++ b/addons/project_todo/data/todo_template.xml
@@ -107,6 +107,52 @@
 </p>
 <p><br /></p>
 
+<h3 class="fw-bolder">Enhance Your To-Dos with Shortcuts &amp;#9889;</h3>
+<hr/>
+<p>
+    <span style="font-size: 14px;">
+        Use these keywords in the title to streamline your to-dos:
+    </span>
+    <br/>
+    <ul>
+        <li>
+            <span style="font-weight: bolder;">
+                <font class="text-o-color-2">#tags:</font>
+            </span>
+            Add tags to categorize the to-do
+        </li>
+        <li>
+            <span style="font-weight: bolder;">
+                <font class="text-o-color-2">@user:</font>
+            </span>
+            Assign the to-do to a specific user
+        </li>
+        <li>
+            <span style="font-weight: bolder;">
+                <font class="text-o-color-2">!:</font>
+            </span>
+            Mark the to-do as medium priority
+        </li>
+        <li>
+            <span style="font-weight: bolder;">
+                <font class="text-o-color-2">!!:</font>
+            </span>
+            Mark the to-do as high priority
+        </li>
+        <li>
+            <span style="font-weight: bolder;">
+                <font class="text-o-color-2">!!!:</font>
+            </span>
+            Mark the to-do as urgent
+        </li>
+    </ul>
+    <br/>
+    <span style="font-size: 14px;">
+        Ensure you follow the correct format and order. For example: Send invitations #event @Mitchell !
+    </span>
+</p>
+<p><br/></p>
+
 <h3 class="fw-bolder">Manage your to-dos and assigned tasks from a single place</h3>
 <hr />
 <p>

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -48,7 +48,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_project_task_kanban_view",
 },
 {
-    trigger: '.o_kanban_quick_create div.o_field_char[name=name] input',
+    trigger: '.o_kanban_quick_create div.o_field_char[name=display_name] input',
     content: "Create a personal task from the To-do kanban view",
     run: "edit Personal Task 1",
 },

--- a/addons/project_todo/tests/__init__.py
+++ b/addons/project_todo/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_access_rights
 from . import test_mail_activity_todo_create
 from . import test_todo_ui
+from . import test_todo_quick_create

--- a/addons/project_todo/tests/test_todo_quick_create.py
+++ b/addons/project_todo/tests/test_todo_quick_create.py
@@ -1,0 +1,44 @@
+from odoo.addons.project.tests.test_project_base import TestProjectCommon
+from odoo.tests import Form, users
+
+
+class TestTodoQuickCreate(TestProjectCommon):
+
+    @users('armandel')
+    def test_create_todo_with_valid_expressions(self):
+        valid_expressions = {
+            'todo A #Tag1 #tag2 @Armande @Bast !': ('todo A', 2, 2, "1"),
+            'todo A #Tag1 #tag2 #tag3 @Armande @Bast': ('todo A', 3, 2, "0"),
+            'todo A ! #Tag1 #tag2 #tag3 @Armande @Bast ! #tag4': ('todo A', 4, 2, "1"),
+            'todo A': ('todo A', 0, 1, "0"),
+            'todo A !': ('todo A', 0, 1, "1"),
+            'todo A #Tag1 #tag2     #tag3    @Armande      @Bast': ('todo A', 3, 2, "0"),
+            'todo A #Tag1 @Armande #tag3 @Bast #tag2 #tag4': ('todo A', 4, 2, "0"),
+            'todo A #tag1 Nothing !': ('todo A #tag1 Nothing', 0, 1, '1'),
+            'todo A #Tag1 #tag2 #tag3 @Armande @Bast !': ('todo A', 3, 2, "1"),
+            'todo A #Tag1 #tag2 #tag3 @Armande @Bastttt !': ('todo A @Bastttt', 3, 1, "1"),
+            'todo A #TAG1 #tag1 #TAG2': ('todo A', 2, 1, "0"),
+        }
+
+        for expression, values in valid_expressions.items():
+            todo_form = Form(self.env['project.task'], view="project_todo.project_task_view_todo_quick_create_form")
+            todo_form.display_name = expression
+            todo = todo_form.save()
+            results = (todo.name, len(todo.tag_ids), len(todo.user_ids), todo.priority)
+            self.assertEqual(results, values)
+
+    @users('armandel')
+    def test_create_todo_with_invalid_expressions(self):
+        invalid_expressions = {
+            '#tag1 #tag2 #tag3 @Armande @Bast': ('Untitled to-do', 0, 1, "0"),
+            '@Armande @Bast': ('Untitled to-do', 0, 1, "0"),
+            '!': ('Untitled to-do', 0, 1, "0"),
+            'todoA!': ('todoA!', 0, 1, "0"),
+        }
+
+        for expression, values in invalid_expressions.items():
+            todo_form = Form(self.env['project.task'], view="project_todo.project_task_view_todo_quick_create_form")
+            todo_form.display_name = expression
+            todo = todo_form.save()
+            results = (todo.name, len(todo.tag_ids), len(todo.user_ids), todo.priority)
+            self.assertEqual(results, values)

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -136,7 +136,17 @@
         <field name="arch" type="xml">
             <form class="o_form_project_tasks">
                 <group>
-                    <field name="name" string="To-do Title" placeholder="e.g. Send Invitations"/>
+                    <field
+                        name="display_name"
+                        string="To-do Title"
+                        placeholder="e.g. Send Invitations"
+                        help='Use these keywords in the title to streamline your to-dos:&#10;&#10;
+                            #tags: Add tags to categorize the to-do&#10;
+                            @user: Assign the to-do to a specific user&#10;
+                            !: Mark the to-do as medium priority&#10;
+                            !!: Mark the to-do as high priority&#10;
+                            !!!: Mark the to-do as urgent&#10;&#10;
+                            Ensure you follow the correct format and order. For example: "Send invitations #event @Mitchell !"'/>
                     <field name="date_deadline" decoration-danger="date_deadline &lt; current_date"/>
                 </group>
             </form>


### PR DESCRIPTION
In this commit,
--------------
  We Ease the quick creation of todo by provding shortcuts allowing the user to set different fields (tags, priority, and assign to users)   without opening the form view.

task-3935867