### PR TITLE
[FIX] sale_timesheet: avoid type error for `_get_range_dates`

### DIFF
--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -88,7 +88,7 @@ class AccountMove(models.Model):
                 timesheets = self.env['account.analytic.line'].sudo().search(domain)
                 timesheets.write({'timesheet_invoice_id': line.move_id.id})
 
-    def _get_range_dates(self):
+    def _get_range_dates(self, sale_order=None):
         # A method that will be overridden in sale_subscription_timesheet
         # to set the start and end dates for the subscription period
         return None, None


### PR DESCRIPTION
### Currently
From this https://github.com/odoo/odoo/pull/205029

if `sale_timesheet` is work standalone and not installed `sale_subscription_timesheet`

then the func  `_get_range_dates` still need to work aswell

### Potential Error:

TypeError: AccountMove._get_range_dates() takes 1 positional argument but 2 were given


### Expected:
This PR will fix this 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
