### PR TITLE
[FIX] sale: update combo product qty_to_invoice on item delivery

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -944,18 +944,20 @@ class SaleOrderLine(models.Model):
         """
         Compute the quantity to invoice. If the invoice policy is order, the quantity to invoice is
         calculated from the ordered quantity. Otherwise, the quantity delivered is used.
-        For combo product lines, first compute all other lines, and then set quantity to invoice
-        only if at least one of its combo item lines is invoiceable.
+        For combo product lines, compute the value if a linked combo item line gets recomputed,
+        and set `qty_to_invoice` only if at least one of its combo item lines is invoiceable.
         """
-        combo_lines = []
+        combo_lines = set()
         for line in self:
             if line.state == 'sale' and not line.display_type:
                 if line.product_id.type == 'combo':
-                    combo_lines.append(line)
+                    combo_lines.add(line)
                 elif line.product_id.invoice_policy == 'order':
                     line.qty_to_invoice = line.product_uom_qty - line.qty_invoiced
                 else:
                     line.qty_to_invoice = line.qty_delivered - line.qty_invoiced
+                if line.combo_item_id and line.linked_line_id:
+                    combo_lines.add(line.linked_line_id)
             else:
                 line.qty_to_invoice = 0
         for combo_line in combo_lines:


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a combo product with only items that are invoiced on delivery;
2. add it to a sale order;
3. validate the delivery;
4. create & confirm an invoice.

Issue
-----
The sale order is still invoicable.

Cause
-----
The `qty_to_invoice` field for the combo item line isn't being updated when its linked lines were delivered.

Solution
--------
Add `linked_line_ids.qty_delivered` to the `api.depends` of the compute method.

opw-4633972