### PR TITLE
[IMP] web: add the base.group_multi_company inside session_info

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -133,6 +133,7 @@ class IrHttp(models.AbstractModel):
             'view_info': self.env['ir.ui.view'].get_view_info(),
             'groups': {
                 'base.group_allow_export': user.has_group('base.group_allow_export') if session_uid else False,
+                'base.group_multi_company': user.has_group('base.group_multi_company') if session_uid else False,
             },
         }
         if request.session.debug:

--- a/addons/web/tests/test_session_info.py
+++ b/addons/web/tests/test_session_info.py
@@ -73,7 +73,8 @@ class TestSessionInfo(common.HttpCase):
             'disallowed_ancestor_companies': expected_disallowed_ancestor_companies,
         }
         self.assertEqual(result["groups"], {
-            'base.group_allow_export': self.user.has_group('base.group_allow_export')
+            'base.group_allow_export': self.user.has_group('base.group_allow_export'),
+            'base.group_multi_company': self.user.has_group('base.group_multi_company')
         })
         self.assertEqual(
             result['user_companies'],


### PR DESCRIPTION
Since the Document app use the `base.group_multi_company` at startup[1], it's made sense to the session_info bundle to avoid an RPC at webclient startup.

[1]: https://github.com/odoo/enterprise/blob/b78e36b16a6b4b157c227d8b222b544f94cb9016/documents/static/src/core/document_service.js#L81

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
