### PR TITLE
Master expense small issues hupo

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1186,6 +1186,11 @@ class HrExpense(models.Model):
         self._message_set_main_attachment_id(self.env["ir.attachment"].browse(kwargs['attachment_ids'][-1:]), force=True)
 
     @api.model
+    def get_untitled_expense_name(self):
+        """ Done in a specific function to be called by hr_expense_extract to keep the same translation """
+        return _("Untitled Expense")
+
+    @api.model
     def create_expense_from_attachments(self, attachment_ids=None, view_type='list'):
         """
             Create the expenses from files.
@@ -1208,7 +1213,7 @@ class HrExpense(models.Model):
 
         for attachment in attachments:
             vals = {
-                'name': _("Untitled Expense %s", format_date(self.env, fields.Date.context_today(self))),
+                'name': self.get_untitled_expense_name(),
                 'price_unit': 0,
                 'product_id': product.id,
             }

--- a/addons/hr_expense/static/src/components/chatter_patch.js
+++ b/addons/hr_expense/static/src/components/chatter_patch.js
@@ -1,0 +1,51 @@
+import { patch } from "@web/core/utils/patch";
+import { Chatter } from "@mail/chatter/web_portal/chatter";
+import { isDragSourceExternalFile } from "@mail/utils/common/misc";
+import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
+import { MailAttachmentDropzone } from "@mail/core/common/mail_attachment_dropzone";
+
+/**
+ * Patch Chatter to add custom logic before the onDrop event.
+ */
+patch(Chatter.prototype, {
+    setup() {
+        super.setup(...arguments);
+
+        if (this.props.record?.resModel === 'hr.expense') {
+            useCustomDropzone(this.rootRef, MailAttachmentDropzone, {
+                extraClass: "o-mail-Chatter-dropzone",
+                /** @param {Event} ev */
+                onDrop: async (ev) => {
+                    if (this.state.composerType) {
+                        return;
+                    }
+
+                    if (isDragSourceExternalFile(ev.dataTransfer)) {
+                        const files = [...ev.dataTransfer.files];
+                        if (!this.state.thread.id) {
+
+                            // custom code to automatically fill the name because it is a required field
+                            if (this.props.record.data.name === "") {
+                                const untitled_expense = await this.orm.call('hr.expense', 'get_untitled_expense_name', [], {});
+                                await this.props.record.update({ 'name': untitled_expense });
+                            }
+
+                            const saved = await this.props.saveRecord?.();
+                            if (!saved) {
+                                return;
+                            }
+                        }
+                        Promise.all(files.map((file) => this.attachmentUploader.uploadFile(file))).then(
+                            () => {
+                                if (this.props.hasParentReloadOnAttachmentsChanged) {
+                                    this.reloadParentView();
+                                }
+                            }
+                        );
+                        this.state.isAttachmentBoxOpened = true;
+                    }
+                },
+            });
+        }
+    },
+});

--- a/addons/hr_expense/static/src/mixins/document_upload.js
+++ b/addons/hr_expense/static/src/mixins/document_upload.js
@@ -80,6 +80,7 @@ export const ExpenseDocumentUpload = (T) => class ExpenseDocumentUpload extends 
 
         useBus(this.env.bus, "change_file_input", async (ev) => {
             this.fileInput.el.files = ev.detail.files;
+            this.uploadsProcessing++;
             await this.onChangeFileInput();
         });
 

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -302,7 +302,7 @@
                     </div>
                 </sheet>
                 <div class="o_attachment_preview o_center_attachment"/>
-                <chatter/>
+                <chatter reload_on_attachment="True"/>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/commit/ca1f644a3c15f17482f56a2ece2a57f0f03098ff
introduced the "untitled expense" title for expense when being uploaded. The user can
then change manually the name. However, if the OCR is called after, it overrides the name
previously set by the user. Therefore, if the name of an expense starts with "Untitled
Expense", the OCR should not override the name. In this community PR, we define a new function
to keep the same translation for "Untitled Expense".

In addition, enables to add an attachment in the form view of an expense that has just
been created, without any field already filled. The "Digitize Document" is also
displayed directly without the need to refresh the page when using the mode "OCR on Demand".

In addition, fix an issue when dragging and dropping an expense on the list view:
Steps to reproduce:
- Go the "My expense" with the list view
- Drag & Drop a file

-> It should lead to the list view of the created expense,
but instead it's stuck to the page and the way out
is to refresh the page.

task-4684825



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
