### PR TITLE
[FIX] sale_stock: give company incoterm as default to incoterm in sale order

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -15,6 +15,7 @@ class SaleOrder(models.Model):
 
     incoterm = fields.Many2one(
         'account.incoterms', 'Incoterm',
+        default=lambda self: self.env.company.incoterm_id,
         help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
     incoterm_location = fields.Char(string='Incoterm Location')
     picking_policy = fields.Selection([


### PR DESCRIPTION
Currently, when creating a new sale order Incoterm value remains empty.

<b>Steps to reproduce:</b>

1) Install sales, stocks, and enable incoterms for sales in settings 
2) Give the default Incoterms value in the settings 
3) Try to create a new SO record

<b>Issue:-</b>

Even after providing the default incoterm value in the settings, 
The value of incoterm remains empty while creating the SO.

<b>Solution:-</b>

Give the company incoterm value as the default incoterm in the definition of incoterm in sale order.

opw-4700346

