### PR TITLE
[FIX] Grant forecast report access to sales users

### DIFF
--- a/addons/purchase_stock/report/stock_forecasted.py
+++ b/addons/purchase_stock/report/stock_forecasted.py
@@ -14,7 +14,11 @@ class StockForecasted(models.AbstractModel):
         warehouse_id = self.env['stock.warehouse']._get_warehouse_id_from_context()
         if warehouse_id:
             domain += [('order_id.picking_type_id.warehouse_id', '=', warehouse_id)]
-        po_lines = self.env['purchase.order.line'].search(domain)
+            company = self.env['stock.warehouse'].browse(warehouse_id).company_id
+        else:
+            company = self.env.company
+        domain += [('company_id', '=', company.id)]
+        po_lines = self.env['purchase.order.line'].sudo().search(domain)
         in_sum = sum(po_lines.mapped('product_uom_qty'))
         res['draft_purchase_qty'] = in_sum
         res['draft_purchase_orders'] = po_lines.mapped("order_id").sorted(key=lambda po: po.name).read(fields=['id', 'name'])

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -34,7 +34,7 @@ class StockMove(models.Model):
 
     def _get_source_document(self):
         res = super()._get_source_document()
-        return self.sudo().sale_line_id.order_id or res
+        return self.sale_line_id.order_id or res
 
     def _get_sale_order_lines(self):
         """ Return all possible sale order lines for one stock move. """

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -126,6 +126,7 @@ class StockForecasted(models.AbstractModel):
         res.update(self._get_report_header(product_template_ids, product_ids, wh_location_ids))
 
         res['lines'] = self._get_report_lines(product_template_ids, product_ids, wh_location_ids, wh_stock_location)
+        res['user_can_edit_pickings'] = self.env.user.has_group('stock.group_stock_user')
         return res
 
     def _prepare_report_line(self, quantity, move_out=None, move_in=None, replenishment_filled=True, product=False, reserved_move=False, in_transit=False, read=True):
@@ -155,7 +156,7 @@ class StockForecasted(models.AbstractModel):
             'uom_id' : product.uom_id.read()[0] if read else product.uom_id,
         }
         if move_in:
-            document_in = move_in._get_source_document()
+            document_in = move_in.sudo()._get_source_document()
             line.update({
                 'move_in': move_in.read(fields=self._get_report_moves_fields())[0] if read else move_in,
                 'document_in' : {
@@ -167,7 +168,7 @@ class StockForecasted(models.AbstractModel):
             })
 
         if move_out:
-            document_out = move_out._get_source_document()
+            document_out = move_out.sudo()._get_source_document()
             line.update({
                 'move_out': move_out.read(fields=self._get_report_moves_fields())[0] if read else move_out,
                 'document_out' : {

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.js
@@ -45,7 +45,7 @@ export class ForecastedDetails extends Component {
     }
 
     displayReserve(line){
-        return !line.in_transit && this.canReserveOperation(line);
+        return this.props.docs.user_can_edit_pickings && !line.in_transit && this.canReserveOperation(line);
     }
 
     canReserveOperation(line){


### PR DESCRIPTION
Task: 4640948

Currently, a sales user with no stock permissions can see the little
forecast icon and, upon clicking on it, a link to the forecast report.
However, trying to access the report results in an "Access Error"
message.

The forecast report is important for sales users. This commit will allow
them to access the report, but without the option to edit stock pickings
(reserve/unreserve buttons).




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
