### PR TITLE
[FIX] sale_loyalty: validate partner id when apply coupon on sale order

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -1353,6 +1353,8 @@ class SaleOrder(models.Model):
                 return {'error': _('This coupon is expired.')}
             elif coupon.points < min(coupon.program_id.reward_ids.mapped('required_points')):
                 return {'error': _('This coupon has already been used.')}
+            elif coupon.partner_id and self.partner_id != coupon.partner_id:
+                return {'error': _('This coupon does not apply to current customer')}
             program = coupon.program_id
 
         if not program or not program.active:

--- a/doc/cla/individual/r4g3ch33m5.md
+++ b/doc/cla/individual/r4g3ch33m5.md
@@ -1,0 +1,11 @@
+Vietnam, 2025-04-10
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Thinh hoangthinh9a7@gmail.com https://github.com/r4g3ch33m5


### PR DESCRIPTION
Description of the issue/feature this PR addresses: https://github.com/odoo/odoo/issues/205431

- Go to Sale>Orders>Discount&Loyalty
-  Create a new coupon program
- Generate coupon for selected user: User A
- Login into user B, go to Website>Checkout and apply coupon B

Current behavior before PR: Can apply coupon of user A for sale_order of user B

Desired behavior after PR is merged: Cannot apply coupon of user A for sale_order of user B




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
