### PR TITLE
[IMP] stock, sale_stock: improve late availability filter for pickings and so

### DIFF
--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -112,4 +112,15 @@
         </field>
     </record>
 
+    <record id="sale_stock_sale_order_view_search_inherit" model="ir.ui.view">
+        <field name="name">sale_stock.sale.order.search.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.sale_order_view_search_inherit_sale"/>
+        <field name="arch" type="xml">
+            <filter name="order_date" position="after">
+                <filter string="Late Availability" name="late_availability" domain="[('late_availability', '=', True)]"/>
+            </filter>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2471,7 +2471,7 @@ Please change the quantity done or the rounding precision in your settings.""",
             moves = self - search_moves
         else:
             raise UserError(_('Operation not supported'))
-        return len(moves) == len(self)
+        return bool(moves)
 
     def _break_mto_link(self, parent_move):
         self.move_orig_ids = [Command.unlink(parent_move.id)]


### PR DESCRIPTION
With this commit
================
- Updated picking filter to show pickings with any late items.
- Added support for filtering sale orders by late pickings.

Task: [4652545](https://www.odoo.com/odoo/my-tasks/4652545)

