### PR TITLE
[FIX] survey: add suggested answers for mandatory choice question

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -141,6 +141,15 @@ class SurveyQuestion(models.Model):
         ('validation_datetime', 'CHECK (validation_min_datetime <= validation_max_datetime)','Max datetime cannot be smaller than min datetime!')
     ]
 
+    @api.constrains('constr_mandatory', 'question_type', 'labels_ids')
+    def _check_multiple_choice_question_answer(self):
+        if (
+            self.question_type in ['simple_choice', 'multiple_choice'] 
+            and self.constr_mandatory
+            and not self.labels_ids
+        ):
+            raise ValidationError(_("A suggested answer should be provided for mandatory multiple choice question."))
+
     @api.onchange('validation_email')
     def _onchange_validation_email(self):
         if self.validation_email:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR is fixing an issue with survey in case of question is a single choice or multiple choices and answer is mandatory.
If there is no any suggested answeres, survey participants can't continue while they are asked to choose an answers and they are stuck because there are no suggestions.

Current behavior before PR:
I get stuck without finishing the survey.

Desired behavior after PR is merged:
Survey will be validated as the multiple choice or single choice questions if the are mandatory the suggested answers should be there before the questions be saved.

The participant will take the survey and certainly will have suggestions for mandatory choices.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
