### PR TITLE
[FIX] l10n_in: prevent error when accessing invoices

### DIFF
--- a/addons/l10n_in_ewaybill/models/account_move.py
+++ b/addons/l10n_in_ewaybill/models/account_move.py
@@ -40,7 +40,7 @@ class AccountMove(models.Model):
     def _compute_l10n_in_ewaybill_details(self):
         for move in self:
             ewaybill = move.l10n_in_ewaybill_ids and move.l10n_in_ewaybill_ids[0]
-            if move.country_code == 'IN' and move.l10n_in_ewaybill_ids.state == 'generated':
+            if move.country_code == 'IN' and ewaybill.state == 'generated':
                 move.l10n_in_ewaybill_name = ewaybill.name
                 move.l10n_in_ewaybill_expiry_date = ewaybill.ewaybill_expiry_date
             else:


### PR DESCRIPTION
This error occurs when users attempt to create an e-Waybill for the same invoice simultaneously from multiple tabs.

Steps to Reproduce:
- Install the `l10n_in` module. -`Switch to `In Company`, Go to Configuration > Indian Electronic Waybill.
- Open an invoice and click on `Create e-Waybill`.
- In a duplicate tab, fill the required e-Waybill details, `save` and do the same in the original tab
- Attempt to access the invoice.

`ValueError : Expected singleton: l10n.in.ewaybill(5, 20)`

This error occurs at [1] when the system attempts to check the e-Waybill state but encounters multiple records with state generated.

This commit resolves the error by ensuring that only a `single e-Waybill` is considered.

[1]-https://github.com/odoo/odoo/blob/2a39cd199ee70311f0f9249403b8fb1352402120/addons/l10n_in_ewaybill/models/account_move.py#L43

Sentry - 6530655516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
