### PR TITLE
[FIX] website: fix animation interaction's impact on animation-delay

### DIFF
--- a/addons/website/static/src/interactions/animation.js
+++ b/addons/website/static/src/interactions/animation.js
@@ -34,14 +34,19 @@ export class Animation extends Interaction {
                 "o_animate_preview": undefined,
             }),
             "t-att-style": (el) => {
-                return {
+                const result = {
                     "animation-name": this.isResetting ? "dummy-none" : undefined,
                     "animation-play-state": (this.isResetting || this.isAnimateOnScroll) ? undefined : this.playState,
-                    "animation-delay": this.delay,
                     // The ones which are invisible in state 0 (like fade_in for
                     // example) will stay invisible.
                     "visibility": "visible",
                 };
+                // Avoid resetting animation-delay upon stop when it is not
+                // supposed to be modified at all.
+                if (this.isAnimateOnScroll) {
+                    result["animation-delay"] = this.delay;
+                }
+                return result;
             },
         },
     };


### PR DESCRIPTION
Since [1] when the animation public widget was converted to an interaction, the `animation-delay` property is reset to its original value when the interaction is stopped.
Because of this, when setting "Start After" on an "On Appearance" animation, the entered value is reset because the interaction is restarted, and therefore stopped.

This fix forbids the animation interaction to manipulate `animation-delay` unless it is an "On Scroll" animation.

Steps to reproduce:
- Drop a text block
- Select some text
- Animate text
- Make sure the animation is "On Appearance"
- Specify "Start After"

=> "Start After" did always reset to 0

[1]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f

task-4708382
