### PR TITLE
[FIX] website: add missing `t-forbid-sanitize` on new form snippets

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -346,7 +346,7 @@
                 </t>
                 <t t-snippet="website.s_opening_hours" string="Opening Hours" group="contact_and_forms"/>
                 <t t-snippet="website.s_contact_info" string="Contact Info" group="contact_and_forms"/>
-                <t t-snippet="website.s_website_form_overlay" string="Form Overlay" group="contact_and_forms">
+                <t t-snippet="website.s_website_form_overlay" string="Form Overlay" t-forbid-sanitize="form" group="contact_and_forms">
                     <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request</keywords>
                 </t>
 


### PR DESCRIPTION
When adding the new snippets, some of them containing forms were not properly sanitized (i.e. they do not have the `t-forbid-sanitize="form"` attribute), meaning that they can be dropped in sanitized areas where forms should normally be excluded.

This commit adds this attribute on them.

Related to task-4138795