### PR TITLE
[FIX] l10n_ro_efactura: Commit after sending each invoice

### DIFF
--- a/addons/l10n_ro_efactura/wizard/account_move_send.py
+++ b/addons/l10n_ro_efactura/wizard/account_move_send.py
@@ -87,6 +87,10 @@ class AccountMoveSend(models.TransientModel):
                     xml_data = None
 
                 invoice._l10n_ro_edi_send_invoice(xml_data)
+
+                if self._can_commit():
+                    self.env.cr.commit()
+
                 active_document = invoice.l10n_ro_edi_document_ids.sorted()[0]
 
                 if active_document.state == 'invoice_sending_failed':


### PR DESCRIPTION
In Romania, when sending multiple invoices to e-Factura, if one invoice is rejected, the Send & Print wizard will raise a UserError at

https://github.com/odoo/odoo/blob/9416ca8cb63fc53a862aa8533dfa60ba33506191/addons/account/wizard/account_move_send.py#L461

This causes the transaction to get rolled back, and any successfully-sent invoices to be lost.

Solution: Commit after each invoice is sent.

opw-4630496