### PR TITLE
[FIX] l10n_es: correct Modelo 390 Section 1 totals

### DIFF
--- a/addons/l10n_es/data/mod390/mod390_section1.xml
+++ b/addons/l10n_es/data/mod390/mod390_section1.xml
@@ -1204,7 +1204,7 @@
                                 aeat_mod_390_685.balance + aeat_mod_390_23.balance + aeat_mod_390_25.balance +
                                 aeat_mod_390_720.balance + aeat_mod_390_687.balance + aeat_mod_390_545.balance +
                                 aeat_mod_390_722.balance + aeat_mod_390_689.balance + aeat_mod_390_547.balance +
-                                aeat_mod_390_551.balance
+                                aeat_mod_390_551.balance + aeat_mod_390_27.balance + aeat_mod_390_29.balance
                             </field>
                         </record>
                         <record id="mod_390_casilla_34" model="account.report.line">
@@ -1225,7 +1225,7 @@
                                 aeat_mod_390_686.balance + aeat_mod_390_24.balance + aeat_mod_390_26.balance +
                                 aeat_mod_390_721.balance + aeat_mod_390_688.balance + aeat_mod_390_546.balance +
                                 aeat_mod_390_723.balance + aeat_mod_390_690.balance + aeat_mod_390_548.balance +
-                                aeat_mod_390_552.balance
+                                aeat_mod_390_552.balance + aeat_mod_390_28.balance + aeat_mod_390_30.balance
                             </field>
                         </record>
                     </field>


### PR DESCRIPTION
In Modelo 390 section 1, the value for [33] and [34] are wrong.

- For [33], the balance of [27] and [29] are missing in the sum expression.
- For [34], the balance of [28] and [30] are missing in the sum expression.

By fixing those two expressions, the total match the Modelo 303 totals.

opw-4520183

