### PR TITLE
[FIX] core: --without-demo=False means --with-demo

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -544,8 +544,8 @@ class configmanager(object):
         )
 
         self.options['init'] = opt.init and dict.fromkeys(opt.init.split(','), 1) or {}
-        self.options['demo'] = (dict(self.options['init'])
-                                if not self.options['without_demo'] else {})
+        self.options['without_demo'] = self.options['without_demo'] not in (False, '', 'False', 'false')
+        self.options['demo'] = (dict(self.options['init']) if self.options['without_demo'] else {})
         self.options['update'] = opt.update and dict.fromkeys(opt.update.split(','), 1) or {}
         self.options['translate_modules'] = opt.translate_modules and [m.strip() for m in opt.translate_modules.split(',')] or ['all']
         self.options['translate_modules'].sort()


### PR DESCRIPTION
Save "without_demo=False" inside the configuration file, Odoo starts with demo data. Do the same but in the CLI "--without-demo=False" and Odoo starts without, this is a bug.

All strings "False" and "false" in the configuration file are automatically converted to the boolean False. The same doesn't apply with the CLI, so it was evaluating `not "False"` which is False.

Change the logic so that "False" and "false" are considered falsy.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
