### PR TITLE
[FIX] base, mail: missing widget in ir_filters_views

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -72,6 +72,7 @@ For more specific needs, you may also assign custom-defined actions
         'wizard/mail_template_reset_views.xml',
         'views/fetchmail_views.xml',
         'views/ir_cron_views.xml',
+        'views/ir_filters_views.xml',
         'views/mail_message_subtype_views.xml',
         'views/mail_tracking_value_views.xml',
         'views/mail_notification_views.xml',

--- a/addons/mail/views/ir_filters_views.xml
+++ b/addons/mail/views/ir_filters_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_filters_view_form" model="ir.ui.view">
+        <field name="name">ir.filters.view.form.inherit</field>
+        <field name="model">ir.filters</field>
+        <field name="inherit_id" ref="base.ir_filters_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='user_ids']" position="attributes">
+                <attribute name="widget">many2many_avatar_user</attribute>
+            </xpath>
+        </field>
+    </record>
+    <record id="ir_filters_view_tree" model="ir.ui.view">
+        <field name="name">ir.filters.view.tree.inherit</field>
+        <field name="model">ir.filters</field>
+        <field name="inherit_id" ref="base.ir_filters_view_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='user_ids']" position="attributes">
+                <attribute name="widget">many2many_avatar_user</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/odoo/addons/base/views/ir_filters_views.xml
+++ b/odoo/addons/base/views/ir_filters_views.xml
@@ -13,7 +13,7 @@
                         <group>
                             <group>
                                 <field name="name"/>
-                                <field name="user_ids" string="Shared with" widget="many2many_avatar_user" placeholder="All users"/>
+                                <field name="user_ids" string="Shared with" widget="many2many_tags_avatar" placeholder="All users"/>
                                 <field name="is_default" widget="boolean_toggle"/>
                                 <field name="model_id" groups="base.group_no_one"/>
                                 <field name="action_id" groups="base.group_no_one"/>
@@ -46,7 +46,7 @@
                 <list string="Filters">
                     <field name="name"/>
                     <field name="model_id"/>
-                    <field name="user_ids" widget="many2many_avatar_user"/>
+                    <field name="user_ids" widget="many2many_tags_avatar"/>
                     <field name="is_default"/>
                     <field name="action_id"/>
                     <field name="domain" groups="base.group_no_one"/>


### PR DESCRIPTION
This commit addresses a widget issue by replacing mail's many2many_avatar_user with web's many2many_tags_avatar in ir_filters_views. Additionally, a xpath is added in mail to revert the substitution after the mail module is installed.

Runbot-error-162965
