### PR TITLE
[FIX] l10n_in: remove onchange for gst treatment field

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -57,22 +57,6 @@ class ResPartner(models.Model):
         for partner in self:
             partner.display_pan_warning = partner.vat and partner.l10n_in_pan and partner.l10n_in_pan != partner.vat[2:12]
 
-    @api.onchange('company_type')
-    def onchange_company_type(self):
-        res = super().onchange_company_type()
-        if self.country_id and self.country_id.code == 'IN':
-            self.l10n_in_gst_treatment = (self.company_type == 'company') and 'regular' or 'consumer'
-        return res
-
-    @api.onchange('country_id')
-    def _onchange_country_id(self):
-        res = super()._onchange_country_id()
-        if self.country_id and self.country_id.code != 'IN':
-            self.l10n_in_gst_treatment = 'overseas'
-        elif self.country_id and self.country_id.code == 'IN':
-            self.l10n_in_gst_treatment = (self.company_type == 'company') and 'regular' or 'consumer'
-        return res
-
     @api.onchange('vat')
     def onchange_vat(self):
         if self.vat and self.check_vat_in(self.vat):


### PR DESCRIPTION
This PR removes the `onchange` logic  previously used to auto-set the l10n_in_gst_treatment field based on company_type and country_id.

The GST Treatment is now set dynamically by the PartnerAutoComplete service.

If a user manually creates a partner (without using autocomplete), they will need to select the GST Treatment manually.

Related IAP-https://github.com/odoo/iap-apps/pull/1051

