### PR TITLE
[FIX] base: compute method for country_group_codes

### DIFF
--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -157,7 +157,7 @@ class ResCountry(models.Model):
         maintains a valid structure.
         '''
         for country in self:
-            country.country_group_codes = country.country_group_ids.mapped('code') or ['']
+            country.country_group_codes = [g.code for g in country.country_group_ids if g.code] or ['']
 
 
 class ResCountryGroup(models.Model):


### PR DESCRIPTION
Currently, if a country group does not have a code, then 'false' is store in the country_group_codes. This **PR** intends to filter out these falsy values.
