### PR TITLE
[FIX] point_of_sale: select correct product variant in configurator

### DIFF
--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -13,7 +13,10 @@ class ProductProduct(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'lst_price', 'display_name', 'product_tmpl_id', 'product_template_variant_value_ids', 'barcode', 'product_tag_ids', 'default_code', 'standard_price']
+        return [
+            'id', 'lst_price', 'display_name', 'product_tmpl_id', 'product_template_variant_value_ids',
+            'product_template_attribute_value_ids', 'barcode', 'product_tag_ids', 'default_code', 'standard_price'
+        ]
 
     def _load_pos_data(self, data):
         products = super()._load_pos_data(data)

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -711,7 +711,7 @@ export class PosStore extends WithLazyGetterTrap {
                     .map((value) => value.id);
 
                 let candidate = productTemplate.product_variant_ids.find((variant) => {
-                    const attributeIds = variant.product_template_variant_value_ids.map(
+                    const attributeIds = variant.product_template_attribute_value_ids.map(
                         (value) => value.id
                     );
                     return (


### PR DESCRIPTION
Before this commit, when a product template had an attribute with only one value and another attribute with multiple values, the PoS would sometimes select the wrong `product.product` after using the variant configurator.

This happened because `product_template_variant_value_ids` only includes attribute values that have more than one possible value.

opw-4689034

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
