### PR TITLE
[FIX] web_editor: prevent traceback when res_id is None in modify_image

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -568,6 +568,7 @@ class Web_Editor(http.Controller):
             'res_model': res_model or 'ir.ui.view',
             'mimetype': mimetype or attachment.mimetype,
             'name': name or attachment.name,
+            'res_id': 0,
         }
         if fields['res_model'] == 'ir.ui.view':
             fields['res_id'] = 0


### PR DESCRIPTION
Problem:
When calling `modify_image` for an attachment linked to a record that hasn't been created yet (`res_id` is `None`), a traceback occurs. This is because `fields` lacks the `res_id` key when we call:

    request.env[fields['res_model']]
        .browse(fields['res_id'])
        .check_access_rights('write')

Solution:
Use `0` as default `res_id`. This is consistent with what `get_existing_attachment` already does:

    fields['res_id'] = fields.get('res_id') or 0

Steps to reproduce:
1. Go to "Email Marketing" > "New".
2. Fill in the "Subject" and choose a mailing list.
3. In the mail body, insert a template containing an image.
4. Click on the image and replace it.
5. Save (only at this step). → Traceback occurs since `modify_image` is called with a `None` res_id.

opw-4715999

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
