### PR TITLE
[FIX] point_of_sale: remove scroll behavior from POS reciept orderline container

### DIFF
--- a/addons/pos_sale/static/src/overrides/components/orderline/orderline.xml
+++ b/addons/pos_sale/static/src/overrides/components/orderline/orderline.xml
@@ -10,7 +10,7 @@
                 <table t-if="line.details" class="sale-order-info">
                     <tr t-foreach="line.details" t-as="soLine" t-key="soLine_index">
                         <td class="text-truncate"><t t-esc="soLine.product_uom_qty"/>x</td>
-                        <td class="text-truncate" t-esc="soLine.product_name" />
+                        <td class="text-truncate product-name" t-esc="soLine.product_name" />
                         <td class="text-truncate">: </td>
                         <td t-if="!props.basic_receipt" class="text-truncate"><t t-esc="soLine.total" /> (tax incl.)</td>
                     </tr>


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1. Go to Sales > Create New Quotation.
2. Add a customer and a product(e.g., "Acoustic Bloc Screens testingggggggggg").
3. Go to POS > Open any register.
4. Navigate to Actions > Quotation/Order, select SO.
5. Apply a down payment percentage.
6. Enter the percentage, select Payment > Cash, and validate the payment.
7. Navigate Print full receipt.

<b>Issue:</b>
Unintended scrolling behavior in the order line section.

<b>Cause:</b> 
Although the container had the class overflow-y-auto, it wasn't the root 
cause. The issue occurred with long product names in certain configurations,
leading to unintended scrolling behavior.

<b>Solution:</b>
Added the product-name class to handle content display and prevent
 unnecessary scrolling.

opw-4479286
