### PR TITLE
[FIX] sale_mrp: update sol for kit product with mto components

### DIFF
--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -127,10 +127,15 @@ class SaleOrderLine(models.Model):
         sorted_moves = self.move_ids.sorted('id')
         triggering_rule_ids = []
         seen_wh_ids = set()
+        seen_bom_id = set()
         for move in sorted_moves:
-            if move.warehouse_id.id not in seen_wh_ids:
+            if move.bom_line_id.bom_id.id in seen_bom_id:
+                triggering_rule_ids.append(move.rule_id.id)
+            elif move.warehouse_id.id not in seen_wh_ids:
                 triggering_rule_ids.append(move.rule_id.id)
                 seen_wh_ids.add(move.warehouse_id.id)
+                if move.bom_line_id and move.bom_line_id.bom_id.type == 'phantom':
+                    seen_bom_id.add(move.bom_line_id.bom_id.id)
 
         return {
             'incoming_moves': lambda m: (


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable Multi-Step
- Unarchive the MTO route
- Create a storable product P with bom of type kit:
    - 1 x MTO COMP: with routes MTO and buy and set vendor
    - 1 X not MTO COMP: without routes
- Create and confirm a sale order for 1 units of P
- Update the quantity of the sale order line from 1 to 5
#### > The delivery is now for 6 units of both kit component

### Cause of the issue:

Updating the quantity on the SOL will launch a call of the `_action_launch_stock_rule`.The quantity of the new procurement is then processed by these lines based on the kit data's: https://github.com/odoo/odoo/blob/65704e58fda293af727f76d5c0741b135817db99/addons/sale_stock/models/sale_order_line.py#L359 https://github.com/odoo/odoo/blob/65704e58fda293af727f76d5c0741b135817db99/addons/sale_mrp/models/sale_order_line.py#L153-L160 However, since one component uses the MTO route and the other does not the filter based on rules will fail since one of the component move refer to the mto rule and the other one to the delivery rule. In particular the computation will always lead to a result of 0 no matter how many are really processed because only one of the 2 moves can respect the filter.

opw-4700925
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
