### PR TITLE
[FIX] l10n_in: fix partner autocomplete for vendor scan feature

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -100,8 +100,9 @@ class ResPartner(models.Model):
     @api.model
     def _l10n_in_get_partner_vals_by_vat(self, vat):
         partner_data = self.enrich_by_gst(vat)
-        partner_data.pop('domain', None)
-        partner_data.pop('unspsc_codes', None)
+        for fname in partner_data:
+            if fname not in self.env['res.partner']._fields:
+                partner_data.pop(fname, None)
         partner_data.update({
             'country_id': partner_data.get('country_id', {}).get('id'),
             'state_id': partner_data.get('state_id', {}).get('id'),


### PR DESCRIPTION
Using the enterprise feature Vendor Bill Scan, When the partner doesn't exists in the database the following traceback:
```py
  File "/home/odoo/odoo18/community/odoo/api.py", line 496, in _model_create_multi
    return create(self, arg)
  File "/home/odoo/odoo18/community/addons/mail/models/mail_thread.py", line 268, in create
    threads = super(MailThread, self).create(vals_list)
  File "<decorator-gen-31>", line 2, in create
  File "/home/odoo/odoo18/community/odoo/api.py", line 496, in _model_create_multi
    return create(self, arg)
  File "/home/odoo/odoo18/community/odoo/models.py", line 4968, in create
    new_vals_list = self._prepare_create_values(vals_list)
  File "/home/odoo/odoo18/community/odoo/models.py", line 5125, in _prepare_create_values
    self._add_precomputed_values(result_vals_list)
  File "/home/odoo/odoo18/community/odoo/models.py", line 5153, in _add_precomputed_values
    records = self.browse().concat(*(self.new(vals) for vals in vals_list_todo))
  File "/home/odoo/odoo18/community/odoo/models.py", line 5153, in <genexpr>
    records = self.browse().concat(*(self.new(vals) for vals in vals_list_todo))
  File "/home/odoo/odoo18/community/odoo/models.py", line 6861, in new
    record._update_cache(values, validate=False)
  File "/home/odoo/odoo18/community/odoo/models.py", line 6411, in _update_cache
    raise ValueError("Invalid field %r on model %r" % (e.args[0], self._name))
ValueError: Invalid field 'duns' on model 'res.partner'
```

In this commit-
We fix the above traceback and the feature works as expected




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
