### PR TITLE
[FIX] analytic: exclude custom fields for distribution retrieval

### DIFF
--- a/addons/analytic/models/analytic_distribution_model.py
+++ b/addons/analytic/models/analytic_distribution_model.py
@@ -74,9 +74,9 @@ class AccountAnalyticDistributionModel(models.Model):
 
     def _get_fields_to_check(self):
         return (
-                set(self.env['account.analytic.distribution.model']._fields)
-                - set(self.env['analytic.mixin']._fields)
-                - set(models.MAGIC_COLUMNS) - {'display_name', '__last_update'}
+            {field.name for field in self._fields.values() if not field.manual}
+            - set(self.env['analytic.mixin']._fields)
+            - set(models.MAGIC_COLUMNS) - {'display_name', '__last_update'}
         )
 
     def _check_score(self, key, value):


### PR DESCRIPTION
After feff1a8 the distribution model uses it's fields to retrieve a matching analytic distribution.

There's an incorrect behavior if a custom field is added to the model, for ex. with Studio or manually.

Steps to reproduce:
- add a custom field to the analytic distribution model with Studio
- create an analytic distribution model and fill the custom field with a value
->> the model is not applied anymore when it should be.

This is because of `_check_score` raising `NonMatchingDistribution` if a field has a non-falsy value and it's not matching in the values dictionary.

The custom fields are excluded from the check to fix this.

opw-4689695

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
