### PR TITLE
[FIX] web: TreeEditor: remove conditions in a sub connector

### DIFF
--- a/addons/web/static/src/core/tree_editor/tree_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor.js
@@ -149,9 +149,21 @@ export class TreeEditor extends Component {
         this.notifyChanges();
     }
 
-    delete(parent, node) {
+    _delete(ancestors, node) {
+        if (ancestors.length === 0) {
+            return;
+        }
+        const parent = ancestors.at(-1);
         const index = parent.children.indexOf(node);
         parent.children.splice(index, 1);
+        ancestors = ancestors.slice(0, ancestors.length - 1);
+        if (parent.children.length === 0) {
+            this._delete(ancestors, parent);
+        }
+    }
+
+    delete(ancestors, node) {
+        this._delete(ancestors, node);
         this.notifyChanges();
     }
 

--- a/addons/web/static/src/core/tree_editor/tree_editor.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor.xml
@@ -4,6 +4,7 @@
     <t t-name="web.TreeEditor">
         <div class="o_tree_editor w-100" aria-atomic="true" t-att-class="className">
             <div t-attf-class="o_tree_editor_node d-flex flex-column #{props.readonly ? (props.isSubTree ? 'gap-0' : 'gap-2') : 'gap-1'}">
+                <t t-set="ancestors" t-value="[]"/>
                 <t t-set="node" t-value="tree" />
                 <div class="o_tree_editor_row d-flex align-items-center flex-wrap" t-att-class="{'ps-4': props.isSubTree}">
                     <div class="o_tree_editor_connector d-flex flex-grow-1 align-items-center">
@@ -65,7 +66,7 @@
                 role="button"
                 title="Delete node"
                 aria-label="Delete node"
-                t-on-click="() => this.delete(parent, node)"
+                t-on-click="() => this.delete(ancestors, node)"
                 t-on-mouseenter="(ev) => this.highlightNode(ev.target, true)"
                 t-on-mouseleave="(ev) => this.highlightNode(ev.target, false)"
             >
@@ -113,6 +114,7 @@
         <t t-foreach="node.children" t-as="child" t-key="child.type + '_' + child_index">
             <div class="o_tree_editor_node" t-att-class="{ 'ps-4': addPadding || props.isSubTree }">
                 <t t-call="web.TreeEditor.{{ child.type }}">
+                    <t t-set="ancestors" t-value="[...ancestors, node]" />
                     <t t-set="parent" t-value="node" />
                     <t t-set="node" t-value="child" />
                 </t>

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -2740,3 +2740,16 @@ test("today operator for datetime field", async () => {
         `["&", ("datetime", ">=", "2019-03-10 23:00:00"), ("datetime", "<=", "2019-03-11 22:59:59")]`,
     ]);
 });
+
+test("remove all conditions in a sub connector", async () => {
+    await makeDomainSelector({
+        domain: `["&", ("bar", "!=", False), "|", ("id", "=", 1), ("id", "=", False)]`,
+        update(domain) {
+            expect.step(domain);
+        },
+    });
+    await clickOnButtonDeleteNode(3);
+    expect.verifySteps([`["&", ("bar", "!=", False), ("id", "=", 1)]`]);
+    await clickOnButtonDeleteNode(2);
+    expect.verifySteps([`[("bar", "!=", False)]`]);
+});


### PR DESCRIPTION
With https://github.com/odoo/odoo/pull/203931/commits/2e1e4ba478c6f0595614632ddc813a37ba05044b, we no more have to restore virtual operators, we simply keep them in the tree editor as long as the domain held by the parent is essentially the same as the one represented in the tree editor.
Thus without noticing it, we have introduced new possibilities in the tree editor: it is now possible to have two successive connectors with the same values (something we wanted) or have a sub connector with a single condition in it. In the latter case remove the condition leads to problems/crashes: a connector with no children does not really make sense in a domain. So we have to normalize things properly.
