### PR TITLE
[REF] point_of_sale: ensure refs exist before creating pos.order instance

### DIFF
--- a/addons/l10n_ar_pos/static/src/app/services/pos_store.js
+++ b/addons/l10n_ar_pos/static/src/app/services/pos_store.js
@@ -16,8 +16,8 @@ patch(PosStore.prototype, {
     isArgentineanCompany() {
         return this.company.country_id?.code == "AR";
     },
-    createNewOrder() {
-        const order = super.createNewOrder(...arguments);
+    async createNewOrder() {
+        const order = await super.createNewOrder(...arguments);
 
         if (this.isArgentineanCompany() && !order.partner_id) {
             order.partner_id = this.config._consumidor_final_anonimo_id;

--- a/addons/l10n_pe_pos/static/src/app/services/pos_store.js
+++ b/addons/l10n_pe_pos/static/src/app/services/pos_store.js
@@ -14,8 +14,8 @@ patch(PosStore.prototype, {
     isPeruvianCompany() {
         return this.company.country_id?.code == "PE";
     },
-    createNewOrder() {
-        const order = super.createNewOrder(...arguments);
+    async createNewOrder() {
+        const order = await super.createNewOrder(...arguments);
 
         if (this.isPeruvianCompany() && !order.partner_id) {
             order.partner_id = this.config._consumidor_final_anonimo_id;

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -95,11 +95,11 @@ export class Navbar extends Component {
         this.bufferedInput = "";
     }
 
-    onClickRegister() {
+    async onClickRegister() {
         let order = this.pos.getOrder();
 
         if (!order) {
-            order = this.pos.addNewOrder();
+            order = await this.pos.addNewOrder();
         }
 
         this.pos.navigateToOrderScreen(order);

--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -21,7 +21,7 @@ export class OrderTabs extends Component {
         this.dialog = useService("dialog");
     }
     async newFloatingOrder() {
-        const order = this.pos.addNewOrder();
+        const order = await this.pos.addNewOrder();
         this.pos.navigate("ProductScreen", {
             orderUuid: order.uuid,
         });

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -421,7 +421,7 @@ export class PaymentScreen extends Component {
                     switchScreen = this.currentOrder.uuid === this.pos.selectedOrderUuid;
                     nextPage = this.pos.defaultPage;
                     if (switchScreen) {
-                        this.selectNextOrder();
+                        await this.selectNextOrder();
                     }
                 }
             }
@@ -431,11 +431,11 @@ export class PaymentScreen extends Component {
             this.pos.navigate(nextPage.page, nextPage.params);
         }
     }
-    selectNextOrder() {
+    async selectNextOrder() {
         if (this.currentOrder.originalSplittedOrder) {
             this.pos.selectedOrderUuid = this.currentOrder.uiState.splittedOrderUuid;
         } else {
-            this.pos.addNewOrder();
+            await this.pos.addNewOrder();
         }
     }
     /**

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -69,10 +69,10 @@ export class ProductScreen extends Component {
             this.numberBuffer.reset();
         });
 
-        onWillRender(() => {
+        onWillRender(async () => {
             // If its a shared order it can be paid from another POS
             if (this.currentOrder?.state !== "draft") {
-                this.pos.addNewOrder();
+                await this.pos.addNewOrder();
             }
         });
 

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -72,10 +72,11 @@ export class ReceiptScreen extends Component {
     showPhoneInput() {
         return false;
     }
-    orderDone() {
+    async orderDone() {
         this.pos.orderDone(this.currentOrder);
         if (!this.pos.config.module_pos_restaurant) {
-            this.pos.selectedOrderUuid = this.pos.getEmptyOrder().uuid;
+            const newOrder = await this.pos.getEmptyOrder();
+            this.pos.selectedOrderUuid = newOrder.uuid;
         }
         this.pos.searchProductWord = "";
         const nextPage = this.pos.defaultPage;

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -297,7 +297,7 @@ export class TicketScreen extends Component {
         const partner = order.getPartner();
         // The order that will contain the refund orderlines.
         // We select the order if it is empty, else we create a new one.
-        const destinationOrder = this._getEmptyOrder(partner);
+        const destinationOrder = await this._getEmptyOrder(partner);
 
         destinationOrder.is_refund = true;
         // Add orderline for each toRefundDetail to the destinationOrder.
@@ -561,7 +561,7 @@ export class TicketScreen extends Component {
      * @param {Object | null} partner
      * @returns {boolean}
      */
-    _getEmptyOrder(partner) {
+    async _getEmptyOrder(partner) {
         let emptyOrderForPartner = null;
         let emptyOrder = null;
         for (const order of this.pos.models["pos.order"].filter((order) => !order.finalized)) {
@@ -575,7 +575,11 @@ export class TicketScreen extends Component {
                 }
             }
         }
-        return emptyOrderForPartner || emptyOrder || this.pos.addNewOrder({ partner_id: partner });
+        return (
+            emptyOrderForPartner ||
+            emptyOrder ||
+            (await this.pos.addNewOrder({ partner_id: partner }))
+        );
     }
     _doesOrderHaveSoleItem(order) {
         const orderlines = order.getOrderlines();

--- a/addons/pos_hr/static/src/app/services/pos_store.js
+++ b/addons/pos_hr/static/src/app/services/pos_store.js
@@ -44,8 +44,8 @@ patch(PosStore.prototype, {
             this.hasLoggedIn = saved_cashier ? true : false;
         }
     },
-    createNewOrder() {
-        const order = super.createNewOrder(...arguments);
+    async createNewOrder() {
+        const order = await super.createNewOrder(...arguments);
 
         if (this.config.module_pos_hr) {
             order.employee_id = this.getCashier();

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -1112,8 +1112,8 @@ export class FloorScreen extends Component {
             return this.deleteFloor();
         }
     }
-    clickNewOrder() {
-        this.pos.addNewOrder();
+    async clickNewOrder() {
+        await this.pos.addNewOrder();
         this.pos.navigate("ProductScreen", {
             orderUuid: this.pos.selectedOrderUuid,
         });

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
@@ -121,7 +121,7 @@ export class SplitBillScreen extends Component {
         const originalOrderName = this._getOrderName(originalOrder);
         const newOrderName = this._getSplitOrderName(originalOrderName);
 
-        const newOrder = this.pos.createNewOrder();
+        const newOrder = await this.pos.createNewOrder();
         newOrder.floating_order_name = newOrderName;
         newOrder.uiState.splittedOrderUuid = curOrderUuid;
         originalOrder.uiState.splittedOrderUuid = newOrder.uuid;

--- a/addons/pos_restaurant/static/src/app/screens/tip_screen/tip_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/tip_screen/tip_screen.js
@@ -100,9 +100,9 @@ export class TipScreen extends Component {
         });
         this.goNextScreen();
     }
-    goNextScreen() {
+    async goNextScreen() {
         if (!this.pos.config.module_pos_restaurant) {
-            this.pos.addNewOrder();
+            await this.pos.addNewOrder();
         }
         this.pos.navigate("ReceiptScreen", {
             orderUuid: this.pos.getOrder().uuid,

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -16,6 +16,9 @@ patch(PosStore.prototype, {
         this.tableSyncing = false;
         this.tableSelectorState = false;
         await super.setup(...arguments);
+        if (this.config.default_screen === "register") {
+            await this.addNewOrder();
+        }
     },
     get firstPage() {
         const screen = super.firstPage;
@@ -95,8 +98,7 @@ patch(PosStore.prototype, {
         }
         return super.defaultScreen;
     },
-
-    createNewOrder(data) {
+    async createNewOrder(data) {
         const order = super.createNewOrder(data);
 
         if (order.table_id) {
@@ -322,7 +324,7 @@ patch(PosStore.prototype, {
         }
 
         if (beforeMergeDetails.length) {
-            const newOrder = this.addNewOrder({ table_id: unmergeTable });
+            const newOrder = await this.addNewOrder({ table_id: unmergeTable });
 
             const courseByLines = {};
             if (beforeMergeCourseDetails?.length) {
@@ -479,9 +481,9 @@ patch(PosStore.prototype, {
         const page = this.defaultPage;
         this.navigate(page.page, page.params);
     },
-    addOrderIfEmpty(forceEmpty) {
+    async addOrderIfEmpty(forceEmpty) {
         if (!this.config.module_pos_restaurant || forceEmpty) {
-            return super.addOrderIfEmpty(...arguments);
+            return await super.addOrderIfEmpty(...arguments);
         }
     },
     async handleUrlParams(event) {
@@ -515,11 +517,11 @@ patch(PosStore.prototype, {
         }
         return order;
     },
-    createOrderIfNeeded(data) {
+    async createOrderIfNeeded(data) {
         if (this.config.module_pos_restaurant && !data["table_id"]) {
             let order = this.models["pos.order"].find((order) => order.isDirectSale);
             if (!order) {
-                order = this.createNewOrder(data);
+                order = await this.createNewOrder(data);
             }
             return order;
         }
@@ -598,7 +600,7 @@ patch(PosStore.prototype, {
                 currentOrder.update({ table_id: table });
                 this.selectedOrderUuid = currentOrder.uuid;
             } else {
-                this.addNewOrder({ table_id: table });
+                await this.addNewOrder({ table_id: table });
             }
         }
     },
@@ -689,7 +691,7 @@ patch(PosStore.prototype, {
                     orderUuid: orders[0].uuid,
                 });
             } else {
-                this.addNewOrder({ table_id: table });
+                await this.addNewOrder({ table_id: table });
                 this.navigate("ProductScreen", {
                     orderUuid: this.getOrder().uuid,
                 });

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -699,10 +699,10 @@ registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
             FloorScreen.clickTable("4"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             Chrome.clickOrders(),
-            TicketScreen.nthRowContains(1, "John"),
-            TicketScreen.nthRowContains(1, "Takeaway", false),
-            TicketScreen.nthRowContains(2, "002"),
-            TicketScreen.nthRowContains(2, "Eat in", false),
+            TicketScreen.nthRowContains(2, "John"),
+            TicketScreen.nthRowContains(2, "Takeaway", false),
+            TicketScreen.nthRowContains(1, "002"),
+            TicketScreen.nthRowContains(1, "Eat in", false),
         ].flat(),
 });
 

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -41,9 +41,9 @@ registry.category("web_tour.tours").add("OrderNumberConflictTour", {
             ProductScreen.addOrderline("Coca-Cola", "1", "3"),
             Chrome.clickPlanButton(),
             Chrome.clickOrders(),
-            TicketScreen.nthRowContains(1, "Self-Order"),
-            TicketScreen.nthRowContains(1, "T 101"),
             TicketScreen.nthRowNotContains(2, "Self-Order"),
             TicketScreen.nthRowContains(2, "T 103"),
+            TicketScreen.nthRowContains(1, "Self-Order"),
+            TicketScreen.nthRowContains(1, "T 101"),
         ].flat(),
 });

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -43,7 +43,7 @@ patch(PosStore.prototype, {
                 linkedSO.partner_invoice_id?.id !== sale_order.partner_invoice_id?.id ||
                 linkedSO.partner_shipping_id?.id !== sale_order.partner_shipping_id?.id
             ) {
-                this.addNewOrder({
+                await this.addNewOrder({
                     partner_id: sale_order.partner_id,
                 });
                 this.notification.add(_t("A new order has been created."));


### PR DESCRIPTION
In the createNewOrder method, the pos.order was created first, and the references were set afterward using getNextOrderRefs.
References are now set before creating the pos.order instance, ensuring proper initialization.

task-4677391
Enterprise PR - https://github.com/odoo/enterprise/pull/83366
