### PR TITLE
[FIX] sale: fix computation of `qty_to_invoice` on combo line

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -947,12 +947,12 @@ class SaleOrderLine(models.Model):
         For combo product lines, first compute all other lines, and then set quantity to invoice
         only if at least one of its combo item lines is invoiceable.
         """
-        combo_lines = []
+        combo_lines = set()
         for line in self:
             if line.state == 'sale' and not line.display_type:
-                if line.product_id.type == 'combo':
-                    combo_lines.append(line)
-                elif line.product_id.invoice_policy == 'order':
+                if line.linked_line_id:
+                    combo_lines.add(line.linked_line_id)
+                if line.product_id.invoice_policy == 'order':
                     line.qty_to_invoice = line.product_uom_qty - line.qty_invoiced
                 else:
                     line.qty_to_invoice = line.qty_delivered - line.qty_invoiced


### PR DESCRIPTION
Steps:
- Create a combo product with all the product in choices should have invoice policy `delivery`.
- Create SO with that product.
- Confirm SO and validate delivery.
- Create invoice.

Issue:
- Combo line is not showing in invoice.

Cause:
- When validating delivery of line compute of `qty_to_invoice` only call for other lines not combo lines because we are not changing `qty_delivered` on combo line.

Fix:
- Add combo lines related to other lines in `combo_lines` variable instead of just checking combo lines in `self` as we do not compute other fields(qty_delivered, qty_invoiced) for combo line

orignal PR: https://github.com/odoo/odoo/pull/203131

opw-4640087
