### PR TITLE
[FIX] web_tour: tour stuck on dropdown loading

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -40,7 +40,7 @@
                                     t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_loading"
                                     role="option"
                                     href="#"
-                                    class="dropdown-item ui-menu-item-wrapper"
+                                    class="o_loading dropdown-item ui-menu-item-wrapper"
                                     aria-selected="true"
                                 >
                                     <i class="fa fa-spin fa-circle-o-notch" /> <t t-esc="source.placeholder" />

--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -455,7 +455,10 @@ export class TourInteractive {
                 this.setActionListeners();
             } else if (!tempAnchors.length && this.anchorEls.length) {
                 this.pointer.hide();
-                if (!hoot.queryFirst(".o_home_menu", { visible: true })) {
+                if (
+                    !hoot.queryFirst(".o_home_menu", { visible: true }) &&
+                    !hoot.queryFirst(".dropdown-item.o_loading", { visible: true })
+                ) {
                     this.backward();
                 }
                 return;

--- a/addons/web_tour/static/src/tour_service/tour_step.js
+++ b/addons/web_tour/static/src/tour_service/tour_step.js
@@ -9,7 +9,7 @@ import { pick } from "@web/core/utils/objects";
  * @property {string} [id]
  * @property {HootSelector} trigger The node on which the action will be executed.
  * @property {string} [content] Description of the step.
- * @property {"top" | "botton" | "left" | "right"} [position] The position where the UI helper is shown.
+ * @property {"top" | "bottom" | "left" | "right"} [position] The position where the UI helper is shown.
  * @property {RunCommand} [run] The action to perform when trigger conditions are verified.
  * @property {number} [timeout] By default, when the trigger node isn't found after 10000 milliseconds, it throws an error.
  * You can change this value to lengthen or shorten the time before the error occurs [ms].


### PR DESCRIPTION
Before this commit, if the tour steps was "edit input" then "click second element dropdown", the tour was stuck and was backwarding to the "edit input" because during a moment the dropdown had only one element (the loading).

Now, the loading will be taken in account to wait for the next mutation observer for the case of a dropdown

TASK-ID: 4623449




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
