### PR TITLE
[IMP] auth_totp: add trusted device age setting

### DIFF
--- a/addons/auth_totp/controllers/home.py
+++ b/addons/auth_totp/controllers/home.py
@@ -9,7 +9,7 @@ from odoo.http import request
 from odoo.addons.web.controllers import home as web_home
 
 TRUSTED_DEVICE_COOKIE = 'td_id'
-TRUSTED_DEVICE_AGE = 90*86400 # 90 days expiration
+TRUSTED_DEVICE_AGE_DAYS = 90
 
 
 class Home(web_home.Home):
@@ -66,15 +66,16 @@ class Home(web_home.Home):
                     if request.geoip.city.name:
                         name += f" ({request.geoip.city.name}, {request.geoip.country_name})"
 
+                    trusted_device_age = request.env['auth_totp.device']._get_trusted_device_age()
                     key = request.env['auth_totp.device'].sudo()._generate(
                         "browser",
                         name,
-                        datetime.now() + timedelta(seconds=TRUSTED_DEVICE_AGE)
+                        datetime.now() + timedelta(seconds=trusted_device_age)
                     )
                     response.set_cookie(
                         key=TRUSTED_DEVICE_COOKIE,
                         value=key,
-                        max_age=TRUSTED_DEVICE_AGE,
+                        max_age=trusted_device_age,
                         httponly=True,
                         samesite='Lax'
                     )

--- a/addons/auth_totp/models/auth_totp.py
+++ b/addons/auth_totp/models/auth_totp.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo import models
+from odoo.addons.auth_totp.controllers.home import TRUSTED_DEVICE_AGE_DAYS
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -20,3 +21,18 @@ class Auth_TotpDevice(models.Model):
         """Return True if device key matches given `scope` for user ID `uid`"""
         assert uid, "uid is required"
         return self._check_credentials(scope=scope, key=key) == uid
+
+    def _get_trusted_device_age(self):
+        ICP = self.env['ir.config_parameter'].sudo()
+        try:
+            nbr_days = int(ICP.get_param('auth_totp.trusted_device_age', TRUSTED_DEVICE_AGE_DAYS))
+            if nbr_days <= 0:
+                nbr_days = None
+        except ValueError:
+            nbr_days = None
+
+        if nbr_days is None:
+            _logger.warning("Invalid value for 'auth_totp.trusted_device_age', using default value.")
+            nbr_days = TRUSTED_DEVICE_AGE_DAYS
+
+        return nbr_days * 86400  # seconds

--- a/addons/auth_totp_mail/tests/test_notify_security_update_totp.py
+++ b/addons/auth_totp_mail/tests/test_notify_security_update_totp.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime, timedelta
 
-from odoo.addons.auth_totp.controllers.home import TRUSTED_DEVICE_AGE
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests import tagged, users
 
@@ -34,11 +33,12 @@ class TestNotifySecurityUpdateTotp(MailCommon):
     def test_security_update_trusted_device_added_removed(self):
         """ Make sure we notify the user when TOTP trusted devices are removed on his account. """
         recipients = [self.env.user.email_formatted]
+        trusted_device_age = self.env['auth_totp.device']._get_trusted_device_age()
         with self.mock_mail_gateway():
             self.env['auth_totp.device'].sudo()._generate(
                 'trusted_device_chrome',
                 'Chrome on Windows',
-                datetime.now() + timedelta(seconds=TRUSTED_DEVICE_AGE)
+                datetime.now() + timedelta(seconds=trusted_device_age)
             )
 
         self.assertNotSentEmail(recipients)


### PR DESCRIPTION
Currently, when we trust a device, we trust it for 90 days. This value is not configurable.

To meet more specific needs, we introduce an `ir.config.parameter` named `auth_totp.trusted_device_age` which lets us define the number of days a device will be trusted.

task-4143609