### PR TITLE
[FIX] sale_pdf_quote_builder: make xpath more selective on sale form

### DIFF
--- a/addons/sale_pdf_quote_builder/views/sale_order_views.xml
+++ b/addons/sale_pdf_quote_builder/views/sale_order_views.xml
@@ -8,11 +8,11 @@
         <field name="arch" type="xml">
             <!-- Needed by customContentKanbanLikeWidget to save selected documents on the product. -->
             <!-- Desktop view -->
-            <xpath expr="//field[@name='order_line']//list" position="inside">
+            <xpath expr="//field[@name='order_line']/list" position="inside">
                 <field name="product_document_ids" column_invisible="1"/>
             </xpath>
             <!-- Mobile view -->
-            <xpath expr="//field[@name='order_line']//kanban" position="inside">
+            <xpath expr="//field[@name='order_line']/kanban" position="inside">
                 <field name="product_document_ids" column_invisible="1"/>
             </xpath>
             <page name="optional_products" position="after">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
sale_pdf_quote_builder uses `//` for selection of the kanban and list views of the order lines rather than `/`. 

Current behavior before PR:
However, in the upstream view the form view is declared first. If any extension, or studio change embeds a list or kanban view inside the form, the current selectors will pick that up instead of the list and kanban views associated with the order line.

Desired behavior after PR is merged:
More accurately select the correct insertion point of the inherited view

OPW-4716782



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
