### PR TITLE
[FIX] website_sale: no href for address form

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -611,10 +611,13 @@ class Website(models.Model):
         next_step = current_step._get_next_checkout_step(allowed_steps_domain)
         previous_step = current_step._get_previous_checkout_step(allowed_steps_domain)
 
-        # try_skip_step option required on /shop/checkout next button
         next_href = next_step.step_href
+        # try_skip_step option required on /shop/checkout next button
         if next_step.step_href == '/shop/checkout':
             next_href = '/shop/checkout?try_skip_step=true'
+        # redirect handled by '/shop/address/submit' route when all values are properly filled
+        if request.httprequest.path == '/shop/address':
+            next_href = False
 
         return {
             'current_website_checkout_step_href': href,


### PR DESCRIPTION
The redirection after submitting the address form has to be handled
by the controllers itself to ensure that all values are filled and
corrects before redirecting.

Issue
-----
The address form can be submitted with invalid or empty values.
An automatic redirection sends the customer back to the address form
as some values are missing but with no clues on the failing elements.

 Cause
------
Commit https://github.com/odoo-dev/odoo/commit/f581b3a92e688491673dfd4af04106d5e7404d8b introduces the bug by moving the submit of the form
to the navigation buttons with href handling redirection.
Fixed with commit https://github.com/odoo-dev/odoo/commit/f2948218da0e59776e5cf42ea07a84d8553fc63b.
Lost during rebase with commit https://github.com/odoo-dev/odoo/commit/7132a4745c6b269a11754381f943cf5674e0024a refactoring the navigation
buttons logic.

Solution
--------
Consider href False when on address form page. Letting then the
controller do his job to redirect after checking the values are
valid.