### PR TITLE
[FIX] payment_paypal: re-enable seller protection

### DIFF
--- a/addons/payment_paypal/models/payment_transaction.py
+++ b/addons/payment_paypal/models/payment_transaction.py
@@ -51,7 +51,8 @@ class PaymentTransaction(models.Model):
             'item_number': self.reference,
             'last_name': partner_last_name,
             'lc': self.partner_lang,
-            'no_shipping': '1',  # Do not prompt for a delivery address.
+            'no_shipping': '1',  # TODO: in 18.0, change `NO_SHIPPING` to `SET_PROVIDED_ADDRESS`
+            'address_override': '1',  # Ensure address cannot be altered
             'notify_url': webhook_url if self.provider_id.paypal_use_ipn else None,
             'return_url': urls.url_join(base_url, PaypalController._return_url),
             'state': self.partner_state_id.name,

--- a/addons/payment_paypal/tests/test_paypal.py
+++ b/addons/payment_paypal/tests/test_paypal.py
@@ -31,7 +31,7 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
             'item_number': self.reference,
             'last_name': 'Buyer',
             'lc': 'en_US',
-            'no_shipping': '1',
+            'address_override': '1',
             'notify_url': self._build_url(PaypalController._webhook_url),
             'return': return_url,
             'rm': '2',

--- a/addons/payment_paypal/views/payment_paypal_templates.xml
+++ b/addons/payment_paypal/views/payment_paypal_templates.xml
@@ -20,7 +20,7 @@
             <input type="hidden" name="item_number" t-att-value="item_number"/>
             <input type="hidden" name="last_name" t-att-value="last_name"/>
             <input type="hidden" name="lc" t-att-value="lc"/>
-            <input type="hidden" name="no_shipping" t-att-value="no_shipping"/>
+            <input type="hidden" name="address_override" t-att-value="address_override"/>
             <input t-if="notify_url"
                    type="hidden" name="notify_url" t-att-value="notify_url"/>
             <input type="hidden" name="return" t-att-value="return_url"/>


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Enable Paypal as payment provider;
2. have a US-based partner;
3. sent them a payment link;
4. pay using Paypal;
5. open transaction on Paypal backend.

Issue
-----
No delivery address is registered, making the merchant ineligible for seller protection.

Cause
-----
Commit 00259dc44a981 added the `no_shipping: '1'` value to the form sent to Paypal to prevent buyers from changing their shipping address on Paypal's end. A side-effect is that it doesn't even register the address provided with the transaction.

Solution (16.0 up to saas-17.4)
-------------------------------
Use the `address_override: '1'` value instead, which prevents buyers from changing the address while still registering the address on the transaction.

In stable, keep the `no_shipping: '1'` value in the rendering values so that user's cannot suddenly change the address again if template hasn't been updated yet.

Solution (18.0+)
----------------
Change the `shipping_preference` value from `NO_SHIPPING` to `SET_PROVIDED_ADDRESS`[^1].

opw-4681336

[^1]: https://developer.paypal.com/docs/checkout/standard/customize/shipping-module/#:~:text=Configuring%20shipping%20preferences