### PR TITLE
[FIX] mail: messaging menu style slight improvement

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -74,6 +74,11 @@ $o-discuss-talkingColor: lighten($success, 10%);
     padding-bottom: map-get($spacers, 1) / 2;
 }
 
+.o-py-1_5 {
+    padding-top: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
+    padding-bottom: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
+}
+
 .o-hover-text-underline:hover {
     text-decoration: underline;
 }

--- a/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
@@ -1,4 +1,4 @@
 .o-mail-MessagingMenu {
-    --mail-MessagingMenu-bg: #{mix($gray-100, $gray-200)};
+    --mail-MessagingMenu-bg: #{mix($gray-100, $gray-200, 65%)};
     --mail-MessagingMenu-activeBorderTopColor: #{lighten($primary, 5%)};
 }

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -6,7 +6,7 @@
 </t>
 
 <t t-name="mail.MessagingMenu.content">
-    <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu`">
+    <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu ${ui.isSmall ? 'o-small' : ''}`">
         <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush px-2 py-1 gap-1" t-ref="notification-list">
             <t t-foreach="threads" name="threads" t-as="thread" t-key="thread.localId">
                 <t t-set="message" t-value="thread.isChatChannel or (thread.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentOfAllMessage : thread.needactionMessages.at(-1)"/>

--- a/addons/mail/static/src/core/public_web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.dark.scss
@@ -1,6 +1,6 @@
 .o-mail-NotificationItem {
     --mail-NotificationItem-activeOutlineOpacity: 1;
-    --mail-MessagingMenu-bg: #{mix($gray-100, $gray-200)};
+    --mail-NotificationItem-bg: #{lighten(mix($gray-100, $gray-200, 65%), 1.5%)};
 
     &.o-important {
         background-color: mix($o-gray-200, $o-info, 90%) !important;

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -1,11 +1,11 @@
 .o-mail-NotificationItem {
     outline: 1px solid transparent;
     outline-offset: -1px;
-    background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
+    background-color: var(--mail-NotificationItem-bg, mix($gray-100, $o-view-background-color, 95%));
 
     &.o-important {
-        background-color: mix($o-gray-100, $o-info, 92.5%) !important;
-        border-color: darken(mix($o-gray-100, $o-info, 92.5%), 5%) !important;
+        background-color: mix($o-gray-100, $o-info, 90%) !important;
+        border-color: darken(mix($o-gray-100, $o-info, 90%), 5%) !important;
     }
     &.o-active {
         outline-color: rgba($o-action, var(--mail-NotificationItem-activeOutlineOpacity, 0.5));

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border rounded-3 py-2" t-on-click="onClick" t-ref="root" t-att-class="{
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border rounded-3 o-py-1_5" t-on-click="onClick" t-ref="root" t-att-class="{
             'o-important': props.muted === 0,
             'text-muted border-transparent': props.muted === 1,
             'opacity-50 border-transparent': props.muted === 2,
@@ -16,7 +16,7 @@
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>
-            <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto">
+            <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto ps-1">
                 <div class="d-flex text-nowrap">
                     <span class="o-mail-NotificationItem-name fw-bold" t-att-class="{ 'fw-bold': props.muted, 'fw-bolder': !props.muted }" t-att-style="props.nameMaxLine !== undefined ? webkitLineClamp(props.nameMaxLine) : ''">
                         <t t-slot="name"/>


### PR DESCRIPTION
- more spacing between avatar and text content
- less spacing between items, thanks to slightly reduced vertical padding for each item
- non-important items have slight different bg compared to messaging menu