### PR TITLE
[FIX] website, web: adjust editor panel width for 150% zoom in Edge

### DIFF
--- a/addons/web/static/src/core/browser/feature_detection.js
+++ b/addons/web/static/src/core/browser/feature_detection.js
@@ -18,6 +18,13 @@ export function isBrowserFirefox() {
 }
 
 /**
+ * True if the browser is Microsoft Edge.
+ */
+export function isBrowserMicrosoftEdge() {
+    return /Edg/i.test(browser.navigator.userAgent);
+}
+
+/**
  * true if the browser is based on Safari (Safari, Epiphany)
  *
  * @returns {boolean}

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -27,6 +27,7 @@ import {
     useState,
     useExternalListener,
 } from "@odoo/owl";
+import { isBrowserMicrosoftEdge } from "@web/core/browser/feature_detection";
 
 class BlockPreview extends Component {}
 BlockPreview.template = 'website.BlockPreview';
@@ -269,6 +270,10 @@ export class WebsitePreview extends Component {
     get aceEditorWidth() {
         const storedWidth = browser.localStorage.getItem("ace_editor_width");
         return storedWidth ? parseInt(storedWidth) : 720;
+    }
+
+    get isMicrosoftEdge() {
+        return isBrowserMicrosoftEdge();
     }
 
     reloadIframe(url) {

--- a/addons/website/static/src/client_actions/website_preview/website_preview.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.scss
@@ -56,6 +56,23 @@
             }
         }
     }
+
+    // Fix for Edge with 150% zoom: when entering edit mode, the page switches
+    // to mobile view because Edge adds extra border around the window, causing
+    // the width to fall below the mobile breakpoint. To prevent this, we reduce
+    // the sidebar width by 5px to keep the page in desktop view.
+    // TODO: In the next sidebar redesign, adjust the sidebar width properly to
+    // avoid this workaround.
+    &.o_is_microsoft_edge.editor_enable.editor_has_snippets {
+        @media (min-resolution: 1.5dppx) and (max-resolution: 1.51dppx) {
+            $o-we-sidebar-width-for-edge: $o-we-sidebar-width - 5px;
+            margin-right: $o-we-sidebar-width-for-edge !important;
+
+            #oe_snippets, .o_we_website_top_actions, we-selection-items.o_we_has_pager {
+                width: $o-we-sidebar-width-for-edge !important;
+            }
+        }
+    }
 }
 
 .o_we_website_top_actions button[data-action="mobile"], .o_mobile_preview {

--- a/addons/website/static/src/client_actions/website_preview/website_preview.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.xml
@@ -13,7 +13,9 @@
          t-att-class="{ 'editor_enable editor_has_snippets': this.websiteContext.snippetsLoaded,
                         'o_is_blocked': this.blockedState.isBlocked,
                         'o_is_mobile': this.websiteContext.isMobile,
-                        'border-top': !this.websiteContext.snippetsLoaded }">
+                        'border-top': !this.websiteContext.snippetsLoaded,
+                        'o_is_microsoft_edge': isMicrosoftEdge,
+                      }">
         <BlockPreview t-if="this.blockedState.showLoader"/>
         <div class="o_iframe_container">
             <iframe t-if="!testMode"


### PR DESCRIPTION
Steps to reproduce the bug:

- Use Edge browser with zoom set to 150% (default zoom on Windows installations).
- On a screen with a resolution of 1920px (and the browser window set to full width).
- Install the Website app and go to the homepage.
- The page is displayed in desktop view.
- Enter edit mode by clicking the "Edit" button.
- The page width becomes smaller than the mobile breakpoint. As a result , the page switches to mobile view: the navbar turns into a hamburger menu, and the layout changes to mobile style.

This should not happen, as the edit mode is designed to remain in desktop view with 150% zoom on 1920px wide screens. The issue is caused by Edge adding a few pixels of border around the browser window, which leads to this problem specific to Edge.

To fix this in the stable version, we reduce the sidebar width in edit mode by 5 pixels to ensure the page stays in desktop view. This change is applied only if the browser is Edge and 150% zoom is used. In all other cases, no changes are made.

This fix is temporary. In the next redesign of the edit mode sidebar, the sidebar width will be adjusted accordingly so that this workaround will no longer be necessary.

Note: The Arc browser has the same issue, but we haven’t fixed it because there’s currently no way to reliably detect it in JavaScript. Since Arc is much less popular than Edge, it’s less critical.

task-4587203