### PR TITLE
[FIX] website_sale: prevent error when updating quantity in cart

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -259,17 +259,17 @@ class Cart(PaymentPortal):
             line_id = order_sudo.order_line.filtered(
                 lambda sol: sol.product_id.id == product_id
             )[:1].id
-            if not line_id:
-                raise UserError(_("This line doesn't exist anymore."))
 
         values = order_sudo._cart_update_line_quantity(line_id, quantity, **kwargs)
 
         values['cart_quantity'] = order_sudo.cart_quantity
         values['cart_ready'] = order_sudo._is_cart_ready()
         values['amount'] = order_sudo.amount_total
-        values['minor_amount'] = payment_utils.to_minor_currency_units(
-            order_sudo.amount_total, order_sudo.currency_id
-        )
+        values['minor_amount'] = (
+            order_sudo and payment_utils.to_minor_currency_units(
+                order_sudo.amount_total, order_sudo.currency_id
+            )
+        ) or 0.0
         values['website_sale.cart_lines'] = request.env['ir.ui.view']._render_template(
             'website_sale.cart_lines', {
                 'website_sale_order': order_sudo,

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import random
-
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
@@ -397,11 +396,22 @@ class SaleOrder(models.Model):
         :return: values used by the cart service to give feedback to the customer.
         :rtype: dict
         """
-        self.ensure_one()
-        self = self.with_company(self.company_id)
+        if self:
+            self.ensure_one()
+
+        self = self.with_company(self.company_id)  # noqa: PLW0642
 
         if not (order_line := self.order_line.filtered(lambda sol: sol.id == line_id)):
-            raise UserError(_("This line doesn't belong to your order."))
+            # If the line isn't found because of wrong parameters, or because the user updated
+            # the cart in other tabs, a warning will be returned.
+            # Note that if the cart is empty, the zero cart_quantity will trigger a page reload
+            # and this warning won't be shown.
+            return {
+                'warning': _(
+                    "We weren't able to update your cart. Please refresh your page before trying"
+                    " again."
+                )
+            }
 
         if quantity > 0:
             quantity, warning = self._verify_updated_quantity(
@@ -798,7 +808,7 @@ class SaleOrder(models.Model):
 
         :rtype: bool
         """
-        return True
+        return bool(self)
 
     def _check_cart_is_ready_to_be_paid(self):
         """ Whether the cart is valid and the user can proceed to the payment

--- a/addons/website_sale/tests/test_website_sale_cart.py
+++ b/addons/website_sale/tests/test_website_sale_cart.py
@@ -195,11 +195,12 @@ class TestWebsiteSaleCart(ProductAttributesCommon, WebsiteSaleCommon):
             self.assertEqual(sale_order.order_line, SaleOrderLine)
 
             # removing the product again doesn't add a line with zero quantity
-            with self.assertRaises(UserError):
-                self.WebsiteSaleCartController.update_cart(
-                    line_id=sale_order.order_line.id,
-                    quantity=0,
-                )
+            self.WebsiteSaleCartController.update_cart(
+                line_id=sale_order.order_line.id,
+                quantity=0,
+            )
+            self.assertEqual(sale_order.cart_quantity, 0.0)
+            self.assertEqual(sale_order.order_line, SaleOrderLine)
 
     def test_unpublished_accessory_product_visibility(self):
         # Check if unpublished product is shown to public user


### PR DESCRIPTION
This error occurs when attempting to update the quantity in the cart.

Steps to Reproduce:
---
- Install the `website_sale` module
- Activate `Demo` payment provider
- Go to Website > Shop > Add a product to Cart > View cart
- Pay with Demo > Pay
- Click the back button(chrome navbar)(Instantly)
- Change the quantity for the product

Traceback:
---
ValueError: Expected singleton: sale.order()

At [1], this error occurs because `order_sudo` is empty. This happens when there are no products in the cart — typically because, upon clicking`Pay`, a sale order is created for the product, and when the user navigates back, the cart is empty.

[1]- https://github.com/odoo/odoo/blob/a8a7a26dbda046db6f679bc29940add510e34485/addons/website_sale/controllers/cart.py#L248

sentry-5682671428

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
