### PR TITLE
[IMP] pos_hr: the UX should be adapted no employee is set

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -158,6 +158,10 @@ export class Navbar extends Component {
         this.notification.add(_t("PoS Customer Display opened in a new window"));
     }
 
+    clickBackend() {
+        this.pos.closePos();
+    }
+
     get showCreateProductButton() {
         return this.isSystemUser;
     }

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -79,7 +79,7 @@
                                 <DropdownItem t-if="pos.receiptPrinter" onSelected="() => this.showSaleDetails()">
                                     Print Report
                                 </DropdownItem>
-                                <DropdownItem onSelected="() => pos.closePos()">
+                                <DropdownItem onSelected="() => this.clickBackend()">
                                     Backend
                                 </DropdownItem>
                                 <DropdownItem onSelected="() => this.pos.closeSession()">

--- a/addons/point_of_sale/static/tests/generic_helpers/dialog_util.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/dialog_util.js
@@ -1,6 +1,6 @@
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
-export function confirm(confirmationText, button = ".btn-primary") {
+export function confirm(confirmationText, button = ".btn-primary", expectUnloadPage = false) {
     let trigger = `.modal:not(.o_inactive_modal) .modal-footer ${button}`;
     if (confirmationText) {
         trigger += `:contains("${confirmationText}")`;
@@ -9,6 +9,7 @@ export function confirm(confirmationText, button = ".btn-primary") {
         content: "confirm dialog",
         trigger,
         run: "click",
+        expectUnloadPage,
     };
 }
 export function cancel() {

--- a/addons/pos_hr/static/src/app/components/navbar/cashier_name/cashier_name.js
+++ b/addons/pos_hr/static/src/app/components/navbar/cashier_name/cashier_name.js
@@ -25,7 +25,7 @@ patch(CashierName.prototype, {
         }
         return super.cssClass;
     },
-    async selectCashier(pin = false, login = false, list = false, excludeCurrentCashier = true) {
+    async selectCashier(pin = false, login = false, list = false) {
         return await this.cashierSelector(...arguments);
     },
 });

--- a/addons/pos_hr/static/src/app/components/navbar/cashier_name/cashier_name.js
+++ b/addons/pos_hr/static/src/app/components/navbar/cashier_name/cashier_name.js
@@ -25,7 +25,7 @@ patch(CashierName.prototype, {
         }
         return super.cssClass;
     },
-    async selectCashier(pin = false, login = false, list = false) {
+    async selectCashier(pin = false, login = false, list = false, excludeCurrentCashier = true) {
         return await this.cashierSelector(...arguments);
     },
 });

--- a/addons/pos_hr/static/src/app/components/navbar/navbar.js
+++ b/addons/pos_hr/static/src/app/components/navbar/navbar.js
@@ -1,11 +1,11 @@
 import { Navbar } from "@point_of_sale/app/components/navbar/navbar";
-import { useCashierSelector } from "@pos_hr/app/utils/select_cashier_mixin";
+import { useCheckPin } from "@pos_hr/app/utils/select_cashier_mixin";
 import { patch } from "@web/core/utils/patch";
 
 patch(Navbar.prototype, {
     setup() {
         super.setup(...arguments);
-        this.cashierSelector = useCashierSelector();
+        this.checkPin = useCheckPin();
     },
     get showCreateProductButton() {
         if (!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin) {
@@ -14,15 +14,15 @@ patch(Navbar.prototype, {
             return false;
         }
     },
-    async selectCashier(pin = false, login = false, list = false, excludeCurrentCashier = true) {
-        return await this.cashierSelector(...arguments);
+    async checkPin(employee = false) {
+        return await this.checkPin(...arguments);
     },
     async clickBackend() {
         if (this.pos.config.module_pos_hr) {
             const posUserEmployee = this.pos.models["hr.employee"].find(
                 (e) => e.user_id?.id === this.pos.user.id
             );
-            if (await this.selectCashier(false, false, [posUserEmployee], false)) {
+            if (await this.checkPin(posUserEmployee)) {
                 super.clickBackend();
             }
         } else {

--- a/addons/pos_hr/static/src/app/components/navbar/navbar.js
+++ b/addons/pos_hr/static/src/app/components/navbar/navbar.js
@@ -1,12 +1,32 @@
 import { Navbar } from "@point_of_sale/app/components/navbar/navbar";
+import { useCashierSelector } from "@pos_hr/app/utils/select_cashier_mixin";
 import { patch } from "@web/core/utils/patch";
 
 patch(Navbar.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.cashierSelector = useCashierSelector();
+    },
     get showCreateProductButton() {
         if (!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin) {
             return super.showCreateProductButton;
         } else {
             return false;
+        }
+    },
+    async selectCashier(pin = false, login = false, list = false, excludeCurrentCashier = true) {
+        return await this.cashierSelector(...arguments);
+    },
+    async clickBackend() {
+        if (this.pos.config.module_pos_hr) {
+            const posUserEmployee = this.pos.models["hr.employee"].find(
+                (e) => e.user_id?.id === this.pos.user.id
+            );
+            if (await this.selectCashier(false, false, [posUserEmployee], false)) {
+                super.clickBackend();
+            }
+        } else {
+            super.clickBackend();
         }
     },
     get showBackend() {

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -148,6 +148,69 @@ registry.category("web_tour.tours").add("CashierCannotClose", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("PosHrTourAdminLoginNoPin", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            Dialog.is("Opening Control"),
+            Dialog.confirm(),
+            PosHr.clickLockButton(),
+            Chrome.clickBtn("Backend", {
+                expectUnloadPage: true,
+            }),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosHrTourAdminLoginWithPin", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Unlock Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            NumberPopup.enterValue("1234"),
+            NumberPopup.isShown("••••"),
+            Dialog.confirm(),
+            PosHr.clickLockButton(),
+            Chrome.clickBtn("Backend"),
+            NumberPopup.enterValue("1234"),
+            NumberPopup.isShown("••••"),
+            Dialog.confirm("", ".btn-primary", true),
+            Chrome.clickBtn("Continue selling", {
+                expectUnloadPage: true,
+            }),
+            // to verify PIN prompt when navigating to backend via menu
+            Chrome.clickBtn("Unlock Register"),
+            PosHr.clickLoginButton(),
+            NumberPopup.enterValue("1234"),
+            NumberPopup.isShown("••••"),
+            Dialog.confirm(),
+            ProductScreen.isShown(),
+            Chrome.clickMenuOption("Backend"),
+            NumberPopup.enterValue("1234"),
+            NumberPopup.isShown("••••"),
+            Dialog.confirm("", ".btn-primary", true),
+            Chrome.clickBtn("Continue selling", {
+                expectUnloadPage: true,
+            }),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosHrTourEmployeeSelectionNoPins", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            CashierSelectionPopup.has("Pos Employee2"),
+            CashierSelectionPopup.has("Mitchell Admin"),
+            CashierSelectionPopup.has("Pos Employee2", { run: "click" }),
+            Dialog.is("Opening Control"),
+            Dialog.confirm(),
+            PosHr.clickCashierName(),
+            CashierSelectionPopup.has("Mitchell Admin", { run: "click" }),
+            ProductScreen.isShown(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_basic_user_can_change_price", {
     steps: () =>
         [
@@ -267,33 +330,8 @@ registry.category("web_tour.tours").add("test_cost_and_margin_visibility", {
 registry.category("web_tour.tours").add("pos_hr_go_backend_closed_registered", {
     steps: () =>
         [
-            // Admin --> 403: not the one that opened the session
-            Chrome.clickBtn("Backend"),
-            CashierSelectionPopup.has("Mitchell Admin", { run: "click" }),
-            PosHr.loginScreenIsShown(),
-
-            // Employee with user --> 403
-            Chrome.clickBtn("Backend"),
-            CashierSelectionPopup.has("Pos Employee1", { run: "click" }),
-            PosHr.enterPin("2580"),
-            PosHr.loginScreenIsShown(),
-
-            // Employee without user --> 403
-            Chrome.clickBtn("Backend"),
-            CashierSelectionPopup.has("Test Employee 3", { run: "click" }),
-            PosHr.loginScreenIsShown(),
-
-            // Manager without user --> 403
-            Chrome.clickBtn("Backend"),
-            CashierSelectionPopup.clickMore(),
-            CashierSelectionPopup.has("Test Manager 2", { run: "click" }),
-            PosHr.enterPin("5652"),
-            PosHr.loginScreenIsShown(),
-
             // Manager that opened the session --> access granted
             Chrome.clickBtn("Backend"),
-            CashierSelectionPopup.clickMore(),
-            CashierSelectionPopup.has("Test Manager 1", { run: "click" }),
             PosHr.enterPin("5651").map((step, index, array) => {
                 if (index === array.length - 1) {
                     return {
@@ -346,7 +384,7 @@ registry.category("web_tour.tours").add("pos_hr_go_backend_opened_registered", {
             CashierSelectionPopup.has("Test Manager 1", { run: "click" }),
             PosHr.enterPin("5651"),
             Chrome.existMenuOption("Close Register"),
-            Chrome.clickMenuOption("Backend", { expectUnloadPage: true }),
+            Chrome.existMenuOption("Backend"),
         ].flat(),
 });
 

--- a/addons/pos_hr/static/tests/unit/components/screens/login_screen.test.js
+++ b/addons/pos_hr/static/tests/unit/components/screens/login_screen.test.js
@@ -11,7 +11,7 @@ describe("pos_login_screen.js", () => {
         const store = await setupPosEnv();
         const comp = await mountWithCleanup(LoginScreen, {});
         comp.openRegister();
-        expect(store.login).toBe(true);
+        expect(store.login).toBe(store.models["hr.employee"].some((emp) => emp._pin));
     });
     test("backBtnName", async () => {
         const store = await setupPosEnv();

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -139,6 +139,40 @@ class TestUi(TestPosHrHttpCommon):
             login="pos_user",
         )
 
+    def test_admin_login_screen_with_and_without_pin(self):
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.admin.pin = False
+        self.manager_user.group_ids -= self.env.ref('point_of_sale.group_pos_manager')
+
+        # Restrict cashier list to include only the admin user
+        self.main_pos_config.write({'basic_employee_ids': [Command.set([self.admin.id])], "minimal_employee_ids": [Command.clear()], "advanced_employee_ids": [Command.set([self.admin.id])]})
+
+        # Tour when admin has no pin
+        self.start_pos_tour(
+            "PosHrTourAdminLoginNoPin",
+            login="pos_admin",
+        )
+
+        # Tour when admin has a pin
+        self.admin.pin = "1234"
+        self.start_pos_tour(
+            "PosHrTourAdminLoginWithPin",
+            login="pos_admin",
+        )
+
+    def test_employee_selection_screen_when_employees_have_no_pin(self):
+        # Restrict cashier list to include only admin user and one basic user
+        self.manager_user.group_ids -= self.env.ref('point_of_sale.group_pos_manager')
+        self.main_pos_config.write({'basic_employee_ids': [Command.set([self.emp2.id])], "minimal_employee_ids": [Command.clear()], "advanced_employee_ids": [Command.set([self.admin.id])]})
+
+        self.emp2.pin = False
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+
+        self.start_pos_tour(
+            "PosHrTourEmployeeSelectionNoPins",
+            login="pos_admin",
+        )
+
     def test_basic_user_can_change_price(self):
         self.main_pos_config.advanced_employee_ids = []
         self.main_pos_config.basic_employee_ids = [


### PR DESCRIPTION
After this commit:
===
- Display the `Enter PIN` screen only when a PIN is set for at any one employee.
- Skip the splash screen if there's only one employee.
- Applies on both when `opening POS` and when `returning to the backend`.
- Only the employee associated with the currently logged-in POS user is allowed to access the backend.
- Ensure PIN verification is prompted when navigating back to the backend via the menu item (only when admin has pin set).

Task: 4717289
