### PR TITLE
[FIX] account_accountant: allow change account code mapping for non-DE companies

### DIFF
--- a/addons/l10n_de/models/account_account.py
+++ b/addons/l10n_de/models/account_account.py
@@ -8,9 +8,12 @@ class AccountAccount(models.Model):
     def write(self, vals):
         if (
             'code' in vals
-            and 'DE' in self.company_ids.account_fiscal_country_id.mapped('code')
+            and self.env.company.root_id.account_fiscal_country_id.code == 'DE'
             and any(a.code != vals['code'] for a in self)
         ):
-            if self.env['account.move.line'].search_count([('account_id', 'in', self.ids)], limit=1):
-                raise UserError(_("You can not change the code of an account."))
+            if self.env['account.move.line'].search_count(
+                domain=[('account_id', 'in', self.ids), ("company_id", "=", self.env.company.id)],
+                limit=1
+            ):
+                raise UserError(_("You can not change a Garman company code mapping of an account that has some journal items linked to it in accordance with GoBD."))
         return super().write(vals)


### PR DESCRIPTION
Description:

Description of the issue/feature this PR addresses:
---
In #172660 we prevent changing the code of accounts used in German companies as part of changes for GoBD compliance. This was valid before V18.0 where we introduced cross company accounts where the same account can have different code mappings for different companies. The constraint needs to adapt to allow changing the mapping of non-German companies even if the account itself is from a German company.

Current behavior before PR (steps to reproduce):
---
1. In a German company, open a used account (has some entries) from chart of accounts.
2. switch to "Mapping" tap, and try to set a code for any other non German company.
3.  you will get the error "You can not change the code of an account" as if you are changing a German company code.

Desired behavior after PR is merged:
---
The error only raises if you change the mapping of a German company, and allow other companies mappings to change.
Also adding a check for non-German accounts, if the code mapping of a German company is changed.
opw-4670638

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
