### PR TITLE
[FIX] mail: hide ControlPanel when no breadcrumbs are present

### DIFF
--- a/addons/mail/static/src/core/web/discuss_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_patch.xml
@@ -6,7 +6,7 @@
         </xpath>
         <xpath expr="//*[@t-ref='root']" position="replace">
             <div class="h-100 d-flex flex-column">
-                <ControlPanel t-if="!ui.isSmall"/>
+                <ControlPanel t-if="!ui.isSmall and env.config?.breadcrumbs?.length > 1"/>
                 <t>$0</t>
             </div>
         </xpath>

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1286,7 +1286,7 @@ test("new message in tab title has precedence over action name", async () => {
     });
     await start();
     await openDiscuss();
-    await contains(".o_breadcrumb:contains(Inbox)"); // wait for action name being Inbox
+    await contains(".o-mail-Discuss-threadName", { value: "Inbox" }); // wait for action name being Inbox
     const titleService = getService("title");
     expect(titleService.current).toBe("Inbox");
     // simulate receiving a new message in chat 1 with odoo out-of-focused
@@ -2370,4 +2370,15 @@ test("Read of unread chat where new message is deleted should mark as read", asy
         text: "Marc Demo",
         contains: [".badge", { count: 0 }],
     });
+});
+
+test("do not show control panel without breadcrumbs", async () => {
+    await start();
+    await openDiscuss();
+    await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
+    await contains(".o_control_panel", { count: 0 });
+    await openFormView("res.partner", serverState.partnerId);
+    await openDiscuss();
+    await contains(".o-mail-Discuss");
+    await contains(".o_control_panel .breadcrumb", { text: serverState.partnerName });
 });


### PR DESCRIPTION
Before this commit,
The ControlPanel was displayed even when there were no breadcrumbs, unnecessarily occupying space.

This commit adds a condition to display the ControlPanel only when breadcrumbs are present.

task-[4690325](https://www.odoo.com/odoo/project/1519/tasks/4690325)
