### PR TITLE
[FIX] tests: catch websocket without cookie

### DIFF
--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -11,11 +11,12 @@ except ImportError:
     websocket = None
 
 import odoo.tools
-from odoo.tests import HOST, HttpCase
+from odoo.tests import HOST, HttpCase, TEST_CURSOR_COOKIE_NAME
 from ..websocket import CloseCode, WebsocketConnectionHandler
 
 
 class WebsocketCase(HttpCase):
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -70,6 +71,7 @@ class WebsocketCase(HttpCase):
         if 'cookie' not in kwargs:
             self.session = self.authenticate(None, None)
             kwargs['cookie'] = f'session_id={self.session.sid}'
+        kwargs['cookie'] += f';{TEST_CURSOR_COOKIE_NAME}={self.http_request_key}'
         if 'timeout' not in kwargs:
             kwargs['timeout'] = 5
         ws = websocket.create_connection(

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -673,10 +673,14 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
     def setUp(self):
         super().setUp()
         self.http_request_key = self.canonical_tag
+        self.http_request_strict_check = False  # by default, don't be to strict
 
         def reset_http_key():
             self.http_request_key = None
         self.addCleanup(reset_http_key)  # this should avoid to have a request executing during teardown
+
+    def mandatory_request_route(self, route):
+        return route == "/websocket"
 
     def check_test_cursor(self, operation):
         if odoo.modules.module.current_test != self:
@@ -684,7 +688,7 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
             _logger.error(message)
             raise BadRequest(message)
         request = odoo.http.request
-        if not request:
+        if not request or isinstance(request, Mock):
             return
         if not self.http_request_key:
             message = f'Using a test cursor without http_request_key, most likely between two tests on request {request.httprequest.path} in {module.current_test.canonical_tag}'
@@ -692,6 +696,13 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
             raise BadRequest(message)
         http_request_key = request.httprequest.cookies.get(TEST_CURSOR_COOKIE_NAME)
         if not http_request_key:
+            if self.http_request_strict_check or self.mandatory_request_route(request.httprequest.path):
+                reason = 'for this path'
+                if self.http_request_strict_check:
+                    reason = 'after a browser_js call'
+                message = f'Using a test cursor without specified test on request {request.httprequest.path} in {module.current_test.canonical_tag} as been ignored since cookie is mandatory {reason}'
+                _logger.info(message)
+                raise BadRequest(message)
             if operation == '__init__':  # main difference with master, don't fail if no cookie is defined_check
                 message = f'Opening a test cursor without specified test on request {request.httprequest.path} in {module.current_test.canonical_tag}'
                 _logger.info(message)
@@ -1560,11 +1571,11 @@ which leads to stray network requests and inconsistencies."""
         """, 'awaitPromise': True})
         # wait for the screenshot or whatever
         wait(self._responses.values(), 10)
+        self.navigate_to('about:blank', wait_stop=True)
         self._logger.info('Deleting cookies and clearing local storage')
+        self._websocket_request('Storage.clearDataForOrigin', params={'origin': HOST, 'storageTypes': 'local_storage, session_storage'})
         self._websocket_request('Network.clearBrowserCache')
         self._websocket_request('Network.clearBrowserCookies')
-        self._websocket_request('Runtime.evaluate', params={'expression': 'try {localStorage.clear(); sessionStorage.clear();} catch(e) {}'})
-        self.navigate_to('about:blank', wait_stop=True)
         # hopefully after navigating to about:blank there's no event left
         self._frames.clear()
         # wait for the clearing requests to finish in case the browser is re-used
@@ -1677,7 +1688,14 @@ class Transport(xmlrpclib.Transport):
     def request(self, *args, **kwargs):
         self.cr.flush()
         self.cr.clear()
-        return super().request(*args, **kwargs)
+        test = module.current_test
+        if test:
+            check = test.http_request_strict_check
+            test.http_request_strict_check = False
+        res = super().request(*args, **kwargs)
+        if test:
+            test.http_request_strict_check = check
+        return res
 
 
 class HttpCase(TransactionCase):
@@ -1874,6 +1892,7 @@ class HttpCase(TransactionCase):
         try:
             self.http_request_key = self.canonical_tag + '_browser_js'
             self.authenticate(login, login)
+            self.http_request_strict_check = True
             # Flush and clear the current transaction.  This is useful in case
             # we make requests to the server, as these requests are made with
             # test cursors, which uses different caches than this transaction.
@@ -1927,7 +1946,6 @@ class HttpCase(TransactionCase):
         finally:
             # clear browser to make it stop sending requests, in case we call
             # the method several times in a test method
-            self.browser.delete_cookie('session_id', domain=HOST)
             self.browser.clear()
             self._wait_remaining_requests()
             self.http_request_key = self.canonical_tag


### PR DESCRIPTION
Despite #205190 we still have sometimes a broken cursor, most of the time because of a websocket request.
This is because this stable solution cannot catch a cursor without cookie that is executed after the browser closes, or during the next test.

Checking the logs:

2025-04-11 05:18:04,048 13 INFO 78181227-16-0-all odoo.tests.common: Opening a test cursor without specified test on request /websocket in /knowledge/tests/test_knowledge_form_ui.py:TestKnowledgeUI.test_knowledge_main_flow
2025-04-11 04:56:57,155 13 INFO 78181121-16-0-all odoo.tests.common: Opening a test cursor without specified test on request /websocket in /test_sale_product_configurators/tests/test_sale_product_configurator.py:TestProductConfiguratorUi.test_02_product_configurator_advanced

That indicates that we are in the case where the request don't have a cookie, despite the route being called from a chrome.

It is most likely due to the fact that the browser cookie are cleared at the end of a browser js call, before navigating to about:blank

2025-04-11 04:56:57,119 13 INFO 78181121-16-0-all odoo.addons.test_sale_product_configurators.tests.test_sale_product_configurator.TestProductConfiguratorUi: Deleting cookies and clearing local storage

It is actually easy to reproduce by adding a sleep before navigating to about:blank in browser.clear(). We can see that the websocket route is still called periodically at the end of a test. This error will occur when this request is made just between
the cookies are cleared and the page navigates to about:blank.

One possibility is to avoid to clear the cookie since the user profile is deleted after the browser is stopped, but unfortunately in this version the browser is kept between tests of the same class.

It is maybe not sufficient but navigating to a blank page before removing the cookies should reduce the possibility of having a request without cookie reaching the server. In this case a sleep after about:blank, before clearing the cookie shows that we don't have repeated call to /websocket anymore.

Another possibility is to check if the request is a websocket request and to not open a cursor in that case if we don't have a cookie identifying the test. This cannot be done for all requests since it is possible that some call are made when generating a pdf, or any call that would open a TestCursor without being inside a browser_js or url_open

Combining both solution should hopefully highly reduce this error. 

A final decision was made to also forbid any request coming after a browser_js.
- browser_js is the main source of request reaching the server asynchronously. Other ways to create a request on the server is synchronous with the test and will wait for the result.
- After a browser js, it is unlikely to make another request outside an url_open or browser_js. It was the case for some xmlrpc requests, the dirty solution was to make the test non strict during this request. Those tests could still be a small cause of randomness.

Note: The explicit deletion of the session cookie is also removed, it is not  needed since all cookies are cleared just after, and having a request that could reach the server without session cookies feels a little like a good solution to have random access error. 