### PR TITLE
[IMP] point_of_sale: Don't get archived products

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -728,7 +728,9 @@ class PosConfig(models.Model):
     def _get_available_product_domain(self):
         domain = [
             *self.env['product.product']._check_company_domain(self.company_id),
-            ('active', '=', True),
+            # Necessary to check 'active' on template as query will be done on variant and active field
+            # is not present on that table
+            ('product_tmpl_id.active', '=', True),
             ('available_in_pos', '=', True),
             ('sale_ok', '=', True),
         ]


### PR DESCRIPTION
As 'active' field is present on product_template table and as '_get_available_domain()' will generate a query on product_product table, include 'active' field on related product template.

This will cause errors when loading too much product pricelist items





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
