### PR TITLE
[FIX] website_slides: fix course access request

### DIFF
--- a/addons/website_slides/static/src/interactions/enroll_email.js
+++ b/addons/website_slides/static/src/interactions/enroll_email.js
@@ -24,7 +24,7 @@ export class EnrollEmail extends Interaction {
             title: _t("Request Access."),
             body: _t("Do you want to request access to this course?"),
             confirmLabel: _t("Yes"),
-            confim: async () => {
+            confirm: async () => {
                 const { error, done } = await this.waitFor(
                     this.services.orm.call(
                         "slide.channel",


### PR DESCRIPTION
A small typo had been made when rewriting the enroll_email public widget that made it unusable. This commit fix the typo.

Task-4721311


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
