### PR TITLE
[FIX] html_editor: wait longer to check link popover is closed

### DIFF
--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -962,7 +962,7 @@ test("link preview in Link Popover", async () => {
     });
     // Click on Discard button to undo changes.
     await contains(".o-we-linkpopover .o_we_discard_link").click();
-    await waitForNone(".o-we-linkpopover", { root: document, timeout: 500 });
+    await waitForNone(".o-we-linkpopover", { root: document, timeout: 1500 });
     expect(".o-we-linkpopover").toHaveCount(0);
     expect(".test_target a").toHaveText("This website");
 
@@ -992,7 +992,7 @@ test("link preview in Link Popover", async () => {
 
     // Move selection outside for auto-save.
     setSelectionInHtmlField(".test_target");
-    await waitForNone(".o-we-linkpopover", { root: document, timeout: 500 });
+    await waitForNone(".o-we-linkpopover", { root: document, timeout: 1500 });
     expect(".o-we-linkpopover").toHaveCount(0);
     expect(".test_target a").toHaveText("Final label", {
         message: "The link's label should be updated",


### PR DESCRIPTION
Before this commit: test fail because of timeout

After this commit: like the tests in popover.test.js, we wait longer when checking popover is closed

runbot-163251




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
