### PR TITLE
[FIX] account: missing residual not null in unrec filter

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -334,7 +334,7 @@
                     <filter string="To check" name="to_check" domain="[('move_id.checked', '=', False), ('parent_state', '!=', 'draft')]"/>
                     <separator/>
                     <filter string="Unreconciled"
-                            domain="[('account_id.reconcile', '=', True), '|', ('matching_number', '=', False), ('matching_number', '=like', 'P%')]"
+                            domain="[('balance', '!=', 0), ('account_id.reconcile', '=', True), '|', ('matching_number', '=', False), ('matching_number', '=like', 'P%')]"
                             name="reconcilable_account"
                             help="Journal items where the account allows reconciliation no matter the residual amount"
                     />


### PR DESCRIPTION
Description of the issue this commit addresses:

Items with a null residual are not reconcilable but when using the unreconciled filter implying that shown items have to be reconciled, those items are not hidden which is confusing.

---

Desired behavior after this commit is merged:

Using the Unreconciled filter on Journal Items will filter out items that have a null residual.

---

task-4723956

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr