### PR TITLE
[FIX] hr_expense: Post employee-paid expenses in company currency

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1575,14 +1575,13 @@ class HrExpense(models.Model):
         for employee_sudo, expenses_sudo in self.sudo().grouped('employee_id').items():
             multiple_expenses_name = _("Expenses of %(employee)s", employee=employee_sudo.name)
             move_ref = expenses_sudo.name if len(expenses_sudo) == 1 else multiple_expenses_name
-            currency = expenses_sudo.currency_id if len(expenses_sudo.currency_id) == 1 else expenses_sudo.company_currency_id
             return_vals.append({
             **expenses_sudo._prepare_move_vals(),
                 'ref': move_ref,
                 'move_type': 'in_invoice',
                 'partner_id': employee_sudo.work_contact_id.id,
                 'commercial_partner_id': employee_sudo.user_partner_id.id,
-                'currency_id': currency.id,
+                'currency_id': expenses_sudo.company_currency_id.id,
                 'line_ids': [Command.create(expense_sudo._prepare_move_lines_vals()) for expense_sudo in expenses_sudo],
                 'partner_bank_id': employee_sudo.bank_account_id.id,
                 'attachment_ids': attachments_data,

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -983,3 +983,17 @@ class TestExpenses(TestExpenseCommon):
         expense.quantity = 0
         self.assertTrue(expense.currency_id.is_zero(expense.total_amount_currency))
         self.assertEqual(expense.company_currency_id.compare_amounts(expense.price_unit, self.product_b.standard_price), 0)
+
+    def test_employee_expense_in_foreign_currency(self):
+        """ Checks that the currency of the posted entries is always the company currency """
+        expense = self.create_expenses({
+            'payment_mode': 'own_account',
+            'currency_id': self.other_currency.id,
+        })
+        expense.action_submit()
+        expense.action_approve()
+        expense._post_without_wizard()
+        self.assertRecordValues(
+            expense.account_move_id,
+            [{'amount_total': 500.0, 'currency_id': expense.account_move_id.company_currency_id.id}],
+        )


### PR DESCRIPTION
Since expense reports removal
(https://www.odoo.com/odoo/967/tasks/4481615), expenses paid by employee and made in foreign currency are posted using the expense currency instead of the company currency.
This is an unwanted behavior. It makes sense for company paid expenses because payments are created: Having the same currency as the one used in the transaction is easier for the reconciliation. It's however unusual to keep the transaction currency for vendor bills representing debts towards the employees. In vast majority of cases employees are indeed reimbursed in company currency.

task-4708953
