### PR TITLE
[FIX] mail: remove duplicate isMobileOS property in composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -123,7 +123,6 @@ export class Composer extends Component {
         });
         this.suggestion = this.store.self.type === "partner" ? useSuggestion() : undefined;
         this.markEventHandled = markEventHandled;
-        this.isMobileOS = isMobileOS;
         this.onDropFile = this.onDropFile.bind(this);
         this.saveContentDebounced = useDebounced(this.saveContent, 5000, {
             execBeforeUnmount: true,
@@ -452,7 +451,7 @@ export class Composer extends Component {
                     ev.preventDefault();
                     return;
                 }
-                if (this.isMobileOS()) {
+                if (this.isMobileOS) {
                     return;
                 }
                 const shouldPost = this.props.mode === "extended" ? ev.ctrlKey : !ev.shiftKey;

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -95,7 +95,7 @@
                 </div>
                 <div t-if="extended and !props.composer.message" class="d-flex align-items-center mt-2 gap-2">
                     <t t-call="mail.Composer.sendButton"/>
-                    <span t-if="!isSendButtonDisabled and !props.composer.message and !isMobileOS()" t-out="SEND_KEYBIND_TO_SEND"/>
+                    <span t-if="!isSendButtonDisabled and !props.composer.message and !isMobileOS" t-out="SEND_KEYBIND_TO_SEND"/>
                 </div>
             </div>
             <div class="o-mail-Composer-footer overflow-auto">


### PR DESCRIPTION
## Description

Forward port PR #201271 missed removal of duplicated isMobileOS property in composer.js during conflict resolution.

This caused `o-mobile border-bottom` class to be added to composer in desktop mode as well.

This commit removes the duplicate and retains the existing property.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
