### PR TITLE
[IMP] account{,_edi_ubl_cii}: Export XMLs

### DIFF
--- a/addons/account/controllers/download_docs.py
+++ b/addons/account/controllers/download_docs.py
@@ -4,6 +4,7 @@ import io
 import zipfile
 
 from odoo import http, _
+from odoo.exceptions import UserError
 from odoo.http import request, content_disposition
 
 
@@ -50,12 +51,13 @@ class AccountDocumentDownloadController(http.Controller):
         invoices.line_ids.check_access('read')
         docs_data = []
         for invoice in invoices:
-            doc_data = invoice._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback)
-            if doc_data:
+            if doc_data := invoice._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback):
+                if (errors := doc_data.get('errors')) and len(invoices) == 1:
+                    raise UserError(_("Error while creating XML:\n- %s", '\n- '.join(errors)))
                 docs_data.append(doc_data)
         if len(docs_data) == 1:
             doc_data = docs_data[0]
-            headers = _get_headers(**doc_data)
+            headers = _get_headers(doc_data['filename'], doc_data['filetype'], doc_data['content'])
             return request.make_response(doc_data['content'], headers)
         elif len(docs_data) > 1:
             zip_content = _build_zip_from_data(docs_data)

--- a/addons/account/static/src/components/account_move_form/account_move_form.js
+++ b/addons/account/static/src/components/account_move_form/account_move_form.js
@@ -25,9 +25,6 @@ export class AccountMoveFormController extends FormController {
     }
 
     async loadExtraPrintItems() {
-        if (!this.model.root.isNew) {
-            return []
-        }
         return this.orm.call("account.move", "get_extra_print_items", [this.model.root.resId]);
     }
 

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -340,6 +340,7 @@ class AccountMove(models.Model):
 
     def _get_invoice_legal_documents(self, filetype, allow_fallback=False):
         # EXTENDS 'account'
+        self.ensure_one()
         if filetype == 'fatturapa':
             if fatturapa_attachment := self.l10n_it_edi_attachment_id:
                 return {


### PR DESCRIPTION
Add the possibility to generate the XML outside of the sending flow. This action is an equivalent of the print of PDF, it has no legal value, is not saved to the invoice record.

task-4546736
