### PR TITLE
[FIX] pos_event: prevent error when deleting orderline

### DIFF
--- a/addons/pos_event/static/src/app/models/pos_order_line.js
+++ b/addons/pos_event/static/src/app/models/pos_order_line.js
@@ -18,7 +18,7 @@ patch(PosOrderline.prototype, {
             };
         } else if (this.event_ticket_id) {
             for (const registration of this.event_registration_ids) {
-                registration.delete();
+                registration.delete({ silent: true });
             }
         }
 


### PR DESCRIPTION
Before this commit, deleting a synced orderline linked to an event registration and then adding a new event product to the same order could cause an error when validating the order.

Steps to reproduce:
1. Enable Events with PoS
2. Enable Online Payment
3. Add a ticket product to the order
4. Proceed to the payment screen, and select online payment
4. Delete the ticket line and add a different one
5. Complete the order using cash or another offline payment method

opw-4714193

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
