### PR TITLE
[REF] iot_base: move longpolling from iot to iot_base

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -20,32 +20,43 @@ from odoo.addons.hw_drivers.tools import helpers, route
 
 _logger = logging.getLogger(__name__)
 
+DEVICE_TYPES = [
+    "display", "printer", "scanner", "keyboard", "camera", "device", "payment", "scale", "fiscal_data_module"
+]
+
 
 class DriverController(http.Controller):
     @route.iot_route('/hw_drivers/action', type='jsonrpc', cors='*', csrf=False, sign=True)
     def action(self, session_id, device_identifier, data):
-        """
-        This route is called when we want to make a action with device (take picture, printing,...)
+        """This route is called when we want to make an action with device (take picture, printing,...)
         We specify in data from which session_id that action is called
         And call the action of specific device
         """
-        iot_device = iot_devices.get(device_identifier)
-        if iot_device:
-            iot_device.data['owner'] = session_id
-            data = json.loads(data)
+        # If device_identifier is a type of device, we take the first device of this type
+        # required for longpolling with community db
+        if device_identifier in DEVICE_TYPES:
+            device_identifier = next((d for d in iot_devices if iot_devices[d].device_type == device_identifier), None)
 
-            # Skip the request if it was already executed (duplicated action calls)
-            iot_idempotent_id = data.get("iot_idempotent_id")
-            if iot_idempotent_id:
-                idempotent_session = iot_device._check_idempotency(iot_idempotent_id, session_id)
-                if idempotent_session:
-                    _logger.info("Ignored request from %s as iot_idempotent_id %s already received from session %s",
-                                 session_id, iot_idempotent_id, idempotent_session)
-                    return False
-            _logger.debug("Calling action %s for device %s", data.get('action', ''), device_identifier)
-            iot_device.action(data)
-            return True
-        return False
+        iot_device = iot_devices.get(device_identifier)
+
+        if not iot_device:
+            _logger.warning("IoT Device with identifier %s not found", device_identifier)
+            return False
+
+        iot_device.data['owner'] = session_id
+        data = json.loads(data)
+
+        # Skip the request if it was already executed (duplicated action calls)
+        iot_idempotent_id = data.get("iot_idempotent_id")
+        if iot_idempotent_id:
+            idempotent_session = iot_device._check_idempotency(iot_idempotent_id, session_id)
+            if idempotent_session:
+                _logger.info("Ignored request from %s as iot_idempotent_id %s already received from session %s",
+                             session_id, iot_idempotent_id, idempotent_session)
+                return False
+        _logger.debug("Calling action %s for device %s", data.get('action', ''), device_identifier)
+        iot_device.action(data)
+        return True
 
     @route.iot_route('/hw_drivers/check_certificate', type='http', cors='*', csrf=False)
     def check_certificate(self):

--- a/addons/hw_drivers/event_manager.py
+++ b/addons/hw_drivers/event_manager.py
@@ -48,7 +48,13 @@ class EventManager(object):
         }
         self.events.append(event)
         for session in self.sessions:
-            if device.device_identifier in self.sessions[session]['devices'] and not self.sessions[session]['event'].is_set():
+            session_devices = self.sessions[session]['devices']
+            if (
+                any(d in [device.device_identifier, device.device_type] for d in session_devices)
+                and not self.sessions[session]['event'].is_set()
+            ):
+                if device.device_type in session_devices:
+                    event['device_identifier'] = device.device_type  # allow to use device type as identifier
                 self.sessions[session]['result'] = event
                 self.sessions[session]['event'].set()
 

--- a/addons/iot_base/__manifest__.py
+++ b/addons/iot_base/__manifest__.py
@@ -14,4 +14,10 @@ Base tools required by all IoT related modules.
     'installable': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'assets': {
+        'web.assets_backend': [
+            'iot_base/static/src/network_utils/*',
+            'iot_base/static/src/device_controller.js',
+        ],
+    },
 }

--- a/addons/iot_base/static/src/@types/services.d.ts
+++ b/addons/iot_base/static/src/@types/services.d.ts
@@ -1,0 +1,7 @@
+declare module "services" {
+    import { iotLongpollingService } from "@iot_base/network_utils/longpolling";
+
+    export interface Services {
+        iot_longpolling: typeof iotLongpollingService
+    }
+}

--- a/addons/iot_base/static/src/device_controller.js
+++ b/addons/iot_base/static/src/device_controller.js
@@ -1,0 +1,39 @@
+import { uniqueId } from "@web/core/utils/functions";
+
+/**
+ * Used to communicate to the iot devices.
+ */
+export class DeviceController {
+    /**
+     * @param {import("@iot_base/network_utils/longpolling").IoTLongpolling} iotLongpolling
+     * @param {{ iot_ip: string, identifier: string, manual_measurement: string }} deviceInfo - Representation of an iot device
+     */
+    constructor(iotLongpolling, deviceInfo) {
+        this.id = uniqueId('listener-');
+        this.iotIp = deviceInfo.iot_ip;
+        this.identifier = deviceInfo.identifier;
+        this.manual_measurement = deviceInfo.manual_measurement;
+        this.iotLongpolling = iotLongpolling;
+    }
+
+    /**
+     * Send an action to the device.
+     * @param data - action to send to the device
+     * @param fallback - if true, no notification will be displayed on fail
+     */
+    action(data, fallback = false) {
+        return this.iotLongpolling.action(this.iotIp, this.identifier, data, fallback);
+    }
+
+    /**
+     * Add a listener to the device.
+     * @param callback - function to call when the listener is triggered
+     * @param fallback - if true, no notification will be displayed on fail
+     */
+    addListener(callback, fallback = false) {
+        return this.iotLongpolling.addListener(this.iotIp, [this.identifier], this.id, callback, fallback);
+    }
+    removeListener() {
+        return this.iotLongpolling.removeListener(this.iotIp, this.identifier, this.id);
+    }
+}

--- a/addons/iot_base/static/src/network_utils/http.js
+++ b/addons/iot_base/static/src/network_utils/http.js
@@ -1,0 +1,52 @@
+import { browser } from "@web/core/browser/browser";
+
+
+/**
+ * Comes from @web/views/utils.js
+ * Generate a unique identifier (64 bits) in hexadecimal.
+ *
+ * @returns {string}
+ */
+export function uuid() {
+    const array = new Uint8Array(8);
+    window.crypto.getRandomValues(array);
+    // Uint8Array to hex
+    return [...array].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Format the endpoint to send the request to
+ * Used to ensure the request is sent with the same protocol as the current page
+ * (e.g. if the current page is HTTPS, the request will be sent to the IoT Box using HTTPS)
+ * @param ip IP Address of the IoT Box
+ * @param route Route to send the request to
+ * @returns {string} The formatted endpoint
+ */
+export function formatEndpoint(ip, route) {
+    const url = new URL(window.location.href);
+    url.search = "";
+    url.hostname = ip;
+    url.pathname = route;
+    return url.toString();
+}
+
+/**
+ * Send a POST request to the IoT Box
+ * @param ip IP Address of the IoT Box
+ * @param route Endpoint to send the request to
+ * @param params Parameters to send with the request (optional)
+ * @param timeout Time before the request times out (default: 6000ms)
+ * @param headers HTTP headers to send with the request (optional)
+ * @returns {Promise<any>}
+ */
+export async function post(ip, route, params = {}, timeout = 6000, headers = {}) {
+    const endpoint = formatEndpoint(ip, route);
+    const response = await browser.fetch(endpoint, {
+        body: JSON.stringify({'params': params}),
+        method: "POST",
+        headers: {"Content-Type": "application/json", ...headers},
+        signal: AbortSignal.timeout(timeout),
+    });
+
+    return response.json();
+}

--- a/addons/iot_base/static/src/network_utils/longpolling.js
+++ b/addons/iot_base/static/src/network_utils/longpolling.js
@@ -1,0 +1,230 @@
+import { registry } from '@web/core/registry';
+import { post, uuid } from '@iot_base/network_utils/http';
+import { _t } from '@web/core/l10n/translation';
+
+export class IoTLongpolling {
+    static serviceDependencies = ["notification", "orm"];
+    actionRoute = '/hw_drivers/action';
+    pollRoute = '/hw_drivers/event';
+
+    rpcDelay = 1500;
+    maxRpcDelay = 15000;
+
+    _retries = 0;
+    _listeners = {};
+
+    constructor() {
+        this.setup(...arguments);
+    }
+
+    /**
+     * Setup in addition to constructor to allow patching
+     */
+    setup({ notification, orm }) {
+        this._session_id = uuid();
+        this._delayedStartPolling(this.rpcDelay);
+        this.notification = notification;
+        this.orm = orm;
+    }
+
+    /**
+     * Add a device_identifier to listeners[iot_ip] and restart polling
+     *
+     * @param {string} iot_ip
+     * @param {Array} devices list of devices
+     * @param {string} listener_id
+     * @param {boolean} fallback if true, no notification will be displayed on fail
+     * @param {Callback} callback
+     */
+    async addListener(iot_ip, devices, listener_id, callback, fallback = false) {
+        if (!this._listeners[iot_ip]) {
+            this._listeners[iot_ip] = {
+                last_event: 0,
+                devices: {},
+                session_id: this._session_id,
+                rpc: false,
+            };
+        }
+        for (const device of devices) {
+            this._listeners[iot_ip].devices[device] = {
+                listener_id: listener_id,
+                device_identifier: device,
+                callback: callback,
+            };
+        }
+        this.stopPolling(iot_ip);
+        this.startPolling(iot_ip, fallback);
+    }
+
+    /**
+     * Stop listening to iot device with id `device_identifier`
+     * @param {string} iot_ip
+     * @param {string} device_identifier
+     * @param {string} listener_id
+     */
+    removeListener(iot_ip, device_identifier, listener_id) {
+        const device = this._listeners[iot_ip].devices[device_identifier];
+        if (device && device.listener_id === listener_id) {
+            delete this._listeners[iot_ip].devices[device_identifier];
+        }
+    }
+
+    /**
+     * Execute an action on device_identifier
+     * Action depends on the driver that supports the device
+     *
+     * @param {string} iot_ip
+     * @param {string} device_identifier
+     * @param {Object} data contains the information needed to perform an action on this device_identifier
+     * @param {boolean} fallback if true, no notification will be displayed on fail
+     * @param {string} route endpoint to call on the IoT Box (default: /hw_drivers/action)
+     */
+    action(iot_ip, device_identifier, data, fallback = false, route = null) {
+        this.protocol = window.location.protocol;
+        const body = {
+            session_id: this._session_id,
+            device_identifier: device_identifier,
+            data: JSON.stringify(data),
+        };
+        return this._rpcIoT(iot_ip, route || this.actionRoute, body, undefined, fallback);
+    }
+
+    /**
+     * Start a long polling, i.e. it continually opens a long poll
+     * connection as long as it is not stopped (@see `stopPolling`)
+     * @param {string} iot_ip
+     * @param {boolean} fallback if true, no notification will be displayed on fail
+     */
+    startPolling(iot_ip, fallback = false) {
+        if (iot_ip) {
+            if (!this._listeners[iot_ip].rpc) {
+                this._poll(iot_ip, fallback);
+            }
+        } else {
+            const self = this;
+            Object.keys(this._listeners).forEach((ip) => {
+                self.startPolling(ip);
+            });
+        }
+    }
+
+    /**
+     * Stops any started long polling
+     *
+     * Aborts a pending long-poll so that we immediately remove ourselves
+     * from listening on notifications on this channel.
+     */
+    stopPolling(iot_ip) {
+        if (this._listeners[iot_ip].rpc) {
+            this._listeners[iot_ip].rpc.abort();
+            this._listeners[iot_ip].rpc = false;
+        }
+    }
+
+    _delayedStartPolling(delay) {
+        // ``fallback: true`` to avoid error notification on longpolling setup
+        setTimeout(() => this.startPolling(null, true), delay);
+    }
+
+    /**
+     * Execute an RPC to the box
+     * Used to do both polling or action
+     *
+     * @param {string} iot_ip IP of the IoT Box
+     * @param {string} route endpoint to call on the IoT Box
+     * @param {Object} params information needed to perform an action or the listener for the polling
+     * @param {number} timeout time before the request times out (undefined to use default timeout from http.js)
+     * @param {boolean} fallback if true, no notification will be displayed on fail
+     * @param {Object} headers headers to send with the request (optional, allows patching)
+     */
+    async _rpcIoT(iot_ip, route, params, timeout = undefined, fallback = false, headers = undefined) {
+        try {
+            const result = await post(iot_ip, route, params, timeout, headers);
+
+            if (this._listeners[iot_ip] && route === this.pollRoute) {
+                this._listeners[iot_ip].rpc = result;
+                return this._listeners[iot_ip].rpc;
+            } else {
+                return result;
+            }
+        } catch {
+            if (!fallback) {
+                this._doWarnFail(iot_ip);
+            }
+            throw new Error("Longpolling action failed");
+        }
+    }
+
+    /**
+     * Make a poll request to an IoT Box
+     *
+     * @param {string} iot_ip
+     * @param {boolean} fallback if true, no notification will be displayed on fail
+     */
+    _poll(iot_ip, fallback = false) {
+        const listener = this._listeners[iot_ip];
+
+        // The backend has a maximum cycle time of 50 seconds so give +10 seconds
+        this._rpcIoT(iot_ip, this.pollRoute, { listener: listener }, 60000).then(
+            (result) => {
+                this._retries = 0;
+                this._listeners[iot_ip].rpc = false;
+                const remainingDevices = Object.keys(this._listeners[iot_ip].devices || {});
+                if (result.result) {
+                    if (this._session_id === result.result.session_id) {
+                        this._onSuccess(iot_ip, result.result);
+                    }
+                } else if (remainingDevices.length > 0) {
+                    this._poll(iot_ip);
+                }
+            },
+            (e) => {
+                if (e.name === "TimeoutError") {
+                    this._onError();
+                } else if (!fallback) {
+                    this._doWarnFail(iot_ip);
+                }
+            }
+        );
+    }
+
+    _onSuccess(iot_ip, result) {
+        this._listeners[iot_ip].last_event = result.time;
+
+        const devices = this._listeners[iot_ip].devices;
+        devices[result.device_identifier]?.callback(result);
+
+        if (Object.keys(devices || {}).length > 0) {
+            this._poll(iot_ip);
+        }
+        this._retries = 0;
+    }
+
+    _onError() {
+        this._retries++;
+        this._delayedStartPolling(Math.min(this.rpcDelay * this._retries, this.maxRpcDelay));
+    }
+
+    /**
+     * This method is needed in _poll.
+     * @param {string} url
+     */
+    _doWarnFail(url) {
+        this.notification.add(
+            _t("Failed to reach IoT Box at %s", url),
+            {
+                title: _t("Connection to IoT Box failed"),
+                type: "danger",
+            }
+        );
+    }
+}
+
+export const iotLongpollingService = {
+    dependencies: IoTLongpolling.serviceDependencies,
+    start(_, deps) {
+        return new IoTLongpolling(deps);
+    },
+};
+
+registry.category('services').add('iot_longpolling', iotLongpollingService);


### PR DESCRIPTION
In order to provide lonpolling features to community users, we moved the longpolling service from the IoT app to the `iot_base` module.

In addition, we added a logic to contact the first device found for a provided type: allowing us to send actions
without knowing the specific device identifier.

Enterprise PR: [https://github.com/odoo/enterprise/pull/83400](https://github.com/odoo/enterprise/pull/83400)
Task: 4480523
