### PR TITLE
[FIX] iot_box_image: fix startup errors

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/default/locale
+++ b/addons/iot_box_image/overwrite_before_init/etc/default/locale
@@ -1,0 +1,3 @@
+LANG=en_US.UTF-8
+LANGUAGE=en_US:en
+LC_ALL=en_US.UTF-8

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -11,14 +11,19 @@ __base="$(basename ${__file} .sh)"
 # Recommends: antiword, graphviz, ghostscript, python-gevent, poppler-utils
 export DEBIAN_FRONTEND=noninteractive
 
+# single-user mode, appropriate for chroot environment
+# explicitly setting the runlevel prevents warnings after installing packages
+export RUNLEVEL=1
+
+# Unset lang variables to prevent locale settings leaking from host
+unset "${!LC_@}"
+unset "${!LANG@}"
+
 # set locale to en_US
 echo "set locale to en_US"
 echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
-locale-gen
-# Environment variables
-echo "export LANGUAGE=en_US.UTF-8" >> ~/.bashrc
-echo "export LANG=en_US.UTF-8" >> ~/.bashrc
-echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc
+dpkg-reconfigure locales
+
 # Aliases
 echo  "alias ll='ls -al'" | tee -a ~/.bashrc /home/pi/.bashrc
 echo  "alias odoo='sudo systemctl stop odoo; sudo -u odoo /usr/bin/python3 /home/pi/odoo/odoo-bin --config /home/pi/odoo.conf'" | tee -a ~/.bashrc /home/pi/.bashrc
@@ -140,9 +145,6 @@ devtools() {
   esac
 }
 " | tee -a ~/.bashrc /home/pi/.bashrc
-
-source ~/.bashrc
-source /home/pi/.bashrc
 
 # Change default hostname from 'raspberrypi' to 'iotbox'
 echo iotbox | tee /etc/hostname
@@ -304,7 +306,7 @@ systemctl disable dphys-swapfile.service
 systemctl enable ssh
 systemctl set-default graphical.target
 systemctl disable getty@tty1.service
-systemctl enable systemd-timesyncd.service
+systemctl disable systemd-timesyncd.service
 systemctl unmask hostapd.service
 systemctl disable hostapd.service
 systemctl disable cups-browsed.service

--- a/addons/iot_box_image/overwrite_before_init/etc/locale.gen
+++ b/addons/iot_box_image/overwrite_before_init/etc/locale.gen
@@ -1,7 +1,0 @@
-# This file lists locales that you wish to have built. You can find a list
-# of valid supported locales at /usr/share/i18n/SUPPORTED, and you can add
-# user defined locales to /usr/local/share/i18n/SUPPORTED. If you change
-# this file, you need to rerun locale-gen.
-#
-
-en_US.UTF-8 UTF-8


### PR DESCRIPTION
This is a backport of commit 9b86deb to saas-18.1.

Before this commit, the following errors would occur during start-up:
- `systemd-timesyncd` would fail to start
- Several errors related to locale settings

The `systemd-timesyncd` problem was actually caused by it trying to start too early. By disabling the autostart of the service, it is instead started as a dependency of `systemd-timedate`. This allows it to start without errors.

The locale errors were caused by the default locale being set to `en_GB` even though only `en_US` was setup during the build process. By setting the `/etc/default/locale` file to `en_US` and removing all the evironment variables, the errors are fixed.
We also unset all language environment variables during the image build process, preventing the same locale errors from appearing.

task-4687121

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
