### PR TITLE
[FIX] partner_autocomplete: prevent autocomplete field keyerror

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -101,7 +101,7 @@ class ResPartner(models.Model):
         query_country_id = query_country_id or self.env.company.country_id.id
         query_country_code = self.env['res.country'].browse(query_country_id).code
         response, _ = self.env['iap.autocomplete.api']._request_partner_autocomplete('search_by_vat', {
-            'query': vat,
+            'query': vat.upper(),
             'query_country_code': query_country_code,
         }, timeout=timeout)
         if response and not response.get("error"):
@@ -169,7 +169,7 @@ class ResPartner(models.Model):
     @api.model
     def enrich_by_gst(self, gst, timeout=15):
         response, error = self.env['iap.autocomplete.api']._request_partner_autocomplete('enrich_by_gst', {
-            'gst': gst,
+            'gst': gst.upper(),
         }, timeout=timeout)
         return self._process_enriched_response(response, error)
 


### PR DESCRIPTION
The system throws an error due to missing `name` in values during RPC `onchange` call

Steps to Reproduce:
1. Open the `Contacts app` and click `New`.
2. Enter `32aadcs3224n1zf` as the name.
3. From the autocomplete dropdown, select a company.

Error:
`KeyError: 'name'`

Solution:
Added upper() transformation for GST and VAT numbers during autocomplete search to normalize input and avoid missing key errors.

Sentry - 6327760196
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
