### PR TITLE
[IMP] hr_timesheet_attendance: only take records in past or today

### DIFF
--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
@@ -44,6 +44,7 @@ class HrTimesheetAttendanceReport(models.Model):
                     hr_employee.company_id as company_id
                 FROM hr_attendance
                 LEFT JOIN hr_employee ON hr_employee.id = hr_attendance.employee_id
+                WHERE check_in::date <= CURRENT_DATE
             UNION ALL
                 SELECT
                     ts.id AS id,
@@ -56,6 +57,7 @@ class HrTimesheetAttendanceReport(models.Model):
                 FROM account_analytic_line AS ts
                 LEFT JOIN hr_employee ON hr_employee.id = ts.employee_id
                 WHERE ts.project_id IS NOT NULL
+                  AND date <= CURRENT_DATE
             ) AS t
             GROUP BY t.employee_id, t.date, t.company_id, t.emp_cost
             ORDER BY t.date


### PR DESCRIPTION
Before this commit, the `Timesheets / Attendance` report also take into account the timesheets created in the future (that is the one generated by time off) but the attendances are only created to record when the employee work on each day. That is, we will never have attendance in the future and so, it makes more sense to only take into account the records in the past or today inside that report.

task-4297336
