### PR TITLE
[FIX] website: image gallery undo after delete

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -487,6 +487,13 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
         this._super(...arguments);
         this.$target.off('.gallery');
     },
+    /**
+     * @override
+     */
+    onRemove() {
+        this.isBeingRemoved = true;
+        this._super(...arguments);
+    },
 
     //--------------------------------------------------------------------------
     // Options
@@ -589,7 +596,7 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
      */
     notify(name, data) {
         this._super(...arguments);
-        if (name === 'image_removed') {
+        if (name === 'image_removed' && !this.isBeingRemoved) {
             data.$image.remove(); // Force the removal of the image before reset
             this.trigger_up('snippet_edition_request', {exec: () => {
                 return this._relayout();


### PR DESCRIPTION
Steps to reproduce:

- Drag and drop image gallery snippet.
- Delete the snippet.
- Click on Undo.
- The snippet appears but images will not be there.

The issue comes from the fact that when the snippet is deleted, a relayout of the snippet is triggered for each image present in it. This is necessary when an image is deleted, but not when the snippet itself is deleted.

task-4690318
