### PR TITLE
[FIX] website_blog: "Add some" {tag} go to backend


### DIFF
--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -307,7 +307,7 @@ Display a sidebar beside the post content.
             <t t-else="">
                 <div class="mb-4 bg-100 py-2 px-3 border" groups="website.group_website_designer">
                     <h6 class="text-muted"><em>No tags defined</em></h6>
-                    <a role="menuitem" t-attf-href="/odoo/action-{{action}}/{{main_object.id}}?menu_id={{menu or main_object.env.ref('website.menu_website_configuration').id}}"
+                    <a role="menuitem" t-attf-href="/odoo/{{main_object._name}}/{{main_object.id}}"
                         title='Edit in backend' id="edit-in-backend">Add some</a>
                 </div>
             </t>


### PR DESCRIPTION
Scenario:
- go on frontend to a blog post without tag
- edit the page and in Customize enable the sidebar
- click on "Add some" link in tag section

Result: the link is like /odoo/action-/1?menu_id=451 and redirects to
the homepage.

Cause: there is no action variable set in the view from 16.0 up to master,
not having the action worked in URL that contained the model and record id
before 18.0 update (9cf0b8c256589ccd71b01bd28bd2e595848ff45e) but it
doesn't work with /action-{action_id}/{res_id}.

Fix: using the model route directly (that is what we would be redirected
if we used the old URL path).

opw-4706629
opw-4783643
