### PR TITLE
[FIX][18] mrp: remove the duplicated field company_id

### DIFF
--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -522,12 +522,12 @@
                         <field  name="workorder_id"/>
                         <field name="workcenter_id"/>
                         <field name="loss_id"/>
-                        <field name="company_id" invisible="1"/>
-                    </group><group>
+                    </group>
+                    <group>
                         <field name="date_start"/>
                         <field name="date_end"/>
                         <field name="duration"/>
-                        <field name="company_id"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
                     </group>
                     <field name="description"/>
                 </group>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Remove the duplicated field company_id in mrp.workcenter.productivity form view, and add  groups="base.group_multi_company"



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
