### PR TITLE
[REF] *: change value of m2o to object

### DIFF
--- a/addons/account/static/src/components/autosave_many2many_tax_tags/autosave_many2many_tax_tags.js
+++ b/addons/account/static/src/components/autosave_many2many_tax_tags/autosave_many2many_tax_tags.js
@@ -30,8 +30,8 @@ export class AutosaveMany2ManyTaxTagsField extends Many2ManyTaxTagsField {
         const line = record.data;
         if (line.tax_ids.records.length > 0) {
             if (line.balance !== this.lastBalance
-                || line.account_id[0] !== this.lastAccount[0]
-                || line.partner_id[0] !== this.lastPartner[0]) {
+                || line.account_id.id !== this.lastAccount.id
+                || line.partner_id.id !== this.lastPartner.id) {
                 this.lastBalance = line.balance;
                 this.lastAccount = line.account_id;
                 this.lastPartner = line.partner_id;

--- a/addons/account/static/src/components/open_move_line_move_widget/open_move_line_move_widget.js
+++ b/addons/account/static/src/components/open_move_line_move_widget/open_move_line_move_widget.js
@@ -23,7 +23,7 @@ class LineOpenMoveWidget extends Component {
     async openAction() {
         return this.action.doActionButton({
             type: "object",
-            resId: this.props.record.data[this.props.name][0],
+            resId: this.props.record.data[this.props.name].id,
             name: "action_open_business_doc",
             resModel: "account.move.line",
         });

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -88,7 +88,7 @@ export class ProductLabelSectionAndNoteField extends Component {
     }
 
     get productName() {
-        return this.props.record.data[this.props.name][1];
+        return this.props.record.data[this.props.name].display_name;
     }
 
     get label() {
@@ -104,13 +104,15 @@ export class ProductLabelSectionAndNoteField extends Component {
 
     get m2oProps() {
         const p = computeM2OProps(this.props);
+        let value = p.value && { ...p.value };
         if (this.props.readonly && this.productName) {
-            p.value[1] = this.productName;
+            value = { ...value, display_name: this.productName };
         }
         return {
             ...p,
             canOpen: !this.props.readonly || this.isProductClickable,
             placeholder: _t("Search a product"),
+            value,
         };
     }
 

--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -302,7 +302,7 @@ export class AnalyticDistribution extends Component {
                 // TODO: check web_read network request
                 const { string, name, type, relation } = this.props.record.fields[currency_field];
                 recordFields[currency_field] = { name, string, type, relation, invisible: true };
-                values[currency_field] = this.props.record.data[currency_field][0];
+                values[currency_field] = this.props.record.data[currency_field].id;
             }
         }
         return {
@@ -333,10 +333,10 @@ export class AnalyticDistribution extends Component {
             args['business_domain'] = this.props.business_domain;
         }
         if (this.props.product_field && record.data[this.props.product_field]) {
-            args['product'] = record.data[this.props.product_field][0];
+            args['product'] = record.data[this.props.product_field].id;
         }
         if (this.props.account_field && record.data[this.props.account_field]) {
-            args['account'] = record.data[this.props.account_field][0];
+            args['account'] = record.data[this.props.account_field].id;
         }
         if (this.props.force_applicability) {
             args['applicability'] = this.props.force_applicability;
@@ -346,7 +346,7 @@ export class AnalyticDistribution extends Component {
             args['existing_account_ids'] = existing_account_ids;
         }
         if (record.data.company_id) {
-            args['company_id'] = record.data.company_id[0];
+            args['company_id'] = record.data.company_id.id;
         }
         return args;
     }
@@ -375,8 +375,8 @@ export class AnalyticDistribution extends Component {
         // record analytic account changes to the state
         for (const account of line.analyticAccounts) {
             const selected = record.data[`x_plan${account.planId}_id`];
-            account.accountId = selected[0];
-            account.accountDisplayName = selected[1];
+            account.accountId = selected.id;
+            account.accountDisplayName = selected.display_name;
             account.accountColor = account.planColor;
             account.accountRootPlanId = account.planId;
         }
@@ -463,9 +463,9 @@ export class AnalyticDistribution extends Component {
         const { record, product_field, account_field } = this.props;
         this.openTemplate({ resId: false, context: {
             'default_analytic_distribution': this.dataToJson(),
-            'default_partner_id': record.data['partner_id'] ? record.data['partner_id'][0] : undefined,
-            'default_product_id': product_field ? record.data[product_field][0] : undefined,
-            'default_account_prefix': account_field ? record.data[account_field][1].substr(0, 3) : undefined,
+            'default_partner_id': record.data['partner_id'] ? record.data['partner_id'].id : undefined,
+            'default_product_id': product_field ? record.data[product_field].id : undefined,
+            'default_account_prefix': account_field ? record.data[account_field].display_name.substr(0, 3) : undefined,
         }});
     }
 

--- a/addons/base_automation/static/src/base_automation_trigger_selection_field.js
+++ b/addons/base_automation/static/src/base_automation_trigger_selection_field.js
@@ -79,7 +79,7 @@ export class TriggerSelectionField extends SelectionField {
         let relatedModelFields;
         useRecordObserver(async (record) => {
             const { data, fields } = record;
-            const modelId = data.model_id?.[0];
+            const modelId = data.model_id?.id;
             if (lastRelatedModelId !== modelId) {
                 lastRelatedModelId = modelId;
                 relatedModelFields = await orm.searchRead(

--- a/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
@@ -54,7 +54,7 @@ export class CalendarFormController extends FormController {
         if (record.data.recurrency) {
             recurrenceUpdate = await this.askRecurrenceUpdatePolicy();
         }
-        if (rootValues.attendees_count == 1 && rootValues.user_id[0] !== rootValues.partner_ids._currentIds[0]) {
+        if (rootValues.attendees_count == 1 && rootValues.user_id.id !== rootValues.partner_ids._currentIds[0]) {
             await this._archiveRecord(record.resId, recurrenceUpdate);
         } else {
             await this.orm.call("calendar.event", "action_unlink_event", [

--- a/addons/event/static/src/views/event_registration_kanban_controller.js
+++ b/addons/event/static/src/views/event_registration_kanban_controller.js
@@ -15,7 +15,7 @@ export class EventRegistrationKanbanController extends KanbanController {
     async openRecord(record) {
         if (this.props.context.is_registration_desk_view) {
             const barcode = record.data.barcode;
-            const eventId = record.data.event_id[0];
+            const eventId = record.data.event_id.id;
 
             const result = await this.orm.call("event.registration", "register_attendee", [], {
                 barcode: barcode,

--- a/addons/event/static/src/views/event_registration_list_controller.js
+++ b/addons/event/static/src/views/event_registration_list_controller.js
@@ -15,7 +15,7 @@ export class EventRegistrationListController extends ListController {
     async openRecord(record) {
         if (this.props.context.is_registration_desk_view) {
             const barcode = record.data.barcode;
-            const eventId = record.data.event_id[0];
+            const eventId = record.data.event_id.id;
 
             const result = await this.orm.call("event.registration", "register_attendee", [], {
                 barcode: barcode,

--- a/addons/event_booth_sale/static/src/js/sale_product_field.js
+++ b/addons/event_booth_sale/static/src/js/sale_product_field.js
@@ -31,15 +31,15 @@ patch(SaleOrderLineProductField.prototype, {
     },
     async _openEventBoothConfigurator(edit) {
         const actionContext = {
-            default_product_id: this.props.record.data.product_id[0],
+            default_product_id: this.props.record.data.product_id.id,
         };
         if (edit) {
             const recordData = this.props.record.data;
             if (recordData.event_id) {
-                actionContext.default_event_id = recordData.event_id[0];
+                actionContext.default_event_id = recordData.event_id.id;
             }
             if (recordData.event_booth_category_id) {
-                actionContext.default_event_booth_category_id = recordData.event_booth_category_id[0];
+                actionContext.default_event_booth_category_id = recordData.event_booth_category_id.id;
             }
             if (recordData.event_booth_pending_ids) {
                 actionContext.default_event_booth_ids = recordData.event_booth_pending_ids.records.map(

--- a/addons/event_sale/static/src/js/sale_product_field.js
+++ b/addons/event_sale/static/src/js/sale_product_field.js
@@ -29,16 +29,16 @@ patch(SaleOrderLineProductField.prototype, {
     },
     async _openEventConfigurator() {
         const actionContext = {
-            default_product_id: this.props.record.data.product_id[0],
+            default_product_id: this.props.record.data.product_id.id,
         };
         if (this.props.record.data.event_id) {
-            actionContext.default_event_id = this.props.record.data.event_id[0];
+            actionContext.default_event_id = this.props.record.data.event_id.id;
         }
         if (this.props.record.data.event_slot_id) {
             actionContext.default_event_slot_id = this.props.record.data.event_slot_id[0];
         }
         if (this.props.record.data.event_ticket_id) {
-            actionContext.default_event_ticket_id = this.props.record.data.event_ticket_id[0];
+            actionContext.default_event_ticket_id = this.props.record.data.event_ticket_id.id;
         }
         this.action.doAction(
             'event_sale.event_configurator_action',

--- a/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
+++ b/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
@@ -114,7 +114,9 @@ export class AddressAutoComplete extends CharField {
 
             const recordFieldName = addressFieldMap[fieldName] || fieldName;
             if (recordFieldName in activeFields) {
-                if (Array.isArray(value) && fields[recordFieldName].type !== "many2one") {
+                if (fields[recordFieldName].type === "many2one") {
+                    value = value && { id: value[0], display_name: value[1] };
+                } else if (Array.isArray(value)) {
                     value = value[1];
                 }
                 valuesToUpdate[recordFieldName] = value || false;

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.js
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.js
@@ -27,7 +27,7 @@ export class KanbanMany2OneAvatarEmployeeField extends Component {
     }
 
     get displayName() {
-        return this.props.displayAvatarName && this.value ? this.value[1] : "";
+        return this.props.displayAvatarName && this.value ? this.value.display_name : "";
     }
 
     get m2oProps() {

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
@@ -4,7 +4,7 @@
     <t t-name="hr.KanbanMany2OneAvatarEmployeeField">
         <KanbanMany2One t-props="m2oProps">
             <t t-set-slot="avatar">
-                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value[0]" noSpacing="true" displayName="displayName"/>
+                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" displayName="displayName"/>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
@@ -5,7 +5,7 @@
         <t t-set="value" t-value="props.record.data[props.name]"/>
         <div class="d-flex align-items-center gap-1">
             <t t-if="value !== false">
-                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value[0]" noSpacing="true"/>
+                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true"/>
             </t>
             <Many2One t-props="m2oProps" cssClass="'w-100'">
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">

--- a/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
+++ b/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
@@ -47,7 +47,7 @@ patch(HrPresenceStatusPrivate.prototype, patchHrPresenceStatus());
 patch(HrPresenceStatusPrivate.prototype, {
     get label() {
         return this.props.record.data.current_leave_id
-            ? this.props.record.data.current_leave_id[1] + _t(", back on ") + this.props.record.data['leave_date_to'].toLocaleString(
+            ? this.props.record.data.current_leave_id.id + _t(", back on ") + this.props.record.data['leave_date_to'].toLocaleString(
                 {
                     day: 'numeric',
                     month: 'short',

--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.js
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.js
@@ -54,14 +54,14 @@ export class LeaveStatsComponent extends Component {
             const proms = [];
             if (
                 dateChanged ||
-                (employee && (this.state.employee && this.state.employee[0]) !== employee[0])
+                (employee && (this.state.employee && this.state.employee.id) !== employee.id)
             ) {
                 proms.push(this.loadLeaves(employee));
             }
             if (
                 dateChanged ||
                 (department &&
-                    (this.state.department && this.state.department[0]) !== department[0])
+                    (this.state.department && this.state.department.id) !== department.id)
             ) {
                 proms.push(this.loadDepartmentLeaves(department, employee));
             }
@@ -70,7 +70,7 @@ export class LeaveStatsComponent extends Component {
             this.state.employee = employee;
             this.state.department = department;
             if (this.state.department) {
-                const department_name_array = this.state.department[1].split('/');
+                const department_name_array = this.state.department.display_name.split('/');
                 this.state.department_name = department_name_array.pop();
                 this.state.has_parent_department = department_name_array.length > 0;
             }
@@ -89,26 +89,27 @@ export class LeaveStatsComponent extends Component {
 
         const dateFrom = serializeDateTime(this.state.date_from);
         const dateTo = serializeDateTime(this.state.date_to);
-        const leaves = await this.orm.searchRead(
+        const leaves = await this.orm.webSearchRead(
             "hr.leave",
             [
-                ["department_id", "=", department[0]],
+                ["department_id", "=", department.id],
                 ["state", "=", "validate"],
-                ["employee_id", "!=", employee],
+                ["employee_id", "!=", employee.id],
                 ["date_from", "<=", dateTo],
                 ["date_to", ">=", dateFrom],
             ],
-            [
-                "employee_id",
-                "date_from",
-                "date_to",
-                "number_of_days",
-                "number_of_hours",
-                "leave_type_request_unit",
-                "request_unit_hours"
-            ]
+            {
+                specification: {
+                    employee_id: { fields: { display_name: {} } },
+                    date_from: {},
+                    date_to: {},
+                    number_of_days: {},
+                    number_of_hours: {},
+                    leave_type_request_unit: {},
+                },
+            }
         );
-        this.state.departmentLeaves = this.arrangeData(leaves)
+        this.state.departmentLeaves = this.arrangeData(leaves.records)
     }
 
     async loadLeaves(employee) {
@@ -119,25 +120,26 @@ export class LeaveStatsComponent extends Component {
 
         const dateFrom = serializeDateTime(this.state.date_from.startOf("year"));
         const dateTo = serializeDateTime(this.state.date_from.endOf("year"));
-        const leaves = await this.orm.searchRead(
+        const leaves = await this.orm.webSearchRead(
             "hr.leave",
             [
-                ["employee_id", "=", employee[0]],
+                ["employee_id", "=", employee.id],
                 ["state", "=", "validate"],
                 ["date_from", "<=", dateTo],
                 ["date_to", ">=", dateFrom],
             ],
-            [
-                "holiday_status_id",
-                "date_from",
-                "date_to",
-                "number_of_days",
-                "number_of_hours",
-                "leave_type_request_unit",
-                "request_unit_hours"
-            ],
+            {
+                specification: {
+                    holiday_status_id: { fields: { display_name: {} } },
+                    date_from: {},
+                    date_to: {},
+                    number_of_days: {},
+                    number_of_hours: {},
+                    leave_type_request_unit: {},
+                },
+            }
         );
-        this.state.leaves = this.arrangeData(leaves);
+        this.state.leaves = this.arrangeData(leaves.records);
     }
     arrangeData(leaves) {
         leaves.forEach((leave) => {

--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
@@ -11,13 +11,13 @@
                         />
                     </div>
                     <div class="o_hr_leave_subtitle">
-                        <t t-esc="state.employee[1]"/>'s summary (<t t-esc="thisYear"/>)
+                        <t t-esc="state.employee.display_name"/>'s summary (<t t-esc="thisYear"/>)
                     </div>
                 </div>
             </div>
             <div class="d-flex flex-column mb-1">
                 <div t-foreach="state.leaves" t-as="leave" t-key="leave.id" class="d-flex mb-2">
-                    <span class="col-4 fw-bold" t-esc="leave.holiday_status_id[1]"/>
+                    <span class="col-4 fw-bold" t-esc="leave.holiday_status_id.display_name"/>
                     <div t-if="leave.leave_type_request_unit == 'hour'" class="d-flex gap-2 col-6">
                         <span t-esc="leave.date_from"/>
                         <span t-esc="leave.hour_from" class="fst-italic"/>
@@ -54,7 +54,7 @@
                                 record="{'data' : {'employee_id': leave.employee_id}, 'fields': this.props.record.fields}"
                                 name="'employee_id'" relation="'hr.employee'"
                             />
-                            <span t-esc="leave.employee_id[1]" class="mx-1 fw-bold"/>
+                            <span t-esc="leave.employee_id.display_name" class="mx-1 fw-bold"/>
                         </div>
                         <div t-if="leave.leave_type_request_unit == 'hour'" class="d-flex gap-2 col-6">
                             <span t-esc="leave.date_from"/>

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.js
@@ -31,7 +31,7 @@ class HrOrgChartPopover extends Component {
      */
     async _onEmployeeRedirect(employeeId) {
         const action = await this.orm.call('hr.employee', 'get_formview_action', [employeeId]);
-        this.actionService.doAction(action); 
+        this.actionService.doAction(action);
     }
 }
 
@@ -54,11 +54,11 @@ export class HrOrgChart extends Component {
             this.employee = this.props.record.data;
             // the widget is either dispayed in the context of a hr.employee form or a res.users form
             this.state.employee_id = this.employee.employee_ids !== undefined ? this.employee.employee_ids.resIds[0] : this.props.record.resId;
-            this.state.parent_id = this.employee.parent_id?.[0] || this.employee.employee_parent_id?.[0];
+            this.state.parent_id = this.employee.parent_id?.id || this.employee.employee_parent_id?.id;
         });
 
         useRecordObserver(async (record) => {
-            const newParentId = record.data.parent_id?.[0] || record.data.employee_parent_id?.[0] || false;
+            const newParentId = record.data.parent_id?.id || record.data.employee_parent_id?.id || false;
             const newEmployeeId = record.data.employee_ids !== undefined ? record.data.employee_ids.resIds[0] :
                                         record.resId;
             this.state.employee_id = newEmployeeId;
@@ -114,7 +114,7 @@ export class HrOrgChart extends Component {
      */
     async _onEmployeeRedirect(employeeId) {
         const action = await this.orm.call('hr.employee', 'get_formview_action', [employeeId]);
-        this.actionService.doAction(action); 
+        this.actionService.doAction(action);
     }
 
     async _onEmployeeMoreManager(managerId) {

--- a/addons/hr_recruitment/static/src/views/form_view.js
+++ b/addons/hr_recruitment/static/src/views/form_view.js
@@ -15,7 +15,7 @@ export class InterviewerFormController extends FormController {
             return result;
         }
         result["o_applicant_interviewer_form"] = root.data.interviewer_ids.records.findIndex(
-            interviewer => interviewer.resId === root.data.user_id[0]) > -1;
+            interviewer => interviewer.resId === root.data.user_id.id) > -1;
         return result;
     }
 }

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.js
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.js
@@ -41,7 +41,7 @@ export class SkillsListRenderer extends CommonSkillsListRenderer {
 
     async openSkillsReport() {
         // fetch id through employee or public.employee
-        const id = this.env.model.root.data.id || this.env.model.root.data.employee_id[0];
+        const id = this.env.model.root.data.id || this.env.model.root.data.employee_id.id;
 -        this.actionService.doAction({
             type: "ir.actions.act_window",
             name: _t("Skills Report"),
@@ -63,7 +63,7 @@ export class SkillsListRenderer extends CommonSkillsListRenderer {
     get SkillsRight() {
         let isSubordinate = false;
         if (this.env.model.root.data.employee_id) {
-            isSubordinate = this.userSubordinates.includes(this.env.model.root.data.employee_id[0]);
+            isSubordinate = this.userSubordinates.includes(this.env.model.root.data.employee_id.id);
         }
         return this.IsHrUser || isSubordinate;
     }
@@ -105,7 +105,7 @@ export class SkillsX2ManyField extends X2ManyField {
     }
 
     async onAdd({ context, editable } = {}) {
-        const employeeId = this.props.record.resModel === "res.users" ? this.props.record.data.employee_id[0] : this.props.record.resId;
+        const employeeId = this.props.record.resModel === "res.users" ? this.props.record.data.employee_id.id : this.props.record.resId;
         return super.onAdd({
             editable,
             context: {

--- a/addons/hr_skills/static/src/views/skills_list_renderer.js
+++ b/addons/hr_skills/static/src/views/skills_list_renderer.js
@@ -22,17 +22,17 @@ export class CommonSkillsListRenderer extends ListRenderer {
             const data = record.data;
             const group = data[this.groupBy];
 
-            if (grouped[group[1]] === undefined) {
-                grouped[group[1]] = {
-                    id: parseInt(group[0]),
-                    name: group[1] || _t('Other'),
+            if (grouped[group.display_name] === undefined) {
+                grouped[group.display_name] = {
+                    id: parseInt(group.id),
+                    name: group.display_name || _t('Other'),
                     list: {
                         records: [],
                     },
                 };
             }
 
-            grouped[group[1]].list.records.push(record);
+            grouped[group.display_name].list.records.push(record);
         }
         return grouped;
     }

--- a/addons/hr_timesheet/static/src/components/task_with_hours/task_with_hours.js
+++ b/addons/hr_timesheet/static/src/components/task_with_hours/task_with_hours.js
@@ -27,7 +27,10 @@ export class TaskWithHours extends Component {
             canCreateEdit: props.canCreateEdit && this.canCreate(),
             canQuickCreate: props.canQuickCreate && this.canCreate(),
             context: { ...props.context, hr_timesheet_display_remaining_hours: true },
-            value: props.value && [props.value[0], props.value[1]?.split("\u00A0")[0]],
+            value: props.value && {
+                ...props.value,
+                display_name: props.value.display_name?.split("\u00A0")[0],
+            },
         };
     }
 }

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -196,7 +196,7 @@ patch(Chatter.prototype, {
         this.mailImpactingFields.recordFields.forEach((field) => {
             const value = record._changes[field];
             if (record.data[field] !== undefined && value) {
-                partnerIds.push(value[0]);
+                partnerIds.push(value.id);
             }
         });
         this.mailImpactingFields.emailFields.forEach((field) => {

--- a/addons/mail/static/src/core/web/activity_button.js
+++ b/addons/mail/static/src/core/web/activity_button.js
@@ -64,7 +64,7 @@ export class ActivityButton extends Component {
             return this.props.record.data.activity_summary;
         }
         if (this.props.record.data.activity_type_id) {
-            return this.props.record.data.activity_type_id[1 /* display_name */];
+            return this.props.record.data.activity_type_id.display_name;
         }
         return _t("Show activities");
     }

--- a/addons/mail/static/src/core/web/mail_composer_template_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.js
@@ -52,7 +52,7 @@ export class MailComposerTemplateSelector extends Component {
      */
     async onLoadTemplate(template) {
         await this.props.record.update({
-            template_id: [template.id]
+            template_id: { id: template.id },
         });
     }
 
@@ -88,7 +88,7 @@ export class MailComposerTemplateSelector extends Component {
             domain: [["model", "=", this.props.record.data.render_model]],
             onSelected: async templateIds => {
                 await this.props.record.update({
-                    template_id: templateIds
+                    template_id: { id: templateIds[0] },
                 });
             },
         });

--- a/addons/mail/static/src/views/web/fields/assign_user_command_hook.js
+++ b/addons/mail/static/src/views/web/fields/assign_user_command_hook.js
@@ -21,7 +21,7 @@ export function useAssignUserCommand() {
 
     const getCurrentIds = () => {
         if (type === "many2one" && component.props.record.data[component.props.name]) {
-            return [component.props.record.data[component.props.name][0]];
+            return [component.props.record.data[component.props.name].id];
         } else if (type === "many2many") {
             return component.props.record.data[component.props.name].currentIds;
         }
@@ -30,7 +30,10 @@ export function useAssignUserCommand() {
 
     const add = async (record) => {
         if (type === "many2one") {
-            component.props.record.update({ [component.props.name]: record });
+            component.props.record.update({ [component.props.name]: {
+                id: record[0],
+                display_name: record[1],
+            } });
         } else if (type === "many2many") {
             component.props.record.data[component.props.name].linkTo(record[0], {
                 display_name: record[1],

--- a/addons/mail/static/src/views/web/fields/list_activity/list_activity.js
+++ b/addons/mail/static/src/views/web/fields/list_activity/list_activity.js
@@ -28,7 +28,7 @@ export class ListActivity extends Component {
             return this.props.record.data.activity_summary;
         }
         if (this.props.record.data.activity_type_id) {
-            return this.props.record.data.activity_type_id[1 /* display_name */];
+            return this.props.record.data.activity_type_id.display_name;
         }
         return undefined;
     }

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.js
@@ -19,7 +19,7 @@ export class KanbanMany2OneAvatarUserField extends Component {
     };
 
     get displayName() {
-        return this.props.displayAvatarName && this.value ? this.value[1] : "";
+        return this.props.displayAvatarName && this.value ? this.value.display_name : "";
     }
 
     get m2oProps() {

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
@@ -5,7 +5,7 @@
         <t t-set="relation" t-value="props.record.fields[props.name].relation"/>
         <KanbanMany2One t-props="m2oProps">
             <t t-set-slot="avatar">
-                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value[0]" noSpacing="true" displayName="displayName"/>
+                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" displayName="displayName"/>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Many2OneAvatarUserField">
         <div class="d-flex align-items-center gap-1">
             <t t-if="value !== false">
-                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value[0]" noSpacing="true"/>
+                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true"/>
             </t>
             <Many2One t-props="m2oProps" cssClass="'w-100'">
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">

--- a/addons/mail/static/src/views/web/fields/properties_field/property_value.js
+++ b/addons/mail/static/src/views/web/fields/properties_field/property_value.js
@@ -20,7 +20,7 @@ patch(PropertyValue.prototype, {
 
     _onAvatarClicked() {
         if (this.openChat && this.showAvatar && this.props.comodel === "res.users") {
-            this.openChat(this.props.value[0]);
+            this.openChat(this.props.value.id);
         }
     },
 });

--- a/addons/mass_mailing/static/src/js/mailing_m2o_filter.js
+++ b/addons/mass_mailing/static/src/js/mailing_m2o_filter.js
@@ -141,7 +141,7 @@ export class FieldMany2OneMailingFilter extends Component {
      * @param {event} ev
      */
     async onRemoveFilter(ev) {
-        const filterId = this.props.record.data.mailing_filter_id[0];
+        const filterId = this.props.record.data.mailing_filter_id.id;
         const mailingDomain = this.props.record.data[this.props.domain_field];
         // Prevent multiple clicks to avoid trying to deleting same record multiple times.
         ev.target.disabled = true;
@@ -178,9 +178,11 @@ export class FieldMany2OneMailingFilter extends Component {
             const [newFilterId] = await this.env.model.orm.create("mailing.filter", [{
                 name: filterName,
                 mailing_domain: this.props.record.data[this.props.domain_field],
-                mailing_model_id: this.props.record.data[this.props.model_field][0],
+                mailing_model_id: this.props.record.data[this.props.model_field].id,
             }]);
-            this.props.record.update({ [this.props.name]: [newFilterId, filterName] });
+            this.props.record.update({
+                [this.props.name]: { id: newFilterId, display_name: filterName },
+            });
         }
     }
 }

--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -358,7 +358,7 @@ export class MassMailingHtmlField extends HtmlField {
 
         // Filter the fetched templates based on the current model
         const args = this.props.filterTemplates
-            ? [[['mailing_model_id', '=', this.props.record.data.mailing_model_id[0]]]]
+            ? [[['mailing_model_id', '=', this.props.record.data.mailing_model_id.id]]]
             : [];
 
         // Templates taken from old mailings
@@ -367,14 +367,14 @@ export class MassMailingHtmlField extends HtmlField {
         const templatesParams = result.map(values => {
             return {
                 id: values.id,
-                modelId: values.mailing_model_id[0],
-                modelName: values.mailing_model_id[1],
+                modelId: values.mailing_model_id.id,
+                modelName: values.mailing_model_id.display_name,
                 name: `template_${values.id}`,
                 nowrap: true,
                 subject: values.subject,
                 template: values.body_arch,
-                userId: values.user_id[0],
-                userName: values.user_id[1],
+                userId: values.user_id.id,
+                userName: values.user_id.display_name,
             };
         });
 
@@ -437,7 +437,7 @@ export class MassMailingHtmlField extends HtmlField {
         const $themeSelectorNew = $(renderToElement("mass_mailing.theme_selector_new", {
             themes: themesParams,
             templates: templatesParams,
-            modelName: this.props.record.data.mailing_model_id[1] || '',
+            modelName: this.props.record.data.mailing_model_id.display_name || '',
         }));
 
         // Check if editable area is empty.
@@ -597,7 +597,7 @@ export class MassMailingHtmlField extends HtmlField {
         }
         const iframeContent = this.wysiwyg.$iframe.contents();
 
-        const mailing_model_id = record.data.mailing_model_id[0];
+        const mailing_model_id = record.data.mailing_model_id.id;
         iframeContent
             .find(`.o_mail_template_preview[model-id!="${mailing_model_id}"]`)
             .addClass('d-none')
@@ -616,7 +616,7 @@ export class MassMailingHtmlField extends HtmlField {
             iframeContent.find('.o_mailing_template_preview_wrapper').removeClass('d-none');
         } else {
             iframeContent.find('.o_mailing_template_message').removeClass('d-none');
-            iframeContent.find('.o_mailing_template_message span').text(record.data.mailing_model_id[1]);
+            iframeContent.find('.o_mailing_template_message span').text(record.data.mailing_model_id.display_name);
             iframeContent.find('.o_mailing_template_preview_wrapper').addClass('d-none');
         }
     }

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -32,7 +32,7 @@ export class PartnerAutoCompleteCharField extends CharField {
             {
                 options: async (request, shouldSearchWorldWide) => {
                     if (await this.validateSearchTerm(request)) {
-                        let queryCountryId = this.props.record.data?.country_id ? this.props.record.data.country_id[0] : false;
+                        let queryCountryId = this.props.record.data?.country_id ? this.props.record.data.country_id.id : false;
                         if (shouldSearchWorldWide){
                         	queryCountryId = 0;
                         }
@@ -62,14 +62,6 @@ export class PartnerAutoCompleteCharField extends CharField {
             const logoField = this.props.record.resModel === 'res.partner' ? 'image_1920' : 'logo';
             data.company[logoField] = data.logo;
         }
-
-        // Format the many2one fields
-        const many2oneFields = ['country_id', 'state_id'];
-        many2oneFields.forEach((field) => {
-            if (data.company[field]) {
-                data.company[field] = [data.company[field].id, data.company[field].display_name];
-            }
-        });
 
         // Save UNSPSC codes (tags)
         const unspsc_codes = data.company.unspsc_codes

--- a/addons/product/static/src/js/product_document_kanban/product_document_kanban_record.js
+++ b/addons/product/static/src/js/product_document_kanban/product_document_kanban_record.js
@@ -18,7 +18,7 @@ export class ProductDocumentKanbanRecord extends KanbanRecord {
             return;
         } else if (ev.target.closest(".o_kanban_previewer")) {
             const attachment = this.store["ir.attachment"].insert({
-                id: this.props.record.data.ir_attachment_id[0],
+                id: this.props.record.data.ir_attachment_id.id,
                 name: this.props.record.data.name,
                 mimetype: this.props.record.data.mimetype,
             });

--- a/addons/product_matrix/static/src/js/matrix_configurator_hook.js
+++ b/addons/product_matrix/static/src/js/matrix_configurator_hook.js
@@ -38,7 +38,7 @@ export function useMatrixConfigurator() {
         openDialog(
             rootRecord,
             rootRecord.data.grid,
-            record.data.product_template_id[0],
+            record.data.product_template_id.id,
             updatedLineAttributes
         );
 

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
@@ -101,7 +101,7 @@ export class SubtaskKanbanList extends Component {
             await this.orm.create("project.task", [{
                 display_name: name,
                 parent_id: this.props.record.resId,
-                project_id: this.props.record.data.project_id[0],
+                project_id: this.props.record.data.project_id.id,
                 user_ids: this.props.record.data.user_ids.resIds,
             }]);
             this.subtaskCreate.open = false;

--- a/addons/purchase_product_matrix/static/src/js/purchase_product_field.js
+++ b/addons/purchase_product_matrix/static/src/js/purchase_product_field.js
@@ -17,7 +17,7 @@ export class PurchaseOrderLineProductField extends ProductLabelSectionAndNoteFie
 
         useRecordObserver((record) => {
             if (record.isInEdition && this.props.record.data[this.props.name]) {
-                if (!this.currentValue || this.currentValue[0] != record.data[this.props.name][0]) {
+                if (!this.currentValue || this.currentValue.id != record.data[this.props.name].id) {
                     // Field was updated if line was open in edit mode,
                     //      field is not emptied,
                     //      new value is different than existing value.
@@ -41,13 +41,13 @@ export class PurchaseOrderLineProductField extends ProductLabelSectionAndNoteFie
         const result = await this.orm.call(
             'product.template',
             'get_single_product_variant',
-            [this.props.record.data.product_template_id[0]],
+            [this.props.record.data.product_template_id.id],
         );
         if(result && result.product_id) {
             if (this.props.record.data.product_id != result.product_id.id) {
                 this.props.record.update({
                     // TODO right name get (same problem as configurator)
-                    product_id: [result.product_id, result.product_name],
+                    product_id: { id: result.product_id, display_name: result.product_name },
                 });
             }
         } else {

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/kanban_many2one_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/kanban_many2one_avatar_resource_field.xml
@@ -8,13 +8,13 @@
             <t t-set-slot="avatar">
                 <t t-if="props.record.data.resource_type === 'material'">
                     <span class="o_avatar o_m2o_avatar">
-                        <span class="d-inline-flex align-items-center justify-content-center rounded o_material_resource cursor-default me-1" t-att-title="value[1]">
+                        <span class="d-inline-flex align-items-center justify-content-center rounded o_material_resource cursor-default me-1" t-att-title="value.display_name">
                             <i class="fa fa-wrench"/>
                         </span>
                     </span>
                 </t>
                 <t t-elif="props.record.data.resource_type === 'user'">
-                    <AvatarResource cssClass="'o_m2o_avatar'" resModel="relation" resId="value[0]"/>
+                    <AvatarResource cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id"/>
                 </t>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.xml
@@ -8,13 +8,13 @@
             <t t-if="value !== false">
                 <t t-if="props.record.data.resource_type === 'material'">
                     <span class="o_avatar o_m2o_avatar">
-                        <span class="d-inline-flex align-items-center justify-content-center rounded o_material_resource cursor-default me-1" t-att-title="value[1]">
+                        <span class="d-inline-flex align-items-center justify-content-center rounded o_material_resource cursor-default me-1" t-att-title="value.display_name">
                             <i class="fa fa-wrench"/>
                         </span>
                     </span>
                 </t>
                 <t t-elif="props.record.data.resource_type === 'user'">
-                    <AvatarResource cssClass="'o_m2o_avatar'" resModel="relation" resId="value[0]"/>
+                    <AvatarResource cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id"/>
                 </t>
             </t>
             <Many2One t-props="m2oProps" cssClass="'w-100'">

--- a/addons/sale/static/src/js/sale_utils.js
+++ b/addons/sale/static/src/js/sale_utils.js
@@ -8,7 +8,7 @@
 export function areSaleOrderLinesLinked(linkingSaleOrderLine, linkedSaleOrderLine) {
     const linkingId = linkedSaleOrderLine.isNew
         ? linkingSaleOrderLine.data.linked_virtual_id
-        : linkingSaleOrderLine.data.linked_line_id[0];
+        : linkingSaleOrderLine.data.linked_line_id.id;
     const linkedId = linkedSaleOrderLine.isNew
         ? linkedSaleOrderLine.data.virtual_id
         : linkedSaleOrderLine.resId;

--- a/addons/sale_project/static/src/components/so_line_create_button/so_line_create_button.js
+++ b/addons/sale_project/static/src/components/so_line_create_button/so_line_create_button.js
@@ -32,7 +32,7 @@ export class SoLineCreateButton extends Component {
                     "get_first_service_line",
                     [rec.resId]
                 );
-                record.update({ sale_line_id: service_line_id });
+                record.update({ sale_line_id: { id: service_line_id[0] } });
             },
         });
     }

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -21,8 +21,8 @@ export class QtyAtDatePopover extends Component {
         this.actionService.doAction("stock.stock_forecasted_product_product_action", {
             additionalContext: {
                 active_model: 'product.product',
-                active_id: this.props.record.data.product_id[0],
-                warehouse_id: this.props.record.data.warehouse_id && this.props.record.data.warehouse_id[0],
+                active_id: this.props.record.data.product_id.id,
+                warehouse_id: this.props.record.data.warehouse_id && this.props.record.data.warehouse_id.id,
                 move_to_match_ids: this.props.record.data.move_ids.records.map(record => record.resId),
                 sale_line_to_match_id: this.props.record.resId,
             },

--- a/addons/sale_timesheet/static/src/components/so_line_field/so_line_field.js
+++ b/addons/sale_timesheet/static/src/components/so_line_field/so_line_field.js
@@ -16,7 +16,7 @@ export class SoLineField extends Component {
                 if (
                     // field is unset AND the old & new so_lines are different
                     !this.props.record.data.is_so_line_edited &&
-                    this.props.record.data[this.props.name][0] != value[0]
+                    this.props.record.data[this.props.name].id != value.id
                 ) {
                     this.props.record.update({ is_so_line_edited: true });
                 }

--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -43,10 +43,10 @@ export class SMLX2ManyField extends X2ManyField {
             search_default_on_hand: true,
             search_default_in_stock: true,
         };
-        const productName = this.props.record.data.product_id[1];
+        const productName = this.props.record.data.product_id.display_name;
         const title = _t("Add line: %s", productName);
         let domain = [
-            ["product_id", "=", this.props.record.data.product_id[0]],
+            ["product_id", "=", this.props.record.data.product_id.id],
             ["location_id", "child_of", this.props.context.default_location_id],
         ];
         if (this.dirtyQuantsData.size) {
@@ -77,7 +77,7 @@ export class SMLX2ManyField extends X2ManyField {
             (ml) => !ml.data.quant_id && ml._values.quantity - ml._changes.quantity
         );
         const dirtyQuantMoveLines = this._move_line_ids.filter(
-            (ml) => ml.data.quant_id[0]
+            (ml) => ml.data.quant_id.id
         );
         const dirtyMoveLines = [...dirtyQuantityMoveLines, ...dirtyQuantMoveLines];
         if (!dirtyMoveLines.length) {
@@ -92,7 +92,7 @@ export class SMLX2ManyField extends X2ManyField {
                     .map((rec) => rec.resId),
                 this.props.record.resId,
                 dirtyMoveLines.filter((rec) => rec.resId).map((rec) => rec.resId),
-                dirtyQuantMoveLines.map((ml) => ml.data.quant_id[0]),
+                dirtyQuantMoveLines.map((ml) => ml.data.quant_id.id),
             ],
             {}
         );
@@ -106,7 +106,7 @@ export class SMLX2ManyField extends X2ManyField {
         }
         const offsetByQuant = new Map();
         for (const ml of dirtyQuantMoveLines) {
-            const quantId = ml.data.quant_id[0];
+            const quantId = ml.data.quant_id.id;
             offsetByQuant.set(quantId, (offsetByQuant.get(quantId) || 0) - ml.data.quantity);
             const dbQuantId = dbMoveLinesData.get(ml.resId)?.quantId;
             if (dbQuantId && quantId != dbQuantId) {

--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -62,9 +62,9 @@ export class GenerateDialog extends Component {
         }
         const move_line_vals = await this.orm.call("stock.move", "action_generate_lot_line_vals", [{
                 ...this.props.move.context,
-                default_product_id: this.props.move.data.product_id[0],
-                default_location_dest_id: this.props.move.data.location_dest_id[0],
-                default_location_id: this.props.move.data.location_id[0],
+                default_product_id: this.props.move.data.product_id.id,
+                default_location_dest_id: this.props.move.data.location_dest_id.id,
+                default_location_id: this.props.move.data.location_id.id,
                 default_tracking: this.props.move.data.has_tracking,
                 default_quantity: qtyToProcess,
             },

--- a/addons/stock/static/src/widgets/stock_pick_from.js
+++ b/addons/stock/static/src/widgets/stock_pick_from.js
@@ -12,7 +12,7 @@ export class StockPickFrom extends Component {
         const props = computeM2OProps(this.props);
         return {
             ...props,
-            value: props.value || [0, this._quant_display_name()],
+            value: props.value || { id: 0, display_name: this._quant_display_name() },
         };
     }
 
@@ -20,15 +20,15 @@ export class StockPickFrom extends Component {
         let name_parts = [];
         // if location group is activated
         const data = this.props.record.data;
-        name_parts.push(data.location_id?.[1])
+        name_parts.push(data.location_id?.display_name)
         if (data.lot_id) {
-            name_parts.push(data.lot_id?.[1] || data.lot_name)
+            name_parts.push(data.lot_id?.display_name || data.lot_name)
         }
         if (data.package_id) {
-            name_parts.push(data.package_id?.[1])
+            name_parts.push(data.package_id?.display_name)
         }
         if (data.owner) {
-            name_parts.push(data.owner?.[1])
+            name_parts.push(data.owner?.display_name)
         }
         const result = name_parts.join(" - ");
         if (result) return result;

--- a/addons/uom/static/src/components/many2one_uom/many2one_uom_field.js
+++ b/addons/uom/static/src/components/many2one_uom/many2one_uom_field.js
@@ -50,7 +50,7 @@ export class Many2OneUomField extends Component {
 
     get m2oProps() {
         const productModel = getProductRelatedModel.call(this);
-        let productId = this.props.record.data[this.props.productField]?.[0] || 0;
+        let productId = this.props.record.data[this.props.productField]?.id || 0;
         if (["product.template", "product.product"].includes(this.props.record.resModel)) {
             productId = this.props.record.resId || 0;
         }

--- a/addons/web/static/src/model/record.js
+++ b/addons/web/static/src/model/record.js
@@ -1,7 +1,7 @@
 import { useService } from "@web/core/utils/hooks";
 import { isObject, pick } from "@web/core/utils/objects";
 import { RelationalModel } from "@web/model/relational_model/relational_model";
-import { createMany2OneValue, getFieldsSpec } from "@web/model/relational_model/utils";
+import { getFieldsSpec } from "@web/model/relational_model/utils";
 import { Component, xml, onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
 
 const defaultActiveField = { attrs: {}, options: {}, domain: "[]", string: "" };
@@ -82,42 +82,42 @@ class _Record extends Component {
                     if (typeof values[fieldName] === "number") {
                         const prom = loadDisplayName(values[fieldName]);
                         prom.then((displayName) => {
-                            values[fieldName] = createMany2OneValue({
+                            values[fieldName] = {
                                 id: values[fieldName],
                                 display_name: displayName,
-                            });
+                            };
                         });
                         proms.push(prom);
                     } else if (Array.isArray(values[fieldName])) {
                         if (values[fieldName][1] === undefined) {
                             const prom = loadDisplayName(values[fieldName][0]);
                             prom.then((displayName) => {
-                                values[fieldName] = createMany2OneValue({
+                                values[fieldName] = {
                                     id: values[fieldName][0],
                                     display_name: displayName,
-                                });
+                                };
                             });
                             proms.push(prom);
                         }
-                        values[fieldName] = createMany2OneValue({
+                        values[fieldName] = {
                             id: values[fieldName][0],
                             display_name: values[fieldName][1],
-                        });
+                        };
                     } else if (isObject(values[fieldName])) {
                         if (values[fieldName].display_name === undefined) {
                             const prom = loadDisplayName(values[fieldName].id);
                             prom.then((displayName) => {
-                                values[fieldName] = createMany2OneValue({
+                                values[fieldName] = {
                                     id: values[fieldName].id,
                                     display_name: displayName,
-                                });
+                                };
                             });
                             proms.push(prom);
                         }
-                        values[fieldName] = createMany2OneValue({
+                        values[fieldName] = {
                             id: values[fieldName].id,
                             display_name: values[fieldName].display_name,
-                        });
+                        };
                     }
                 }
                 await Promise.all(proms);

--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -2,7 +2,7 @@
 
 import { Domain } from "@web/core/domain";
 import { DynamicList } from "./dynamic_list";
-import { createMany2OneValue, getGroupServerValue } from "./utils";
+import { getGroupServerValue } from "./utils";
 
 /**
  * @typedef {import("./record").Record} RelationalRecord
@@ -131,7 +131,7 @@ export class DynamicGroupList extends DynamicList {
         // step 2: update record value
         const value =
             targetGroup.groupByField.type === "many2one"
-                ? createMany2OneValue([targetGroup.value, targetGroup.displayName])
+                ? { id: targetGroup.value, display_name: targetGroup.displayName }
                 : targetGroup.value;
         const revert = () => {
             targetGroup._removeRecords([record.id]);

--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -13,8 +13,8 @@ import { markRaw } from "@odoo/owl";
 
 function compareFieldValues(v1, v2, fieldType) {
     if (fieldType === "many2one") {
-        v1 = v1 ? v1[1] : "";
-        v2 = v2 ? v2[1] : "";
+        v1 = v1 ? v1.display_name : "";
+        v2 = v2 ? v2.display_name : "";
     }
     return v1 < v2;
 }

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -508,7 +508,11 @@ export function parseServerValue(field, value) {
             };
         }
         case "many2one": {
-            return createMany2OneValue(value);
+            if (Array.isArray(value)) {
+                // Used for web_read_group, where the value is an array of [id, display_name]
+                value = { id: value[0], display_name: value[1] };
+            }
+            return value;
         }
         case "properties": {
             return value
@@ -867,21 +871,4 @@ export async function resequence({
         records.splice(0, records.length, ...originalOrder);
         throw error;
     }
-}
-
-/**
- * @param {object | [number, string] | false} value
- * @returns {object}
- */
-export function createMany2OneValue(value) {
-    if (!value) {
-        return false;
-    }
-
-    if (Array.isArray(value)) {
-        value = Object.assign(value, { id: value[0], display_name: value[1] });
-    } else {
-        value = Object.assign([value.id, value.display_name], value);
-    }
-    return value;
 }

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -142,8 +142,8 @@ class GetMetadataDialog extends Component {
         this.state.xmlid = metadata.xmlid;
         this.state.xmlids = metadata.xmlids;
         this.state.noupdate = metadata.noupdate;
-        this.state.creator = formatMany2one(metadata.create_uid);
-        this.state.lastModifiedBy = formatMany2one(metadata.write_uid);
+        this.state.creator = formatMany2one(metadata.create_uid && { display_name: metadata.create_uid[1] });
+        this.state.lastModifiedBy = formatMany2one(metadata.write_uid && { display_name: metadata.write_uid[1] });
         this.state.createDate = formatDateTime(deserializeDateTime(metadata.create_date));
         this.state.writeDate = formatDateTime(deserializeDateTime(metadata.write_date));
     }
@@ -302,8 +302,8 @@ class SetDefaultDialog extends Component {
     display(fieldInfo, value) {
         let displayed = value;
         if (value && fieldInfo.type === "many2one") {
-            displayed = value[1];
-            value = value[0];
+            displayed = value.display_name;
+            value = value.id;
         } else if (value && fieldInfo.type === "selection") {
             displayed = fieldInfo.selection.find((option) => {
                 return option[0] === value;

--- a/addons/web/static/src/views/fields/attachment_image/attachment_image_field.xml
+++ b/addons/web/static/src/views/fields/attachment_image/attachment_image_field.xml
@@ -4,8 +4,8 @@
     <t t-name="web.AttachmentImageField">
         <div class="o_attachment_image">
             <img t-if="props.record.data[props.name]"
-                t-attf-src="/web/image/{{ props.record.data[props.name][0] }}/300x300?unique=1"
-                t-att-title="!!env.debug and props.record.data[props.name][1]"
+                t-attf-src="/web/image/{{ props.record.data[props.name].id }}/300x300?unique=1"
+                t-att-title="!!env.debug and props.record.data[props.name].display_name"
                 alt="Image"/>
         </div>
     </t>

--- a/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
@@ -44,7 +44,7 @@ export class BadgeSelectionField extends Component {
         switch (this.type) {
             case "many2one":
                 return this.props.record.data[this.props.name]
-                    ? this.props.record.data[this.props.name][1]
+                    ? this.props.record.data[this.props.name].display_name
                     : "";
             case "selection":
                 return this.props.record.data[this.props.name] !== false
@@ -56,7 +56,7 @@ export class BadgeSelectionField extends Component {
     }
     get value() {
         const rawValue = this.props.record.data[this.props.name];
-        return this.type === "many2one" && rawValue ? rawValue[0] : rawValue;
+        return this.type === "many2one" && rawValue ? rawValue.id : rawValue;
     }
 
     stringify(value) {
@@ -72,8 +72,9 @@ export class BadgeSelectionField extends Component {
                 if (value === false) {
                     this.props.record.update({ [this.props.name]: false });
                 } else {
+                    const option =  this.options.find((option) => option[0] === value);
                     this.props.record.update({
-                        [this.props.name]: this.options.find((option) => option[0] === value),
+                        [this.props.name]: { id: option[0], display_name: option[1] },
                     });
                 }
                 break;

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -248,11 +248,11 @@ formatInteger.extractOptions = ({ attrs, options }) => ({
 
 /**
  * Returns a string representing a many2one value. The value is expected to be
- * either `false` or an array in the form [id, display_name]. The returned
- * value will then be the display name of the given value, or an empty string
- * if the value is false.
+ * either `false` or an array in the form [id, display_name] or an object
+ * containing at least the key "display_name". The returned value will then be
+ * the display name of the given value, or an empty string if the value is false.
  *
- * @param {[number, string] | false} value
+ * @param {[number, string] | { display_name: string } | false} value
  * @param {Object} [options] additional options
  * @param {boolean} [options.escape=false] if true, escapes the formatted value
  * @returns {string}
@@ -260,8 +260,8 @@ formatInteger.extractOptions = ({ attrs, options }) => ({
 export function formatMany2one(value, options) {
     if (!value) {
         value = "";
-    } else if (value[1]) {
-        value = value[1];
+    } else if ("display_name" in value ? value.display_name : value[1]) {
+        value = "display_name" in value ? value.display_name : value[1];
     } else {
         value = _t("Unnamed");
     }
@@ -327,7 +327,7 @@ export function formatMonetary(value, options = {}) {
             (options.field && options.field.currency_field) ||
             "currency_id";
         const dataValue = options.data[currencyField];
-        currencyId = Array.isArray(dataValue) ? dataValue[0] : dataValue;
+        currencyId = dataValue?.id ?? dataValue;
     }
     return formatCurrency(value, currencyId, options);
 }
@@ -379,7 +379,7 @@ function formatProperties(value, field) {
  * @returns {string}
  */
 export function formatReference(value, options) {
-    return formatMany2one(value ? [value.resId, value.displayName] : false, options);
+    return formatMany2one(value ? { id: value.resId, display_name: value.displayName } : false, options);
 }
 
 /**
@@ -389,7 +389,7 @@ export function formatReference(value, options) {
  * @returns {string}
  */
 export function formatMany2oneReference(value) {
-    return value ? formatMany2one([value.resId, value.displayName]) : "";
+    return value ? formatMany2one({ id: value.resId, display_name: value.displayName }) : "";
 }
 
 /**

--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -76,7 +76,7 @@ export class ImageField extends Component {
 
     get imgAlt() {
         if (this.fieldType === "many2one" && this.props.record.data[this.props.name]) {
-            return this.props.record.data[this.props.name][1];
+            return this.props.record.data[this.props.name].display_name;
         }
         return this.props.alt;
     }
@@ -130,7 +130,7 @@ export class ImageField extends Component {
         if (this.fieldType === "many2one") {
             this.lastURL = imageUrl(
                 this.props.record.fields[this.props.name].relation,
-                this.props.record.data[this.props.name][0],
+                this.props.record.data[this.props.name].id,
                 imageFieldName,
                 { unique: this.rawCacheKey }
             );

--- a/addons/web/static/src/views/fields/many2one/many2one.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one.xml
@@ -19,7 +19,7 @@
     <t t-name="web.Many2One">
         <div class="o_many2one" t-att-class="props.cssClass">
             <t t-if="props.readonly">
-                <t t-if="value">
+                <t t-if="props.value">
                     <t t-if="props.canOpen">
                         <a class="o_form_uri" t-att-class="props.linkCssClass" t-att-href="linkHref" t-on-click.prevent.stop="() => this.openRecord('action')" t-esc="displayName"/>
                     </t>

--- a/addons/web/static/src/views/fields/monetary/monetary_field.js
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.js
@@ -50,7 +50,7 @@ export class MonetaryField extends Component {
             this.props.record.fields[this.props.name].currency_field ||
             "currency_id";
         const currency = this.props.record.data[currencyField];
-        return currency && currency[0];
+        return currency && currency.id;
     }
     get currency() {
         if (!isNaN(this.currencyId)) {

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -81,7 +81,7 @@ export class PropertiesField extends Component {
                     if (!canChangeDefinition) {
                         this.notification.add(
                             _t('Oops! You cannot edit the %(parentFieldLabel)s "%(parentName)s".', {
-                                parentName: this.props.record.data[this.definitionRecordField][1],
+                                parentName: this.props.record.data[this.definitionRecordField].display_name,
                                 parentFieldLabel:
                                     this.props.record.fields[this.definitionRecordField].string,
                             }),
@@ -354,7 +354,7 @@ export class PropertiesField extends Component {
      * @returns {integer}
      */
     get definitionRecordId() {
-        return this.props.record.data[this.definitionRecordField][0];
+        return this.props.record.data[this.definitionRecordField].id;
     }
 
     /**
@@ -654,7 +654,7 @@ export class PropertiesField extends Component {
             body: _t(
                 'Are you sure you want to delete this property field? It will be removed for everyone using the "%(parentName)s" %(parentFieldLabel)s.',
                 {
-                    parentName: this.props.record.data[this.definitionRecordField][1],
+                    parentName: this.props.record.data[this.definitionRecordField].display_name,
                     parentFieldLabel: this.props.record.fields[this.definitionRecordField].string,
                 }
             ),

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -18,11 +18,20 @@ import { TagsList } from "@web/core/tags_list/tags_list";
 import { useService } from "@web/core/utils/hooks";
 import { formatInteger, formatMany2one } from "@web/views/fields/formatters";
 import { formatFloat } from "@web/core/utils/numbers";
-import { m2oTupleFromData } from "@web/views/fields/many2one/many2one";
 import { parseFloat, parseInteger } from "@web/views/fields/parsers";
 import { Many2XAutocomplete, useOpenMany2XRecord } from "@web/views/fields/relational_utils";
 import { PropertyTags } from "./property_tags";
 import { imageUrl } from "@web/core/utils/urls";
+
+function extractData(record) {
+    let name;
+    if ("display_name" in record) {
+        name = record.display_name;
+    } else if ("name" in record) {
+        name = record.name.id ? record.name.display_name : record.name;
+    }
+    return { id: record.id, display_name: name };
+}
 
 /**
  * Represent one property value.
@@ -84,8 +93,8 @@ export class PropertyValue extends Component {
                 }
                 // maybe the record display name has changed
                 await record.load();
-                const recordData = m2oTupleFromData(record.data);
-                await this.onValueChange([{ id: recordData[0], name: recordData[1] }]);
+                const recordData = extractData(record.data);
+                await this.onValueChange([recordData]);
             },
             fieldString: this.props.string,
         });
@@ -119,8 +128,6 @@ export class PropertyValue extends Component {
             const options = this.props.selection || [];
             const option = options.find((option) => option[0] === value);
             return option && option.length === 2 && option[0] ? option[0] : "";
-        } else if (this.props.type === "many2one") {
-            return !value || value.length !== 2 || !value[0] ? false : value;
         } else if (this.props.type === "many2many") {
             if (!value || !value.length) {
                 return [];
@@ -248,29 +255,24 @@ export class PropertyValue extends Component {
                 newValue = 0;
             }
         } else if (["many2one", "many2many"].includes(this.props.type)) {
-            // {id: 5, name: 'Demo'} => [5, 'Demo']
-            newValue =
-                newValue && newValue.length && newValue[0].id
-                    ? [newValue[0].id, newValue[0].name]
-                    : false;
-
-            if (newValue && newValue[0] && newValue[1] === undefined) {
+            newValue = newValue[0];
+            if (newValue && newValue.id && newValue.display_name === undefined) {
                 // The "Search more" option in the Many2XAutocomplete component
                 // only return the record ID, and not the name. But we need to name
                 // in the component props to be able to display it.
                 // Make a RPC call to resolve the display name of the record.
-                newValue = await this._nameGet(newValue[0]);
+                newValue = await this._nameGet(newValue.id);
             }
 
             if (this.props.type === "many2many" && newValue) {
                 // add the record in the current many2many list
                 const currentValue = this.props.value || [];
-                const recordId = newValue[0];
-                const exists = currentValue.find((rec) => rec[0] === recordId);
+                const recordId = newValue.id;
+                const exists = currentValue.find((rec) => rec.id === recordId);
                 if (exists) {
                     return;
                 }
-                newValue = [...currentValue, newValue];
+                newValue = [...currentValue, [newValue.id, newValue.display_name]];
             }
         }
 
@@ -286,7 +288,7 @@ export class PropertyValue extends Component {
     async onMany2oneClick(event) {
         if (this.props.readonly) {
             event.stopPropagation();
-            await this._openRecord(this.props.comodel, this.propertyValue[0]);
+            await this._openRecord(this.props.comodel, this.propertyValue.id);
         }
     }
 
@@ -295,7 +297,7 @@ export class PropertyValue extends Component {
      */
     onExternalLinkClick() {
         return this.openMany2X({
-            resId: this.propertyValue[0],
+            resId: this.propertyValue.id,
             forceModel: this.props.comodel,
             context: this.context,
         });
@@ -323,7 +325,7 @@ export class PropertyValue extends Component {
         const result = await this.orm.call(this.props.comodel, "name_create", [name], {
             context: this.props.context,
         });
-        this.onValueChange([{ id: result[0], name: result[1] }]);
+        this.onValueChange([{ id: result[0], display_name: result[1] }]);
     }
 
     /* --------------------------------------------------------
@@ -355,6 +357,6 @@ export class PropertyValue extends Component {
         const result = await this.orm.read(this.props.comodel, [recordId], ["display_name"], {
             context: this.props.context,
         });
-        return [result[0].id, result[0].display_name];
+        return result[0];
     }
 }

--- a/addons/web/static/src/views/fields/properties/property_value.xml
+++ b/addons/web/static/src/views/fields/properties/property_value.xml
@@ -70,27 +70,27 @@
                 class="o_field_property_many2one_value d-flex flex-row align-items-center"
                 t-att-class="{'avatar': showAvatar}">
                 <t t-if="props.comodel">
-                    <t t-set="hasAccess" t-value="!propertyValue || propertyValue[1]"/>
-                    <img t-if="showAvatar and propertyValue[0] and hasAccess"
-                        t-attf-src="/web/image/{{props.comodel}}/{{propertyValue[0]}}/avatar_128"
+                    <t t-set="hasAccess" t-value="!propertyValue || propertyValue.display_name"/>
+                    <img t-if="showAvatar and propertyValue.id and hasAccess"
+                        t-attf-src="/web/image/{{props.comodel}}/{{propertyValue.id}}/avatar_128"
                         class="o_avatar rounded me-1"/>
                     <t t-if="props.readonly || !hasAccess">
                         <a
                             t-if="clickableRelational || !hasAccess"
-                            t-attf-class="o_form_uri {{propertyValue and propertyValue[1] ? '' : 'disabled'}}"
-                            t-att-href="propertyValue[0] ? `#id=${propertyValue[0]}&amp;model=${props.comodel}` : '#'"
+                            t-attf-class="o_form_uri {{propertyValue and propertyValue.display_name ? '' : 'disabled'}}"
+                            t-att-href="propertyValue.id ? `#id=${propertyValue.id}&amp;model=${props.comodel}` : '#'"
                             t-on-click.prevent="onMany2oneClick">
-                            <t t-if="hasAccess" t-out="propertyValue[1]"/>
+                            <t t-if="hasAccess" t-out="propertyValue.display_name"/>
                             <t t-else="">No Access</t>
                         </a>
                         <span
                             t-else=""
-                            t-out="propertyValue and propertyValue[1] || ''" />
+                            t-out="propertyValue and propertyValue.display_name || ''" />
                     </t>
                     <Many2XAutocomplete
                         t-else=""
                         t-key="props.id + '_' + props.comodel + '_' + props.string"
-                        value="propertyValue[1] || ''"
+                        value="propertyValue.display_name || ''"
                         id="props.id"
                         resModel="props.comodel"
                         autoSelect="true"
@@ -102,7 +102,7 @@
                         activeActions="{ create: true, createEdit: true, write: true }"
                     />
                     <button
-                        t-if="!props.readonly and propertyValue and propertyValue[0] and hasAccess"
+                        t-if="!props.readonly and propertyValue and propertyValue.id and hasAccess"
                         type="button"
                         class="btn btn-secondary oi oi-arrow-right o_external_button o_properties_external_button py-0"
                         tabindex="-1"

--- a/addons/web/static/src/views/fields/radio/radio_field.js
+++ b/addons/web/static/src/views/fields/radio/radio_field.js
@@ -47,13 +47,12 @@ export class RadioField extends Component {
         }
     }
     get value() {
+        const value = this.props.record.data[this.props.name];
         switch (this.type) {
             case "selection":
-                return this.props.record.data[this.props.name];
+                return value;
             case "many2one":
-                return Array.isArray(this.props.record.data[this.props.name])
-                    ? this.props.record.data[this.props.name][0]
-                    : this.props.record.data[this.props.name];
+                return value && value.id;
             default:
                 return null;
         }
@@ -68,7 +67,9 @@ export class RadioField extends Component {
                 this.props.record.update({ [this.props.name]: value[0] });
                 break;
             case "many2one":
-                this.props.record.update({ [this.props.name]: value });
+                this.props.record.update({
+                    [this.props.name]: value && { id: value[0], display_name: value[1] },
+                });
                 break;
         }
     }

--- a/addons/web/static/src/views/fields/reference/reference_field.js
+++ b/addons/web/static/src/views/fields/reference/reference_field.js
@@ -61,12 +61,12 @@ export class ReferenceField extends Component {
         } else if (this.props.modelField) {
             /** Fetch the technical name of the co model */
             useRecordObserver(async (record, props) => {
-                if (this.currentModelId !== record.data[props.modelField]?.[0]) {
+                if (this.currentModelId !== record.data[props.modelField]?.id) {
                     this.state.modelName = await this._fetchModelTechnicalName(props);
                     if (this.currentModelId !== undefined) {
                         record.update({ [props.name]: false });
                     }
-                    this.currentModelId = record.data[props.modelField]?.[0];
+                    this.currentModelId = record.data[props.modelField]?.id;
                 }
             });
         }
@@ -77,7 +77,7 @@ export class ReferenceField extends Component {
         return {
             ...computeM2OProps(this.props),
             relation: this.getRelation(),
-            value: value && [value.resId, value.displayName],
+            value: value && { id: value.resId, display_name: value.displayName },
             update: this.updateM2O.bind(this),
         };
     }
@@ -134,8 +134,8 @@ export class ReferenceField extends Component {
         this.props.record.update({
             [this.props.name]: value && {
                 resModel,
-                resId: value[0],
-                displayName: value[1],
+                resId: value.id,
+                displayName: value.display_name,
             },
         });
     }
@@ -197,7 +197,7 @@ export class ReferenceField extends Component {
     async _fetchModelTechnicalName(props) {
         this._assertMany2OneToIrModel(props);
         const record = props.record;
-        const modelId = record.data[props.modelField]?.[0];
+        const modelId = record.data[props.modelField]?.id;
         if (!modelId) {
             return false;
         }

--- a/addons/web/static/src/views/fields/selection/selection_field.js
+++ b/addons/web/static/src/views/fields/selection/selection_field.js
@@ -45,7 +45,7 @@ export class SelectionField extends Component {
         switch (this.type) {
             case "many2one":
                 return this.props.record.data[this.props.name]
-                    ? this.props.record.data[this.props.name][1]
+                    ? this.props.record.data[this.props.name].display_name
                     : "";
             case "selection":
                 return this.props.record.data[this.props.name] !== false
@@ -57,7 +57,7 @@ export class SelectionField extends Component {
     }
     get value() {
         const rawValue = this.props.record.data[this.props.name];
-        return this.type === "many2one" && rawValue ? rawValue[0] : rawValue;
+        return this.type === "many2one" && rawValue ? rawValue.id : rawValue;
     }
 
     stringify(value) {
@@ -77,9 +77,10 @@ export class SelectionField extends Component {
                         { save: this.props.autosave }
                     );
                 } else {
+                    const option = this.options.find((option) => option[0] === value);
                     this.props.record.update(
                         {
-                            [this.props.name]: this.options.find((option) => option[0] === value),
+                            [this.props.name]: { id: option[0], display_name: option[1] },
                         },
                         { save: this.props.autosave }
                     );

--- a/addons/web/static/src/views/fields/signature/signature_field.js
+++ b/addons/web/static/src/views/fields/signature/signature_field.js
@@ -97,7 +97,7 @@ export class SignatureField extends Component {
                 const fullNameData = record.data[fullName];
                 if (record.fields[fullName].type === "many2one") {
                     // If m2o is empty, it will have falsy value in recordData
-                    signName = fullNameData && fullNameData[1];
+                    signName = fullNameData && fullNameData.display_name;
                 } else {
                     signName = fullNameData;
                 }

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -102,7 +102,7 @@ export class StatusBarField extends Component {
                 const value = record.data[fieldName];
                 let domain = getFieldDomain(record, fieldName, props.domain);
                 if (domain.length && value) {
-                    domain = Domain.or([[["id", "=", value[0]]], domain]).toList(
+                    domain = Domain.or([[["id", "=", value.id]], domain]).toList(
                         record.evalContext
                     );
                 }
@@ -250,7 +250,7 @@ export class StatusBarField extends Component {
                 value: option.id,
                 label: option.display_name,
                 isFolded: option[foldField],
-                isSelected: Boolean(currentValue && option.id === currentValue[0]),
+                isSelected: Boolean(currentValue && option.id === currentValue.id),
             }));
         } else {
             // Selection
@@ -305,7 +305,7 @@ export class StatusBarField extends Component {
      */
     async selectItem(item) {
         const { name, record } = this.props;
-        const value = this.field.type === "many2one" ? [item.value, item.label] : item.value;
+        const value = this.field.type === "many2one" ? { id: item.value, display_name: item.label } : item.value;
         await record.update({ [name]: value });
         await record.save();
     }

--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.js
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.js
@@ -15,10 +15,10 @@ export class KanbanCoverImageDialog extends Component {
         this.orm = useService("orm");
         this.http = useService("http");
         const { record, fieldName } = this.props;
-        const attachment = (record && record.data[fieldName]) || [];
+        const attachment = record.data[fieldName];
         this.state = useState({
             selectFile: false,
-            selectedAttachmentId: attachment[0],
+            selectedAttachmentId: attachment?.id || false,
         });
         onWillStart(async () => {
             this.attachments = await this.orm.searchRead(
@@ -63,8 +63,8 @@ export class KanbanCoverImageDialog extends Component {
     }
 
     async setCover() {
-        const id = this.state.selectedAttachmentId ? [this.state.selectedAttachmentId] : false;
-        await this.props.record.update({ [this.props.fieldName]: id }, { save: true });
+        const value = this.state.selectedAttachmentId ? { id: this.state.selectedAttachmentId } : false;
+        await this.props.record.update({ [this.props.fieldName]: value }, { save: true });
         this.props.close();
     }
 

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -61,7 +61,7 @@ export function getRawValue(record, fieldName) {
             return value.count ? value.currentIds : [];
         }
         case "many2one": {
-            return (value && value[0]) || false;
+            return (value && value.id) || false;
         }
         case "date":
         case "datetime": {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -656,10 +656,10 @@ export class ListRenderer extends Component {
                     };
                     continue;
                 }
-                currencyId = values[0][currencyField] && values[0][currencyField][0];
+                currencyId = values[0][currencyField] && values[0][currencyField].id;
                 if (currencyId && func) {
                     const sameCurrency = values.every(
-                        (value) => currencyId === value[currencyField][0]
+                        (value) => currencyId === value[currencyField].id
                     );
                     if (!sameCurrency) {
                         aggregates[fieldName] = {

--- a/addons/web/static/src/views/widgets/signature/signature.js
+++ b/addons/web/static/src/views/widgets/signature/signature.js
@@ -33,7 +33,7 @@ export class SignatureWidget extends Component {
             let signName;
             const fullNameData = record.data[fullName];
             if (record.fields[fullName].type === "many2one") {
-                signName = fullNameData && fullNameData[1];
+                signName = fullNameData && fullNameData.display_name;
             } else {
                 signName = fullNameData;
             }

--- a/addons/web/static/src/webclient/settings_form_view/fields/settings_binary_field/settings_binary_field.js
+++ b/addons/web/static/src/webclient/settings_form_view/fields/settings_binary_field/settings_binary_field.js
@@ -6,11 +6,12 @@ export class SettingsBinaryField extends BinaryField {
 
     getDownloadData() {
         const related = this.props.record.fields[this.props.name].related;
+        const [fieldName, relatedFieldName] = related.split(".");
         return {
             ...super.getDownloadData(),
-            model: this.props.record.fields[related.split(".")[0]].relation,
-            field: related.split(".")[1] ?? related.split(".")[0],
-            id: this.props.record.data[related.split(".")[0]][0],
+            model: this.props.record.fields[fieldName].relation,
+            field: relatedFieldName ?? fieldName,
+            id: this.props.record.data[fieldName].id,
         }
     }
 

--- a/addons/web/static/tests/model/record.test.js
+++ b/addons/web/static/tests/model/record.test.js
@@ -344,9 +344,9 @@ test(`handles many2one fields: value is an object`, async () => {
         onRecordChanged(record, changes) {
             expect.step("record changed");
             expect(changes).toEqual({ foo: 3 });
-            // data is an array with properties defined on it
-            // Object.assign([id, name], { id, name, ... })
-            expect(record.data).toEqual({ foo: [3, "abc"] });
+            expect(record.data).toEqual({ foo: { id: 3, display_name: "abc" } });
+            expect(record.data.foo.id).toBe(3);
+            expect(record.data.foo.display_name).toBe("abc");
         }
     }
 
@@ -394,7 +394,7 @@ test(`handles many2one fields: value is a pair id, display_name`, async () => {
                 },
             };
             this.values = {
-                foo: [1, "bar1"],
+                foo: { id: 1, display_name: "bar1" },
             };
             this.hooks = {
                 onRecordChanged: this.onRecordChanged.bind(this),
@@ -404,7 +404,9 @@ test(`handles many2one fields: value is a pair id, display_name`, async () => {
         onRecordChanged(record, changes) {
             expect.step("record changed");
             expect(changes).toEqual({ foo: 3 });
-            expect(record.data).toEqual({ foo: [3, "abc"] });
+            expect(record.data).toEqual({ foo: { id: 3, display_name: "abc" } });
+            expect(record.data.foo.id).toBe(3);
+            expect(record.data.foo.display_name).toBe("abc");
         }
     }
 
@@ -462,7 +464,7 @@ test(`handles many2one fields: value is an id`, async () => {
     expect(`.o_field_many2one_selection input`).toHaveValue("bar1");
 });
 
-test(`handles many2one fields: value is an array with id only`, async () => {
+test(`handles many2one fields: value is an object with id only`, async () => {
     class Bar extends models.Model {
         name = fields.Char();
 
@@ -491,7 +493,7 @@ test(`handles many2one fields: value is an array with id only`, async () => {
                 },
             };
             this.values = {
-                foo: [1],
+                foo: { id: 1 },
             };
         }
     }

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -96,6 +96,10 @@ test("formatMany2one", () => {
     expect(formatMany2one([1, false])).toBe("Unnamed");
     expect(formatMany2one([1, "M2O value"])).toBe("M2O value");
     expect(formatMany2one([1, "M2O value"], { escape: true })).toBe("M2O%20value");
+    expect(formatMany2one({ id: false, display_name: "M2O value" })).toBe("M2O value");
+    expect(formatMany2one({ id: 1, display_name: false })).toBe("Unnamed");
+    expect(formatMany2one({ id: 1, display_name: "M2O value" })).toBe("M2O value");
+    expect(formatMany2one({ id: 1, display_name: "M2O value" }, { escape: true })).toBe("M2O%20value");
 });
 
 test("formatText", () => {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -16689,7 +16689,7 @@ test(`Properties: many2one`, async () => {
 
     onRpc("web_save", ({ args }) => {
         expect.step("web_save");
-        expect(args[1].properties[0].value[0]).toEqual(2);
+        expect(args[1].properties[0].value[0]).toBe(2);
     });
 
     await mountView({


### PR DESCRIPTION
Currently, in the RelationalModel, the value of a many2one is represented by an Array [id, display_name].
In the PR [1], we already introduced a change on their value. The value is still an Array but properties are set on it too. This allows to add relatedFields on many2ones.
With this commit, we fully replace the array value by an object thus properties 0 and 1 are not available anymore.
Calling an orm method like read or search_read still gives the array representation, the change is done only by using RelationalModel (in form view, list, kanban, fields, etc.).

[1]: https://github.com/odoo/odoo/pull/202534

task-3547961
task-4658840