### PR TITLE
[FIX] website_sale: make Tags filter collapsible and adjust margin

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1194,14 +1194,23 @@
     </template>
 
     <template id="filter_products_tags" name="Filter by Tags" active="True">
-        <div t-if="all_tags">
-            <h6 class="mb-3">
-                <b>Tags</b>
+        <div t-if="all_tags" class="accordion-item">
+            <h6 class="accordion-header">
+                <button class="accordion-button px-0 bg-transparent shadow-none"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        aria-expanded="true"
+                        t-attf-data-bs-target="#o_wsale_tags_option_inner"
+                        t-attf-aria-controls="o_wsale_tags_option_inner">
+                    <b>Tags</b>
+                </button>
             </h6>
-            <div class="flex-column mb-3">
-                <t t-call="website_sale.filter_products_tags_list">
-                    <t t-set="all_tags" t-value="all_tags"/>
-                </t>
+            <div id="o_wsale_tags_option_inner" class="accordion-collapse collapse show">
+                <div class="flex-column mb-3">
+                    <t t-call="website_sale.filter_products_tags_list">
+                        <t t-set="all_tags" t-value="all_tags"/>
+                    </t>
+                </div>
             </div>
         </div>
     </template>


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1. Go to website > Shop > Scroll to tags filter (If tags aren't visible in the sidebar, go to Sales > Configuration > Product Tags > create tags)
2. Notice that Tags filter cannot be collapsed unlike other filters
3. Observe that margins and spacing don't match other filter components

<b>Issue:</b>
The "Tags" filter on the website shop sidebar lacked a collapsible header, unlike other filters  such as "Price Range".
This caused UI inconsistency. Additionally, the margin and spacing did not align visually with other filter components.

<b>Solution:</b>
Applied Bootstrap collapse classes to the Tags filter to enable accordion-style toggling.
Adjusted margin and structure to match the layout of other sidebar filters for visual consistency.

opw-4702463
