### PR TITLE
[FIX] base_import: missing xlsx

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -25,7 +25,7 @@ from PIL import Image
 try:
     import xlrd
 except ImportError:
-    xlrd = None
+    xlrd = xlsx = None
 else:
     try:
         from xlrd import xlsx


### PR DESCRIPTION
Moving stuff around as part of #172761 I forgot the `xlsx` assignment if `xlrd`'s import fails (if xlrd is not installed), which leads to an error when defining `FILE_TYPE_DICT` if `openpyxl` is not installed either.
