### PR TITLE
[IMP] account,account_payment,l10n_id: Adjust portal view for overriding

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -1,7 +1,7 @@
 <odoo>
     <template id="portal_my_home_menu_invoice" name="Portal layout : invoice menu entries" inherit_id="portal.portal_breadcrumbs" priority="30">
         <xpath expr="//ol[hasclass('o_portal_submenu')]" position="inside">
-            <li t-if="page_name == 'invoice'" t-attf-class="breadcrumb-item #{'active ' if not invoice else ''}">
+            <li name="invoices_breadcrumb" t-if="page_name == 'invoice'" t-attf-class="breadcrumb-item #{'active ' if not invoice else ''}">
                 <a t-if="invoice" t-attf-href="/my/invoices?{{ keep_query() }}">Invoices &amp; Bills</a>
                 <t t-else="">Invoices &amp; Bills</t>
             </li>
@@ -72,7 +72,7 @@
                             t-att-class="'text-danger' if invoice.invoice_date_due and invoice.invoice_date_due &lt; datetime.date.today() and invoice.payment_state in ['not_paid', 'partial'] else ''">
                             <span t-field="invoice.invoice_date_due"/>
                         </td>
-                        <td class="text-end pe-3"><span t-out="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/></td>
+                        <td name="invoice_amount" class="text-end pe-3"><span t-out="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/></td>
                         <td name="invoice_status">
                             <t t-if="invoice.state == 'posted'" name="invoice_status_posted">
                                 <span t-if="invoice.currency_id.is_zero(invoice.amount_residual)"

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -289,7 +289,7 @@
     <template id="portal_invoice_page_inherit_payment" name="Payment on My Invoices" inherit_id="account.portal_invoice_page">
         <xpath expr="//t[@t-call='portal.portal_record_sidebar']//h2[1]" position="after">
             <t t-set="pending_txs" t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('pending', 'authorized') and tx.provider_code not in ('none', 'custom'))"/>
-            <div t-if="invoice.currency_id.is_zero(invoice.amount_residual)" class="rounded text-bg-success fw-normal badge">
+            <div name="invoice_paid_badge" t-if="invoice.currency_id.is_zero(invoice.amount_residual)" class="rounded text-bg-success fw-normal badge">
                 <i class="fa fa-fw fa-check-circle"/> Paid
             </div>
             <div t-if="invoice.payment_state == 'in_payment' and not invoice.currency_id.is_zero(invoice.amount_residual)" class="rounded text-bg-info fw-normal badge">

--- a/addons/l10n_id/controllers/portal.py
+++ b/addons/l10n_id/controllers/portal.py
@@ -6,8 +6,8 @@ from odoo.http import request
 
 class Portal(PortalAccount):
     @http.route()
-    def portal_my_invoice_detail(self, **kw):
+    def portal_my_invoice_detail(self, *args, **kw):
         """ Override
         force QR code generation from QRIS to come only from portal"""
         request.update_context(is_online_qr=True)
-        return super().portal_my_invoice_detail(**kw)
+        return super().portal_my_invoice_detail(*args, **kw)


### PR DESCRIPTION
To add a new filter type of withholdings in Ecuador, some changes needed to be made in the base modules.

1) `account` and `account_payment` needed additional name attributes to be able to xpath nicely to them when overriding in the ecuador module.

2) `l10n_id` had an override of `/my/invoices/ID` that had a different signature than any of the other overrides that was missed until now, adding the override in `l10n_ec_edi` leads to the wrong number of positional arguments in super calls. Fixed to add `args`.

Enterprise PR: https://github.com/odoo/enterprise/pull/83178

task-4304037