### PR TITLE
[PERF] hr_expense: Optimize lookup in move's expense `ir.rule`

### DIFF
--- a/addons/hr_expense/security/ir_rule.xml
+++ b/addons/hr_expense/security/ir_rule.xml
@@ -54,7 +54,7 @@
         <record id="hr_expense_team_approver_account_move_rule" model="ir.rule">
             <field name="name">Expense Team Approver Account Move</field>
             <field name="model_id" ref="account.model_account_move"/>
-            <field name="domain_force">[('line_ids.expense_id', '!=', False)]</field>
+            <field name="domain_force">[('expense_ids', '!=', False)]</field>
             <field name="groups" eval="[(4, ref('hr_expense.group_hr_expense_team_approver'))]"/>
         </record>
 


### PR DESCRIPTION
Description
------------
The current `ir.rule` for `account.move` for users in the `hr_expense.group_hr_expense_team_approver` group involves checking if any `account.move.line` are linked to an `expense_id`. This requires querying `account.move.line`, which is a large table and lacks indexing on `expense_id`, resulting in a performance bottleneck due to sequential scans.

Instead, this can be simplified by utilizing the `expense_ids` field to directly query the significantly smaller `hr.expense` table.

This approach is valid under the assumption that for a given `move`, `move.line_ids.expense_id` is always part of `move.expense_ids`.

Benchmark
----------
On odoo.com, for a user in the expense team approver group, opening an invoice now takes:

| Before | After | Speedup |
|--------|-------|---------|
| 29.7s  | 340ms | 87x     |

Reference
---------
opw-4720221

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
