### PR TITLE
[IMP] mail: init the web push notif stuff when the webclient is ready

### DIFF
--- a/addons/mail/static/src/webclient/web/webclient.js
+++ b/addons/mail/static/src/webclient/web/webclient.js
@@ -16,7 +16,9 @@ patch(WebClient.prototype, {
         this.orm = useService("orm");
         this.notification = useService("notification");
         if (this._canSendNativeNotification) {
-            this._subscribePush();
+            this.env.bus.addEventListener("WEB_CLIENT_READY", () => this._subscribePush(), {
+                once: true,
+            });
         }
         if (browser.navigator.permissions) {
             let notificationPerm;


### PR DESCRIPTION
In this commit, we postpone the web push notification initialization
stuff after the WEB_CLIENT_READY event is triggered.
Because they're not needed to start the web client.

task-4341388


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
