### PR TITLE
[IMP] mail: enter should validate the message deletion

### DIFF
--- a/addons/mail/static/src/core/common/message_confirm_dialog.js
+++ b/addons/mail/static/src/core/common/message_confirm_dialog.js
@@ -3,6 +3,7 @@ import { Component } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
 import { discussComponentRegistry } from "./discuss_component_registry";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 
 export class MessageConfirmDialog extends Component {
     static components = { Dialog };
@@ -23,6 +24,10 @@ export class MessageConfirmDialog extends Component {
         title: _t("Confirmation"),
     };
     static template = "mail.MessageConfirmDialog";
+
+    setup() {
+        useHotkey("enter", () => this.onClickConfirm());
+    }
 
     get messageComponent() {
         return discussComponentRegistry.get("Message");

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -2020,3 +2020,27 @@ test("display the notification message's posting date and time", async () => {
         text: "Tom Riddle joined the channel1:00 PM",
     });
 });
+
+test("Pressing 'Enter' while the delete confirmation dialog is open should delete the message", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+    });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "Message with content",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message:contains('Message with content')");
+    await click(".o-mail-Message [title='Edit']");
+    await insertText(".o-mail-Message .o-mail-Composer-input", "", { replace: true });
+    triggerHotkey("Enter", false);
+    await contains(".modal-body p", { text: "Are you sure you want to delete this message?" });
+    triggerHotkey("Enter", false);
+    await contains(".o-mail-Message", { text: "This message has been removed" });
+});


### PR DESCRIPTION
Purpose of this commit:
When MessageConfirmDialog is open, 'enter' should validate deletion of message.

task-4642538
