### PR TITLE
[PERF] im_livechat: improve compute duration method

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -36,10 +36,12 @@ class DiscussChannel(models.Model):
 
     @api.depends('message_ids')
     def _compute_duration(self):
+        last_msg_by_channel_id = {
+            message.res_id: message for message in self._get_last_messages()
+        }
         for record in self:
-            start = record.message_ids[-1].date if record.message_ids else record.create_date
-            end = record.message_ids[0].date if record.message_ids else fields.Datetime.now()
-            record.duration = (end - start).total_seconds() / 3600
+            end = last.date if (last := last_msg_by_channel_id.get(record.id)) else fields.Datetime.now()
+            record.duration = (end - record.create_date).total_seconds() / 3600
 
     def _sync_field_names(self):
         return super()._sync_field_names() + ["livechat_operator_id"]


### PR DESCRIPTION
Before this PR, the `_compute_duration` method of the `discuss.channel` livechat model was very inefficient. Indeed, the method computes the duration of the chat by substracting the last message date to the first message date.

This is done by directly getting the first and last message through the `message_ids` recordset which force the ORM to fetch every message.

This PR updates this compute to use the `_get_last_messages` method that was rewritten to use lateral joins and it very fast. As for the first message, live chats are created after the first message is posted, so channel's create_date works just fine.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
