### PR TITLE
[IMP] maintenance: add 'Scheduled End' date on request

### DIFF
--- a/addons/maintenance/static/src/views/calendar_with_recurrence/calendar_with_recurrence_model.js
+++ b/addons/maintenance/static/src/views/calendar_with_recurrence/calendar_with_recurrence_model.js
@@ -17,14 +17,18 @@ export class CalendarWithRecurrenceModel extends CalendarModel {
                 if (rawRecord.repeat_type == 'until') {
                     end = luxon.DateTime.min(end, deserializeDateTime(rawRecord.repeat_until)).endOf('day');
                 }
+                const duration = rawRecord.duration || 1;
+                const [unit, interval] = [rawRecord.repeat_unit + "s", rawRecord.repeat_interval]
                 let date = deserializeDateTime(rawRecord.schedule_date);
-                date = this._getNextDate(date, rawRecord.repeat_unit + 's', rawRecord.repeat_interval);
+                date = this._getNextDate(date, unit, interval);
                 let counter = 1;
                 while (date <= end) {
                     if (date > start) {
+                        const endDate = date.plus({ hours: duration });
                         const rawRecordCopy = { ...rawRecord };
                         rawRecordCopy.display_name = rawRecord.display_name + " (+" + counter + ")";
                         rawRecordCopy.schedule_date = serializeDateTime(date);
+                        rawRecordCopy.schedule_end = serializeDateTime(endDate);
                         records[recordsCounter] = {
                             ...this.normalizeRecord(rawRecordCopy),
                             id: recordsCounter,
@@ -32,7 +36,7 @@ export class CalendarWithRecurrenceModel extends CalendarModel {
                         };
                         recordsCounter++;
                     }
-                    date = this._getNextDate(date, rawRecord.repeat_unit + 's', rawRecord.repeat_interval);
+                    date = this._getNextDate(date, unit, interval);
                     counter++;
                 }
             }
@@ -41,5 +45,21 @@ export class CalendarWithRecurrenceModel extends CalendarModel {
     }
     _getNextDate(date, unit, interval) {
         return date.plus({ [unit]: interval });
+    }
+    computeRangeDomain(data) {
+        // Override to fix recurrence: show records even if end is before next range start.
+        const formattedEnd = serializeDateTime(data.range.end);
+        const domain = [[this.meta.fieldMapping.date_start, "<=", formattedEnd]];
+        return domain;
+    }
+    normalizeRecord(rawRecord) {
+        // Override to set end = start + 1h if schedule_end is False.
+        const record = super.normalizeRecord(rawRecord);
+        const { duration, start, end } = record;
+        if (!end.isValid && duration) {
+            record.end = start.plus({ hours: duration });
+            record.isTimeHidden = false;
+        }
+        return record;
     }
 }

--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -33,14 +33,16 @@ registry.category("web_tour.tours").add("test_dblclick_event_from_calendar", {
             run: "dblclick",
         },
         {
-            content: "Change equipment",
-            trigger: "input#duration_0",
-            run: "edit 2:00",
-        },
-        {
-            content: "Save duration change",
-            trigger: 'button[data-hotkey="s"]',
-            run: "click",
+            content: "Change Scheduled End",
+            trigger: "button#schedule_end_0",
+            run() {
+                const input = document.querySelector("button#schedule_end_0");
+                input.value = luxon.DateTime
+                    .fromFormat(input.value, "MM/dd/yyyy hh:mm:ss a")
+                    .plus({ hours: 1 })
+                    .toFormat("MM/dd/yyyy hh:mm:ss a");
+                input.dispatchEvent(new Event("change"));
+            },
         },
         {
             content: "Return to calendar",

--- a/addons/maintenance/tests/test_calendar_with_recurrence.py
+++ b/addons/maintenance/tests/test_calendar_with_recurrence.py
@@ -29,7 +29,6 @@ class TestCalendarWithRecurrence(HttpCase):
             'repeat_until': datetime.now() + relativedelta(days=+8),
             'repeat_interval': 1,
             'repeat_unit': 'day',
-            'duration': 1,
         }])
         request = requests[2]
 
@@ -37,7 +36,7 @@ class TestCalendarWithRecurrence(HttpCase):
         self.start_tour(url, 'test_dblclick_event_from_calendar', login='admin')
 
         self.assertEqual(request.name, 'make your bed', "The event modification should update the request")
-        self.assertEqual(request.duration, 2, "The event modification should update the request")
+        self.assertAlmostEqual(request.duration, 2, 2, "The event modification should update the request")
 
     def test_drag_and_drop_calendar_event(self):
         """
@@ -61,7 +60,6 @@ class TestCalendarWithRecurrence(HttpCase):
             'repeat_interval': 1,
             'repeat_until': datetime.now() + relativedelta(weeks=+2),
             'repeat_unit': 'week',
-            'duration': 1,
         }])
         request = requests[2]
 

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -114,12 +114,7 @@
                             <field name="maintenance_team_id" options="{'no_create': True, 'no_open': True}"/>
                             <field name="user_id" string="Responsible"/>
                             <field name="schedule_date"/>
-                            <label for="duration"/>
-                            <div>
-                                <field name="duration"
-                                       widget="float_time"
-                                       class="oe_inline"/> <span class="ml8">hours</span>
-                            </div>
+                            <field name="schedule_end"/>
                             <label for="recurring_maintenance" invisible="maintenance_type == 'corrective'"/>
                             <div class="d-inline-flex" invisible="maintenance_type == 'corrective'">
                                 <field name="recurring_maintenance" nolabel="1" class="ms-0" style="width: fit-content;"/>
@@ -196,7 +191,7 @@
         <field name="name">equipment.request.list</field>
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
-            <list string="maintenance Request" multi_edit="1" sample="1">
+            <list string="Maintenance Request" multi_edit="1" sample="1">
                 <field name="message_needaction" column_invisible="True"/>
                 <field name="name"/>
                 <field name="request_date" groups="base.group_no_one"/>
@@ -214,9 +209,12 @@
         <field name="name">equipment.request.graph</field>
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
-            <graph string="maintenance Request" sample="1">
+            <graph string="Maintenance Request" sample="1">
                 <field name="user_id"/>
                 <field name="stage_id"/>
+                <field name="duration" type="measure"/>
+                <field name="color" type="measure" invisible="1"/>
+                <field name="repeat_interval" type="measure" invisible="1"/>
             </graph>
         </field>
     </record>
@@ -225,7 +223,7 @@
         <field name="name">equipment.request.pivot</field>
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
-            <pivot string="maintenance Request" sample="1">
+            <pivot string="Maintenance Request" sample="1">
                 <field name="user_id"/>
                 <field name="stage_id"/>
                 <field name="color" invisible="1"/>
@@ -238,7 +236,7 @@
         <field name="name">equipment.request.calendar</field>
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
-            <calendar date_start="schedule_date" date_delay="duration" color="user_id" event_limit="5" js_class="calendar_with_recurrence">
+            <calendar date_start="schedule_date" date_stop="schedule_end" color="user_id" event_limit="5" js_class="calendar_with_recurrence">
                 <field name="user_id" filters="1"/>
                 <field name="priority"/>
                 <field name="maintenance_type"/>
@@ -249,6 +247,7 @@
                 <field name="repeat_until" invisible="1"/>
                 <field name="done" invisible="1"/>
                 <field name="archive" invisible="1"/>
+                <field name="duration" invisible="1"/>
             </calendar>
         </field>
     </record>


### PR DESCRIPTION
With This Commit:
-------------------------
- Replaced the `duration` field with an `scheduled end` on maintenance requests,
  in preparation for removing the problematic `date_delay` attribute in calendar
  views.
- Improves time range visibility by making the end time explicit in the form
  view.
- Defaulted the scheduled end to `start time + 1 hour` to improve user
  experience by ensuring all events have a clear and valid time range.
- Adjusted the calendar logic to ensure recurring maintenance requests are
  properly displayed, even when they span across calendar boundaries.
- Improved the display of maintenance events by ensuring all entries show a
  proper time range, avoiding `Invalid Datetime` in calendar view when the
  end date is missing.
- Refined the `Maintenance Requests Analysis` report by removing low-impact
  measures to improve clarity and focus.
- Retained the duration measure to help users analyze time spent by assignee.
- Corrected the view titles in pivot, list, and graph views from
  "maintenance Request" to "Maintenance Request" for improved UI consistency.

Framework task: [4609678](https://www.odoo.com/odoo/all-tasks/4609678)
task-4582789