### PR TITLE
[IMP] web: Mouse select dropdown/autocomplete only on mousemove

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -63,6 +63,7 @@ export class AutoComplete extends Component {
         this.nextOptionId = 0;
         this.sources = [];
         this.inEdition = false;
+        this.mouseSelectionActive = false;
 
         this.state = useState({
             navigationRev: 0,
@@ -99,6 +100,7 @@ export class AutoComplete extends Component {
 
         useExternalListener(window, "scroll", this.externalClose, true);
         useExternalListener(window, "pointerdown", this.externalClose, true);
+        useExternalListener(window, "mousemove", () => this.mouseSelectionActive = true, true);
 
         this.hotkey = useService("hotkey");
         this.hotkeysToRemove = [];
@@ -169,6 +171,7 @@ export class AutoComplete extends Component {
     close() {
         this.state.open = false;
         this.state.activeSourceOption = null;
+        this.mouseSelectionActive = false;
     }
 
     cancel() {
@@ -430,6 +433,9 @@ export class AutoComplete extends Component {
     }
 
     onOptionMouseEnter(indices) {
+        if (!this.mouseSelectionActive) {
+            return;
+        }
         this.state.activeSourceOption = indices;
     }
     onOptionMouseLeave() {

--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -78,9 +78,15 @@
         outline: none;
     }
 
-    .dropdown-toggle.focus,
-    .dropdown-item.focus {
-        background-color: $dropdown-link-hover-bg;
+    .dropdown-toggle,
+    .dropdown-item {
+        // Remove default active/hover effects so it's only controlled via the .focus class
+        &:not(.focus) {
+            background-color: transparent;
+        }
+        &.focus {
+            background-color: $dropdown-link-hover-bg;
+        }
     }
 
     &.o-dropdown--menu-submenu {      // the value comes from bootstrap's ".dropdown-menu" padding and border style

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -25,14 +25,23 @@ class NavigationItem {
      */
     target = undefined;
 
-    constructor({ index, el, setActiveItem, options }) {
+    constructor({ index, el, setActiveItem, options, navigator }) {
         this.index = index;
 
         /**@private */
         this._options = options;
 
-        /**@private*/
+        /**
+         * @deprecated
+         * @private
+        */
         this._setActiveItem = setActiveItem;
+
+        /**
+         * @private
+         * @type {Navigator}
+        */
+        this._navigator = navigator;
 
         this.el = el;
         if (this._options.shouldFocusChildInput) {
@@ -43,15 +52,15 @@ class NavigationItem {
         }
 
         const onFocus = () => this.setActive(false);
-        const onMouseEnter = () => this._onMouseEnter();
+        const onMouseMove = () => this._onMouseMove();
 
         this.target.addEventListener("focus", onFocus);
-        this.target.addEventListener("mouseenter", onMouseEnter);
+        this.target.addEventListener("mousemove", onMouseMove);
 
         /**@private*/
         this._removeListeners = () => {
             this.target.removeEventListener("focus", onFocus);
-            this.target.removeEventListener("mouseenter", onMouseEnter);
+            this.target.removeEventListener("mousemove", onMouseMove);
         };
     }
 
@@ -62,7 +71,7 @@ class NavigationItem {
 
     setActive(focus = true) {
         scrollTo(this.target);
-        this._setActiveItem(this.index);
+        this._navigator._setActiveItem(this.index);
         this.target.classList.add(ACTIVE_ELEMENT_CLASS);
 
         if (focus && !this._options.virtualFocus) {
@@ -72,11 +81,22 @@ class NavigationItem {
     }
 
     /**
+     * @deprecated
      * @private
      */
     _onMouseEnter() {
         this.setActive(false);
         this._options.onMouseEnter?.(this);
+    }
+
+    /**
+     * @private
+     */
+    _onMouseMove() {
+        if (this._navigator.activeItem !== this) {
+            this.setActive(false);
+            this._options.onMouseEnter?.(this);
+        }
     }
 }
 
@@ -263,7 +283,7 @@ export class Navigator {
                 index: i,
                 el: elements[i],
                 options: this._options,
-                setActiveItem: (index) => this._setActiveItem(index),
+                navigator: this,
             });
 
             if (i >= this.items.length) {

--- a/addons/web/static/tests/core/autocomplete.test.js
+++ b/addons/web/static/tests/core/autocomplete.test.js
@@ -2,6 +2,7 @@ import { expect, test } from "@odoo/hoot";
 import {
     isInViewPort,
     isScrollable,
+    manuallyDispatchProgrammaticEvent,
     pointerDown,
     pointerUp,
     press,
@@ -806,4 +807,50 @@ test("autocomplete scrolls when moving with arrows", async () => {
     expect(activeItemSelector).toHaveText("Never");
     expect(isInViewWithinScrollableY(activeItemSelector)).toBe(true, { message: msgInView });
     expect(isInViewWithinScrollableY(".o-autocomplete--dropdown-item:last")).toBe(false, { message: "last " + msgNotInView });
+});
+
+test("items are selected only when the mouse moves, not just on enter", async () => {
+    class Parent extends Component {
+        static template = xml`
+            <AutoComplete value="''" sources="[source]" onSelect.bind="onSelect"/>
+        `;
+        static props = ["*"];
+        static components = { AutoComplete };
+        get source() {
+            return {
+                options: [
+                    { label: "one" },
+                    { label: "two" },
+                    { label: "three" },
+                ],
+            };
+        }
+        onSelect(option) {}
+    }
+
+    // In this test we use custom events to prevent unwanted mouseenter/mousemove events
+
+    await mountWithCleanup(Parent);
+    queryOne(`.o-autocomplete input`).focus();
+    queryOne(`.o-autocomplete input`).click();
+    await animationFrame();
+
+    expect(".o-autocomplete--dropdown-item:nth-child(1) .dropdown-item").toHaveClass("ui-state-active");
+
+    const item2 = queryOne(".o-autocomplete--dropdown-item:nth-child(2)");
+    await manuallyDispatchProgrammaticEvent(item2, "mouseenter");
+    await animationFrame();
+    // mouseenter should be ignored
+    expect(".o-autocomplete--dropdown-item:nth-child(2) .dropdown-item").not.toHaveClass("ui-state-active");
+
+    await press("arrowdown");
+    await animationFrame();
+    expect(".o-autocomplete--dropdown-item:nth-child(2) .dropdown-item").toHaveClass("ui-state-active");
+
+    await manuallyDispatchProgrammaticEvent(item2, "mousemove");
+    const item3 = queryOne(".o-autocomplete--dropdown-item:nth-child(3)");
+    await manuallyDispatchProgrammaticEvent(item3, "mouseenter");
+    await animationFrame();
+    expect(".o-autocomplete--dropdown-item:nth-child(2) .dropdown-item").not.toHaveClass("ui-state-active");
+    expect(".o-autocomplete--dropdown-item:nth-child(3) .dropdown-item").toHaveClass("ui-state-active");
 });

--- a/addons/web/static/tests/core/navigation_hook.test.js
+++ b/addons/web/static/tests/core/navigation_hook.test.js
@@ -2,7 +2,7 @@ import { Component, xml } from "@odoo/owl";
 import { Navigator, useNavigation } from "@web/core/navigation/navigation";
 import { useAutofocus } from "@web/core/utils/hooks";
 import { describe, destroy, expect, test } from "@odoo/hoot";
-import { hover, press } from "@odoo/hoot-dom";
+import { hover, manuallyDispatchProgrammaticEvent, press, queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import {
     asyncStep,
@@ -210,4 +210,36 @@ test("navigation disabled when component is destroyed", async () => {
     await waitForSteps(["enable"]);
     destroy(component);
     await waitForSteps(["disable"]);
+});
+
+test("items are focused only on mousemove, not on mouseenter", async () => {
+    class Parent extends BasicHookParent {
+        navOptions = {
+            onMouseEnter: () => expect.step("onMouseEnter"),
+        };
+    }
+    await mountWithCleanup(Parent);
+
+    expect(".one").toBeFocused();
+
+    manuallyDispatchProgrammaticEvent(queryOne(".two"), "mouseenter");
+    await animationFrame();
+    // mouseenter should be ignored
+    expect(".two").not.toHaveClass("focus");
+
+    await press("arrowdown");
+    await animationFrame();
+    expect(".two").toHaveClass("focus");
+
+    manuallyDispatchProgrammaticEvent(queryOne(".three"), "mousemove");
+    await animationFrame();
+    // mousemove should not be ignored
+    expect(".three").toHaveClass("focus");
+    expect(".two").not.toHaveClass("focus");
+    expect.verifySteps(["onMouseEnter"]);
+
+    manuallyDispatchProgrammaticEvent(queryOne(".three"), "mousemove");
+    await animationFrame();
+    expect(".three").toHaveClass("focus");
+    expect.verifySteps([]); // onMouseEnter is not triggered again
 });


### PR DESCRIPTION
The mouse cursor automaticaly selects dropdown and autocomplete items if the mouse is on top of the item when the menu opens, this is not expected.

After this commit, the mouse cursor only select items if it moves.

Task: 4687065

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
