### PR TITLE
[FIX] base: allow search on `res.groups.all_user_ids`

### DIFF
--- a/odoo/addons/base/models/res_groups.py
+++ b/odoo/addons/base/models/res_groups.py
@@ -230,6 +230,10 @@ class ResGroups(models.Model):
 
     def _search_all_implied_by_ids(self, operator, value):
         """ Compute the search on the reflexive transitive closure of implied_by_ids. """
+        if operator in ("any", "not any") and isinstance(value, Domain):
+            value = self.search(value).ids
+            operator = "in" if operator == "any" else "not in"
+
         assert isinstance(value, (int, list, tuple))
 
         if isinstance(value, int):

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -355,6 +355,9 @@ class TestUsers2(UsersCommonCase):
         self.assertEqual(set(user.read(['group_ids'])[0]['group_ids']), set((group_manager + group_user).ids))
         self.assertEqual(set(user.read(['all_group_ids'])[0]['all_group_ids']), set((group_visitor + group_manager + group_user).ids))
 
+        groups = self.env['res.groups'].search([('all_user_ids', '=', user.id)])
+        self.assertEqual(groups, user.all_group_ids)
+
     def test_implied_groups_on_change(self):
         """Test that a change on a reified fields trigger the onchange of group_ids."""
         group_public = self.env.ref('base.group_public')


### PR DESCRIPTION
Handle the `any` and `not any` operators on `all_implied_by_ids` field.
