### PR TITLE
[IMP] account: _increase_rank in postcommit

### DIFF
--- a/addons/account/tests/test_account_partner.py
+++ b/addons/account/tests/test_account_partner.py
@@ -46,5 +46,23 @@ class TestAccountPartner(AccountTestInvoicingCommon):
             },
         ]).action_post()
 
+        # rank updates are updated in the post-commit phase
+        with self.enter_registry_test_mode():
+            self.env.cr.postcommit.run()
         self.assertEqual(self.partner_a.supplier_rank, 1)
         self.assertEqual(self.partner_a.customer_rank, 1)
+
+        # a second move is updated in postcommit
+        self.env['account.move'].create([
+            {
+                'move_type': 'out_invoice',
+                'date': '2017-01-02',
+                'invoice_date': '2017-01-02',
+                'partner_id': self.partner_a.id,
+                'invoice_line_ids': [(0, 0, {'name': 'aaaa', 'price_unit': 100.0})],
+            },
+        ]).action_post()
+        # rank updates are updated in the post-commit phase
+        with self.enter_registry_test_mode():
+            self.env.cr.postcommit.run()
+        self.assertEqual(self.partner_a.customer_rank, 2)

--- a/addons/account/tests/test_audit_trail.py
+++ b/addons/account/tests/test_audit_trail.py
@@ -131,7 +131,8 @@ class TestAuditTrail(AccountTestInvoicingCommon):
             notification_type='email',
         )
         # identify that user as being a customer
-        user.partner_id._increase_rank('customer_rank', 1)
+        user.partner_id.sudo().customer_rank += 1
+        self.assertGreater(user.partner_id.customer_rank, 0)
         user.partner_id.message_post(body='Test', partner_ids=user.partner_id.ids)
 
     def test_partner_unlink(self):


### PR DESCRIPTION
Run increase rank in postcommit in most cases. This prevents possible serialization errors on partners when posting account moves. We still increment the field directly when a partner becomes a supplier or a customer.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

task-4723964



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
