### PR TITLE
[FIX] payment_adyen: await loading Adyen SDK

### DIFF
--- a/addons/payment_adyen/static/src/js/payment_form.js
+++ b/addons/payment_adyen/static/src/js/payment_form.js
@@ -170,7 +170,7 @@ odoo.define('payment_adyen.payment_form', require => {
                             ? parseInt(this.txContext.currencyId)
                             : undefined,
                     },
-                }).then(paymentMethodsResult => {
+                }).then(async (paymentMethodsResult) => {
                     // Instantiate the drop-in
                     const configuration = {
                         paymentMethodsResponse: paymentMethodsResult['payment_methods_data'],
@@ -195,8 +195,8 @@ odoo.define('payment_adyen.payment_form', require => {
                         'link[href="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/4.7.3/adyen.css"]'
                     );
                     if (link) link.remove();
-                    loadJS('https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/6.9.0/adyen.js')
-                    loadCSS('https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/6.9.0/adyen.css')
+                    await loadJS('https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/6.9.0/adyen.js');
+                    await loadCSS('https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/6.9.0/adyen.css');
 
                     const { AdyenCheckout, Dropin } = window.AdyenWeb;
                     AdyenCheckout(configuration)


### PR DESCRIPTION
Versions
--------
- 16.0

`await` was added in forward ports.

Steps
-----
1. Set up Adyen as a payment provider;
2. go to eCommerce;
3. try to pay for a cart using Adyen.

Issue
-----
`window.AdyenWeb` is `undefined`

Cause
-----
Commit 41ab7c25282c4 updated the Adyen SDK used. Part of this was replacing the SDK link, and loading it.

The issue is that loading the script is an asynchronous operation, which hasn't finished yet when it's needed to access `AdyenWeb`.

Solution
--------
Await the loading of external files.

opw-4690447
opw-4715066
