### PR TITLE
[FIX] hr_holidays: fix time off wizard with an attachment

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -388,6 +388,12 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//div[hasclass('col_right')]" position="replace"/>
+            <xpath expr="//chatter" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//div[hasclass('o_attachment_preview')]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Steps:
- Install the hr_holidays module
- apply for leave from the calendar and add an attachment.
- open the form view from the wizard using the expand button at the top right.
- then, open the same leave again from the calendar in the wizard view

Description of the issue/feature this PR addresses:
When opening a leave request in the wizard view that includes an attachment, the chatter and attachment preview are displayed. This makes the wizard layout inconsistent.

Cause:
The chatter and attachment preview are unintentionally shown in the wizard due to the attachment being linked to the record.

Fix:
This PR hides the chatter and attachment preview in the wizard view, ensuring a cleaner and more consistent user experience.

task-4703080
