### PR TITLE
[FIX] product, sale_pdf_quote_builder: update pdf examples download link

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -641,7 +641,7 @@ class ProductTemplate(models.Model):
                     %s
                 </p>
                 <p>
-                    <a class="oe_link" href="https://www.odoo.com/documentation/18.0/_downloads/5f0840ed187116c425fdac2ab4b592e1/pdfquotebuilderexamples.zip">
+                    <a class="oe_link" href="https://www.odoo.com/documentation/18.0/_downloads/c2c6ce32294dfddffcfefcf2775f7a09/pdfquotebuilderexamples.zip">
                     %s
                     </a>
                 </p>

--- a/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
+++ b/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
@@ -25,7 +25,12 @@
                         The pdf of your quotes will be built by putting together header pages, product descriptions,
                         details of the quote and then the footer pages. <br/>
                         If empty, it will use those define in the company settings. <br/>
-                        <widget name="documentation_link" path="/_downloads/5f0840ed187116c425fdac2ab4b592e1/pdfquotebuilderexamples.zip" label=" Download examples" icon="fa-arrow-right"/>
+                        <widget
+                            name="documentation_link"
+                            path="/_downloads/c2c6ce32294dfddffcfefcf2775f7a09/pdfquotebuilderexamples.zip"
+                            icon="fa-arrow-right"
+                            label=" Download examples"
+                        />
                     </p>
                 </page>
             </notebook>


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Open a quotation template;
2. open the Quote Builder tab;
3. click "Download examples".

Issue
-----
404 not found

Cause
-----
For product:
- When commit 3e58523 updated the versions of documentation links from 17.0 to 18.0, it overlooked changing the hash part of the url for `pdfquotebuilderexamples.zip`.

For sale_pdf_quote_builder:
- The version in the url gets added by the `documentation_link` widget, but it doesn't update the hash part of the download link.

Solution
--------
Change it so it links to https://www.odoo.com/documentation/18.0/_downloads/c2c6ce32294dfddffcfefcf2775f7a09/pdfquotebuilderexamples.zip

opw-4680248
