### PR TITLE
[IMP] web_tour: allow changing tooltip position on custom tours

### DIFF
--- a/addons/web_tour/models/tour.py
+++ b/addons/web_tour/models/tour.py
@@ -87,6 +87,12 @@ class Web_TourTourStep(models.Model):
 
     trigger = fields.Char(required=True)
     content = fields.Char()
+    tooltip_position = fields.Selection(selection=[
+        ["bottom", "Bottom"],
+        ["top", "Top"],
+        ["right", "Right"],
+        ["left", "left"],
+    ], default="bottom")
     tour_id = fields.Many2one("web_tour.tour", required=True, index=True, ondelete="cascade")
     run = fields.Char()
     sequence = fields.Integer()
@@ -94,8 +100,11 @@ class Web_TourTourStep(models.Model):
     def get_steps_json(self):
         steps = []
 
-        for step in self.read(fields=["trigger", "content", "run"]):
+        for step in self.read(fields=["trigger", "content", "run", "tooltip_position"]):
             del step["id"]
+            step["tooltipPosition"] = step["tooltip_position"]
+            del step["tooltip_position"]
+
             if not step["content"]:
                 del step["content"]
             steps.append(step)

--- a/addons/web_tour/tests/test_tours.py
+++ b/addons/web_tour/tests/test_tours.py
@@ -59,6 +59,7 @@ class TestTour(BaseCommon):
             "steps": [{
                 "content": "Click here",
                 "trigger": "button",
+                "tooltipPosition": "bottom",
                 "run": "click",
             }]
         })

--- a/addons/web_tour/views/tour_views.xml
+++ b/addons/web_tour/views/tour_views.xml
@@ -29,6 +29,7 @@
                                         <field name="sequence" widget="handle"/>
                                         <field name="trigger"/>
                                         <field name="run"/>
+                                        <field name="tooltip_position"/>
                                         <field name="content"/>
                                     </list>
                                 </field>


### PR DESCRIPTION
Before this commit, changing the tooltip position of a custom tour was impossible. So, if the tooltip was missplaced, like when pointing at the button to return to the home.

Now, the tooltip position of the step can be changed in the custom tour view and the default value is "bottom".

TASK-ID: 4623449


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
