### PR TITLE
[FIX] auth_totp{_mail}: return value on check_credentials

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -72,6 +72,11 @@ class ResUsers(models.Model):
                 _logger.info("2FA check: FAIL for %s %r", self, sudo.login)
                 raise AccessDenied(_("Verification failed, please double-check the 6-digit code"))
             _logger.info("2FA check: SUCCESS for %s %r", self, sudo.login)
+            return {
+                'uid': self.env.user.id,
+                'auth_method': 'totp',
+                'mfa': 'default',
+            }
         else:
             return super()._check_credentials(credentials, env)
 

--- a/addons/auth_totp_mail/models/res_users.py
+++ b/addons/auth_totp_mail/models/res_users.py
@@ -148,6 +148,11 @@ class ResUsers(models.Model):
             _logger.info("2FA check(mail): SUCCESS for %s %r", user, user.login)
             self._totp_rate_limit_purge('code_check')
             self._totp_rate_limit_purge('send_email')
+            return {
+                'uid': self.env.user.id,
+                'auth_method': 'totp_mail',
+                'mfa': 'default',
+            }
         else:
             return super()._check_credentials(credentials, env)
 


### PR DESCRIPTION
  - Since TOTP checks now pass through the `check_credentials` method, it needs to return a dict with the check result.

    It wasn't done, on the PR modifying the totp check code. The new code need to respect the specification of the `check_credentials` function.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
