### PR TITLE
[FIX] project: allow project user to subscribe partners to task

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1460,7 +1460,7 @@ class Task(models.Model):
     def message_subscribe(self, partner_ids=None, subtype_ids=None):
         """ Set task notification based on project notification preference if user follow the project"""
         if not subtype_ids:
-            project_followers = self.project_id.message_follower_ids.filtered(lambda f: f.partner_id.id in partner_ids)
+            project_followers = self.project_id.sudo().message_follower_ids.filtered(lambda f: f.partner_id.id in partner_ids)
             for project_follower in project_followers:
                 project_subtypes = project_follower.subtype_ids
                 task_subtypes = (project_subtypes.mapped('parent_id') | project_subtypes.filtered(lambda sub: sub.internal or sub.default)).ids if project_subtypes else None

--- a/doc/cla/corporate/moduon.md
+++ b/doc/cla/corporate/moduon.md
@@ -16,4 +16,4 @@ moduonbot moduonbot@moduon.team https://github.com/moduonbot
 Rafael Blasco rblasco@moduon.team https://github.com/rafaelbn
 Andrea Cattalani andrea@moduon.team https://github.com/anddago78 (up to 2024-01-31)
 Emilio Pascual emilio@moduon.team https://github.com/emiliopascual
-David Vidal david.vidal@moduon.team https://github.com/chienandalu
+David Vidal david@moduon.team https://github.com/chienandalu


### PR DESCRIPTION
Description of the issue/feature this PR addresses:


Current behavior before PR:

Project users can't subscribe partners in projectw which visibility is set to 'Invited internal users':

- Set a project to that visibility type.
- Create a task.
- Assign a user outside the project who just has 'Project user' permissions to that task.
- With that user: in the task, try to subscribe a partner to the chatter.
- With that user: in the chatter, try to mention a partner who's not subscribed to the task's thread.

The user couldn't subscribe any user due to permission issues on project.project.

Desired behavior after PR is merged:

User's are able to operate normally where access is granted.

OPW-4725100 MT-9830

cc @moduon @rafaelbn @EmilioPascual 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
