### PR TITLE
[FIX] hr_expense: readonly tax on split wizard

### DIFF
--- a/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
@@ -20,7 +20,7 @@
                                 context="{'default_detailed_type': 'service', 'default_can_be_expensed': 1, 'tree_view_ref': 'hr_expense.product_product_expense_tree_view', 'form_view_ref': 'hr_expense.product_product_expense_form_view'}"
                             />
                             <field name="total_amount_currency" force_save="1" readonly="product_has_cost"/>
-                            <field name="tax_ids" widget="many2many_tags" readonly="not product_has_tax"/>
+                            <field name="tax_ids" widget="many2many_tags"/>
                             <field name="tax_amount_currency"/>
                             <field name="analytic_distribution" widget="analytic_distribution"
                                 optional="show"


### PR DESCRIPTION
This commit remove the readonly on the tax_ids field, in the expense_split wizard.

task-4703493