### PR TITLE
[FIX] im_livechat: prevent error on opening website due to invalid url regex

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -386,7 +386,7 @@ class ImLivechatChannelRule(models.Model):
             for rule in rules:
                 # url might not be set because it comes from referer, in that
                 # case match the first rule with no regex_url
-                if not re.search(rule.regex_url or "", url or ""):
+                if not re.search(re.escape(rule.regex_url) or "", url or ""):
                     continue
                 if rule.chatbot_script_id and (
                     not rule.chatbot_script_id.active or not rule.chatbot_script_id.script_step_ids


### PR DESCRIPTION
Setting special regex characters for`regex_url` inside live chat rules throws unhandled regex error.

**Steps to reproduce:**
- Install `website` and `im_livechat`
- Go to `livechat>YourWebsite.com Dropdown Menu>configure channel`
- Go to `channel rules>Add a line`
- Inside URL Regex field enter any of the quantifier regex such as `+`, `*`, `
`{any number}`, `[]`,`{any number range start,any number range limit}` and save
the rule.
-Open `website`.

Error:
`re.error: nothing to repeat at position 0`

**Solution:**
- We use `re.escape()` to safely handle user input that may contain special regex characters.

**Sentry-6538643923**