### PR TITLE
[FIX] sale_timesheet: avoid type error for _get_range_dates

### DIFF
--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -88,7 +88,7 @@ class AccountMove(models.Model):
                 timesheets = self.env['account.analytic.line'].sudo().search(domain)
                 timesheets.write({'timesheet_invoice_id': line.move_id.id})
 
-    def _get_range_dates(self):
-        # A method that will be overridden in sale_subscription_timesheet
-        # to set the start and end dates for the subscription period
+    def _get_range_dates(self, order):
+        # A method that can be overridden
+        # to set the start and end dates according to order values
         return None, None


### PR DESCRIPTION
From this #205029

If sale_timesheet is installed standalone sale_subscription_timesheet is not installed, the get_range_dates method will crash as the parameter is not defined.

TypeError: AccountMove._get_range_dates() takes 1 positional argument but 2 were given

See https://github.com/odoo/odoo/pull/205816

OPW-4723777

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
