### PR TITLE
[FIX] uom: Many2ManyUomTagsField error

### DIFF
--- a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
+++ b/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
@@ -16,9 +16,11 @@ import { onWillUpdateProps } from "@odoo/owl";
 function _getProductRelatedModel() {
     const field = this.props.record.fields[this.props.productField];
     // The widget is either used alongisde a product related field or either used in a product view.
-    let resModel = field?.relation || this.props.record.resModel;
+    const resModel = field?.relation || this.props.record.resModel;
     if (!["product.product", "product.template"].includes(resModel)) {
-        throw new Error(`The widget '${this.constructor.name}' (field '${this.props.name}') needs a 'product.product' or 'product.template' field. '${this.props.productField}' is used but is related to '${field?.relation}' model.`);
+        console.warn(`The widget '${this.constructor.name}' (field '${this.props.name}') needs a 'product.product' or 'product.template' field. '${this.props.productField}' is used but is related to '${field?.relation}' model.`);
+        // In case widget's config is wrong, use `product.product` by default.
+        return "product.product";
     }
     return resModel;
 }


### PR DESCRIPTION
In 8ce6e7a426834210dc861b5f92d216a86062dc2e an error is thrown if the `many2many_uom_tags` is not correctly configured. Following that, some uses of this widget were removed (see
51c4e461eb13b01f6c752171c25214d5b612a443 for example) but the issue is, for DB with unreloaded view, the wrong uses of widget will still be in the templates alongside with the code throwing an error is triggered. To avoid that, this commit replaces the thrown error by a warning in the console and will use `product.product` as the model if those cases (which can also causes a traceback since it was the initial error.)
