### PR TITLE
[FIX] website_blog: fix name field overflow in website record display

### DIFF
--- a/addons/website_blog/views/website_pages_views.xml
+++ b/addons/website_blog/views/website_pages_views.xml
@@ -51,7 +51,7 @@
                 <t t-name="card">
                     <div class="row mb-auto">
                         <div class="col-8 fw-bolder">
-                            <field class="text-truncate" name="name"/>
+                            <field class="d-block text-truncate" name="name"/>
                             <div class="text-muted" t-if="record.website_id.value" groups="website.group_multi_website">
                                 <i class="fa fa-globe me-1" title="Website"/>
                                 <field name="website_id"/>


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1. Install website_blog.
2. Go to Website > Site > Blog Posts > Kanban View.

<b>Issue:</b>
  The titles in the Blog Post Pages are not displaying correctly.
  
  When the titles had long text, they overflowed their container boundaries and
  visually overlapped adjacent UI elements.
  
  The text-truncate class was not solving the problem, causing the titles to still
  overlap.

<b>Solution:</b>
  Fixed the text overflow by applying the d-block class directly to the field
  element, ensuring proper containment and preventing overlap.

opw-4635231