### PR TITLE
[FIX] website_slides: fix incorrect copied URL link

### DIFF
--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -106,7 +106,7 @@
                                                readonly="1"
                                                invisible="not prerequisite_of_channel_ids"/>
                                         <field name="visibility" widget="radio" options="{'horizontal': true}"/>
-                                        <field name="website_url" widget="CopyClipboardChar" nolabel="1" colspan="2" invisible="visibility != 'link'"/>
+                                        <field name="website_absolute_url" widget="CopyClipboardChar" nolabel="1" colspan="2" invisible="visibility != 'link'"/>
                                         <field name="enroll" widget="radio" options="{'horizontal': true}" invisible="visibility == 'members'"/>
                                         <field name="upload_group_ids" widget="many2many_tags" groups="base.group_no_one"/>
                                         <field name="enroll_group_ids" widget="many2many_tags" groups="base.group_no_one"/>


### PR DESCRIPTION
Steps to reproduce:
1. Create a new course.
2. Go to 'Options' tab.
3. Select show course to 'Anyone with the link' .
4. The link is not generated correctly, copy the link.

Technical Reason:
Previously, the 'website_url' field returned only a relative path (e.g., /slides/...), which broke redirection.

After this commit:
redirect to the intended URL.

Task-4703290