### PR TITLE
[FIX] hr_recruitment: prevent error when loading sample data

### DIFF
--- a/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
+++ b/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
@@ -88,7 +88,7 @@
             <field name="department_id" ref="dep_marketing" />
             <field name="salary_expected">3100</field>
             <field name="salary_proposed">3100</field>
-            <field name="stage_id" ref="stage_job5" />
+            <field name="stage_id" eval="ref('stage_job5', raise_if_not_found=False)" />
 
             <field name="create_date" eval="DateTime.today() - relativedelta(days=20)" />
             <field name="write_date" eval="DateTime.today() - relativedelta(days=20)" />
@@ -112,7 +112,7 @@
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_marketing" />
             <field name="salary_expected">2900</field>
-            <field name="stage_id" ref="stage_job3" />
+            <field name="stage_id" eval="ref('stage_job3ob3', raise_if_not_found=False)" />
 
             <field name="create_date" eval="DateTime.today() - relativedelta(months=2)" />
             <field name="date_last_stage_update"
@@ -138,7 +138,7 @@
 
             <field name="department_id" ref="dep_rd" />
             <field name="salary_expected">3800</field>
-            <field name="stage_id" ref="stage_job1" />
+            <field name="stage_id" eval="ref('stage_job1', raise_if_not_found=False)" />
 
             <field name="create_date" eval="DateTime.today() - relativedelta(days=5)" />
             <field name="date_last_stage_update"
@@ -163,7 +163,7 @@
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_rd" />
             <field name="salary_expected">3000</field>
-            <field name="stage_id" ref="stage_job1" />
+            <field name="stage_id" eval="ref('stage_job1', raise_if_not_found=False)" />
             <field name="active">False</field>
             <field name="application_status">refused</field>
             <field name="refuse_reason_id" ref="refuse_reason_1"></field>
@@ -191,7 +191,7 @@
             <field name="user_id" ref="base.user_admin" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_rd" />
-            <field name="stage_id" ref="stage_job0" />
+            <field name="stage_id" eval="ref('stage_job0', raise_if_not_found=False)" />
             <field name="applicant_notes">
                 I had a discussion with Maria during the last networking event we organized. I was
                 impressed by her enthusiasm for the company and I suggested to her that she should
@@ -274,8 +274,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">New</field>
             <field name="new_value_char">Initial Qualification</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_macm_helen_mm_1" />
         </record>
 
@@ -307,8 +307,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">Initial Qualification</field>
             <field name="new_value_char">First Interview</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job1')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job2')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job1', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job2', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_macm_helen_mm_2" />
         </record>
 
@@ -340,8 +340,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">First Interview</field>
             <field name="new_value_char">Second Interview</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job2')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job3')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job2', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job3', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_macm_helen_mm_3" />
         </record>
 
@@ -375,8 +375,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">Second Interview</field>
             <field name="new_value_char">Contract Proposal</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job3')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job4')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job3', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job4', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_macm_helen_mm_4" />
         </record>
 
@@ -408,8 +408,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">Contract Proposal</field>
             <field name="new_value_char">Contract Signed</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job4')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job5')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job4', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job5', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_macm_helen_mm_5" />
         </record>
 
@@ -428,8 +428,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">New</field>
             <field name="new_value_char">Initial Qualification</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_macm_enrique_mm_1" />
         </record>
 
@@ -464,8 +464,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">Initial Qualification</field>
             <field name="new_value_char">First Interview</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job1')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job2')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job1', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job2', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_macm_enrique_mm_2" />
         </record>
 
@@ -501,8 +501,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">First Interview</field>
             <field name="new_value_char">Second Interview</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job2')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job3')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job2', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job3', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_macm_enrique_mm_3" />
         </record>
 
@@ -542,8 +542,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">New</field>
             <field name="new_value_char">Initial Qualification</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_fsd_hannah_mm_1" />
         </record>
 
@@ -585,8 +585,8 @@
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">New</field>
             <field name="new_value_char">Initial Qualification</field>
-            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0')" />
-            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1')" />
+            <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0', raise_if_not_found=False)" />
+            <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1', raise_if_not_found=False)" />
             <field name="mail_message_id" ref="scenario_applicant_fsd_simon_mm_1" />
         </record>
 


### PR DESCRIPTION
When the user clicks on Load sample data button after deleting the stages,
A traceback will appear.

Steps to reproduce the error:
- Install ``hr_recruitment`` module
- Go to Recruitment > Configuration > Stages > Delete all stages
- Go to Recruitment > Applications > By Job Positions > Load sample data

Traceback:
```
ValueError: External ID not found in the system: hr_recruitment.stage_job3

ParseError: while parsing /home/odoo/src/odoo/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml:94, somewhere inside <record id="scenario_applicant_macm_enrique" model="hr.applicant">
    <field name="candidate_id" ref="scenario_candidate_enrique" />
    <field name="priority">2</field>
    <field name="linkedin_profile">www.example.linkedin.com/in/enrique.jones</field>
    <field name="job_id" ref="job_marketing" />
    <field name="user_id" ref="base.user_admin" />
    <field name="medium_id" ref="utm.utm_medium_direct" />
    <field name="department_id" ref="dep_marketing" />
    <field name="salary_expected">2900</field>
    <field name="stage_id" eval="ref('stage_job3ob3', raise_if_not_found=False)" />

    <field name="create_date" eval="DateTime.today() - relativedelta(months=2)" />
    <field name="date_last_stage_update"
       eval="DateTime.today() - relativedelta(days=1)" />
 </record>
```

This commit resolves the error by ``raise_if_not_found=False`` for the field if the stage is missing.

sentry-6530485438

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
