### PR TITLE
[IMP] sale_project: prevent duplicate project creation from on-fly SO

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -246,6 +246,7 @@ class ProjectProject(models.Model):
             **ast.literal_eval(action_window['context']),
             "create": self.env.context.get("create_for_project_id", embedded_action_context),
             "show_sale": True,
+            "disable_project_task_generation": True,
             "default_partner_id": self.partner_id.id,
             "default_project_id": self.id,
             "create_for_project_id": self.id if not embedded_action_context else False,

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -271,6 +271,7 @@ class SaleOrder(models.Model):
         if project or task:
             service_sol = next((sol for sol in created_records.order_line if sol.is_service), self.env['sale.order.line'])
             if project and not project.sale_line_id:
+                created_records.with_context(disable_project_task_generation=True).action_confirm()
                 project.sale_line_id = service_sol
                 if not project.reinvoiced_sale_order_id:
                     project.reinvoiced_sale_order_id = service_sol.order_id or created_records[0] if created_records else False

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -118,7 +118,15 @@
                 </group>
             </xpath>
             <xpath expr="//page[@name='settings']//field[@name='privacy_visibility']" position="after">
-                <field name="reinvoiced_sale_order_id" invisible="not allow_billable or not partner_id or is_template"  context="{'default_partner_id': partner_id}"/>
+                <field name="reinvoiced_sale_order_id"
+                    invisible="not allow_billable or not partner_id or is_template"
+                    options="{'no_quick_create': True}"
+                    context="{
+                        'form_view_ref': 'sale_project.view_order_simple_form',
+                        'create_for_project_id': id,
+                        'default_partner_id': partner_id
+                    }"
+                />
                 <label for="sale_line_id" invisible="not allow_billable or not partner_id or is_template"/>
                 <div 
                     class="o_row" 


### PR DESCRIPTION
When a user creates a Sales Order on the fly from a project, a new project and task are created automatically. As a result, the user has to delete or archive the duplicate project manually.
To simplify the process for the user, this commit prevents such duplication. there by saving the user's time.

Task: 4306263
