### PR TITLE
[FIX] web: ensure full clickable area for dropdown item button in mobile

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -104,6 +104,8 @@
     &, .o_web_client.o_touch_device & {
         button, button:hover, button:disabled {
             all: unset;
+            display: inline-block;
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
Reproduce:
- Switch to mobile view
- Go to Project module
- Click on the gear icon next to a task or project
- Click the Start (or Launch) button in the dropdown
- Try tapping anywhere on the button (not just on the text)

Description of the issue/feature this PR addresses:
In the mobile view of the Project module, clicking the Start button from the dropdown menu only works if the user taps directly on the text. Tapping on the surrounding area within the button does not trigger the action—instead, it closes the menu without starting the timer.

Root cause:
The button inside the dropdown is wrapped in a `<span>` element, but its width does not extend across the entire span. As a result, only the text area is interactive, which causes usability issues on mobile where precise tapping is harder.

Solution:
Ensure the button inside the dropdown item spans the full width of its container by setting `width: 100%`. This allows the entire area of the button to be clickable,  improving usability on mobile devices.

Desired behavior after PR is merged:
Tapping anywhere on the button (not just the text) now consistently triggers the timer as expected.


opw-4561724
