### PR TITLE
[FIX] pos_self_order: Fix shared orders when no table

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -115,16 +115,19 @@ class PosSelfOrderController(http.Controller):
         pos_config = self._verify_pos_config(access_token)
         session = pos_config.current_session_id
         table = pos_config.env["restaurant.table"].search([('identifier', '=', table_identifier)], limit=1)
+        domain = False
 
-        domain = ['&', '&',
-            ('table_id', '=', table.id),
-            ('state', '=', 'draft'),
-            ('access_token', 'not in', [data.get('access_token') for data in order_access_tokens])
-        ]
+        if not table_identifier:
+            domain = [(False, '=', True)]
+        else:
+            domain = ['&', '&',
+                ('table_id', '=', table.id),
+                ('state', '=', 'draft'),
+                ('access_token', 'not in', [data.get('access_token') for data in order_access_tokens])
+            ]
 
         for data in order_access_tokens:
-            domain = expression.OR([domain, [
-                '&',
+            domain = expression.OR([domain, ['&',
                 ('access_token', '=', data.get('access_token')),
                 ('write_date', '>', data.get('write_date'))
             ]])


### PR DESCRIPTION
Before this commit orders were synchronized between devices even when no table were used.

This commit add a check to ensure that orders are only synchronized when a table is set.

The behavior will be test after the backport of 205293
