### PR TITLE
[FIX] website: prevent crash when mega menu toggles not found

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -839,17 +839,16 @@ publicWidget.registry.MegaMenuDropdown = publicWidget.Widget.extend({
                 }
             });
             if (matchingLink) {
-                const megaMenuToggleEl = megaMenuEl
-                    .closest(".nav-item")
-                    .querySelector(".o_mega_menu_toggle");
+                const navItem = megaMenuEl.closest(".nav-item");
+                const megaMenuToggleEl = navItem ? navItem.querySelector(".o_mega_menu_toggle") : null;
                 // Target the corresponding link in the mobile navigation. Since the
                 // mega-menu for mobile is dynamically rendered, it is not
                 // accessible at this moment.
                 const mobileMegaMenuToggleEl = this.el.querySelectorAll(
                     "#top_menu_collapse_mobile .top_menu .o_mega_menu_toggle"
                 )[position];
-                megaMenuToggleEl.classList.add("active");
-                mobileMegaMenuToggleEl.classList.add("active");
+                megaMenuToggleEl?.classList.add("active");
+                mobileMegaMenuToggleEl?.classList.add("active");
             }
         });
     },


### PR DESCRIPTION
This commit ensures that the mega menu toggles are only accessed if they exist in the DOM. This prevents a crash when the mega menu toggles are not present.

The PR that added this code can be found here:
5be1280

This first appeared in an 18.1 ticket where a customer had a view created by the web editor that was missing the expected mega menu mobile version. This view had been edited and not upgraded properly, leading to a case where the mobile mega menu toggle element was not present.

opw-4670537