### PR TITLE
[IMP] project: keep task state with shared stage

### DIFF
--- a/addons/project/tests/test_task_state.py
+++ b/addons/project/tests/test_task_state.py
@@ -103,9 +103,21 @@ class TestTaskState(TestProjectCommon):
         (self.task_1 + self.task_2).write({
             'project_id': project_pigs.id
         })
-        self.task_1._onchange_project_id()
         self.assertEqual(self.task_1.state, '01_in_progress', "task_1 state should automatically switch back to in_progress when its project changes")
         self.assertEqual(self.task_2.state, '01_in_progress', "task_2 state should automatically switch back to in_progress when its project changes")
+
+    def test_task_state_unchanged_when_changing_project_with_shared_stage(self):
+        # copying the project because we want shared stage among projects
+        project_cows = self.project_goats.copy()
+        self.task_1.write({
+            'state': '03_approved',
+            'project_id': project_cows.id
+        })
+        self.assertEqual(self.task_1.state, '03_approved', "Task state should remain unchanged when moving to a project with the same shared stage.")
+        self.task_1.write({
+            'project_id': self.project_pigs.id
+        })
+        self.assertEqual(self.task_1.state, '01_in_progress', "Task state should change when moving to a project with non-shared stage.")
 
     def test_duplicate_dependent_task(self):
         self.task_1.write({


### PR DESCRIPTION
Issue:
- When a task is moved from one project to another, and both projects use the same shared stage (e.g., SPEC), the task’s state is reset. This can lead to confusion or missed context.

Steps to reproduce:
- Create a Project A and Project A (copy) with shared stage (e.g., SPEC)
- Create a Task A in Project A
- Set a state (e.g., Approved) for the Task A in Project A.
- Change project_id Project A to Project A (copy) in Task A .
- Observe the Task A after it moves to Project A(copy).

Current behavior:
- The task’s state is lost after moving to the new project.

Desired behavior:
- The task should keep its state when moved between projects sharing the same stage.

task-[4210148](https://www.odoo.com/odoo/my-tasks/4210148)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
