### PR TITLE
[FIX] website_sale: fix ecommerce product rating acl check

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -184,7 +184,8 @@ class ProductProduct(models.Model):
         if website.is_view_active('website_sale.product_comment') and self.rating_count:
             markup_data['aggregateRating'] = {
                 '@type': 'AggregateRating',
-                'ratingValue': self.rating_avg,
+                # sudo: product.product - visitor can access product average rating
+                'ratingValue': self.sudo().rating_avg,
                 'reviewCount': self.rating_count,
             }
         return markup_data

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1575,7 +1575,8 @@
                             <t t-if="is_view_active('website_sale.product_comment')">
                                 <a href="#o_product_page_reviews" class="o_product_page_reviews_link text-decoration-none">
                                     <t t-call="portal_rating.rating_widget_stars_static">
-                                        <t t-set="rating_avg" t-value="product.rating_avg"/>
+                                        <!-- sudo: product.product - visitor can access product average rating -->
+                                        <t t-set="rating_avg" t-value="product.sudo().rating_avg"/>
                                         <t t-set="trans_text_plural">%s reviews</t>
                                         <t t-set="trans_text_singular">%s review</t>
                                         <t t-set="rating_count" t-value="(trans_text_plural if product.rating_count > 1 else trans_text_singular) % product.rating_count"/>


### PR DESCRIPTION
Before this commit, opening the ecommerce page of a product with rating enabled as a public user would cause an ACL error.

Steps to reproduce:
- Install website and ecommerce
- Open a product page and enable ratings
- Post a rating on the product
- Open said product page as a public visitor -> ACL Error

This error was introduced by
https://github.com/odoo/odoo/pull/201565.
This commit fixes the issue by adding sudo when accessing the product average rating.

task-4714916
