### PR TITLE
[IMP] web, *: cache data (web_read, web_search_read)

### DIFF
--- a/addons/product/static/src/product_catalog/kanban_model.js
+++ b/addons/product/static/src/product_catalog/kanban_model.js
@@ -14,6 +14,7 @@ class ProductCatalogRecord extends Record {
 
 export class ProductCatalogKanbanModel extends RelationalModel {
     static Record = ProductCatalogRecord;
+    static withCache = false;
 
     async _loadData(params) {
         // if orm have isSample field and its value set to be true then we have sample data as there is no product found for selected vendor, show sample data

--- a/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
+++ b/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
@@ -147,9 +147,9 @@ export class OdooViewsDataSource extends LoadableDataSource {
      * @returns {Promise<string>} Display name of the model
      */
     async getModelLabel() {
-        const result = await this._orm.cached.call("ir.model", "display_name_for", [
-            [this._metaData.resModel],
-        ]);
+        const result = await this._orm
+            .cached()
+            .call("ir.model", "display_name_for", [[this._metaData.resModel]]);
         return result[0]?.display_name || "";
     }
 }

--- a/addons/spreadsheet/static/src/pivot/odoo_pivot_loader.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot_loader.js
@@ -103,9 +103,9 @@ export class OdooPivotLoader {
      * @returns {Promise<string>} Display name of the model
      */
     async getModelLabel(model) {
-        const result = await this.odooDataProvider.orm.cached.call("ir.model", "display_name_for", [
-            [model],
-        ]);
+        const result = await this.odooDataProvider.orm
+            .cached()
+            .call("ir.model", "display_name_for", [[model]]);
         return result[0]?.display_name || "";
     }
 

--- a/addons/web/static/lib/hoot/mock/crypto.js
+++ b/addons/web/static/lib/hoot/mock/crypto.js
@@ -1,0 +1,22 @@
+/** @odoo-module */
+
+export const mockCrypto = {
+    subtle: {
+        importKey: (_format, keyData, _algorithm, _extractable, _keyUsages) => {
+            if (!keyData || keyData.length === 0) {
+                throw Error(`KeyData is mandatory`);
+            }
+            return Promise.resolve("I'm a key");
+        },
+        encrypt: (_algorithm, _key, data) =>
+            Promise.resolve(`encrypted data:${new TextDecoder().decode(data)}`),
+        decrypt: (_algorithm, _key, data) =>
+            Promise.resolve(new TextEncoder().encode(data.replace("encrypted data:", ""))),
+    },
+    getRandomValues: (typedArray) => {
+        typedArray.forEach((_element, index) => {
+            typedArray[index] = Math.round(Math.random() * 100);
+        });
+        return typedArray;
+    },
+};

--- a/addons/web/static/lib/hoot/mock/window.js
+++ b/addons/web/static/lib/hoot/mock/window.js
@@ -47,6 +47,7 @@ import {
 import { MockNotification } from "./notification";
 import { MockStorage } from "./storage";
 import { MockBlob } from "./sync_values";
+import { mockCrypto } from "./crypto";
 
 //-----------------------------------------------------------------------------
 // Global
@@ -463,11 +464,13 @@ const WINDOW_MOCK_DESCRIPTORS = {
     clearTimeout: { value: mockedClearTimeout, writable: false },
     ClipboardItem: { value: MockClipboardItem },
     console: { value: mockConsole, writable: false },
+    crypto: { value: mockCrypto, writable: false },
     Date: { value: MockDate, writable: false },
     fetch: { value: interactor("server", mockedFetch).as("fetch"), writable: false },
     history: { value: mockHistory },
     innerHeight: { get: () => getCurrentDimensions().height },
     innerWidth: { get: () => getCurrentDimensions().width },
+    isSecureContext: { value: true, writable: false },
     Intl: { value: MockIntl },
     localStorage: { value: mockLocalStorage, writable: false },
     matchMedia: { value: mockedMatchMedia },

--- a/addons/web/static/lib/hoot/tests/index.html
+++ b/addons/web/static/lib/hoot/tests/index.html
@@ -40,6 +40,7 @@
                     "/web/static/lib/hoot/main_runner": "/web/static/lib/hoot/main_runner.js",
                     "/web/static/lib/hoot/mock/animation": "/web/static/lib/hoot/mock/animation.js",
                     "/web/static/lib/hoot/mock/console": "/web/static/lib/hoot/mock/console.js",
+                    "/web/static/lib/hoot/mock/crypto": "/web/static/lib/hoot/mock/crypto.js",
                     "/web/static/lib/hoot/mock/date": "/web/static/lib/hoot/mock/date.js",
                     "/web/static/lib/hoot/mock/math": "/web/static/lib/hoot/mock/math.js",
                     "/web/static/lib/hoot/mock/navigator": "/web/static/lib/hoot/mock/navigator.js",

--- a/addons/web/static/src/core/field_service.js
+++ b/addons/web/static/src/core/field_service.js
@@ -92,10 +92,9 @@ export const fieldService = {
             if (typeof resModel !== "string" || !resModel) {
                 throw new Error(`Invalid model name: ${resModel}`);
             }
-            return orm.cached.call(resModel, "fields_get", [
-                options.fieldNames,
-                options.attributes,
-            ]);
+            return orm
+                .cached()
+                .call(resModel, "fields_get", [options.fieldNames, options.attributes]);
         }
 
         /**

--- a/addons/web/static/src/core/network/rpc.js
+++ b/addons/web/static/src/core/network/rpc.js
@@ -68,7 +68,8 @@ rpc._rpc = function (url, params, settings) {
         return rpcCache.read(
             params?.method || url, // table
             JSON.stringify({ url, params }), // key
-            () => rpc._rpc(url, params, omit(settings, "cached"))
+            () => rpc._rpc(url, params, omit(settings, "cached")),
+            typeof settings.cached === "boolean" ? {} : settings.cached // cached can be boolean or an object with options (or an empty object of course)
         );
     }
     const XHR = browser.XMLHttpRequest;

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -107,9 +107,12 @@ export class ORM {
         return Object.assign(Object.create(this), { _silent: true });
     }
 
-    /** @returns {ORM} */
-    get cached() {
-        return Object.assign(Object.create(this), { _cached: true });
+    /**
+     * @param {object} options
+     * @returns {ORM}
+     */
+    cached(options = {}) {
+        return Object.assign(Object.create(this), { _cached: options });
     }
 
     /**
@@ -130,7 +133,10 @@ export class ORM {
             args,
             kwargs: fullKwargs,
         };
-        return this.rpc(url, params, { silent: this._silent, cached: this._cached });
+        return this.rpc(url, params, {
+            silent: this._silent,
+            cached: this._cached,
+        });
     }
 
     /**

--- a/addons/web/static/src/core/utils/indexed_db.js
+++ b/addons/web/static/src/core/utils/indexed_db.js
@@ -52,13 +52,13 @@ export class IndexedDB {
     /**
      * Invalidates a table, or the whole database.
      *
-     * @param {string} [table] if not given, the whole database is invalidated
+     * @param {string|Array} [table=null] if not given, the whole database is invalidated
      * @returns Promise
      */
-    async invalidate(table = null) {
+    async invalidate(tables = null) {
         return this.execute((db) => {
             if (db) {
-                return this._invalidate(db, table);
+                return this._invalidate(db, typeof tables === "string" ? [tables] : tables);
             }
         });
     }
@@ -175,12 +175,13 @@ export class IndexedDB {
         });
     }
 
-    async _invalidate(db, table) {
+    async _invalidate(db, tables) {
         return new Promise((resolve, reject) => {
             const objectStoreNames = [...db.objectStoreNames].filter(
                 (table) => table !== VERSION_TABLE
             );
-            const tables = table && objectStoreNames.includes(table) ? [table] : objectStoreNames;
+            tables = tables ? objectStoreNames.filter((t) => tables.includes(t)) : objectStoreNames;
+
             if (tables.length === 0) {
                 return resolve();
             }

--- a/addons/web/static/src/core/utils/persistent_cache.js
+++ b/addons/web/static/src/core/utils/persistent_cache.js
@@ -1,6 +1,55 @@
 import { Deferred } from "@web/core/utils/concurrency";
 import { IndexedDB } from "@web/core/utils/indexed_db";
 
+const CRYPTO_ALGO = "AES-GCM";
+
+class Crypto {
+    constructor(secret) {
+        this._cryptoKey = null;
+        this._ready = window.crypto.subtle
+            .importKey(
+                "raw",
+                new Uint8Array(secret.match(/../g).map((h) => parseInt(h, 16))).buffer,
+                CRYPTO_ALGO,
+                false,
+                ["encrypt", "decrypt"]
+            )
+            .then((encryptedKey) => {
+                this._cryptoKey = encryptedKey;
+            });
+    }
+
+    async encrypt(value) {
+        await this._ready;
+        // The iv must never be reused with a given key.
+        const iv = window.crypto.getRandomValues(new Uint8Array(12));
+        const ciphertext = await window.crypto.subtle.encrypt(
+            {
+                name: CRYPTO_ALGO,
+                iv,
+                length: 64, // length of the counter in bits
+            },
+            this._cryptoKey,
+            new TextEncoder().encode(JSON.stringify(value)) // encoded Data
+        );
+        return { ciphertext, iv };
+    }
+
+    async decrypt({ ciphertext, iv }) {
+        await this._ready;
+        const decrypted = await window.crypto.subtle.decrypt(
+            {
+                name: CRYPTO_ALGO,
+                iv,
+                length: 64,
+            },
+            this._cryptoKey,
+            ciphertext
+        );
+        return JSON.parse(new TextDecoder().decode(decrypted));
+    }
+}
+
 class RamCache {
     constructor() {
         this.ram = {};
@@ -21,10 +70,13 @@ class RamCache {
         delete this.ram[table]?.[key];
     }
 
-    invalidate(table) {
-        if (table) {
-            if (table in this.ram) {
-                this.ram[table] = {};
+    invalidate(tables = null) {
+        if (tables) {
+            tables = typeof tables === "string" ? [tables] : tables;
+            for (const table of tables) {
+                if (table in this.ram) {
+                    this.ram[table] = {};
+                }
             }
         } else {
             this.ram = {};
@@ -32,40 +84,77 @@ class RamCache {
     }
 }
 
+function compareValues(value1, value2) {
+    return JSON.stringify(value1) === JSON.stringify(value2);
+}
+
 export class PersistentCache {
-    constructor(name, version) {
-        this.indexedDB = new IndexedDB(name, version);
+    constructor(name, version, secret) {
+        this.crypto = new Crypto(secret);
+        this.indexedDB = new IndexedDB(name, version + CRYPTO_ALGO);
         this.ramCache = new RamCache();
     }
 
-    read(table, key, fallback) {
+    read(table, key, fallback, { onUpdate } = {}) {
         const ramValue = this.ramCache.read(table, key);
-        if (ramValue) {
+        if (ramValue && !onUpdate) {
             return ramValue;
         }
-
         const def = new Deferred();
-        this.indexedDB.read(table, key).then((result) => {
-            if (result) {
-                def.resolve(result);
-            }
-        });
+        const fromCache = new Deferred();
+        let fromCacheValue;
         const prom = fallback()
             .then((result) => {
-                this.indexedDB.write(table, key, result);
                 def.resolve(result);
+                this.ramCache.write(table, key, Promise.resolve(result));
+                if (onUpdate && fromCacheValue && !compareValues(fromCacheValue, result)) {
+                    onUpdate(result);
+                }
+                this.crypto.encrypt(result).then((encryptedResult) => {
+                    this.indexedDB.write(table, key, encryptedResult);
+                });
                 return result;
             })
-            .catch((error) => {
-                this.ramCache.delete(table, key);
+            .catch(async (error) => {
+                await fromCache;
+                if (fromCacheValue) {
+                    // def has already been fullfilled with the cached value
+                    throw error;
+                }
+                this.ramCache.delete(table, key); // remove rejected prom from ram cache
                 def.reject(error);
             });
-        this.ramCache.write(table, key, prom);
+        if (ramValue) {
+            ramValue.then((value) => {
+                def.resolve(value);
+                fromCacheValue = value;
+                fromCache.resolve();
+            });
+        } else {
+            this.ramCache.write(table, key, prom);
+            this.indexedDB.read(table, key).then(async (result) => {
+                if (result) {
+                    let decrypted;
+                    try {
+                        decrypted = await this.crypto.decrypt(result);
+                    } catch {
+                        fromCache.resolve();
+                        // Do nothing ! The cryptoKey is probably different.
+                        // The data will be updated with the new cryptoKey.
+                        return;
+                    }
+                    def.resolve(decrypted);
+                    this.ramCache.write(table, key, Promise.resolve(decrypted));
+                    fromCacheValue = decrypted;
+                }
+                fromCache.resolve();
+            });
+        }
         return def;
     }
 
-    invalidate(table) {
-        this.indexedDB.invalidate(table);
-        this.ramCache.invalidate(table);
+    invalidate(tables) {
+        this.indexedDB.invalidate(tables);
+        this.ramCache.invalidate(tables);
     }
 }

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -174,6 +174,7 @@ export function highlightText(query, text, classes) {
 export function isEmail(value) {
     // http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
     const re =
+        // eslint-disable-next-line no-useless-escape
         /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
     return re.test(value);
 }
@@ -212,4 +213,26 @@ export function uuid() {
     window.crypto.getRandomValues(array);
     // Uint8Array to hex
     return [...array].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Generate a hash, also known as a 'digest', for the given string.
+ * This algorithm is based on the Java hashString method
+ * (see: https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#hashCode()).
+ * Please note that this hash function is non-cryptographic and does not exhibit collision resistance.
+ *
+ * If a cryptographic hash function is required, the digest() function of the SubtleCrypto
+ * interface makes various hash functions available:
+ * https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+export function hashCode(str) {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+        hash += Math.pow(str.charCodeAt(i) * 31, str.length - i);
+        hash = hash & hash; // Convert to 32bit integer
+    }
+    return hash;
 }

--- a/addons/web/static/src/start.js
+++ b/addons/web/static/src/start.js
@@ -24,7 +24,11 @@ export async function startWebClient(Webclient) {
     };
     odoo.isReady = false;
 
-    rpc.setCache(new PersistentCache("rpc", session.registry_hash));
+    if (window.isSecureContext && session.browser_cache_secret) {
+        rpc.setCache(
+            new PersistentCache("rpc", session.registry_hash, session.browser_cache_secret)
+        );
+    }
 
     await whenReady();
     const app = await mountComponent(Webclient, document.body, { name: "Odoo Web Client" });

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -106,6 +106,7 @@ export function getDefaultConfig() {
     const config = {
         actionId: false,
         actionType: false,
+        cache: true,
         embeddedActions: [],
         currentEmbeddedActionId: false,
         parentActionId: false,

--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -92,7 +92,7 @@ export const viewService = {
                 )
             );
 
-            const result = await orm.cached.call(resModel, "get_views", [], {
+            const result = await orm.cached().call(resModel, "get_views", [], {
                 context: filteredContext,
                 views,
                 options: loadViewsOptions,

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -749,6 +749,7 @@ export function makeActionManager(env, router = _router) {
             config: {
                 actionId: action.id,
                 actionName: action.name,
+                cache: action.cache,
                 actionType: "ir.actions.act_window",
                 embeddedActions,
                 parentActionId,

--- a/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
+++ b/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
@@ -19,10 +19,13 @@ export function mockIndexedDB(_name, { fn }) {
                 return Promise.resolve(this.mockIndexedDB[table]?.[key]);
             }
 
-            invalidate(table) {
-                if (table) {
-                    if (table in this.mockIndexedDB) {
-                        this.mockIndexedDB[table] = {};
+            invalidate(tables = null) {
+                if (tables) {
+                    tables = typeof tables === "string" ? [tables] : tables;
+                    for (const table of tables) {
+                        if (table in this.mockIndexedDB) {
+                            this.mockIndexedDB[table] = {};
+                        }
                     }
                 } else {
                     this.mockIndexedDB = {};

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -491,7 +491,7 @@ export class MockServer {
         registerDebugInfo("mock server", this);
 
         // Add RPC cache
-        rpc.setCache(new PersistentCache("mockRpc", 1));
+        rpc.setCache(new PersistentCache("mockRpc", 1, "23aeb0ff5d46cfa8aa44163720d871ac"));
         after(() => rpc.setCache(null));
 
         // Intercept all server calls
@@ -697,6 +697,7 @@ export class MockServer {
                 action.target ??= "current";
                 action.view_ids ||= [];
                 action.view_mode ??= "list,form";
+                action.cache ??= true;
                 for (const embeddedAction of this.actions) {
                     if (
                         embeddedAction.type === ACTION_TYPES.embedded &&

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -123,7 +123,7 @@ test("[cache] write into the cache", async () => {
         },
         modules: { web: { messages: [{ id: "Hello", string: "Bonjour" }] } },
         multi_lang: false,
-        hash: "5d62e6f31a2e19f1f128bd7f56d11088a746e001",
+        hash: "6b1bcfb1",
     };
     expect.verifySteps([
         "hash: ",
@@ -150,7 +150,7 @@ test("[cache] read from cache, and don't wait to render", async () => {
                 },
                 modules: { web: { messages: [{ id: "Hello", string: "Bonjour" }] } },
                 multi_lang: false,
-                hash: "5d62e6f31a2e19f1f128bd7f56d11088a746e001",
+                hash: "30b70a0e",
             };
         },
     });
@@ -167,7 +167,7 @@ test("[cache] read from cache, and don't wait to render", async () => {
     expect("#main").toHaveText("Bonjour"); //Don't wait the end of the fetch to render
     def.resolve();
     await animationFrame();
-    expect.verifySteps(["hash: 5d62e6f31a2e19f1f128bd7f56d11088a746e001"]); //Fetch with the hash of the translation in cache
+    expect.verifySteps(["hash: 30b70a0e"]); //Fetch with the hash of the translation in cache
 });
 
 test("[cache] update the cache if hash are different - template", async () => {
@@ -187,7 +187,7 @@ test("[cache] update the cache if hash are different - template", async () => {
                 },
                 modules: { web: { messages: [{ id: "Hello", string: "Different Bonjour" }] } },
                 multi_lang: false,
-                hash: "5d62e6f31a2e",
+                hash: "30b",
             };
         },
         write(table, key, value) {
@@ -223,10 +223,10 @@ test("[cache] update the cache if hash are different - template", async () => {
         },
         modules: { web: { messages: [{ id: "Hello", string: "Bonjour" }] } }, // value was updated in the cache
         multi_lang: false,
-        hash: "5d62e6f31a2e19f1f128bd7f56d11088a746e001", // hash was updated in the cache
+        hash: "6b1bcfb1", // hash was updated in the cache
     };
     expect.verifySteps([
-        "hash: 5d62e6f31a2e", //Fetch with the hash of the translation in cache
+        "hash: 30b", //Fetch with the hash of the translation in cache
         "table: /web/webclient/translations",
         'key: {"lang":"en"}',
         `value: ${JSON.stringify(expectedValue)}`,
@@ -260,7 +260,7 @@ test("[cache] update the cache if hash are different - js", async () => {
                     },
                 },
                 multi_lang: false,
-                hash: "5d62e6f31a2e",
+                hash: "30b",
             };
         },
         write(table, key, value) {
@@ -310,10 +310,10 @@ test("[cache] update the cache if hash are different - js", async () => {
             },
         }, // value was updated in the cache
         multi_lang: false,
-        hash: "267b5f5848b78a58ff6f57530b5f6fcdc46ecad0", // hash was updated in the cache
+        hash: "6b1bcfb1", // hash was updated in the cache
     };
     expect.verifySteps([
-        "hash: 5d62e6f31a2e", //Fetch with the hash of the translation in cache
+        "hash: 30b", //Fetch with the hash of the translation in cache
         "table: /web/webclient/translations",
         'key: {"lang":"en"}',
         `value: ${JSON.stringify(expectedValue)}`,

--- a/addons/web/static/tests/core/network/rpc.test.js
+++ b/addons/web/static/tests/core/network/rpc.test.js
@@ -148,7 +148,13 @@ test("rpc can send additional headers", async () => {
 });
 
 test("Cache: can cache a simple rpc", async () => {
-    rpc.setCache(new PersistentCache("mockRpc", 1));
+    rpc.setCache(
+        new PersistentCache(
+            "mockRpc",
+            1,
+            "85472d41873cdb504b7c7dfecdb8993d90db142c4c03e6d94c4ae37a7771dc5b"
+        )
+    );
     mockFetch(() => {
         expect.step("Fetch");
         return { result: { action_id: 123 } };

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -3360,12 +3360,10 @@ test("quick create several records in a row", async () => {
     });
 });
 
-test("quick create is disabled until record is created and onchange is done", async () => {
+test("quick create is re-enabled directly after the validation", async () => {
     let webSaveDef;
-    let onchangeDef;
     let webReadDef;
     onRpc("web_save", () => webSaveDef);
-    onRpc("onchange", () => onchangeDef);
     onRpc("web_read", () => webReadDef);
 
     await mountView({
@@ -3393,28 +3391,17 @@ test("quick create is disabled until record is created and onchange is done", as
 
     await editKanbanRecordQuickCreateInput("display_name", "new partner 1");
     webSaveDef = new Deferred();
-    onchangeDef = new Deferred();
     webReadDef = new Deferred();
     await validateKanbanRecord();
 
     expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(1, {
         message: "first column should still contain one record",
     });
-    expect(".o_kanban_quick_create.o_disabled").toHaveCount(1, {
-        message: "quick create should be disabled",
+    expect(".o_kanban_quick_create.o_disabled").toHaveCount(0, {
+        message: "quick create should be enabled",
     });
 
     webSaveDef.resolve();
-    await animationFrame();
-
-    expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(1, {
-        message: "first column should still contain one record",
-    });
-    expect(".o_kanban_quick_create.o_disabled").toHaveCount(1, {
-        message: "quick create should be disabled",
-    });
-
-    onchangeDef.resolve();
     await animationFrame();
 
     expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(1, {

--- a/addons/web/static/tests/webclient/actions/concurrency.test.js
+++ b/addons/web/static/tests/webclient/actions/concurrency.test.js
@@ -652,28 +652,16 @@ test("switching when doing an action -- search_read slow", async () => {
 test.tags("desktop");
 test("click multiple times to open a record", async () => {
     const def = new Deferred();
-    const defs = [null, def];
-    onRpc("web_read", () => defs.shift());
+    onRpc("web_read", () => def);
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(3);
-    expect(".o_list_view").toHaveCount(1);
-
-    await contains(".o_list_view .o_data_cell").click();
-    expect(".o_form_view").toHaveCount(1);
-
-    await contains(".o_back_button").click();
     expect(".o_list_view").toHaveCount(1);
 
     const row1 = queryAll(".o_list_view .o_data_row")[0];
     const row2 = queryAll(".o_list_view .o_data_row")[1];
     await contains(row1.querySelector(".o_data_cell")).click();
     await contains(row2.querySelector(".o_data_cell")).click();
-    expect(".o_form_view").toHaveCount(1);
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
-        "Partners",
-        "Second record",
-    ]);
 
     def.resolve();
     await animationFrame();

--- a/addons/web/static/tests/webclient/actions/error_handling.test.js
+++ b/addons/web/static/tests/webclient/actions/error_handling.test.js
@@ -202,7 +202,8 @@ test("connection lost when coming back to kanban from form", async () => {
     await animationFrame();
     expect(".o_form_view").toHaveCount(0);
     expect(".o_kanban_view").toHaveCount(1);
-    expect(".o_kanban_view .o_kanban_renderer").toHaveCount(0);
+    expect(".o_kanban_view .o_kanban_renderer").toHaveCount(1);
+    expect(".o_kanban_view .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(2);
     expect(".o_notification").toHaveCount(1);
     expect(".o_notification").toHaveText("Connection lost. Trying to reconnect...");
     expect.verifySteps([

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -1461,7 +1461,7 @@ describe(`new urls`, () => {
         expect(`.o_kanban_record:not(.o_kanban_ghost)`).toHaveCount(1);
         expect.verifySteps([
             "get current_action-null",
-            'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":100,"type":"ir.actions.act_window","xml_id":100,"res_model":"partner","res_id":1,"views":[[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form"}',
+            'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":100,"type":"ir.actions.act_window","xml_id":100,"res_model":"partner","res_id":1,"views":[[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
             'set current_action-{"id":200,"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"domain":[["id","=",1]]}',
         ]);
 

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -760,6 +760,10 @@ test.tags("desktop");
 test("there is no flickering when switching between views", async () => {
     let def;
     onRpc(() => def);
+    Partner._views.list = `<list>
+                                <field name="display_name"/>
+                                <field name="foo"/>
+                            </list>`;
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(3);
@@ -781,7 +785,8 @@ test("there is no flickering when switching between views", async () => {
     await switchView("list");
     expect(".o_kanban_view").toHaveCount(0, { message: "shouldn't display the kanban anymore" });
     expect(".o_list_view").toHaveCount(1, { message: "should display an empty list view" });
-    expect(".o_list_view table").toHaveCount(0);
+    expect(".o_list_view table").toHaveCount(1);
+    expect(".o_list_view table .o_data_row").toHaveCount(5); // Cached values
 
     def.resolve();
     await animationFrame();
@@ -812,7 +817,8 @@ test("there is no flickering when switching between views", async () => {
     await contains(".o_control_panel .breadcrumb a").click();
     expect(".o_form_view").toHaveCount(0, { message: "shouldn't display the form anymore" });
     expect(".o_list_view").toHaveCount(1, { message: "should display an empty list" });
-    expect(".o_list_view table").toHaveCount(0);
+    expect(".o_list_view table").toHaveCount(1);
+    expect(".o_list_view table .o_data_row").toHaveCount(5); // Cached values
     expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual(["Partners"]);
 
     def.resolve();

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -43,8 +43,8 @@ class TestPerfSessionInfo(common.HttpCase):
 
         # cold fields cache - warm ormcache:
         # - Only web: 5
-        # - All modules: 31
-        with self.assertQueryCount(31):
+        # - All modules: 32
+        with self.assertQueryCount(32):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -327,6 +327,7 @@ class IrActionsAct_Window(models.Model):
     search_view_id = fields.Many2one('ir.ui.view', string='Search View Ref.')
     embedded_action_ids = fields.One2many('ir.embedded.actions', compute="_compute_embedded_actions")
     filter = fields.Boolean()
+    cache = fields.Boolean(string="Data Caching", default=True, help="If enabled, this action will cache the related data used in list, Kanban and form views with the aim to increase the loading speed")
 
     def _compute_embedded_actions(self):
         embedded_actions = self.env["ir.embedded.actions"].search([('parent_action_id', 'in', self.ids)]).filtered(lambda x: x.is_visible)
@@ -375,7 +376,7 @@ class IrActionsAct_Window(models.Model):
 
     def _get_readable_fields(self):
         return super()._get_readable_fields() | {
-            "context", "mobile_view_mode", "domain", "filter", "group_ids", "limit",
+            "context", "cache", "mobile_view_mode", "domain", "filter", "group_ids", "limit",
             "res_id", "res_model", "search_view_id", "target", "view_id", "view_mode", "views", "embedded_action_ids",
             # this is used by frontend, with the document layout wizard before send and print
             "close_on_report_download",

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -208,6 +208,7 @@
                             <field name="usage"/>
                             <field name="type" readonly="1"/>
                             <field name="target"/>
+                            <field name="cache"/>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
This commit implements a caching system for the data used in List, Kanban and
Form views, with the aim of increasing loading speed.

It modifies the PersistentCache system, introduced in [1], to be able to call
a callback (`onUpdate`) when the RPC finishes and the data differs from the
cached data. This new callback allows the relational model to re-render the
view when the latest data arrives.

Please note that, for security reasons, all the stored data in the browser is
encrypted using the `AES-GCM` algorithm (see [2]).

If necessary, caching of the data could be disabled for a specific action, by
setting the `cache` field (introduced in this commit) to `False`.

[1] : https://github.com/odoo/odoo/commit/f3d955b3235cb256bda79e834df38da0f6a4ac1a
[2] : https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm

task-id: 4479845
Co-authored-by: Aaron Bohy <aab@odoo.com>
