### PR TITLE
[FIX] partner_autocomplete: use correct value for placeholder

### DIFF
--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -32,7 +32,7 @@
                     sources="sources"
                     onSelect.bind="onSelect"
                     input="inputRef"
-                    placeholder="placeholder || ''"
+                    placeholder="props.placeholder || ''"
                 >
                     <t t-set-slot="partnerOption" t-slot-scope="partnerOptionScope">
                         <t t-call="partner_autocomplete.DropdownOption">


### PR DESCRIPTION
With this commit https://github.com/odoo/odoo/commit/752d159aa7b79344ff7b513ec9838a902f08ce9d we have built-in placeholder_field option for most fields,
so the `placeholder` getter was removed from the char field. However, a reference
to it remained in the partner_autocomplete widget, which led to empty placeholders
being displayed on fields.

This commit replaces it with placeholder in props.

