### PR TITLE
[FIX] account: payment modification access error in branch accounting

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -780,7 +780,8 @@ class AccountBankStatementLine(models.Model):
         for st_line in self.with_context(skip_account_move_synchronization=True):
             liquidity_lines, suspense_lines, other_lines = st_line._seek_for_lines()
             journal = st_line.journal_id
-            company_currency = journal.company_id.currency_id
+            # bypassing access rights restrictions for branch-specific users in a branch company environment.
+            company_currency = journal.company_id.sudo().currency_id
             journal_currency = journal.currency_id if journal.currency_id != company_currency else False
 
             line_vals_list = st_line._prepare_move_line_default_vals()

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -207,7 +207,7 @@ class AccountPayment(models.Model):
 
     def _get_valid_liquidity_accounts(self):
         journal_comp = self.journal_id.company_id or self.env.company
-        accessible_branches = journal_comp.with_company(journal_comp)._accessible_branches()
+        accessible_branches = journal_comp._accessible_branches()
         return (
             self.journal_id.default_account_id |
             self.payment_method_line_id.payment_account_id |


### PR DESCRIPTION
PROBLEM 1:

Steps to reproduce:
- Create branch company
- Create a user for the branch company and assign the bookkeeper role
- Log in as the newly created user
- Inside accounting module navigate to Vendor menu -> Payment
- Create a payment and set the amount
- Attempt to edit the payment

Error:- Access Error: Access to unauthorized or invalid companies.

Cause:
Before this pr, the context passed during the accessible branches
calculation included 'journal_id.company_id' (i.e., the parent company_id). This
led to an error during validation in the companies method of the env class,
since the parent company_id is not valid for branch-specific operations/users.

Solution:
After this pr, remove the context modification introduced by the
'with_company()' method during the invocation of '_accessible_branches()',
ensuring that the correct branch context is used for access validation.

PROBLEM 2:

Steps to reproduce:
- First 3 steps are same as problem 1
- Inside accounting module navigate to bank reconciliation list view
- Create new bank statement line
- Attempt to edit the bank statement line

Error:- Access Error: because of company rule employee

Cause:
Before this pr, in the '_synchronize_to_moves' method the 'company_currency'
calculation   included 'journal.company_id.currency_id' in which
'journal.company_id' is the parent company_id to which the user does not have
access.

Solution:
After this pr, adding 'sudo()' method call at the time of accessing
'journal.comapny_id' (i.e., parent company_id) for bypassing the access rights.

Task - 4654866