### PR TITLE
[IMP] html_editor: add vertical alignment toolbar button for table cells

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -45,6 +45,7 @@ This addon provides an extensible, maintainable editor.
             ('remove', 'html_editor/static/src/main/movenode.dark.scss'),
             ('remove', 'html_editor/static/src/main/toolbar/toolbar.dark.scss'),
             ('remove', 'html_editor/static/src/main/chatgpt/language_selector.dark.scss'),
+            ('remove', 'html_editor/static/src/main/table/table_align_selector.dark.scss'),
         ],
         'html_editor.assets_media_dialog': [
             # Bundle to use the media dialog in the backend and the frontend
@@ -67,6 +68,7 @@ This addon provides an extensible, maintainable editor.
             'html_editor/static/src/main/movenode.dark.scss',
             'html_editor/static/src/main/toolbar/toolbar.dark.scss',
             'html_editor/static/src/main/chatgpt/language_selector.dark.scss',
+            'html_editor/static/src/main/table/table_align_selector.dark.scss',
         ],
         'web.assets_unit_tests': [
             'html_editor/static/tests/**/*',

--- a/addons/html_editor/static/src/main/table/table_align_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_align_plugin.js
@@ -1,0 +1,117 @@
+import { Plugin } from "@html_editor/plugin";
+import { closestElement } from "@html_editor/utils/dom_traversal";
+import { _t } from "@web/core/l10n/translation";
+import { reactive } from "@odoo/owl";
+import { TableAlignSelector } from "./table_align_selector";
+
+const verticalAlignmentItems = [
+    {
+        mode: "top",
+        template: "html_editor.VerticalAlignTop",
+    },
+    {
+        mode: "middle",
+        template: "html_editor.VerticalAlignMiddle",
+    },
+    {
+        mode: "bottom",
+        template: "html_editor.VerticalAlignBottom",
+    },
+];
+
+export class TableAlignPlugin extends Plugin {
+    static id = "tableAlign";
+    static dependencies = ["history", "selection"];
+
+    resources = {
+        user_commands: [
+            {
+                id: "alignTop",
+                run: () => this.setVerticalAlignment("top"),
+            },
+            {
+                id: "alignMiddle",
+                run: () => this.setVerticalAlignment("middle"),
+            },
+            {
+                id: "alignBottom",
+                run: () => this.setVerticalAlignment("bottom"),
+            },
+        ],
+        toolbar_items: [
+            {
+                id: "table_alignment",
+                groupId: "layout",
+                description: _t("Vertical align table cells content"),
+                isAvailable: () =>
+                    this.dependencies.selection
+                        .getTargetedNodes()
+                        .some((node) => closestElement(node, "td, th")),
+                Component: TableAlignSelector,
+                props: {
+                    getItems: () => verticalAlignmentItems,
+                    getDisplay: () => this.verticalAlignMode,
+                    onSelected: (item) => {
+                        this.setVerticalAlignment(item.mode);
+                    },
+                },
+            },
+        ],
+
+        /** Handlers */
+        selectionchange_handlers: this.updateVerticalAlignParams.bind(this),
+        post_undo_handlers: this.updateVerticalAlignParams.bind(this),
+        post_redo_handlers: this.updateVerticalAlignParams.bind(this),
+        remove_format_handlers: this.setVerticalAlignment.bind(this),
+
+        /** Predicates */
+        has_format_predicates: (node) => closestElement(node, "td, th")?.style.verticalAlign,
+    };
+
+    setup() {
+        this.verticalAlignMode = reactive({ displayName: "" });
+    }
+
+    get currentVerticalAlign() {
+        const targetedCells = this.dependencies.selection
+            .getTargetedNodes()
+            .map((node) => closestElement(node, "td, th"))
+            .filter(Boolean);
+
+        if (!targetedCells.length) {
+            return "";
+        }
+
+        const verticalAlign = targetedCells[0].style.verticalAlign;
+        return verticalAlign &&
+            targetedCells.every((cell) => cell.style.verticalAlign === verticalAlign)
+            ? verticalAlign
+            : "";
+    }
+
+    setVerticalAlignment(mode = "") {
+        const targetedCells = new Set(
+            this.dependencies.selection
+                .getTargetedNodes()
+                .map((node) => closestElement(node, "td, th"))
+                .filter(Boolean)
+        );
+        let isAlignmentUpdated = false;
+
+        for (const cell of targetedCells) {
+            if (cell.isContentEditable && cell.style.verticalAlign !== mode) {
+                cell.style.verticalAlign = mode;
+                isAlignmentUpdated = true;
+            }
+        }
+
+        if (isAlignmentUpdated) {
+            this.dependencies.history.addStep();
+        }
+        this.updateVerticalAlignParams();
+    }
+
+    updateVerticalAlignParams() {
+        this.verticalAlignMode.displayName = this.currentVerticalAlign;
+    }
+}

--- a/addons/html_editor/static/src/main/table/table_align_selector.dark.scss
+++ b/addons/html_editor/static/src/main/table/table_align_selector.dark.scss
@@ -1,0 +1,3 @@
+.oe-vertical-align-icon {
+    fill: #fff;
+}

--- a/addons/html_editor/static/src/main/table/table_align_selector.js
+++ b/addons/html_editor/static/src/main/table/table_align_selector.js
@@ -1,0 +1,23 @@
+import { Component, useState } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
+
+export class TableAlignSelector extends Component {
+    static template = "html_editor.TableAlignSelector";
+    static props = {
+        getItems: Function,
+        getDisplay: Function,
+        onSelected: Function,
+        ...toolbarButtonProps,
+    };
+    static components = { Dropdown };
+
+    setup() {
+        this.items = this.props.getItems();
+        this.state = useState(this.props.getDisplay());
+    }
+
+    onSelected(item) {
+        this.props.onSelected(item);
+    }
+}

--- a/addons/html_editor/static/src/main/table/table_align_selector.scss
+++ b/addons/html_editor/static/src/main/table/table_align_selector.scss
@@ -1,0 +1,3 @@
+.oe-vertical-align-icon {
+    fill: #000;
+}

--- a/addons/html_editor/static/src/main/table/table_align_selector.xml
+++ b/addons/html_editor/static/src/main/table/table_align_selector.xml
@@ -1,0 +1,64 @@
+<templates xml:space="preserve">
+    <t t-name="html_editor.TableAlignSelector">
+        <Dropdown menuClass="'o-we-toolbar-dropdown'">
+            <button class="btn btn-light" t-att-title="props.title" name="vertical_align">
+                <t t-set="selectedItem" t-value="items.find(item => item.mode === state.displayName)" />
+                <t t-call="{{ selectedItem ? selectedItem.template : 'html_editor.VerticalAlignTop' }}" />
+            </button>
+            <t t-set-slot="content">
+                <t t-foreach="items" t-as="item" t-key="item.mode">
+                    <button
+                        t-attf-class="btn btn-light"
+                        t-att-class="{ active: item.mode === state.displayName }"
+                        t-on-pointerdown.prevent="() => {}"
+                        t-on-click="() => this.onSelected(item)"
+                    >
+                        <t t-call="{{item.template}}" />
+                    </button>
+                </t>
+            </t>
+        </Dropdown>
+    </t>
+
+    <t t-name="html_editor.VerticalAlignTop">
+        <svg class="oe-vertical-align-icon" name="vertical_align_top" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="16" height="16">
+            <g>
+                <path d="M51.542,9.5H36.458C34.551,9.5,33,11.051,33,12.958v29.083c0,1.907,1.551,3.458,3.458,3.458h15.083
+                    c1.907,0,3.458-1.551,3.458-3.458V12.958C55,11.051,53.449,9.5,51.542,9.5z M53,13.5v28.042
+                    c0,0.804-0.654,1.458-1.458,1.458H36.458C35.654,43.5,35,42.846,35,42.042V12.958c0-0.804,0.654-1.458,1.458-1.458h15.083
+                    c0.804,0,1.458,0.654,1.458,1.458V13.5z"/>
+                <path d="M23.542,9.5H8.458C6.551,9.5,5,11.051,5,12.958v39.083C5,53.949,6.551,55.5,8.458,55.5h15.083
+                    c1.907,0,3.458-1.551,3.458-3.458V12.958C27,11.051,25.449,9.5,23.542,9.5z"/>
+                <path d="M59,4.5H1c-0.552,0-1,0.448-1,1s0.448,1,1,1h58c0.552,0,1-0.448,1-1S59.552,4.5,59,4.5z"/>
+            </g>
+        </svg>
+    </t>
+
+    <t t-name="html_editor.VerticalAlignMiddle">
+        <svg class="oe-vertical-align-icon" name="vertical_align_middle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="16" height="16">
+            <g>
+                <path d="M59,29h-4V15.458C55,13.551,53.448,12,51.541,12H36.458C34.551,12,33,13.551,33,15.458V29h-6V10.458
+                    C27,8.551,25.449,7,23.542,7H8.458C6.551,7,5,8.551,5,10.458V29H1c-0.552,0-1,0.448-1,1s0.448,1,1,1h4v18.542
+                    C5,51.449,6.551,53,8.458,53h15.083C25.449,53,27,51.449,27,49.542V31h6v13.542C33,46.449,34.551,48,36.458,48h15.083
+                    C53.449,48,55,46.449,55,44.542V31h4c0.553,0,1-0.448,1-1S59.553,29,59,29z M53,34v10.542
+                    C53,45.346,52.346,46,51.542,46H36.458C35.654,46,35,45.346,35,44.542V15.458C35,14.654,35.654,14,36.458,14h15.083
+                    C52.346,14,53,14.654,53,15.458V34z"/>
+            </g>
+        </svg>
+    </t>
+
+    <t t-name="html_editor.VerticalAlignBottom">
+        <svg class="oe-vertical-align-icon" name="vertical_align_bottom" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="16" height="16">
+            <g>
+                <path d="M36.458,50.5h15.083c1.669,0,3.065-1.188,3.388-2.762C54.976,47.513,55,47.28,55,47.042V17.958
+                    c0-1.907-1.551-3.458-3.458-3.458H36.459C34.552,14.5,33,16.051,33,17.958v29.083c0,0.238,0.024,0.471,0.07,0.696
+                    C33.393,49.312,34.789,50.5,36.458,50.5z M35,17.958c0-0.804,0.654-1.458,1.459-1.458h15.083c0.804,0,1.458,0.654,1.458,1.458
+                    v29.584c0,0.201-0.041,0.393-0.115,0.567c-0.222,0.523-0.741,0.891-1.344,0.891H36.459c-0.604,0-1.122-0.368-1.344-0.891
+                    C35.041,47.434,35,47.243,35,47.042V17.958z"/>
+                <path d="M8.458,50.5h15.083c1.907,0,3.459-1.551,3.459-3.458V7.958C27,6.051,25.449,4.5,23.542,4.5H8.459
+                    C6.552,4.5,5,6.051,5,7.958v39.083C5,48.949,6.551,50.5,8.458,50.5z"/>
+                <path d="M59,53.5H1c-0.553,0-1,0.448-1,1s0.447,1,1,1h58c0.553,0,1-0.448,1-1S59.553,53.5,59,53.5z"/>
+            </g>
+        </svg>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -46,6 +46,7 @@ import { PowerboxPlugin } from "./main/powerbox/powerbox_plugin";
 import { SearchPowerboxPlugin } from "./main/powerbox/search_powerbox_plugin";
 import { SignaturePlugin } from "./main/signature_plugin";
 import { StarPlugin } from "./main/star_plugin";
+import { TableAlignPlugin } from "./main/table/table_align_plugin";
 import { TablePlugin } from "./main/table/table_plugin";
 import { TableResizePlugin } from "./main/table/table_resize_plugin";
 import { TableUIPlugin } from "./main/table/table_ui_plugin";
@@ -145,6 +146,7 @@ export const MAIN_PLUGINS = [
     SignaturePlugin,
     StarPlugin,
     TablePlugin,
+    TableAlignPlugin,
     TableUIPlugin,
     TabulationPlugin,
     ToolbarPlugin,

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -241,6 +241,18 @@ export function alignRight(editor) {
 export function justify(editor) {
     execCommand(editor, "justify");
 }
+/** @param {Editor} editor */
+export function alignTop(editor) {
+    execCommand(editor, "alignTop");
+}
+/** @param {Editor} editor */
+export function alignMiddle(editor) {
+    execCommand(editor, "alignMiddle");
+}
+/** @param {Editor} editor */
+export function alignBottom(editor) {
+    execCommand(editor, "alignBottom");
+}
 
 /**
  * @param {string} color

--- a/addons/html_editor/static/tests/align.test.js
+++ b/addons/html_editor/static/tests/align.test.js
@@ -1,6 +1,14 @@
 import { describe, test } from "@odoo/hoot";
 import { testEditor } from "./_helpers/editor";
-import { alignCenter, justify, alignLeft, alignRight } from "./_helpers/user_actions";
+import {
+    alignCenter,
+    justify,
+    alignLeft,
+    alignRight,
+    alignTop,
+    alignMiddle,
+    alignBottom,
+} from "./_helpers/user_actions";
 
 describe("left", () => {
     test("should align left", async () => {
@@ -307,6 +315,138 @@ describe("justify", () => {
             stepFunction: justify,
             contentAfter:
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: justify;">a[]b</h1></div>',
+        });
+    });
+});
+
+describe("top", () => {
+    test("should align top a selected cell", async () => {
+        await testEditor({
+            contentBefore: "<table><tbody><tr><td>a[]b</td></tr></tbody></table>",
+            stepFunction: alignTop,
+            contentAfter:
+                '<table><tbody><tr><td style="vertical-align: top;">a[]b</td></tr></tbody></table>',
+        });
+    });
+
+    test("should align top multiple selected cells", async () => {
+        await testEditor({
+            contentBefore: "<table><tbody><tr><td>a[b</td><td>c]d</td></tr></tbody></table>",
+            stepFunction: alignTop,
+            contentAfter:
+                '<table><tbody><tr><td style="vertical-align: top;">a[b</td><td style="vertical-align: top;">c]d</td></tr></tbody></table>',
+        });
+    });
+
+    test("should change previous alignment to top", async () => {
+        await testEditor({
+            contentBefore: `
+                <table>
+                    <tbody>
+                        <tr>
+                            <td style="vertical-align: bottom;">a[b</td>
+                            <td style="vertical-align: middle;">c]d</td>
+                        </tr>
+                    </tbody>
+                </table>`,
+            stepFunction: alignTop,
+            contentAfter: `
+                <table>
+                    <tbody>
+                        <tr>
+                            <td style="vertical-align: top;">a[b</td>
+                            <td style="vertical-align: top;">c]d</td>
+                        </tr>
+                    </tbody>
+                </table>`,
+        });
+    });
+});
+
+describe("middle", () => {
+    test("should align middle a selected cell", async () => {
+        await testEditor({
+            contentBefore: "<table><tbody><tr><td>a[b]c</td></tr></tbody></table>",
+            stepFunction: alignMiddle,
+            contentAfter:
+                '<table><tbody><tr><td style="vertical-align: middle;">a[b]c</td></tr></tbody></table>',
+        });
+    });
+
+    test("should align middle multiple selected cells", async () => {
+        await testEditor({
+            contentBefore: "<table><tbody><tr><td>a[b</td><td>c]d</td></tr></tbody></table>",
+            stepFunction: alignMiddle,
+            contentAfter:
+                '<table><tbody><tr><td style="vertical-align: middle;">a[b</td><td style="vertical-align: middle;">c]d</td></tr></tbody></table>',
+        });
+    });
+
+    test("should change previous alignment to middle", async () => {
+        await testEditor({
+            contentBefore: `
+                <table>
+                    <tbody>
+                        <tr>
+                            <td style="vertical-align: top;">a[b</td>
+                            <td style="vertical-align: bottom;">c]d</td>
+                        </tr>
+                    </tbody>
+                </table>`,
+            stepFunction: alignMiddle,
+            contentAfter: `
+                <table>
+                    <tbody>
+                        <tr>
+                            <td style="vertical-align: middle;">a[b</td>
+                            <td style="vertical-align: middle;">c]d</td>
+                        </tr>
+                    </tbody>
+                </table>`,
+        });
+    });
+});
+
+describe("bottom", () => {
+    test("should align bottom a selected cell", async () => {
+        await testEditor({
+            contentBefore: "<table><tbody><tr><td>a[b]c</td></tr></tbody></table>",
+            stepFunction: alignBottom,
+            contentAfter:
+                '<table><tbody><tr><td style="vertical-align: bottom;">a[b]c</td></tr></tbody></table>',
+        });
+    });
+
+    test("should align bottom multiple selected cells", async () => {
+        await testEditor({
+            contentBefore: "<table><tbody><tr><td>a[b</td><td>c]d</td></tr></tbody></table>",
+            stepFunction: alignBottom,
+            contentAfter:
+                '<table><tbody><tr><td style="vertical-align: bottom;">a[b</td><td style="vertical-align: bottom;">c]d</td></tr></tbody></table>',
+        });
+    });
+
+    test("should change previous alignment to bottom", async () => {
+        await testEditor({
+            contentBefore: `
+                <table>
+                    <tbody>
+                        <tr>
+                            <td style="vertical-align: top;">a[b</td>
+                            <td style="vertical-align: middle;">c]d</td>
+                        </tr>
+                    </tbody>
+                </table>`,
+            stepFunction: alignBottom,
+            contentAfter: `
+                <table>
+                    <tbody>
+                        <tr>
+                            <td style="vertical-align: bottom;">a[b</td>
+                            <td style="vertical-align: bottom;">c]d</td>
+                        </tr>
+                    </tbody>
+                </table>`,
         });
     });
 });

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -5,6 +5,7 @@ import { click, press, queryAll } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { execCommand } from "../_helpers/userCommands";
 import { expandToolbar } from "../_helpers/toolbar";
+import { unformat } from "../_helpers/format";
 
 test("should do nothing if no format is set", async () => {
     await testEditor({
@@ -866,6 +867,42 @@ describe("Toolbar", () => {
         await removeFormatClick();
         expect(getContent(el)).toBe(
             `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td style="" class="o_selected_td"><p>[\u200b</p></td><td style="" class="o_selected_td"><p>]\u200b</p></td></tr></tbody></table>`
+        );
+    });
+
+    test("Should remove vertical-align style from table cells", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr style="height: 100px;">
+                            <td>1</td>
+                            <td class="o_selected_td" style="vertical-align: bottom;">[</td>
+                        </tr>
+                        <tr style="height: 100px;">
+                            <td>3</td>
+                            <td class="o_selected_td" style="vertical-align: bottom;">4]</td>
+                        </tr>
+                    </tbody>
+                </table>
+            `)
+        );
+        await removeFormatClick();
+        expect(getContent(el)).toBe(
+            unformat(`
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr style="height: 100px;">
+                            <td>1</td>
+                            <td style="" class="o_selected_td">[</td>
+                        </tr>
+                        <tr style="height: 100px;">
+                            <td>3</td>
+                            <td style="" class="o_selected_td">4]</td>
+                        </tr>
+                    </tbody>
+                </table>
+            `)
         );
     });
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -650,6 +650,133 @@ test("toolbar should close on keypress tab inside table", async () => {
     expect(".o-we-toolbar").toHaveCount(0);
 });
 
+test("toolbar works: show the correct vertical alignment", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr style="height: 100px;">
+                        <td>[1</td>
+                        <td></td>
+                        <td>3</td>
+                    </tr>
+                    <tr style="height: 100px;">
+                        <td>4</td>
+                        <td>5]</td>
+                        <td>6</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await expandToolbar();
+    expect("button[name='vertical_align'] svg[name='vertical_align_top']").toHaveCount(1);
+    await click("button[name='vertical_align']");
+    await animationFrame();
+    await contains(".dropdown-menu button svg[name='vertical_align_middle']").click();
+    expect("button[name='vertical_align'] svg[name='vertical_align_middle']").toHaveCount(1);
+    expect(".dropdown-menu button.active svg[name='vertical_align_middle']").toHaveCount(1);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr style="height: 100px;">
+                        <td class="o_selected_td" style="vertical-align: middle;">[1</td>
+                        <td class="o_selected_td" style="vertical-align: middle;"></td>
+                        <td>3</td>
+                    </tr>
+                    <tr style="height: 100px;">
+                        <td class="o_selected_td" style="vertical-align: middle;">4</td>
+                        <td class="o_selected_td" style="vertical-align: middle;">5]</td>
+                        <td>6</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+});
+
+test("toolbar works: show the correct vertical alignment after undo/redo", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr style="height: 100px;">
+                        <td>1</td>
+                        <td>[</td>
+                    </tr>
+                    <tr style="height: 100px;">
+                        <td>3</td>
+                        <td>4]</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await expandToolbar();
+    expect("button[name='vertical_align'] svg[name='vertical_align_top']").toHaveCount(1);
+    await click("button[name='vertical_align']");
+    await animationFrame();
+    await contains(".dropdown-menu button svg[name='vertical_align_bottom']").click();
+    expect("button[name='vertical_align'] svg[name='vertical_align_bottom']").toHaveCount(1);
+    expect(".dropdown-menu button.active svg[name='vertical_align_bottom']").toHaveCount(1);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr style="height: 100px;">
+                        <td>1</td>
+                        <td class="o_selected_td" style="vertical-align: bottom;">[</td>
+                    </tr>
+                    <tr style="height: 100px;">
+                        <td>3</td>
+                        <td class="o_selected_td" style="vertical-align: bottom;">4]</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await press(["ctrl", "z"]);
+    await animationFrame();
+    expect("button[name='vertical_align'] svg[name='vertical_align_top']").toHaveCount(1);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr style="height: 100px;">
+                        <td>1</td>
+                        <td>[</td>
+                    </tr>
+                    <tr style="height: 100px;">
+                        <td>3</td>
+                        <td>4]</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await press(["ctrl", "y"]);
+    await animationFrame();
+    expect("button[name='vertical_align'] svg[name='vertical_align_bottom']").toHaveCount(1);
+    expect(".dropdown-menu button.active svg[name='vertical_align_bottom']").toHaveCount(1);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr style="height: 100px;">
+                        <td>1</td>
+                        <td class="o_selected_td" style="vertical-align: bottom;">[</td>
+                    </tr>
+                    <tr style="height: 100px;">
+                        <td>3</td>
+                        <td class="o_selected_td" style="vertical-align: bottom;">4]</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+});
+
 test("toolbar buttons shouldn't be active without text node in the selection", async () => {
     await setupEditor("<div>[<p><br></p>]</div>");
     await waitFor(".o-we-toolbar");


### PR DESCRIPTION
### Desired behavior after PR is merged:

- A vertical alignment button is added next to the text alignment button in expanded mode.
- The button is shown only when at least one table cell is selected.
- Vertical alignment options include top, middle, and bottom.
- The button displays the current alignment value and updates accordingly.

task-4630353

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
