### PR TITLE
[FIX] stock_account: fix wrong move directions

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -93,7 +93,7 @@ class StockMove(models.Model):
         move_out_ids = set()
         locations_should_be_valued = (self.move_line_ids.location_id | self.move_line_ids.location_dest_id).filtered(lambda l: l._should_be_valued())
         for record in self:
-            for move_line in self.move_line_ids:
+            for move_line in record.move_line_ids:
                 if move_line._should_exclude_for_valuation() or not move_line.picked:
                     continue
                 if move_line.location_id not in locations_should_be_valued and move_line.location_dest_id in locations_should_be_valued:


### PR DESCRIPTION
### Description:

The commit b15bdb6 introduces a bug causing the `account.move.line` to be broken. This is caused by the fact that rather than looping over the move_line_ids of one move, it does it on all of them, causing the moves to all have the same direction, even if the move lines have different directions.

### Fix:

Changing the `self` to `record` should fix the issue.

### Reference:

b15bdb65b11b3772c1d288b8b65e48f0cb221d24