### PR TITLE
[FIX] core: fix force upgrade

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -183,7 +183,7 @@ def load_module_graph(
 
         new_install = package.state == 'to install'
         if needs_update:
-            if not new_install:
+            if not new_install or package.name in registry._force_upgrade_scripts:
                 if package.name != 'base':
                     registry._setup_models__(env.cr)
                 migrations.migrate_module(package, 'pre')


### PR DESCRIPTION
in odoo#189000, ``_force_upgrade_of_fresh_module`` was added for upgrade-util to force upgrade scripts of new modules. But the `pre` scripts were still ignored for ``new_install`` modules. This commit fixes the bug.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
