### PR TITLE
[FIX] mail: chatter note should not be squashed in chat chat_window

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -553,7 +553,7 @@ export class Thread extends Component {
         if (!msg.thread?.eq(prevMsg.thread)) {
             return false;
         }
-        if (msg.parentMessage) {
+        if (msg.parentMessage || msg.is_note) {
             return false;
         }
         return msg.datetime.ts - prevMsg.datetime.ts < 60 * 1000;

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -1018,3 +1018,59 @@ test("mark as read when opening chat window", async () => {
     await contains(".o-mail-ChatWindow .o-mail-ChatWindow-header", { text: "bob" });
     await contains(".o-mail-ChatWindow-counter", { count: 0 });
 });
+
+test("Do not squash logged notes", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
+    const messageId = pyEnv["mail.message"].create([
+        {
+            model: "res.partner",
+            body: "Test Message",
+            author_id: partnerId,
+            needaction: true,
+            res_id: partnerId,
+        },
+        {
+            model: "res.partner",
+            body: "Message",
+            author_id: serverState.partnerId,
+            needaction: true,
+            res_id: partnerId,
+        },
+        {
+            model: "res.partner",
+            body: "Message Squashed",
+            author_id: serverState.partnerId,
+            needaction: true,
+            res_id: partnerId,
+        },
+        {
+            model: "res.partner",
+            body: "Hello",
+            author_id: serverState.partnerId,
+            needaction: true,
+            res_id: partnerId,
+            is_note: true,
+        },
+        {
+            model: "res.partner",
+            body: "World!",
+            author_id: serverState.partnerId,
+            needaction: true,
+            res_id: partnerId,
+            is_note: true,
+        },
+    ]);
+    pyEnv["mail.notification"].create({
+        mail_message_id: messageId[0],
+        notification_status: "sent",
+        notification_type: "inbox",
+        res_partner_id: serverState.partnerId,
+    });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-NotificationItem");
+    await contains(".o-mail-Message.o-squashed", { text: "Message Squashed" });
+    await contains(".o-mail-Message:not(.o-squashed)", { text: "Hello" });
+    await contains(".o-mail-Message:not(.o-squashed)", { text: "World!" });
+});


### PR DESCRIPTION
Purpose of this commit:
This commit aims to restrict the log notes to not be squashed 
when posted on a record from a chat window.

task-4718225
