### PR TITLE
[FIX] base: handled ProgramLimitExceeded error

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -345,6 +345,10 @@ class Cursor(BaseCursor):
         try:
             params = params or None
             res = self._obj.execute(query, params)
+        except psycopg2.errors.ProgramLimitExceeded as e:
+            _logger.error("ProgramLimitExceeded: Index value too large.\nQuery: %s\nParams: %s\nError: %s", query, params, str(e))
+            raise odoo.exceptions.UserError("It looks like you're trying to import too many records at once or the data is too large. \n"
+                                            "Please try importing fewer records at a time or reduce the size of your input.")
         except Exception as e:
             if log_exceptions:
                 _logger.error("bad query: %s\nERROR: %s", tools.ustr(self._obj.query or query), e)


### PR DESCRIPTION
The error can occur when a user imports too many records at once or when individual fields (e.g., translated names) exceed PostgreSQL's index size limit.

Steps to reproduce:
* Go to Settings > Translations > Languages and select all the languages(you need to have around 85+ languages installed to get this error) and click activate.
* Go to apps and click activate on Sales(sale_management).

(Note: It takes some time to install all the translation files, so please be patient.)

Error:
`ProgramLimitExceeded: index row size XXXX exceeds btree version 4 maximum 2704`

Solution:
* Added a new except block to specifically catch
  `psycopg2.errors.ProgramLimitExceeded`.
* Raised a clean `UserError` with guidance to reduce the number or size
  of imported records.

sentry-6266102534,6150576233,6356036545,6255658827
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
