### PR TITLE
[FIX] web: name_andsignature font index wrong assignment

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -182,7 +182,7 @@ export class NameAndSignature extends Component {
     }
 
     onSelectFont(index) {
-        this.currentFont = this.fonts[index];
+        this.currentFont = index;
         this.drawCurrentName();
     }
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

CurrentFont should be of type Number to indicate the index of font. It had wrong assignment of the font data not the index which cause fonts are not updated in UI.

Current behavior before PR:

When I open signature dialog and choose `auto` type then write my name, if I like to change the font and select a different font I find myself stuck with a specific different one.

Desired behavior after PR is merged:

When I open signature dialog and choose `auto` type then write my name, if I like to change the font and select a different font I find the signatue is updated to the specific selected font.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
