### PR TITLE
[FIX] point_of_sale, pos_epson_printer: Correctly handle print error

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/pos_printer_service.js
@@ -51,7 +51,9 @@ export class PosPrinterService extends PrinterService {
                 // We want to call the _printWeb when the dialog is fully gone
                 // from the screen which happens after the next animation frame.
                 await new Promise(requestAnimationFrame);
-                this.printWeb(...arguments);
+
+                // Element is the first argument of the printHtml function
+                this.printWeb(printArguments[0]);
             },
         });
     }

--- a/addons/pos_epson_printer/static/src/app/utils/payment/epson_printer.js
+++ b/addons/pos_epson_printer/static/src/app/utils/payment/epson_printer.js
@@ -59,18 +59,25 @@ export class EpsonPrinter extends BasePrinter {
      * @override
      */
     async sendPrintingJob(img) {
-        const res = await fetch(this.address, {
-            method: "POST",
-            body: img,
-        });
-        const body = await res.text();
-        const parser = new DOMParser();
-        const parsedBody = parser.parseFromString(body, "application/xml");
-        const response = parsedBody.querySelector("response");
-        return {
-            result: response.getAttribute("success") === "true",
-            printerErrorCode: response.getAttribute("code"),
-        };
+        try {
+            const res = await fetch(this.address, {
+                method: "POST",
+                body: img,
+            });
+            const body = await res.text();
+            const parser = new DOMParser();
+            const parsedBody = parser.parseFromString(body, "application/xml");
+            const response = parsedBody.querySelector("response");
+            return {
+                result: response.getAttribute("success") === "true",
+                printerErrorCode: response.getAttribute("code"),
+            };
+        } catch {
+            return {
+                result: false,
+                printerErrorCode: "Not found, the printer is not reachable",
+            };
+        }
     }
 
     /**


### PR DESCRIPTION
When printer isn't reacheable a traceback is shown when trying to print a receipt. This is because the error is not handled correctly.

This commit adds a check to ensure that the error is correctly handled and that the user is notified of the error in a user-friendly manner.

ticket= 4715051