### PR TITLE
[FIX] account: allways compute sequence fields

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -329,6 +329,8 @@ class SequenceMixin(models.AbstractModel):
                 except (pgerrors.ExclusionViolation, pgerrors.UniqueViolation):
                     sp.rollback()
 
+        self._compute_split_sequence()
+
     def _get_next_sequence_format(self):
         """Get the next sequence format and its values.
 

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -30,6 +30,8 @@ class TestManual(common.TestAr):
         self._post(invoice)
         self.assertEqual(invoice.state, 'posted', 'invoice has not been validate in Odoo')
         self.assertEqual(invoice.name, 'FA-A %05d-00000001' % self.journal.l10n_ar_afip_pos_number, 'Invoice number is wrong')
+        self.assertEqual(invoice.sequence_prefix, 'FA-A %05d-' % self.journal.l10n_ar_afip_pos_number)
+        self.assertEqual(invoice.sequence_number, 1)
 
     def test_02_fiscal_position(self):
         # ADHOC SA > IVA Responsable Inscripto > Without Fiscal Positon


### PR DESCRIPTION
### Steps to reproduce:
*Happening in all LATAM localizations*
- Install 'l10n_pe' and switch to a Peruvian company
- In Accounting > Configuration > Journals duplicate "Customer Invoices"
- In the new journal tick the option "Secure Posted Entries with Hash"
- Create a new invoice with this journal, confirm
- Duplicate this invoice and try to confirm
- Cannot confirm

### Cause:
When confirming an invoice with LATAM localization, the fields "sequence_number" and "sequence_prefix" are no longer populated. These fields are necessary with the hash option.

During a previous series of commits, a call to `_compute_split_sequence` was removed:
- [1st commit](https://github.com/odoo/odoo/commit/10565c6968a5d0f285f93c4bdc610350999a88e3) 
- [2nd commit](https://github.com/odoo/odoo/commit/658542e17dfe421b83bf610564042c8b643b3b78) 
- [3rd commit](https://github.com/odoo/odoo/commit/7f08a7ebbcc8fc856f961d7ca6f001ce69e8771c) 

This for some reason does not compute the fields for invoices in LATAM.

### Solution:
Add the call to `_compute_split_sequence`.

opw-4685796