### PR TITLE
[FIX] l10n_fr_post_cert: gap in order sequence

### DIFF
--- a/addons/l10n_fr_pos_cert/__manifest__.py
+++ b/addons/l10n_fr_pos_cert/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'France - VAT Anti-Fraud Certification for Point of Sale (CGI 286 I-3 bis)',
     'icon': '/l10n_fr/static/description/icon.png',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Accounting/Localizations/Point of Sale',
     'description': """
 This add-on brings the technical requirements of the French regulation CGI art. 286, I. 3° bis that stipulates certain criteria concerning the inalterability, security, storage and archiving of data related to sales to private individuals (B2C).

--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -22,6 +22,9 @@ class pos_config(models.Model):
                     config.current_session_id._check_session_timing()
         return super(pos_config, self).open_ui()
 
+    def _config_sequence_implementation(self):
+        return 'no_gap' if self.env.company._is_accounting_unalterable() else super()._config_sequence_implementation()
+
 
 class pos_session(models.Model):
     _inherit = 'pos.session'

--- a/addons/l10n_fr_pos_cert/upgrades/1.1/post-sequence-no-gap.py
+++ b/addons/l10n_fr_pos_cert/upgrades/1.1/post-sequence-no-gap.py
@@ -1,0 +1,12 @@
+def migrate(cr, version):
+    cr.execute("""
+        UPDATE ir_sequence iseq
+        SET implementation = 'no_gap'
+        FROM pos_config pconfig,res_company rcomp, res_country rcount, res_partner rpart
+        WHERE rcount.code in ('FR', 'MF', 'MQ', 'NC', 'PF', 'RE', 'GF', 'GP', 'TF', 'BL', 'PM', 'YT', 'WF')
+        AND rpart.country_id = rcount.id
+        AND rcomp.partner_id = rpart.id
+        AND pconfig.company_id = rcomp.id
+        AND (pconfig.sequence_id = iseq.id or pconfig.sequence_line_id = iseq.id)
+        AND iseq.implementation = 'standard'
+        """)

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -365,6 +365,9 @@ class PosConfig(models.Model):
         if not self.env.is_admin() and {'is_header_or_footer', 'receipt_header', 'receipt_footer'} & values.keys():
             raise AccessError(_('Only administrators can edit receipt headers and footers'))
 
+    def _config_sequence_implementation(self):
+        return 'standard'
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
@@ -376,6 +379,7 @@ class PosConfig(models.Model):
                 'prefix': "%s/" % vals['name'],
                 'code': "pos.order",
                 'company_id': vals.get('company_id', False),
+                'implementation': self._config_sequence_implementation(),
             }
             # force sequence_id field to new pos.order sequence
             vals['sequence_id'] = IrSequence.create(val).id


### PR DESCRIPTION
Steps to reproduce:
Using POS configs in french company with l10n_fr_post_cert module installed.
- Checkout 1: Prepare an order with several lines held in stock, to ensure that Odoo takes sufficient time for payment.
- Cash desk 2: Prepare an order
- Cash-desk 1: Start order payment.
- Cash-desk 2: Start order payment while cash-desk 1 is still paying.

Issue:
When writing 'paid' in a pos_order the l10n_fr_post_cert sets the l10n_fr_pos_cert_sequence_id field. A competition error occurs on cash desk 2 during payment: could not obtain lock on row in relation “ir_sequence”. The odoo.service.model retries to create the order and since the ir_sequence of pos_config used in the pos_order name is not set to "no_gap", the pos_order names have a gap equal to the number of retries.

Task-4708543

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
