### PR TITLE
[IMP] base, web: allow filtering action server state options

### DIFF
--- a/addons/web/static/src/views/fields/badge_selection_with_filter/badge_selection_field_with_filter.js
+++ b/addons/web/static/src/views/fields/badge_selection_with_filter/badge_selection_field_with_filter.js
@@ -1,0 +1,33 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import {
+    BadgeSelectionField,
+    badgeSelectionField,
+} from "@web/views/fields/badge_selection/badge_selection_field";
+
+export class BadgeSelectionWithFilterField extends BadgeSelectionField {
+    static props = {
+        ...BadgeSelectionField.props,
+        allowedSelectionField: { type: String },
+    };
+
+    get options() {
+        const allowedSelection = this.props.record.data[this.props.allowedSelectionField];
+        return super.options.filter(([value, _]) => allowedSelection.includes(value));
+    }
+}
+
+export const badgeSelectionFieldWithFilter = {
+    ...badgeSelectionField,
+    component: BadgeSelectionWithFilterField,
+    displayName: _t("Badges for Selection With Filter"),
+    supportedTypes: ["selection"],
+    extractProps({ options }) {
+        return {
+            ...badgeSelectionField.extractProps(...arguments),
+            allowedSelectionField: options.allowed_selection_field,
+        };
+    },
+};
+
+registry.category("fields").add("selection_badge_with_filter", badgeSelectionFieldWithFilter);

--- a/addons/web/static/tests/views/fields/badge_selection_with_filter_field.test.js
+++ b/addons/web/static/tests/views/fields/badge_selection_with_filter_field.test.js
@@ -1,0 +1,220 @@
+import { expect, test } from "@odoo/hoot";
+import { click } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
+
+class Partner extends models.Model {
+    is_raining_outside = fields.Boolean();
+    mood = fields.Selection({
+        selection: [
+            ["happy", "Happy"],
+            ["sad", "Sad"],
+        ],
+    });
+    color = fields.Selection({
+        selection: [
+            ["white", "White"],
+            ["grey", "Grey"],
+            ["black", "Black"],
+        ],
+    });
+    allowed_colors = fields.Json();
+    allowed_moods = fields.Json();
+
+    _onChanges = {
+        is_raining_outside(record) {
+            record.allowed_moods = ["happy"] + (record.is_raining_outside ? ["sad"] : []);
+        },
+        color(record) {
+            record.allowed_moods =
+                (record.color !== "black" ? ["happy"] : []) +
+                (record.color !== "white" ? ["sad"] : []);
+        },
+        mood(record) {
+            record.allowed_colors =
+                (record.mood === "happy" ? ["white"] : []) +
+                ["grey"] +
+                (record.mood === "sad" ? ["black"] : []);
+        },
+    };
+
+    _records = [
+        {
+            id: 1,
+            allowed_colors: "['white', 'grey']",
+            allowed_moods: "['happy']",
+            display_name: "first record",
+            is_raining_outside: false,
+            mood: "happy",
+            color: "white",
+        },
+    ];
+}
+
+defineModels([Partner]);
+
+test("badge selection field with filter, empty list", async () => {
+    Partner._records[0].allowed_colors = [];
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <field name="allowed_colors" invisible="1"/>
+                <field name="color" widget="selection_badge_with_filter"
+                    options="{'allowed_selection_field': 'allowed_colors'}"/>
+            </form>
+        `,
+    });
+
+    expect(".o_selection_badge").toHaveCount(0);
+});
+
+test("badge selection field with filter, single choice", async () => {
+    Partner._records[0].allowed_colors = ["grey"];
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <field name="allowed_colors" invisible="1"/>
+                <field name="color" widget="selection_badge_with_filter"
+                    options="{'allowed_selection_field': 'allowed_colors'}"/>
+            </form>
+        `,
+    });
+
+    expect(".o_selection_badge").toHaveCount(1);
+    expect(".o_selection_badge[value='\"white\"']").toHaveCount(0);
+    expect(".o_selection_badge[value='\"grey\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"black\"']").toHaveCount(0);
+});
+
+test("badge selection field with filter, all choices", async () => {
+    Partner._records[0].allowed_colors = ["white", "grey", "black"];
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <field name="allowed_colors" invisible="1"/>
+                <field name="color" widget="selection_badge_with_filter"
+                    options="{'allowed_selection_field': 'allowed_colors'}"/>
+            </form>
+        `,
+    });
+
+    expect(".o_selection_badge").toHaveCount(3);
+    expect(".o_selection_badge[value='\"white\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"grey\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"black\"']").toBeVisible();
+});
+
+test("badge selection field with filter, synchronize with other field", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <group>
+                    <field name="is_raining_outside"/>
+                    <field name="allowed_moods" invisible="1"/>
+                    <field name="mood" widget="selection_badge_with_filter"
+                        options="{'allowed_selection_field': 'allowed_moods'}"/>
+                </group>
+            </form>
+        `,
+    });
+    // not raining outside => sad should be invisible
+    expect("[name='is_raining_outside'] input").not.toBeChecked();
+    expect("div[name='mood'] .o_selection_badge").toHaveCount(1);
+    expect(".o_selection_badge[value='\"happy\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"sad\"']").toHaveCount(0);
+
+    await click("[name='is_raining_outside'] input");
+    await animationFrame();
+
+    // raining outside => sad should be visible
+    expect("[name='is_raining_outside'] input").toBeChecked();
+    expect("div[name='mood'] .o_selection_badge").toHaveCount(2);
+    expect(".o_selection_badge[value='\"happy\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"sad\"']").toBeVisible();
+
+    await click("[name='is_raining_outside'] input");
+    await animationFrame();
+
+    // not raining outside => sad should be invisible
+    expect("[name='is_raining_outside'] input").not.toBeChecked();
+    expect("div[name='mood'] .o_selection_badge").toHaveCount(1);
+    expect(".o_selection_badge[value='\"happy\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"sad\"']").toHaveCount(0);
+});
+
+test("badge selection field with filter, cross badge synchronization", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <group>
+                    <field name="allowed_moods"/>
+                    <field name="allowed_colors"/>
+                    <field name="mood" widget="selection_badge_with_filter" 
+                        options="{'allowed_selection_field': 'allowed_moods'}"/>
+                    <field name="color" widget="selection_badge_with_filter"
+                        options="{'allowed_selection_field': 'allowed_colors'}"/>
+                </group>
+            </form>
+        `,
+    });
+
+    // happy and white by default, sad and black should be invisible
+    expect("div[name='mood'] .o_selection_badge").toHaveCount(1);
+    expect("div[name='color'] .o_selection_badge").toHaveCount(2);
+    expect(".o_selection_badge[value='\"happy\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"sad\"']").toHaveCount(0);
+    expect(".o_selection_badge[value='\"white\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"grey\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"black\"']").toHaveCount(0);
+
+    await click(".o_selection_badge[value='\"grey\"']");
+    await animationFrame();
+
+    // happy and grey, sad should be revealed
+    expect("div[name='mood'] .o_selection_badge").toHaveCount(2);
+    expect("div[name='color'] .o_selection_badge").toHaveCount(2);
+    expect(".o_selection_badge[value='\"happy\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"sad\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"white\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"grey\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"black\"']").toHaveCount(0);
+
+    await click(".o_selection_badge[value='\"sad\"']");
+    await animationFrame();
+
+    // sad and grey, white should disappear and black should appear
+    expect("div[name='mood'] .o_selection_badge").toHaveCount(2);
+    expect("div[name='color'] .o_selection_badge").toHaveCount(2);
+    expect(".o_selection_badge[value='\"happy\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"sad\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"white\"']").toHaveCount(0);
+    expect(".o_selection_badge[value='\"grey\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"black\"']").toBeVisible();
+
+    await click(".o_selection_badge[value='\"black\"']");
+    await animationFrame();
+
+    // sad and black, happy should disappear
+    expect("div[name='mood'] .o_selection_badge").toHaveCount(1);
+    expect("div[name='color'] .o_selection_badge").toHaveCount(2);
+    expect(".o_selection_badge[value='\"happy\"']").toHaveCount(0);
+    expect(".o_selection_badge[value='\"sad\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"white\"']").toHaveCount(0);
+    expect(".o_selection_badge[value='\"grey\"']").toBeVisible();
+    expect(".o_selection_badge[value='\"black\"']").toBeVisible();
+});

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -559,6 +559,7 @@ class IrActionsServer(models.Model):
              "- 'Execute Code': a block of Python code that will be executed\n"
              "- 'Send Webhook Notification': send a POST request to an external system, also known as a Webhook\n"
              "- 'Multi Actions': define an action that triggers several other server actions\n")
+    allowed_states = fields.Json(string='Allowed states', compute="_compute_allowed_states")
     # Generic
     sequence = fields.Integer(default=5,
                               help="When dealing with multiple actions, the execution order is "
@@ -695,6 +696,9 @@ class IrActionsServer(models.Model):
                                 "have to remove the following fields from the webhook payload:\n%(restricted_fields)s", restricted_fields="\n".join(restricted_fields)))
 
         return warnings
+
+    def _compute_allowed_states(self):
+        self.allowed_states = [value for value, __ in self._fields['state'].selection]
 
     @api.depends(lambda self: self._warning_depends())
     def _compute_warning(self):

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -366,9 +366,10 @@
                             </group>
                         </group>
                         <t name="action_content" invisible="not model_id">
+                            <field name="allowed_states" invisible="1"/> <!-- Used to filter state using selection_badge_with_filter -->
                             <div class="d-flex flex-column">
                                 <label for="state"/>
-                                <field name="state" widget="selection_badge" options="{'size': 'sm'}"/>
+                                <field name="state" widget="selection_badge_with_filter" options="{'size': 'sm', 'allowed_selection_field': 'allowed_states'}"/>
                             </div>
                             <div class="alert alert-warning" role="alert" invisible="not warning">
                                 <i class="fa fa-warning pe-2" title="Warning"/><field class="d-inline" name="warning" nolabel="1"/>
@@ -494,7 +495,7 @@ env['res.partner'].create({'name': partner_name})
                             <!-- Icon section -->
                             <i
                                 data-name="server_action_icon"
-                                t-att-title="record.state.value" 
+                                t-att-title="record.state.value"
                                 class="fa fa-fw"
                                 t-att-class="{
                                     'code': 'fa-code',


### PR DESCRIPTION
Similarly to "radio selection field with filter", we introduce a new field widget "badge selection field with filter" allowing to filter dynamically the action server state options using a computed field. The test is also an adaptation of survey radio_selection_field_with_filter.test.js.

This is useful, for example, to display only the states that applies on the selected model.

[REF] account: determine suitable journals without a move instance

We extract the method _get_suitable_journal_ids to allow getting suitable journals without having to rely on _compute_suitable_journal_ids which requires to create an instance of account_move.

Task-4711378