### PR TITLE
[FIX] account_edi_ubl_cii,l10n_tr_nilvera_einvoice: fixes TR export

### DIFF
--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -290,6 +290,15 @@
         </t>
     </template>
 
+    <template id="ubl_20_ExchangeRateType">
+        <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:SourceCurrencyCode t-out="vals['source_currency_code']"/>
+            <cbc:TargetCurrencyCode t-out="vals['target_currency_code']"/>
+            <cbc:CalculationRate t-out="vals.get('calculation_rate')"/>
+            <cbc:Date t-out="vals.get('date')"/>
+        </t>
+    </template>
+
     <template id="ubl_20_CommonLineType">
         <t xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
@@ -422,6 +431,9 @@
             <cbc:DocumentCurrencyCode
                 t-att="vals.get('document_currency_code_attrs', {})"
                 t-out="invoice.currency_id.name.upper()"/>
+            <cbc:PricingCurrencyCode
+                t-att="vals.get('pricing_currency_code_attrs', {})"
+                t-out="vals.get('pricing_currency_code')"/>
             <cbc:TaxCurrencyCode
                 t-att="vals.get('tax_currency_code_attrs', {})"
                 t-out="vals.get('tax_currency_code')"/>
@@ -476,6 +488,11 @@
                     </t>
                 </cac:Party>
             </cac:AccountingCustomerParty>
+            <cac:PricingExchangeRate t-foreach="vals.get('pricing_exchange_rate_vals_list', [])" t-as="foreach_vals">
+                <t t-call="{{ExchangeRateType_template}}">
+                    <t t-set="vals" t-value="foreach_vals"/>
+                </t>
+            </cac:PricingExchangeRate>
             <cac:TaxTotal t-foreach="vals.get('tax_total_vals', [])" t-as="foreach_vals">
                 <t t-call="{{TaxTotalType_template}}">
                     <t t-set="vals" t-value="foreach_vals"/>

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -340,6 +340,20 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             })
         return vals_list
 
+    def _get_pricing_exchange_rate_vals_list(self, invoice):
+        """ To be overridden if needed to fill the PricingExchangeRate node.
+
+        This is used when the currency of the 'Exchange' (e.g.: an invoice) is not the same as the Document currency.
+
+        If used, it should return a list of dict, following this format: [{
+            'source_currency_code': str,  (required)
+            'target_currency_code': str,  (required)
+            'calculation_rate': float,
+            'date': date,
+        }]
+        """
+        return []
+
     def _get_invoice_line_allowance_vals_list(self, line, tax_values_list=None):
         """ Method used to fill the cac:{Invoice,CreditNote,DebitNote}Line>cac:AllowanceCharge node.
 
@@ -600,6 +614,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'InvoiceType_template': 'account_edi_ubl_cii.ubl_20_InvoiceType',
             'CreditNoteType_template': 'account_edi_ubl_cii.ubl_20_CreditNoteType',
             'DebitNoteType_template': 'account_edi_ubl_cii.ubl_20_DebitNoteType',
+            'ExchangeRateType_template': 'account_edi_ubl_cii.ubl_20_ExchangeRateType',
 
             'vals': {
                 'ubl_version_id': 2.0,
@@ -632,6 +647,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 ),
                 'line_vals': invoice_line_vals_list,
                 'currency_dp': self._get_currency_decimal_places(invoice.currency_id),  # currency decimal places
+                'pricing_exchange_rate_vals_list': self._get_pricing_exchange_rate_vals_list(invoice),
             },
         }
 


### PR DESCRIPTION
- Fixes the error coming from using discounts in invoices: the node
`AllowanceChargeReasonCode` was added while not accepted by the
Turkish implementation, and the amounts might not respect the asked
format in some cases.

- Fixes the error coming from invoices using a different currency than
the company one (TRY). Although the documentation says the node
`PricingExchangeRate` is only needed "If the prices of goods or services
on the invoice are shown in a currency other than the
'Document Currency", and our file did indeed use only one currency at a
time (either all TRY or all USD amounts, e.g.), the server was still
refusing our file.

- Limits the decimal precision to 2 for most amoutns, as requested by
the nilvera format.

- Use uppercase on invoice names when putting them in the xml.

task-4356940