### PR TITLE
[FIX] stock_dropshipping: archive dropship operation if module uninstall

### DIFF
--- a/addons/stock_dropshipping/__init__.py
+++ b/addons/stock_dropshipping/__init__.py
@@ -2,3 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+
+
+def uninstall_hook(env):
+    # Uninstalling the module will archive the dropshipping picking type.
+    env['stock.picking.type'].search([('code', '=', 'dropship')]).active = False

--- a/addons/stock_dropshipping/__manifest__.py
+++ b/addons/stock_dropshipping/__manifest__.py
@@ -30,6 +30,7 @@ internal transfer document is needed.
     'demo': [
         'data/stock_dropshipping_demo.xml',
     ],
+    'uninstall_hook': "uninstall_hook",
     'installable': True,
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to inventory settings and enable dropshipping option -> the operation type: dropship in created

- Disable the drop-shipping option in the settings -> The module is uninstalled, but the operation type is not archived so it can cause a traceback if using it.

Problem:
The best solution, is to remove completely the picking type, but as is linked to several other records, like rule or purchase order, it will be impossible to delete everything related, so the best solution is to archive it, so we can limit the impact of the uninstallation.

opw-4690502
