### PR TITLE
[FIX] account_edi_ubl_cii: do not set default tax for import

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -750,7 +750,7 @@ class AccountEdiCommon(models.AbstractModel):
 
         invoice_line_form.price_unit = inv_line_vals['price_unit']
         invoice_line_form.discount = inv_line_vals['discount']
-        invoice_line_form.tax_ids = inv_line_vals['taxes']
+        invoice_line_form.tax_ids = inv_line_vals['taxes'] or False
         return logs
 
     def _correct_invoice_tax_amount(self, tree, invoice):

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_without_tax.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_without_tax.xml
@@ -1,0 +1,115 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>FAC/2023/00052</cbc:ID>
+  <cbc:IssueDate>2023-08-04</cbc:IssueDate>
+  <cbc:DueDate>2023-09-04</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>FAC/2023/00052</cbc:ID>
+    <cbc:SalesOrderID>S00012</cbc:SalesOrderID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>FAC_2023_00052.pdf</cbc:ID>
+    <cac:Attachment>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9938">LU25587702</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>ALD Automotive LU</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>270 rte d'Arlon</cbc:StreetName>
+        <cbc:CityName>Strassen</cbc:CityName>
+        <cbc:PostalZone>8010</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>LU12977109</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>ALD Automotive LU</cbc:RegistrationName>
+        <cbc:CompanyID>LU12977109</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>ALD Automotive LU</cbc:Name>
+        <cbc:ElectronicMail>adl@test.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9938">LU25587702</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Odoo Lu</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Rue de l'industrie 13</cbc:StreetName>
+        <cbc:CityName>Windhof</cbc:CityName>
+        <cac:Country>
+          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>LU25587702</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Odoo Lu</cbc:RegistrationName>
+        <cbc:CompanyID>LU25587702</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Odoo Lu</cbc:Name>
+        <cbc:ElectronicMail>odoo@test.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Rue de l'industrie 13</cbc:StreetName>
+        <cbc:CityName>Windhof</cbc:CityName>
+        <cac:Country>
+          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentID>FAC/2023/00052</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>LU071241358706500000</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">100.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">100.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>Locations et leasing opérationnel - Véhicule HG6542</cbc:Description>
+      <cbc:Name>Locations et leasing opérationnel</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">100.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -162,3 +162,29 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             'city': 'Strassen',
             'zip': '8010',
         }])
+
+    def test_import_bill_without_tax(self):
+        """ Test that no tax is set (even the default one) when importing a bill without tax."""
+        file_path = "bis3_bill_without_tax.xml"
+        file_path = f"{self.test_module}/tests/test_files/{file_path}"
+        with file_open(file_path, 'rb') as file:
+            xml_attachment = self.env['ir.attachment'].create({
+                'mimetype': 'application/xml',
+                'name': 'test_invoice.xml',
+                'raw': file.read(),
+            })
+        purchase_tax = self.env['account.tax'].create({
+            'type_tax_use': 'purchase',
+            'name': 'purchase_tax_10',
+            'amount': 10,
+        })
+        self.company_data['company'].account_purchase_tax_id = purchase_tax
+        bill = self.env['account.journal']\
+                .with_context(default_journal_id=self.company_data['default_journal_purchase'].id)\
+                ._create_document_from_attachment(xml_attachment.id)
+
+        self.assertRecordValues(bill.invoice_line_ids, [{
+            'amount_currency': 100.00,
+            'quantity': 1.0,
+            'tax_ids': self.env['account.tax'],
+        }])


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Go to "Accounting / Vendors / Bills"
- Upload a PDF having an embedded factur-x XML with no tax or a tax that doesn't exist in the database

**Issue:**
The bill generated from the embedded XML has the default purchase tax set on it.

**Cause:**
At the beginning of the process, an empty account move is created and then it is populated with the data retrieved from the XML.
At the creation of the account move, the default tax is set. When the taxes are populated, if there is no tax or if it doesn't exist, "tax_ids" fields of the account move line is set to the empty list (i.e. []).
However, if "tax_ids" has already a value (e.g. the default tax), setting it to `[]` will not remove it, unlike `False`.

opw-4600822



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
