### PR TITLE
[FIX] sale: open valid quotation sample pdf when clicking check sample button

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -973,7 +973,7 @@
             <a
                 role="button"
                 class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/master/_downloads/56a93429515b36105d952e1d2b802f9e/sample_quotation.pdf"
+                href="https://www.odoo.com/documentation/18.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
                 target="_blank"
             >
                 Check a sample. It's clean!
@@ -1010,7 +1010,7 @@
             <a
                 role="button"
                 class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/master/_downloads/56a93429515b36105d952e1d2b802f9e/sample_quotation.pdf"
+                href="https://www.odoo.com/documentation/18.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
                 target="_blank"
             >
                 Check a sample. It's clean!


### PR DESCRIPTION
Currently, a 404 error is occurring when the user clicks on the Check the sample button.

<b>Steps to reproduce this issue:</b>

1) Install sales without demo data
2) Click on the `Check a sample. Its clean!` button

<b>Issue:- </b>

A 404 error occurs with a blank page

<b>Cause:-</b>
This issue is occurring because the link to open the sample quotation
was changed in the Odoo documentation.

<b>Solution:-</b>

Give a valid link to open the sample quotation pdf

opw-4708039

