### PR TITLE
[FIX] purchase_stock: handle exchange diff & conversion bill before receipt

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -308,7 +308,7 @@ class PurchaseOrderLine(models.Model):
         res = super()._prepare_account_move_line(move=move)
         if 'balance' not in res:
             res['balance'] = self.currency_id._convert(
-                self.price_unit_discounted * (self.qty_received or 1),
+                self.price_unit_discounted * self.qty_to_invoice,
                 self.company_id.currency_id,
                 round=False,
             )

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -71,7 +71,7 @@ class StockMove(models.Model):
                 # Adjust unit price to account for discounts before adding taxes.
                 adjusted_unit_price = invoice_line.price_unit * (1 - (invoice_line.discount / 100)) if invoice_line.discount else invoice_line.price_unit
                 if invoice_line.tax_ids:
-                    invoice_line_value = invoice_line.tax_ids.with_context(round=False).compute_all(
+                    invoice_line_value = invoice_line.tax_ids.with_context(round=False, round_base=False).compute_all(
                         adjusted_unit_price, currency=invoice_line.currency_id, quantity=invoice_line.quantity)['total_void']
                 else:
                     invoice_line_value = adjusted_unit_price * invoice_line.quantity

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -518,43 +518,97 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
         picking2 = purchase_order2.picking_ids[0]
         self.assertEqual(picking2.state, 'done')
 
-    @freeze_time('2000-05-05')
-    def test_currency_exchange_journal_items(self):
-        """ Prices modified by discounts and currency exchanges should still yield accurate price
-        units when calculated by valuation mechanisms.
+    def test_currency_exchange_journal_items1(self):
+        """ Do symmetric rounding between receipt valuation journal items and bill journal items.
         """
         self.env.company.currency_id = self.env.ref('base.IQD').id
-        self.test_product_order.standard_price = 500
+        product = self.test_product_delivery
+        product.standard_price = 500
         self.stock_account_product_categ.property_cost_method = 'average'
         self.env['res.currency.rate'].create({
-            'name': '2000-05-05',
+            'name': fields.Date.today(),
             'company_rate': .00756,
             'currency_id': self.env.ref('base.USD').id,
             'company_id': self.env.company.id,
         })
-
         purchase_order = self.env['purchase.order'].create({
             'partner_id': self.partner_a.id,
             'currency_id': self.env.ref('base.USD').id,
-            'order_line': [(0, 0, {
-                'product_id': self.test_product_order.id,
-                'product_uom_qty': 13,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 13,
                 'discount': 1,
             })],
         })
         purchase_order.button_confirm()
-        purchase_order.picking_ids.move_ids.quantity = 13
-        purchase_order.picking_ids.button_validate()
+        receipt = purchase_order.picking_ids
+        receipt.button_validate()
         pre_bill_remaining_value = purchase_order.picking_ids.move_ids.stock_valuation_layer_ids.remaining_value
         purchase_order.action_create_invoice()
-        purchase_order.invoice_ids.invoice_date = '2000-05-05'
+        purchase_order.invoice_ids.invoice_date = fields.Date.today()
         purchase_order.invoice_ids.action_post()
         post_bill_remaining_value = purchase_order.picking_ids.move_ids.stock_valuation_layer_ids.remaining_value
         self.assertEqual(post_bill_remaining_value, pre_bill_remaining_value)
-        amls = self.env['account.move.line'].search([('product_id', '=', self.test_product_order.id)])
+        stock_input_account, stock_valuation_account, tax_paid_account, accounts_payable_account = (
+            self.company_data['default_account_stock_in'],
+            self.company_data['default_account_stock_valuation'],
+            self.company_data['default_account_tax_purchase'],
+            self.company_data['default_account_payable'],
+        )
+        amls = self.env['account.move.line'].search([], order='id asc')
         self.assertRecordValues(
             amls,
-            [{'debit': 0.0, 'credit': 6435.0}, {'debit': 6435.0, 'credit': 0.0}, {'debit': 6435.0, 'credit': 0.0}]
+            [
+                {'account_id': stock_input_account.id,        'debit':    0.000,   'credit': 6435.000},
+                {'account_id': stock_valuation_account.id,    'debit': 6435.000,   'credit':    0.000},
+                {'account_id': stock_input_account.id,        'debit': 6435.000,   'credit':    0.000},
+                {'account_id': tax_paid_account.id,           'debit':  965.581,   'credit':    0.000},
+                {'account_id': accounts_payable_account.id,   'debit':    0.000,   'credit': 7400.581},
+            ]
+        )
+
+    def test_currency_exchange_journal_items2(self):
+        """ ^^^ With billing before reception"""
+        self.env.company.currency_id = self.env.ref('base.IQD').id
+        product = self.test_product_order
+        product.write({'purchase_method': 'purchase', 'standard_price': 500})
+        self.env['res.currency.rate'].create({
+            'name': fields.Date.today(),
+            'company_rate': .00756,
+            'currency_id': self.env.ref('base.USD').id,
+            'company_id': self.env.company.id,
+        })
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': self.env.ref('base.USD').id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 13,
+                'discount': 1,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.action_create_invoice()
+        purchase_order.invoice_ids.invoice_date = fields.Date.today()
+        purchase_order.invoice_ids.action_post()
+        receipt = purchase_order.picking_ids
+        receipt.button_validate()
+        stock_input_account, stock_valuation_account, tax_paid_account, accounts_payable_account = (
+            self.company_data['default_account_stock_in'],
+            self.company_data['default_account_stock_valuation'],
+            self.company_data['default_account_tax_purchase'],
+            self.company_data['default_account_payable'],
+        )
+        amls = self.env['account.move.line'].search([], order='id asc')
+        self.assertRecordValues(
+            amls,
+            [
+                {'account_id': stock_input_account.id,        'debit': 6435.000,   'credit':    0.000},
+                {'account_id': tax_paid_account.id,           'debit':  965.581,   'credit':    0.000},
+                {'account_id': accounts_payable_account.id,   'debit':    0.000,   'credit': 7400.581},
+                {'account_id': stock_input_account.id,        'debit':    0.000,   'credit': 6435.000},
+                {'account_id': stock_valuation_account.id,    'debit': 6435.000,   'credit':    0.000},
+            ]
         )
 
     def test_manual_cost_adjustment_journal_items_quantity(self):
@@ -695,12 +749,12 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
             self.assertRecordValues(
                 self.env['account.move.line'].search([], order='id asc'),
                 [
-                    {'account_id': stock_input_account.id,          'debit':  42.0,         'credit':   0.0},
-                    {'account_id': tax_purchase_account.id,         'debit':   6.3,         'credit':   0.0},
-                    {'account_id': account_payable_account.id,      'debit':   0.0,         'credit':  48.3},
-                    {'account_id': stock_input_account.id,          'debit':   0.0,         'credit': 420.0},
-                    {'account_id': stock_valuation_account.id,      'debit': 420.0,         'credit':   0.0},
-                    {'account_id': stock_input_account.id,          'debit': 382.67,        'credit':   0.0},
-                    {'account_id': stock_valuation_account.id,      'debit':   0.0,         'credit': 382.67},
+                    {'account_id': stock_input_account.id,       'debit': 420.00,   'credit':   0.00},
+                    {'account_id': tax_purchase_account.id,      'debit':  63.00,   'credit':   0.00},
+                    {'account_id': account_payable_account.id,   'debit':   0.00,   'credit': 483.00},
+                    {'account_id': stock_input_account.id,       'debit':   0.00,   'credit': 420.00},
+                    {'account_id': stock_valuation_account.id,   'debit': 420.00,   'credit':   0.00},
+                    {'account_id': stock_input_account.id,       'debit':  46.67,   'credit':   0.00},
+                    {'account_id': stock_valuation_account.id,   'debit':   0.00,   'credit':  46.67},
                 ]
             )

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
 from odoo.exceptions import UserError
@@ -822,3 +822,58 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         line = invoice.invoice_line_ids[0]
         self.assertEqual(line.amount_currency, 100.0)
         self.assertEqual(line.balance, 66.67)
+
+    def test_bill_on_ordered_qty_correct_converted_amount_on_bill(self):
+        """ Ensure bill line balance is correctly calculated from a purchase order line."""
+        product1, product2 = self.test_product_order, self.test_product_delivery
+        product1.write({'purchase_method': 'purchase', 'standard_price': 500})
+        euro = self.env.ref('base.EUR')
+        euro.active = True
+        self.env['res.currency.rate'].create({
+            'name': fields.Date.today(),
+            'company_rate': 1.10,
+            'currency_id': euro.id,
+            'company_id': self.env.company.id,
+        })
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': euro.id,
+            'order_line': [Command.create({
+                'product_id': product1.id,
+                'product_qty': 8,
+            }), Command.create({
+                'product_id': product2.id,
+                'product_qty': 8,
+            })],
+        })
+        purchase_order.button_confirm()
+        purchase_order.action_create_invoice()
+        product1_order_line_price_unit = purchase_order.order_line.filtered(
+            lambda ol: ol.product_id == product1
+        ).price_unit
+        bill1_line_balance = purchase_order.invoice_ids.invoice_line_ids.balance
+        self.assertAlmostEqual(
+            bill1_line_balance,
+            purchase_order.currency_id._convert(
+                product1_order_line_price_unit * 8,
+                self.env.company.currency_id,
+            ),
+            places=self.env.company.currency_id.decimal_places,
+        )
+
+        purchase_order.picking_ids.button_validate()
+        purchase_order.action_create_invoice()
+        product2_order_line_price_unit = purchase_order.order_line.filtered(
+            lambda ol: ol.product_id == product2
+        ).price_unit
+        bill2_line_balance = purchase_order.invoice_ids.invoice_line_ids.filtered(
+            lambda bl: bl.product_id == product2
+        ).balance
+        self.assertAlmostEqual(
+            bill2_line_balance,
+            purchase_order.currency_id._convert(
+                product2_order_line_price_unit * 8,
+                self.env.company.currency_id,
+            ),
+            places=self.env.company.currency_id.decimal_places,
+        )


### PR DESCRIPTION
**Current behavior:**
Creating a purchase order in a foreign currency and billing the
product prior to reception will produce 2 issues:
A) The bill line for the product will only make a conversion of
1 single unit of the product with the defined currency exchange
rate, making the amount on the line incorrect when qty > 1

B) When the receipt is finally validated, there will be an
unwanted exchange difference on the journal items generated due
to asymmetrical rounding for the bill AMLs and receipt valuation
AMLs

**Expected behavior:**
Correct bill line currency amounts and symmetric rounding.

**Steps to reproduce:**
1. Set the company currenct to IQD, make a product invoiced on
ordered qty, for sake of example set cost to 500 IQD

2. Create a currency exchange record to USD with a company rate
of `0.00756`

3. Create a PO for 13 of the product created in step 1, with a
discount of 1%

4. Confirm the PO and create the bill -> post it

* Issue A) look at invoice line, see only 1 unit in the
converted currency amount is accounted for by the `balance`

5) Receive the product -> look at the journal items generated
and see that there is a diff of 0.185 IQD

**Cause of the issue:**
A) commit: 90158f6 added a method to try and calculate an AML
balance from its purchase line values, but mistakenly is using
`qty_received` instead of `qty_to_invoice` which explains why
this issue only presents for the bill-before-receipt flow

B) commit: 9f046d5 is using `round=False` context for
`AccountTax.compute_all()` when the expected key is `round_base`

**Fix:**
A) Replace `qty_received or 1` with `qty_to_invoice`
* Also make the test added in 90158f6 more robust

B) Add `round_base=False` alongside the `round` key (not
removing as that existing one could have become expected in this
context)

opw-4689170