### PR TITLE
[IMP] website_sale_stock: use `default_` prefix for settings and minor UX fixes

### DIFF
--- a/addons/website_sale_stock/models/res_config_settings.py
+++ b/addons/website_sale_stock/models/res_config_settings.py
@@ -1,43 +1,30 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api
+from odoo import fields, models
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    allow_out_of_stock_order = fields.Boolean(
-        string='Continue selling when out-of-stock',
-        default=True)
-    available_threshold = fields.Float(
-        string='Show Threshold',
-        default=5.0)
-    show_availability = fields.Boolean(
-        string='Show availability Qty',
-        default=False)
+    default_allow_out_of_stock_order = fields.Boolean(
+        string="Continue selling when out-of-stock",
+        default=True,
+        default_model='product.template',
+    )
+    default_available_threshold = fields.Float(
+        string="Show Threshold",
+        default=5.0,
+        default_model='product.template',
+    )
+    default_show_availability = fields.Boolean(
+        string="Show availability Qty",
+        default=False,
+        default_model='product.template',
+    )
     website_warehouse_id = fields.Many2one(
         'stock.warehouse',
         related='website_id.warehouse_id',
         domain="[('company_id', '=', website_company_id)]",
-        readonly=False)
-
-    def set_values(self):
-        super(ResConfigSettings, self).set_values()
-        IrDefault = self.env['ir.default'].sudo()
-
-        IrDefault.set('product.template', 'allow_out_of_stock_order', self.allow_out_of_stock_order)
-        IrDefault.set('product.template', 'available_threshold', self.available_threshold)
-        IrDefault.set('product.template', 'show_availability', self.show_availability)
-
-    @api.model
-    def get_values(self):
-        res = super(ResConfigSettings, self).get_values()
-        IrDefaultGet = self.env['ir.default'].sudo()._get
-        allow_out_of_stock_order = IrDefaultGet('product.template', 'allow_out_of_stock_order')
-
-        res.update(
-            allow_out_of_stock_order=allow_out_of_stock_order if allow_out_of_stock_order is not None else True,
-            available_threshold=IrDefaultGet('product.template', 'available_threshold') or 5.0,
-            show_availability=IrDefaultGet('product.template', 'show_availability') or False)
-        return res
+        readonly=False,
+    )

--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -55,7 +55,7 @@
                 t-attf-class="availability_message_#{product_template} badge text-bg-warning"
             >
                 <i class="fa fa-circle text-warning me-2" role="presentation"/>
-                <t t-esc="formatQuantity(free_qty)"/> <t t-esc="uom_name" /> left in stock
+                <t t-esc="formatQuantity(free_qty)"/> <t t-esc="uom_name" /> in stock
                 <span
                     id="already_in_cart_message"
                     t-if="!allow_out_of_stock_order and show_availability and cart_qty"

--- a/addons/website_sale_stock/views/product_template_views.xml
+++ b/addons/website_sale_stock/views/product_template_views.xml
@@ -16,9 +16,12 @@
                 <div invisible="not is_storable">
                     <field name="show_availability" class="oe_inline" />
                     <span invisible="not show_availability">
-                        <label for="available_threshold" string="only if below" class="o_light_label"/>
+                        <label
+                            for="available_threshold"
+                            string="only if below"
+                            class="o_light_label me-1"
+                        />
                         <field name="available_threshold" class="oe_inline col-1" digits="[42, 0]"/>
-                        Units
                     </span>
                 </div>
                 <field name="out_of_stock_message" invisible="not is_storable"/>

--- a/addons/website_sale_stock/views/res_config_settings_views.xml
+++ b/addons/website_sale_stock/views/res_config_settings_views.xml
@@ -21,9 +21,9 @@
                                 id="allow_out_of_stock_order_setting"
                                 title="Default availability mode set on newly created storable products. This can be changed at the product level.">
                                 <div class="col-12">
-                                    <label for="allow_out_of_stock_order" string="Out-of-Stock" class="p-0 col-4 o_light_label"/>
-                                    <field name="allow_out_of_stock_order" class=" w-auto"/>
-                                    <label for="allow_out_of_stock_order" class="o_light_label" string="Continue Selling"/>
+                                    <label for="default_allow_out_of_stock_order" string="Out-of-Stock" class="p-0 col-4 o_light_label"/>
+                                    <field name="default_allow_out_of_stock_order" class=" w-auto"/>
+                                    <label for="default_allow_out_of_stock_order" class="o_light_label" string="Continue Selling"/>
                                 </div>
                             </div>
                         </div>
@@ -32,11 +32,15 @@
                                 id="show_availability_setting"
                                 title="Default visibility for custom messages.">
                                 <div class="col-12">
-                                    <label for="show_availability" string="Show Available Qty" class="p-0 col-4 o_light_label mb-3 mt-2"/>
-                                    <field name="show_availability" class="w-auto"/>
-                                    <label for="available_threshold" string="only if below" class="o_light_label" invisible="not show_availability"/>
-                                    <field name="available_threshold" class="oe_inline col-1" digits="[42, 0]" invisible="not show_availability"/>
-                                    <span invisible="not show_availability">Units</span>
+                                    <label for="default_show_availability" string="Show Available Qty" class="p-0 col-4 o_light_label mt-2"/>
+                                    <field name="default_show_availability" class="w-auto"/>
+                                    <label for="default_available_threshold" string="only if below" class="o_light_label" invisible="not default_show_availability"/>
+                                    <field
+                                        name="default_available_threshold"
+                                        class="w-25"
+                                        digits="[42, 0]"
+                                        invisible="not default_show_availability"
+                                    />
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
- Updated the settings to use the `default_` prefix so values are stored and
  fetched directly from the `default_model`.
- Also made some small UX improvements, such as fixing spacing and changing
  default out-of-stock messages.

See also: https://github.com/odoo/upgrade/pull/8053

Task-4713082