### PR TITLE
[FIX] mrp: avoid traceback when computing Qty Packaging for Kit with UoM

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -89,13 +89,14 @@ class StockMoveLine(models.Model):
         for move_line in kit_lines:
             move = move_line.move_id
             bom_line = move.bom_line_id
+            kit_bom = bom_line.bom_id
 
             # Convert the move line quantity to the product's move uom
             qty_move_uom = move_line.product_uom_id._compute_quantity(move_line.quantity, move_line.move_id.product_uom)
             # Convert the product's move uom to the bom line's uom
             qty_bom_uom = move.product_uom._compute_quantity(qty_move_uom, bom_line.product_uom_id)
             # calculate the bom's kit qty in kit product uom qty
-            bom_qty_product_uom = bom_line.bom_id.product_uom_id._compute_quantity(bom_line.bom_id.product_qty, move_line.move_id.bom_line_id.bom_id.product_id.uom_id)
+            bom_qty_product_uom = kit_bom.product_uom_id._compute_quantity(kit_bom.product_qty, kit_bom.product_tmpl_id.uom_id)
             # calculate the quantity needed of packging
             move_line.product_packaging_qty = (qty_bom_uom / (bom_line.product_qty / bom_qty_product_uom)) / move_line.move_id.product_packaging_id.qty
         super(StockMoveLine, self - kit_lines)._compute_product_packaging_qty()

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -677,8 +677,9 @@ class TestKitPicking(common.TestMrpCommon):
         - Packaging (qty=2 units of kit)
         """
         bom = self.bom_4
+        bom.product_id = False
         bom.type = 'phantom'
-        kit = bom.product_id
+        kit = bom.product_tmpl_id.product_variant_id
         kit.is_storable = True
         # product is in unit and bom in dozen
         kit.uom_id = self.uom_unit


### PR DESCRIPTION
When printing a delivery order with a kit product that has a BoM with a product template (not a product_id) and a packaging quantity, we encounter a traceback due to the conversion of the quantity from the product's UoM to the order line's UoM. This happens because the product's UoM is not defined.

Steps to reproduce the bug:
- Create a storage “P1”:
    - UoM: Kg

- Create a storable “Kit 1”:
    - UoM: unit
    - BoM:
       - set only the product template field (not the product_id)
        - 1 Kg of P1

- Create a delivery order for 1 unit of Kit 1
- Mark it as to do
- Set the quantity of P1 to 1kg
- try to print

Problem:
A traceback is triggered because we try to convert 1kg to an undefined uom

```
Error while render the template
UserError: The unit of measure Units defined on the order line doesn't
belong to the same category as the unit of measure False defined on
the product. Please correct the unit of measure defined on the order
line or on the product. They should belong to the same category.

```

opw-4619140


