### PR TITLE
[IMP] im_livechat: handle by bot/agent on statistic view

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -41,6 +41,10 @@ Help your customers with this chat, and analyse their feedback.
     ],
     'demo': [
         "demo/im_livechat_channel/im_livechat_channel.xml",
+        "demo/im_livechat_channel/im_livechat_chatbot.xml",
+        "demo/im_livechat_channel/im_livechat_chatbot_session_1.xml",
+        "demo/im_livechat_channel/im_livechat_chatbot_session_2.xml",
+        "demo/im_livechat_channel/im_livechat_chatbot_session_3.xml",
         "demo/im_livechat_channel/im_livechat_session_1.xml",
         "demo/im_livechat_channel/im_livechat_session_2.xml",
         "demo/im_livechat_channel/im_livechat_session_3.xml",

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <record id="welcome_bot_operator_partner_demo" model="res.partner">
+            <field name="name">Odoo</field>
+            <field name="image_1920" type="base64" file="mail/static/src/img/odoobot.png"/>
+            <field name="active">False</field>
+        </record>
+        <record id="chatbot_script_welcome_bot_demo" model="chatbot.script">
+            <field name="title">Odoo</field>
+            <field name="image_1920" type="base64" file="mail/static/src/img/odoobot.png"/>
+            <field name="operator_partner_id" ref="welcome_bot_operator_partner_demo"/>
+        </record>
+
+        <record id="chatbot_script_welcome_step_welcome_demo" model="chatbot.script.step">
+            <field name="message">Welcome to CompanyName! 👋</field>
+            <field name="sequence">1</field>
+            <field name="step_type">text</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
+        </record>
+        <record id="chatbot_script_welcome_step_dispatch_demo" model="chatbot.script.step">
+            <field name="message">What are you looking for?</field>
+            <field name="sequence">2</field>
+            <field name="step_type">question_selection</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
+        </record>
+        <record id="chatbot_script_welcome_step_dispatch_answer_pricing_demo" model="chatbot.script.answer">
+            <field name="name">I have a pricing question</field>
+            <field name="sequence">1</field>
+            <field name="script_step_id" ref="chatbot_script_welcome_step_dispatch_demo"/>
+        </record>
+        <record id="chatbot_script_welcome_step_dispatch_answer_documentation_demo" model="chatbot.script.answer">
+            <field name="name">I am looking for your documentation</field>
+            <field name="redirect_link">/</field>
+            <field name="sequence">2</field>
+            <field name="script_step_id" ref="chatbot_script_welcome_step_dispatch_demo"/>
+        </record>
+        <record id="chatbot_script_welcome_step_dispatch_answer_just_looking_demo" model="chatbot.script.answer">
+            <field name="name">I am just looking around</field>
+            <field name="sequence">3</field>
+            <field name="script_step_id" ref="chatbot_script_welcome_step_dispatch_demo"/>
+        </record>
+        <record id="chatbot_script_welcome_step_pricing_demo" model="chatbot.script.step">
+            <field name="message">Hmmm, let me check if I can find someone that could help you with that...</field>
+            <field name="sequence">3</field>
+            <field name="step_type">text</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
+            <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_welcome_step_dispatch_answer_pricing_demo'))]"/>
+        </record>
+        <record id="chatbot_script_welcome_step_pricing_forward_operator_demo" model="chatbot.script.step">
+            <field name="sequence">4</field>
+            <field name="step_type">forward_operator</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
+            <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_welcome_step_dispatch_answer_pricing_demo'))]"/>
+        </record>
+        <record id="chatbot_script_welcome_step_pricing_noone_available_demo" model="chatbot.script.step">
+            <field name="message">Hu-ho, it looks like none of our operators are available 🙁</field>
+            <field name="sequence">5</field>
+            <field name="step_type">text</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
+            <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_welcome_step_dispatch_answer_pricing_demo'))]"/>
+        </record>
+        <record id="chatbot_script_welcome_step_pricing_email_demo" model="chatbot.script.step">
+            <field name="message">Would you mind leaving your email address so that we can reach you back?</field>
+            <field name="sequence">6</field>
+            <field name="step_type">question_email</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
+            <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_welcome_step_dispatch_answer_pricing_demo'))]"/>
+        </record>
+        <record id="chatbot_script_welcome_step_documentation_redirect_demo" model="chatbot.script.step">
+            <field name="message">And tadaaaa here you go! 🌟</field>
+            <field name="sequence">7</field>
+            <field name="step_type">text</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
+            <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_welcome_step_dispatch_answer_documentation_demo'))]"/>
+        </record>
+        <record id="chatbot_script_welcome_step_documentation_exit_demo" model="chatbot.script.step">
+            <field name="message">If you need anything else, feel free to get back in touch</field>
+            <field name="sequence">8</field>
+            <field name="step_type">text</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
+            <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_welcome_step_dispatch_answer_documentation_demo'))]"/>
+        </record>
+        <record id="chatbot_script_welcome_step_just_looking_demo" model="chatbot.script.step">
+            <field name="message">Please do! If there is anything we can help with, let us know</field>
+            <field name="sequence">9</field>
+            <field name="step_type">text</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
+            <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_welcome_step_dispatch_answer_just_looking_demo'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record id="livechat_channel_chatbot_session_1_demo" model="discuss.channel">
+            <field name="channel_type">livechat</field>
+            <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
+            <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="name">Visitor #234, Odoo</field>
+            <field name="anonymous_name">Visitor #234</field>
+        </record>
+        <record id="livechat_channel_chatbot_session_1_member_bot_demo" model="discuss.channel.member">
+            <field name="partner_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="channel_id" ref="livechat_channel_chatbot_session_1_demo"/>
+            <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">bot</field>
+        </record>
+        <record id="livechat_channel_chatbot_session_1_guest_demo" model="mail.guest">
+            <field name="name">Visitor #234</field>
+        </record>
+        <record id="livechat_channel_chatbot_session_1_member_guest_demo" model="discuss.channel.member">
+            <field name="guest_id" ref="livechat_channel_chatbot_session_1_guest_demo"/>
+            <field name="channel_id" ref="livechat_channel_chatbot_session_1_demo"/>
+            <field name="livechat_member_type">visitor</field>
+        </record>
+
+        <record id="livechat_channel_chatbot_session_1_message_1_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_1_demo"/>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">Welcome to CompanyName! 👋</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_1_message_2_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_1_demo"/>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">What are you looking for?</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_1_message_3_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_1_demo"/>
+            <field name="author_id"/>
+            <field name="author_guest_id" ref="livechat_channel_chatbot_session_1_guest_demo"/>
+            <field name="body">I am just looking around</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_1_message_4_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_1_demo"/>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">Please do! If there is anything we can help with, let us know</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="date"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record id="livechat_channel_chatbot_session_2_demo" model="discuss.channel">
+            <field name="channel_type">livechat</field>
+            <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
+            <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="name">Visitor #235, Odoo</field>
+            <field name="anonymous_name">Visitor #235</field>
+        </record>
+        <record id="livechat_channel_chatbot_session_2_member_bot_demo" model="discuss.channel.member">
+            <field name="partner_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="channel_id" ref="livechat_channel_chatbot_session_2_demo"/>
+            <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">bot</field>
+        </record>
+        <record id="livechat_channel_chatbot_session_2_guest_demo" model="mail.guest">
+            <field name="name">Visitor #235</field>
+        </record>
+        <record id="livechat_channel_chatbot_session_2_member_guest_demo" model="discuss.channel.member">
+            <field name="guest_id" ref="livechat_channel_chatbot_session_2_guest_demo"/>
+            <field name="channel_id" ref="livechat_channel_chatbot_session_2_demo"/>
+            <field name="livechat_member_type">visitor</field>
+        </record>
+
+        <record id="livechat_channel_chatbot_session_2_message_1_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_2_demo"/>
+            <field name="message_type">comment</field>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">Welcome to CompanyName! 👋</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_2_message_2_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_2_demo"/>
+            <field name="author_guest_id" ref="livechat_channel_chatbot_session_2_guest_demo"/>
+            <field name="author_id"/>
+            <field name="body">I am looking for your documentation</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_2_message_3_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_2_demo"/>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">And tadaaaa here you go! 🌟</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_2_message_4_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_2_demo"/>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">If you need anything else, feel free to get back in touch!</field>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="date"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <record id="livechat_channel_chatbot_session_3_demo" model="discuss.channel">
+            <field name="channel_type">livechat</field>
+            <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
+            <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="name">Visitor #236, Odoo</field>
+            <field name="anonymous_name">Visitor #235</field>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_member_bot_demo" model="discuss.channel.member">
+            <field name="partner_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="channel_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
+            <field name="livechat_member_type">bot</field>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_guest_demo" model="mail.guest">
+            <field name="name">Visitor #236</field>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_member_guest_demo" model="discuss.channel.member">
+            <field name="guest_id" ref="livechat_channel_chatbot_session_3_guest_demo"/>
+            <field name="channel_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="livechat_member_type">visitor</field>
+        </record>
+
+        <record id="livechat_channel_chatbot_session_3_message_1_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="message_type">comment</field>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">Welcome to CompanyName! 👋</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_message_2_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="message_type">comment</field>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">What are you looking for?</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_message_3_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="message_type">comment</field>
+            <field name="author_guest_id" ref="livechat_channel_chatbot_session_3_guest_demo"/>
+            <field name="author_id"/>
+            <field name="body">I have a pricing question</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_message_4_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="message_type">comment</field>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">Hmmm, let me check if I can find someone that could help you with that...</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_message_5_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="message_type">comment</field>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">Hu-ho, it looks like none of our operators are available 🙁</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_message_6_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="message_type">comment</field>
+            <field name="author_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="body">Would you mind leaving your email address so that we can reach you back?</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=6)" name="date"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_message_7_demo" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="message_type">comment</field>
+            <field name="author_guest_id" ref="livechat_channel_chatbot_session_3_guest_demo"/>
+            <field name="author_id"/>
+            <field name="body">visitor@example.com</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=7)" name="date"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -38,6 +38,8 @@ class Im_LivechatReportChannel(models.Model):
     rating_text = fields.Char('Satisfaction Rate', readonly=True)
     is_unrated = fields.Integer('Session not rated', readonly=True)
     partner_id = fields.Many2one('res.partner', 'Operator', readonly=True)
+    handled_by_bot = fields.Integer("Handled by Bot", readonly=True, aggregator="sum")
+    handled_by_agent = fields.Integer("Handled by Agent", readonly=True, aggregator="sum")
 
     def init(self):
         # Note : start_date_hour must be remove when the read_group will allow grouping on the hour of a datetime. Don't forget to change the view !
@@ -138,7 +140,9 @@ class Im_LivechatReportChannel(models.Model):
                     WHEN rate.rating > 0 THEN 0
                     ELSE 1
                 END as is_unrated,
-                C.livechat_operator_id as partner_id
+                C.livechat_operator_id as partner_id,
+                CASE WHEN channel_member_history.has_agent THEN 1 ELSE 0 END as handled_by_agent,
+                CASE WHEN channel_member_history.has_bot and not channel_member_history.has_agent THEN 1 ELSE 0 END as handled_by_bot
             """,
         )
 

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -47,7 +47,6 @@
                     <separator/>
                     <filter name="filter_start_date" date="start_date"/>
                     <group expand="0" string="Group By...">
-                        <filter name="group_by_session" string="Code" domain="[]" context="{'group_by':'technical_name'}"/>
                         <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'channel_id'}"/>
                         <filter name="group_by_operator" string="Operator" domain="[('partner_id','!=', False)]" context="{'group_by':'partner_id'}"/>
                         <separator orientation="vertical" />

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
@@ -15,8 +16,14 @@ class TestImLivechatReport(TestImLivechatCommon):
         def _compute_available_operator_ids(channel_self):
             for record in channel_self:
                 record.available_operator_ids = self.operators
-
-        with patch.object(type(self.env['im_livechat.channel']), '_compute_available_operator_ids', _compute_available_operator_ids):
+        with (
+            patch.object(
+                type(self.env["im_livechat.channel"]),
+                "_compute_available_operator_ids",
+                _compute_available_operator_ids,
+            ),
+            freeze_time("2023-03-17 06:05:54"),
+        ):
             channel_id = self.make_jsonrpc_request(
                 "/im_livechat/get_session",
                 {"anonymous_name": "Anonymous", "channel_id": self.livechat_channel.id},
@@ -25,7 +32,7 @@ class TestImLivechatReport(TestImLivechatCommon):
         channel = self.env['discuss.channel'].browse(channel_id)
         self.operator = channel.livechat_operator_id
 
-        self._create_message(channel, self.visitor_user.partner_id, '2023-03-17 06:05:54')
+        self._create_message(channel, self.visitor_user.partner_id, '2023-03-17 06:06:59')
         self._create_message(channel, self.operator, '2023-03-17 08:15:54')
         self._create_message(channel, self.operator, '2023-03-17 08:45:54')
 
@@ -41,7 +48,8 @@ class TestImLivechatReport(TestImLivechatCommon):
         self.assertEqual(len(report), 1, 'Should have one channel report for this live channel')
         # We have those messages, ordered by creation;
         # 05:05:54: wrong model
-        # 06:05:54: visitor message
+        # 06:05:54: session create
+        # 06:06:59: visitor message
         # 08:15:54: operator first answer
         # 08:45:54: operator second answer
         # 09:15:54: wrong model


### PR DESCRIPTION
1.
This commit improves the query used in the `im_livechat_report_channel`
view which is too heavy. Indeed, it joins 2 times on the `mail_message`
table which is one of the biggest table in Odoo and also uses an `EXISTS`
query on the same table.

Moreover, there is another join on `im_livechat_channel` which is only
here to compute `technical_name`. As this task aims to remove it, the
join has been removed as well.

Before this commit, the query took ~25s for a database with 1M messages,
65K channels, 130K members (all related to live chat). After this
commit, the query takes ~1s.

2.
This PR adds a new measure to the live chat statistic view
whose goal it to allow live chat managers to see how many
conversations are handled by agent or bots.

3.
A new measure is available in the live chat's session statistic
view which shows whether a conversation was handled by agents or
bot.

In order to discover/test this measure, 3 conversations handled
solely by the welcome bot are added to the demo data.

upgrade: https://github.com/odoo/upgrade/pull/7546

task-4614273