### PR TITLE
[FIX] l10n_latam_invoice_document: create debit note from credit note

### DIFF
--- a/addons/l10n_latam_invoice_document/wizards/account_debit_note.py
+++ b/addons/l10n_latam_invoice_document/wizards/account_debit_note.py
@@ -14,3 +14,9 @@ class AccountDebitNote(models.TransientModel):
             new_move._compute_l10n_latam_document_type()
             new_move._onchange_l10n_latam_document_type_id()
         return res
+
+    def _prepare_default_values(self, move):
+        """ Needed to avoid constraint when creating Debit Note from Credit Note """
+        vals = super()._prepare_default_values(move)
+        vals['l10n_latam_document_type_id'] = False
+        return vals


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

In debit notes wizards: If we make a wrong credit note and we want to correct it we must generate a debit note related to it.
Currently odoo only allows to generate debit notes from an invoice.

### Steps to reproduce the error.

1. Install the Argentine localization
2. Create an invoice and post it
3. From the invoice using the wizard create a credit note and post it.
4. From the credit note open the wizard to create a debit note.
5. On submit the wizard we obtain an exception "You can not use a credit_note document type with a invoice"

This happens because the debit note wizard use copy method without change the l10n_latam_document_type_id value.

### Current behavior before PR:

When creating a debit note from a credit note get an error.

### Desired behavior after PR is merged:

We can create a debit memo from a credit note.

Adhoc tiket 69428 - 69854

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
