### PR TITLE
[FIX] account: missing commercial partner country field on amls

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -4229,6 +4229,11 @@ msgid "Commercial Entity"
 msgstr ""
 
 #. module: account
+#: model:ir.model.fields,field_description:account.field_account_move_line__commercial_partner_country
+msgid "Commercial Partner Country"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__invoice_reference_model
 msgid "Communication Standard"
 msgstr ""

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -183,6 +183,10 @@ class AccountMoveLine(models.Model):
         index='btree_not_null',
         copy=False,
         help="The bank statement used for bank reconciliation")
+    commercial_partner_country = fields.Many2one(
+        string="Commercial Partner Country",
+        related="move_id.commercial_partner_id.country_id",
+    )
 
     # === Tax fields === #
     tax_ids = fields.Many2many(


### PR DESCRIPTION
The commercial partner country field is required for later improvements namely filtering or reports related ones.

---

task-4725240

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr