### PR TITLE
[FIX] l10n_de: Raise validation error only if the value is changed

### DIFF
--- a/addons/l10n_de/models/res_company.py
+++ b/addons/l10n_de/models/res_company.py
@@ -21,6 +21,7 @@ class ResCompany(models.Model):
         if (
             'account_fiscal_country_id' in vals
             and (german_companies := self.filtered(lambda c: c.account_fiscal_country_id.code == 'DE'))
+            and self.env['res.country'].browse(vals['account_fiscal_country_id']).code != 'DE'
             and self.env['account.move'].search_count([('company_id', 'in', german_companies.ids)], limit=1)
         ):
             raise ValidationError(_("You cannot change the fiscal country."))


### PR DESCRIPTION
Description of the issue/feature this PR addresses: If we try to reload the template, an error is raised. So, we will raise the error if the change has some meaning

Current behavior before PR: an Error is raised when updating a German plan

Desired behavior after PR is merged: no Error is raised

@alialfie 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
