### PR TITLE
[FIX] account_edi{_ubl_cii}: improve product detection for import

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -31,11 +31,30 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
         })
 
     def test_import_product(self):
+        products = self.env['product.product'].create([{
+            'name': 'XYZ',
+            'default_code': '1234',
+        }, {
+            'name': 'XYZ',
+            'default_code': '5678',
+        }, {
+            'name': 'XXX',
+            'default_code': '1111',
+            'barcode': '00001',
+        }, {
+            'name': 'YYY',
+            'default_code': '1111',
+            'barcode': '00002',
+        }])
         line_vals = [
            {'product_id': self.place_prdct.id, 'product_uom_id': self.uom_units.id},
            {'product_id': self.displace_prdct.id, 'product_uom_id': self.uom_units.id},
            {'product_id': self.displace_prdct.id, 'product_uom_id': self.uom_units.id},
-           {'product_id': self.displace_prdct.id, 'product_uom_id': self.uom_dozens.id}
+           {'product_id': self.displace_prdct.id, 'product_uom_id': self.uom_dozens.id},
+           {'product_id': products[0].id, 'product_uom_id': self.uom_units.id},
+           {'product_id': products[1].id, 'product_uom_id': self.uom_units.id},
+           {'product_id': products[2].id, 'product_uom_id': self.uom_units.id},
+           {'product_id': products[3].id, 'product_uom_id': self.uom_units.id},
         ]
         # To allow for the creation of Factur-X EDI the company must be either French or German
         company = self.company_data['company']


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Create a product:
  * Product Name: XYZ
  * Internal Reference: 1234
- Create a second product with the same name:
  * Product Name: XYZ
  * Internal Reference: 5678
- Go to "Accounting / Vendors / Bills"
- Upload a Peppol BIS Billing 3.0 XML containing 2 invoice lines with the created products:
`<cbc:Name>XYZ</cbc:Name>`
`<cac:SellersItemIdentification><cbc:ID>1234</cbc:ID></cac:SellersItemIdentification>` and
`<cbc:Name>XYZ</cbc:Name>`
`<cac:SellersItemIdentification><cbc:ID>5678</cbc:ID></cac:SellersItemIdentification>`

**Issue:**
The 2 invoice lines of the generated bill have the same exact product, even when 2 different codes are provided for the products.

**Cause:**
In "_retrieve_product" method, a search is made on the name, the code and the barcode, but an "OR" operator is applied.
Not an "AND".
Several products may satisfy the domain but only the first one is returned.

**Solution:**
If several products matches the conditions, instead of directly returning the first one, try to select one based on the following
priority: barcode, code, name.
opw-4466322




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
