### PR TITLE
[FIX] mail: `@mention` suggestion hover does not affect keyboard nav

### DIFF
--- a/addons/mail/static/src/core/common/navigable_list.dark.scss
+++ b/addons/mail/static/src/core/common/navigable_list.dark.scss
@@ -1,3 +1,4 @@
 .o-mail-NavigableList {
     --mail-NavigableList-activeBgColor: #{mix($white, $o-action, 90%)};
+    --mail-NavigableList-hoverBgColor: #{mix($white, $o-action, 82.5%)};
 }

--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -170,7 +170,5 @@ export class NavigableList extends Component {
         ev.preventDefault();
     }
 
-    onOptionMouseEnter(index) {
-        this.state.activeIndex = index;
-    }
+    onOptionMouseEnter(index) {}
 }

--- a/addons/mail/static/src/core/common/navigable_list.scss
+++ b/addons/mail/static/src/core/common/navigable_list.scss
@@ -6,6 +6,10 @@
     background-color: var(--mail-NavigableList-activeBgColor, mix($o-view-background-color, $o-action, 90%));
 }
 
+.o-mail-NavigableList-item:hover {
+    background-color: var(--mail-NavigableList-hoverBgColor, mix($o-view-background-color, $o-action, 95%));
+}
+
 .o-mail-NavigableList-floatingLoading {
     right: $border-width; // as to not overlap border
 }


### PR DESCRIPTION
Before this commit, when typing a `@mention` in a discuss or chatter composer, pressing ENTER was selecting the item hovered on cursor rather than the 1st item.

This happens because by default the active suggestion is the 1st one in list, and keyboard navigation changes the active item. However mouse-enter was also selecting the active item. When the suggestion opens initially, if the cursor happens to be on the list, it is being considered as a `mouseenter` this it sets the active suggestion.

This is a problem because this is very prone to mistakes. The feature to set the active item for following keyboard navigation is very niche and not necessarily much intuitive than just typing more specific search and rely solely on keyboard navigation or mouse-click.

One solution could be to only take mouse hover into account if it moves after the suggestion list is rendered, but this is still prone to mistakes like people typing on a laptop keyboard while accidentally touching the trackpad.

This commit fixes the issue by making mouse-hover on suggestion list only trigger the visual style but it doesn't change the internal state of the active suggestion.

Task-4724275

Cursor in middle of suggestion list, quickly `@` + `ENTER`
Before (selects suggestion in middle of list, at cursor position)
![Apr-14-2025 15-23-50](https://github.com/user-attachments/assets/afdc08fe-d79e-4faf-9bc6-f0050584300f)
After (selects 1st suggestion in list, independently of cursor position in list)
![Apr-14-2025 15-21-04](https://github.com/user-attachments/assets/a309183e-7576-40c1-aca8-251dcff42ff6)

