### PR TITLE
[FIX] hr_homeworking_calendar: prevent error when changing time format in calendar

### DIFF
--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_year_renderer.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_year_renderer.js
@@ -1,0 +1,11 @@
+/** @odoo-module **/
+
+import { AttendeeCalendarYearRenderer } from "@calendar/views/attendee_calendar/year/attendee_calendar_year_renderer";
+import { patch } from "@web/core/utils/patch";
+
+patch(AttendeeCalendarYearRenderer, {
+    props: {
+        ...AttendeeCalendarYearRenderer.props,
+        openWorkLocationWizard: { type: Function, optional: true },
+    }
+});


### PR DESCRIPTION
**Issue**:
an error is thrown in debug mode when switching between calendar views ("year", "week", etc.) after changing the time format.

**Steps to reproduce:**
- ensure hr_homeworking_calendar is installed
- activate debug mode
- Calendar > change the time format

opw-4684831