### PR TITLE
[FIX] hr_skills: prevent error while loading sample data

### DIFF
--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -46,4 +46,7 @@ class Employee(models.Model):
         demo_tag = self.env.ref('hr_skills.employee_resume_line_emp_eg_1', raise_if_not_found=False)
         if demo_tag:
             return
+
+        convert.convert_file(self.env, 'hr_skills', 'data/hr_skill_data.xml', None, mode='init', kind='data')
+        convert.convert_file(self.env, 'hr_skills', 'data/hr_resume_data.xml', None, mode='init', kind='data')
         convert.convert_file(self.env, 'hr_skills', 'data/scenarios/hr_skills_scenario.xml', None, mode='init', kind='data')


### PR DESCRIPTION
Currently, an error is produced when loading sample data if a referenced skill type record in the skill level has been deleted by the user.

**Steps to Reproduce:**
- Install the `hr_appraisal` module without demo data.
- Navigate to `Employee > Skills Types` and delete the `Languages` record.
- Load the sample data for appraisal.
- Observe the error.

`ValueError: ParseError('while parsing /home/odoo/src/odoo/saas-18.2/addons/hr_skills/data/scenarios/hr_skills_scenario.xml:19...`

Here, the error occurs because the method at [1] attempts to load the `hr_skills_scenario.xml` file that references a deleted `skill_type_id` [2], leading to a parsing error.

[1] - https://github.com/odoo/odoo/blob/547327f30d2d4bf778b9d358dbea4b133d55188a/addons/hr_skills/models/hr_employee.py#L49
[2] - https://github.com/odoo/odoo/blob/547327f30d2d4bf778b9d358dbea4b133d55188a/addons/hr_skills/data/scenarios/hr_skills_scenario.xml#L23

This commit ensures that all the referenced data is loaded properly, preventing errors due to missing references.

Sentry - 6533879252