### PR TITLE
[FIX] hw_drivers: no config after checking out

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/migrate_config.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/migrate_config.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+ODOO_CONF=$(</home/pi/odoo.conf)
+
+migrate_setting() {
+    TARGET_FILE="$1"
+    CONF_KEY="$2"
+    APPEND="$3"
+    if [ ! -f "$TARGET_FILE" ] || [ -n "$APPEND" ]
+    then
+        REGEX="$CONF_KEY = ([^[:space:]]+)"
+        if [[ "$ODOO_CONF" =~ $REGEX ]]
+        then
+            VALUE=${BASH_REMATCH[1]}
+            echo "$VALUE" >> "$TARGET_FILE"
+            SETTINGS_MIGRATED='true'
+        fi
+    fi
+}
+
+migrate_setting '/home/pi/odoo-remote-server.conf'    'remote_server'
+migrate_setting '/home/pi/token'                      'token'
+migrate_setting '/home/pi/odoo-db-uuid.conf'          'db_uuid'
+migrate_setting '/home/pi/odoo-enterprise-code.conf'  'enterprise_code'
+migrate_setting '/home/pi/odoo-subject.conf'          'subject'
+
+if [ ! -f '/home/pi/wifi_network.txt' ]
+then
+    migrate_setting '/home/pi/wifi_network.txt'       'wifi_ssid'
+    migrate_setting '/home/pi/wifi_network.txt'       'wifi_password'   'true'
+fi
+
+if [ -n "$SETTINGS_MIGRATED" ]
+then
+    cp '/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo.conf' '/home/pi/odoo.conf'
+fi


### PR DESCRIPTION
Before this commit, if a new IoT box image (>=24.10) checked out a v16.0 database, the settings would be saved to `odoo.conf`, but the v16.0 code looks for specific files (e.g. `odoo-remote-server.conf`). The result is that the IoT box remains unpaired after checking out v16.

After this commit, in v16 only, we run a bash script at startup to look for any 'modern' config and migrate it to the old config files. Doing it this way allows the problem to be fixed without relying on a new image.

task-4718315

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
