### PR TITLE
[FIX] payment_adyen: default country_code

### DIFF
--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -68,7 +68,9 @@ class AdyenController(http.Controller):
             'value': converted_amount,
             'currency': request.env['res.currency'].browse(currency_id).name,  # ISO 4217
         }
-        partner_country_code = partner_sudo.country_id.code or None
+        partner_country_code = (
+            partner_sudo.country_id.code or provider_sudo.company_id.country_id.code or 'NL'
+        )
         data = {
             'merchantAccount': provider_sudo.adyen_merchant_account,
             'amount': amount,


### PR DESCRIPTION
country_code has to be defined. Required field from Adyen. 
Falling back to the company country code or NL if the partner country is empty.

opw-4698444