### PR TITLE
[FIX] account: prevent error while duplicating multiple payment terms

### DIFF
--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -265,10 +265,10 @@ class AccountPaymentTerm(models.Model):
             return None
         return format_date(self.env, self._get_last_discount_date(date_ref))
 
-    def copy(self, default=None):
+    def copy_data(self, default=None):
         default = dict(default or {})
-        default['name'] = _('%s (copy)', self.name)
-        return super().copy(default)
+        vals_list = super().copy_data(default=default)
+        return [dict(vals, name=_("%s (copy)", line.name)) for line, vals in zip(self, vals_list)]
 
 
 class AccountPaymentTermLine(models.Model):


### PR DESCRIPTION
Currently, an error occurs when a user tries to duplicate more than one payment term at once from the list view.

**Steps to produce:**
- Install the `account` module.
- Navigate to `Invoicing > Payment Terms` (list view).
- Select at least two records and duplicate them.
- Observe the error.

`ValueError - Expected singleton: account.payment.term(3, 4, 5, 6, 7, 8, 9, 10)`

An error occurs because the **copy** method accesses `self.name`, assuming a single record, when multiple records are duplicated, causing the `ValueError`.

[1] - https://github.com/odoo/odoo/blob/6b970a0bfbcdac92d05389aac994c0db36730a34/addons/account/models/account_payment_term.py#L270

This commit ensures that each duplicated payment term has its name individually updated after being copied.

Sentry - 6531350963