### PR TITLE
[FIX] l10n_nz: fix the display of invoice name

### DIFF
--- a/addons/l10n_nz/views/report_invoice.xml
+++ b/addons/l10n_nz/views/report_invoice.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
-        <xpath expr="//div[hasclass('page')]/t[@t-set='layout_document_title']" position="replace">
         <t name="invoice_title" position="replace">
             <t name="invoice_title">Tax Invoice</t>
         </t>
@@ -50,7 +49,6 @@
         <t name="proforma_vendor_bill_title" position="replace">
             <t name="proforma_vendor_bill_title">Proforma Tax Vendor Bill</t>
         </t>
-        </xpath>
     </template>
 
     <!-- Workaround for Studio reports, see odoo/odoo#60660 -->


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_nz" and switch company
- Create an invoice
- Click "Print"
- On the generated PDF all possible document titles show

### Cause:
This [commit](https://github.com/odoo/odoo/commit/af06243092fd194c993451ea9c165be9ec2b4188) changed the way the invoices title were displayed but it has a typo: it hasn't deleted the xpath like in `l10n_au` but added the change inside the xpath.

### Solution:
Remove the xpath.

opw-4710851