### PR TITLE
[FIX] point_of_sale: sale details w/ blackbox

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -273,8 +273,8 @@ class ReportSaleDetails(models.AbstractModel):
             refund_products.append(category_dictionnary)
         refund_products = sorted(refund_products, key=lambda l: str(l['name']))
 
-        products, products_info = self._get_total_and_qty_per_category(products)
-        refund_products, refund_info = self._get_total_and_qty_per_category(refund_products)
+        products, products_info = self.with_context(config_id=configs[0].id if len(configs) > 0 else False)._get_total_and_qty_per_category(products)
+        refund_products, refund_info = self.with_context(config_id=configs[0].id if len(configs) > 0 else False)._get_total_and_qty_per_category(refund_products)
 
         currency = {
             'symbol': user_currency.symbol,


### PR DESCRIPTION
Before this commit, if the POS blackbox module was installed, the sale details report would display total price in price included because of an override. In this commit, we add the config id to the method computing this price so that the blackbox module can override this computation only if the config is a blackbox one.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
