### PR TITLE
[FIX] l10n_ch: remove unnecessary invisible fields

### DIFF
--- a/addons/l10n_ch/views/qr_invoice_wizard_view.xml
+++ b/addons/l10n_ch/views/qr_invoice_wizard_view.xml
@@ -5,8 +5,8 @@
         <field name="model">l10n_ch.qr_invoice.wizard</field>
         <field name="arch" type="xml">
             <form string="QR printing encountered a problem">
-                <field name='nb_qr_inv' invisible="1"/>
-                <field name="nb_classic_inv" invisible="1"/>
+                <field name='nb_qr_inv' invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="nb_classic_inv" invisible="1"/> <!-- TODO: to be removed in master -->
                 <p>
                     <field name="qr_inv_text"/>
                     <field name="classic_inv_text"/>

--- a/addons/l10n_ch/views/res_bank_view.xml
+++ b/addons/l10n_ch/views/res_bank_view.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='acc_number']" position="after">
                     <field name="l10n_ch_qr_iban" invisible="not l10n_ch_display_qr_bank_options"/>
-                    <field name="l10n_ch_display_qr_bank_options" invisible="1"/>
+                    <field name="l10n_ch_display_qr_bank_options" invisible="1"/> <!-- TODO: to be removed in master -->
                 </xpath>
             </field>
         </record>

--- a/addons/l10n_ch/views/setup_wizard_views.xml
+++ b/addons/l10n_ch/views/setup_wizard_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.setup_bank_account_wizard"/>
             <field name="arch" type="xml">
                 <field name="bank_bic" position="after">
-                    <field name="l10n_ch_display_qr_bank_options" invisible="1"/>
+                    <field name="l10n_ch_display_qr_bank_options" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_ch_qr_iban" invisible="not l10n_ch_display_qr_bank_options"/>
                 </field>
             </field>


### PR DESCRIPTION
Before this commit, several invisible fields were present in the views in `l10n_ch`, whereas after https://github.com/odoo/odoo/pull/162009 these fields need to be either justified or removed.

The needed fields are fetched automatically after https://github.com/odoo/odoo/pull/137031.

This commit adds a comment to each field so that the tests pass in stable versions, to avoid potential issues with inheritance in custom views.

We will removes the unnecessary invisible fields in master.

opw-4629332




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
