### PR TITLE
[FIX] l10n_latam_invoice_document: create debit note from credit note

### DIFF
--- a/addons/l10n_latam_invoice_document/wizards/account_debit_note.py
+++ b/addons/l10n_latam_invoice_document/wizards/account_debit_note.py
@@ -7,14 +7,16 @@ class AccountDebitNote(models.TransientModel):
 
     def _prepare_default_values(self, move):
         default_values = super()._prepare_default_values(move)
+        if move.company_id._localization_use_documents():
+            # properly compute debit type
+            debit_note = self.env['account.move'].new({
+                'move_type': default_values.get('move_type'),
+                'journal_id': default_values.get('journal_id'),
+                'partner_id': move.partner_id.id,
+                'company_id': move.company_id.id,
+                'debit_origin_id': move.id,
+            })
+            document_types = debit_note.l10n_latam_available_document_type_ids.filtered(lambda x: x.internal_type == 'debit_note')
+            default_values['l10n_latam_document_type_id'] = document_types and document_types[0].ids[0]
 
-        # properly compute debit type
-        debit_note = self.env['account.move'].new({
-            'move_type': default_values.get('move_type'),
-            'journal_id': default_values.get('journal_id'),
-            'partner_id': move.partner_id.id,
-            'company_id': move.company_id.id,
-        })
-        document_types = debit_note.l10n_latam_available_document_type_ids.filtered(lambda x: x.internal_type == 'debit_note')
-        default_values['l10n_latam_document_type_id'] = document_types and document_types[0].ids[0]
         return default_values

--- a/addons/l10n_latam_invoice_document/wizards/account_debit_note.py
+++ b/addons/l10n_latam_invoice_document/wizards/account_debit_note.py
@@ -5,12 +5,16 @@ class AccountDebitNote(models.TransientModel):
 
     _inherit = 'account.debit.note'
 
-    def create_debit(self):
-        """ Properly compute the latam document type of type debit note. """
-        res = super().create_debit()
-        new_move_id = res.get('res_id')
-        if new_move_id:
-            new_move = self.env['account.move'].browse(new_move_id)
-            new_move._compute_l10n_latam_document_type()
-            new_move._onchange_l10n_latam_document_type_id()
-        return res
+    def _prepare_default_values(self, move):
+        default_values = super()._prepare_default_values(move)
+
+        # properly compute debit type
+        debit_note = self.env['account.move'].new({
+            'move_type': default_values.get('move_type'),
+            'journal_id': default_values.get('journal_id'),
+            'partner_id': move.partner_id.id,
+            'company_id': move.company_id.id,
+        })
+        document_types = debit_note.l10n_latam_available_document_type_ids.filtered(lambda x: x.internal_type == 'debit_note')
+        default_values['l10n_latam_document_type_id'] = document_types and document_types[0].ids[0]
+        return default_values


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

In debit notes wizards: If we make a wrong credit note and we want to correct it we must generate a debit note related to it.
Currently odoo only allows to generate debit notes from an invoice.

### Steps to reproduce the error.

1. Install the Argentine localization
2. Create an invoice and post it
3. From the invoice using the wizard create a credit note and post it.
4. From the credit note open the wizard to create a debit note.
5. On submit the wizard we obtain an exception "You can not use a credit_note document type with a invoice"

This happens because the debit note wizard use copy method without change the l10n_latam_document_type_id value.

### Current behavior before PR:

When creating a debit note from a credit note get an error.

### Desired behavior after PR is merged:

We can create a debit memo from a credit note.

Adhoc tiket 69428 - 69854

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
