### PR TITLE
[FIX] l10n_ch: prevent qr code in draft

### DIFF
--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -13,11 +13,12 @@ class AccountMove(models.Model):
 
     l10n_ch_is_qr_valid = fields.Boolean(compute='_compute_l10n_ch_qr_is_valid', help="Determines whether an invoice can be printed as a QR or not")
 
-    @api.depends('partner_id', 'currency_id')
+    @api.depends('partner_id', 'currency_id', 'display_qr_code')
     def _compute_l10n_ch_qr_is_valid(self):
         for move in self:
             error_messages = move.partner_bank_id._get_error_messages_for_qr('ch_qr', move.partner_id, move.currency_id)
             move.l10n_ch_is_qr_valid = (
+                move.display_qr_code and
                 move.move_type == 'out_invoice' and
                 not error_messages and
                 (move.company_id.account_fiscal_country_id.code == 'CH' or move._is_swiss_qr_iban())

--- a/addons/l10n_ch/tests/test_ch_qr_code.py
+++ b/addons/l10n_ch/tests/test_ch_qr_code.py
@@ -108,7 +108,11 @@ class TestSwissQRCode(AccountTestInvoicingCommon):
         self._assign_partner_address(move.partner_id)
         move.qr_code_method = 'ch_qr'
 
+        self.assertFalse(move.l10n_ch_is_qr_valid)
         self.assertIsNone(move._generate_qr_code(), "QR-code should not be generated.")
+
+        move.action_post()
+        self.assertTrue(move.l10n_ch_is_qr_valid)
 
     def test_ch_qr_code_detection(self):
         """ Checks Swiss QR-code auto-detection when no specific QR-method

--- a/addons/l10n_ch/tests/test_gen_qrr_reference.py
+++ b/addons/l10n_ch/tests/test_gen_qrr_reference.py
@@ -48,6 +48,7 @@ class TestGenQRRReference(AccountTestInvoicingCommon):
             'invoice_date': '2019-01-01',
             'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id})],
         })
+        test_invoice.action_post()
         test_invoice.name = "INV/01234567890"
         expected_qrr = "000000000000000012345678903"
         self.assertEqual(test_invoice.get_l10n_ch_qrr_number(), expected_qrr)
@@ -61,6 +62,7 @@ class TestGenQRRReference(AccountTestInvoicingCommon):
             'invoice_date': '2019-01-01',
             'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id})],
         })
+        test_invoice.action_post()
         test_invoice.name = "INV/123456789012345678901234567890"
         expected_qrr = "567890123456789012345678901"
         self.assertEqual(test_invoice.get_l10n_ch_qrr_number(), expected_qrr)


### PR DESCRIPTION
Through the many iteration, one of the condition was removed: https://github.com/odoo/odoo/pull/198498

and `move.display_qr_code` is not enough to translate the apparently necessary condition `move.company_id.account_fiscal_country_id.code == 'CH'` https://github.com/odoo/odoo/commit/84152f2d65712b1c21d1e627a3801e94db3c3992

Testing the flow is quite complex without tour hence the the `assert`

opw-4585574
