### PR TITLE
[IMP] hr_holiday: new col in timeoff type duration type and small UI and bug fix

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -105,7 +105,7 @@ class HrLeaveType(models.Model):
     request_unit = fields.Selection([
         ('day', 'Day'),
         ('half_day', 'Half-Day'),
-        ('hour', 'Hours')], default='day', string='Take Time Off in', required=True)
+        ('hour', 'Hours')], default='day', string='Duration Type', required=True)
     unpaid = fields.Boolean('Is Unpaid', default=False)
     include_public_holidays_in_duration = fields.Boolean('Ignore Public Holidays', default=False, help="Public holidays should be counted in the leave duration when applying for leaves")
     leave_notif_subtype_id = fields.Many2one('mail.message.subtype', string='Time Off Notification Subtype', default=lambda self: self.env.ref('hr_holidays.mt_leave', raise_if_not_found=False))

--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -116,7 +116,7 @@ export class TimeOffCalendarModel extends CalendarModel {
         if (!this.employeeId) {
             context["short_name"] = 1;
         }
-        const fieldNamesToAdd = resModel === "hr.leave" ? ["request_unit_half", "request_date_from_period"] : [];
+        const fieldNamesToAdd = resModel === "hr.leave" ? ["request_unit_half", "request_date_from_period", "request_unit_hours"] : [];
         return this.orm.searchRead(resModel, this.computeDomain(data), [...fieldNames, ...fieldNamesToAdd], { context });
     }
 

--- a/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
+++ b/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
@@ -78,6 +78,14 @@ export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
                 ? classesToAdd.push("o_event_half_left")
                 : classesToAdd.push("o_event_half_right");
         }
+        // handling half pill UX for custom_hours
+        if (record?.rawRecord?.request_unit_hours) {
+            if (record.end.c.hour < 12) {
+                classesToAdd.push("o_event_half_left");
+            } else if (record.end.c.hour >= 12) {
+                classesToAdd.push("o_event_half_right");
+            }
+        }
         return classesToAdd;
     }
 }

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -150,6 +150,7 @@
             <list string="Time Off Type" multi_edit="1">
                 <field name="sequence" widget="handle"/>
                 <field name="display_name"/>
+                <field name="request_unit" optional="hide"/>
                 <field name="leave_validation_type" optional="hide" string="Time Off Approval"/>
                 <field name="responsible_ids" widget="many2many_tags" invisible="leave_validation_type in ['no_validation', 'manager'] and (not requires_allocation or allocation_validation_type != 'hr')" optional="hide"/>
                 <field name="requires_allocation" optional="hide"/>


### PR DESCRIPTION
- Added the column "Duration Type" in the Time Off Types list view and set it as optional
- When it is "Custom hours", if the start time is (0 - 11:59), show the left half capsule (same as Morning leave), and for (12:00 - 23:59), show the right half capsule (same as the Afternoon leave)

task-4702467

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
