### PR TITLE
[FIX] l10n_in_stock:fix key error when printing report

### DIFF
--- a/addons/l10n_in_stock/views/report_stockpicking_operations.xml
+++ b/addons/l10n_in_stock/views/report_stockpicking_operations.xml
@@ -3,7 +3,7 @@
 
     <template id="gst_report_picking_inherit" inherit_id="stock.report_picking">
         <xpath expr="//span[@t-field='move.description_picking']" position="after">
-            <t t-if="move.product_id and move.product_id.l10n_in_hsn_code and o.company_id.account_fiscal_country_id.code == 'IN'"><h6><strong class="ml16">HSN/SAC Code:</strong> <span t-field="ml.product_id.l10n_in_hsn_code"/></h6></t>
+            <t t-if="move.product_id and move.product_id.l10n_in_hsn_code and o.company_id.account_fiscal_country_id.code == 'IN'"><h6><strong class="ml16">HSN/SAC Code:</strong> <span t-field="move.product_id.l10n_in_hsn_code"/></h6></t>
         </xpath>
     </template>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- there is typo, where 'ml' is not correctly replaced with 'move', in this commit https://github.com/odoo/odoo/commit/381615636185b88585e5ca112e43b6a7d81e1895.

## steps to reproduce
- Create an Indian company
- install stock module and create a delivery
- select a product which has `'HSN/SAC Code` field set and validate the order.
- print `Picking Operations` report

## Traceback received: 
```py 
File "/data/build/odoo/odoo/addons/base/models/[ir_ui_view.py](http://ir_ui_view.py/)", line 2206, in _render_template
    return self.env['ir.qweb']._render(template, values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/tools/[profiler.py](http://profiler.py/)", line 313, in _tracked_method_render
    return method_render(self, template, values, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/addons/base/models/[ir_qweb.py](http://ir_qweb.py/)", line 605, in _render
    result = ''.join(rendering)
             ^^^^^^^^^^^^^^^^^^
  File "<2221>", line 2048, in template_2221
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
KeyError: 'ml'
Template: stock.report_picking
Path: /t/t/div/t/div/table[1]/tbody/t/tr/td[1]/t/h6/span
Node: <span t-field="ml.product_id.l10n_in_hsn_code"/>

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
```



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
