### PR TITLE
[FIX] web_editor: fix caret navigation with mixed nodes

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -988,6 +988,7 @@ export function getDeepRange(editable, { range, sel, splitText, select, correctT
 
 export function getAdjacentCharacter(editable, side) {
     let { focusNode, focusOffset } = editable.ownerDocument.getSelection();
+    [focusNode, focusOffset] = getDeepestPosition(focusNode, focusOffset);
     const originalBlock = closestBlock(focusNode);
     let adjacentCharacter;
     while (!adjacentCharacter && focusNode) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/tabs.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/tabs.test.js
@@ -550,4 +550,23 @@ describe('Tabs', () => {
             });
         });
     });
+
+    describe("Selection", () => {
+        it("should move to the previous character", async () => {
+            const TAB = (size) => `<span class="oe-tabs" style="width: ${size}px; tab-size: ${size}px;">\u0009</span>`;
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>ab[]</p>`,
+                stepFunction: async (editor) => {
+                    await triggerEvent(editor.editable, 'keydown', { key: 'Tab', shiftKey: false });
+                    const event = await triggerEvent(editor.editable, 'keydown', { key: 'ArrowLeft' });
+                    if (event.defaultPrevented) {
+                        throw "Should handover the arrow left event to the browser";
+                    }
+                },
+                contentAfter: `<p>ab${TAB(24.8906)}[]\u200B</p>`,
+                // content after browser move the selection will be
+                // `<p>ab[]${oeTab(24.8906)}</p>`
+            });
+        });
+    });
 });


### PR DESCRIPTION
Problem:
In `getAdjacentCharacter`, accessing `focusNode.textContent[focusOffset - 1]` directly fails when there are child nodes between text nodes.

Example:
Given `<p>ab<span>\u0009</span>\u200B[]</p>`:
- `focusNode.childNodes` → [text("ab"), span, text("\u200B")]
- `focusNode.textContent` → ["a", "b", "/TAB/", "/ZWS/"]
- `focusOffset` → 3 (nodes offset not text offset)
- Accessing `focusNode.textContent[2]` is wrong because `focusOffset` counts nodes, not characters, it should return `/ZWS/` not `/TAB/`.

Solution:
Align with 18.0+ (`html_editor`) behavior by calling `getDeepestPosition(focusNode, focusOffset)` inside `getAdjacentCharacter`.

Steps to reproduce:
1. Type `ab`
2. Press `Tab`
3. Press `Arrow Left` → Caret does not move left as expected.

opw-4720904

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
