### PR TITLE
[FIX] mail: show desktop push notification in edge

### DIFF
--- a/addons/mail/web_push.py
+++ b/addons/mail/web_push.py
@@ -131,6 +131,8 @@ def push_to_end_point(base_url, device, payload, vapid_private_key, vapid_public
         'Content-Encoding': 'aes128gcm',
         'TTL': '0',
     }
+    if 'wns2-ln2p.notify.windows' in endpoint:
+        headers['TTL'] = '20'
 
     response = session.post(endpoint, headers=headers, data=payload, timeout=5)
     if response.status_code == 201:


### PR DESCRIPTION
When desktop notifications are active, we can receive notifications to our system from, for example a Discuss conversation, this works as intended in every browser except for Edge. This is because we are using different push notification servers for different browsers, and the TTL in the Windows Push Notification Services (wns) when this one is set to 0 it seems to not show the notification at all most of the time.

To avoid this issue we should avoid setting the TTL for Edge, and leaving it as 0 for the rest, another potential solution would be to set the TTL to a certain amount.

FW bot up to master

opw-4365219
