### PR TITLE
[FIX] l10n_hu_edi: display bank account under customer on credit note

### DIFF
--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -28,7 +28,7 @@
                         <li t-if="o.partner_id.commercial_partner_id.country_id and o.partner_id.commercial_partner_id.country_id.code!='HU'">
                             EU Tax ID: <span t-out="'HU%s' % o.company_id.vat[:8]"/>
                         </li>
-                        <li t-if="'out' in o.move_type and o.partner_bank_id">Bank Account: <span t-field="o.partner_bank_id.acc_number"/></li>
+                        <li t-if="o.move_type in ['out_invoice', 'out_receipt'] and o.partner_bank_id">Bank Account: <span t-field="o.partner_bank_id.acc_number"/></li>
                         <li t-if="o.company_id.l10n_hu_tax_regime=='ie'">The issuer of the invoice is <u>Exempt from VAT</u>.</li>
                         <li t-if="o.company_id.l10n_hu_tax_regime=='ca'">The issuer of the invoice is <u>Cash accounting</u>.</li>
                         <li t-if="o.company_id.l10n_hu_tax_regime=='sb'">The issuer of the invoice is <u>Small taxpayer</u>.</li>
@@ -57,6 +57,7 @@
         </xpath>
         <xpath expr="//div[@name='address_same_as_shipping']//span[@t-field='o.partner_id.vat']/.." position="after">
             <div t-if="o.partner_id.l10n_hu_group_vat">Group Member Tax ID: <span t-field="o.partner_id.l10n_hu_group_vat"/></div>
+            <div t-if="o.move_type == 'out_refund' and o.partner_bank_id">Bank Account: <span t-field="o.partner_bank_id.acc_number"/></div>
         </xpath>
         <xpath expr="//div[@name='no_shipping']//address" position="before">
             <strong>Customer:</strong>


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_hu" and switch to Hungarian company
- In Settings set NAV credentials to "demo"
- Make sure accounts are set on the company & customer
- Create an invoice, confirm, Sent & Print
- Create a Credit Note for this invoice, Send & Print
- On the Credit Note PDF the account of the customer is displayed under the "Supplier"

### Cause:
The account always shows under the supplier `if 'out' in o.move_type` so also for credit notes ('out_refund').

### Solution:
Change the condition of the display and add the bank account in a xpath.

opw-4710449