### PR TITLE
[FIX] partner_autocomplete: shown proper name field for large input

### DIFF
--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -23,6 +23,7 @@ Auto-complete partner companies' data
     'auto_install': True,
     'assets': {
         'web.assets_backend': [
+            'partner_autocomplete/static/src/scss/*',
             'partner_autocomplete/static/src/js/*',
             'partner_autocomplete/static/src/xml/*',
         ],

--- a/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
+++ b/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
@@ -1,0 +1,4 @@
+// Same rule as .oe_title .o_field_char
+.o_form_view .o_form_editable .oe_title .o_field_field_partner_autocomplete {
+	width: 100%;
+}


### PR DESCRIPTION
**Steps to reproduce:**
Create a new contact/company with more than 25 character

**Issue:**
The name field is partially shown as compared to version 16.

**Cause:**
The issue occurs after this change (odoo/odoo@a68cfbb) in version 17. The below CSS for the partner autocomplete field has been removed as the field has 'field_partner_autocomplete' widget.
https://github.com/odoo/odoo/blob/05e60f226a0d15bfa3b71eaebe2786f4d687f23e/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss#L31-L34

**Solution:**
Reintroduce partner autocomplete CSS fix (odoo/odoo@b9788544b7101e5a202cf87989bc3f5fc0495249)

[opw-4686705](https://www.odoo.com/odoo/project/49/tasks/4686705)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
