### PR TITLE
[FIX] product: force UoM computation when default is False

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -24,7 +24,7 @@ class ProductTemplate(models.Model):
 
     def default_get(self, fields_list):
         res = super().default_get(fields_list)
-        if 'uom_id' in fields_list and not res.get('uom_id'):
+        if 'uom_id' in fields_list and not res.get('uom_id') or self.env.context.get('default_uom_id') is False:
             res['uom_id'] = self._get_default_uom_id().id
         return res
 

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -391,6 +391,16 @@ class TestVariants(ProductVariantsCommon):
         self.assertFalse(variant_2.active, 'Should not re-activate other variant')
         self.assertTrue(template.active, 'Should re-activate template')
 
+    def test_open_product_form_with_default_uom_id_is_false(self):
+        """ Test default UoM is False when creating a product. """
+        uom_unit = self.env.ref('uom.product_uom_unit')
+        product_form = Form(self.env['product.product'].with_context(
+            default_uom_id=False,
+        ))
+        product_form.name = 'Test Product'
+        product = product_form.save()
+        self.assertEqual(uom_unit, product.uom_id)
+
 @tagged('post_install', '-at_install')
 class TestVariantsNoCreate(ProductAttributesCommon):
 


### PR DESCRIPTION
Bug introduced by: https://github.com/odoo/odoo/commit/25d0c760bbfabb3cc7d471b08b5b06fe1cfc2ec4

**Steps to reproduce the bug:**
- Install the “Sales” module.
- Do not enable the "Units of Measure" option in the settings.
- Create a new quotation.
- In the sale order line, enable the Product Variant field.
- Try to create a new “product.product”

**Problem:**
A validation Error is triggered:

```
The operation cannot be completed
 - Create/update: a mandatory field is not set.
- Delete: another model requires the record being deleted. If possible, archive it instead.

Model: Product (product.template) Field: Unit of Measure (uom_id)

```
**Explanation:**
This happens because a default value for the UoM is passed through the
context. As a result, we skip the computation of “uom_id”:
https://github.com/odoo/odoo/blob/2b38c1f446441e04f8d85125a9ec6562d13b7ce8/addons/product/models/product_template.py#L27

However, this default is derived from the field “product_uom” that is
present in the view but restricted to users in the "uom.group_uom"
group. If the current user doesn't belong to this group (if you don't
enable the param in the settings), the field is hidden and its value is
empty, causing the default to be set to False.

https://github.com/odoo/odoo/blob/25d0c760bbfabb3cc7d471b08b5b06fe1cfc2ec4/addons/sale/views/sale_order_views.xml#L537


**Solution:**
Force the computation of “uom_id” by removing “default_uom_id” from the
context when its value is “False”.

opw-4717913
