### PR TITLE
[FIX] mail: allow background-image in style whitelist

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -88,6 +88,8 @@ class _Cleaner(clean.Cleaner):
         'padding', 'padding-top', 'padding-left', 'padding-bottom', 'padding-right',
         'margin', 'margin-top', 'margin-left', 'margin-bottom', 'margin-right',
         'white-space',
+        # appearance
+        'background-image', 'background-position', 'background-size', 'background-repeat', 'background-origin',
         # box model
         'border', 'border-color', 'border-radius', 'border-style', 'border-width', 'border-top', 'border-bottom',
         'height', 'width', 'max-width', 'min-width', 'min-height',


### PR DESCRIPTION
Problem:
Images used via `background-image` in Email Marketing disappear upon email delivery. This is due to the CSS sanitization filter removing the `background-image` property.

Solution:
Add `background-image` related properties to`_style_whitelist`:
- background-image
- background-position
- background-size
- background-repeat
- background-origin

Steps to reproduce:
1. Add a "Header" > "Cover" block in an Email Marketing template.
2. Set a background image on the block.
3. Send the email.
4. Observe that the background image does not appear in the received email.

opw-4558819

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
