### PR TITLE
[IMP] web: reset interaction's content with INITIAL_VALUE

### DIFF
--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -1,6 +1,6 @@
 import { renderToFragment } from "@web/core/utils/render";
 import { debounce, throttleForAnimation } from "@web/core/utils/timing";
-import { SKIP_IMPLICIT_UPDATE } from "./colibri";
+import { INITIAL_VALUE, SKIP_IMPLICIT_UPDATE } from "./colibri";
 import { makeAsyncHandler, makeButtonHandler } from "./utils";
 
 /**
@@ -39,6 +39,11 @@ export class Interaction {
      * @type {string}
      */
     static selectorHas = "";
+
+    /**
+     * Constant to reset dynamicContent t-att-* and t-out.
+     */
+    static INITIAL_VALUE = INITIAL_VALUE;
 
     /**
      * Note that a dynamic selector is allowed to return a falsy value, for ex
@@ -82,6 +87,9 @@ export class Interaction {
      * - other falsy values (`""`, `0`) are applied as such (`required=""`)
      * - boolean `true` is applied as the attribute's name
      *   (e.g. `{ "t-att-required": () => true }` applies `required="required"`)
+     *
+     * t-att-* and t-out directives also accept `Interaction.INITIAL_VALUE`,
+     * which resets them to the value they had before the interaction's start.
      *
      * Note that this is not owl! It is similar, to make it easy to learn, but
      * it is different, the syntax and semantics are somewhat different.

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -1305,6 +1305,45 @@ describe("t-att-class", () => {
         expect(span).toHaveClass(["a", "c"]);
         expect(span).not.toHaveClass("b");
     });
+
+    test("reset t-att-class to initial content", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                span: {
+                    "t-att-class": () => ({
+                        a: true, // will remain toggled on
+                        b: false, // will remain toggled off
+                        c: this.withClass, // initial = false
+                        d: this.withClass, // initial = true
+                        "e f": this.withClass, // multi class with initial = false
+                    }),
+                },
+            };
+            setup() {
+                this.withClass = true;
+            }
+            start() {
+                this.waitForTimeout(() => {
+                    this.withClass = Interaction.INITIAL_VALUE;
+                }, 1000);
+            }
+        }
+        await startInteraction(Test, `<div class="test"><span class="b d">Hi</span></div>`);
+        expect("span").toHaveClass("a");
+        expect("span").not.toHaveClass("b");
+        expect("span").toHaveClass("c");
+        expect("span").toHaveClass("d");
+        expect("span").toHaveClass("e");
+        expect("span").toHaveClass("f");
+        await advanceTime(1000);
+        expect("span").toHaveClass("a");
+        expect("span").not.toHaveClass("b");
+        expect("span").not.toHaveClass("c");
+        expect("span").toHaveClass("d");
+        expect("span").not.toHaveClass("e");
+        expect("span").not.toHaveClass("f");
+    });
 });
 
 describe("t-att-style", () => {
@@ -1491,6 +1530,34 @@ describe("t-att-style", () => {
         }
         await startInteraction(Test, TemplateBase);
         expect("span").toHaveOuterHTML(`<span style="color: red !important;">coucou</span>`);
+    });
+
+    test("reset t-att-style to initial content", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                span: {
+                    "t-att-style": () => ({
+                        "background-color": this.bgColor,
+                        "color": this.color,
+                    }),
+                },
+            };
+            setup() {
+                this.bgColor = "rgb(0, 255, 0)";
+                this.color = "rgb(255, 0, 0)";
+            }
+            start() {
+                this.waitForTimeout(() => {
+                    this.bgColor = Interaction.INITIAL_VALUE;
+                    this.color = Interaction.INITIAL_VALUE;
+                }, 1000);
+            }
+        }
+        await startInteraction(Test, `<div class="test" style="color: black;"><span style="background-color: rgb(0, 0, 255);">Hi</span></div>`);
+        expect("span").toHaveStyle({ "background-color": "rgb(0, 255, 0)", "color": "rgb(255, 0, 0)" });
+        await advanceTime(1000);
+        expect("span").toHaveStyle({ "background-color": "rgb(0, 0, 255)", "color": "rgb(0, 0, 0)" });
     });
 });
 
@@ -1728,6 +1795,56 @@ describe("t-att and t-out", () => {
         await click("span");
         expect.verifySteps(["clicked"]);
     });
+
+    test("reset t-out to initial content", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                span: { "t-out": () => this.tOut },
+            };
+            setup() {
+                this.tOut = "colibri";
+            }
+            start() {
+                this.waitForTimeout(() => {
+                    this.tOut = Interaction.INITIAL_VALUE;
+                }, 1000);
+            }
+        }
+        await startInteraction(Test, TemplateTest);
+        expect("span").toHaveText("colibri");
+        await advanceTime(1000);
+        expect("span").toHaveText("coucou");
+    });
+
+    test("reset t-att to initial content", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                span: {
+                    "t-att-animal": () => this.animal,
+                    "t-att-egg": () => this.egg,
+                },
+            };
+            setup() {
+                this.animal = "colibri";
+                this.egg = "easter";
+            }
+            start() {
+                this.waitForTimeout(() => {
+                    this.animal = Interaction.INITIAL_VALUE;
+                    this.egg = Interaction.INITIAL_VALUE;
+                }, 1000);
+            }
+        }
+        await startInteraction(Test, `<div class="test"><span egg="mysterious"></span></div>`);
+        expect("span").toHaveAttribute("animal", "colibri");
+        expect("span").toHaveAttribute("egg", "easter");
+        await advanceTime(1000);
+        expect("span").not.toHaveAttribute("animal");
+        expect("span").toHaveAttribute("egg", "mysterious");
+    });
+
 });
 
 describe("components", () => {


### PR DESCRIPTION
This commit introduces a mechanism for Interactions to retrieve the
initial content of an element targeted by a dynamicContent's `t-out` or
`t-att-*` directives.

A constant `this.INITIAL_VALUE` is instantiated on the Interactions and
can be called to reset a value. It could for instance be used like this:

```
dynamicContent = {
	_root: {
		"t-out": () => this.tOut,
		"t-att-class": () => ({
			active: this.condition ? this.isActive : this.INITIAL_VALUE,
		}),
	}
};
setup() {
	this.tOut = this.INITIAL_VALUE;
}
onSomeUpdate() {
	this.tOut = "Some completely new value";
}
```