### PR TITLE
[FIX] l10n_ar: Fix '_l10n_ar_prices_and_taxes'

### DIFF
--- a/addons/l10n_ar/models/account_move_line.py
+++ b/addons/l10n_ar/models/account_move_line.py
@@ -26,19 +26,19 @@ class AccountMoveLine(models.Model):
             raw_total = tax_details['raw_total_excluded_currency']
 
         if discount == 100.0:
-            price_subtotal = price_unit * quantity
+            price_subtotal_before_discount = price_unit * quantity
         else:
-            price_subtotal = raw_total / (1 - discount / 100.0)
+            price_subtotal_before_discount = raw_total / (1 - discount / 100.0)
 
         if quantity:
-            price_unit = raw_total / quantity
-            price_net = price_subtotal / quantity
+            price_unit = price_subtotal_before_discount / quantity
+            price_net = raw_total / quantity
         else:
             price_unit = 0.0
             price_net = 0.0
 
         return {
             'price_unit': price_unit,
-            'price_subtotal': price_subtotal,
+            'price_subtotal': invoice.currency_id.round(raw_total),
             'price_net': price_net,
         }

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -189,7 +189,7 @@ class TestManual(common.TestAr):
             if len_l10n_ar_price_unit_digits == len_line_price_unit_digits == decimal_price_digits_setting:
                 self.assertEqual(l10n_ar_price_unit_decimal_part, line_price_unit_decimal_part)
 
-    def test_16_invoice_b_tax_breakdown_1(self):
+    def test_18_invoice_b_tax_breakdown_1(self):
         """ Display Both VAT and Other Taxes """
         invoice = self._create_invoice_from_dict({
             'ref': 'test_invoice_20:  Final Consumer Invoice B with multiple vat/perceptions/internal/other/national taxes',
@@ -250,7 +250,7 @@ class TestManual(common.TestAr):
             ],
         })
 
-    def test_17_invoice_b_tax_breakdown_2(self):
+    def test_19_invoice_b_tax_breakdown_2(self):
         """ Display only Other Taxes (VAT taxes are 0) """
         invoice = self._create_invoice_from_dict({
             'ref': 'test_invoice_21:  inal Consumer Invoice B with 0 tax and internal tax',
@@ -279,3 +279,34 @@ class TestManual(common.TestAr):
             'total_amount_currency': 10300.0,
             'subtotals': [],
         })
+
+    def test_l10n_ar_prices_and_taxes(self):
+        invoice = self.env['account.move'].create({
+            "move_type": 'out_invoice',
+            "partner_id": self.partner_cf.id,
+            "invoice_date": "2020-01-21",
+            "invoice_line_ids": [
+                Command.create({
+                    'product_id': self.product_iva_105_perc.id,
+                    'quantity': 24.0,
+                    'price_unit': 5470.0,
+                    'discount': 5.0,
+                    'tax_ids': [Command.set(self.tax_21.ids)],
+                }),
+            ],
+        })
+        invoice_line = invoice.invoice_line_ids
+
+        # Included in VAT
+        l10n_ar_values = invoice_line._l10n_ar_prices_and_taxes()
+        self.assertAlmostEqual(l10n_ar_values['price_unit'], 6618.7)
+        self.assertAlmostEqual(l10n_ar_values['price_subtotal'], 150906.36)
+        self.assertAlmostEqual(l10n_ar_values['price_net'], 6287.765)
+
+        # Not include in VAT
+        doc_27_lu_a = self.env.ref('l10n_ar.dc_liq_uci_a')
+        invoice.l10n_latam_document_type_id = doc_27_lu_a
+        l10n_ar_values = invoice_line._l10n_ar_prices_and_taxes()
+        self.assertAlmostEqual(l10n_ar_values['price_unit'], 5470.0)
+        self.assertAlmostEqual(l10n_ar_values['price_subtotal'], 124716.0)
+        self.assertAlmostEqual(l10n_ar_values['price_net'], 5196.5)


### PR DESCRIPTION
Fix a bug introduced by:
https://github.com/odoo/odoo/pull/200117
... making a bad handling of the discount during the computation of 'price_unit' / 'price_subtotal'.

opw-4679139

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
