### PR TITLE
[FIX] account_edi_ubl_cii: line template

### DIFF
--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -328,14 +328,14 @@
                 </cac:ClassifiedTaxCategory>
             </cac:Item>
             <cac:Price>
-                <t t-set="vals" t-value="vals.get('price_vals', {})"/>
+                <t t-set="price_vals" t-value="vals.get('price_vals', {})"/>
                 <cbc:PriceAmount
-                    t-att-currencyID="vals['currency'].name"
-                    t-out="vals.get('price_amount')"/>
+                    t-att-currencyID="price_vals['currency'].name"
+                    t-out="price_vals.get('price_amount')"/>
                 <!-- nbr of item units to which the price applies), i.e.: 1 Dozen = 12 units, not mandatory -->
                 <cbc:BaseQuantity
-                    t-att="vals.get('base_quantity_attrs', {})"
-                    t-out="vals.get('base_quantity')"/>
+                    t-att="price_vals.get('base_quantity_attrs', {})"
+                    t-out="price_vals.get('base_quantity')"/>
             </cac:Price>
         </t>
     </template>

--- a/addons/l10n_jo_edi/data/ubl_jo_templates.xml
+++ b/addons/l10n_jo_edi/data/ubl_jo_templates.xml
@@ -66,7 +66,7 @@
         <xpath expr="//*[local-name()='Price']//*[local-name()='BaseQuantity']" position="after">
             <cac:AllowanceCharge
                 xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                t-foreach="vals['allowance_charge_vals']" t-as="foreach_vals">
+                t-foreach="price_vals['allowance_charge_vals']" t-as="foreach_vals">
                 <t t-call="{{AllowanceChargeType_template}}">
                     <t t-set="vals" t-value="foreach_vals"/>
                 </t>
@@ -75,7 +75,7 @@
 
         <xpath expr="//*[local-name()='Price']//*[local-name()='PriceAmount']" position="attributes">
             <attribute name="t-out">
-                format_float(vals['price_amount'], vals['product_price_dp'])
+                format_float(price_vals['price_amount'], price_vals['product_price_dp'])
             </attribute>
         </xpath>
     </template>


### PR DESCRIPTION
There is an issue in the line template, where the
'vals' of the line are reassigned to the 'price_vals' when building the 'cac:Price'.

This means that any extension done to add values after the price no longer have access to the line vals but only the price ones.

This is unwanted, and the template is adapted to avoid reassigning 'vals'.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
