### PR TITLE
[FIX] web_editor: fix blue border on snippet previews when hovered

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2993,10 +2993,11 @@ we-select.o_grid we-toggler {
                 padding: 6px 12px;
                 border-bottom-left-radius: 5px;
             }
-            &:not(:has([data-preview-interaction-enabled="true"]))::after {
+            &::after {
                 content: "";
                 @include o-position-absolute(0, 0, 0, 0);
                 outline: 6px solid transparent;
+                pointer-events: none;
                 z-index: 1;
             }
             &:hover {


### PR DESCRIPTION
Steps to reproduce:

- Go to Website edit mode.
- Click on the "Intro" snippet category to open the snippets dialog.
- Hover over the different snippet previews; you'll see a blue border added to them when hovered. However, the issue is that there is no blue border on the "Carousel" snippets.

The issue was introduced by this commit [1], where "mouseenter" and "mouseleave" events were added to trigger the carousel animation on hover. In that commit, the blue border was removed on "Carousel" snippets because it was preventing the events from being triggered, and thus blocking the animation. However, the blue border doesn't need to be removed — it just needs a CSS rule: "pointer-events: none;". This has been done in this commit.

[1]: https://github.com/odoo/odoo/commit/e008c92fcad2b8cc160586ba6ab94bc077b9bf3d

task-4717504