### PR TITLE
[FIX] l10n_cl: vat format on invoice report

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -249,7 +249,7 @@ class AccountMove(models.Model):
                     'tax_ids': gd.tax_ids,
                 }
             )
-        values['vat_percent'] = '%.2f' % vat_percent if vat_percent > 0 else False
+        values['vat_percent'] = '%.2f%%' % vat_percent if vat_percent > 0 else False
         return values
 
     def _l10n_cl_get_withholdings(self):


### PR DESCRIPTION
The percentage sign is missing on the tax line
in the invoice report

opw-4661577
