### PR TITLE
[FIX] website_sale: set extra price currency symbol according to the pricelist

### DIFF
--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -153,7 +153,7 @@
                 style="white-space: nowrap;"
                 t-options='{
                     "widget": "monetary",
-                    "display_currency": (pricelist or product.env.company).currency_id
+                    "display_currency": (website.pricelist_id or product.env.company).currency_id
                 }'/>
         </span>
     </template>


### PR DESCRIPTION
Steps to reproduce :

1) Install Ecommerce
2) Open a product that has an extra price (take the customizable desk) 
3) Change the pricelist to Euro (€)

<b>Issue</b>:-

The extra price keeps being displayed in $ even if the price is in €.

<b>Cause</b>:-

We displayed the monetary symbol of the extra price based on the pricelist or company currency.
https://github.com/odoo/odoo/blob/99d00987aa0fba0e52a8c416e1a6a3b514b9e99a/addons/website_sale/views/variant_templates.xml#L154-L156

We don't get any pricelist value because in the below-mentioned commit, we removed the pricelist from the values that are used in the template. So it keeps displaying the company currency.

https://github.com/odoo/odoo/pull/159746/files#diff-83686977d1607bdb0a3e755e9d22ec4496c1dc4caebfff4bee3902ddd1b3e866L641

<b>Solution</b>:-

Since the value of the pricelist is provided from the website previously, 
So take the value of the pricelist from the website directly in the template.

opw-4712968
