### PR TITLE
[FIX] l10n_hu_edi: last credit note as Storno

### DIFF
--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -510,10 +510,19 @@ class AccountMove(models.Model):
         for i, invoice in enumerate(self, start=1):
             invoice.l10n_hu_edi_batch_upload_index = i
 
+        def get_operation_type(invoice):
+            operation_type = 'MODIFY'
+            base_invoice = invoice._l10n_hu_get_chain_base()
+            if invoice == base_invoice:
+                operation_type = 'CREATE'
+            elif base_invoice.amount_residual == 0:
+                operation_type = 'STORNO'
+            return operation_type
+
         invoice_operations = [
             {
                 'index': invoice.l10n_hu_edi_batch_upload_index,
-                'operation': 'CREATE' if invoice._l10n_hu_get_chain_base() == invoice else 'MODIFY',
+                'operation': get_operation_type(invoice),
                 'invoice_data': base64.b64decode(invoice.l10n_hu_edi_attachment),
             }
             for invoice in self

--- a/addons/l10n_hu_edi/models/l10n_hu_edi_connection.py
+++ b/addons/l10n_hu_edi/models/l10n_hu_edi_connection.py
@@ -126,7 +126,7 @@ class L10nHuEdiConnection:
         :param invoice_operations: a list of dictionaries:
             {
                 'index': <index given to invoice>,
-                'operation': 'CREATE' or 'MODIFY',
+                'operation': 'CREATE' or 'MODIFY' or 'STORNO',
                 'invoice_data': <XML data of the invoice as bytes>
             }
         :return str: The transaction code issued by NAV.


### PR DESCRIPTION
In Hungary, when you fully reverse what is left to pay of an invoice with a Credit Note, it's usually called a "Storno" invoice, meaning an invoice that fully cancels what was previously sent. In the Hungarian EDI, invoices and credit notes are linked together, and they make a clear difference between a "modification" invoice (like a partial credit note, a debit note, etc) and a "cancellation" (Storno) invoice.

We used to send it as a "modification" even when the residual amount was zero. This fix makes sure that it is sent as "cancellation" (Storno) in that case. 

task - 4707254