### PR TITLE
[FIX] website_event: replace incorrect Unicode character in date range

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 import json
 import werkzeug.urls
 
+from markupsafe import Markup
 from pytz import utc, timezone
 
 from odoo import api, fields, models, _
@@ -615,5 +616,8 @@ class Event(models.Model):
             for event, data in zip(self, results_data):
                 begin = self.env['ir.qweb.field.date'].record_to_html(event, 'date_begin', {})
                 end = self.env['ir.qweb.field.date'].record_to_html(event, 'date_end', {})
-                data['range'] = '%s🠖%s' % (begin, end) if begin != end else begin
+                data['range'] = (
+                    Markup('{} <i class="fa fa-long-arrow-right"></i> {}').format(begin, end)
+                    if begin != end else begin
+                )
         return results_data


### PR DESCRIPTION
Replace the non-standard '🠖' (->) character with an arrow icon in the
`_search_render_results()` method for consistent and proper rendering
across browsers and platforms.
