### PR TITLE
[FIX] website_sale_collect: adapt names

### DIFF
--- a/addons/website_sale_collect/static/src/js/location_selector/location/location.xml
+++ b/addons/website_sale_collect/static/src/js/location_selector/location/location.xml
@@ -3,12 +3,13 @@
 
     <t t-inherit="delivery.locationSelector.location" t-inherit-mode="extension">
         <small name="location_opening_hours" position="before">
-            <t t-if="props.additionalData and !!props.additionalData.in_store_stock">
-                <t t-if="!!props.additionalData.in_store_stock.in_stock">
-                    <t t-if="!!props.additionalData.in_store_stock.show_quantity">
+            <t t-if="props.additionalData and !!props.additionalData.in_store_stock_data">
+                <t t-if="!!props.additionalData.in_store_stock_data.in_stock">
+                    <t t-if="!!props.additionalData.in_store_stock_data.show_quantity">
                         <span class="text-warning">
                             <i class="fa fa-circle"/>
-                            Only <t t-out="props.additionalData.in_store_stock.quantity"/> available
+                            Only <t t-out="props.additionalData.in_store_stock_data.quantity"/>
+                            available
                         </span>
                     </t>
                     <t t-else="">

--- a/addons/website_sale_collect/static/src/js/location_selector/map_container/map_container.xml
+++ b/addons/website_sale_collect/static/src/js/location_selector/map_container/map_container.xml
@@ -5,14 +5,14 @@
         <button id="submit_location_large" position="attributes">
             <attribute
                 name="t-att-disabled"
-                add="!(selectedLocation?.additional_data?.in_store_stock?.in_stock ?? true)"
+                add="!(selectedLocation?.additional_data?.in_store_stock_data?.in_stock ?? true)"
                 separator=" || "
             />
         </button>
         <button id="submit_location_medium" position="attributes">
             <attribute
                 name="t-att-disabled"
-                add="!(selectedLocation?.additional_data?.in_store_stock?.in_stock ?? true)"
+                add="!(selectedLocation?.additional_data?.in_store_stock_data?.in_stock ?? true)"
                 separator=" || "
             />
         </button>

--- a/addons/website_sale_collect/static/src/xml/product_availability.xml
+++ b/addons/website_sale_collect/static/src/xml/product_availability.xml
@@ -4,10 +4,10 @@
 
     <t t-inherit="website_sale_stock.product_availability" t-inherit-mode="extension">
         <div id="out_of_stock_message" position="replace">
-            <t t-if="!in_store_stock">$0</t>
+            <t t-if="!show_click_and_collect_availability">$0</t>
         </div>
         <div id="threshold_message" position="attributes">
-            <attribute name="t-elif" add="!in_store_stock" separator=" and "/>
+            <attribute name="t-elif" add="!show_click_and_collect_availability" separator=" and "/>
         </div>
     </t>
 


### PR DESCRIPTION
In dfe368915d802d69f29f879ea7890bfea9d9220e the data name was
 changed from 'in_store_stock' to 'in_store_stock_data' that was not
 correctly applied in all occurrences.
