### PR TITLE
[FIX] purchase: Use float_compare to avoid posting wrong messages

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1490,7 +1490,7 @@ class PurchaseOrderLine(models.Model):
         # and doesn't actually change anything to the current record
         if  self.env.context.get('accrual_entry_date'):
             return
-        if new_qty != self.qty_received and self.order_id.state == 'purchase':
+        if not float_compare(new_qty, self.qty_received, precision_rounding=self.product_uom.rounding) and self.order_id.state == 'purchase':
             self.order_id.message_post_with_view(
                 'purchase.track_po_line_qty_received_template',
                 values={'line': self, 'qty_received': new_qty},


### PR DESCRIPTION
To reproduce: Use a product that has a purchase uom in kg and a base uom in tons. Create a purchase order and deliver 1656 kg of the product. This will save as 1.6560000000001 due to python arithmetic. If you save the value again, another message will be posted even though the value does not change.

To fix this, I changed the condition for posting a new message from using a '!=' comparator to using float_compare which circumvents the issue.

OPW-4631076


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
