### PR TITLE
[IMP] l10n_sa_edi: 400 should be handled as the "rejected"

### DIFF
--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -54,10 +54,16 @@ class AccountMove(models.Model):
             if record.country_code == 'SA' and record.move_type in ('out_invoice', 'out_refund'):
                 if not record.l10n_sa_show_delivery_date:
                     raise UserError(_('Delivery Date cannot be empty'))
-                self.write({
-                    'l10n_sa_confirmation_datetime': fields.Datetime.now()
-                })
+                if not record.l10n_sa_confirmation_datetime:
+                    record.l10n_sa_confirmation_datetime = fields.Datetime.now()
         return res
+
+    def _l10n_sa_reset_confirmation_datetime(self):
+        self.filtered(lambda m: m.country_code == 'SA').l10n_sa_confirmation_datetime = False
+
+    def button_draft(self):
+        self._l10n_sa_reset_confirmation_datetime()
+        super().button_draft()
 
     def _get_l10n_sa_totals(self):
         self.ensure_one()

--- a/addons/l10n_sa_edi/models/__init__.py
+++ b/addons/l10n_sa_edi/models/__init__.py
@@ -7,3 +7,4 @@ from . import res_partner
 from . import res_company
 from . import res_config_settings
 from . import account_edi_xml_ubl_21_zatca
+from . import ir_attachment

--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -1,6 +1,6 @@
-import json
 import logging
-import pytz
+
+from markupsafe import Markup
 from hashlib import sha256
 from base64 import b64decode, b64encode
 from lxml import etree
@@ -166,21 +166,25 @@ class AccountEdiFormat(models.Model):
         """
         clearance_data = invoice.journal_id._l10n_sa_api_clearance(invoice, signed_xml.decode(), PCSID_data)
         if clearance_data.get('json_errors'):
-            errors = [json.loads(j).get('validationResults', {}) for j in clearance_data['json_errors']]
+            error = clearance_data['json_errors']
             error_msg = ''
+            status_code = error.get('status_code')
+            if status_code:
+                error_msg = Markup("<b>[%s] </b>") % status_code
+
             is_warning = True
-            for error in errors:
-                validation_results = error.get('validationResults', {})
-                for err in validation_results.get('warningMessages', []):
-                    error_msg += '\n - %s | %s' % (err['code'], err['message'])
-                for err in validation_results.get('errorMessages', []):
-                    is_warning = False
-                    error_msg += '\n - %s | %s' % (err['code'], err['message'])
+            validation_results = error.get('validationResults', {})
+            for err in validation_results.get('warningMessages', []):
+                error_msg += Markup('<b>%s</b> : %s <br/>') % (err['code'], err['message'])
+            for err in validation_results.get('errorMessages', []):
+                is_warning = False
+                error_msg += Markup('<b>%s</b> : %s <br/>') % (err['code'], err['message'])
             return {
                 'error': error_msg,
                 'rejected': not is_warning,
                 'response': signed_xml.decode(),
-                'blocking_level': 'warning' if is_warning else 'error'
+                'blocking_level': 'warning' if is_warning else 'error',
+                'status_code': status_code,
             }
         if not clearance_data.get('error'):
             return self._l10n_sa_assert_clearance_status(invoice, clearance_data)

--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -548,6 +548,7 @@ class AccountJournal(models.Model):
         """
         api_url = ZATCA_API_URLS[self.company_id.l10n_sa_api_mode]
         request_url = urljoin(api_url, request_url)
+        status_code = False
         try:
             request_response = requests.request(method, request_url, data=request_data.get('body'),
                                                 headers={
@@ -556,15 +557,26 @@ class AccountJournal(models.Model):
                                                 }, timeout=(30, 30))
             request_response.raise_for_status()
         except (ValueError, HTTPError) as ex:
-            # In the case of an explicit error from ZATCA, i.e we got a response but the code of the response is not 2xx
-            return {
-                'error': _("Server returned an unexpected error: ") + (request_response.text or str(ex)),
-                'blocking_level': 'error'
-            }
+            # The 400 case means that it is rejected by ZATCA, but we need to update the hash as done for accepted.
+            # In the 401+ cases, it is like the server is overloaded e.g. and we still need to resend later.  We do not
+            # erase the index chain (excepted) because for ZATCA, one ICV (index chain) needs to correspond to one invoice.
+            status_code = ex.response.status_code
+            if status_code != 400:
+                return {
+                    'error': (Markup("<b>[%s]</b>") % status_code) + _("Server returned an unexpected error: %(error)s",
+                               error=(request_response.text or str(ex))),
+                    'blocking_level': 'warning',
+                    'status_code': status_code,
+                    'excepted': True,
+                }
         except RequestException as ex:
             # Usually only happens if a Timeout occurs. In this case we're not sure if the invoice was accepted or
             # rejected, or if it even made it to ZATCA
             return {'error': str(ex), 'blocking_level': 'warning', 'excepted': True}
+
+        if request_response.status_code == '303':
+            return {'error': _('Clearance and reporting seem to have been mixed up. '),
+                    'blocking_level': 'warning', 'excepted': True}
 
         try:
             response_data = request_response.json()
@@ -573,17 +585,22 @@ class AccountJournal(models.Model):
                 'error': _("JSON response from ZATCA could not be decoded"),
                 'blocking_level': 'error'
             }
+        response_data['status_code'] = request_response.status_code
 
-        if not request_response.ok and (response_data.get('errors') or response_data.get('warnings')):
-            if isinstance(response_data, dict) and response_data.get('errors'):
+        val_res = response_data.get('validationResults', {})
+        if not request_response.ok and (val_res.get('errorMessages') or val_res.get('warningMessages')):
+            error = "" if not status_code else Markup("<b>[%s]</b>") % (status_code)
+            if isinstance(response_data, dict) and val_res.get('errorMessages'):
+                error += _("Invoice submission to ZATCA returned errors")
                 return {
-                    'error': _("Invoice submission to ZATCA returned errors"),
-                    'json_errors': response_data['errors'],
+                    'error': error,
+                    'json_errors': response_data,
                     'blocking_level': 'error',
                 }
+            error += request_response.reason
             return {
-                'error': request_response.reason,
-                'blocking_level': 'error'
+                'error': error,
+                'blocking_level': 'error',
             }
         return response_data
 

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -146,6 +146,13 @@ class AccountMove(models.Model):
             if move.l10n_sa_chain_index:
                 move.show_reset_to_draft_button = False
 
+    def _l10n_sa_reset_confirmation_datetime(self):
+        """ OVERRIDE: we want rejected phase 2 invoices to keep the original confirmation datetime"""
+        for move in self.filtered(lambda m: m.country_code == 'SA'):
+            zatca_doc = move.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'sa_zatca')
+            if not zatca_doc or zatca_doc[0].blocking_level != 'error':  # Error is the rejection case
+                move.l10n_sa_confirmation_datetime = False
+
     def _l10n_sa_generate_unsigned_data(self):
         """
             Generate UUID and digital signature to be used during both Signing and QR code generation.
@@ -174,8 +181,21 @@ class AccountMove(models.Model):
             xml_content)
         bootstrap_cls, title, content = ("success", _("Invoice Successfully Submitted to ZATCA"),
                                          "" if (not error or not response_data) else response_data)
+        attachment = False
         if error:
+            xml_filename = self.env['account.edi.xml.ubl_21.zatca']._export_invoice_filename(self)
+            xml_filename = xml_filename[:-4] + '-rejected.xml'
+            attachment = self.env['ir.attachment'].create({
+                'raw': xml_content,
+                'name': xml_filename,
+                'description': 'Rejected ZATCA Document not to be deleted - ثيقة ZATCA المرفوضة لا يجوز حذفها',
+                'res_id': self.id,
+                'res_model': self._name,
+                'type': 'binary',
+                'mimetype': 'application/xml',
+            })
             bootstrap_cls, title = ("danger", _("Invoice was rejected by ZATCA"))
+            error_msg = response_data['error']
             content = Markup("""
                 <p class='mb-0'>
                     %s
@@ -184,8 +204,9 @@ class AccountMove(models.Model):
                 <p class='mb-0'>
                     %s
                 </p>
-            """) % (_('The invoice was rejected by ZATCA. Please, check the response below:'), response_data)
+            """) % (_('The invoice was rejected by ZATCA. Please, check the response below:'), error_msg)
         if response_data and response_data.get('validationResults', {}).get('warningMessages'):
+            status_code = response_data.get('status_code')
             bootstrap_cls, title = ("warning", _("Invoice was Accepted by ZATCA (with Warnings)"))
             content = Markup("""
                 <p class='mb-0'>
@@ -193,14 +214,18 @@ class AccountMove(models.Model):
                 </p>
                 <hr>
                 <p class='mb-0'>
-                    %s
+                    <b>%s</b>%s
                 </p>
-            """) % (_('The invoice was accepted by ZATCA, but returned warnings. Please, check the response below:'), "<br/>".join([Markup("<b>%s</b> : %s") % (m['code'], m['message']) for m in response_data['validationResults']['warningMessages']]))
-        self.message_post(body=Markup("""
-            <div role='alert' class='alert alert-%s'>
-                <h4 class='alert-heading'>%s</h4>%s
-            </div>
-        """) % (bootstrap_cls, title, content))
+            """) % (_('The invoice was accepted by ZATCA, but returned warnings. Please, check the response below:'),
+                    f"[{status_code}] " if status_code else "",
+                    Markup("<br/>").join([Markup("<b>%s</b> : %s") % (m['code'], m['message']) for m in response_data['validationResults']['warningMessages']]))
+        self.with_context(no_new_invoice=True).message_post(body=Markup("""
+                <div role='alert' class='alert alert-%s'>
+                    <h4 class='alert-heading'>%s</h4>%s
+                </div>
+            """) % (bootstrap_cls, title, content),
+            attachment_ids=attachment and [attachment.id] or []
+        )
 
     def _is_l10n_sa_eligibile_invoice(self):
         self.ensure_one()

--- a/addons/l10n_sa_edi/models/ir_attachment.py
+++ b/addons/l10n_sa_edi/models/ir_attachment.py
@@ -1,0 +1,17 @@
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class IrAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_rejected_zatca_document(self):
+        '''
+        Prevents unlinking of rejected XML documents
+        '''
+        descr = 'Rejected ZATCA Document not to be deleted - ثيقة ZATCA المرفوضة لا يجوز حذفها'
+        for attach in self.filtered(lambda a: a.description == descr and a.res_model == 'account.move'):
+            move = self.env['account.move'].browse(attach.res_id)
+            if move.country_code == "SA":
+                raise UserError(_("You can't unlink an attachment being an EDI document refused by the government."))


### PR DESCRIPTION
This started with noticing that the way the rejected invoices were handled in the response changed.  Before, it was handled as a json in a string in a json, now it is directly in a json and most importantly, when the invoice is considered "rejected", ZATCA returns it as a 400 error.

This made us check further and e.g. when we resend a rejected, the issue time is supposed to be the same, so the logic of the confirmation time was changed so it still behaves the same in pure l10n_sa, but if you have a rejected one, it won't be overwritten when you confirm the invoice again.

We also added the rejected invoice as an attachment for auditibility and put a mechanism in place to avoid the user to delete it.

When we have a 400 error, the chain index is reset (ICV field), because then, when we send a new one, it will have a new ICV. The goal for auditibility is that each chain index corresponds to one submission of an invoice.  E.g. if we have a timeout, the chain index is kept and we are supposed to check that invoice first before proceeding with other invoices because we do not know whether the invoice was submitted or not, so we need to retry and that way it might override the existing ICV with ZATCA.

We do the same for 401+ errors just to make sure that one ICV equals one invoice (although here, we could reset the sequence after we get the error if it causes too much trouble)

The error/warning messages were a bit updated to clearly indicate the HTTP status code and the error code from ZATCA in bold and to avoid putting Python dicts, but nicely formatted messages.

opw-4689622

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
