### PR TITLE
[FIX] web: `once` parameter for lazy_session event listener

### DIFF
--- a/addons/web/static/src/webclient/session_service.js
+++ b/addons/web/static/src/webclient/session_service.js
@@ -11,7 +11,7 @@ export const lazySession = {
             return orm.call("ir.http", "lazy_session_info", [[]]);
         };
         const webClientReadyPromise = new Promise((r) => (resolveWebClientReady = r));
-        env.bus.addEventListener("WEB_CLIENT_READY", resolveWebClientReady);
+        env.bus.addEventListener("WEB_CLIENT_READY", resolveWebClientReady, { once: true });
         return {
             getValue(key, callback) {
                 if (!lazyConfigPromise) {


### PR DESCRIPTION
Since the web_client is started only once, we can safely add the `once`[1] parameter to the `WEB_CLIENT_READY` event listener.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#once


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
