### PR TITLE
[DRAFT][FIX] pos_self_order: improve kiosk order handling

### DIFF
--- a/addons/pos_online_payment/static/src/app/services/pos_store.js
+++ b/addons/pos_online_payment/static/src/app/services/pos_store.js
@@ -11,7 +11,8 @@ patch(PosStore.prototype, {
             // notification to invite the local browser to do a safe RPC to
             // the server to check the new state of the order.
             const order = this.models["pos.order"].find((o) => o.id == id);
-            const updatedOrder = await this.data.read("pos.order", [id])[0];
+            const result = await this.data.read("pos.order", [id]);
+            const updatedOrder = result[0];
             if (updatedOrder) {
                 order.state = updatedOrder.state;
             }

--- a/addons/pos_online_payment_self_order/models/pos_payment_method.py
+++ b/addons/pos_online_payment_self_order/models/pos_payment_method.py
@@ -9,7 +9,7 @@ class PosPaymentMethod(models.Model):
     def _load_pos_self_data_domain(self, data):
         if data['pos.config'][0]['self_ordering_mode'] == 'kiosk':
             domain = super()._load_pos_self_data_domain(data)
-            domain = expression.OR([[('is_online_payment', '=', True)], domain])
+            domain = expression.OR([[('is_online_payment', '=', True), ('id', 'in', data['pos.config'][0]['payment_method_ids'])], domain])
             return domain
         else:
             return [('is_online_payment', '=', True)]

--- a/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
@@ -21,7 +21,12 @@ patch(SelfOrder.prototype, {
                 (o) => o.access_token === data["pos.order"][0].access_token
             );
             if (status === "success" && !this.currentOrder.access_token && order) {
-                this.confirmationPage("order", this.config.self_ordering_mode, order.access_token);
+                this.confirmationPage(
+                    "order",
+                    this.config.self_ordering_mode,
+                    order.access_token,
+                    true
+                );
             }
         });
     },

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -25,6 +25,9 @@ class PosSelfOrderController(http.Controller):
         if not (sequence_number and pos_reference and tracking_number):
             pos_reference, sequence_number, tracking_number = pos_session.get_next_order_refs(ref_prefix=ref_prefix, tracking_prefix=tracking_prefix)
 
+        if device_type == 'kiosk':
+            order['floating_order_name'] = f"Table tracker {order['table_stand_number']}" if order.get('table_stand_number') else tracking_number
+
         if 'picking_type_id' in order:
             del order['picking_type_id']
 

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
@@ -19,7 +19,7 @@
             <h3 t-if="this.confirmedOrder.table_id || confirmedOrder.table_stand_number" class="text-muted mb-3">
                 Service at table
                 <t t-if="selfOrder.config.self_ordering_mode === 'mobile'" t-esc="this.confirmedOrder.table_id?.getName() + ' (' + this.confirmedOrder.table_id?.floor_id?.name + ')'" />
-                <t t-else="" t-esc="confirmedOrder.table_stand_number" />
+                <t t-else="" t-esc="` tracker ${confirmedOrder.table_stand_number}`" />
             </h3>
             <h3 t-else="">Order to pick-up at the counter</h3>
             <span role="button" t-if="selfOrder.showDownloadButton(confirmedOrder) and confirmedOrder.uiState.receiptReady" t-on-click="() => this.selfOrder.downloadReceipt(this.confirmedOrder)">

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -101,7 +101,8 @@ export class SelfOrder extends Reactive {
                         this.confirmationPage(
                             "order",
                             this.config.self_ordering_mode,
-                            order.access_token
+                            order.access_token,
+                            true
                         );
                     }
                 } else {
@@ -321,7 +322,7 @@ export class SelfOrder extends Reactive {
             newLine.setDirty();
         }
     }
-    async confirmationPage(screen_mode, device, access_token) {
+    async confirmationPage(screen_mode, device, access_token, print = false) {
         if (!access_token) {
             throw new Error("No access token provided for confirmation page");
         }
@@ -330,7 +331,7 @@ export class SelfOrder extends Reactive {
             orderAccessToken: access_token,
             screenMode: screen_mode,
         });
-        if (device === "kiosk") {
+        if (device === "kiosk" && print) {
             this.printKioskChanges(access_token);
         }
     }
@@ -363,7 +364,6 @@ export class SelfOrder extends Reactive {
             this.router.navigate("stand_number");
             return;
         }
-
         order = await this.sendDraftOrderToServer(paymentMethods.length > 0);
         if (!order) {
             return;

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -4,13 +4,22 @@ import { patch } from "@web/core/utils/patch";
 patch(PosStore.prototype, {
     async getServerOrders() {
         if (this.session._self_ordering) {
+            const kioskOrderToFetch = this.data.models["pos.order"]
+                .filter((order) => order.state == "draft" && order.pos_reference.includes("Kiosk"))
+                .map((order) => order.id);
+
             await this.loadServerOrders([
+                "|",
+                "&",
+                "&",
                 ["company_id", "=", this.config.company_id.id],
                 ["state", "=", "draft"],
+                "&",
                 "|",
                 ["pos_reference", "ilike", "Kiosk"],
                 ["pos_reference", "ilike", "Self-Order"],
                 ["table_id", "=", false],
+                ["id", "in", kioskOrderToFetch],
             ]);
         }
 

--- a/addons/pos_self_order/static/src/overrides/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_self_order/static/src/overrides/screens/ticket_screen/ticket_screen.js
@@ -1,0 +1,16 @@
+import { _t } from "@web/core/l10n/translation";
+import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
+import { patch } from "@web/core/utils/patch";
+
+patch(TicketScreen.prototype, {
+    getStatus(order) {
+        if (
+            order.state === "paid" &&
+            (order.pos_reference.includes("Kiosk") || order.pos_reference.includes("Self-Order")) &&
+            !["ReceiptScreen", "TipScreen"].includes(order.getScreenData().name)
+        ) {
+            return _t("Paid");
+        }
+        return super.getStatus(...arguments);
+    },
+});


### PR DESCRIPTION
- When paying an order from Kiosk/self-order:
   - The order's state is updated in the ticket screen (as paid)
   - Preparation ticket is printed (before it was already printed even if the order was not paid)
- When in Kiosk using Table (Tracker number):
    - Rename order floating order name from "Direct Sale" to "Table tracker XX" (visible in ticket screen)

task-id: 4711661




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
