### PR TITLE
[FIX] mass_mailing: compute error message only if type=mail

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -344,7 +344,8 @@ class MassMailing(models.Model):
 
     @api.depends('email_from', 'mail_server_id')
     def _compute_warning_message(self):
-        for mailing in self:
+        self.warning_message = False
+        for mailing in self.filtered(lambda mailing: mailing.mailing_type == "mail"):
             mail_server = mailing.mail_server_id
             if mail_server and not mail_server._match_from_filter(mailing.email_from, mail_server.from_filter):
                 mailing.warning_message = _(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
mailing.mailing model is reused between Mail Marketing and SMS Marketing apps, however warning message defined in Mail Marketing about incorrect mail server is not relevant for SMS Marketing.
Affected versions : 16.0+ (probably since v13.0 but older versions not maintained anymore)

Current behavior before PR:
In some cases, you can end up with a warning on SMS mailing form stating "This email from can not be used with this mail server.[...]"

For instance you can end up in this case if : 
- You have defined an ir.config_parameter mass_mailing.mail_server_id
- from_filter from this mail_server does not match email_from from user creating SMS Marketing

Desired behavior after PR is merged:
The above warning is only relevant for Mail marketing but not for SMS marketing.

This PR therefore proposes to generate warning message only if mailing_type == "mail"




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
