### PR TITLE
[IMP] hr_attendance: add date filter to attendance management

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -206,10 +206,10 @@ class HrEmployee(models.Model):
             "res_model": "hr.attendance",
             "views": [[self.env.ref('hr_attendance.hr_attendance_employee_simple_tree_view').id, "list"]],
             "context": {
-                "create": 0
+                "create": 0,
+                "search_default_check_in_filter": 1,
             },
-            "domain": [('employee_id', '=', self.id),
-                       ('check_in', ">=", fields.Datetime.today().replace(day=1))]
+            "domain": [('employee_id', '=', self.id)]
         }
 
     def action_open_last_month_overtime(self):

--- a/addons/hr_attendance/models/res_users.py
+++ b/addons/hr_attendance/models/res_users.py
@@ -50,10 +50,10 @@ class ResUsers(models.Model):
             "res_model": "hr.attendance",
             "views": [[self.env.ref('hr_attendance.hr_attendance_employee_simple_tree_view').id, "list"]],
             "context": {
-                "create": 0
+                "create": 0,
+                "search_default_check_in_filter": 1,
             },
-            "domain": [('employee_id', '=', self.employee_id.id),
-                       ('check_in', ">=", fields.Datetime.today().replace(day=1))]
+            "domain": [('employee_id', '=', self.employee_id.id)]
         }
 
     def action_open_last_month_overtime(self):

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -350,6 +350,8 @@
                 <filter string="Approved" name="approved" domain="[('overtime_status','=', 'approved')]"/>
                 <filter string="Refused" name="refused" domain="[('overtime_status','=', 'refused')]"/>
                 <separator/>
+                <filter string="Date" name="check_in_filter" date="check_in"/>
+                <separator/>
                 <filter
                     string="Active Employees"
                     name="activeemployees"
@@ -360,6 +362,7 @@
                     domain="[('employee_id.active', '=', False)]"/>
                 <group string="Group By">
                     <filter string="Employee" name="employee" context="{'group_by': 'employee_id'}"/>
+                    <filter string="Date" name="groupby_date" context="{'group_by': 'check_in'}"/>
                 </group>
             </search>
         </field>


### PR DESCRIPTION
Currently, employees can only view their attendance records for the current month under 'My Profile' → 'This Month' due to the absence of a date filter.

After this PR, employees will be able to view all attendance records and filter them by date. By default, the records will be filtered to show the current month's attendance.

A date filter has been added to the attendance management section, as well as to the 'My Profile' and employee 'This Month' smart buttons."

task-4715510
