### PR TITLE
[REV] account: improve sequence mixin to restore stable performance

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -291,27 +291,36 @@ class SequenceMixin(models.AbstractModel):
             format_values['year_end'] = self._truncate_year_to_length(date_end.year, format_values['year_end_length'])
             format_values['month'] = date_start.month
 
+        # before flushing inside the savepoint (which may be rolled back!), make sure everything
+        # is already flushed, otherwise we could lose non-sequence fields values, as the ORM believes
+        # them to be flushed.
         self.flush_recordset()
-        with self.env.cr.savepoint(flush=False) as sp:
-            while True:
-                format_values['seq'] = format_values['seq'] + 1
-                sequence = format_string.format(**format_values)
-                try:
-                    with mute_logger('odoo.sql_db'):
-                        self[self._sequence_field] = sequence
-                        self.flush_recordset([self._sequence_field])
-                        break
-                except DatabaseError as e:
-                    # 23P01 ExclusionViolation
-                    # 23505 UniqueViolation
-                    if e.pgcode not in ('23P01', '23505'):
-                        raise e
-                    sp.rollback()
-
         # because we are flushing, and because the business code might be flushing elsewhere (i.e. to
         # validate constraints), the fields depending on the sequence field might be protected by the
         # ORM. This is not desired, so we already reset them here.
-        self.modified([self._sequence_field])
+        registry = self.env.registry
+        triggers = registry._field_triggers[self._fields[self._sequence_field]]
+        for inverse_field, triggered_fields in triggers.items():
+            for triggered_field in triggered_fields:
+                if not triggered_field.store or not triggered_field.compute:
+                    continue
+                for field in registry.field_inverses[inverse_field[0]] if inverse_field else [None]:
+                    self.env.add_to_compute(triggered_field, self[field.name] if field else self)
+        while True:
+            format_values['seq'] = format_values['seq'] + 1
+            sequence = format_string.format(**format_values)
+            try:
+                with self.env.cr.savepoint(flush=False), mute_logger('odoo.sql_db'):
+                    self[self._sequence_field] = sequence
+                    self.flush_recordset([self._sequence_field])
+                    break
+            except DatabaseError as e:
+                # 23P01 ExclusionViolation
+                # 23505 UniqueViolation
+                if e.pgcode not in ('23P01', '23505'):
+                    raise
+        self._compute_split_sequence()
+        self.flush_recordset(['sequence_prefix', 'sequence_number'])
 
     def _is_last_from_seq_chain(self):
         """Tells whether or not this element is the last one of the sequence chain.


### PR DESCRIPTION
This reverts commit be20a51cf1787487bdf0bcb65fd20f0bb8b33dd4.

The reverted change caused a performance regression when assigning sequences to large batches of invoices. Specifically, the sequence number and prefix were not written to the database during the transaction, causing `_get_last_sequence` to consistently return the first sequence in the batch. This resulted in an `O(n^2)` time complexity when searching for the next valid, non-duplicate sequence.

opw-4711955
(non-exhaustive)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
