### PR TITLE
[FIX] mrp: generate backorder names correctly

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1732,7 +1732,7 @@ class MrpProduction(models.Model):
             return name
         seq_back = "-" + "0" * (SIZE_BACK_ORDER_NUMERING - 1 - int(math.log10(sequence))) + str(sequence)
         regex = re.compile(r"-\d+$")
-        if regex.search(name) and sequence > 1:
+        if regex.search(name) and (max(self.procurement_group_id.mrp_production_ids.mapped("backorder_sequence")) > 1 or sequence > 1):
             return regex.sub(seq_back, name)
         return name + seq_back
 

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -478,6 +478,45 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertEqual(production.name.split('-')[0], backorder_ids.name.split('-')[0])
         self.assertEqual(int(production.name.split('-')[1]) + 1, int(backorder_ids.name.split('-')[1]))
 
+    def test_backorder_name_with_multiple_backorder(self):
+        """ Test that the backorder name is correct when splitting and creating
+        multiple backorders.
+        """
+        # create a mo for 5 units and split it into 2
+        mo = self.generate_mo(qty_final=5)[0]
+        action = mo.action_split()
+        wizard = Form(self.env[action['res_model']].with_context(action['context']))
+        wizard.counter = 2
+        wizard.save().action_split()
+
+        # Ensure that the MO was correctly split into 2 MOs
+        self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 2)
+        mo_2 = mo.procurement_group_id.mrp_production_ids[1]
+
+        # Check that the sequence names are correct after splitting
+        self.assertEqual(mo.name.split('-')[1], '001')
+        self.assertEqual(mo_2.name.split('-')[1], '002')
+
+        # Validate the first MO and create a backorder
+        mo_form = Form(mo)
+        mo_form.qty_producing = 1
+        mo = mo_form.save()
+        action = mo.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+        backorder_mo1 = mo.procurement_group_id.mrp_production_ids[-1]
+        self.assertEqual(backorder_mo1.name.split('-')[1], '003')
+
+        # Validate the second MO and create another backorder
+        mo_form = Form(mo_2)
+        mo_form.qty_producing = 1
+        mo = mo_form.save()
+        action = mo.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+        backorder_mo2 = mo_2.procurement_group_id.mrp_production_ids[-1]
+        self.assertEqual(backorder_mo2.name.split('-')[1], '004')
+
     def test_split_draft(self):
         mo_form = Form(self.env['mrp.production'])
         mo_form.product_id = self.bom_1.product_id


### PR DESCRIPTION
Steps to reproduce the issue:
- Create a storable product “P1”
- Create a Bill of Materials:
    - Finished product: 1 unit of P1
    - Components:
        - 1 unit of C1
- Create a manufacturing order to produce 10 units of P1
- Confirm the MO
- Split the MO into two:
    - This creates two new MOs, each for 5 units: - “WH-MO-001” - ”WH-MO-002”

- For the first MO (WH-MO-001):
    - Set Quantity Produced to 1.
    - Validate it and choose to create a backorder.

Problem:
- The backorder is incorrectly named “WH-MO-001-003” instead of the expected WH-MO-003.

- Additionally, the original MO is renamed “WH-MO-001-001”, which is unexpected.

- However, if you perform the same steps on the second MO (WH-MO-002), the backorder is correctly named “WH-MO-003”, and the original name remains unchanged.

Root cause:
- When the original MO is first split, each resulting MO receives a backorder sequence:

    - First split MO (WH-MO-001): backorder_sequence = 1

    - Second split MO (WH-MO-002): backorder_sequence = 2

- When creating a backorder from an MO with backorder_sequence = 1, the following logic is triggered:

    - https://github.com/odoo/odoo/blob/18.0/addons/mrp/models/mrp_production.py#L1844

- Since the condition if backorder_sequence > 1 is false for WH-MO-001:

    - https://github.com/odoo/odoo/blob/18.0/addons/mrp/models/mrp_production.py#L1782

- So the name + seq_back is added:

    https://github.com/odoo/odoo/blob/18.0/addons/mrp/models/mrp_production.py#L1784

opw-4686959
