### PR TITLE
[FIX] hr_holidays: prevent unallocated time off creation via smart button

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -709,6 +709,14 @@ class HolidaysRequest(models.Model):
                 continue
             if holiday.employee_id:
                 leave_days = mapped_days[holiday.employee_id.id][holiday.holiday_status_id.id]
+                allocation_exists = self.env['hr.leave.allocation'].search_count([
+                    ('employee_id', '=', holiday.employee_id.id),
+                    ('holiday_status_id', '=', holiday.holiday_status_id.id),
+                    ('state', '=', 'validate')
+                ], limit=1)
+                if not allocation_exists:
+                    raise ValidationError(_('You do not have any allocation for this time off type.\n'
+                                            'Please request an allocation before submitting your time off request.'))
                 if float_compare(leave_days['remaining_leaves'], 0, precision_digits=2) == -1\
                         or float_compare(leave_days['virtual_remaining_leaves'], 0, precision_digits=2) == -1:
                     raise ValidationError(_('The number of remaining time off is not sufficient for this time off type.\n'

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -91,7 +91,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             'leave_validation_type': 'both',
             'responsible_id': self.user_hrmanager_id,
         })
-        self.env['hr.leave.allocation'].create({
+        allocation = self.env['hr.leave.allocation'].create({
             'employee_id': self.employee_emp_id,
             'name': '2 days allocation',
             'holiday_status_id': leave_type.id,
@@ -100,6 +100,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             'date_from': date(2024, 2, 1),
             'date_to': date(2024, 2, 29),
         })
+        allocation.action_validate()
         covered_leave_1 = self.env['hr.leave'].create({
             'name': 'Covered Leave',
             'employee_id': self.employee_emp_id,
@@ -198,7 +199,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             'leave_validation_type': 'both',
             'responsible_id': self.user_hrmanager_id,
         })
-        self.env['hr.leave.allocation'].create({
+        allocation = self.env['hr.leave.allocation'].create({
             'employee_id': self.employee_emp_id,
             'name': '5 days allocation',
             'holiday_status_id': leave_type.id,
@@ -207,6 +208,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             'date_from': date(2024, 12, 1),
             'date_to': date(2024, 12, 30),
         })
+        allocation.action_validate()
         partially_covered_leave = self.env['hr.leave'].create({
             'name': 'Covered Leave',
             'employee_id': self.employee_emp_id,


### PR DESCRIPTION
Steps:
- Navigate to Time Off > Configuration > Time Off Types.
- Open a time off type that requires allocation.
- Click on the 'Time Off' smart button and try to create a request.

Issues:
- Employees could create time off requests via the smart button even without an approved allocation.
- This bypassed the existing restriction enforced in the standard time off request creation flow.

Fix:
- Added validation in the `create` method to check for approved allocations, even when using the smart button.
- Raised a 'UserError' if no valid allocation exists.
- Added a test case to verify the restriction.
- Modified some related demo data according to changes.

Task - 4671236

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
