### PR TITLE
[WIP][FIX] base: cli option `--without_demo=False` enables 'all' demo

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -543,6 +543,8 @@ class configmanager(object):
             else ""
         )
 
+        self.options["without_demo"] = False if self.options['without_demo'] == 'False' else self.options['without_demo']
+
         self.options['init'] = opt.init and dict.fromkeys(opt.init.split(','), 1) or {}
         self.options['demo'] = (dict(self.options['init'])
                                 if not self.options['without_demo'] else {})


### PR DESCRIPTION
Currently the command line option `--without_demo=False` disables the installation of demo data for all modules. Just omitting this command line option leads to the desired behavior (in versions < 18.3). But in version 18.3 this command line option is necessary to install demo data. Having the same option in all versions to install modules with demo data would ease development.

The problem is that the value `False` is stored as a string in `tools.config['without_demo']` So during the DB intialization in `load_modules` the following `if` does nothing:
```
            if not tools.config['without_demo']:
                tools.config["demo"]['all'] = 1
```
(The `if` branch would be executed in case the command line option was ommitted.)

During the installation of a module it is then not marked as to be installed with 'demo' See the following code snippet from `add_modules` (from `odoo.modules.graph`). The variable `package` refers to the module name.
```
                for kind in ('init', 'demo', 'update'):
                    if package in tools.config[kind] or 'all' in tools.config[kind] or kind in force:
                        setattr(node, kind, True)
```

After this commit the command line option `--without_demo=False` enables 'all' demo data.

Undesired side effect: Demo data cannot be disabled just for a module named `False`. Since module names are usually all lowercase it should be okay.