### PR TITLE
[IMP] website_sale: Remove `Magnifier on hover` zoom option from eCommerce

### DIFF
--- a/addons/website_sale/const.py
+++ b/addons/website_sale/const.py
@@ -235,8 +235,6 @@ PRODUCT_PAGE_STYLE_MAPPING = {
                 'website_sale.product_picture_magnify_click',
             ],
             'disable': [
-                'website_sale.product_picture_magnify_hover',
-                'website_sale.product_picture_magnify_both',
                 'website_sale_comparison.product_add_to_compare',  # Comparison
                 'website_sale.product_terms_and_conditions',  # Terms and Conditions
             ],
@@ -273,8 +271,6 @@ PRODUCT_PAGE_STYLE_MAPPING = {
                 'website_sale.product_picture_magnify_click',
             ],
             'disable': [
-                'website_sale.product_picture_magnify_hover',
-                'website_sale.product_picture_magnify_both',
                 'website_sale_comparison.product_add_to_compare',  # Comparison
                 'website_sale.product_terms_and_conditions',  # Terms and Conditions
             ],

--- a/addons/website_sale/static/src/website_builder/product_page_option.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option.js
@@ -2,9 +2,6 @@ import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 
 export class ProductPageOption extends BaseOptionComponent {
     static template = "website_sale.ProductPageOption";
-    static props = {
-        getZoomLevels: Function,
-    };
     setup() {
         super.setup();
         this.domState = useDomState((el) => {

--- a/addons/website_sale/static/src/website_builder/product_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/product_page_option.xml
@@ -315,15 +315,11 @@
     </BuilderRow>
 
     <t t-if="domState.hasImages and !this.isActiveItem('opt_product_page_image_width_hide')">
-        <div class="pt-2"/> <!-- Spacer -->
-	    <BuilderRow label.translate="Zoom">
-	        <BuilderSelect action="'websiteConfig'" id="'o_wsale_zoom_mode'">
-	            <t t-foreach="props.getZoomLevels()" t-as="zoomLevel" t-key="zoomLevel.id">
-	                <t t-if="zoomLevel.visible">
-                        <BuilderSelectItem id="zoomLevel.id" actionParam="{ views: zoomLevel.views }" t-out="zoomLevel.label"/>
-	                </t>
-	            </t>
-	        </BuilderSelect>
+	    <BuilderRow label.translate="Zoom on click" level="1">
+            <BuilderCheckbox
+                action="'websiteConfig'"
+                actionParam="{ views: ['website_sale.product_picture_magnify_click'] }"
+            />
 	    </BuilderRow>
     </t>
 

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -13,13 +13,10 @@ export const productPageSelector = "main:has(.o_wsale_product_page)";
 class ProductPageOptionPlugin extends Plugin {
     static id = "productPageOption";
     static dependencies = ["builderActions", "media", "customizeWebsite"];
-    static shared = ["getDisabledOtherZoomViews", "forceCarouselRedraw"];
+    static shared = ["forceCarouselRedraw"];
     resources = {
         builder_options: {
             OptionComponent: ProductPageOption,
-            props: {
-                getZoomLevels: this.getZoomLevels.bind(this),
-            },
             selector: productPageSelector,
             editableOnly: false,
             title: _t("Product Page"),
@@ -92,46 +89,6 @@ class ProductPageOptionPlugin extends Plugin {
         }
     }
 
-    getZoomLevels() {
-        const hasImages = !this.productDetailEl.classList.contains("o_wsale_product_page_opt_image_width_none");
-        const isFullImage = this.productDetailEl.classList.contains("o_wsale_product_page_opt_image_width_100_pc");
-        return [
-            {
-                id: "o_wsale_zoom_hover",
-                views: ["website_sale.product_picture_magnify_hover"],
-                label: _t("Magnifier on hover"),
-                visible: hasImages && !isFullImage,
-            },
-            {
-                id: "o_wsale_zoom_click",
-                views: ["website_sale.product_picture_magnify_click"],
-                label: _t("Pop-up on Click"),
-                visible: hasImages,
-            },
-            {
-                id: "o_wsale_zoom_both",
-                views: ["website_sale.product_picture_magnify_both"],
-                label: _t("Both"),
-                visible: hasImages && !isFullImage,
-            },
-            {
-                id: "o_wsale_zoom_none",
-                views: [],
-                label: _t("None"),
-                visible: hasImages,
-            },
-        ];
-    }
-    getZoomViews() {
-        const views = [];
-        for (const zoomLevel of this.getZoomLevels()) {
-            views.push(...zoomLevel.views);
-        }
-        return views;
-    }
-    getDisabledOtherZoomViews(keptView) {
-        return this.getZoomViews().map((view) => (view === keptView ? view : `!${view}`));
-    }
     forceCarouselRedraw() {
         if (!this.productPageCarousel) {
             return;
@@ -225,25 +182,7 @@ export class ProductPageImageLayoutAction extends WebsiteConfigAction {
     getValue({ editingElement: productDetailMainEl }) {
         return productDetailMainEl.dataset.image_layout;
     }
-    async apply({ editingElement: productDetailMainEl, value }) {
-        const imageIsFullWidth = productDetailMainEl.classList.contains(
-            "o_wsale_product_page_opt_image_width_100_pc"
-        );
-        let defaultZoomOption =
-            value === "grid"
-                ? "website_sale.product_picture_magnify_click"
-                : "website_sale.product_picture_magnify_hover";
-        if (
-            imageIsFullWidth &&
-            defaultZoomOption === "website_sale.product_picture_magnify_hover"
-        ) {
-            defaultZoomOption = "website_sale.product_picture_magnify_click";
-        }
-        await super.apply({
-            params: {
-                views: this.dependencies.productPageOption.getDisabledOtherZoomViews(defaultZoomOption),
-            },
-        });
+    async apply({ value }) {
         return rpc("/shop/config/website", { product_page_image_layout: value });
     }
 }

--- a/addons/website_sale/static/tests/builder/product_page_option.test.js
+++ b/addons/website_sale/static/tests/builder/product_page_option.test.js
@@ -115,7 +115,7 @@ test("Product page options", async () => {
     await waitForEndOfOperation();
     expect.verifySteps([
         // Activate the carousel view and change the shop config
-        "theme_customize_data", "config",
+        "config",
         // Shop config changes don't trigger the `savePlugin`; image edits are saved because of the
         // theme customization.
         "modify_image",

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -210,9 +210,6 @@ class TestWebsiteSaleImage(HttpCaseWithWebsiteUser):
 
         # Make sure we have zoom on click
         self.env['ir.ui.view'].with_context(active_test=False).search(
-            [('key', 'in', ('website_sale.product_picture_magnify_hover', 'website_sale.product_picture_magnify_click', 'website_sale.product_picture_magnify_both'))]
-        ).write({'active': False})
-        self.env['ir.ui.view'].with_context(active_test=False).search(
             [('key', '=', 'website_sale.product_picture_magnify_click')]
         ).write({'active': True})
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2439,23 +2439,8 @@
     </template>
 
     <!-- Product options: Zoom -->
-    <template inherit_id='website_sale.product' id="product_picture_magnify_hover" name="Automatic Image Zoom">
+    <template inherit_id='website_sale.product' id="product_picture_magnify_click" name="Image Zoom On Click">
         <xpath expr='//div[hasclass("o_wsale_product_page")]' position='attributes'>
-            <attribute name="data-ecom-zoom-auto">1</attribute>
-            <attribute name="class" separator=" " add="ecom-zoomable zoomodoo-next" />
-        </xpath>
-    </template>
-
-    <template inherit_id='website_sale.product' id="product_picture_magnify_click" active="False" name="Image Zoom On Click">
-        <xpath expr='//div[hasclass("o_wsale_product_page")]' position='attributes'>
-            <attribute name="data-ecom-zoom-click">1</attribute>
-            <attribute name="class" separator=" " add="ecom-zoomable zoomodoo-next" />
-        </xpath>
-    </template>
-
-    <template inherit_id='website_sale.product' id="product_picture_magnify_both" active="False" name="Automatic Image Zoom And On Click">
-        <xpath expr='//div[hasclass("o_wsale_product_page")]' position='attributes'>
-            <attribute name="data-ecom-zoom-auto">1</attribute>
             <attribute name="data-ecom-zoom-click">1</attribute>
             <attribute name="class" separator=" " add="ecom-zoomable zoomodoo-next" />
         </xpath>


### PR DESCRIPTION
**Before this commit:**
- The product image zoom behavior in eCommerce was controlled by a selection field with options: `None`, `Magnify on hover`, and `Zoom on click` and `Both`.
- `Magnifier on hover` does not work on mobile and provides limited added value.

**After this commit:**
- Remove the `Magnifier on hover` option and related logic.
- Replace the zoom mode selector with a boolean `Zoom on click` toggle.
- During upgrade, activate `Zoom on click` for all configurations except those set to `None`.

See Also: https://github.com/odoo/upgrade/pull/7540

task - 4712502

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
