### PR TITLE
[IMP] account, l10n_be: professional% column, private part account

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5136,6 +5136,10 @@ class AccountMove(models.Model):
             'posted_before': True,
         })
 
+        if not self.env.user.has_group('account.group_partial_purchase_deductibility') and \
+                self.filtered(lambda move: move.move_type == 'in_invoice' and move.invoice_line_ids.filtered(lambda l: l.deductible_amount != 100)):
+            self.env.user.sudo().group_ids = [Command.link(self.env.ref('account.group_partial_purchase_deductibility').id)]
+
         # Add the move number to the non_deductible lines for easier auditing
         if non_deductible_lines := self.line_ids.filtered(lambda line: (line.display_type in ('non_deductible_product_total', 'non_deductible_tax'))):
             for line in non_deductible_lines:

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -87,6 +87,10 @@
         <field name="name">Allow the cash rounding management</field>
     </record>
 
+    <record id="group_partial_purchase_deductibility" model="res.groups">
+        <field name="name">Partial Purchase Deductibility</field>
+    </record>
+
     <!-- Add a new setting that can be enabled to allow the user to "trust" a partner bank account -->
     <record model="res.groups.privilege" id="res_group_privilege_accounting_bank">
         <field name="name">Bank</field>

--- a/addons/account/static/tests/tours/deductible_amount_column.js
+++ b/addons/account/static/tests/tours/deductible_amount_column.js
@@ -1,0 +1,23 @@
+import { registry } from '@web/core/registry';
+import { stepUtils } from "@web_tour/tour_utils";
+
+registry.category("web_tour.tours").add("deductible_amount_column", {
+    url: "/odoo/vendor-bills/new",
+    steps: () => [
+    {
+        content: "Add item",
+        trigger: "div[name='invoice_line_ids'] .o_field_x2many_list_row_add a:contains('Add a line')",
+        run: "click",
+    },
+    {
+        content: "Edit name",
+        trigger: ".o_field_widget[name='name'] .o_input",
+        run: "edit Laptop"
+    },
+    {
+        content: "Edit deductible amount",
+        trigger: ".o_field_widget[name='deductible_amount'] > .o_input",
+        run: "edit 80"
+    },
+    ...stepUtils.saveForm(),
+]})

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -95,3 +95,15 @@ class TestUi(AccountTestInvoicingHttpCommon):
             'default_code': '0',
         })
         self.start_tour("/odoo/customer-invoices/new", 'test_use_product_catalog_on_invoice', login="admin")
+
+    def test_deductible_amount_column(self):
+        self.assertFalse(self.env.user.has_group('account.group_partial_purchase_deductibility'))
+        partner = self.env['res.partner'].create({'name': "Test Partner", 'email': "test@test.odoo.com"})
+        move = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': partner.id,
+            'line_ids': [Command.create({'name': "T-shirt", 'deductible_amount': 50.0})],
+        })
+        move.action_post()
+        self.assertTrue(self.env.user.has_group('account.group_partial_purchase_deductibility'))
+        self.start_tour("/odoo/vendor-bills/new", 'deductible_amount_column', login=self.env.user.login)

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1206,9 +1206,15 @@
                                                options="{'no_create': True}"
                                                optional="show"/>
                                         <field name="deductible_amount"
-                                               column_invisible="parent.move_type not in ['in_invoice', 'in_refund']"
+                                               column_invisible="parent.move_type not in ('in_invoice', 'in_refund')"
                                                string="Professional %"
-                                               optional="hide"/>
+                                               optional="hide"
+                                               groups="!account.group_partial_purchase_deductibility"/>
+                                        <field name="deductible_amount"
+                                               column_invisible="parent.move_type not in ('in_invoice', 'in_refund')"
+                                               string="Professional %"
+                                               optional="show"
+                                               groups="account.group_partial_purchase_deductibility"/>
                                         <field name="price_subtotal"
                                                column_invisible="parent.move_type not in ['in_invoice', 'in_refund', 'in_receipt'] and parent.company_price_include == 'tax_included'"
                                                string="Amount"/>

--- a/addons/l10n_be/models/template_be.py
+++ b/addons/l10n_be/models/template_be.py
@@ -74,3 +74,10 @@ class AccountChartTemplate(models.AbstractModel):
         # as possible in case it's modified so it's missing and not replaced.
         be_account = self.with_company(company).ref('a6560', raise_if_not_found=False)
         return be_account or super()._get_bank_fees_reco_account(company)
+
+    def _post_load_data(self, template_code, company, template_data):
+        super()._post_load_data(template_code, company, template_data)
+        if template_code in ('be_comp', 'be_asso') and \
+                (purchase_journal := self.ref('purchase', raise_if_not_found=False)) and \
+                (non_deductible_account := self.ref('a416', raise_if_not_found=False)):
+            purchase_journal.non_deductible_account_id = non_deductible_account


### PR DESCRIPTION
- account: When a Vendor Bill is posted with any line having `deductible_amount` other
  than 100(default value), add a group `group_partial_purchase_deductibility`
  which will make the field from optional='hide' to optional='show' so that in
  enterprise when `deductible_amount` is predicted it is visible to user.

- l10n_be: For Purchase Journal add a default value in Private Part Account(non_deductible_account_id): '416000 Sundry Amounts Receivable'.

Enterprise PR: https://github.com/odoo/enterprise/pull/83207

task-4661380