### PR TITLE
[IMP] html_editor: copy-paint format text

### DIFF
--- a/addons/html_editor/static/img/format-painter.svg
+++ b/addons/html_editor/static/img/format-painter.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" standalone="no"?>
+
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" width="800px" height="800px" viewBox="0 0 1024 1024" t="1569683552617"
+    class="icon" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="11173"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+    <path
+        d="
+        M840 192h-56v-72c0-13.3-10.7-24-24-24H168
+        c-13.3 0-24 10.7-24 24v272c0 13.3 10.7 24 24 24
+        h592c13.3 0 24-10.7 24-24V256h32v200H465c-22.1 0-40 17.9-40 40
+        v136h-44c-4.4 0-8 3.6-8 8v228c0 0.6 0.1 1.3 0.2 1.9
+        -0.1 2-0.2 4.1-0.2 6.1 0 46.4 37.6 84 84 84
+        s84-37.6 84-84c0-2.1-0.1-4.1-0.2-6.1 0.1-0.6 0.2-1.2 0.2-1.9
+        V640c0-4.4-3.6-8-8-8h-44V520h351c22.1 0 40-17.9 40-40
+        V232c0-22.1-17.9-40-40-40zM720 352H208V160h512v192z
+        M477 876c0 11-9 20-20 20s-20-9-20-20V696h40v180z
+    " />
+</svg>

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -58,6 +58,7 @@ export class ColorPlugin extends Plugin {
         /** Handlers */
         selectionchange_handlers: this.updateSelectedColor.bind(this),
         remove_format_handlers: this.removeAllColor.bind(this),
+        apply_format_handlers: (mode, color) => this._applyColor(color, mode),
 
         /** Predicates */
         has_format_predicates: [

--- a/addons/html_editor/static/src/main/toolbar/toolbar.scss
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.scss
@@ -59,3 +59,13 @@
     padding: 2px;
 }
 
+.oe-paint-format-icon {
+    display: inline-block;
+    width: 21px;
+    height: 21px;
+    margin-top: 2px;
+    background-image: url('/html_editor/static/img/format-painter.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -135,6 +135,7 @@ export class ToolbarPlugin extends Plugin {
     resources = {
         selectionchange_handlers: this.handleSelectionChange.bind(this),
         step_added_handlers: () => this.updateToolbar(),
+        update_ui_handlers: () => this.updateToolbar(),
         user_commands: {
             id: "expandToolbar",
             run: () => {

--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -134,3 +134,30 @@ export function getTextColorOrClass(node) {
     }
     return null;
 }
+
+/**
+ * Returns the visible color (foreground or background) from the given node
+ * or its ancestors, depending on the specified mode.
+ *
+ * @param {Element} element
+ * @param {string} mode 'color' or 'backgroundColor'
+ * @returns {string | null}
+ */
+export function getColor(element, mode) {
+    const targetEl = closestElement(
+        element,
+        (node) => node.isContentEditable && hasColor(node, mode)
+    );
+    if (!targetEl) {
+        return null;
+    }
+    const elStyle = getComputedStyle(targetEl);
+    const backgroundImage = elStyle.backgroundImage;
+    const hasGradient = isColorGradient(backgroundImage);
+    const hasTextGradientClass = targetEl.classList.contains("text-gradient");
+    if (mode === "color") {
+        return hasGradient && hasTextGradientClass ? backgroundImage : elStyle.color;
+    } else {
+        return hasGradient && !hasTextGradientClass ? backgroundImage : elStyle.backgroundColor;
+    }
+}

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -82,7 +82,8 @@ export const formatsSpecs = {
             ),
     },
     fontFamily: {
-        isFormatted: (node) => !!closestElement(node, (el) => el.style["font-family"]),
+        isFormatted: (node) =>
+            closestElement(node, (el) => el.style["font-family"])?.style["font-family"],
         hasStyle: (node) => node.style && node.style["font-family"],
         addStyle: (node, props) => {
             removeStyle(node, "font-family");
@@ -91,25 +92,31 @@ export const formatsSpecs = {
             }
         },
         removeStyle: (node) => removeStyle(node, "font-family"),
+        propName: "fontFamily",
     },
     fontSize: {
-        isFormatted: (node) => closestElement(node)?.style["font-size"],
+        isFormatted: (node) =>
+            closestElement(node, (el) => el.style["font-size"])?.style["font-size"],
         hasStyle: (node) => node.style && node.style["font-size"],
         addStyle: (node, props) => {
             node.style["font-size"] = props.size;
             removeClass(node, ...FONT_SIZE_CLASSES);
         },
         removeStyle: (node) => removeStyle(node, "font-size"),
+        propName: "size",
     },
     setFontSizeClassName: {
         isFormatted: (node) =>
-            FONT_SIZE_CLASSES.find((cls) => closestElement(node)?.classList?.contains(cls)),
+            FONT_SIZE_CLASSES.find((cls) =>
+                closestElement(node, (element) => element.classList.contains(cls))
+            ),
         hasStyle: (node, props) => FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls)),
         addStyle: (node, props) => {
             node.style.removeProperty("font-size");
             node.classList.add(props.className);
         },
         removeStyle: (node) => removeClass(node, ...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES),
+        propName: "className",
     },
     switchDirection: {
         isFormatted: isDirectionSwitched,

--- a/addons/html_editor/static/tests/format/paint_format.test.js
+++ b/addons/html_editor/static/tests/format/paint_format.test.js
@@ -1,0 +1,241 @@
+import { expect, test } from "@odoo/hoot";
+import { setupEditor } from "../_helpers/editor";
+import { expandToolbar } from "../_helpers/toolbar";
+import { queryAll, click } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { getContent, setContent } from "../_helpers/selection";
+import { unformat } from "../_helpers/format";
+
+test("paint format button should be the second last one in the decoration button group", async () => {
+    await setupEditor("<p>[abc]</p>");
+    await expandToolbar();
+    const formatButtons = queryAll(".o-we-toolbar .btn-group[name='decoration'] .btn");
+    expect(formatButtons.at(-2)).toHaveAttribute("name", "paint_format");
+});
+
+test("should be able to copy and apply bold format using paint format button", async () => {
+    const { el } = await setupEditor("<p><strong>[abc]</strong></p><p>test</p>");
+    await expandToolbar();
+    expect(".btn[name='paint_format']").toHaveAttribute("title", "Copy format");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    expect(".btn[name='paint_format']").toHaveAttribute("title", "Apply format");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveAttribute("title", "Copy format");
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe("<p><strong>abc</strong></p><p><strong>[test]</strong></p>");
+});
+
+test("should be able to copy and apply italic format using paint format button", async () => {
+    const { el } = await setupEditor("<p><em>[abc]</em></p><p>test</p>");
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe("<p><em>abc</em></p><p><em>[test]</em></p>");
+});
+
+test("should be able to copy and apply strikeThrough format using paint format button", async () => {
+    const { el } = await setupEditor("<p><s>[abc]</s></p><p>test</p>");
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe("<p><s>abc</s></p><p><s>[test]</s></p>");
+});
+
+test("should be able to copy and apply font-size format using paint format button", async () => {
+    const { el } = await setupEditor(
+        '<p><span style="font-size: 36px;">[abc]</span></p><p>test</p>'
+    );
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe(
+        '<p><span style="font-size: 36px;">abc</span></p><p><span style="font-size: 36px;">[test]</span></p>'
+    );
+});
+
+test("should be able to copy and apply font-size class format using paint format button", async () => {
+    const { el } = await setupEditor('<p><span class="h1-fs">[abc]</span></p><p>test</p>');
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe(
+        '<p><span class="h1-fs">abc</span></p><p><span class="h1-fs">[test]</span></p>'
+    );
+});
+
+test("should be able to copy and apply fontFamily using paint format button", async () => {
+    const { el } = await setupEditor(
+        '<p><span style="font-family: testFont;">[abc]</span></p><p>test</p>'
+    );
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe(
+        '<p><span style="font-family: testFont;">abc</span></p><p><span style="font-family: testFont;">[test]</span></p>'
+    );
+});
+
+test("should be able to copy and apply text and background colors using paint format button", async () => {
+    const { el } = await setupEditor(
+        '<p><font style="color: rgb(0, 0, 255); background-color: rgb(0, 255, 0);">[abc]</font></p><p>test</p>'
+    );
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe(
+        unformat(
+            `<p><font style="color: rgb(0, 0, 255); background-color: rgb(0, 255, 0);">abc</font></p>
+            <p><font style="color: rgb(0, 0, 255); background-color: rgb(0, 255, 0);">[test]</font></p>`
+        )
+    );
+});
+
+test("should be able to copy and apply multiple formats using paint format button", async () => {
+    const { el } = await setupEditor(
+        '<p><span class="h1-fs"><em><strong><font style="color: rgb(0, 255, 255);background-color: rgb(255, 0, 255);">[abc]</font></strong></em></span></p><p>test</p>'
+    );
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe(
+        unformat(
+            `<p><span class="h1-fs"><em><strong><font style="color: rgb(0, 255, 255);background-color: rgb(255, 0, 255);">abc</font></strong></em></span></p>
+            <p><span class="h1-fs"><em><strong><font style="color: rgb(0, 255, 255); background-color: rgb(255, 0, 255);">[test]</font></strong></em></span></p>`
+        )
+    );
+});
+
+test("should be able to copy and apply formats from a list item", async () => {
+    const { el } = await setupEditor(
+        '<ul><li class="h1-fs" style="color: rgb(0, 255, 0);">[abc]</li></ul><p>test</p>'
+    );
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelector("p");
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe(
+        unformat(
+            `<ul>
+                <li class="h1-fs" style="color: rgb(0, 255, 0);">abc</li>
+            </ul>
+            <p><span class="h1-fs"><font style="color: rgb(0, 255, 0);">[test]</font></span></p>`
+        )
+    );
+});
+
+test("should not copy formats when selection has multiple inline elements", async () => {
+    await setupEditor("<p><strong>[abc</strong><em>def]</em></p>");
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+});
+
+test("should remove existing formats when applying copied formats", async () => {
+    const { el } = await setupEditor(
+        '<p><strong><font style="color: rgb(0, 255, 0);">[abc]</font></strong></p><p><u>test</u></p>'
+    );
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe(
+        unformat(
+            `<p><strong><font style="color: rgb(0, 255, 0);">abc</font></strong></p>
+            <p><strong><font style="color: rgb(0, 255, 0);">[test]</font></strong></p>`
+        )
+    );
+});
+
+test("should not copy text-align when copying formats", async () => {
+    const { el } = await setupEditor(
+        '<p style="text-align: center;"><strong>[abc]</strong></p><p>test</p>'
+    );
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe(
+        '<p style="text-align: center;"><strong>abc</strong></p><p><strong>[test]</strong></p>'
+    );
+});
+
+test("should not remove existing text-align format when applying copied formats", async () => {
+    const { el } = await setupEditor(
+        '<p><strong>[abc]</strong></p><p style="text-align: center;">test</p>'
+    );
+    await expandToolbar();
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").toHaveClass("active");
+    const testParagraph = el.querySelectorAll("p")[1];
+    setContent(testParagraph, "[test]");
+    await click(".btn[name='paint_format']");
+    await animationFrame();
+    expect(".btn[name='paint_format']").not.toHaveClass("active");
+    expect(getContent(el)).toBe(
+        '<p><strong>abc</strong></p><p style="text-align: center;"><strong>[test]</strong></p>'
+    );
+});


### PR DESCRIPTION
This PR introduces a new "Paint format" option in the toolbar.

- On first click, formatting is copied from the selected text.
- On second click, copied formatting is applied to the selected content.

task-3980788




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
