### PR TITLE
[ADD] iot_drivers: IoT compatibility for Linux/Mac computers

### DIFF
--- a/addons/iot_box_image/configuration/requirements.txt
+++ b/addons/iot_box_image/configuration/requirements.txt
@@ -1,16 +1,19 @@
 # The following requirements are needed only on Raspberry Pi IoT:
-gatt; sys_platform == "linux"
-/home/pi/odoo/addons/iot_box_image/configuration/aiortc-1.4.0-py3-none-any.whl; sys_platform == "linux"
+gatt; sys_platform == "linux" and "rpi" in platform_release
+/home/pi/odoo/addons/iot_box_image/configuration/aiortc-1.4.0-py3-none-any.whl; sys_platform == "linux" and "rpi" in platform_release
 
 # The following requirements are needed only on Windows Virtual IoT:
 aiortc==1.4.0; sys_platform == "win32"
 ghostscript==0.7; sys_platform == "win32"
 
-# The following requirements are needed on both platforms, but are installed
+# The following requirements are needed on every platforms, but are installed
 # via apt-get on the Raspberry Pi:
 PyKCS11==1.5.16; sys_platform == "win32"
 schedule==1.2.1; sys_platform == "win32"
 
-# The following requirements are needed on both platforms:
+# The following requirements are needed on every platforms:
 python-escpos==3.1
 websocket-client==1.6.3
+
+# The following requirements are needed only on Test IoT server:
+./addons/iot_box_image/configuration/aiortc-1.4.0-py3-none-any.whl; sys_platform == "linux" and "rpi" not in platform_release

--- a/addons/iot_drivers/__manifest__.py
+++ b/addons/iot_drivers/__manifest__.py
@@ -17,7 +17,7 @@ are found in other modules that must be installed separately.
 
 """,
     'assets': {
-        'web.assets_backend': [
+        'iot_drivers.assets': [  # dummy asset name to make sure it does not load outside of IoT homepage
             'iot_drivers/static/**/*',
         ],
     },

--- a/addons/iot_drivers/connection_manager.py
+++ b/addons/iot_drivers/connection_manager.py
@@ -7,7 +7,7 @@ import time
 
 from odoo.addons.iot_drivers.main import iot_devices, manager
 from odoo.addons.iot_drivers.tools import helpers, upgrade, wifi
-from odoo.addons.iot_drivers.tools.system import IS_RPI
+from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_TEST
 
 _logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ class ConnectionManager(Thread):
         # Save DB URL and token
         helpers.save_conf_server(url, token, db_uuid, enterprise_code)
         # Send already detected devices and IoT Box info to the database
-        manager.send_all_devices()
+        manager._send_all_devices()
         # Switch git branch before restarting, this avoids restarting twice
         upgrade.check_git_branch()
         # Restart to get a certificate, load the IoT handlers...
@@ -111,4 +111,5 @@ class ConnectionManager(Thread):
 
 
 connection_manager = ConnectionManager()
-connection_manager.start()
+if not IS_TEST:
+    connection_manager.start()

--- a/addons/iot_drivers/exception_logger.py
+++ b/addons/iot_drivers/exception_logger.py
@@ -4,6 +4,8 @@ from io import StringIO
 import logging
 import sys
 
+from odoo.addons.iot_drivers.tools.system import IS_TEST
+
 _logger = logging.getLogger(__name__)
 
 
@@ -32,4 +34,5 @@ class ExceptionLogger:
         self.flush()
 
 
-sys.stderr = ExceptionLogger()
+if not IS_TEST:
+    sys.stderr = ExceptionLogger()

--- a/addons/iot_drivers/http.py
+++ b/addons/iot_drivers/http.py
@@ -4,6 +4,7 @@ import collections
 import odoo.http
 
 from odoo.http import JsonRPCDispatcher, serialize_exception
+from odoo.addons.iot_drivers.tools.system import IS_TEST
 from werkzeug.exceptions import Forbidden
 
 
@@ -31,8 +32,10 @@ class JsonRPCDispatcherPatch(JsonRPCDispatcher):
         return self._response(error=error)
 
 
-def db_list(force=False, host=None):
-    return []
+if not IS_TEST:
+    # Test IoT system is expected to handle Odoo database unlike "real" IoT systems.
 
+    def db_list(force=False, host=None):
+        return []
 
-odoo.http.db_list = db_list
+    odoo.http.db_list = db_list

--- a/addons/iot_drivers/server_logger.py
+++ b/addons/iot_drivers/server_logger.py
@@ -5,6 +5,7 @@ import threading
 import time
 
 from odoo.addons.iot_drivers.tools import helpers
+from odoo.addons.iot_drivers.tools.system import IS_TEST
 from odoo.netsvc import DBFormatter
 
 _logger = logging.getLogger(__name__)
@@ -127,7 +128,8 @@ def close_server_log_sender_handler():
 
 
 def get_odoo_config_log_to_server_option():
-    return helpers.get_conf(IOT_LOG_TO_SERVER_CONFIG_NAME, section='options') or True  # Enabled by default
+    # Enabled by default if not in test mode
+    return not IS_TEST and (helpers.get_conf(IOT_LOG_TO_SERVER_CONFIG_NAME, section='options') or True)
 
 
 def check_and_update_odoo_config_log_to_server_option(new_state):
@@ -162,7 +164,8 @@ def _server_log_sender_handler_filter(log_record):
 # The only other possible case is when the server URL value is "Cleared",
 # in this case we force close the log handler (as it does not make sense anymore)
 _server_log_sender_handler = AsyncHTTPHandler(helpers.get_odoo_server_url(), get_odoo_config_log_to_server_option())
-_server_log_sender_handler.setFormatter(DBFormatter('%(asctime)s %(pid)s %(levelname)s %(dbname)s %(name)s: %(message)s %(perf_info)s'))
-_server_log_sender_handler.addFilter(_server_log_sender_handler_filter)
-# Set it in the 'root' logger, on which every logger (including odoo) is a child
-logging.getLogger().addHandler(_server_log_sender_handler)
+if not IS_TEST:
+    _server_log_sender_handler.setFormatter(DBFormatter('%(asctime)s %(pid)s %(levelname)s %(dbname)s %(name)s: %(message)s %(perf_info)s'))
+    _server_log_sender_handler.addFilter(_server_log_sender_handler_filter)
+    # Set it in the 'root' logger, on which every logger (including odoo) is a child
+    logging.getLogger().addHandler(_server_log_sender_handler)

--- a/addons/iot_drivers/tools/certificate.py
+++ b/addons/iot_drivers/tools/certificate.py
@@ -14,7 +14,7 @@ from odoo.addons.iot_drivers.tools.helpers import (
     start_nginx_server,
     update_conf,
 )
-from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_WINDOWS
+from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_TEST, IS_WINDOWS
 
 _logger = logging.getLogger(__name__)
 
@@ -66,6 +66,9 @@ def download_odoo_certificate():
     """Send a request to Odoo with customer db_uuid and enterprise_code
     to get a true certificate
     """
+    if IS_TEST:
+        _logger.info("Skipping certificate download in test mode.")
+        return None
     db_uuid = get_conf('db_uuid')
     enterprise_code = get_conf('enterprise_code')
     if not db_uuid:

--- a/addons/iot_drivers/tools/system.py
+++ b/addons/iot_drivers/tools/system.py
@@ -1,13 +1,22 @@
 """Operating system-related utilities for the IoT"""
 
-from platform import system
+from platform import system, release
 
 IOT_SYSTEM = system()
 
-IOT_RPI_CHAR, IOT_WINDOWS_CHAR = "L", "W"
+IOT_RPI_CHAR, IOT_WINDOWS_CHAR, IOT_TEST_CHAR = "L", "W", "T"
 
-IS_RPI = IOT_SYSTEM[0] == IOT_RPI_CHAR
 IS_WINDOWS = IOT_SYSTEM[0] == IOT_WINDOWS_CHAR
+IS_RPI = 'rpi' in release()
+IS_TEST = not IS_RPI and not IS_WINDOWS
+"""IoT system "Test" correspond to any non-Raspberry Pi nor windows system.
+Expected to be Linux or macOS used locally for development purposes."""
+
+IOT_CHAR = IOT_RPI_CHAR if IS_RPI else IOT_WINDOWS_CHAR if IS_WINDOWS else IOT_TEST_CHAR
+"""IoT system character used in the identifier and version.
+- 'L' for Raspberry Pi
+- 'W' for Windows
+- 'T' for Test (non-Raspberry Pi nor Windows)"""
 
 if IS_RPI:
     def rpi_only(function):

--- a/addons/iot_drivers/tools/upgrade.py
+++ b/addons/iot_drivers/tools/upgrade.py
@@ -9,7 +9,7 @@ from odoo.addons.iot_drivers.tools.helpers import (
     require_db,
     toggleable,
 )
-from odoo.addons.iot_drivers.tools.system import rpi_only, IS_RPI
+from odoo.addons.iot_drivers.tools.system import rpi_only, IS_RPI, IS_TEST
 
 _logger = logging.getLogger(__name__)
 
@@ -73,6 +73,8 @@ def check_git_branch(server_url=None):
 
     :param server_url: The URL of the connected Odoo database (provided by decorator).
     """
+    if IS_TEST:
+        return
     db_branch = get_db_branch(server_url)
     if not db_branch:
         _logger.warning("Could not get the database branch, skipping git checkout")


### PR DESCRIPTION
Testing IoT flows is tricky due to the hardware constraints.
The goal of this PR is **NOT** to propose a new kind of IoT, but rather an easier way to run IoT's code on a Linux/Mac OS environment.
As such, handlers will NOT be implemented to work on this IoT system.

We plan to add more unit tests using a Linux environment to use real IoT interactions to better cover IoT's code.

Current focus of this PR is to be able to run an odoo regular instance alongside IoT's code.
This needed to adapt some part of IoT's code as IoT is not meant to run with a database.

Example of run with IoT code locally with a database (assuming to be on a Linux computer with a regular odoo setup installation):

1. Make sure to have installed IoT requirements with:
`pip3 install -r <odoo>/addons/iot_box_image/configuration/requirements.txt`
&
`apt-get install < <odoo>/addons/iot_box_image/configuration/packages.txt`
2. Run odoo and explicitely load IoT related modules
`odoo-bin --load=iot_drivers -d test-with-iot`