### PR TITLE
[FIX] product: avoid negative cost

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -345,6 +345,11 @@ class ProductProduct(models.Model):
             return [('product_tag_ids', operator, operand), ('additional_product_tag_ids', operator, operand)]
         return ['|', ('product_tag_ids', operator, operand), ('additional_product_tag_ids', operator, operand)]
 
+    @api.onchange('standard_price')
+    def _onchange_standard_price(self):
+        if self.standard_price < 0:
+            raise ValidationError(_("The cost of a product can't be negative."))
+
     @api.onchange('default_code')
     def _onchange_default_code(self):
         if not self.default_code:

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -399,6 +399,11 @@ class ProductTemplate(models.Model):
         for template in self:
             template.product_variant_count = len(template.product_variant_ids)
 
+    @api.onchange('standard_price')
+    def _onchange_standard_price(self):
+        if self.standard_price < 0:
+            raise ValidationError(_("The cost of a product can't be negative."))
+
     @api.onchange('default_code')
     def _onchange_default_code(self):
         if not self.default_code:

--- a/addons/product/tests/test_product_pricelist.py
+++ b/addons/product/tests/test_product_pricelist.py
@@ -4,7 +4,9 @@
 from datetime import datetime
 import time
 
+from odoo.exceptions import ValidationError
 from odoo.fields import Command
+from odoo.tests import Form
 from odoo.tools import float_compare
 
 from odoo.addons.product.tests.common import ProductCommon
@@ -341,3 +343,12 @@ class TestProductPricelist(ProductCommon):
             child_address.with_company(company_2).property_product_pricelist,
             self.customer_pricelist,
         )
+
+    def test_no_negative_cost(self):
+        form = Form(self.product)
+        with self.assertRaises(ValidationError):
+            form.standard_price = -5
+
+        form = Form(self.product.product_tmpl_id)
+        with self.assertRaises(ValidationError):
+            form.standard_price = -5

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -64,6 +64,7 @@ class ProductTemplate(models.Model):
 
     @api.onchange('standard_price')
     def _onchange_standard_price(self):
+        super()._onchange_standard_price()
         if self.lot_valuated and any(p.quantity_svl for p in self.product_variant_ids):
             return {
                 'warning': {
@@ -226,6 +227,7 @@ class ProductProduct(models.Model):
 
     @api.onchange('standard_price')
     def _onchange_standard_price(self):
+        super()._onchange_standard_price()
         if self.lot_valuated:
             return {
                 'warning': {


### PR DESCRIPTION
The stock valuation will be broken if the user tries to play with
negative costs

Example: in mrp, produce one product based on one component that has
a negative cost. The value of the finished product will then be the
positive value of the component cost, which is wrong.

This comes from the use of `abs()` when creating the in-SVLs:
https://github.com/odoo/odoo/blob/ee5bd93e7386542f2490045698b268e621c5b892/addons/stock_account/models/stock_move.py#L527-L529

Considering the code, the design of the stock valuation in that case is
not intended to work with negative values. We could also consider the
above use case as an edge/not-supported one.

So, for now, the idea is to limit this not-working setup. It's not
perfect:
\- Users can still set negative cost on POL
\- Some weird flows may still `write()` some negative costs

Yet, that's a first and temporary step. Doing so, users won't think
that the configuration is ok and won't then break their stock
valuation (and, won't need a lot of work from tech support to fix the
whole database...). Also, the R&D team is aware of the situation and
will try to make the valuation work with negative values in the future.

OPW-3619709