### PR TITLE
[IMP] l10n_fr_account: include SIRET on document layout footer

### DIFF
--- a/addons/l10n_fr_account/i18n/fr.po
+++ b/addons/l10n_fr_account/i18n/fr.po
@@ -110,6 +110,11 @@ msgid "Companies"
 msgstr "Sociétés"
 
 #. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_base_document_layout
+msgid "Company Document Layout"
+msgstr "Mise en page des documents de votre société"
+
+#. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "CompteLib"
 msgstr "CompteLib"
@@ -145,7 +150,12 @@ msgid "Debit"
 msgstr "Debit"
 
 #. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_fr_account.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_fr_account.field_base_document_layout__display_name
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__display_name
+#: model:ir.model.fields,field_description:l10n_fr_account.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_fr_account.field_res_partner__display_name
 msgid "Display Name"
 msgstr "Nom d'affichage"
 
@@ -205,6 +215,11 @@ msgid "Filename"
 msgstr "Nom de fichier"
 
 #. module: l10n_fr_account
+#: model:ir.model.fields,help:l10n_fr_account.field_base_document_layout__report_footer
+msgid "Footer text displayed at the bottom of all reports."
+msgstr "Pied de page de tous les rapports."
+
+#. module: l10n_fr_account
 #: model:ir.ui.menu,name:l10n_fr_account.account_reports_fr_statements_menu
 msgid "France"
 msgstr "France"
@@ -220,7 +235,12 @@ msgid "Goods Delivery"
 msgstr "Livraison de biens"
 
 #. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_fr_account.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_fr_account.field_base_document_layout__id
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__id
+#: model:ir.model.fields,field_description:l10n_fr_account.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_fr_account.field_res_partner__id
 msgid "ID"
 msgstr "ID"
 
@@ -312,9 +332,20 @@ msgid "PieceRef"
 msgstr "PieceRef"
 
 #. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_base_document_layout__report_footer
+msgid "Report Footer"
+msgstr "Pied de page du rapport"
+
+#. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid "SIRET:"
 msgstr "SIRET :"
+
+#. module: l10n_fr_account
+#. odoo-python
+#: code:addons/l10n_fr_account/models/base_document_layout.py:0
+msgid "SIRET: %s"
+msgstr ""
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document

--- a/addons/l10n_fr_account/i18n/l10n_fr_account.pot
+++ b/addons/l10n_fr_account/i18n/l10n_fr_account.pot
@@ -105,6 +105,11 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_base_document_layout
+msgid "Company Document Layout"
+msgstr ""
+
+#. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "CompteLib"
 msgstr ""
@@ -147,6 +152,7 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_account_chart_template__display_name
 #: model:ir.model.fields,field_description:l10n_fr_account.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_fr_account.field_base_document_layout__display_name
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__display_name
 #: model:ir.model.fields,field_description:l10n_fr_account.field_res_company__display_name
 #: model:ir.model.fields,field_description:l10n_fr_account.field_res_partner__display_name
@@ -209,6 +215,11 @@ msgid "Filename"
 msgstr ""
 
 #. module: l10n_fr_account
+#: model:ir.model.fields,help:l10n_fr_account.field_base_document_layout__report_footer
+msgid "Footer text displayed at the bottom of all reports."
+msgstr ""
+
+#. module: l10n_fr_account
 #: model:ir.ui.menu,name:l10n_fr_account.account_reports_fr_statements_menu
 msgid "France"
 msgstr ""
@@ -226,6 +237,7 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_account_chart_template__id
 #: model:ir.model.fields,field_description:l10n_fr_account.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_fr_account.field_base_document_layout__id
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__id
 #: model:ir.model.fields,field_description:l10n_fr_account.field_res_company__id
 #: model:ir.model.fields,field_description:l10n_fr_account.field_res_partner__id
@@ -325,6 +337,11 @@ msgid "PieceRef"
 msgstr ""
 
 #. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_base_document_layout__report_footer
+msgid "Report Footer"
+msgstr ""
+
+#. module: l10n_fr_account
 #. odoo-python
 #: code:addons/l10n_fr_account/models/res_partner.py:0
 msgid "SIRET Number"
@@ -333,6 +350,12 @@ msgstr ""
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid "SIRET:"
+msgstr ""
+
+#. module: l10n_fr_account
+#. odoo-python
+#: code:addons/l10n_fr_account/models/base_document_layout.py:0
+msgid "SIRET: %s"
 msgstr ""
 
 #. module: l10n_fr_account

--- a/addons/l10n_fr_account/models/__init__.py
+++ b/addons/l10n_fr_account/models/__init__.py
@@ -4,3 +4,4 @@ from . import template_fr
 from . import template_mc
 from . import res_company
 from . import res_partner
+from . import base_document_layout

--- a/addons/l10n_fr_account/models/base_document_layout.py
+++ b/addons/l10n_fr_account/models/base_document_layout.py
@@ -1,0 +1,15 @@
+from markupsafe import Markup
+from odoo import api, fields, models, _
+
+
+class BaseDocumentLayout(models.TransientModel):
+    _inherit = 'base.document.layout'
+
+    @api.model
+    def _default_report_footer(self):
+        # Override to add the company.registry for FR companies
+        if not (self.env.company.company_registry and self.env.company.country_code == 'FR'):
+            return super()._default_report_footer()
+        return super()._default_report_footer() + Markup('<br/>%s') % _('SIRET: %s', self.env.company.company_registry)
+
+    report_footer = fields.Html(default=_default_report_footer)


### PR DESCRIPTION
In France, the SIRET number has to be displayed in the footer of documents. This commit will add the information, only for french companies and new layouts

Task-4655438
Runbot: https://runbot.odoo.com/runbot/bundle/master-l10n-fr-siret-on-footer-roto-361678



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
