### PR TITLE
[IMP] tools: LRU with less locks

### DIFF
--- a/addons/web/tests/test_db_manager.py
+++ b/addons/web/tests/test_db_manager.py
@@ -221,7 +221,7 @@ class TestDatabaseOperations(BaseCase):
         self.session.cookies['session_id'] = session.sid
 
         # make it possible to inject the registry back
-        patcher = patch.dict(Registry.registries.d, {test_db_name: registry})
+        patcher = patch.dict(Registry.registries, {test_db_name: registry})
         registries = patcher.start()
         self.addCleanup(patcher.stop)
 

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -1914,11 +1914,12 @@ class TestAssetsManifest(AddonManifestPatched):
             """
         )
 
+
 @tagged('-at_install', 'post_install')
 class AssetsNodeOrmCacheUsage(TransactionCase):
 
     def cache_keys(self):
-        keys = self.env.registry._Registry__caches['assets'].d
+        keys = list(self.env.registry._Registry__caches['assets'])
 
         asset_keys = [key for key in keys if key[0] == 'ir.asset' and '_get_asset_paths' in str(key[1])] # ignore topological sort entry
         qweb_keys = [key for key in keys if key[0] == 'ir.qweb']

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -663,7 +663,7 @@ class ThreadedServer(CommonServer):
             if config['test_enable']:
                 from odoo.tests.result import _logger as logger  # noqa: PLC0415
                 with Registry.registries._lock:
-                    for db, registry in Registry.registries.d.items():
+                    for db, registry in Registry.registries.items():
                         report = registry._assertion_report
                         log = logger.error if not report.wasSuccessful() \
                          else logger.warning if not report.testsRun \

--- a/odoo/tools/cache.py
+++ b/odoo/tools/cache.py
@@ -123,8 +123,9 @@ class ormcache:
             counter.miss += 1
             counter.cache_name = self.cache_name
             start = time.monotonic()
-            value = d[key] = self.method(*args, **kwargs)
+            value = self.method(*args, **kwargs)
             counter.gen_time += time.monotonic() - start
+            d[key] = value
             return value
         except TypeError:
             _logger.warning("cache lookup error on %r", key, exc_info=True)

--- a/odoo/tools/cache.py
+++ b/odoo/tools/cache.py
@@ -173,8 +173,11 @@ def log_ormcache_stats(sig=None, frame=None):   # noqa: ARG001 (arguments are th
             cache_stats.append(f"Database {dbname_display}")
         if dbname:   # mainly for MockPool
             if (dbname, stat.cache_name) not in cache_entries:
-                cache = Registry.registries.d[dbname]._Registry__caches[stat.cache_name]
-                cache_entries[dbname, stat.cache_name] = Counter(k[:2] for k in cache.d)
+                try:
+                    cache = Registry.registries[dbname]._Registry__caches[stat.cache_name]
+                    cache_entries[dbname, stat.cache_name] = Counter(k[:2] for k in cache)
+                except KeyError:
+                    cache_entries[dbname, stat.cache_name] = Counter()
             nb_entries = cache_entries[dbname, stat.cache_name][model, method]
         else:
             nb_entries = 0

--- a/odoo/tools/lru.py
+++ b/odoo/tools/lru.py
@@ -1,9 +1,8 @@
-import collections
 import threading
 import typing
 from collections.abc import Iterable, Iterator, MutableMapping
 
-from .func import locked
+from .misc import SENTINEL
 
 __all__ = ['LRU']
 
@@ -13,50 +12,112 @@ V = typing.TypeVar('V')
 
 class LRU(MutableMapping[K, V], typing.Generic[K, V]):
     """
-    Implementation of a length-limited O(1) LRU map.
+    Implementation of a length-limited LRU map.
 
-    Original Copyright 2003 Josiah Carlson, later rebuilt on OrderedDict and added typing.
+    The mapping is thread-safe, and internally uses a lock to avoid concurrency
+    issues. However, access operations like ``lru[key]`` are fast and
+    lock-free.
     """
+
+    __slots__ = ('_count', '_lock', '_ordering', '_values')
+
     def __init__(self, count: int, pairs: Iterable[tuple[K, V]] = ()):
+        assert count > 0, "LRU needs a positive count"
+        self._count = count
         self._lock = threading.RLock()
-        self.count = max(count, 1)
-        self.d: collections.OrderedDict[K, V] = collections.OrderedDict()
+        self._values: dict[K, V] = {}
+        #
+        # The dict self._values contains the LRU items, while self._ordering
+        # only keeps track of their order, the most recently used ones being
+        # last. For performance reasons, we only use the lock when modifying
+        # the LRU, while reading it is lock-free (and thus faster).
+        #
+        # This strategy may result in inconsistencies between self._values and
+        # self._ordering. Indeed, concurrently accessed keys may be missing
+        # from self._ordering, but will eventually be added. This could result
+        # in keys being added back in self._ordering after their actual removal
+        # from the LRU. This results in the following invariant:
+        #
+        #     self._values <= self._ordering | "keys being accessed"
+        #
+        self._ordering: dict[K, None] = {}
+
+        # Initialize
         for key, value in pairs:
             self[key] = value
 
-    @locked
-    def __contains__(self, obj: K) -> bool:
-        return obj in self.d
+    @property
+    def count(self) -> int:
+        return self._count
 
-    @locked
-    def __getitem__(self, obj: K) -> V:
-        a = self.d[obj]
-        self.d.move_to_end(obj, last=False)
-        return a
+    def __contains__(self, key: object) -> bool:
+        return key in self._values
 
-    @locked
-    def __setitem__(self, obj: K, val: V):
-        self.d[obj] = val
-        self.d.move_to_end(obj, last=False)
-        while len(self.d) > self.count:
-            self.d.popitem(last=True)
+    def __getitem__(self, key: K) -> V:
+        val = self._values[key]
+        # move key at the last position in self._ordering
+        self._ordering[key] = self._ordering.pop(key, None)
+        return val
 
-    @locked
-    def __delitem__(self, obj: K):
-        del self.d[obj]
+    def __setitem__(self, key: K, val: V):
+        values = self._values
+        ordering = self._ordering
+        with self._lock:
+            values[key] = val
+            ordering[key] = ordering.pop(key, None)
+            while True:
+                # if we have too many keys in ordering, filter them out
+                if len(ordering) > len(values):
+                    # (copy to avoid concurrent changes on ordering)
+                    for k in ordering.copy():
+                        if k not in values:
+                            ordering.pop(k, None)
+                # check if we have too many keys
+                if len(values) <= self._count:
+                    break
+                # if so, pop the least recently used
+                try:
+                    # have a default in case of concurrent accesses
+                    key = next(iter(ordering), key)
+                except RuntimeError:
+                    # ordering modified during iteration, retry
+                    continue
+                values.pop(key, None)
+                ordering.pop(key, None)
 
-    @locked
+    def __delitem__(self, key: K):
+        self.pop(key)
+
     def __len__(self) -> int:
-        return len(self.d)
+        return len(self._values)
 
-    @locked
     def __iter__(self) -> Iterator[K]:
-        return iter(self.d)
+        return iter(self.snapshot)
 
-    @locked
-    def pop(self, key: K) -> V:
-        return self.d.pop(key)
+    @property
+    def snapshot(self) -> dict[K, V]:
+        """ Return a copy of the LRU (ordered according to LRU first). """
+        with self._lock:
+            values = self._values
+            # build result in expected order (copy self._ordering to avoid concurrent changes)
+            result = {
+                key: val
+                for key in self._ordering.copy()
+                if (val := values.get(key, SENTINEL)) is not SENTINEL
+            }
+            if len(result) < len(values):
+                # keys in value were missing from self._ordering, add them
+                result.update(values)
+        return result
 
-    @locked
+    def pop(self, key: K, /, default=SENTINEL) -> V:
+        with self._lock:
+            self._ordering.pop(key, None)
+            if default is SENTINEL:
+                return self._values.pop(key)
+            return self._values.pop(key, default)
+
     def clear(self):
-        self.d.clear()
+        with self._lock:
+            self._ordering.clear()
+            self._values.clear()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The most common operation is getting the value for which we would like to avoid locking so that when we run in multi-threaded mode, there are less concurrency issues. We also implement the operations using as much as possible native structures to avoid overhead.

Performance:
```
lru = LRU(50)
%timeit lru[99] = "ok"
%timeit lru[99]
%timeit for i, v in enumerate("hello world"): lru[i] = v

lru = LRU(50)
%timeit lru[randint(1, 60)] = 1
%timeit lru[randint(1, 160)] = 1
%timeit lru[randint(1, 600)] = 1

"""
NEW:

223 ns ± 2.98 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
65.5 ns ± 0.229 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
2.79 μs ± 95.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

496 ns ± 16.6 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
593 ns ± 2.72 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
668 ns ± 6.67 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

OLD:

3.11 μs ± 32.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.73 μs ± 54.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
34.9 μs ± 1.22 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

3.28 μs ± 26.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.63 μs ± 265 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.6 μs ± 135 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
"""
```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
