### PR TITLE
[FIX] website_sale(_*): various fixes

### DIFF
--- a/addons/loyalty/models/product_product.py
+++ b/addons/loyalty/models/product_product.py
@@ -32,13 +32,3 @@ class ProductProduct(models.Model):
                 " Please archive it instead.",
                 name=product.with_context(display_default_code=False).display_name
             ))
-
-    def _get_product_placeholder_filename(self):
-        if self.env['loyalty.reward'].search_count([('discount_line_product_id', '=', self.id)], limit=1):
-            if self.env['loyalty.reward'].search_count([
-                ('program_type', '=', 'gift_card'),
-                ('discount_line_product_id', '=', self.id)
-            ], limit=1):
-                return 'loyalty/static/img/gift_card.png'
-            return 'loyalty/static/img/discount_placeholder_thumbnail.png'
-        return super()._get_product_placeholder_filename()

--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -57,7 +57,11 @@ class SaleOrderLine(models.Model):
         :return: Whether the line is sellable or not.
         :rtype: bool
         """
-        return super()._is_sellable() and not self.is_reward_line
+        return super()._is_sellable() and (
+            not self.is_reward_line
+            # Sellable so the link is clickable in the cart.
+            or self.reward_id.reward_type == 'product'
+        )
 
     def _reset_loyalty(self, complete=False):
         """

--- a/addons/website_event_sale/models/product.py
+++ b/addons/website_event_sale/models/product.py
@@ -9,6 +9,24 @@ class ProductProduct(models.Model):
 
     event_ticket_ids = fields.One2many('event.event.ticket', 'product_id', string='Event Tickets')
 
+    def _can_return_content(self, field_name=None, access_token=None):
+        """ Override of `orm` to give public users access to the unpublished product image.
+
+        Give access to the public users to the unpublished product images if they are linked to an
+        event ticket.
+
+        :param field_name: The name of the field to check.
+        :param access_token: The access token.
+        :return: Whether to allow the access to the image.
+        :rtype: bool
+        """
+        if (
+            field_name in ["image_%s" % size for size in [1920, 1024, 512, 256, 128]]
+            and self.sudo().event_ticket_ids
+        ):
+            return True
+        return super()._can_return_content(field_name, access_token)
+
     def _get_product_placeholder_filename(self):
         if self.event_ticket_ids:
             return 'website_event_sale/static/img/event_ticket_placeholder_thumbnail.png'

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -230,11 +230,6 @@ $input-border-color: $gray-400;
         }
     }
 
-    .activeDrag * {
-        cursor: grabbing !important;
-        cursor: -webkit-grabbing;
-    }
-
     .o_wsale_products_grid_before_rail{
         scrollbar-width: none;
         -ms-overflow-style: none;
@@ -243,6 +238,38 @@ $input-border-color: $gray-400;
     .o_wsale_products_grid_before_rail::-webkit-scrollbar {
         width: 0;
         height: 0;
+    }
+
+    #products_grid_before {
+        flex: 0 0 25%;
+        min-width: o-to-rem(240px);
+        max-width: var(--o-wsale-sidebar-maxwidth, 15rem);
+
+        // == Guess the distance with the navbar
+        $-container-top-gap: $grid-gutter-width / 2; // = o_wsale_products_main_row
+
+        // == Guess the distance with the viewport's top.
+        // Defined using CSS variables to ease custom-headers overrides.
+        --o_ws_sidebar_top_gap: calc(#{$navbar-padding-y * 2} + #{$btn-padding-y-lg * 2} + #{$-container-top-gap});
+
+        @if (o-website-value('header-scroll-effect') == null) or (o-website-value('header-scroll-effect') == 'fixed') {
+            top: var(--o_ws_sidebar_top_gap);
+        } @else {
+            top: $-container-top-gap;
+        }
+
+        .css_attribute_color {
+            height: 32px;
+            width: 32px;
+        }
+    }
+}
+
+// ==== Generic rules for any website_sale view
+.oe_website_sale {
+    .activeDrag * {
+        cursor: grabbing !important;
+        cursor: -webkit-grabbing;
     }
 
     .o_payment_form .card {
@@ -288,29 +315,6 @@ $input-border-color: $gray-400;
         padding-bottom: map-get($spacers, 2);
     }
 
-    #products_grid_before {
-        flex: 0 0 25%;
-        min-width: o-to-rem(240px);
-        max-width: var(--o-wsale-sidebar-maxwidth, 15rem);
-
-        // == Guess the distance with the navbar
-        $-container-top-gap: $grid-gutter-width / 2; // = o_wsale_products_main_row
-
-        // == Guess the distance with the viewport's top.
-        // Defined using CSS variables to ease custom-headers overrides.
-        --o_ws_sidebar_top_gap: calc(#{$navbar-padding-y * 2} + #{$btn-padding-y-lg * 2} + #{$-container-top-gap});
-
-        @if (o-website-value('header-scroll-effect') == null) or (o-website-value('header-scroll-effect') == 'fixed') {
-            top: var(--o_ws_sidebar_top_gap);
-        } @else {
-            top: $-container-top-gap;
-        }
-
-        .css_attribute_color {
-            height: 32px;
-            width: 32px;
-        }
-    }
     .o_pricelist_dropdown, .o_sortby_dropdown {
         //truncates the dropdown pricelist > 8rem
         .o_pricelist_dropdown_span {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2105,7 +2105,6 @@
         <div id="cart_products"
              t-if="website_sale_order and website_sale_order.website_order_line"
              class="js_cart_lines d-flex flex-column mb32">
-            <t t-set="show_qty" t-value="is_view_active('website_sale.product_quantity')"/>
             <t t-foreach="website_sale_order.website_order_line" t-as="line">
                 <t t-set="is_combo" t-value="line.product_type == 'combo'"/>
                 <div
@@ -2192,7 +2191,7 @@
                         </div>
                         <div
                             name="o_wsale_cart_line_button_container_mobile"
-                            class="d-flex d-md-none flex-wrap"
+                            class="d-flex d-md-none"
                         >
                             <div
                                 class="d-flex d-md-none align-items-center me-auto"
@@ -2218,60 +2217,54 @@
             class="css_quantity input-group justify-content-end h-100"
             t-attf-name="{{'website_sale_cart_line_quantity' if not is_mobile else 'website_sale_cart_line_quantity_mobile'}}"
         >
-            <t t-if="line._is_sellable()">
-                <t t-if="show_qty">
-                    <a
-                        href="#"
-                        class="js_add_cart_json btn btn-link d-inline-block border-end-0"
-                        aria-label="Remove one"
-                        title="Remove one"
-                    >
-                        <i class="position-relative z-1 fa fa-minus"/>
-                    </a>
-                    <input
-                        type="text"
-                        class="js_quantity quantity form-control border-start-0 border-end-0"
-                        t-att-data-line-id="line.id"
-                        t-att-data-product-id="line.product_id.id"
-                        t-att-value="line._get_displayed_quantity()"
-                    />
-                    <t t-if="line._get_shop_warning(clear=False)">
-                        <a href="#" class="btn btn-link">
-                            <i
-                                class="fa fa-warning text-warning"
-                                t-att-title="line._get_shop_warning()"
-                                role="img"
-                                aria-label="Warning"
-                            />
-                        </a>
-                    </t>
-                    <a
-                        t-else=""
-                        href="#"
-                        class="js_add_cart_json d-inline-block btn btn-link border-start-0"
-                        aria-label="Add one"
-                        title="Add one"
-                    >
-                        <i class="fa fa-plus position-relative z-1"/>
-                    </a>
-                </t>
-                <t t-else="">
-                    <input
-                        type="hidden"
-                        class="js_quantity form-control quantity"
-                        t-att-data-line-id="line.id"
-                        t-att-data-product-id="line.product_id.id"
-                        t-att-value="line._get_displayed_quantity()"
-                    />
-                </t>
-            </t>
-            <t t-else="">
+            <t
+                t-set="should_show_quantity_selector"
+                t-value="is_view_active('website_sale.product_quantity')"
+            />
+            <t t-if="should_show_quantity_selector and line._is_sellable()">
+                <a
+                    href="#"
+                    class="js_add_cart_json btn btn-link d-inline-block border-end-0"
+                    aria-label="Remove one"
+                    title="Remove one"
+                >
+                    <i class="position-relative z-1 fa fa-minus"/>
+                </a>
                 <input
-                    type="hidden"
-                    class="js_quantity quantity form-control"
+                    type="text"
+                    class="js_quantity quantity form-control border-start-0 border-end-0"
                     t-att-data-line-id="line.id"
                     t-att-data-product-id="line.product_id.id"
                     t-att-value="line._get_displayed_quantity()"
+                />
+                <t t-if="line._get_shop_warning(clear=False)">
+                    <a href="#" class="btn btn-link">
+                        <i
+                            class="fa fa-warning text-warning"
+                            t-att-title="line._get_shop_warning()"
+                            role="img"
+                            aria-label="Warning"
+                        />
+                    </a>
+                </t>
+                <a
+                    t-else=""
+                    href="#"
+                    class="js_add_cart_json d-inline-block btn btn-link border-start-0"
+                    aria-label="Add one"
+                    title="Add one"
+                >
+                    <i class="fa fa-plus position-relative z-1"/>
+                </a>
+            </t>
+            <t t-else="">
+                <input
+                    type="text"
+                    class="js_quantity form-control quantity text-start text-md-end text-md-end border-0 p-0 shadow-none mw-100"
+                    t-att-data-line-id="line.id"
+                    t-att-data-product-id="line.product_id.id"
+                    t-att-value="line._get_displayed_quantity()"
+                    readonly="True"
                 />
             </t>
         </div>
@@ -2282,7 +2275,7 @@
             class="d-flex flex-column flex-md-row align-items-end align-items-md-start justify-content-md-end small fw-bold"
             name="website_sale_cart_line_price"
         >
-            <t t-if="line.discount and line._is_sellable()">
+            <t t-if="line.discount and line._is_sellable() and line._get_displayed_unit_price()">
                 <del
                     class="me-md-2 text-muted text-nowrap opacity-50"
                     t-out="line._get_displayed_unit_price() * line.product_uom_qty"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2285,7 +2285,7 @@
             <t t-set="product_price" t-value="line._get_cart_display_price()"/>
             <t t-call="website_sale.cart_product_price"/>
             <small
-                t-if="not line._is_not_sellable_line() and line.env['res.groups']._is_feature_enabled('website_sale.group_show_uom_price') and line.product_id.base_unit_price"
+                t-if="line._is_sellable() and line.env['res.groups']._is_feature_enabled('website_sale.group_show_uom_price') and line.product_id.base_unit_price"
                 class="cart_product_base_unit_price d-block text-muted"
                 groups="website_sale.group_show_uom_price"
             >

--- a/addons/website_sale_loyalty/models/__init__.py
+++ b/addons/website_sale_loyalty/models/__init__.py
@@ -4,5 +4,6 @@
 from . import loyalty_card
 from . import loyalty_program
 from . import loyalty_rule
+from . import product_product
 from . import sale_order_line
 from . import sale_order

--- a/addons/website_sale_loyalty/models/product_product.py
+++ b/addons/website_sale_loyalty/models/product_product.py
@@ -1,0 +1,41 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    def _can_return_content(self, field_name=None, access_token=None):
+        """ Override of `orm` to give public users access to the unpublished product image.
+
+        Give access to the public users to the unpublished product images if they are linked to a
+        reward.
+
+        :param field_name: The name of the field to check.
+        :param access_token: The access token.
+        :return: Whether to allow the access to the image.
+        :rtype: bool
+        """
+        if (
+            field_name in ["image_%s" % size for size in [1920, 1024, 512, 256, 128]]
+            and self.env['loyalty.reward'].sudo().search_count([
+                ('discount_line_product_id', '=', self.id),
+            ], limit=1)
+        ):
+            return True
+        return super()._can_return_content(field_name, access_token)
+
+    def _get_product_placeholder_filename(self):
+        """ Override of `product` to set a default image for reward products. """
+        # In sudo mode to allow eCommerce customers to see the placeholder
+        if self.env['loyalty.reward'].sudo().search_count([
+            ('discount_line_product_id', '=', self.id),
+        ], limit=1):
+            if self.env['loyalty.reward'].sudo().search_count([
+                ('program_type', '=', 'gift_card'),
+                ('discount_line_product_id', '=', self.id),
+            ], limit=1):
+                return 'loyalty/static/img/gift_card.png'
+            return 'loyalty/static/img/discount_placeholder_thumbnail.png'
+        return super()._get_product_placeholder_filename()

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -175,6 +175,21 @@
         </xpath>
     </template>
 
+    <template
+        id="website_sale_loyalty.cart_lines_quantity"
+        inherit_id="website_sale.cart_lines_quantity"
+        name="Shopping Cart Lines"
+    >
+        <xpath expr="//t[@t-set='should_show_quantity_selector']" position="after">
+            <!-- Keep customers from changing the quantity for free product .-->
+            <t
+                t-set="should_show_quantity_selector"
+                t-value="should_show_quantity_selector and not line.reward_id.reward_type == 'product'"
+            />
+        </xpath>
+    </template>
+
+
     <template id="cart_line_product_no_link" inherit_id="website_sale.cart_lines">
         <xpath expr="//h6[@t-field='line.name_short']" position="replace">
             <h6 t-if="line.is_reward_line" class="d-inline align-top fw-bold text-wrap small" t-field="line.name"/>


### PR DESCRIPTION
[FIX] website_sale: address incorrectly scoped css selectors

[FIX] (website_)sale(_loyalty): add quantity to unsellable product

[FIX] website_sale: rename _is_not_sellable_line to _is_sellable
`_is_not_sellable_line` was renamed `_is_sellable` in https://github.com/odoo/odoo/commit/c52453f8374d988127b2a18f7b357058b01501d9 but one
occurence was left.

[FIX] * : Allow public access to custom product placeholders
* : loyalty, website_sale_loyalty, website_event_sale

Placeholders were introduced in https://github.com/odoo/odoo/commit/c52453f8374d988127b2a18f7b357058b01501d9 for meta products such as
discounts, gift cards, event tickets, and appointments.

Previously, access rights prevented public users from viewing these
placeholders. Even when no image was linked to a record, access was
denied due to read restrictions, defaulting to the generic placeholder
instead of the custom one provided by `_get_product_placeholder_filename`.

This commit overrides `_can_return_content` in relevant modules to allow
proper access for public users, ensuring the intended placeholder is
displayed.

See also:
- https://github.com/odoo/enterprise/pull/83326