### PR TITLE
[FIX] product,*: adjust uom and price of generated purchase order

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -721,6 +721,8 @@ class ProductProduct(models.Model):
                 continue
             if seller.date_end and seller.date_end < date:
                 continue
+            if params and params.get('force_uom') and seller.product_uom_id != uom_id and seller.product_uom_id != self.uom_id:
+                continue
             if partner_id and seller.partner_id not in [partner_id, partner_id.parent_id]:
                 continue
             if quantity is not None and float_compare(quantity_uom_seller, seller.min_qty, precision_digits=precision) == -1:

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -281,7 +281,7 @@ class TestPurchase(AccountTestInvoicingCommon):
         po = po_form.save()
 
         self.assertEqual(po.order_line[0].price_unit, 200)
-        self.assertEqual(po.order_line[1].price_unit, 1200)
+        self.assertEqual(po.order_line[1].price_unit, 0, "No vendor with matching UoM is found, so price should be 0")
 
     def test_on_change_quantity_description(self):
         """
@@ -951,3 +951,36 @@ class TestPurchase(AccountTestInvoicingCommon):
         po = po_form.save()
         self.assertEqual(po.order_line.product_qty, 10.0)
         self.assertEqual(po.order_line.name, '[HHH] product_a')
+
+    def test_purchase_order_uom(self):
+        fuzzy_drink = self.env['product.product'].create({
+            'name': 'Fuzzy Drink',
+            'is_storable': True,
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'seller_ids': [Command.create({
+                'partner_id': self.partner_a.id,
+                'product_uom_id': self.env.ref('uom.product_uom_unit').id,
+                'price': 1,
+            }),
+            Command.create({
+                'partner_id': self.partner_a.id,
+                'product_uom_id': self.env.ref('uom.product_uom_pack_6').id,
+                'min_qty': 2,
+                'price': 5,
+            })],
+        })
+
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': fuzzy_drink.id,
+                'product_qty': 15,
+                'product_uom_id': self.env.ref('uom.product_uom_unit').id,
+            })],
+        })
+        self.assertEqual(po.order_line.price_unit, 1)
+        po.order_line.product_qty = 1
+        po.order_line.product_uom_id = self.env.ref('uom.product_uom_pack_6')
+        self.assertEqual(po.order_line.price_unit, 6)
+        po.order_line.product_qty = 2
+        self.assertEqual(po.order_line.price_unit, 5)

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -996,7 +996,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         self.component_d.write({
             'route_ids': [Command.link(buy_route.id)],
             'seller_ids': [
-                Command.create({'partner_id': self.partner_a.id, 'product_uom_id': self.uom_dozen.id, 'min_qty': 1, 'price': 10}),
+                Command.create({'partner_id': self.partner_a.id, 'min_qty': 12, 'price': 10}),
             ]
         })
 

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -64,7 +64,9 @@ class StockRule(models.Model):
                     partner_id=self._get_partner_id(procurement.values, rule),
                     quantity=procurement.product_qty,
                     date=max(procurement_date_planned.date(), fields.Date.today()),
-                    uom_id=procurement.product_uom)
+                    uom_id=procurement.product_uom,
+                    params={'force_uom': procurement.values.get('force_uom')},
+                )
 
             # Fall back on a supplier for which no price may be defined. Not ideal, but better than
             # blocking the user.
@@ -123,7 +125,7 @@ class StockRule(models.Model):
             procurements = self._merge_procurements(procurements_to_merge)
 
             po_lines_by_product = {}
-            grouped_po_lines = groupby(po.order_line.filtered(lambda l: not l.display_type and l.product_uom_id == l.product_id.uom_id), key=lambda l: l.product_id.id)
+            grouped_po_lines = groupby(po.order_line.filtered(lambda l: not l.display_type), key=lambda l: l.product_id.id)
             for product, po_lines in grouped_po_lines:
                 po_lines_by_product[product] = self.env['purchase.order.line'].concat(*po_lines)
             po_line_values = []
@@ -243,13 +245,13 @@ class StockRule(models.Model):
 
     def _update_purchase_order_line(self, product_id, product_qty, product_uom, company_id, values, line):
         partner = values['supplier'].partner_id
-        uom = values['supplier'].product_uom_id or values['supplier'].product_id.uom_id
-        procurement_uom_po_qty = product_uom._compute_quantity(product_qty, uom, rounding_method='HALF-UP')
+        procurement_uom_po_qty = product_uom._compute_quantity(product_qty, line.product_uom_id, rounding_method='HALF-UP')
         seller = product_id.with_company(company_id)._select_seller(
             partner_id=partner,
             quantity=line.product_qty + procurement_uom_po_qty,
             date=line.order_id.date_order and line.order_id.date_order.date(),
-            uom_id=uom)
+            uom_id=line.product_uom_id,
+            params={'force_uom': values.get('force_uom')})
 
         price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.sudo().taxes_id, company_id) if seller else 0.0
         if price_unit and seller and line.order_id.currency_id and seller.currency_id != line.order_id.currency_id:
@@ -261,6 +263,9 @@ class StockRule(models.Model):
             'price_unit': price_unit,
             'move_dest_ids': [(4, x.id) for x in values.get('move_dest_ids', [])]
         }
+        if seller.product_uom_id != line.product_uom_id and not values.get('force_uom'):
+            res['product_qty'] = line.product_uom_id._compute_quantity(res['product_qty'], seller.product_uom_id, rounding_method='HALF-UP')
+            res['product_uom_id'] = seller.product_uom_id
         orderpoint_id = values.get('orderpoint_id')
         if orderpoint_id:
             res['orderpoint_id'] = orderpoint_id.id
@@ -343,4 +348,4 @@ class StockRule(models.Model):
         return res
 
     def _get_partner_id(self, values, rule):
-        return values.get("supplierinfo_name") or (values.get("group_id") and values.get("group_id").partner_id)
+        return values.get("supplier_id")

--- a/addons/purchase_stock/tests/common.py
+++ b/addons/purchase_stock/tests/common.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import timedelta
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo import tools
 
@@ -60,3 +60,19 @@ class PurchaseTestCommon(TestStockCommon):
             'email': "purchaseuser@yourcompany.com",
             'groups_id': [(6, 0, [cls.env.ref('purchase.group_purchase_user').id])],
             })
+
+        cls.fuzzy_drink = cls.env['product.product'].create({
+            'name': 'Fuzzy Drink',
+            'is_storable': True,
+            'route_ids': [Command.set([cls.route_buy, cls.route_mto])],
+            'seller_ids': [Command.create({
+                'partner_id': cls.partner_1.id,
+                'product_uom_id': cls.env.ref('uom.product_uom_unit').id,
+                'price': 1.0,
+            }), Command.create({
+                'partner_id': cls.partner_1.id,
+                'product_uom_id': cls.env.ref('uom.product_uom_pack_6').id,
+                'price': 5.0,
+                'min_qty': 2,
+            })]
+        })

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -623,7 +623,7 @@ class TestReorderingRule(TransactionCase):
                     "rule_id": warehouse.buy_pull_id,
                     "group_id": False,
                     "route_ids": [],
-                    "supplierinfo_name": secondary_vendor,
+                    "supplier_id": secondary_vendor,
                 }
             )])
         po_line = self.env["purchase.order.line"].search(

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -2,14 +2,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from freezegun import freeze_time
 
-from odoo.addons.stock.tests.common import TestStockCommon
+from odoo.addons.purchase_stock.tests.common import PurchaseTestCommon
 
 from odoo import fields
 from odoo.fields import Command
 from odoo.tests import Form
 
 
-class TestReplenishWizard(TestStockCommon):
+class TestReplenishWizard(PurchaseTestCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -33,6 +33,7 @@ class TestReplenishWizard(TestStockCommon):
 
         # Additional Values required by the replenish wizard
         cls.uom_unit = cls.env.ref('uom.product_uom_unit')
+        cls.uom_pack_6 = cls.env.ref('uom.product_uom_pack_6')
         cls.wh = cls.env['stock.warehouse'].search([('company_id', '=', cls.env.user.id)], limit=1)
 
     def test_replenish_buy_1(self):
@@ -525,3 +526,76 @@ class TestReplenishWizard(TestStockCommon):
         stock_picking = self.env[model_name].browse(int(stock_picking_id))
 
         self.assertEqual(stock_picking.partner_id, second_warehouse.partner_id)
+
+    def test_purchase_order_uom(self):
+        replenish_wizard = self.env['product.replenish'].create({
+            'product_id': self.fuzzy_drink.id,
+            'product_tmpl_id': self.fuzzy_drink.product_tmpl_id.id,
+            'product_uom_id': self.uom_unit.id,
+            'quantity': 10,
+            'warehouse_id': self.wh.id,
+            'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
+            'supplier_id': self.fuzzy_drink.seller_ids[1].id,  # pricelist with uom "Pack of 6"
+        })
+        replenish_wizard.launch_replenishment()
+        po = self.env['purchase.order'].search([
+            ('partner_id', '=', self.fuzzy_drink.seller_ids[1].partner_id.id)
+        ], order='id DESC', limit=1)
+        self.assertEqual(po.order_line.product_qty, 10, 'Generated PO line must respect the requested quantity from the wizard')
+        self.assertEqual(po.order_line.product_uom_id, replenish_wizard.product_uom_id, 'Generated PO line must respect the requested UOM from the wizard')
+        self.assertEqual(po.order_line.price_unit, 1, 'Generated PO line must respect the supplier price of UoM "Unit"')
+        po.button_cancel()
+
+        replenish_wizard = self.env['product.replenish'].create({
+            'product_id': self.fuzzy_drink.id,
+            'product_tmpl_id': self.fuzzy_drink.product_tmpl_id.id,
+            'product_uom_id': self.uom_unit.id,
+            'quantity': 15,
+            'warehouse_id': self.wh.id,
+            'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
+            'supplier_id': self.fuzzy_drink.seller_ids[1].id,  # pricelist with uom "Pack of 6"
+        })
+        replenish_wizard.launch_replenishment()
+        po = self.env['purchase.order'].search([
+            ('partner_id', '=', self.fuzzy_drink.seller_ids[1].partner_id.id)
+        ], order='id DESC', limit=1)
+        self.assertEqual(po.order_line.product_qty, 15, 'Generated PO line must respect the requested quantity from the wizard')
+        self.assertEqual(po.order_line.product_uom_id, replenish_wizard.product_uom_id, 'Generated PO line must respect the requested UOM from the wizard')
+        self.assertEqual(po.order_line.price_unit, 1, 'Generated PO line must respect the supplier price of UoM "Unit"')
+        po.button_cancel()
+
+        replenish_wizard = self.env['product.replenish'].create({
+            'product_id': self.fuzzy_drink.id,
+            'product_tmpl_id': self.fuzzy_drink.product_tmpl_id.id,
+            'product_uom_id': self.uom_pack_6.id,
+            'quantity': 1,
+            'warehouse_id': self.wh.id,
+            'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
+            'supplier_id': self.fuzzy_drink.seller_ids[1].id,  # pricelist with uom "Pack of 6"
+        })
+        replenish_wizard.launch_replenishment()
+        po = self.env['purchase.order'].search([
+            ('partner_id', '=', self.fuzzy_drink.seller_ids[1].partner_id.id)
+        ], order='id DESC', limit=1)
+        self.assertEqual(po.order_line.product_qty, 1, 'Generated PO line must respect the requested quantity from the wizard')
+        self.assertEqual(po.order_line.product_uom_id, replenish_wizard.product_uom_id, 'Generated PO line must respect the requested UOM from the wizard')
+        self.assertEqual(po.order_line.price_unit, 6, 'Generated PO line must respect the supplier price of UoM "Unit" because the quantity doesn\'t match the "Pack of 6" pricelist')
+        po.button_cancel()
+
+        replenish_wizard = self.env['product.replenish'].create({
+            'product_id': self.fuzzy_drink.id,
+            'product_tmpl_id': self.fuzzy_drink.product_tmpl_id.id,
+            'product_uom_id': self.uom_pack_6.id,
+            'quantity': 2,
+            'warehouse_id': self.wh.id,
+            'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
+            'supplier_id': self.fuzzy_drink.seller_ids[0].id,  # pricelist with uom "Unit"
+        })
+        replenish_wizard.launch_replenishment()
+        po = self.env['purchase.order'].search([
+            ('partner_id', '=', self.fuzzy_drink.seller_ids[0].partner_id.id)
+        ], order='id DESC', limit=1)
+        self.assertEqual(po.order_line.product_qty, 2, 'Generated PO line must respect the requested quantity from the wizard')
+        self.assertEqual(po.order_line.product_uom_id, replenish_wizard.product_uom_id, 'Generated PO line must respect the requested UOM from the wizard')
+        self.assertEqual(po.order_line.price_unit, 5, 'Generated PO line must respect the supplier price of UoM "Pack of 6" because the quantity matches the "Pack of 6" pricelist')
+        po.button_cancel()

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -43,8 +43,7 @@ class ProductReplenish(models.TransientModel):
     def _prepare_run_values(self):
         res = super()._prepare_run_values()
         if self.supplier_id:
-            res['supplierinfo_id'] = self.supplier_id
-            res['group_id'].partner_id = self.supplier_id.partner_id
+            res['supplier_id'] = self.supplier_id.partner_id
         return res
 
     def action_stock_replenishment_info(self):

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -513,3 +513,51 @@ class TestSalePurchaseStockFlow(TransactionCase):
 
         deliveries.button_validate()
         self.assertEqual(sale_orders.order_line.mapped('qty_delivered'), [1.0, 1.0, 1.0])
+
+    def test_purchase_order_uom(self):
+        fuzzy_drink = self.env['product.product'].create({
+            'name': 'Fuzzy Drink',
+            'is_storable': True,
+            'route_ids': [Command.set((self.mto_route + self.buy_route).ids)],
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'seller_ids': [Command.create({
+                'partner_id': self.vendor.id,
+                'product_uom_id': self.env.ref('uom.product_uom_unit').id,
+                'price': 1,
+            }),
+            Command.create({
+                'partner_id': self.vendor.id,
+                'product_uom_id': self.env.ref('uom.product_uom_pack_6').id,
+                'min_qty': 2,
+                'price': 5,
+            })],
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({
+                'name': fuzzy_drink.name,
+                'product_id': fuzzy_drink.id,
+                'product_uom_qty': 10,
+                'product_uom_id': self.env.ref('uom.product_uom_unit').id,
+            })],
+        })
+        so.action_confirm()
+        po = so._get_purchase_orders()
+        self.assertEqual(po.order_line.product_uom_id, self.env.ref('uom.product_uom_unit'))
+        self.assertEqual(po.order_line.product_qty, 10)
+        self.assertEqual(po.order_line.price_unit, 1)
+        po.button_cancel()
+
+        so = so.copy({
+            'order_line': [Command.create({
+                'name': fuzzy_drink.name,
+                'product_id': fuzzy_drink.id,
+                'product_uom_qty': 15,
+                'product_uom_id': self.env.ref('uom.product_uom_unit').id,
+            })]
+        })
+        so.action_confirm()
+        po = so._get_purchase_orders()
+        self.assertEqual(po.order_line.product_uom_id, self.env.ref('uom.product_uom_pack_6'))
+        self.assertEqual(po.order_line.product_qty, 2.5)
+        self.assertEqual(po.order_line.price_unit, 5)

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -138,6 +138,7 @@ class ProductReplenish(models.TransientModel):
             'route_ids': self.route_id,
             'date_planned': self.date_planned,
             'group_id': replenishment,
+            'force_uom': True,
         }
         return values
 


### PR DESCRIPTION
This commit adjusts setting `product_uom_id` field on the generated purchase order line in the 3 main scenarios: manual purchase order, procurement from MTO, and procurement from replenishment wizard. The intended behavior is as follows:

* Manual PO: The selected pricelist must respect the uom of the PO line. Even if the quantity of the line matches a pricelist with a cheaper price (but different uom), it should not be selected. If there is no pricelist with the unit of the line, the pricelist with the product base unit is chosen. If it doesn't exist too, no pricelist is chosen, and the price is left to the user (default value of 0).

* Procurement from MTO: The selected pricelist must be the cheapest pricelist that respects the requested quantity, even if that cheaper pricelist has a different uom than the source of procurement (SO, MO, etc.). However, the generated PO line uses the uom of the pricelist not the source.

* Replenishment Wizard: The behavior is similar to manual PO. The selected unit in the wizard must be respected, even if there is a cheaper pricelist that matches the requested quantity (with different uom). Also now, the selected vendor in the wizard doesn't affect the chosen priclist. It's only used to look for pricelists with the same partner.

Task-4471379


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
