### PR TITLE
[FIX] point_of_sale: correctly return the product when loaded

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -200,12 +200,15 @@ export class ProductScreen extends Component {
         }
 
         if (!product) {
-            await this.pos.data.callRelated("pos.session", "find_product_by_barcode", [
-                odoo.pos_session_id,
-                code.base_code,
-                this.pos.config.id,
-            ]);
+            const records = await this.pos.data.callRelated(
+                "pos.session",
+                "find_product_by_barcode",
+                [odoo.pos_session_id, code.base_code, this.pos.config.id]
+            );
             await this.pos.processProductAttributes();
+            if (records && records["product.product"].length > 0) {
+                return records["product.product"][0];
+            }
         }
 
         return product;


### PR DESCRIPTION
Before this commit, when scanning a barcode, if the product was loaded from the server, it would not return the product, causing issues in the flow.

commit that causes issue: https://github.com/odoo/odoo/commit/15a0c7ddcb01fb597f72bf02f05aaa5a66be5313

opw-4725585

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
