### PR TITLE
[IMP] fleet: add fold option to kanban stages of vehicle

### DIFF
--- a/addons/fleet/models/fleet_vehicle_state.py
+++ b/addons/fleet/models/fleet_vehicle_state.py
@@ -11,6 +11,7 @@ class FleetVehicleState(models.Model):
 
     name = fields.Char(required=True, translate=True)
     sequence = fields.Integer()
+    fold = fields.Boolean(string='Folded in Kanban')
 
     _fleet_state_name_unique = models.Constraint(
         'unique(name)',

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -493,6 +493,7 @@
             <list string="State" editable="bottom">
                 <field name="sequence" widget="handle"/>
                 <field name="name" />
+                <field name="fold"/>
             </list>
         </field>
     </record>
@@ -506,6 +507,7 @@
                     <group>
                         <field name="name" />
                         <field name="sequence"/>
+                        <field name="fold"/>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
Added option to mark vehicle state stages as folded in the kanban view for better stage management.

task-4717242

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
