### PR TITLE
[FIX] hw_drivers: force touch in kiosk mode

### DIFF
--- a/addons/hw_drivers/browser.py
+++ b/addons/hw_drivers/browser.py
@@ -72,7 +72,7 @@ class Browser:
         browser_args = list(CHROMIUM_ARGS) if self.browser == 'chromium-browser' else []
 
         if state == BrowserState.KIOSK:
-            browser_args.append("--kiosk")
+            browser_args.extend(["--kiosk", "--touch-events"])
         elif state == BrowserState.FULLSCREEN:
             browser_args.append("--start-fullscreen")
 


### PR DESCRIPTION
Before this commit, when Chromium was running in kiosk mode under Wayland, it would not detect that the input device was a touchscreen. This resulted in touchscreen-specific code (such as hiding the cursor in the self-order kiosk) not working.

After this commit, we pass the `--touch-events` flag to Chromium when running in kiosk mode, which forces touch events to be enabled.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
