### PR TITLE
[FIX] discuss: raise the default log level of `peer_to_peer` to `ERROR`

### DIFF
--- a/addons/mail/static/src/discuss/call/common/peer_to_peer.js
+++ b/addons/mail/static/src/discuss/call/common/peer_to_peer.js
@@ -245,7 +245,7 @@ export class PeerToPeer extends EventTarget {
      */
     constructor({
         notificationRoute = DEFAULT_NOTIFICATION_ROUTE,
-        logLevel = LOG_LEVEL.WARN,
+        logLevel = LOG_LEVEL.ERROR,
         batchDelay = DEFAULT_BUS_BATCH_DELAY,
         antiGlare = true,
         enableStreaming = true,


### PR DESCRIPTION
Before this commit, the default log level of `peer_to_peer` was set to `WARN` which includes:

- recovery candidates: recoveries can be triggered for various non critical reasons as recovery is initiated eagerly but will only realize if necessary (in which case it is logged at `ERROR` level).

- reception of bus events for peers that aren't registered: can happen in race conditions that are already handled.

- offer collision rollback: offer collisions can happen during recovery and fallbacks, and are already handled.

This commit raises the default log level from `WARN` to `ERROR` which will prevent the aforementioned situations to be logged by default (outside of the `debug` mode) and fill the logging database.

