### PR TITLE
[FIX] pos_restaurant: prevent floor plan copy

### DIFF
--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -12,7 +12,7 @@ class PosConfig(models.Model):
 
     iface_splitbill = fields.Boolean(string='Bill Splitting', help='Enables Bill Splitting in the Point of Sale.')
     iface_printbill = fields.Boolean(string='Bill Printing', help='Allows to print the Bill before payment.')
-    floor_ids = fields.Many2many('restaurant.floor', string='Restaurant Floors', help='The restaurant floors served by this point of sale.')
+    floor_ids = fields.Many2many('restaurant.floor', string='Restaurant Floors', help='The restaurant floors served by this point of sale.', copy=False)
     set_tip_after_payment = fields.Boolean('Set Tip After Payment', help="Adjust the amount authorized by payment terminals to add a tip after the customers left or at the end of the day.")
     module_pos_restaurant_appointment = fields.Boolean("Table Booking")
     takeaway = fields.Boolean("Takeaway", help="Allow to create orders for takeaway customers.")


### PR DESCRIPTION
The original issue was that when you duplicated a pos restaurant, it would also duplicate it's floors. And when you would make an order on the same table in the 2 restaurant the second one would take the first one and override it.

Steps to reproduce:
-------------------
* Duplicate a restaurant
* Make an order on the same table in the 2 restaurant
* The second one will take the first one and override it
> Observation: The new order contains the first order lines in it if you
check the db

Why the fix:
------------
To avoid confusion when duplicating restaurant we prevent duplicating
the floor plans automatically.

opw-4536327