### PR TITLE
[IMP] stock_landed_costs,*: streamline landed cost operation

### DIFF
--- a/addons/mrp_landed_costs/models/stock_landed_cost.py
+++ b/addons/mrp_landed_costs/models/stock_landed_cost.py
@@ -13,6 +13,7 @@ class StockLandedCost(models.Model):
     mrp_production_ids = fields.Many2many(
         'mrp.production', string='Manufacturing order',
         copy=False, groups='stock.group_stock_manager')
+    mrp_productions_count = fields.Integer(compute='_compute_mrp_productions_count')
 
     @api.onchange('target_model')
     def _onchange_target_model(self):
@@ -26,3 +27,23 @@ class StockLandedCost(models.Model):
             | self.mrp_production_ids.move_finished_ids
             - self.mrp_production_ids.move_byproduct_ids.filtered(lambda move: not move.cost_share)
         )
+
+    @api.depends('mrp_production_ids')
+    def _compute_mrp_productions_count(self):
+        for cost in self:
+            cost.mrp_productions_count = len(cost.mrp_production_ids)
+
+    def action_view_mrp_productions(self):
+        self.ensure_one()
+        action = {
+            'type': 'ir.actions.act_window',
+            'res_model': 'mrp.production',
+            'view_mode': 'list,form',
+        }
+        if len(self.mrp_production_ids) == 1:
+            action['res_id'] = self.mrp_production_ids.id
+            action['view_mode'] = 'form'
+        elif self.mrp_production_ids:
+            action['name'] = self.env._("Manufacturing Orders")
+            action['domain'] = [('id', 'in', self.mrp_production_ids.ids)]
+        return action

--- a/addons/mrp_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/mrp_landed_costs/views/stock_landed_cost_views.xml
@@ -17,6 +17,12 @@
                     readonly="state == 'done'"
                     domain="[('company_id', '=', company_id), ('move_finished_ids.is_in', '!=', False)]"/>
             </field>
+            <button name="action_view_pickings" position="after">
+                <button class="oe_stat_button" name="action_view_mrp_productions" icon="fa-wrench"
+                    type="object" invisible="mrp_productions_count == 0">
+                    <field name="mrp_productions_count" string="Manufacturing" widget="statinfo"/>
+                </button>
+            </button>
         </field>
     </record>
 </odoo>

--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -24,10 +24,14 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
         landed_costs_lines = self.line_ids.filtered(lambda line: line.is_landed_costs_line)
+        landed_cost_picking_ids = self.invoice_line_ids.purchase_order_id.picking_ids.filtered(
+            lambda picking: any(move.is_valued for move in picking.move_ids)
+        )
 
         sign = -1 if self.move_type in ['in_refund'] else 1
         landed_costs = self.env['stock.landed.cost'].with_company(self.company_id).create({
             'vendor_bill_id': self.id,
+            'picking_ids': landed_cost_picking_ids.ids,
             'cost_lines': [(0, 0, {
                 'product_id': l.product_id.id,
                 'name': l.product_id.name,

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -480,7 +480,6 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         bill.action_post()
         action = bill.button_create_landed_costs()
         lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
-        lc_form.picking_ids.add(receipt)
         lc = lc_form.save()
         lc.button_validate()
         self.assertEqual(self.product1.standard_price, 2)
@@ -606,7 +605,6 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         bill.action_post()
         action = bill.button_create_landed_costs()
         lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
-        lc_form.picking_ids.add(receipt)
         lc = lc_form.save()
         lc.button_validate()
         self.assertEqual(product.standard_price, 2.35)
@@ -668,7 +666,6 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
 
         action = bill.button_create_landed_costs()
         lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
-        lc_form.picking_ids.add(receipt)
         lc = lc_form.save()
         lc.button_validate()
 

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -14,6 +14,12 @@
                         <field name="state" widget="statusbar" statusbar_visible="draft,done"/>
                     </header>
                     <sheet>
+                        <div class="oe_button_box" name="button_box">
+                            <button class="oe_stat_button" name="action_view_pickings" icon="fa-truck"
+                                type="object" invisible="pickings_count == 0">
+                                <field name="pickings_count" string="Transfers" widget="statinfo"/>
+                            </button>
+                        </div>
                         <div class="oe_title">
                             <label for="name" string="Landed Cost"/>
                             <h1>


### PR DESCRIPTION
*: mrp_landed_costs

- In most of the cases `Purchase Order` is linked to only a `single Transfer`.
  However, during a landed cost operation, users still need to `manually search`
  for it and `select this Picking`, resulting in unnecessary clicks and reducing
  overall efficiency.

- Currently, if users want to `review` the `Transfers` or `Manufacturing Orders`
  added to a landed cost, they must manually navigate and search for them,
  which slows down verification and increases user effort.

These changes reduce manual steps for picking selection and unnecessary clicks,
streamline landed cost operations, and provide users with quickly access
to related documents.

Task ID: 4689809