### PR TITLE
[IMP] project_purchase_stock, _*: assign project on resupply subcontractor operation

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tools.float_utils import float_compare
+from odoo.tools.misc import clean_context
 from dateutil.relativedelta import relativedelta
 
 
@@ -170,7 +171,8 @@ class StockPicking(models.Model):
         for company, group in group_by_company.items():
             vals_list, moves = group
             grouped_mo = self.env['mrp.production'].with_company(company).create(vals_list)
-            grouped_mo.with_context(self._get_subcontract_mo_confirmation_ctx()).action_confirm()
+            ctx = {**clean_context(self.env.context), **self._get_subcontract_mo_confirmation_ctx()}
+            grouped_mo.with_context(ctx).action_confirm()
             for mo, move in zip(grouped_mo, moves):
                 mo.date_finished = move.date
                 finished_move = mo.move_finished_ids.filtered(lambda m: m.product_id == move.product_id)

--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tools.float_utils import float_compare
+from odoo.tools.misc import clean_context
 from dateutil.relativedelta import relativedelta
 
 
@@ -187,7 +188,10 @@ class StockPicking(models.Model):
         for company, group in group_by_company.items():
             vals_list, moves = group
             grouped_mo = self.env['mrp.production'].with_company(company).create(vals_list)
-            grouped_mo.with_context(self._get_subcontract_mo_confirmation_ctx()).action_confirm()
+            ctx = clean_context(self.env.context)
+            ctx.pop('move_picking_partner_id', None)
+            ctx.update(self._get_subcontract_mo_confirmation_ctx())
+            grouped_mo.with_context(ctx).action_confirm()
             for mo, move in zip(grouped_mo, moves):
                 mo.date_finished = move.date
                 finished_move = mo.move_finished_ids.filtered(lambda m: m.product_id == move.product_id)

--- a/addons/project_purchase_stock/models/__init__.py
+++ b/addons/project_purchase_stock/models/__init__.py
@@ -1,4 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import purchase_order
+from . import purchase_order_line
+from . import stock_move
 from . import stock_rule

--- a/addons/project_purchase_stock/models/__init__.py
+++ b/addons/project_purchase_stock/models/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import purchase_order_line
 from . import stock_move
 from . import stock_rule

--- a/addons/project_purchase_stock/models/purchase_order_line.py
+++ b/addons/project_purchase_stock/models/purchase_order_line.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    def _create_stock_moves(self, picking):
+        """
+            There is no bridge module between project_purchase_stock and
+            mrp_subcontracting, so we have passed the context here. The project
+            is used while creating the Resupply.
+        """
+        stock_moves = super()._create_stock_moves(picking)
+        return stock_moves.with_context(project_id=picking.project_id.id)

--- a/addons/project_purchase_stock/models/purchase_order_line.py
+++ b/addons/project_purchase_stock/models/purchase_order_line.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    def _create_stock_moves(self, picking=False):
+        """
+            There is no bridge module between project_purchase_stock and
+            mrp_subcontracting, so we have passed the context here. The project
+            is used while creating the Resupply.
+        """
+        stock_moves = super()._create_stock_moves(picking)
+        if project := picking.project_id if picking else self.order_id.project_id:
+            return stock_moves.with_context(project_id=project.id)
+        return stock_moves

--- a/addons/project_purchase_stock/models/stock_move.py
+++ b/addons/project_purchase_stock/models/stock_move.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _get_new_picking_values(self):
+        vals = super()._get_new_picking_values()
+        if project_id := self.env.context.get('project_id'):
+            vals['project_id'] = project_id
+        return vals

--- a/addons/project_purchase_stock/models/stock_move.py
+++ b/addons/project_purchase_stock/models/stock_move.py
@@ -9,5 +9,5 @@ class StockMove(models.Model):
     def _get_new_picking_values(self):
         return {
             **super()._get_new_picking_values(),
-            'project_id': self.purchase_line_id.order_id.project_id.id,
+            'project_id': self.env.context.get('project_id') or self.purchase_line_id.order_id.project_id.id,
         }

--- a/addons/project_purchase_stock/models/stock_rule.py
+++ b/addons/project_purchase_stock/models/stock_rule.py
@@ -10,6 +10,8 @@ class StockRule(models.Model):
         res = super()._prepare_purchase_order(company_id, origins, values)
         if values[0].get('project_id'):
             res['project_id'] = values[0].get('project_id')
+        elif project := self.env.context.get('project_id'):
+            res['project_id'] = project
         return res
 
     def _make_po_get_domain(self, company_id, values, partner):

--- a/addons/project_purchase_stock/models/stock_rule.py
+++ b/addons/project_purchase_stock/models/stock_rule.py
@@ -10,6 +10,8 @@ class StockRule(models.Model):
         res = super()._prepare_purchase_order(company_id, origins, values)
         if values[0].get('project_id'):
             res['project_id'] = values[0].get('project_id')
+        elif project_id := self.env.context.get('project_id'):
+            res['project_id'] = project_id
         return res
 
     def _make_po_get_domain(self, company_id, values, partner):

--- a/addons/project_purchase_stock/tests/__init__.py
+++ b/addons/project_purchase_stock/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_reordering_rule
+from . import test_subcontracting_project

--- a/addons/project_purchase_stock/tests/test_subcontracting_project.py
+++ b/addons/project_purchase_stock/tests/test_subcontracting_project.py
@@ -1,0 +1,126 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+from odoo import Command
+
+
+@tagged('post_install', '-at_install')
+class TestProjectPurchaseStockSubcontracting(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if cls.env['ir.module.module']._get('mrp_subcontracting').state != 'installed':
+            cls.skipTest(cls, "mrp_subcontracting is not installed")
+
+        cls.project = cls.env['project.project'].create({'name': 'Test Project'})
+        cls.subcontractor = cls.env['res.partner'].create({'name': 'Subcontractor'})
+        cls.finished_product, cls.component = cls.env['product.product'].create([
+            {
+                'name': 'Finished Product',
+                'is_storable': True,
+                'seller_ids': [Command.create({
+                    'partner_id': cls.subcontractor.id,
+                    'price': 1.0,
+                })],
+            },
+            {
+                'name': 'Component',
+                'is_storable': True,
+            },
+        ])
+        cls.bom = cls.env['mrp.bom'].create({  # noqa: OLS03001
+            'product_tmpl_id': cls.finished_product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'subcontract',
+            'subcontractor_ids': [Command.link(cls.subcontractor.id)],
+            'bom_line_ids': [Command.create({
+                'product_id': cls.component.id,
+                'product_qty': 1.0,
+            })],
+        })
+
+    def test_project_is_propagated_to_subcontracting_resupply_picking(self):
+        """
+        Test project propagation from PO through subcontracting flow.
+
+        Scenario:
+        - Create PO for subcontracted product with project
+        - Confirm PO --> receipt picking created with project
+        - Receipt has existing MO with resupply picking
+        - Resupply picking should have project inherited
+        """
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor.id,
+            'project_id': self.project.id,
+            'order_line': [Command.create({
+                'product_id': self.finished_product.id,
+                'product_qty': 1.0,
+                'price_unit': 1.0,
+            })],
+        })
+        po.button_confirm()
+
+        # Verify receipt picking inherits project from PO
+        receipt = po.picking_ids
+        self.assertEqual(receipt.project_id, self.project, "Receipt should inherit project from PO")
+
+        # Get the subcontracting MO created for this receipt
+        subcontracting_mo = receipt._get_subcontract_production()
+        self.assertEqual(len(subcontracting_mo), 1, "One MO should be created for subcontracting")
+
+        # Get resupply picking from MO
+        resupply_picking = subcontracting_mo.picking_ids.filtered(
+            lambda picking: picking.picking_type_id == receipt.picking_type_id.warehouse_id.subcontracting_resupply_type_id
+        )
+        self.assertEqual(len(resupply_picking), 1, "One resupply picking should be created")
+
+        # Verify resupply picking inherits project
+        self.assertEqual(resupply_picking.project_id, self.project, "Resupply picking should inherit project")
+
+    def test_project_is_propagated_to_auto_generated_subcontracting_purchase(self):
+        """
+        Test project propagation when reordering rule auto-creates PO for component.
+
+        Scenario:
+        - Finished product has subcontracting BoM with component
+        - Component has a seller and a reordering rule to buy from subcontractor
+        - Create PO for finished product with project, confirm it
+        - Auto-generated PO for component should inherit the project
+        """
+        self.component.seller_ids = [Command.create({
+            'partner_id': self.subcontractor.id,
+            'price': 1.0,
+        })]
+
+        # Reordering rule for component, triggers PO creation when stock is needed
+        warehouse = self.env.ref('stock.warehouse0')
+        self.env['stock.warehouse.orderpoint'].create({
+            'name': 'Reorder Component',
+            'product_id': self.component.id,
+            'location_id': warehouse.lot_stock_id.id,
+            'product_min_qty': 0.0,
+            'product_max_qty': 1.0,
+        })
+
+        # Create and confirm PO for finished product with project
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor.id,
+            'project_id': self.project.id,
+            'order_line': [Command.create({
+                'product_id': self.finished_product.id,
+                'product_qty': 1.0,
+                'price_unit': 1.0,
+            })],
+        })
+        po.button_confirm()
+
+        # Verify that PO for component was auto-created with project
+        po_component = self.env['purchase.order'].search([
+            ('partner_id', '=', self.subcontractor.id),
+            ('state', '=', 'draft'),
+            ('order_line.product_id', '=', self.component.id),
+        ], limit=1)
+        self.assertTrue(po_component, "Reordering rule should auto-create PO for component")
+        self.assertEqual(po_component.project_id, self.project, "Auto-generated PO for component should inherit project")

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -381,7 +381,7 @@ class PurchaseOrder(models.Model):
             if any(product.type == 'consu' for product in order.order_line.product_id):
                 order = order.with_company(order.company_id)
                 moves = order.order_line._create_stock_moves()
-                moves = moves.filtered(lambda x: x.state not in ('done', 'cancel')).with_context({'move_picking_partner_id': self.partner_id}).sudo()._action_confirm()
+                moves = moves.filtered(lambda x: x.state not in ('done', 'cancel')).with_context(move_picking_partner_id=self.partner_id).sudo()._action_confirm()
                 seq = 0
                 for move in sorted(moves, key=lambda move: move.date):
                     seq += 5

--- a/addons/sale_project_stock/models/stock_move.py
+++ b/addons/sale_project_stock/models/stock_move.py
@@ -58,10 +58,10 @@ class StockMove(models.Model):
         }
 
     def _get_new_picking_values(self):
-        return {
-            **super()._get_new_picking_values(),
-            'project_id': self.sale_line_id.order_id.project_id.id,
-        }
+        vals = super()._get_new_picking_values()
+        if not vals.get('project_id') and self.sale_line_id.order_id.project_id:
+            vals['project_id'] = self.sale_line_id.order_id.project_id.id
+        return vals
 
     def _assign_picking_values(self, picking):
         return {


### PR DESCRIPTION
_*= mrp_subcontracting, purchase_stock, sale_project_stock

This commit fixes project propagation issues in subcontracting workflows where 
resupply transfers lose project association, resulting in it not appearing in
the project overview under 'Stock Moves'.

**1. Project not propagated to resupply subcontractor transfers**

**Steps to reproduce:**
- Install `project_purchase_stock` and `mrp_subcontracting` modules
- Create a project 'Project 1'
- Create a vendor (subcontractor)
- Create a finished product 'P1' with:
  * Routes: Buy
  * Vendor: the subcontractor created above
- Create a component product 'P2' with:
  * Routes: Resupply Subcontractor on Order
- Create a subcontracting BoM for 'P1' with component 'P2'
- Create a PO with:
  * Vendor: the subcontractor
  * Product: P1 (1 unit)
  * Project: 'Project 1' (in Other Info tab)
- Confirm the PO

**Issue:**
Two transfers are created:
- 'Receipt' transfer: correctly shows `project_id` = 'Project 1'
- 'Resupply Subcontractor' transfer: `project_id` is empty

The resupply transfer is missing from the project's 'Stock Moves' view,

**2. Project not propagated in nested subcontracting with auto-procurement**

**Steps to reproduce:**
- Create product 'P1' with:
  * Routes: Buy
  * Subcontracting BoM using component 'P2'
- Create product 'P2' with:
  * Subcontracting BoM using component 'P3'
  * Routes: Resupply Subcontractor on Order
  * Reordering rule: Min=1, Max=1, Route=Buy
- Create PO for 'P1' linked to a project
- Confirm the PO

**Issue:**
The system auto-creates a PO for 'P2' due to the reordering rule,
but this auto-generated PO lacks project association. When confirmed, its
resupply picking also misses the project id.

**Fix:**
- `PurchaseOrderLine._create_stock_moves`: Pass `project_id` via context to
  ensure downstream operations inherit project association
- `StockMove._get_new_picking_values`: Check context for `project_id` when
  creating new pickings (resupply transfers)
- `StockRule._prepare_purchase_order`: Propagate `project_id` from procurement
  values or context to auto-created purchase orders

task-4638950
