### PR TITLE
[IMP] auth_totp: not storing code during check

### DIFF
--- a/addons/auth_totp/wizard/auth_totp_wizard.py
+++ b/addons/auth_totp/wizard/auth_totp_wizard.py
@@ -29,7 +29,7 @@ class Auth_TotpWizard(models.TransientModel):
         attachment=False, store=True, readonly=True,
         compute='_compute_qrcode',
     )
-    code = fields.Char(string="Verification Code", size=7)
+    code = fields.Char(string="Verification Code", size=7, store=False)
 
     @api.depends('user_id.login', 'user_id.company_id.display_name', 'secret')
     def _compute_qrcode(self):
@@ -58,7 +58,7 @@ class Auth_TotpWizard(models.TransientModel):
     @check_identity
     def enable(self):
         try:
-            c = int(compress(self.code))
+            c = int(compress(self.env.context.get('code', '')))
         except ValueError:
             raise UserError(_("The verification code should only contain numbers"))
         if self.user_id._totp_try_setting(self.secret, c):

--- a/addons/auth_totp/wizard/auth_totp_wizard_views.xml
+++ b/addons/auth_totp/wizard/auth_totp_wizard_views.xml
@@ -66,7 +66,7 @@
                     </div>
                 </sheet>
                 <footer>
-                    <button type="object" name="enable" class="btn btn-primary"
+                    <button type="object" name="enable" class="btn btn-primary" context="{'code': code}"
                             string="Enable Two-Factor Authentication" data-hotkey="q"/>
                     <button string="Cancel" special="cancel" data-hotkey="x"/>
                 </footer>

--- a/addons/auth_totp_portal/static/src/interactions/totp_enable.js
+++ b/addons/auth_totp_portal/static/src/interactions/totp_enable.js
@@ -166,9 +166,11 @@ export class TOTPEnable extends Interaction {
                 }
 
                 try {
-                    await this.services.orm.write(model, [record.id], { code: inputEl.value });
                     await handleCheckIdentity(
-                        this.waitFor(this.services.orm.call(model, "enable", [record.id])),
+                        this.waitFor(this.services.orm.call(model, "enable",
+                            [ record.id ],
+                            { 'context': {'code': inputEl.value} },
+                        )),
                         this.services.orm,
                         this.services.dialog
                     );


### PR DESCRIPTION
The `code` field is a sensitive field.

The aim of this commit is to ensure that the code
is no longer stored in the database even for a short time.