### PR TITLE
[FIX] hr: enable json route for tests

### DIFF
--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -463,6 +463,11 @@ class TestHrEmployee(TestHrCommon):
 @tagged('-at_install', 'post_install')
 class TestHrEmployeeWebJson(HttpCase):
 
+    def setUp(self):
+        super().setUp()
+        # JSON route needs to be enabled for the tests
+        self.env['ir.config_parameter'].sudo().set_param('web.json.enabled', True)
+
     def test_webjson_employees(self):
         #check that json employees can be accessed
         url = "/json/1/employees"


### PR DESCRIPTION
Before this commit the test `test_webjson_employees` was failing in no demo builds as the json route only works in demo databases or when explicitly set. See https://github.com/odoo/odoo/pull/182196

This commit enables the system parameter, so that the test can be run as intended in no demo databases.


Runbot Error: https://runbot.odoo.com/odoo/error/162907


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
