### PR TITLE
[FIX] ruff: sort `odoo.addons` imports behind `odoo` imports

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -80,3 +80,4 @@ ignore = [
 # https://www.odoo.com/documentation/18.0/contributing/development/coding_guidelines.html#imports
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 known-first-party = ["odoo"]
+known-local-folder = ["odoo.addons"]


### PR DESCRIPTION
Currently, ruff wants us to sort
```python
from odoo import fields
from odoo.tests import tagged

from odoo.addons.sale.tests.common import SaleCommon
```
as
```python
from odoo import fields
from odoo.addons.sale.tests.common import SaleCommon
from odoo.tests import tagged
```

By adding `odoo.addons` as `known-local-folder`, we get it to sort as specified in our guidelines: https://www.odoo.com/documentation/18.0/contributing/development/coding_guidelines.html#imports
