### PR TITLE
[FIX] mail: message translate shows lang code if cannot display name

### DIFF
--- a/addons/mail/controllers/google_translate.py
+++ b/addons/mail/controllers/google_translate.py
@@ -29,9 +29,13 @@ class GoogleTranslateController(Controller):
                 translation = request.env["mail.message.translation"].sudo().create(vals)
             except requests.exceptions.HTTPError as err:
                 return {"error": err.response.json()["error"]["message"]}
+        try:
+            lang_name = babel.Locale(translation.source_lang).get_display_name(request.env.user.lang)
+        except babel.UnknownLocaleError:
+            lang_name = translation.source_lang
         return {
             "body": translation.body,
-            "lang_name": babel.Locale(translation.source_lang).get_display_name(request.env.user.lang),
+            "lang_name": lang_name,
         }
 
     def _detect_source_lang(self, message):

--- a/addons/mail/tests/test_translation_controller.py
+++ b/addons/mail/tests/test_translation_controller.py
@@ -129,3 +129,9 @@ class TestTranslationController(HttpCaseWithUserDemo):
         self.authenticate("user_test_portal", "user_test_portal")
         with self.assertRaises(JsonRpcException, msg="odoo.exceptions.AccessError"), mute_logger("odoo.http"):
             self._mock_translation_request({"message_id": self.message.id})
+
+    def test_unknown_language(self):
+        self.authenticate("admin", "admin")
+        with patch.dict(SAMPLE, {"src": "unknown_by_babel_but_known_by_google_api"}):
+            result = self._mock_translation_request({"message_id": self.message.id})
+        self.assertEqual(result["body"], "<p>Au mauvais temps, bonne tête.</p>")


### PR DESCRIPTION
Before this commit, if the language name couldn't be detected by babel, attempting to translate the message resulted in a crash with `UnknownLocaleError`.

Steps to reproduce:
- make a livechat with visitor with `crh-Latn` locale
- as livechat operator, attempt to translate the message

This happens because babel is unable to parse `crh-Latn`, which stands for Crimean Tatar based on Latin script. This locale has been officially approved by the National Commission on the Crimean Tatar Language on April 4th [1], very recently from the date of this commit.

Because of the recency of the new locale, babel lack its parsing. Failure lead to error `UnknownLocaleError`, which is a problem because data of translated message also passes the Language name, which requires the good parsing of the locale by babel.

This commit fixes the issue by displaying the language name as the locale code in case babel was unable to parse it. In practice this happens rarely, and there's incentive to update babel as quickly as possible, but that's not a reason to display the translated message even if it cannot deduce the lang name.

[1]: https://babel.ua/en/news/116901-ukraine-approves-new-crimean-tatar-orthography-based-on-latin-script