### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: improve withholding taxes in UBL TR

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/__manifest__.py
+++ b/addons/l10n_tr_nilvera_einvoice/__manifest__.py
@@ -8,6 +8,7 @@ For sending and receiving electronic invoices to Nilvera.
     'depends': ['l10n_tr_nilvera', 'account_edi_ubl_cii'],
     'data': [
         'data/cron.xml',
+        'data/ubl_tr_templates.xml',
         'views/account_journal_dashboard_views.xml',
         'views/account_move_views.xml',
         'wizard/account_move_send_views.xml',

--- a/addons/l10n_tr_nilvera_einvoice/data/ubl_tr_templates.xml
+++ b/addons/l10n_tr_nilvera_einvoice/data/ubl_tr_templates.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="ubl_21_InvoiceType_tr" inherit_id="account_edi_ubl_cii.ubl_20_InvoiceType" primary="True">
+        <xpath expr="//*[local-name()='TaxTotal']" position="replace">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" 
+               t-foreach="vals.get('tax_total_vals', [])"
+               t-as="foreach_vals">
+                <t t-if="foreach_vals.get('tax_amount') >= 0">
+                    <cac:TaxTotal>
+                        <t t-call="{{TaxTotalType_template}}">
+                            <t t-set="vals" t-value="foreach_vals"/>
+                        </t>
+                    </cac:TaxTotal>
+                </t>
+                <t t-else="">
+                    <cac:WithholdingTaxTotal>
+                        <t t-call="{{TaxTotalType_template}}">
+                            <t t-set="vals" t-value="foreach_vals"/>
+                        </t>
+                    </cac:WithholdingTaxTotal>
+                </t>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_21_InvoiceLineType_tr" inherit_id="account_edi_ubl_cii.ubl_20_InvoiceLineType" primary="True">
+        <xpath expr="//*[local-name()='TaxTotal']" position="replace">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" 
+               t-foreach="vals.get('tax_total_vals', [])"
+               t-as="foreach_vals">
+                <t t-if="foreach_vals.get('tax_amount') >= 0">
+                    <cac:TaxTotal>
+                        <t t-call="{{TaxTotalType_template}}">
+                            <t t-set="vals" t-value="foreach_vals"/>
+                        </t>
+                    </cac:TaxTotal>
+                </t>
+                <t t-else="">
+                    <cac:WithholdingTaxTotal>
+                        <t t-call="{{TaxTotalType_template}}">
+                            <t t-set="vals" t-value="foreach_vals"/>
+                        </t>
+                    </cac:WithholdingTaxTotal>
+                </t>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_20_TaxTotalType_tr" inherit_id="account_edi_ubl_cii.ubl_20_TaxTotalType">
+        <xpath expr="//*[local-name()='TaxAmount']" position="replace">
+            <cbc:TaxAmount
+                xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+                xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(abs(vals.get('tax_amount')), vals.get('currency_dp'))"/>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxSubtotal']/*[local-name()='TaxAmount']" position="replace">
+            <cbc:TaxAmount
+                xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+                xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                t-att-currencyID="foreach_vals['currency'].name"
+                t-out="format_float(abs(foreach_vals.get('tax_amount')), foreach_vals.get('currency_dp'))"/>
+        </xpath>
+        <xpath expr="//*[local-name()='Percent']" position="replace">
+            <cbc:Percent
+                xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+                xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                t-out="abs(foreach_vals.get('percent'))"/>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -25,6 +25,12 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         # EXTENDS account.edi.xml.ubl_21
         vals = super()._export_invoice_vals(invoice)
 
+        vals.update({
+            'InvoiceType_template': 'l10n_tr_nilvera_einvoice.ubl_21_InvoiceType_tr',
+            'InvoiceLineType_template': 'l10n_tr_nilvera_einvoice.ubl_21_InvoiceLineType_tr',
+            'TaxTotalType_template': 'l10n_tr_nilvera_einvoice.ubl_20_TaxTotalType_tr',
+        })
+
         # Check the customer status if it hasn't been done before as it's needed for profile_id
         if invoice.partner_id.l10n_tr_nilvera_customer_status == 'not_checked':
             invoice.partner_id.check_nilvera_customer()
@@ -105,7 +111,7 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         res = []
         for tax in taxes:
             is_withholding = invoice.currency_id.compare_amounts(tax.amount, 0) == -1
-            tax_type_code = '9015' if is_withholding else '0015'
+            tax_type_code = '602' if is_withholding else '0015' #'9015' if is_withholding else '0015'
             tax_scheme_name = 'KDV Tevkifatı' if is_withholding else 'Gerçek Usulde KDV'
             res.append({
                 'id': tax_type_code,


### PR DESCRIPTION
When using withholding taxes, the taxes amounts are negative, which is refused by the TR servers for bad format. In UBL 2.1, there is the `WithholdingTaxTotal` node, of the type `TaxTotalType`, which is designed specifically for withholding taxes. The TR version of UBL 1.2 should accept it and this should resolve our problem.

WIP