### PR TITLE
[FIX] l10n_nz: remove unnecessary information in nz invoice report

### DIFF
--- a/addons/l10n_nz/views/report_invoice.xml
+++ b/addons/l10n_nz/views/report_invoice.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
-        <xpath expr="//div[hasclass('page')]/t[@t-set='layout_document_title']" position="replace">
         <t name="invoice_title" position="replace">
             <t name="invoice_title">Tax Invoice</t>
         </t>
@@ -50,7 +49,6 @@
         <t name="proforma_vendor_bill_title" position="replace">
             <t name="proforma_vendor_bill_title">Proforma Tax Vendor Bill</t>
         </t>
-        </xpath>
     </template>
 
     <!-- Workaround for Studio reports, see odoo/odoo#60660 -->


### PR DESCRIPTION
Currently, unnecessary information is displaying on the NZ invoice report.

<b>Steps:-</b>

1) Install l10n_nz and shift the company to a NZ company 
2) Print a customer invoice

<b>Issue:-</b>
 unnecessary information is displaying on the invoice report

This issue is occurring because of the changes from the below commit.
Initially, the inherited template was replacing the `layout_document_title`
and printing the `invoice_title` based on the move type condition.

https://github.com/odoo/odoo/pull/189664/commits/1accf51091229811a0b0c1d2356a56e5f7fde44c

<b>Solution:-</b>

Remove the XPath of the `layout_document_title` as the inherited 
template is directly replacing the original invoice title

opw-4706957

