### PR TITLE
[FIX] stock: forecast graph color stock picking

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -331,9 +331,9 @@
                                             role="img" title="Assign Serial Numbers"
                                             invisible="not display_assign_serial"/>
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart"
-                                        invisible="quantity == 0 and forecast_availability &lt;= 0 or (parent.picking_type_code == 'outgoing' and state != 'draft')"/>
+                                        invisible="(quantity - product_uom_qty &lt; 0) or (parent.picking_type_code == 'outgoing' and state != 'draft')"/>
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart text-danger"
-                                        invisible="quantity &gt; 0 or forecast_availability &gt; 0 or (parent.picking_type_code == 'outgoing' and state != 'draft')"/>
+                                        invisible="(quantity - product_uom_qty &gt;= 0) or (parent.picking_type_code == 'outgoing' and state != 'draft')"/>
                                 </tree>
                             </field>
                             <field name="id" invisible="1"/>


### PR DESCRIPTION
**Problem:**
In the stock.picking Form view, the forecast report button on the stock moves (in the Operations page) is not red when Demand is higher than quantity

**Steps to reproduce:**
- Open Inventory/Configuration/Wharehouse Management/Wharehouses
- Select your Wharehouse and for the "Outgoing Shipments" field, select 3 steps
- Open Sales/products and create a new product
- For the "Product Type field" select "Storable Product"
- Click on the "On Hand" Smart Button
- Click on new and set an on hand quantity of 100
- Create a new quotation and add your new product
- Set a quantity of 120 and confirm the order
- Click on the delivery smart button
- Select th Pick order created (the last of the 3 lines and also the one with a "ready" status)

**Current behavior:**
In the Operations tab, the graph icon is blue

**Expected behavior:**
It should be red to reflect the fact that the Demand quantity is higher thant the available quantity

**Cause of the issue:**
The invisible condition for the blue button and the red one do not properly reflect the situation.
https://github.com/odoo/odoo/blob/8b721374e47fc8ac4c4baccfe32b4f59a253bc82/addons/stock/views/stock_picking_views.xml#L333-L336 The condition is partly based on the value of forecast_availability which is 0 if the quantity is higher than demand and also if demand is higher than quantity

**Fix:**
The difference between quantity and product_uom_qty uses the same logic used for the QtyAtDateWidget widget color in sale orders
https://github.com/odoo/odoo/blob/8b721374e47fc8ac4c4baccfe32b4f59a253bc82/addons/sale_stock/static/src/widgets/qty_at_date_widget.js#L45
opw-4650157

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
