### PR TITLE
[FIX] ir_sequence: prevent an error when generating a sequences

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -234,7 +234,7 @@ class IrSequence(models.Model):
         try:
             interpolated_prefix = _interpolate(self.prefix, d)
             interpolated_suffix = _interpolate(self.suffix, d)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, KeyError):
             raise UserError(_('Invalid prefix or suffix for sequence %r', self.name))
         return interpolated_prefix, interpolated_suffix
 

--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -192,6 +192,21 @@ class TestIrSequenceGenerate(BaseCase):
             with self.assertRaises(UserError):
                 env['ir.sequence'].next_by_code('test_sequence_type_7')
 
+    def test_ir_sequence_suffix(self):
+        """ test whether the raise a user error for an invalid sequence """
+
+        # try to create a sequence with invalid suffix
+        with environment() as env:
+            seq = env['ir.sequence'].create({
+                'code': 'test_sequence_type_8',
+                'name': 'Test sequence',
+                'prefix': '',
+                'suffix': '%(y)s %(y + 1)s 000',
+            })
+            self.assertTrue(seq)
+            with self.assertRaises(UserError):
+                env['ir.sequence'].next_by_code('test_sequence_type_8')
+
     @classmethod
     def tearDownClass(cls):
         drop_sequence('test_sequence_type_5')


### PR DESCRIPTION
This error occurs when the user provides an invalid suffix in ir_sequence.

Steps to Reproduce:
- Install `sale_managment`.
- Open `Sequences` from `Technical` and open `Sales.Order.`
- Add Suffix as `S %(y)s %(y + 1)s 000`.
- Create a new sale order and save it.

`KeyError: 'y + 1'`

This error occurs when the system tries to generate a sequence at [1] but receives an invalid suffix format.

This commit resolves the error by raising a `user error` for an invalid sequence.

Link [1]
https://github.com/odoo/odoo/blob/0f452cab601350df1dd1a8322c91a9f7da736873/odoo/addons/base/models/ir_sequence.py#L236

Sentry- 6541044217

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
