### PR TITLE
[FIX] product: fix ptav cache issue on website

### DIFF
--- a/addons/website_sale/models/product_template_attribute_value.py
+++ b/addons/website_sale/models/product_template_attribute_value.py
@@ -36,3 +36,8 @@ class ProductTemplateAttributeValue(models.Model):
             )
 
         return price_extra
+
+    def write(self, vals):
+        res = super().write(vals)
+        self.env.registry.clear_cache()
+        return res


### PR DESCRIPTION
When updating ptav price extra value on the backend, the badge
which displays this value on the website does not properly update
to the current value of price extra while the actual price of the
product does. This causes a discrepancy between what the customer
views as the price extra versus what the price extra actually is.
This problem is due to a t-cache on product and pricelist in the
product template which was removed in v18.0. Since we cannot
force all customers to update their views if we remove the t-cache
on the view, a clear cache call is added to ptav write instead to
overcome this issue.

Issue was fixed in Odoo v18 in commit: https://github.com/odoo/odoo/commit/ad01a8dfa407407e33c4a8c84c5f1937ab81267b

To reproduce error on blank DB:
1) Go to any product that is for sale in website
2) Go to configure one of its attribute values
3) Change the price extra field of the selected ptav
4) View this product and the price extra badge on website

opw-4710687