### PR TITLE
[IMP] spreadsheet: add `funnel` chart for odoo data

### DIFF
--- a/addons/spreadsheet/static/src/chart/index.js
+++ b/addons/spreadsheet/static/src/chart/index.js
@@ -12,6 +12,7 @@ chartComponentRegistry.add("odoo_pyramid", ChartJsComponent);
 chartComponentRegistry.add("odoo_scatter", ChartJsComponent);
 chartComponentRegistry.add("odoo_combo", ChartJsComponent);
 chartComponentRegistry.add("odoo_geo", ChartJsComponent);
+chartComponentRegistry.add("odoo_funnel", ChartJsComponent);
 
 import { OdooChartCorePlugin } from "./plugins/odoo_chart_core_plugin";
 import { ChartOdooMenuPlugin } from "./plugins/chart_odoo_menu_plugin";

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_funnel_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_funnel_chart.js
@@ -1,0 +1,86 @@
+import { registries, chartHelpers } from "@odoo/o-spreadsheet";
+import { _t } from "@web/core/l10n/translation";
+import { OdooChart } from "./odoo_chart";
+import { onOdooChartItemHover, onOdooChartItemClick } from "./odoo_chart_helpers";
+
+const { chartRegistry } = registries;
+
+const {
+    getFunnelChartDatasets,
+    CHART_COMMON_OPTIONS,
+    getChartLayout,
+    getChartTitle,
+    getChartShowValues,
+    getFunnelChartScales,
+    getFunnelChartTooltip,
+    makeDatasetsCumulative,
+} = chartHelpers;
+
+export class OdooFunnelChart extends OdooChart {
+    constructor(definition, sheetId, getters) {
+        super(definition, sheetId, getters);
+        this.cumulative = definition.cumulative;
+        this.funnelColors = definition.funnelColors;
+    }
+
+    getDefinition() {
+        return {
+            ...super.getDefinition(),
+            cumulative: this.cumulative,
+            funnelColors: this.funnelColors,
+        };
+    }
+}
+
+chartRegistry.add("odoo_funnel", {
+    match: (type) => type === "odoo_funnel",
+    createChart: (definition, sheetId, getters) =>
+        new OdooFunnelChart(definition, sheetId, getters),
+    getChartRuntime: createOdooChartRuntime,
+    validateChartDefinition: (validator, definition) =>
+        OdooFunnelChart.validateChartDefinition(validator, definition),
+    transformDefinition: (definition) => OdooFunnelChart.transformDefinition(definition),
+    getChartDefinitionFromContextCreation: () => OdooFunnelChart.getDefinitionFromContextCreation(),
+    name: _t("Funnel"),
+});
+
+function createOdooChartRuntime(chart, getters) {
+    const definition = chart.getDefinition();
+    const background = chart.background || "#FFFFFF";
+    let { datasets, labels } = chart.dataSource.getData();
+    if (definition.cumulative) {
+        datasets = makeDatasetsCumulative(datasets, "desc");
+    }
+
+    const locale = getters.getLocale();
+
+    const chartData = {
+        labels,
+        dataSetsValues: datasets.map((ds) => ({ data: ds.data, label: ds.label })),
+        locale,
+    };
+
+    const config = {
+        type: "funnel",
+        data: {
+            labels: chartData.labels,
+            datasets: getFunnelChartDatasets(definition, chartData),
+        },
+        options: {
+            ...CHART_COMMON_OPTIONS,
+            indexAxis: "y",
+            layout: getChartLayout(definition),
+            scales: getFunnelChartScales(definition, chartData),
+            plugins: {
+                title: getChartTitle(definition),
+                legend: { display: false },
+                tooltip: getFunnelChartTooltip(definition, chartData),
+                chartShowValuesPlugin: getChartShowValues(definition, chartData),
+            },
+            onHover: onOdooChartItemHover(),
+            onClick: onOdooChartItemClick(getters, chart),
+        },
+    };
+
+    return { background, chartJsConfig: config };
+}


### PR DESCRIPTION
### [IMP] spreadsheet: add `funnel` chart for odoo data

This commit adds the `odoo_funnel` chart type.

Task: [4629660](https://www.odoo.com/web#id=4629660&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
