### PR TITLE
[IMP] web: allow customizing selectMenu's fuzzyLookup fn

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -28,6 +28,7 @@ export class SelectMenu extends Component {
         choices: [],
         groups: [],
         disabled: false,
+        fuzzyLookupFn: (choice) => choice.label,
     };
 
     static props = {
@@ -78,6 +79,7 @@ export class SelectMenu extends Component {
         onSelect: { type: Function, optional: true },
         slots: { type: Object, optional: true },
         disabled: { type: Boolean, optional: true },
+        fuzzyLookupFn: { type: Function, optional: true },
     };
 
     static SCROLL_SETTINGS = {
@@ -269,7 +271,7 @@ export class SelectMenu extends Component {
                 filteredOptions = fuzzyLookup(
                     searchString,
                     group.choices,
-                    (choice) => choice.label
+                    this.props.fuzzyLookupFn
                 );
             } else {
                 filteredOptions = group.choices;


### PR DESCRIPTION
Purpose: allow customizing how options are filtered.

In documents, we chose to limit the amount of information present in the `label` of `choice`s, but we should still be able to display all our fetched options, even those that do not match what is in the `label`, and is fixed in the related PR.

Task-4656596
