### PR TITLE
[FIX] mail: discuss style improvement message/border/avatar

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -134,7 +134,7 @@
         'ms-3': !thread,
         'ps-2': !hasActionsMenu,
     }">
-        <img t-if="thread" class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
+        <img t-if="thread" class="rounded-3 o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
     </div>
     <t t-if="thread?.parent_channel_id">
         <span class="fw-bold small ms-1 p-1 opacity-75 opacity-100-hover cursor-pointer o-hover-text-underline rounded fs-6" t-esc="thread.parent_channel_id.displayName" title="Open Channel" t-ref="parentChannel" t-on-click.stop="() => this.thread.parent_channel_id.open({ focus: true })"/>

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -29,7 +29,7 @@
                 </t>
             </FileUploader>
             <div t-if="showComposerAvatar" class="o-mail-Composer-sidebarMain flex-shrink-0">
-                <img class="o-mail-Composer-avatar mx-auto o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
+                <img class="o-mail-Composer-avatar mx-auto o_avatar rounded-3" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -74,6 +74,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     padding-bottom: map-get($spacers, 1) / 2;
 }
 
+.o-pt-0_5 {
+    padding-top: map-get($spacers, 1) / 2;
+}
+
 .o-hover-text-underline:hover {
     text-decoration: underline;
 }

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -13,7 +13,7 @@
 .o-mail-Message-bubble {
     &.o-blue {
         background-color: mix($gray-100, $info, 87.5%) !important;
-        border-color: lighten(mix($gray-100, $info, 87.5%), 2.5%) !important;
+        border-color: rgba(lighten(mix($gray-100, $info, 87.5%), 2.5%), .5) !important;
     
         &.o-muted {
             background-color: darken(mix($gray-100, $info, 87.5%), 5%) !important;
@@ -21,7 +21,7 @@
     }
     &.o-green {
         background-color: mix($gray-100, $success, 87.5%) !important;
-        border-color: lighten(mix($gray-100, $success, 87.5%), 2.5%) !important;
+        border-color: rgba(lighten(mix($gray-100, $success, 87.5%), 2.5%), .5) !important;
     
         &.o-muted {
             background-color: darken(mix($gray-100, $success, 87.5%), 5%) !important;
@@ -29,7 +29,7 @@
     }
     &.o-orange {
         background-color: mix($gray-100, $warning, 72.5%) !important;
-        border-color: lighten(mix($gray-100, $warning, 72.5%), 2.5%) !important;
+        border-color: rgba(lighten(mix($gray-100, $warning, 72.5%), 2.5%), .5) !important;
     
         &.o-muted {
             background-color: darken(mix($gray-100, $warning, 72.5%), 10%) !important;

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -227,7 +227,8 @@ export class Message extends Component {
         return {
             [this.props.className]: true,
             "o-card p-2 ps-1 mx-1 mt-2 mb-2 border border-secondary rounded-3": this.props.asCard,
-            "pt-1": !this.props.asCard,
+            "pt-1": !this.props.asCard && !this.props.squashed,
+            "o-pt-0_5": !this.props.asCard && this.props.squashed,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,
             "o-selected": this.props.messageToReplyTo?.isSelected(
                 this.props.thread,

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -86,7 +86,7 @@
 .o-mail-Message-bubble {
     &.o-blue {
         background-color: mix($o-view-background-color, $info, 87.5%) !important;
-        border-color: darken(mix($o-view-background-color, $info, 87.5%), 10%) !important;
+        border-color: rgba(darken(mix($o-view-background-color, $info, 87.5%), 10%), .5) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $info, 87.5%)) !important;
@@ -94,7 +94,7 @@
     }
     &.o-green {
         background-color: mix($o-view-background-color, $success, 87.5%) !important;
-        border-color: darken(mix($o-view-background-color, $success, 87.5%), 10%) !important;
+        border-color: rgba(darken(mix($o-view-background-color, $success, 87.5%), 10%), .5) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $success, 87.5%)) !important;
@@ -102,7 +102,7 @@
     }
     &.o-orange {
         background-color: mix($o-view-background-color, $warning, 75%) !important;
-        border-color: darken(mix($o-view-background-color, $warning, 75%), 10%) !important;
+        border-color: rgba(darken(mix($o-view-background-color, $warning, 75%), 10%), .5) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $warning, 75%), 85%) !important;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.Message">
-        <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-muted opacity-75 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
+        <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-muted opacity-50 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1"/>
             <span class="o-mail-NotificationMessage-author d-inline" t-if="authorName and !message.body.includes(escape(authorName))" t-esc="authorName"/> <t t-out="message.body"/>
         </div>
@@ -20,7 +20,7 @@
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
                     <div class="o-mail-Message-sidebar d-flex flex-shrink-0 justify-content-center" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
                         <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view" t-att-class="getAvatarContainerAttClass()">
-                            <img class="o-mail-Message-avatar w-100 h-100 rounded" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
+                            <img class="o-mail-Message-avatar w-100 h-100 rounded-3" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
                         </div>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>
                         <t t-elif="!message.is_transient">
@@ -31,7 +31,7 @@
                     </div>
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
                         <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note }" name="header">
-                            <span t-if="authorName and shouldDisplayAuthorName" class="o-mail-Message-author small" t-att-class="getAuthorAttClass()">
+                            <span t-if="authorName and shouldDisplayAuthorName" class="o-mail-Message-author smaller" t-att-class="getAuthorAttClass()">
                                 <strong class="me-1" t-esc="authorName"/>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -8,7 +8,7 @@
                 'o-orange': props.message.parentMessage.bubbleColor === 'orange',
             }">
                 <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
-                    <img class="o-mail-MessageInReply-avatar me-2 rounded o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
+                    <img class="o-mail-MessageInReply-avatar me-2 rounded-3 o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
                     <span class="o-mail-MessageInReply-content overflow-hidden smaller">
                         <b><t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
                         <span class="o-mail-MessageInReply-message ms-1 text-break">

--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -1,5 +1,5 @@
 .o-mail-Discuss {
-    --mail-Discuss-headerActionsGroupBorderOpacity: .1;
+    --mail-Discuss-headerActionsGroupBorderOpacity: 0;
 }
 
 .o-mail-Discuss-header {

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -19,16 +19,21 @@
 .o-mail-Discuss-header {
     background-color: $white;
     box-shadow: 0px 1px 6px -3px rgba(50, 50, 50, 0.15);
-    --border-opacity: .35;
+    --border-opacity: 0;
 }
 
 .o-mail-Discuss-headerActions button {
     --btn-disabled-opacity: 0.25;
-    opacity: 75%;
     background-color: transparent !important;
 
+    i {
+        opacity: 65%;
+    }
+
     &:hover, &.o-isActive {
-        opacity: 100%;
+        i {
+            opacity: 100%;
+        }
     }
     &:not(.o-isActive):hover {
         background-color: $gray-200 !important;
@@ -45,7 +50,8 @@
 }
 
 .o-mail-Discuss-headerActionsGroup {
-    --border-opacity: var(--mail-Discuss-headerActionsGroupBorderOpacity, .075);
+    --border-opacity: var(--mail-Discuss-headerActionsGroupBorderOpacity, .0);
+    background-color: mix($gray-100, $gray-200, 65%);
 }
 
 .o-mail-Discuss-headerCountry {
@@ -53,7 +59,7 @@
 }
 
 .o-mail-Discuss-panelContainer {
-    --border-opacity: .5;
+    --border-opacity: .25;
 }
 
 .o-mail-Discuss-threadAvatar {
@@ -78,5 +84,5 @@
 }
 
 .o_web_client:has(.o-mail-Discuss) .o_control_panel {
-    --ControlPanel-border-bottom: #{$border-width} solid #{rgba($border-color, .35)};
+    --ControlPanel-border-bottom: #{$border-width} solid #{rgba($border-color, 0)};
 }

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -9,7 +9,7 @@
             <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center ms-1 me-2 my-1">
-                        <img class="rounded o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
+                        <img class="rounded-3 o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="!thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
                                 <a href="#" class="position-absolute z-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">
@@ -72,7 +72,7 @@
                             <span t-if="!group_last" class="text-muted align-self-stretch ms-2 me-1"/>
                         </t>
                         <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">
-                            <img class="o-mail-Discuss-selfAvatar mx-1 rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl"/>
+                            <img class="o-mail-Discuss-selfAvatar mx-1 rounded-3 o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl"/>
                             <div class="lead fw-bold flex-shrink-1 text-dark">
                                 <t t-if="store.self.type === 'partner'" t-esc="store.self.name"/>
                                 <t t-else="">

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -1,7 +1,7 @@
 .o-mail-DiscussSidebar {
     box-shadow: 1px 0px 6px -3px rgba(50, 50, 50, 0.15);
     width: 60px;
-    --border-opacity: .5;
+    --border-opacity: 0;
 
     &:not(.o-compact) {
         width: $o-mail-Discuss-inspector;
@@ -45,7 +45,7 @@
 
     &.o-active {
         background-color: var(--mail-DiscussSidebar-itemActiveBgColor, mix($o-view-background-color, $o-action, 90%)) !important;
-        outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, rgba($o-action, .2)) !important;
+        outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, rgba($o-action, .15)) !important;
     }
 
     &.o-active, &:hover {

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -23,7 +23,7 @@
 
     <t t-name="mail.Mailbox.main">
         <button
-            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-baseline px-0 mx-2 border-0 rounded-2 fw-normal text-reset"
+            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-baseline px-0 mx-2 border-0 rounded-3 fw-normal text-reset"
             t-att-class="{
                 'bg-inherit': mailbox.notEq(store.discuss.thread),
                 'o-active': mailbox.eq(store.discuss.thread),

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -15,6 +15,6 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.startMeetingButton">
-        <button class="btn btn-primary rounded d-flex align-items-center gap-1 mx-5" t-att-class="{ 'py-2': store.discuss.isSidebarCompact, 'btn-sm': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75" t-att-class="{ 'fa-lg': store.discuss.isSidebarCompact }"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
+        <button class="btn btn-primary rounded-3 d-flex align-items-center gap-1 mx-5" t-att-class="{ 'py-2': store.discuss.isSidebarCompact, 'btn-sm': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75" t-att-class="{ 'fa-lg': store.discuss.isSidebarCompact }"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -22,7 +22,7 @@
                         <li class="o-discuss-ChannelInvitation-selectable o_object_fit_cover d-flex align-items-center px-1 py-0 btn list-group-item border-0 rounded-0" t-att-class="{ 'o-odd': selectablePartner_index % 2 === 1, 'o-selected': selectablePartner.in(selectedPartners) }" t-on-click="() => this.onClickSelectablePartner(selectablePartner)">
                             <div class="d-flex align-items-center p-1 bg-inherit">
                                 <div class="o-discuss-ChannelInvitation-avatar position-relative d-flex flex-shrink-0 bg-inherit">
-                                    <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="selectablePartner.avatarUrl"/>
+                                    <img class="w-100 h-100 rounded-3 o_object_fit_cover" t-att-src="selectablePartner.avatarUrl"/>
                                     <ImStatus persona="selectablePartner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
                                 </div>
                             </div>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel title.translate="Members" minWidth="200" initialWidth="250" icon="'fa fa-users'">
-            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded"><i class="fa fa-user-plus opacity-75"/><span>Invite a User</span></button>
+            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3"><i class="fa fa-user-plus opacity-75"/><span>Invite a User</span></button>
             <t t-if="props.thread.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="onlineSectionText"/>
@@ -37,7 +37,7 @@
     <t t-name="discuss.channel_member">
         <div class="o-discuss-ChannelMember d-flex align-items-center p-1 bg-inherit rounded" t-att-class="{ 'cursor-pointer': canOpenChatWith(member), 'o-offline': offline }" t-on-click.stop="(ev) => this.onClickAvatar(ev, member)">
             <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex flex-shrink-0">
-                <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="member.persona.avatarUrl"/>
+                <img class="w-100 h-100 rounded-3 o_object_fit_cover" t-att-src="member.persona.avatarUrl"/>
                 <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
             </div>
             <div t-ref="displayName" class="d-flex overflow-hidden flex-column">

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -5,7 +5,7 @@
         <div class="o-mail-DiscussCommand o_command_default d-flex align-items-center ps-3 pe-4" t-att-class="{ 'o-uiSmall': ui.isSmall }">
             <i t-if="props.channel" class="fa-fw opacity-50 text-muted me-2" t-att-class="props.channel.parent_channel_id ? 'fa fa-comments-o' : props.channel.discussAppCategory?.icon ?? 'fa fa-user opacity-0'"/>
             <i t-elif="props.persona" class="fa fa-fw fa-user opacity-50 text-muted me-2"/>
-            <img class="rounded me-2 o_object_fit_cover" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 25px; height: 25px"/>
+            <img class="rounded-3 me-2 o_object_fit_cover" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 25px; height: 25px"/>
             <ImStatus t-if="props.persona" className="'me-1'" persona="props.persona"/>
             <span class="pe-1 text-ellipsis d-flex align-items-center fw-bold" t-att-class="{ 'o-action': props.action }">
                 <t t-if="props.channel?.parent_channel_id">

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
@@ -12,5 +12,5 @@
 }
 
 .o-mail-DiscussSidebarCategories-search {
-    --border-opacity: .5;
+    --border-opacity: 0;
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -92,7 +92,7 @@ export class DiscussSidebarChannel extends Component {
 
     get attClassContainer() {
         return {
-            "border border-dark rounded-2 o-bordered": this.bordered,
+            "border border-dark rounded-3 o-bordered": this.bordered,
             "o-compact": this.store.discuss.isSidebarCompact,
         };
     }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -81,6 +81,8 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 }
 
 .o-mail-DiscussSidebarCategories-search {
+    --border-opacity: .5;
+
     &, & input {
         background-color: $o-view-background-color !important;
     }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -9,7 +9,7 @@
                 </div>
             </t>
         </Dropdown>
-        <div t-else="" class="o-mail-DiscussSidebarCategories-search rounded mx-3 my-2 border border-secondary position-relative d-flex align-items-center justify-content-center gap-1" t-on-click="onClickFindOrStartConversation">
+        <div t-else="" class="o-mail-DiscussSidebarCategories-search rounded-3 mx-3 my-2 border border-secondary position-relative d-flex align-items-center justify-content-center gap-1" t-on-click="onClickFindOrStartConversation">
             <input class="form-control rounded-3 border-0 bg-inherit" t-att-class="{ 'lh-1': !ui.isSmall }" disabled="true" placeholder="Find or start a conversation" tabindex="0"/>
             <div class="o-mail-DiscussSidebarCategories-searchClickable position-absolute z-1 opacity-0 cursor-pointer w-100 h-100"/>
         </div>
@@ -93,7 +93,7 @@
                     </t>
                 </Dropdown>
                 <t t-else="" t-call="mail.DiscussSidebarChannel.main"/>
-                <ul t-if="subChannels.length > 0" class="list-unstyled position-relative flex-grow-1 my-0 d-flex flex-column gap-1">
+                <ul t-if="subChannels.length > 0" class="list-unstyled position-relative flex-grow-1 my-0 d-flex flex-column gap-1" t-att-class="{ 'mb-1': store.discuss.isSidebarCompact }">
                     <t t-foreach="subChannels" t-as="sub" t-key="sub.localId">
                         <DiscussSidebarSubchannel t-if="showThread(sub)" thread="sub" isFirst="sub_first or !thread.discussAppCategory.open"/>
                     </t>
@@ -124,7 +124,7 @@
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
             </t>
-            <button class="o-mail-DiscussSidebarChannel-subChannel o-mail-DiscussSidebar-item btn btn-secondary border-0 bg-inherit d-flex flex-grow-1 smaller rounded text-start text-truncate align-items-center" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName" t-on-click="(ev) => this.openThread(ev, thread)" t-att-class="{
+            <button class="o-mail-DiscussSidebarChannel-subChannel o-mail-DiscussSidebar-item btn btn-secondary border-0 bg-inherit d-flex flex-grow-1 smaller rounded-3 text-start text-truncate align-items-center" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName" t-on-click="(ev) => this.openThread(ev, thread)" t-att-class="{
                 'o-active': thread.eq(this.store.discuss.thread),
                 'px-1 py-2 mx-1 text-wrap word-break lh-1': store.discuss.isSidebarCompact,
                 'o-nonCompact me-1 p-0 ps-1': !store.discuss.isSidebarCompact,
@@ -148,14 +148,14 @@
     </t>
 
     <t t-name="mail.DiscussSidebarChannel.main">
-        <button class="o-mail-DiscussSidebarChannel btn o-mail-DiscussSidebar-item d-flex align-items-center cursor-pointer o-py-0_5 mb-0 position-relative rounded-2 gap-1 border-0"
+        <button class="o-mail-DiscussSidebarChannel btn o-mail-DiscussSidebar-item d-flex align-items-center cursor-pointer o-py-0_5 mb-0 position-relative rounded-3 gap-1 border-0"
             t-att-class="attClass"
             t-on-click="(ev) => this.openThread(ev, thread)"
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
                 <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5" style="width:32px;height:32px;" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
-                    <img class="w-100 h-100 rounded o_object_fit_cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                    <img class="w-100 h-100 rounded-3 o_object_fit_cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>
                 </div>


### PR DESCRIPTION
Message style improvements:
- author name is slightly smaller
- squashed message are slightly closer to previous message
- border around message bubble has opacity reduced

Borders:
- reduced/removed borders around discuss sidebar/header/panel
- header thread action have border replaced by bg color

Avatar
- avatar are rounder (`.rounded` => `.rounded-3`)

NotificationMessage
- slightly reduced opacity