### PR TITLE
[FIX] html_editor: consider all links as unclickable

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -242,9 +242,10 @@ export class LinkPlugin extends Plugin {
             { sequence: 50 }
         );
         this.addDomListener(this.editable, "click", (ev) => {
-            if (ev.target.tagName === "A" && ev.target.isContentEditable) {
+            const linkEl = ev.target.closest("a");
+            if (linkEl) {
                 if (ev.ctrlKey || ev.metaKey) {
-                    window.open(ev.target.href, "_blank");
+                    window.open(linkEl.href, "_blank");
                 }
                 ev.preventDefault();
             }


### PR DESCRIPTION
This commit changes the links behavior when clicking on them, in order
to consider any link as disabled, and not only those that are editable.
The ctrl + click behavior is kept for all links.

This will mostly be needed for website, where non-editable links can
appear in edit mode (e.g. social media, menus,...), and which we do not
want to be clickable, as they would leave the page we are editing.