### PR TITLE
[FIX] web: Sample Server - Handle max/min aggregators

### DIFF
--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -165,7 +165,7 @@ export class SampleServer {
     _aggregateFields(measures, records) {
         const group = {};
         for (const { fieldName, func, name } of measures) {
-            if (["sum", "avg"].includes(func)) {
+            if (["sum", "avg", "max", "min"].includes(func)) {
                 if (!records.length) {
                     group[name] = false;
                 } else {
@@ -173,7 +173,6 @@ export class SampleServer {
                     for (const record of records) {
                         group[name] += record[fieldName];
                     }
-                    // TODO: avg ? lot of test to change for it
                 }
                 group[name] = this._sanitizeNumber(group[name]);
             } else if (func === "array_agg") {
@@ -650,9 +649,10 @@ export class SampleServer {
         const groupedByM2O = groupByField.type === "many2one";
         if (groupedByM2O) {
             // re-populate co model with relevant records
-            this.data[groupByField.relation].records = groups.map((g) => {
-                return { id: g[groupBy][0], display_name: g[groupBy][1] };
-            });
+            this.data[groupByField.relation].records = groups.map((g) => ({
+                id: g[groupBy][0],
+                display_name: g[groupBy][1],
+            }));
         }
         for (const r of this.data[params.model].records) {
             const group = getSampleFromId(r.id, groups);

--- a/addons/web/static/tests/model/sample_server.test.js
+++ b/addons/web/static/tests/model/sample_server.test.js
@@ -287,6 +287,19 @@ describe("RPC calls", () => {
         expect(result.groups.every((g) => g.__count === g.__recordIds.length)).toBe(true);
     });
 
+    test("'web_read_group': 'max' aggregator", async () => {
+        const server = new DeterministicSampleServer("res.users", fields["res.users"]);
+        const result = await server.mockRpc({
+            method: "web_read_group",
+            model: "res.users",
+            groupBy: ["name"],
+            aggregates: ["age:max", "height:min"],
+        });
+        // didn't crash, but we can't assert the aggregate values as they are non deterministic,
+        // and we don't really mind actually (max/min aren't even implemented, they behave as sum)
+        expect(result.length).toEqual(5);
+    });
+
     test("'formatted_read_group': groupBy", async () => {
         const server = new DeterministicSampleServer("hobbit", fields.hobbit);
         const result = await server.mockRpc({


### PR DESCRIPTION
The click-all tests were failing for the `fleet.vehicle.odometer.value` field when the aggregator was set to `max`. This was due to the Sample Server implementation not supporting `max` or `min` aggregators (see https://runbot.odoo.com/odoo/error/161783).

This commit adds support for `max` and `min` aggregators in the Sample Server. The implementation mirrors the behavior of the `sum` aggregator, as the primary purpose of the Sample Server is to display dummy data to the user. This keeps the implementation simple while resolving the test failures.