### PR TITLE
[IMP] base: display uninstallation wizard in settings

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -634,7 +634,7 @@ class IrModuleModule(models.Model):
             'name': _('Uninstall module'),
             'view_mode': 'form',
             'res_model': 'base.module.uninstall',
-            'context': {'default_module_id': self.id},
+            'context': {'default_module_ids': self.ids},
         }
 
     def button_uninstall_cancel(self):

--- a/odoo/addons/base/wizard/base_module_uninstall_views.xml
+++ b/odoo/addons/base/wizard/base_module_uninstall_views.xml
@@ -16,7 +16,7 @@
                         <div class="me-auto p-2 bd-highlight"><h3>Apps to Uninstall</h3></div>
                         <div class="p-2 bd-highlight"><field name="show_all"/> Show All</div>
                     </div>
-                    <field name="module_ids" mode="kanban" class="o_modules_field">
+                    <field name="impacted_module_ids" mode="kanban" class="o_modules_field">
                         <kanban create="false" class="o_modules_kanban">
                             <field name="state"/>
                                 <templates>


### PR DESCRIPTION
Specifications:
- When a user unchecks a boolean field that triggers the uninstallation of a module, the module uninstallation wizard should open automatically.

- If the user unchecks multiple boolean fields, they should be able to uninstall multiple modules at once through a single wizard.

Purpose:
- The current warning is not sufficiently clear or informative.

- The existing wizard does not support the uninstallation of multiple modules at once, making it inconvenient for users to uninstall several modules simultaneously.

Enterprise: https://github.com/odoo/enterprise/pull/83320

task-4513796

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
