### PR TITLE
[FIX] mail, portal_rating: empty message save opens composer in dialogbox

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -17,6 +17,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     background-color: rgba(0, 0, 0, var(--bg-opacity, 1));
 }
 
+.o-bg-body {
+    background-color: $body-bg !important;
+}
+
 .o-discuss-badge {
     &, & .o-innerBadge {
         --o-discuss-badge-bg: #{$o-success}; // sync with --o-navbar-badge-bg

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -92,6 +92,7 @@ export class Message extends Component {
         "className?",
         "showDates?",
         "isFirstMessage?",
+        "isReadOnly?",
     ];
     static template = "mail.Message";
 
@@ -199,16 +200,16 @@ export class Message extends Component {
                 this.message.richTranslationValue,
                 this.props.messageSearch?.searchTerm,
                 this.message.richBody,
-                this.message.composer,
+                this.isEditing,
             ]
         );
         useEffect(
             () => {
-                if (!this.message.composer) {
+                if (!this.isEditing) {
                     this.prepareMessageBody(this.messageBody.el);
                 }
             },
-            () => [this.message.composer, this.message.richBody]
+            () => [this.isEditing, this.message.richBody]
         );
     }
 
@@ -228,7 +229,7 @@ export class Message extends Component {
             "px-1": this.props.isInChatWindow,
             "opacity-50": this.props.thread?.composer.replyToMessage?.notEq(this.props.message),
             "o-actionMenuMobileOpen": this.state.actionMenuMobileOpen,
-            "o-editing": this.props.message.composer,
+            "o-editing": this.isEditing,
         };
     }
 
@@ -260,7 +261,7 @@ export class Message extends Component {
     }
 
     get isEditing() {
-        return this.props.message.composer;
+        return !this.props.isReadOnly && this.props.message.composer;
     }
 
     get message() {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -25,7 +25,7 @@
                             </small>
                         </t>
                     </div>
-                    <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
+                    <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': isEditing }" t-ref="messageContent">
                         <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note }" name="header">
                             <span t-if="message.authorName and shouldDisplayAuthorName" class="o-mail-Message-author small" t-att-class="getAuthorAttClass()">
                                 <strong class="me-1" t-esc="message.authorName"/>

--- a/addons/mail/static/src/core/common/message_confirm_dialog.xml
+++ b/addons/mail/static/src/core/common/message_confirm_dialog.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.MessageConfirmDialog">
-    <Dialog size="props.size" title="props.title">
+    <Dialog size="props.size" title="props.title" contentClass="'o-bg-body'">
         <p class="mx-3 mb-3" t-esc="props.prompt"/>
         <blockquote class="mx-3 mb-3 fst-normal" style="pointer-events:none;">
-            <t t-component="messageComponent" message="props.message" hasActions="false"/>
+            <t t-component="messageComponent" message="props.message" isReadOnly="true" hasActions="false"/>
         </blockquote>
         <t t-set-slot="footer">
             <button class="btn me-2" t-att-class="props.confirmColor" t-on-click="onClickConfirm" t-out="props.confirmText"/>
@@ -15,4 +15,3 @@
 </t>
 
 </templates>
-

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1136,6 +1136,7 @@ test("Editing a message to clear its composer opens message delete dialog.", asy
     await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message.o-editing .o-mail-Composer-input", "", { replace: true });
     triggerHotkey("Enter");
+    await contains(".o-mail-Message", { text: "not empty" });
     await contains(".modal-body p", { text: "Are you sure you want to delete this message?" });
 });
 

--- a/addons/portal_rating/static/src/chatter/frontend/message_patch.js
+++ b/addons/portal_rating/static/src/chatter/frontend/message_patch.js
@@ -11,7 +11,7 @@ patch(Message.prototype, {
     },
 
     get isEditing() {
-        return !this.state.editRating && this.props.message.composer;
+        return !this.state.editRating && super.isEditing;
     },
 
     get ratingValue() {


### PR DESCRIPTION
Before this PR:

When trying to save an empty message after editing, a confirmation dialog would appear asking if you want to delete the message. However, instead of showing a preview of the message, it displayed an empty composer.

After this PR:

The confirmation dialog now correctly displays the preview of the message.

Task-4708569

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
