### PR TITLE
[FIX] l10n_it: Missing 0% EU S tax

### DIFF
--- a/addons/l10n_it/data/account_tax_template.xml
+++ b/addons/l10n_it/data/account_tax_template.xml
@@ -488,11 +488,38 @@
     <record id="00eu" model="account.tax.template">
         <field name="description">00eu</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
-        <field name="name">0% EU</field>
+        <field name="name">0% EU G</field>
         <field name="sequence">180</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
+        <field name="tax_scope">consu</field>
+        <field name="price_include">False</field>
+        <field name="tax_group_id" ref="tax_group_fuori"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_expression_ids': [ref('tax_report_line_vp2_tag')],
+            }),
+            (0,0, {'repartition_type': 'tax'}),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [ref('tax_report_line_vp2_tag')],
+            }),
+            (0,0, {'repartition_type': 'tax'}),
+        ]"/>
+    </record>
+    <record id="00eus" model="account.tax.template">
+        <field name="description">00eus</field>
+        <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
+        <field name="name">0% EU S</field>
+        <field name="sequence">185</field>
+        <field name="amount">0</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_scope">service</field>
         <field name="price_include">False</field>
         <field name="tax_group_id" ref="tax_group_fuori"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1222,7 +1249,7 @@
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="tax_scope">service</field>
+        <field name="tax_scope">consu</field>
         <field name="price_include">False</field>
         <field name="tax_group_id" ref="tax_group_fuori"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),

--- a/addons/l10n_it_edi/__init__.py
+++ b/addons/l10n_it_edi/__init__.py
@@ -18,6 +18,13 @@ def _l10n_it_edi_update_export_tax(env):
                     'l10n_it_kind_exoneration': 'N3.2',
                     'l10n_it_law_reference': 'Art. 41, DL n. 331/93',
                 })
+            service_tax = env.ref(f'l10n_it.{company.id}_00eus', raise_if_not_found=False)
+            if service_tax:
+                service_tax.write({
+                    'l10n_it_has_exoneration': True,
+                    'l10n_it_kind_exoneration': 'N3.2',
+                    'l10n_it_law_reference': 'Art. 7ter, DPR 633/1972',
+                })
 
 
 def _l10n_it_edi_post_init(cr, registry):

--- a/addons/l10n_it_edi/models/account_chart_template.py
+++ b/addons/l10n_it_edi/models/account_chart_template.py
@@ -23,4 +23,11 @@ class AccountChartTemplate(models.Model):
                     'l10n_it_kind_exoneration': 'N3.2',
                     'l10n_it_law_reference': 'Art. 41, DL n. 331/93',
                 })
+            service_tax = self.env.ref(f'l10n_it.{company.id}_00eus', raise_if_not_found=False)
+            if service_tax:
+                service_tax.write({
+                    'l10n_it_has_exoneration': True,
+                    'l10n_it_kind_exoneration': 'N3.2',
+                    'l10n_it_law_reference': 'Art. 7ter, DPR 633/1972',
+                })
         return result


### PR DESCRIPTION
Description of the issue this commit addresses:

The export tax for services is missing in the italian localization. It's required because it has a different legal note than the usual 0% EU tax.

---

Desired behavior after this commit is merged:

The italian localization has a 0% EU S for exported services in EU with the right legal note.

---

task-4715771

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
