### PR TITLE
[FIX] sale_margin,sale_timesheet_margin: no recompute purchase price when confirmed

### DIFF
--- a/addons/sale_timesheet_margin/models/sale_order_line.py
+++ b/addons/sale_timesheet_margin/models/sale_order_line.py
@@ -7,10 +7,17 @@ class SaleOrderLine(models.Model):
 
     @api.depends('analytic_line_ids.amount', 'qty_delivered_method')
     def _compute_purchase_price(self):
+        # filter out the ale.order.lines called by this override of _compute_purchase_price for which
+        # we don't want the purchase price to be recomputed. Without filtring out the sale.order.lines
+        # for which the recomputation was triggered by a depency from another override of _compute_purchase_price
+        service_non_timesheet_sols = self.filtered(
+            lambda sol: not sol.is_expense and sol.is_service and
+            sol.product_id.service_policy == 'ordered_prepaid' and sol.state == 'sale'
+        )
         timesheet_sols = self.filtered(
             lambda sol: sol.qty_delivered_method == 'timesheet' and not sol.product_id.standard_price
         )
-        super(SaleOrderLine, self - timesheet_sols)._compute_purchase_price()
+        super(SaleOrderLine, self - timesheet_sols - service_non_timesheet_sols)._compute_purchase_price()
         if timesheet_sols:
             group_amount = self.env['account.analytic.line']._read_group(
                 [('so_line', 'in', timesheet_sols.ids), ('project_id', '!=', False)],


### PR DESCRIPTION
**Problem:**
The problem happens when  a service is linked to a task but it's not billed on timesheet.

If a quotation is created with this service (which creates the task linked to it) and a timesheet is added to the task, this will trigger a recompute of `purchase_price` (the cost column) of the sale order line in the quotation.

If the client had written another cost on the sale order line of the quotation than the original one (coming from the `standard_price` of the product) this will erase it and set the value back to the standard price of the product. 

Because the service is not billed on timesheet we don't want a modification of timesheet to affect the cost set on the quotation.

**Steps to reproduce:**
- In settings, activate the "margins" setting in Sales
- Open Sales/products and create a new product
- Set the product type as "Service"
- Set the "create on order" field as Task
- Set the "project" field to an existing project
- Set a strictly positive value in the cost field
- Set a name and save
- Create a new quotation and add the product you just created
- Confirm the quotation
- In the order lines page, add the cost column
- Change the value of the cost column
- Click on the "Tasks" smart button
- Add a new timesheet in the timesheet page and save
- Come back to the sale order via the smart button

**Current behavior:**
The value of the cost column was reset the the cost of the product

**Expected behavior:**
Mofifying the timesheets shouldn't impact the cost of a service which is not invoiced on timesheets

**Cause of the issue:**
Because the sale_timesheet_margin module is installed the
_compute_purchase_price method is overriden and depends on
analytic_line_ids.amount
https://github.com/odoo/odoo/blob/c335d03e776014e0b7172a3f44507404a083aaed/addons/sale_timesheet_margin/models/sale_order_line.py#L8
when this method is called in our flow, because
sol.product_id.purchase_price is not null our sale order line
will not get filtered out
https://github.com/odoo/odoo/blob/c335d03e776014e0b7172a3f44507404a083aaed/addons/sale_timesheet_margin/models/sale_order_line.py#L11
and it will reach the original
_compute_purchase_price method were the value of purchase_price
will be reset to the value of self.product_id.standard_price
https://github.com/odoo/odoo/blob/c335d03e776014e0b7172a3f44507404a083aaed/addons/sale_margin/models/sale_order_line.py#L30


**Fix:**
We want to filter out the sale.order.lines for which the computation
of purchase_price has been triggered via the analytic_line_ids.amount
dependency and for which we don't want the computation to happen
(when the service_policy is not "timesheet").
We need to do this without filtering out the sales.order.lines for which the
computation of purchase_price has been triggered by a dependency from
the original compute_purchase_price method
https://github.com/odoo/odoo/blob/11cdfe50bda17b004249546a67708e954b3667fc/addons/sale_margin/models/sale_order_line.py#L20-L21
or another orverride of this method
(for now there are two of those : one in sale_expense_margin
https://github.com/odoo/odoo/blob/11cdfe50bda17b004249546a67708e954b3667fc/addons/sale_expense_margin/models/sale_order_line.py#L10-L11
and one in sale_stock_margin
https://github.com/odoo/odoo/blob/11cdfe50bda17b004249546a67708e954b3667fc/addons/sale_stock_margin/models/sale_order_line.py#L10-L11
)

is_expense is defined in the sale module
is_service is defined in the sale_service module
service_policy is defined in the sale_project module
all those field are available when sale_timesheet_margin is installed



opw-4627037
