### PR TITLE
[FIX] account: Ignore zero balance lines in reconciliation

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2354,6 +2354,7 @@ class AccountMoveLine(models.Model):
                                     This is usefull if you want to preview the reconciliation before doing some changes
                                     on amls like changing a date or an account.
         """
+        self = self.filtered(lambda x: x.balance or x.amount_currency)  # noqa: PLW0642
         if not self:
             return
 


### PR DESCRIPTION
Description of the issue this commit addresses:

Zero balance lines are creating friction when reconciling lines. They will never need a renconciliation but they still impair the user's ability to reconcile other lines together if selected.

---

Desired behavior after this commit is merged:

When reconciling lines, the zero balance ones are simply ignored and the reconciliation proceeds as if they were not selected.

---

task-4723956

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
