### PR TITLE
[FIX] account_payment_invoice_online_payment_patch: translate frontend invoice


### DIFF
--- a/addons/account_payment_invoice_online_payment_patch/views/account_portal_templates.xml
+++ b/addons/account_payment_invoice_online_payment_patch/views/account_portal_templates.xml
@@ -55,7 +55,7 @@
                 invoice._has_to_be_paid()
             </attribute>
         </xpath>
-        <xpath expr="//t[@t-call='portal.portal_record_sidebar']//div[hasclass('d-grid')]//a[starts-with(@href, '#')][i]" position="attributes">
+        <xpath expr="//t[@t-call='portal.portal_record_sidebar']//div[hasclass('d-grid')]//a[starts-with(@href, '#')][//i]" position="attributes">
             <attribute name="t-if">
                 invoice._has_to_be_paid()
             </attribute>


### PR DESCRIPTION
Scenario: click on Translate on frontend invoice page

Result: Error 500 is shown, because this XPath is not found:

`//t[@t-call='portal.portal_record_sidebar']//div[hasclass('d-grid')]//a[starts-with(@href, '#')][i]`

Cause: translation mode wraps `<span data-oe-translation-state="..."/>`
nodes around text node and some inline tags, so the "`<i />` Pay now"
nodes are wrapped by a `<span/>` which breaks the XPath.

Fix: change XPath predicate from direct child I tag to any level
descendent I tag.

note: only necessary for 16.0, this has been refactored without the
issue from saas-16.2 d86238d0a8d1f3d02a88c97deef9a5ee47d57f94

opw-4702481
