### PR TITLE
[FIX] l10n_es: Modelo 390 section 1 and 2 totals.

### DIFF
--- a/addons/l10n_es/data/mod390/mod390_section1.xml
+++ b/addons/l10n_es/data/mod390/mod390_section1.xml
@@ -1204,7 +1204,7 @@
                                 aeat_mod_390_685.balance + aeat_mod_390_23.balance + aeat_mod_390_25.balance +
                                 aeat_mod_390_720.balance + aeat_mod_390_687.balance + aeat_mod_390_545.balance +
                                 aeat_mod_390_722.balance + aeat_mod_390_689.balance + aeat_mod_390_547.balance +
-                                aeat_mod_390_551.balance + aeat_mod_390_27.balance + aeat_mod_390_29.balance
+                                aeat_mod_390_551.balance
                             </field>
                         </record>
                         <record id="mod_390_casilla_34" model="account.report.line">
@@ -1225,7 +1225,7 @@
                                 aeat_mod_390_686.balance + aeat_mod_390_24.balance + aeat_mod_390_26.balance +
                                 aeat_mod_390_721.balance + aeat_mod_390_688.balance + aeat_mod_390_546.balance +
                                 aeat_mod_390_723.balance + aeat_mod_390_690.balance + aeat_mod_390_548.balance +
-                                aeat_mod_390_552.balance + aeat_mod_390_28.balance + aeat_mod_390_30.balance
+                                aeat_mod_390_552.balance
                             </field>
                         </record>
                     </field>

--- a/addons/l10n_es/data/mod390/mod390_section2.xml
+++ b/addons/l10n_es/data/mod390/mod390_section2.xml
@@ -1670,8 +1670,8 @@
                             aeat_mod_390_53.balance + aeat_mod_390_55.balance +
                             aeat_mod_390_57.balance + aeat_mod_390_59.balance +
                             aeat_mod_390_598.balance + aeat_mod_390_61.balance +
-                            aeat_mod_390_62.balance + aeat_mod_390_652.balance +
-                            aeat_mod_390_63.balance + aeat_mod_390_522.balance
+                            aeat_mod_390_652.balance + aeat_mod_390_63.balance +
+                            aeat_mod_390_522.balance
                         </field>
                     </record>
                     <record id="mod_390_casilla_65" model="account.report.line">


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/205403 I did some wrong changes to the totals of Modelo 390 section 1. This PR reverts these changes and fixes the section 2, which was the initial plan.

Details:

l10n_es tax has two main tax reports, modelo 303 (quarterly taxes) and modelo 390 (annual taxes).

For both of these reports, for invoices, the taxes use positive tax tags corresponding the to tax line in the tax report. For refunds, the two reports work differently. Modelo 303 links all the refund amounts to some special report line (modification/correction of base/taxes), whereas the modelo 390 uses the negative tax tags corresponding to the tax line in the report.

The issue lies in the multiple cross report references from modelo 303 to modelo
390. In section 1, some base and tax amounts are referrenced from modelo 303, as well as the modification amounts (the total of refunds mentionned above). When we compute the totals for that section, some refunds can be counted twice (once from the report using the negative tax tags, and a second time if we count the modification cross referenced from modelo 303). Since we have more taxes using the negative tags than cross-referenced in that section, it is better to omit the modification from the totals (i.e. we do not subtract [30] for the totals, as the negative amounts are already accounted for for the majority of the taxes). The totals will still be incorrect for that section, but less wrong.

A future PR for master will fix the report by splitting all the tags used for the two reports.

In section 2, we are in a similar case, so we remove the subtraction of [62] from the totals. In this case, the totals are correct after this modification.
