### PR TITLE
[FIX] *: tour_enabled should be unset during tests

### DIFF
--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -7,12 +7,6 @@ from odoo.tests.common import tagged
 
 @tagged('post_install', '-at_install')
 class TestUi(HttpCase, TestCrmCommon):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env.ref('base.user_admin').tour_enabled = False
-
     def test_01_crm_tour(self):
         # TODO: The tour is raising a JS error when selecting Brandon Freeman
         # but with the demo data it succeeds to continue if there is already another lead

--- a/odoo/addons/test_main_flows/tests/test_flow.py
+++ b/odoo/addons/test_main_flows/tests/test_flow.py
@@ -14,7 +14,6 @@ class BaseTestUi(AccountTestMockOnlineSyncCommon):
     def main_flow_tour(self):
         # Disable all onboarding tours
         self.env.ref('base.user_admin').write({
-            'tour_enabled': False,
             'email': 'mitchell.admin@example.com',
         })
         # Enable Make to Order


### PR DESCRIPTION
Any time a tour is run, the web client can decide to run an onboarding tour at the same time. With the tests being run without demo, this becomes *very* likely, as the presence of modules with demo data is one of the base conditions for `_compute_tour_enabled`.

Some tours were fixed ad-hoc when trying to get everything working without demo, but the issue is basically universal, it just doesn't show up in all cases (possibly through side effects of other modules) e.g. before this change

- create a database with the modules `auth_totp_mail` and `website_event`
- run the test `/auth_totp_mail:TestTOTPInvite.test_totp_administration`

The test fails with

    Error in schema for TourStep
    [...]
    Invalid object: unknown key 'noPrepend'

This is because website does a mess in the tours, adding its own magic tour keys which are not handled by the generic tour framework, but when we try to run the tour `totp_admin_disables` the client retrieves the active onboarding tours, finds `event_tour`, and starts running that[^1] apparently without the magic from website. Which reveals that the tour is being loaded / running even as we're trying to run an other tour.

Fix by patching `tour_enabled` globally, and remove the ad-hoc unsets.

[^1]: via the `session.current_tour` case of the tour service
