### PR TITLE
[IMP] stock: allow search '[Internal Ref] Name' in product list view

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -631,6 +631,8 @@ class ProductProduct(models.Model):
                     domains.append([('default_code', '=', m.group(2))])
         elif operator.endswith('like') and is_positive:
             domains.append([('barcode', 'in', [value])])
+            if isinstance(value, str) and (m := re.search(r'\[(.*?)\]', value)):
+                domains.append([('default_code', '=', m.group(1))])
         if partner_id := self.env.context.get('partner_id'):
             supplier_domain = [
                 ('partner_id', '=', partner_id),

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -234,7 +234,7 @@
         <field name="model">product.template</field>
         <field name="arch" type="xml">
             <search string="Product">
-                <field name="name" string="Product" filter_domain="['|', '|', '|', ('default_code', 'ilike', self), ('product_variant_ids.default_code', 'ilike', self),('name', 'ilike', self), ('barcode', 'ilike', self)]"/>
+                <field name="name" string="Product" filter_domain="['|', '|', '|', '|', ('default_code', 'ilike', self), ('product_variant_ids.default_code', 'ilike', self), ('name', 'ilike', self), ('barcode', 'ilike', self), ('display_name', '=', self)]"/>
                 <field name="categ_id" filter_domain="[('categ_id', 'child_of', raw_value)]"/>
                 <field name="product_tag_ids" string="Tags"/>
                 <separator/>
@@ -296,7 +296,7 @@
                     <field name="all_product_tag_ids" string="Tags"/>
                 </field>
                 <field name="name" position="replace">
-                    <field name="name" string="Product" filter_domain="['|', '|', ('default_code', 'ilike', self), ('name', 'ilike', self), ('barcode', 'ilike', self)]"/>
+                    <field name="name" string="Product" filter_domain="['|', '|', '|', ('default_code', 'ilike', self), ('name', 'ilike', self), ('barcode', 'ilike', self), ('display_name', '=', self)]"/>
                 </field>
                 <field name="attribute_line_ids" position="replace">
                     <field name="product_template_attribute_value_ids" groups="product.group_product_variant"/>


### PR DESCRIPTION
This commit enhances the product search functionality by allowing users
to search using the combined `[Internal Ref] Name` format across all views in stock module. 

Previously, searching with this full `display_name` format was not possible,
which could be limiting and confusing, especially when users have both values
available from sources like PDFs, exports, or printed labels.

With this improvement, users can now search using the full `[default_code] name`
string, making the search experience more intuitive and user-friendly.

TaskId :- 4639300
