### PR TITLE
[FIX] mail: bigger avatars in discuss ctrl-k

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.scss
@@ -1,6 +1,6 @@
 .o-mail-DiscussCommand {
-    padding-top: map-get($spacers, 1) * 3 / 2;
-    padding-bottom: map-get($spacers, 1) * 3 / 2;
+    padding-top: map-get($spacers, 1);
+    padding-bottom: map-get($spacers, 1);
 
     &.o-uiSmall {
         padding-top: map-get($spacers, 2);

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -5,7 +5,7 @@
         <div class="o-mail-DiscussCommand o_command_default d-flex align-items-center ps-3 pe-4" t-att-class="{ 'o-uiSmall': ui.isSmall }">
             <i t-if="props.channel" class="fa-fw opacity-50 text-muted me-2" t-att-class="props.channel.parent_channel_id ? 'fa fa-comments-o' : props.channel.discussAppCategory?.icon ?? 'fa fa-user opacity-0'"/>
             <i t-elif="props.persona" class="fa fa-fw fa-user opacity-50 text-muted me-2"/>
-            <img class="rounded me-2 o_object_fit_cover" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 25px; height: 25px"/>
+            <img class="rounded me-2 o_object_fit_cover shadow-sm" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 32px; height: 32px"/>
             <ImStatus t-if="props.persona" className="'me-1'" persona="props.persona"/>
             <span class="pe-1 text-ellipsis d-flex align-items-center fw-bold" t-att-class="{ 'o-action': props.action }">
                 <t t-if="props.channel?.parent_channel_id">
@@ -14,7 +14,7 @@
                 </t>
                 <t t-slot="name" />
             </span>
-            <span t-if="props.persona and props.persona.email" class="text-muted smaller" t-out="'- ' + props.persona.email"/>
+            <span t-if="props.persona and props.persona.email" class="text-muted smaller opacity-75" t-out="'- ' + props.persona.email"/>
             <i t-if="props.action?.icon" class="o-mail-DiscussCommand-actionIcon fa fa-fw opacity-75 o-action" t-attf-class="{{ props.action.icon }}"/>
             <span t-if="props.action?.searchValueSuffix" class="o-action fw-bold" t-esc="props.searchValue"/>
             <span class="flex-grow-1"/>


### PR DESCRIPTION
Conversation avatars were smaller than in discuss and also not integer scaling from `avatar_128`. This is fixed by using 32px width/height.

Also reduce padding as to not make command palette significantly bigger + reduced opacity of secondary text for better difference with main text (conversation name).

Before
<img width="661" alt="Screenshot 2025-04-10 at 15 02 45" src="https://github.com/user-attachments/assets/ad7a8a6c-7f72-4e9d-a26e-4f19ee127a07" />

After
<img width="654" alt="Screenshot 2025-04-10 at 15 02 24" src="https://github.com/user-attachments/assets/da510fe5-6904-4096-bc3b-4cf3b74c9f28" />

