### PR TITLE
[FIX] mail: return guest and user both in _get_current_persona

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -998,21 +998,22 @@ class MailMessage(models.Model):
     def _message_reaction(self, content, action, partner, guest, store: Store = None):
         self.ensure_one()
         # search for existing reaction
-        domain = [
-            ("message_id", "=", self.id),
-            ("partner_id", "=", partner.id),
-            ("guest_id", "=", guest.id),
-            ("content", "=", content),
-        ]
+        domain = [("message_id", "=", self.id), ("content", "=", content)]
+        if partner:
+            domain.append(("partner_id", "=", partner.id))
+        elif guest:
+            domain.append(("guest_id", "=", guest.id))
         reaction = self.env["mail.message.reaction"].search(domain)
         # create/unlink reaction if necessary
         if action == "add" and not reaction:
             create_values = {
                 "message_id": self.id,
                 "content": content,
-                "partner_id": partner.id,
-                "guest_id": guest.id,
             }
+            if partner:
+                create_values["partner_id"] = partner.id
+            elif guest:
+                create_values["guest_id"] = guest.id
             self.env["mail.message.reaction"].create(create_values)
         if action == "remove" and reaction:
             reaction.unlink()

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -666,6 +666,6 @@ class ResUsers(models.Model):
 
     @api.model
     def _get_current_persona(self):
-        if not self.env.user or self.env.user._is_public():
-            return (self.env["res.users"], self.env["mail.guest"]._get_guest_from_context())
-        return (self.env.user, self.env["mail.guest"])
+        user = self.env.user if not self.env.user._is_public() else self.env["res.users"]
+        guest = self.env["mail.guest"]._get_guest_from_context()
+        return (user, guest)

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -1089,7 +1089,7 @@ export class DiscussChannel extends models.ServerModel {
         }
         return DiscussChannelMember._filter([
             ["channel_id", "=", id],
-            guest ? ["guest_id", "=", guest.id] : ["partner_id", "=", partner.id],
+            partner ? ["partner_id", "=", partner.id] : ["guest_id", "=", guest.id],
         ])[0];
     }
 

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -132,9 +132,9 @@ export class DiscussChannelMember extends models.ServerModel {
     _compute_is_self() {
         const [partner, guest] = this.env["res.partner"]._get_current_persona();
         for (const member of this) {
-            member.is_self = member.partner_id
-                ? member.partner_id === partner?.id
-                : member.guest_id === guest?.id;
+            member.is_self =
+                (member.partner_id && member.partner_id === partner?.id) ||
+                (member.guest_id && member.guest_id === guest?.id);
         }
     }
 
@@ -286,7 +286,7 @@ export class DiscussChannelMember extends models.ServerModel {
         if (notify) {
             const [channel] = this.search_read([["id", "in", ids]]);
             const [partner, guest] = ResPartner._get_current_persona();
-            let target = guest ?? partner;
+            let target = partner ?? guest;
             if (DiscussChannel._types_allowing_seen_infos().includes(channel.channel_type)) {
                 target = channel;
             }
@@ -346,7 +346,7 @@ export class DiscussChannelMember extends models.ServerModel {
 
         const [partner, guest] = this.env["res.partner"]._get_current_persona();
         this.env["bus.bus"]._sendone(
-            guest ?? partner,
+            partner ?? guest,
             "mail.record/insert",
             new mailDataHelpers.Store(
                 DiscussChannelMember.browse(channelMememberId),

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -432,11 +432,11 @@ export class ResPartner extends webModels.ResPartner {
         const MailGuest = this.env["mail.guest"];
         /** @type {import("mock_models").ResUsers} */
         const ResUsers = this.env["res.users"];
-
-        if (ResUsers._is_public(this.env.uid)) {
-            return [null, MailGuest._get_guest_from_context()];
-        }
-        return [this.browse(this.env.user.partner_id)[0], null];
+        const guest = MailGuest._get_guest_from_context();
+        const partner = ResUsers._is_public(this.env.uid)
+            ? null
+            : this.browse(this.env.user.partner_id)[0];
+        return [partner, guest];
     }
 
     _get_store_avatar_card_fields() {


### PR DESCRIPTION
**Current behavior before PR:**

`_get_current_persona` returns the guest record if available, falling back to the current user otherwise. This made it impossible to access both contexts when both records were relevant.

**Desired behavior after PR is merged:**

`_get_current_persona` returns both the guest and the current user when possible.

**Task**-4715081


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
