### PR TITLE
[IMP] web: Prevent missing avatar images in record selectors

### DIFF
--- a/addons/web/static/src/core/record_selectors/multi_record_selector.js
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.js
@@ -1,10 +1,11 @@
 import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
-import { TagsList } from "@web/core/tags_list/tags_list";
-import { useService } from "@web/core/utils/hooks";
-import { RecordAutocomplete } from "./record_autocomplete";
 import { _t } from "@web/core/l10n/translation";
-import { useTagNavigation } from "./tag_navigation_hook";
+import { TagsList } from "@web/core/tags_list/tags_list";
+import { isId } from "@web/core/tree_editor/utils";
+import { useService } from "@web/core/utils/hooks";
 import { imageUrl } from "@web/core/utils/urls";
+import { RecordAutocomplete } from "./record_autocomplete";
+import { useTagNavigation } from "./tag_navigation_hook";
 
 export class MultiRecordSelector extends Component {
     static props = {
@@ -68,7 +69,10 @@ export class MultiRecordSelector extends Component {
                     this.deleteTag(index);
                 },
                 onKeydown: this.onTagKeydown,
-                img: this.isAvatarModel && imageUrl(this.props.resModel, id, "avatar_128"),
+                img:
+                    this.isAvatarModel &&
+                    isId(id) &&
+                    imageUrl(this.props.resModel, id, "avatar_128"),
             };
         });
     }

--- a/addons/web/static/src/core/record_selectors/record_selector.js
+++ b/addons/web/static/src/core/record_selectors/record_selector.js
@@ -1,7 +1,8 @@
 import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { isId } from "@web/core/tree_editor/utils";
 import { useService } from "@web/core/utils/hooks";
 import { RecordAutocomplete } from "./record_autocomplete";
-import { _t } from "@web/core/l10n/translation";
 
 export class RecordSelector extends Component {
     static props = {
@@ -27,6 +28,10 @@ export class RecordSelector extends Component {
         return ["res.partner", "res.users", "hr.employee", "hr.employee.public"].includes(
             this.props.resModel
         );
+    }
+
+    get hasAvatarImg() {
+        return this.isAvatarModel && isId(this.props.resId);
     }
 
     async computeDerivedParams(props = this.props) {

--- a/addons/web/static/src/core/record_selectors/record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/record_selector.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.RecordSelector" >
         <div class="o_input d-flex flex-wrap gap-1 o_record_selector">
-            <span t-if="isAvatarModel and props.resId" class="o_avatar o_m2o_avatar">
+            <span t-if="hasAvatarImg" class="o_avatar o_m2o_avatar">
                 <img class="rounded" t-attf-src="/web/image/{{props.resModel}}/{{props.resId}}/avatar_128"/>
             </span>
             <RecordAutocomplete

--- a/addons/web/static/src/core/tree_editor/tree_editor_autocomplete.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_autocomplete.js
@@ -1,11 +1,10 @@
-import { MultiRecordSelector } from "@web/core/record_selectors/multi_record_selector";
 import { _t } from "@web/core/l10n/translation";
 import { formatAST, toPyValue } from "@web/core/py_js/py_utils";
-import { Expression } from "@web/core/tree_editor/condition_tree";
+import { MultiRecordSelector } from "@web/core/record_selectors/multi_record_selector";
 import { RecordSelector } from "@web/core/record_selectors/record_selector";
+import { Expression } from "@web/core/tree_editor/condition_tree";
+import { isId } from "@web/core/tree_editor/utils";
 import { imageUrl } from "@web/core/utils/urls";
-
-export const isId = (val) => Number.isInteger(val) && val >= 1;
 
 export const getFormat = (val, displayNames) => {
     let text;
@@ -48,7 +47,10 @@ export class DomainSelectorAutocomplete extends MultiRecordSelector {
                         ...this.props.resIds.slice(index + 1),
                     ]);
                 },
-                img: this.isAvatarModel && imageUrl(this.props.resModel, val, "avatar_128"),
+                img:
+                    this.isAvatarModel &&
+                    isId(val) &&
+                    imageUrl(this.props.resModel, val, "avatar_128"),
             };
         });
     }

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -2532,3 +2532,29 @@ test("preserve virtual operators in sub domains", async () => {
         `[("product_id", "any", [("team_id", "any", ["&", ("active", "=", False), ("name", "=", False)])])]`,
     ]);
 });
+
+test("don't show avatar for expressions", async () => {
+    class Users extends models.Model {
+        _name = "res.users";
+        name = fields.Char();
+
+        _records = [
+            { id: 1, name: "Mitchell Admin" },
+            { id: 2, name: "Marc Demo" },
+        ];
+    }
+    defineModels([Users]);
+    Partner._fields.user_id = fields.Many2one({ relation: "res.users" });
+    await makeDomainSelector({
+        isDebugMode: true,
+        domain: `[("user_id", "in", [1, uid, 2])]`,
+        resModel: "partner",
+    });
+    expect(".o_tag").toHaveCount(3);
+    expect(".o_tag.o_avatar").toHaveCount(2);
+    expect(".o_tag:not(.o_avatar)").toHaveText("uid");
+    expect(".o_tag:not(.o_avatar) img").toHaveCount(0);
+    await contains(SELECTORS.debugArea).edit(`[("user_id", "=", uid)]`);
+    expect(".o_record_selector input").toHaveValue("uid");
+    expect(".o_record_selector img").toHaveCount(0);
+});


### PR DESCRIPTION
This commit fixes a bug where record_selector and multi_record_selector attempted to display avatar images for abstract values (e.g., domain selector expressions), resulting in broken image icons. The components now only try to render avatar images when a proper record ID is present.
