### PR TITLE
[FIX] {im, website}_livechat: show unread messages after forward

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -346,7 +346,11 @@ class ChatbotScriptStep(models.Model):
                 posted_message = discuss_channel._chatbot_post_message(self.chatbot_script_id, plaintext2html(self.message))
 
             # next, add the human_operator to the channel and post a "Operator joined the channel" notification
-            discuss_channel.with_user(human_operator).sudo().add_members(human_operator.partner_id.ids, open_chat_window=True)
+            discuss_channel.sudo()._add_members(
+                users=human_operator,
+                inviting_partner=self.chatbot_script_id.operator_partner_id,
+                open_chat_window=True,
+            )
 
             # finally, rename the channel to include the operator's name
             discuss_channel.sudo().name = ' '.join([

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -402,9 +402,31 @@ class Channel(models.Model):
 
     def add_members(self, partner_ids=None, guest_ids=None, invite_to_rtc_call=False, open_chat_window=False, post_joined_message=True):
         """ Adds the given partner_ids and guest_ids as member of self channels. """
+        return self._add_members(
+            partners=self.env["res.partner"].browse(partner_ids or []).exists(),
+            guests=self.env["mail.guest"].browse(guest_ids or []).exists(),
+            invite_to_rtc_call=invite_to_rtc_call,
+            open_chat_window=open_chat_window,
+            post_joined_message=post_joined_message,
+        )
+
+    def _add_members(
+        self,
+        *,
+        guests=None,
+        partners=None,
+        users=None,
+        invite_to_rtc_call=False,
+        open_chat_window=False,
+        post_joined_message=True,
+        inviting_partner=None,
+    ):
+        inviting_partner = inviting_partner or self.env["res.partner"]
+        partners = partners or self.env["res.partner"]
+        if users:
+            partners |= users.partner_id
+        guests = guests or self.env["mail.guest"]
         current_partner, current_guest = self.env["res.partner"]._get_current_persona()
-        partners = self.env['res.partner'].browse(partner_ids or []).exists()
-        guests = self.env['mail.guest'].browse(guest_ids or []).exists()
         all_new_members = self.env["discuss.channel.member"]
         for channel in self:
             members_to_create = []
@@ -444,6 +466,7 @@ class Channel(models.Model):
                         else _("invited %s to the channel", member._get_html_link(for_persona=True))
                     )
                     member.channel_id.message_post(
+                        author_id=inviting_partner.id or None,
                         body=Markup('<div class="o_mail_notification">%s</div>') % notification,
                         message_type="notification",
                         subtype_xmlid="mail.mt_comment",

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -33,11 +33,13 @@ class TestLivechatChatbotUI(TestImLivechatCommon, TestWebsiteLivechatCommon, Cha
             ('livechat_operator_id', '=', operator.id),
             ('message_ids', '!=', False),
         ])
-
         self.assertTrue(bool(livechat_discuss_channel))
         self.assertEqual(len(livechat_discuss_channel), 1)
 
         conversation_messages = livechat_discuss_channel.message_ids.sorted('id')
+        operator_member = livechat_discuss_channel.channel_member_ids.filtered(
+            lambda m: m.partner_id == self.operator.partner_id
+        )
 
         expected_messages = [
             ("Hello! I'm a bot!", operator, False),
@@ -76,10 +78,17 @@ class TestLivechatChatbotUI(TestImLivechatCommon, TestWebsiteLivechatCommon, Cha
             ("How can I help you?", operator, self.step_dispatch_operator),
             ("I want to speak with an operator", False, False),
             ("I will transfer you to a human", operator, False),
-            ("joined the channel", self.operator.partner_id, False), # human_operator has joined the channel
+            (
+                'invited <a href="#" data-oe-model="res.partner" data-oe-id="'
+                f'{operator_member.partner_id.id}">@Operator Michel</a> to the channel',
+                self.chatbot_script.operator_partner_id,
+                False,
+            ),
         ]
 
         self.assertEqual(len(conversation_messages), len(expected_messages))
+        # "invited" notification is not taken into account in unread counter contribution.
+        self.assertEqual(len(conversation_messages) - 1, operator_member.message_unread_counter)
 
         # check that the whole conversation is correctly saved
         # including welcome steps: see chatbot.script#_post_welcome_steps


### PR DESCRIPTION
Before this PR, the operator was not notified after being forwarded by a bot. This happened because the notification was posted as the operator. Messages are automatically marked as read when a user posts them. As a result, nothing in the UI indicated that the chat was new or required the operator's attention.

This PR resolves the issue by posting the message as the chatbot. It both makes sense from a UX perspective (displaying something like "Bot invited the operator to the user") and ensures the chat is properly flagged for the operator.

task-4689496

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
