### PR TITLE
[FIX] website: no gap for on hover navbar menu


### DIFF
--- a/addons/website/static/src/interactions/dropdown/hoverable_dropdown.js
+++ b/addons/website/static/src/interactions/dropdown/hoverable_dropdown.js
@@ -10,12 +10,6 @@ export class HoverableDropdown extends Interaction {
             "t-on-mouseenter.withTarget": this.onMouseEnter,
             "t-on-mouseleave.withTarget": this.onMouseLeave,
         },
-        ".dropdown-menu": {
-            "t-att-style": () => ({
-                "top": this.isSmall() ? "" : "unset",
-                "margin-top": this.isSmall() ? "" : "0",
-            }),
-        },
         _window: {
             "t-on-resize": this.onResize,
         },


### PR DESCRIPTION
Scenario:
- go on website and edit navbar and set option "Sub Menus" to "On Hover"
- save and hover a menu and move the mouse to the dropdown menu

Result: the dropdown menu disappear before we reach it because there is
a gap between the hovered menu item and the dropdown menu.

Cause:

In saas-13.3, 135fccdc2c9a1d0b074b44a6667e2510acc07790 added the
dropdown menu on over, and used some custom CSS to prevent the small
margin-top gap that we had in bootstrap between the menu item and the
dropdown menu.

In bootstrap 5 (saas-15.5), the gap was no longer there but the code was
not removed and didn't cause any issue because when showing the
dropdown, bootstrap was setting top to 0.

In saas-18.2, the code was still there and refactored using interactions
(b9b3a605e0f4c5da3a258c980107d6162da7f44f) but the colibri code happens
after bootstrap code that set top to 0, so we had "top: unset" which is
not 0, but the bottom of the hovered menu item and that was added to
bootstrap computed "transform: translate3d" with a "top: 0" value
which creates a gap.

Fix: remove the custom CSS since it was not necessary since saas-15.5
version.

opw-4699451
