### PR TITLE
[IMP] web: restart interactions on t-out

### DIFF
--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -157,7 +157,18 @@ export class Colibri {
             }
         }
         if (Markup && value instanceof Markup) {
+            let nodes = el === this.interaction.el ? el.children : [el];
+            for (const node of nodes) {
+                this.core.env.services["public.interactions"].stopInteractions(node);
+            }
             el.innerHTML = value;
+            if (el === this.interaction.el) {
+                nodes = el.children;
+            }
+            for (const node of nodes) {
+                this.core.env.services["public.interactions"].startInteractions(node);
+            }
+            this.refreshListeners();
         } else {
             el.textContent = value;
         }


### PR DESCRIPTION
Since the introduction of Interactions, if a `t-out` used markup and contained elements tied to other interactions, you would need to restart them manually.
This commit ensures that, when `t-out` is called with markup, it now restarts its inner interactions.
After the innerHTML has been replaced, we also call `refreshListeners`.

Note: we avoid stopping the current interaction if `t-out` is applied on the `_root` element. In that case, we restart each child. Otherwise, we restart the element on which t-out is attached directly.