### PR TITLE
[FIX] purchase_mrp,mrp_account: kit product bill then receive

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -78,3 +78,11 @@ class StockMove(models.Model):
                         'value': price_unit_map[move_id][1](unit_cost * svl_vals['quantity']),
                     })
         return svl_vals_list
+
+    def _get_all_related_sm(self, product):
+        moves = super()._get_all_related_sm(product)
+        return moves | self.filtered(
+            lambda m:
+            m.bom_line_id.bom_id.type == 'phantom' and
+            m.bom_line_id.bom_id == moves.bom_line_id.bom_id
+        )

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1251,3 +1251,70 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         # however, due to rounding differences, the expected value is 100
         svl_val = self.env['stock.valuation.layer'].search([('stock_move_id', '=', move.id)]).value
         self.assertEqual(svl_val, 100)
+
+    def test_purchase_kit_bill_before_reception_component_cost_exactly_aligns_with_kit_product_cost(self):
+        """ When a kit product is invoiced prior to delivery, we want to make sure to reconcile all
+        the AMLs from its explosion together, else we risk re-reconciliation attempts (which will
+        block certain actions from being performed altogether).
+        """
+        kit_product = self.env['product.product'].create({
+            'name': 'kit prod',
+            'purchase_method': 'purchase',
+            'type': 'product',
+            'standard_price': 10,
+            'list_price': 20,
+        })
+        kit_product.categ_id.write({
+            'property_cost_method': 'average',
+            'property_valuation': 'real_time',
+        })
+        components = self.env['product.product'].create([{
+            'name': f'comp {i}',
+            'type': 'product',
+            'standard_price': 5,
+            'list_price': 5,
+        } for i in (1, 2)])
+        self.env['mrp.bom'].create({
+            'type': 'phantom',
+            'product_id': kit_product.id,
+            'product_tmpl_id': kit_product.product_tmpl_id.id,
+            'product_qty': 1,
+            'bom_line_ids': [Command.create({
+                'product_id': comp.id,
+                'product_qty': 1,
+            }) for comp in components
+        ]})
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': kit_product.id,
+                'product_qty': 1,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids
+        bill.invoice_date = fields.Date.today()
+        bill.action_post()
+        receipt = purchase_order.picking_ids
+        # would fail due to attempted re-reconciliation prior to this commit
+        receipt.button_validate()
+        stock_input_account, stock_valuation_account, tax_paid_account, account_payable_account = (
+            kit_product.categ_id.property_stock_account_input_categ_id,
+            kit_product.categ_id.property_stock_valuation_account_id,
+            self.company_data['default_account_tax_purchase'],
+            self.company_data['default_account_payable'],
+        )
+        # stock input account move lines should be reconciled
+        self.assertRecordValues(
+            self.env['account.move.line'].search([], order='id asc'),
+            [
+                {'account_id': stock_input_account.id,       'product_id': kit_product.id,     'reconciled': True,    'debit': 10.0,   'credit':  0.0},
+                {'account_id': tax_paid_account.id,          'product_id': False,              'reconciled': False,   'debit':  1.5,   'credit':  0.0},
+                {'account_id': account_payable_account.id,   'product_id': False,              'reconciled': False,   'debit':  0.0,   'credit': 11.5},
+                {'account_id': stock_input_account.id,       'product_id': components[0].id,   'reconciled': True,    'debit':  0.0,   'credit':  5.0},
+                {'account_id': stock_valuation_account.id,   'product_id': components[0].id,   'reconciled': False,   'debit':  5.0,   'credit':  0.0},
+                {'account_id': stock_input_account.id,       'product_id': components[1].id,   'reconciled': True,    'debit':  0.0,   'credit':  5.0},
+                {'account_id': stock_valuation_account.id,   'product_id': components[1].id,   'reconciled': False,   'debit':  5.0,   'credit':  0.0},
+            ]
+        )


### PR DESCRIPTION
**Current behavior:**
With anglo saxon accounting and real-time valuation, purchasing
a kit product with a BoM that has components whose costs add up
to the exact price of the kit product and that is invoiced on
ordered qty and has avg costing, then billing before receiving
will prevent the reception from being validate-able.

**Expected behavior:**
Can validate

**Steps to reproduce:**
1. Create a kit product with avg costing, invoiced on ordered
qty, and a BoM with 2 components that have a cumulative cost
equalling that of the final kit product

2. Make a purchase for it, invoice -> post

3. Try to validate the receipt -> can't due to attempted
re-reconicilation

**Cause of the issue:**
When validating the receipt, we end up here:
https://github.com/odoo/odoo/blob/c9ea75efb8e260d6bea5b777f4f950f106ffcfa5/addons/stock_account/models/stock_valuation_layer.py#L81-L90
And attempt to reconcile both the original kit product AML from
corresponding to the purchase line as well as the AML for the
component in the stock input account.

But we only will capture 1 exploded component AML in each loop
iteration, so the original kit product AML will not actually be
set `reconciled = True`, so we will also add it to be
reconciled again:
https://github.com/odoo/odoo/blob/c9ea75efb8e260d6bea5b777f4f950f106ffcfa5/addons/stock_account/models/stock_valuation_layer.py#L90

The same thing happens in subsequent calls to
`_stock_account_anglo_saxon_reconcile_valuation()`, except on
a final call for the last component line- if the components'
cumulative cost aligns with the total cost of the kit product
(which it should) then the reconciliation attempt will succeed.

Then here: https://github.com/odoo/odoo/blob/c9ea75efb8e260d6bea5b777f4f950f106ffcfa5/addons/stock_account/models/stock_valuation_layer.py#L92
`reconcile()` is called on the already-reconciled AML which will
cause the re-reconiliation error.

**Fix**
Reconcile all the resulting kit AMLs (component AMLs + actual
kit product AML from the bill) together.

opw-4668004