### PR TITLE
[FIX] mail: empty sub thread name when created from deleted msg

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1263,11 +1263,18 @@ class DiscussChannel(models.Model):
         message = self.env["mail.message"]
         if from_message_id:
             message = self.env["mail.message"].search([("id", "=", from_message_id)])
+        if not name:
+            name = self.env._("New Thread")
+            if message:
+                if message._filter_empty():
+                    name = self.env._("This message has been removed")
+                elif stripped := message.body and message.body.striptags():
+                    name = stripped[:30]
         sub_channel = self.create(
             {
                 "channel_type": self.channel_type,
                 "from_message_id": message.id,
-                "name": name or (message.body.striptags()[:30] if message.body else _("New Thread")),
+                "name": name,
                 "parent_channel_id": self.id,
             }
         )

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -166,3 +166,10 @@ class TestDiscussSubChannels(HttpCase):
         sub_channel = parent._create_sub_channel(from_message_id=message.id)
         self.assertIn(bob_user.partner_id, sub_channel.channel_member_ids.partner_id)
         self.assertEqual(len(sub_channel.channel_member_ids), 2)
+
+    def test_11_sub_channel_fallback_name_on_empty_message(self):
+        parent = self.env["discuss.channel"].create({"name": "General"})
+        message = parent.message_post(body="Hello there!", message_type="comment")
+        parent._message_update_content(message, "")
+        sub_channel = parent._create_sub_channel(from_message_id=message.id)
+        self.assertEqual(sub_channel.name, "This message has been removed")


### PR DESCRIPTION
**Current behavior before PR:**

Prior to this PR, when a subthread was created from a deleted message, the thread name appeared empty.

**Desired behavior after PR is merged:**

the issue is resolved by setting the thread name to "New Thread" when the original message is deleted.

task-4665143

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
