### PR TITLE
[IMP] web, mail, hr_attendance: remove params from lazy session info

### DIFF
--- a/addons/hr_attendance/models/ir_http.py
+++ b/addons/hr_attendance/models/ir_http.py
@@ -1,14 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.hr_attendance.controllers.main import HrAttendance
-from odoo import models
+from odoo import api, models
 
 
 class IrHttp(models.AbstractModel):
     _inherit = 'ir.http'
 
-    def lazy_session_info(self, **kwargs):
-        res = super().lazy_session_info(**kwargs)
+    @api.model
+    def lazy_session_info(self):
+        res = super().lazy_session_info()
         if self.env.user and self.env.user.employee_id:
             employee = self.env.user.employee_id
             res['attendance_user_data'] = HrAttendance._get_user_attendance_data(employee)

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -9,15 +9,6 @@ from odoo.addons.mail.tools.discuss import Store
 class IrHttp(models.AbstractModel):
     _inherit = 'ir.http'
 
-    def lazy_session_info(self, **kwargs):
-        res = super().lazy_session_info(**kwargs)
-        if fetch_params := kwargs.get("store_fetch_params"):
-            routing_map = request.env["ir.http"].routing_map()
-            map_adapter = routing_map.bind_to_environ(request.httprequest.environ)
-            endpoint, _args = map_adapter.match(path_info="/mail/data")
-            res["store_data"] = endpoint(fetch_params=fetch_params, context=request.context)
-        return res
-
     def session_info(self):
         """Override to add the current user data (partner or guest) if applicable."""
         result = super().session_info()

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -1,13 +1,9 @@
 import { fields } from "@mail/core/common/record";
-import { Store, storeService } from "@mail/core/common/store_service";
+import { Store } from "@mail/core/common/store_service";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 
 import { patch } from "@web/core/utils/patch";
-
-patch(storeService, {
-    dependencies: [...storeService.dependencies, "lazy_session"],
-});
 
 /** @type {import("models").Store} */
 const StorePatch = {
@@ -40,19 +36,6 @@ const StorePatch = {
             this.fetchStoreData("systray_get_activities"),
             super.initialize(...arguments),
         ]);
-    },
-    /**
-     * Override to group the first fetch with the lazy session fetch if it is not done yet.
-     */
-    _fetchStoreDataRpc(fetchParams) {
-        if (this.env.services.lazy_session.rpcDone()) {
-            return super._fetchStoreDataRpc(...arguments);
-        }
-        return new Promise((resolve, reject) =>
-            this.env.services.lazy_session.getValue("store_data", resolve, {
-                store_fetch_params: fetchParams,
-            })
-        );
     },
     onStarted() {
         super.onStarted(...arguments);

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -687,11 +687,7 @@ export function assertChatHub({ opened = [], folded = [] }) {
     expect(browser.localStorage.getItem(CHAT_HUB_KEY)).toEqual(toChatHubData(opened, folded));
 }
 
-export const STORE_FETCH_ROUTES = [
-    "/mail/action",
-    "/mail/data",
-    "/web/dataset/call_kw/ir.http/lazy_session_info",
-];
+export const STORE_FETCH_ROUTES = ["/mail/action", "/mail/data"];
 
 /**
  * Prepares listeners for the various ways a store fetch could be triggered. It is important to call
@@ -742,10 +738,6 @@ export function listenStoreFetch(nameOrNames = [], { logParams = [], onRpc: onRp
     onRpc("/mail/data", async (request) => {
         const { params } = await request.json();
         return registerSteps(request, params.fetch_params);
-    });
-    onRpc("/web/dataset/call_kw/ir.http/lazy_session_info", async (request) => {
-        const { params } = await request.json();
-        return registerSteps(request, params.kwargs.store_fetch_params);
     });
 }
 

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1400,17 +1400,6 @@ class Store {
     }
 }
 
-registerRoute("/web/dataset/call_kw/ir.http/lazy_session_info", async function (request) {
-    const { kwargs } = await parseRequestParams(request);
-    const res = {}; // missing super call for simplicity
-    if (kwargs.store_fetch_params) {
-        res.store_data = processRequest
-            .call(this, kwargs.store_fetch_params, kwargs.context)
-            .get_result();
-    }
-    return res;
-});
-
 export const mailDataHelpers = {
     _process_request_for_all,
     _process_request_for_internal_user,

--- a/addons/mail/static/tests/utils/decorate_emojis.test.js
+++ b/addons/mail/static/tests/utils/decorate_emojis.test.js
@@ -1,9 +1,15 @@
 import { decorateEmojis } from "@mail/utils/common/format";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+
 import { expect, test } from "@odoo/hoot";
 import { markup } from "@odoo/owl";
+
 import { makeMockEnv } from "@web/../tests/web_test_helpers";
 import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
+
 const Markup = markup().constructor;
+
+defineMailModels();
 
 test("emojis in text content are wrapped with title and marked up", async () => {
     await makeMockEnv();

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import hashlib
-import json
 import warnings
 
 import odoo
@@ -72,7 +70,8 @@ class IrHttp(models.AbstractModel):
             'session_info': self.session_info(),
         }
 
-    def lazy_session_info(self, **kwargs):
+    @api.model
+    def lazy_session_info(self):
         return {}
 
     def session_info(self):

--- a/addons/web/static/src/webclient/session_service.js
+++ b/addons/web/static/src/webclient/session_service.js
@@ -6,20 +6,19 @@ export const lazySession = {
     start(env, { orm }) {
         let resolveWebClientReady;
         let lazyConfigPromise;
-        const fetchServerData = async (params) => {
+        const fetchServerData = async () => {
             await webClientReadyPromise;
-            return orm.call("ir.http", "lazy_session_info", [[]], params);
+            return orm.call("ir.http", "lazy_session_info");
         };
         const webClientReadyPromise = new Promise((r) => (resolveWebClientReady = r));
         env.bus.addEventListener("WEB_CLIENT_READY", resolveWebClientReady);
         return {
-            getValue(key, callback, params) {
+            getValue(key, callback) {
                 if (!lazyConfigPromise) {
-                    lazyConfigPromise = fetchServerData(params);
+                    lazyConfigPromise = fetchServerData();
                 }
                 lazyConfigPromise.then((config) => callback(deepCopy(config)[key]));
             },
-            rpcDone: () => !!lazyConfigPromise,
         };
     },
 };


### PR DESCRIPTION
Follow up of https://github.com/odoo/odoo/pull/197893
Follow up of https://github.com/odoo/odoo/pull/194391

After discussion with the framework team, it was determined that it was more detrimental to have a "complex" lazy session API with params rather than keeping multiple RPC at init.

Especially considering HTTP 2 is now implemented at nginx level in our saas platform, it makes little sense to group requests that have little to no overlap in their DB access or in their returned data.

This commit therefore removes the params from the lazy session info and removes init messaging and other discuss params from the lazy session mechanism as it needs params to work (in particular chat window are stored locally and need to be validated by the server at init).

In terms of discuss, it's best to group global init + chat hub init together in the same RPC (as there is an overlap in terms of DB queries and returned data) rather than grouping one with lazy session (which has nothing else in common) and the other being done standalone.

On top of that, one could also argue the discuss init is rather "slow" (depending on the number of data for the current user, it can take 200ms or more) and it is better if the "rest" of the webclient init is loaded as fast as possible.

https://github.com/odoo/enterprise/pull/83313