### PR TITLE
[FIX] account: track analytic distrib for tax line sync

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2800,7 +2800,7 @@ class AccountMove(models.Model):
             return self.env['account.move.line']._fields[field].convert_to_write(record[field], record)
 
         def get_tax_line_tracked_fields(line):
-            return ('amount_currency', 'balance')
+            return ('amount_currency', 'balance', 'analytic_distribution')
 
         def get_base_line_tracked_fields(line):
             grouping_key = AccountTax._prepare_base_line_grouping_key(fake_base_line)


### PR DESCRIPTION
Analytic distribution is not tracked when synchronising
the tax line

Steps:

- Have an income account X with a sale tax set
- Create a journal entry with one line, having account X
  and debit xxx$
- Save the form, two lines should have been created, auto balancing line
  and tax line
- Set an analytic distribution on these two lines and save the form
-> The analytic distribution is unset from the tax line

Before this commit, we were keeping values of `amount_currency` and
`balance`, now we keep also `analytic_distribution` in the tracked
fields

opw-4662784
