### PR TITLE
[FIX] web_editor: Fix TypeError in onClose handler of openChatGPTDialog

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1604,7 +1604,7 @@ export class Wysiwyg extends Component {
         this.env.services.dialog.add(
             mode === 'prompt' ? ChatGPTPromptDialog : mode === 'translate' ? ChatGPTTranslateDialog : ChatGPTAlternativesDialog,
             params,
-            { onClose: restore },
+            { onClose: () => restore() },
         );
     }
     /**


### PR DESCRIPTION
Steps to reproduce the bug:

- Enter Website Edit mode.
- Drag and drop a snippet onto the page.
- Click on the text in the snippet and then click on the AI text generator button in the editor toolbar.
- Close the dialog.
- A traceback occurs.

The `onClose` handler in the `openChatGPTDialog` function was previously passing the `restore` function directly. This caused a TypeError when `closeParams` was introduced as an argument in the `onClose` function of the `dialogService` since  this commit [1].

The bug comes from the fact that the `preserveCursor` function's `restore` expects a Map object, but `closeParams` is an object.

To fix this, the `onClose` handler now calls `restore` inside an anonymous function (`() => restore()`) to avoid passing unexpected values and prevent the TypeError.

[1]: https://github.com/odoo/odoo/commit/31c00161fd3a77c9fbd260754cb8c142fcb0d652

task-4708314