### PR TITLE
[FIX] l10n_fr: add missing pcg_758 in Chart of Accounts

### DIFF
--- a/addons/l10n_fr/data/account.account.template.csv
+++ b/addons/l10n_fr/data/account.account.template.csv
@@ -601,6 +601,7 @@
 "pcg_7551","Quote-part de perte transférée (comptabilité du gérant)","755100","income","l10n_fr.l10n_fr_pcg_chart_template","","False"
 "pcg_7555","Quote-part de bénéfice attribuée (comptabilité des associés non-gérants)","755500","income","l10n_fr.l10n_fr_pcg_chart_template","","False"
 "pcg_757","Produits des cessions d’immobilisations incorporelles et corporelles","757000","income","l10n_fr.l10n_fr_pcg_chart_template","account.account_tag_investing","False"
+"pcg_758","Indemnités et autres produits","758000","income","l10n_fr.l10n_fr_pcg_chart_template","account.account_tag_investing","False"
 "pcg_7581","Dédits et pénalités perçus sur achats et ventes","758100","income","l10n_fr.l10n_fr_pcg_chart_template","account.account_tag_investing","False"
 "pcg_7582","Libéralités reçues","758200","income","l10n_fr.l10n_fr_pcg_chart_template","account.account_tag_investing","False"
 "pcg_7583","Rentrées sur créances amorties","758300","income","l10n_fr.l10n_fr_pcg_chart_template","account.account_tag_investing","False"


### PR DESCRIPTION
[FIX] accounting: missing chart line

"758 Indemnités et autres produits" was missing

Steps to reproduce:
-------------------
* French Fiscal Localization
* Open the Chart of Accounts
* Line 758 missing


Why the fix:
------------
Based on French government documentation
https://www.anc.gouv.fr/files/anc/files/1_Normes_fran%C3%A7aises/Plans%20comptables/Plan-de-comptes-PCG-2025.pdf

opw-4699235


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
