### PR TITLE
[FIX] payment_xendit: subscription single-use tokens

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -409,6 +409,7 @@ class PaymentTransaction(models.Model):
         - `amount`: The rounded amount of the transaction.
         - `currency_id`: The currency of the transaction, as a `res.currency` id.
         - `partner_id`: The partner making the transaction, as a `res.partner` id.
+        - `should_tokenize`: Whether this transaction should be tokenized.
         - Additional provider-specific entries.
 
         Note: `self.ensure_one()`
@@ -425,6 +426,7 @@ class PaymentTransaction(models.Model):
             'amount': self.amount,
             'currency_id': self.currency_id.id,
             'partner_id': self.partner_id.id,
+            'should_tokenize': self.tokenize,
         }
 
         # Complete generic processing values with provider-specific values.

--- a/addons/payment/tests/test_flows.py
+++ b/addons/payment/tests/test_flows.py
@@ -68,6 +68,7 @@ class TestFlows(PaymentHttpCommon):
         self.assertEqual(processing_values['currency_id'], self.currency.id)
         self.assertEqual(processing_values['partner_id'], self.partner.id)
         self.assertEqual(processing_values['reference'], self.reference)
+        self.assertFalse(processing_values['should_tokenize'])
 
         # Verify computed values not provided, but added during the flow
         self.assertIn("tx_id=", tx_sudo.landing_route)

--- a/addons/payment_xendit/static/src/js/payment_form.js
+++ b/addons/payment_xendit/static/src/js/payment_form.js
@@ -119,8 +119,8 @@ paymentForm.include({
         Xendit.card.createToken(
             {
                 ...this._xenditGetPaymentDetails(paymentOptionId),
-                // Allow reusing tokens when the users wants to tokenize.
-                is_multiple_use: this.paymentContext.tokenizationRequested,
+                // Allow reusing tokens when the transaction should be tokenized.
+                is_multiple_use: processingValues['should_tokenize'],
                 amount: processingValues['rounded_amount'],
             },
             (err, token) => this._xenditHandleResponse(err, token, processingValues),


### PR DESCRIPTION
Currently, when paying for subscriptions via credit card, eventhough it will force tokenization in the backend, it will only create single-use tokens. This is because creation of multi-use tokens is dependent on `paymentContext.tokenizationRequested` which is only True when the "Save my payment details" button is checked. However when paying subscriptions, this button is not there because it should be tokenized by default. With this commit, we're making sure that the creation of multi-use tokens is reliant on whether the backend will tokenize it or not

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
