### PR TITLE
[FIX] project_mrp: access to project field in an MO

### DIFF
--- a/addons/project_mrp/views/mrp_production_views.xml
+++ b/addons/project_mrp/views/mrp_production_views.xml
@@ -23,7 +23,7 @@
                 }</attribute>
             </field>
             <xpath expr="//page[@name='miscellaneous']//field[@name='date_deadline']" position="after">
-                <t groups="stock.group_stock_manager">
+                <t groups="project.group_project_user">
                     <field name="project_id" groups="project.group_project_user"/>
                 </t>
             </xpath>


### PR DESCRIPTION
Reproduce:
Give user Inventory User rights > MO > Miscellaneous > Project

Solution:
Removed the group for Inventory Admin from the field project_id in mrp_production view

Description of the issue/feature this PR addresses:
The project field in an MO is only visible if you are administrator of Inventory.  If you have admin rights to MRP and/or projects you can't see the field.

Current behavior before PR:
In MO under Miscellaneous page we can not see project field without Inventory admin group

Desired behavior after PR is merged:
In MO under Miscellaneous page user can see project field with group project admin only.

opw-4708084

