### PR TITLE
[FIX] web: reference field with both select and many2one alignment

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one_field.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.xml
@@ -66,7 +66,7 @@
                     data-tooltip="Scan barcode"
                 />
             </div>
-            <div class="o_field_many2one_extra">
+            <div class="o_field_many2one_extra d-empty-none">
                 <t t-foreach="extraLines" t-as="extraLine" t-key="extraLine_index">
                     <br t-if="!extraLine_first" />
                     <span t-esc="extraLine" />

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -183,6 +183,15 @@
         }
     }
 
+    &, & .o_form_editable {
+        // FIXME: those specific rules shouldn't be necessary but require a more 
+        // global cleanup of the fields + .o_row styling to be removed in master.
+        .o_field_reference .o_row > * {
+            flex: 1 1 auto;
+            width: auto !important;
+        }
+    }
+
     .o_form_view_container {
         display: flex;
         flex-flow: column nowrap;


### PR DESCRIPTION
This commit fixes a miss-alignment between the first select and the following many2one field in a reference field. When choosing a longer value in the first select, it overlaps with the many2one field.

Steps to reproduce:
- Open Marketing Card app
- Click to open a record
- Choose a longer value in the first select in the Recipients field => overlap between the select's value and the following many2one field

task-4387904

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
