### PR TITLE
[FIX] l10n_in_edi: use correct IDs for batch send

### DIFF
--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -150,7 +150,7 @@ class AccountMove(models.Model):
                 'special_economic_zone',
                 'deemed_export',
             )
-            and any(tag.id in self._get_l10n_in_gst_tags() for tag in self.line_ids.tax_tag_ids)
+            and any(tag in self._get_l10n_in_gst_tags() for tag in self.line_ids.tax_tag_ids.ids)
         )
 
     def _get_l10n_in_edi_response_json(self):


### PR DESCRIPTION
Sending multiple invoices via Indian E-invoicing
did not work as expected because incorrect record IDs were used the any conditions on `tag.id` (exemple: id will be like `<NewId origin=781>` instead of the actual ID, 781).

Steps to reproduce:
- Set up Indian E-invoicing
- Create two new invoices
- In list view, select both and click "Send"

Although the invoices are eligible for E-invoicing, this option are not present because the backend fails to detect them properly.

opw-4709070