### PR TITLE
[FIX] website_sale: handle products' ecommerce translations from file

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -180,8 +180,19 @@ class ProductTemplate(models.Model):
     def write(self, vals):
         # Clear empty ecommerce description content to avoid side-effects on product pages
         # when there is no content to display anyway.
-        if vals.get('description_ecommerce') and is_html_empty(vals['description_ecommerce']):
-            vals['description_ecommerce'] = ''
+        user_lang = self.env.lang
+        self_with_context = self.with_context(lang=user_lang)
+
+        for field in ('description_ecommerce', 'website_description'):
+            if vals.get(field):
+                if is_html_empty(vals[field]):
+                    vals[field] = ''
+                if self[field] and self_with_context[field] != vals.get(field):
+                    self.update_field_translations(
+                        field, {user_lang: {self[field]: vals.get(field)}},
+                    )
+                    vals[field] = self[field]
+
         return super().write(vals)
 
     #=== BUSINESS METHODS ===#


### PR DESCRIPTION
## Version:
saas-18.0+

## Issue:
Importing eCommerce translations for products erase all existing translations and set the new one as default value, whatever the user's current language is.
The `website_description` acts the same.

## Steps to reproduce:
- From the user's `Preferences`:
  - Add a second language you understand;
  - Translate all websites and close without switching;
- Access `Sales / Products / Products`:
  - Set a product as favorite and open it:
    - Under the `Sales` tab, write something in the `ECOMMERCE DESCRIPTION` field;
    - Open the translation wizard by clicking the `EN` link appearing when hovering the input:
      - Write anything else in the second language's input field and save;
- Come back to the general products view (*`Sales / Products / Products`*):
  - Change view to list and select the favorite item (*check the case of the record line*);
  - Via the `Actions` button, click on `Export`:
    - Check `I want to update data (import-compatible export)`;
    - From the `Available fields` list, add `eCommerce Description`;
- Open the exported file:
  - Change the `description_ecommerce` content and save;
- From the general products view (*`Sales / Products / Products`*):
  - Ensure no product is selected;
  - Click the gear next to `Products` then `Import records`
    - Click `Upload Data File` and select the exported and modified file;
    - Ensure the fields are well mapped;
    - Test then import data;

## Cause:
Translation method refactoring via this PR: https://github.com/odoo/odoo/pull/170779, especially `update_field_translations(field_name, {"fr_FR": {"en2": "fr2"}})`, requiring a key (`en2`) and a value (`fr2`) for a given language as a `field_name` translation. Before the fix, giving only one value erases value and key for a given `field_name`

opw-4600662