### PR TITLE
[FIX] *: remove unnecessary invisible fields

### DIFF
--- a/addons/l10n_ar/views/account_journal_view.xml
+++ b/addons/l10n_ar/views/account_journal_view.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <field name="l10n_latam_use_documents" position="after">
                 <field name="l10n_ar_is_pos" invisible="country_code != 'AR' or not l10n_latam_use_documents or type not in ['sale', 'purchase']"/>
-                <field name="company_partner" invisible="1"/>
+                <field name="company_partner" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_ar_afip_pos_system" invisible="not l10n_ar_is_pos" required="l10n_ar_is_pos"/>
                 <field name="l10n_ar_afip_pos_number" invisible="not l10n_ar_is_pos" required="l10n_ar_is_pos"/>
                 <field name="l10n_ar_afip_pos_partner_id" invisible="not l10n_ar_is_pos" required="l10n_ar_is_pos"/>

--- a/addons/l10n_br/views/res_partner_views.xml
+++ b/addons/l10n_br/views/res_partner_views.xml
@@ -8,9 +8,9 @@
             <field name="arch" type="xml">
                 <form>
                     <div class="o_address_format">
-                        <field name="country_enforce_cities" invisible="1"/>
-                        <field name="parent_id" invisible="1"/>
-                        <field name="type" invisible="1"/>
+                        <field name="country_enforce_cities" invisible="1"/> <!-- TODO: to be removed in master -->
+                        <field name="parent_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                        <field name="type" invisible="1"/> <!-- TODO: to be removed in master -->
                         <field name="street" placeholder="Street..." class="o_address_street oe_read_only"
                                readonly="type == 'contact' and parent_id"/>
                         <div class="oe_edit_only o_row">

--- a/addons/l10n_cl/views/account_move_view.xml
+++ b/addons/l10n_cl/views/account_move_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <form>
-                <field name="l10n_latam_internal_type" invisible="1"/>
+                <field name="l10n_latam_internal_type" invisible="1"/> <!-- TODO: to be removed in master -->
             </form>
         </field>
     </record>
@@ -44,8 +44,8 @@
                 <field name="amount_tax_signed" string="Tax" sum="Total" optional="show"/>
                 <field name="amount_total_signed" string="Total" sum="Total" optional="show"/>
                 <field name="amount_residual_signed" string="Amount Due" sum="Amount Due" optional="show"/>
-                <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'posted']"/>
-                <field name="company_currency_id" column_invisible="True"/>
+                <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'posted']"/> <!-- TODO: to be removed in master -->
+                <field name="company_currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                 <field name="state" optional="show"/>
                 <field name="payment_state" optional="hide"/>
                 <field name="move_type" column_invisible="context.get('default_move_type', True)"/>

--- a/addons/l10n_cl/views/res_bank_view.xml
+++ b/addons/l10n_cl/views/res_bank_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="base.view_res_bank_form" />
             <field name="arch" type="xml">
                 <field name="name" position="before">
-                    <field name="fiscal_country_codes" invisible="1"/>
+                    <field name="fiscal_country_codes" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_cl_sbif_code" invisible="'CL' not in fiscal_country_codes"/>
                 </field>
             </field>

--- a/addons/l10n_cn/views/account_move_view.xml
+++ b/addons/l10n_cn/views/account_move_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.view_move_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='ref']" position="after">
-                    <field name="move_type" invisible='1'/>
+                    <field name="move_type" invisible='1'/> <!-- TODO: to be removed in master -->
                     <field name="fapiao" invisible="country_code != 'CN' or move_type not in ['out_invoice', 'out_refund', 'in_invoice', 'in_refund']"/>
                 </xpath>
             </field>

--- a/addons/l10n_ec/views/account_journal_view.xml
+++ b/addons/l10n_ec/views/account_journal_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="l10n_latam_invoice_document.view_account_journal_form"/>
             <field name="arch" type="xml">
                 <field name="l10n_latam_use_documents" position="after">
-                    <field name="l10n_ec_require_emission" invisible="1"/>
+                    <field name="l10n_ec_require_emission" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_ec_entity"
                            placeholder="001"
                            invisible="not l10n_ec_require_emission"

--- a/addons/l10n_eg_edi_eta/data/res_country_data.xml
+++ b/addons/l10n_eg_edi_eta/data/res_country_data.xml
@@ -7,12 +7,12 @@
         <field name="arch" type="xml">
             <form>
                 <div class="o_address_format">
-                    <field name="parent_id" invisible="1"/>
-                    <field name="type" invisible="1"/>
+                    <field name="parent_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="type" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_eg_building_no" placeholder="Building Number..." class="o_address_street"/>
                     <field name="street" placeholder="Street" class="o_address_street"
                            readonly="type == 'contact' and parent_id"/>
-                    <field name="street2" invisible="1"/>
+                    <field name="street2" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="city"/>
                     <field name="state_id" class="o_address_state" placeholder="State..." options='{"no_open": True}'
                            readonly="type == 'contact' and parent_id"/>

--- a/addons/l10n_eg_edi_eta/views/account_move_view.xml
+++ b/addons/l10n_eg_edi_eta/views/account_move_view.xml
@@ -32,8 +32,8 @@
                                 <field name="l10n_eg_submission_number" readonly="1"/>
                             </group>
                             <group>
-                                <field name="l10n_eg_eta_json_doc_id" readonly="1" invisible="1"/>
-                                <field name="l10n_eg_is_signed" invisible="1"/>
+                                <field name="l10n_eg_eta_json_doc_id" readonly="1" invisible="1"/> <!-- TODO: to be removed in master -->
+                                <field name="l10n_eg_is_signed" invisible="1"/> <!-- TODO: to be removed in master -->
                             </group>
                             <group>
                                 <button name="action_get_eta_invoice_pdf" type="object"

--- a/addons/l10n_eg_edi_eta/views/eta_thumb_drive.xml
+++ b/addons/l10n_eg_edi_eta/views/eta_thumb_drive.xml
@@ -5,8 +5,8 @@
             <field name="model">l10n_eg_edi.thumb.drive</field>
             <field name="arch" type="xml">
                 <tree editable="top">
-                    <field name="user_id" column_invisible="True"/>
-                    <field name="certificate" column_invisible="True"/>
+                    <field name="user_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
+                    <field name="certificate" column_invisible="True"/> <!-- TODO: to be removed in master -->
                     <field name="company_id"/>
                     <field name="pin" password="True"/>
                     <field name="access_token" password="True"/>

--- a/addons/l10n_eg_edi_eta/views/res_config_settings_view.xml
+++ b/addons/l10n_eg_edi_eta/views/res_config_settings_view.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//app[@name='account']/block" position="after">
                 <block title="ETA E-Invoicing Settings" name="egyption_eta_edi" invisible="country_code != 'EG'">
-                    <field name="country_code" invisible="1"/>
+                    <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
                     <setting string="ETA API Integration" help="Enter your API credentials to enable ETA E-Invoicing." company_dependent="1">
                         <div class="content-group">
                             <div class="row mt16">

--- a/addons/l10n_es_edi_facturae/views/account_tax_views.xml
+++ b/addons/l10n_es_edi_facturae/views/account_tax_views.xml
@@ -7,7 +7,7 @@
             <field name="model">account.tax</field>
             <field name="arch" type="xml">
                 <field name="country_id" position="after">
-                    <field name="country_code" column_invisible="True"/>
+                    <field name="country_code" column_invisible="True"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_es_edi_facturae_tax_type" string="Spanish Tax Type" optional="hide"
                         invisible="country_code != 'ES'"/>
                 </field>

--- a/addons/l10n_es_edi_facturae/wizard/account_move_reversal_view.xml
+++ b/addons/l10n_es_edi_facturae/wizard/account_move_reversal_view.xml
@@ -8,7 +8,7 @@
             <field name="model">account.tax</field>
             <field name="arch" type="xml">
                 <field name="country_id" position="after">
-                    <field name="country_code" column_invisible="True"/>
+                    <field name="country_code" column_invisible="True"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_es_edi_facturae_tax_type" string="Spanish Tax Type" optional="hide"
                            invisible="country_code != 'ES'"/>
                 </field>
@@ -20,7 +20,7 @@
             <field name="model">account.move.reversal</field>
             <field name="arch" type="xml">
                 <field name="reason" position="replace">
-                    <field name="country_code" invisible="1"/>
+                    <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_es_edi_facturae_reason_code" string="Reason" invisible="country_code != 'ES'"/>
                     <field name="reason" string="Reason" invisible="move_type == 'entry' and country_code == 'ES'"/>
                 </field>

--- a/addons/l10n_es_edi_facturae/wizard/account_move_send_views.xml
+++ b/addons/l10n_es_edi_facturae/wizard/account_move_send_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.account_move_send_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='advanced_options']" position="inside">
-                <field name="l10n_es_edi_facturae_enable_xml" invisible="1"/>
+                <field name="l10n_es_edi_facturae_enable_xml" invisible="1"/> <!-- TODO: to be removed in master -->
                 <div name="option_xml"
                      invisible="not l10n_es_edi_facturae_enable_xml">
                     <!-- Use one field as the label for another -->

--- a/addons/l10n_es_edi_sii/views/account_move_views.xml
+++ b/addons/l10n_es_edi_sii/views/account_move_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//group[@id='other_tab_group']//group[@name='accounting_info_group']" position="inside">
                     <field name="l10n_es_registration_date" readonly="state == 'posted'" invisible="country_code != 'ES'"/>
-                    <field name="l10n_es_edi_csv" invisible="1"/>
+                    <field name="l10n_es_edi_csv" invisible="1"/> <!-- TODO: to be removed in master -->
                 </xpath>
                 <field name="ref" position="attributes">
                     <attribute name="readonly">l10n_es_edi_csv</attribute>

--- a/addons/l10n_es_edi_sii/views/res_config_settings_views.xml
+++ b/addons/l10n_es_edi_sii/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//app[@name='account']/block" position="after">
                 <block title="Spain Localization" name="spain_localization" invisible="country_code != 'ES'">
                     <!-- Invisible fields -->
-                    <field name="l10n_es_edi_certificate_ids" invisible="1"/>
+                    <field name="l10n_es_edi_certificate_ids" invisible="1"/> <!-- TODO: to be removed in master -->
                     <setting string="Registro de Libros connection SII" company_dependent="1">
                         <div class="content-group">
                             <div class="mt16">

--- a/addons/l10n_es_edi_tbai/views/account_move_view.xml
+++ b/addons/l10n_es_edi_tbai/views/account_move_view.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//group[@id='other_tab_group']/group[last()]" position='after'>
                     <group id="ticketbai_group" string="TicketBAI" invisible="not l10n_es_tbai_is_required">
-                        <field name="l10n_es_tbai_is_required" invisible="1"/>
+                        <field name="l10n_es_tbai_is_required" invisible="1"/> <!-- TODO: to be removed in master -->
                         <field name="l10n_es_tbai_chain_index" groups="base.group_no_one"/>
                         <field name="l10n_es_tbai_refund_reason"
                             invisible="move_type not in ('in_refund', 'out_refund')"

--- a/addons/l10n_es_edi_tbai/wizards/account_move_reversal_views.xml
+++ b/addons/l10n_es_edi_tbai/wizards/account_move_reversal_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_account_move_reversal"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='journal_id']" position="after">
-                <field name="l10n_es_tbai_is_required" invisible="1"/>
+                <field name="l10n_es_tbai_is_required" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field invisible="not l10n_es_tbai_is_required" name="l10n_es_tbai_refund_reason" widget="selection"/>
             </xpath>
         </field>

--- a/addons/l10n_fr/views/res_company_views.xml
+++ b/addons/l10n_fr/views/res_company_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
         <data>
              <xpath expr="//field[@name='company_registry']" position="after">
-                 <field name="is_france_country" invisible="1"/>
+                 <field name="is_france_country" invisible="1"/> <!-- TODO: to be removed in master -->
                  <field name="siret" invisible="not is_france_country"/>
                  <field name="ape" invisible="not is_france_country"/>
              </xpath>

--- a/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
+++ b/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <block name="work_organization_setting_container" position="after">
-                <field name="company_country_code" invisible="1"/>
+                <field name="company_country_code" invisible="1"/> <!-- TODO: to be removed in master -->
                 <block title="French Time Off Localization" invisible="company_country_code != 'FR'">
                     <setting company_dependent="1" help="Set the time off type used as the company Paid Time Off to compute part-timers leave duration">
                         <field name="l10n_fr_reference_leave_type"

--- a/addons/l10n_fr_pos_cert/views/account_sale_closure.xml
+++ b/addons/l10n_fr_pos_cert/views/account_sale_closure.xml
@@ -7,7 +7,7 @@
                 <field name="date_closing_start"/>
                 <field name="date_closing_stop"/>
                 <field name="company_id" groups="base.group_multi_company"/>
-                <field name="currency_id" column_invisible="True"/>
+                <field name="currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                 <field name="frequency"/>
                 <field name="sequence_number" groups="base.group_no_one"/>
                 <field name="total_interval"/>
@@ -42,7 +42,7 @@
                         </group>
                         <group>
                             <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="currency_id" invisible="1"/>
+                            <field name="currency_id" invisible="1"/> <!-- TODO: to be removed in master -->
                         </group>
                     </group>
                 </sheet>

--- a/addons/l10n_fr_pos_cert/views/res_config_settings_views.xml
+++ b/addons/l10n_fr_pos_cert/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <form position="inside">
-                <field name="country_code" invisible="1"/>
+                <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
             </form>
             <xpath expr="//field[@name='point_of_sale_use_ticket_qr_code']/.." position="attributes">
                 <attribute name="invisible">country_code in ['FR', 'MF', 'MQ', 'NC', 'PF', 'RE', 'GF', 'GP', 'TF']</attribute>

--- a/addons/l10n_hu_edi/views/account_move_views.xml
+++ b/addons/l10n_hu_edi/views/account_move_views.xml
@@ -27,7 +27,7 @@
             <xpath expr="//sheet" position="before">
                 <div class="alert alert-warning mb-0" role="alert"
                      invisible="not l10n_hu_edi_messages or not l10n_hu_edi_messages.get('blocking_level') or l10n_hu_edi_messages.get('hide_banner')">
-                    <field name="l10n_hu_edi_messages" invisible="1"/>
+                    <field name="l10n_hu_edi_messages" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_hu_edi_message_html" readonly="1"/>
                     <button name="l10n_hu_edi_button_hide_banner"
                             type="object"
@@ -58,7 +58,7 @@
                     <group>
                         <field name="l10n_hu_edi_message_html" readonly="1"/>
                         <field name="l10n_hu_edi_attachment" widget="binary" filename="l10n_hu_edi_attachment_filename" readonly="1"/>
-                        <field name="l10n_hu_edi_attachment_filename" invisible="1"/>
+                        <field name="l10n_hu_edi_attachment_filename" invisible="1"/> <!-- TODO: to be removed in master -->
                     </group>
                 </page>
             </xpath>

--- a/addons/l10n_hu_edi/views/res_company_views.xml
+++ b/addons/l10n_hu_edi/views/res_company_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_registry']" position="after">
-                <field name="account_fiscal_country_id" invisible="1"/>
+                <field name="account_fiscal_country_id" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_hu_group_vat" invisible="account_fiscal_country_id != %(base.hu)d"/>
             </xpath>
         </field>

--- a/addons/l10n_hu_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_hu_edi/views/res_config_settings_views.xml
@@ -14,7 +14,7 @@
                              help="Enter your e-invoicing credentials given by the Hungarian Authority."
                              name="l10n_hu_edi_nav_credentials">
                         <div class="row">
-                            <field name="l10n_hu_edi_is_active" invisible="1"/>
+                            <field name="l10n_hu_edi_is_active" invisible="1"/> <!-- TODO: to be removed in master -->
                             <div class="alert alert-success text-center ms-3" role="alert"
                                  invisible="not l10n_hu_edi_is_active">
                                 Authentication with NAV 3.0 successful.

--- a/addons/l10n_hu_edi/wizard/account_move_send_views.xml
+++ b/addons/l10n_hu_edi/wizard/account_move_send_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.account_move_send_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='advanced_options']" position="inside">
-                <field name="l10n_hu_edi_enable_nav_30" invisible="1"/>
+                <field name="l10n_hu_edi_enable_nav_30" invisible="1"/> <!-- TODO: to be removed in master -->
                 <div name="option_nav_30_xml"
                      invisible="not l10n_hu_edi_enable_nav_30">
                     <field name="l10n_hu_edi_checkbox_nav_30"/>

--- a/addons/l10n_hu_edi/wizard/l10n_hu_edi_tax_audit_export.xml
+++ b/addons/l10n_hu_edi/wizard/l10n_hu_edi_tax_audit_export.xml
@@ -19,7 +19,7 @@
                 </group>
                 <div invisible="not export_file">
                     <field name="export_file" widget="binary" filename="filename" readonly="1"/>
-                    <field name="filename" invisible="1"/>
+                    <field name="filename" invisible="1"/> <!-- TODO: to be removed in master -->
                 </div>
                 <footer>
                     <button string="Export" name="action_export" type="object" default_focus="1" class="btn-primary"/>

--- a/addons/l10n_id_efaktur/views/account_move_views.xml
+++ b/addons/l10n_id_efaktur/views/account_move_views.xml
@@ -7,8 +7,8 @@
             <field name="inherit_id" ref="account.view_move_form"/>
             <field name="arch" type="xml">
                 <field name="partner_shipping_id" position="before">
-                    <field name="l10n_id_need_kode_transaksi" invisible="1"/>
-                    <field name="l10n_id_attachment_id" invisible="1"/>
+                    <field name="l10n_id_need_kode_transaksi" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_id_attachment_id" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_id_kode_transaksi" invisible="country_code != 'ID' or not l10n_id_need_kode_transaksi" readonly="state in ['cancel', 'posted']" required="l10n_id_need_kode_transaksi"/>
                     <field name="l10n_id_replace_invoice_id" invisible="country_code != 'ID'" readonly="state != 'draft'" options="{'m2o_dialog': False, 'no_create': True}"/>
                 </field>

--- a/addons/l10n_id_efaktur/views/efaktur_views.xml
+++ b/addons/l10n_id_efaktur/views/efaktur_views.xml
@@ -10,7 +10,7 @@
                     <field name="max"/>
                     <field name="available" sum="Total Available"/>
                     <field name="company_id" groups="base.group_multi_company"/>
-                    <field name="company_id" column_invisible="True" groups="!base.group_multi_company"/>
+                    <field name="company_id" column_invisible="True" groups="!base.group_multi_company"/> <!-- TODO: to be removed in master -->
                 </tree>
             </field>
         </record>

--- a/addons/l10n_id_efaktur_coretax/views/account_move.xml
+++ b/addons/l10n_id_efaktur_coretax/views/account_move.xml
@@ -16,7 +16,7 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='l10n_id_replace_invoice_id']" position="after">
-                <field name="l10n_id_coretax_efaktur_available" invisible="1"/>
+                <field name="l10n_id_coretax_efaktur_available" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_id_coretax_add_info_07" invisible="l10n_id_kode_transaksi != '07'" string="Additional Information"/>
                 <field name="l10n_id_coretax_facility_info_07" invisible="l10n_id_kode_transaksi != '07'" string="Facility Stamp"/>
                 <field name="l10n_id_coretax_add_info_08" invisible="l10n_id_kode_transaksi != '08'" string="Additional Information"/>

--- a/addons/l10n_id_efaktur_coretax/views/efaktur_document.xml
+++ b/addons/l10n_id_efaktur_coretax/views/efaktur_document.xml
@@ -7,7 +7,7 @@
             <field name="arch" type="xml">
                 <form string="E-faktur Document" create="false">
                     <header>
-                        <field name="attachment_id" invisible="1" />
+                        <field name="attachment_id" invisible="1" /> <!-- TODO: to be removed in master -->
                         <button name="action_download" string="Download" class="btn-primary"
                                 type="object" groups="account.group_account_invoice" data-hotkey="q"
                                 invisible="not invoice_ids"/>

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -13,8 +13,8 @@
                 </div>
             </xpath>
             <xpath expr="//field[@name='ref']" position="after">
-                <field name="country_code" invisible="1"/>
-                <field name="l10n_in_journal_type" invisible="1"/>
+                <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="l10n_in_journal_type" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_in_state_id" domain="[('country_id.code', '=', 'IN')]"
                     options="{'no_create': True, 'no_open': True}"
                     invisible="country_code != 'IN' or move_type == 'entry'"

--- a/addons/l10n_in/views/product_template_view.xml
+++ b/addons/l10n_in/views/product_template_view.xml
@@ -13,7 +13,7 @@
             </xpath>
             <field name="categ_id" position="after">
                 <field name="l10n_in_hsn_code" widget="l10n_in_hsn_autocomplete" invisible="'IN' not in fiscal_country_codes"/>
-                <field name="l10n_in_hsn_description" invisible="1"/>
+                <field name="l10n_in_hsn_description" invisible="1"/> <!-- TODO: to be removed in master -->
             </field>
         </field>
     </record>

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -17,7 +17,7 @@
                 </setting>
             </block>
             <xpath expr="//app[@name='account']" position="inside">
-                <div id="india_integration_section" invisible="1">
+                <div id="india_integration_section" invisible="1"> <!-- TODO: to be removed in master -->
                     <block title="Indian Integration" id="india_localization" invisible="country_code != 'IN'">
                     </block>
                 </div>

--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -25,7 +25,7 @@
                             invisible="country_code != 'IN'"
                             type="object"/>
                 </div>
-                <field name="display_pan_warning" invisible="1"/>
+                <field name="display_pan_warning" invisible="1"/> <!-- TODO: to be removed in master -->
                 <div class="alert alert-warning" role="alert"
                         invisible="not display_pan_warning">
                         PAN number is not same as the 3rd to 12th characters of the GST number.

--- a/addons/l10n_in_edi/views/account_move_views.xml
+++ b/addons/l10n_in_edi/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_info_group']" position="inside">
-                <field name="l10n_in_edi_show_cancel" invisible="1"/>
+                <field name="l10n_in_edi_show_cancel" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_in_edi_cancel_reason" invisible="country_code != 'IN' or state != 'posted' or not l10n_in_edi_show_cancel"/>
                 <field name="l10n_in_edi_cancel_remarks" invisible="country_code != 'IN' or state != 'posted' or not l10n_in_edi_show_cancel"/>
             </xpath>

--- a/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
@@ -6,13 +6,13 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='button_set_checked']" position="after">
-                <field name="l10n_in_edi_ewaybill_show_send_button" invisible="1"/>
+                <field name="l10n_in_edi_ewaybill_show_send_button" invisible="1"/> <!-- TODO: to be removed in master -->
                 <button name="l10n_in_edi_ewaybill_send" string="Send E-waybill" class="oe_highlight" type="object" groups="account.group_account_invoice" invisible="not l10n_in_edi_ewaybill_show_send_button"/>
             </xpath>
             <xpath expr="//notebook/page[@name='other_info']" position="before">
                 <page string="eWayBill" name="l10n_in_edi_ewaybill_page"
                     invisible="move_type in ('entry', 'out_refund') or country_code != 'IN'">
-                    <field name="l10n_in_edi_ewaybill_direct_api" invisible="1"/>
+                    <field name="l10n_in_edi_ewaybill_direct_api" invisible="1"/> <!-- TODO: to be removed in master -->
                     <group name="ewaybill_group">
                         <group string="Transaction Details" name="Transaction_group" 
                             invisible="not l10n_in_edi_ewaybill_direct_api">

--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -13,7 +13,7 @@
                     <button name="action_export_json" string="Download JSON" class="oe_highlight" type="object" invisible="not error_message" groups="base.group_no_one"/>
                     <field name="state" widget="statusbar" statusbar_visible="pending,generated" invisible="state == 'challan'"/>
                 </header>
-                <field name="blocking_level" invisible="1"/>
+                <field name="blocking_level" invisible="1"/> <!-- TODO: to be removed in master -->
                 <div class="alert alert-danger" role="alert" style="margin-bottom:0px;" invisible="not error_message or blocking_level == 'error'">
                     <div class="o_row">
                         <field name="error_message"/>
@@ -32,9 +32,9 @@
                     </div>
                     <group name="document_details" string="Document Details">
                         <group>
-                            <field name="picking_id" invisible="1"/>
-                            <field name="picking_type_code" invisible="1"/>
-                            <field name="sub_type_code" invisible="1"/>
+                            <field name="picking_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                            <field name="picking_type_code" invisible="1"/> <!-- TODO: to be removed in master -->
+                            <field name="sub_type_code" invisible="1"/> <!-- TODO: to be removed in master -->
                             <field name="type_id" widget="selection" readonly="state != 'pending'" domain="[
                                         ('allowed_supply_type', 'in', (picking_type_code == 'incoming' and 'in' or 'out', 'both')), ('code','=','CHL')]"/>
                             <field name="type_description" invisible="sub_type_code != '8'" required="sub_type_code == '8'"/>
@@ -46,11 +46,11 @@
                         </group>
                     </group>
                     <group name="partners" string="Address Details">
-                        <field name="company_id" invisible="1"/>
-                        <field name="is_bill_to_editable" invisible="1"/>
-                        <field name="is_bill_from_editable" invisible="1"/>
-                        <field name="is_ship_to_editable" invisible="1"/>
-                        <field name="is_ship_from_editable" invisible="1"/>
+                        <field name="company_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                        <field name="is_bill_to_editable" invisible="1"/> <!-- TODO: to be removed in master -->
+                        <field name="is_bill_from_editable" invisible="1"/> <!-- TODO: to be removed in master -->
+                        <field name="is_ship_to_editable" invisible="1"/> <!-- TODO: to be removed in master -->
+                        <field name="is_ship_from_editable" invisible="1"/> <!-- TODO: to be removed in master -->
                         <group>
                             <field name="fiscal_position_id" readonly="state != 'pending'"/>
                         </group>
@@ -129,8 +129,8 @@
                         <page string="Item Details">
                             <field name="move_ids" mode="tree,kanban" force_save="1" readonly="state != 'pending'">
                                 <tree editable="bottom" create="0" delete="0">
-                                    <field name="company_currency_id" column_invisible="1"/>
-                                    <field name="company_id" column_invisible="1"/>
+                                    <field name="company_currency_id" column_invisible="1"/> <!-- TODO: to be removed in master -->
+                                    <field name="company_id" column_invisible="1"/> <!-- TODO: to be removed in master -->
                                     <field name="product_id" readonly="1"/>
                                     <field name="quantity" string="Quantity" readonly="1"/>
                                     <field name="ewaybill_price_unit" string="Unit Price"/>

--- a/addons/l10n_in_ewaybill_stock/views/stock_picking_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/stock_picking_views.xml
@@ -18,7 +18,7 @@
                         groups="stock.group_stock_manager"/>
             </xpath>
             <xpath expr="//sheet/div[hasclass('oe_button_box')]" position="inside">
-                <field name="l10n_in_ewaybill_id" invisible="1" groups="stock.group_stock_manager"/>
+                <field name="l10n_in_ewaybill_id" invisible="1" groups="stock.group_stock_manager"/> <!-- TODO: to be removed in master -->
                 <button name="action_open_l10n_in_ewaybill"
                         class="oe_stat_button"
                         icon="fa-truck"

--- a/addons/l10n_in_purchase/views/purchase_order_views.xml
+++ b/addons/l10n_in_purchase/views/purchase_order_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="purchase.purchase_order_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="country_code" invisible="1"/>
+                <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_in_gst_treatment" invisible="country_code != 'IN'" required="country_code == 'IN'"/>
             </xpath>
         </field>

--- a/addons/l10n_in_sale/views/sale_views.xml
+++ b/addons/l10n_in_sale/views/sale_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="country_code" invisible="1"/>
+                <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_in_reseller_partner_id" groups="l10n_in.group_l10n_in_reseller"
                     invisible="country_code != 'IN'"
                     readonly="state not in ['draft', 'sent']"/>

--- a/addons/l10n_in_withholding/views/account_move_views.xml
+++ b/addons/l10n_in_withholding/views/account_move_views.xml
@@ -5,12 +5,12 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                <field name="l10n_in_is_withholding" invisible="1"/>
+                <field name="l10n_in_is_withholding" invisible="1"/> <!-- TODO: to be removed in master -->
                 <button name="%(l10n_in_withholding_entry_form_action)d" string="TDS Entry" type="action" class="btn btn-secondary float-end"
                         invisible="country_code != 'IN' or move_type not in ('out_invoice', 'in_invoice', 'out_refund', 'in_refund') or state != 'posted'"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
-                <field name="l10n_in_withhold_move_ids" invisible="1"/>
+                <field name="l10n_in_withhold_move_ids" invisible="1"/> <!-- TODO: to be removed in master -->
                 <button name="action_l10n_in_withholding_entries"
                         class="oe_stat_button"
                         type="object"

--- a/addons/l10n_in_withholding/views/account_payment_views.xml
+++ b/addons/l10n_in_withholding/views/account_payment_views.xml
@@ -10,7 +10,7 @@
                         invisible="country_code != 'IN' or is_internal_transfer or state != 'posted' or is_reconciled"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
-                <field name="l10n_in_withhold_move_ids" invisible="1"/>
+                <field name="l10n_in_withhold_move_ids" invisible="1"/> <!-- TODO: to be removed in master -->
                 <button name="action_l10n_in_withholding_entries"
                         class="oe_stat_button"
                         type="object"

--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
@@ -20,11 +20,11 @@
                     <field name="warning_message"/>
                 </div>
                 <sheet>
-                    <field name="related_move_id" invisible="1"/>
-                    <field name="related_payment_id" invisible="1"/>
-                    <field name="currency_id" invisible="1"/>
-                    <field name="type_name" invisible="1"/>
-                    <field name="company_id" invisible="1"/>
+                    <field name="related_move_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="related_payment_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="currency_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="type_name" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="company_id" invisible="1"/> <!-- TODO: to be removed in master -->
                     <group>
                         <group id="header_left_group">
                             <field name="date"/>
@@ -38,8 +38,8 @@
                         <page string="TDS Tax Details">
                             <field name="withhold_line_ids">
                                 <tree editable="bottom">
-                                    <field name="currency_id" column_invisible="True"/>
-                                    <field name="l10n_in_tds_tax_type" column_invisible="True"/>
+                                    <field name="currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
+                                    <field name="l10n_in_tds_tax_type" column_invisible="True"/> <!-- TODO: to be removed in master -->
                                     <field name="tax_id" domain="[('l10n_in_tds_tax_type', '=', l10n_in_tds_tax_type)]"/>
                                     <field name="base" sum="Total Base" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                                     <field name="amount" sum="Total Amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -117,8 +117,8 @@
                             data-hotkey="y"/>
                 </xpath>
                 <xpath expr="//sheet" position="before">
-                    <field name="l10n_it_edi_is_self_invoice" invisible="1"/>
-                    <field name="l10n_it_edi_attachment_id" invisible="1"/>
+                    <field name="l10n_it_edi_is_self_invoice" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_it_edi_attachment_id" invisible="1"/> <!-- TODO: to be removed in master -->
                     <div class="alert alert-warning" role="alert"
                         invisible="not l10n_it_edi_header 
                                    or state == 'draft'
@@ -148,7 +148,7 @@
                                 <field name="l10n_it_stamp_duty" readonly="state != 'draft'"/>
                                 <field name="l10n_it_ddt_id" readonly="state != 'draft'" invisible="move_type not in ('out_invoice', 'out_refund')"/>
                             </group>
-                            <field name="l10n_it_partner_pa" invisible="1"/>
+                            <field name="l10n_it_partner_pa" invisible="1"/> <!-- TODO: to be removed in master -->
                             <group invisible="not l10n_it_partner_pa">
                                 <field name="l10n_it_origin_document_type" readonly="state != 'draft'"/>
                                 <field name="l10n_it_origin_document_name" readonly="state != 'draft'"/>

--- a/addons/l10n_it_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi/views/res_config_settings_views.xml
@@ -10,7 +10,7 @@
                 <block title="Italian Electronic Invoicing" invisible="country_code != 'IT'" id='account_edi'>
                     <setting>
                         <div class="group-content">
-                            <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
+                            <field name="l10n_it_edi_proxy_current_state" invisible="1"/> <!-- TODO: to be removed in master -->
                             <span class="o_form_label">
                                 Fattura Elettronica mode
                             </span>

--- a/addons/l10n_it_edi/wizard/account_move_send_views.xml
+++ b/addons/l10n_it_edi/wizard/account_move_send_views.xml
@@ -6,10 +6,10 @@
             <field name="inherit_id" ref="account.account_move_send_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='option_send_mail']" position='after'>
-                    <field name="l10n_it_edi_readonly_xml_export" invisible="1"/>
-                    <field name="l10n_it_edi_enable_xml_export" invisible="1"/>
-                    <field name="l10n_it_edi_readonly_send" invisible="1"/>
-                    <field name="l10n_it_edi_enable_send" invisible="1"/>
+                    <field name="l10n_it_edi_readonly_xml_export" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_it_edi_enable_xml_export" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_it_edi_readonly_send" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_it_edi_enable_send" invisible="1"/> <!-- TODO: to be removed in master -->
                     <div name="option_l10n_it_edi">
                         <div name="option_l10n_it_edi_xml_export" invisible="not l10n_it_edi_enable_xml_export">
                             <field name="l10n_it_edi_checkbox_xml_export" readonly="l10n_it_edi_readonly_xml_export"/>

--- a/addons/l10n_it_edi_doi/views/account_move_views.xml
+++ b/addons/l10n_it_edi_doi/views/account_move_views.xml
@@ -27,12 +27,12 @@
         <field name="model">account.move</field>
         <field name="arch" type="xml">
             <tree string="Invoices" sample="1" decoration-info="state == 'draft'" expand="context.get('expand', False)">
-                <field name="made_sequence_hole" column_invisible="True"/>
+                <field name="made_sequence_hole" column_invisible="True"/> <!-- TODO: to be removed in master -->
                 <field name="name" decoration-bf="1" decoration-danger="made_sequence_hole"/>
                 <field name="invoice_partner_display_name" string="Customer"/>
                 <field name="invoice_date" string="Invoice Date"/>
                 <field name="date" string="Accounting Date" optional="hidden"/>
-                <field name="currency_id" column_invisible="True"/>
+                <field name="currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state == 'posted'"/>
                 <field name="l10n_it_edi_doi_amount" decoration-bf="1" sum="Total" string="Tax excluded"/>
             </tree>
@@ -63,7 +63,7 @@
                 </div>
             </xpath>
             <xpath expr="//field[@name='fiscal_position_id']" position="before">
-                <field name="l10n_it_edi_doi_use" invisible="True"/>
+                <field name="l10n_it_edi_doi_use" invisible="True"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_it_edi_doi_id"
                        invisible="not l10n_it_edi_doi_use"
                        readonly="state != 'draft'"

--- a/addons/l10n_it_edi_doi/views/l10n_it_edi_doi_declaration_of_intent_views.xml
+++ b/addons/l10n_it_edi_doi/views/l10n_it_edi_doi_declaration_of_intent_views.xml
@@ -11,7 +11,7 @@
                 <control>
                     <create name="add_line_control" string="Add a Declaration of Intent"/>
                 </control>
-                <field name="currency_id" column_invisible="True"/>
+                <field name="currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                 <field name="partner_id" readonly="state != 'draft'"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hidden"/>
                 <field name="protocol_number_part1" readonly="state != 'draft'"/>
@@ -48,8 +48,8 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <field name="invoice_ids" invisible="True"/>
-                        <field name="sale_order_ids" invisible="True"/>
+                        <field name="invoice_ids" invisible="True"/> <!-- TODO: to be removed in master -->
+                        <field name="sale_order_ids" invisible="True"/> <!-- TODO: to be removed in master -->
                         <button type="object"
                                 class="oe_stat_button"
                                 name="action_open_invoice_ids"
@@ -91,7 +91,7 @@
                             <div colspan="2" class="o_wrap_label">
                                 <span class="o_form_label">Amounts:</span>
                             </div>
-                            <field name="currency_id" invisible="True"/>
+                            <field name="currency_id" invisible="True"/> <!-- TODO: to be removed in master -->
                             <field name="threshold" widget="monetary" readonly="state != 'draft'"/>
                             <field name="not_yet_invoiced" widget="monetary"/>
                             <field name="invoiced" widget="monetary"/>

--- a/addons/l10n_it_edi_doi/views/sale_order_views.xml
+++ b/addons/l10n_it_edi_doi/views/sale_order_views.xml
@@ -30,7 +30,7 @@
                 <field name="name" string="Number"/>
                 <field name="date_order" widget="date"/>
                 <field name="partner_id"/>
-                <field name="currency_id" column_invisible="True"/>
+                <field name="currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                 <field name="state"
                        decoration-success="state == 'sale'"
                        decoration-info="state == 'draft'"
@@ -65,7 +65,7 @@
                 </div>
             </xpath>
             <xpath expr="//label[@for='fiscal_position_id']" position="before">
-                <field name="l10n_it_edi_doi_use" invisible="True"/>
+                <field name="l10n_it_edi_doi_use" invisible="True"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_it_edi_doi_id"
                        invisible="not l10n_it_edi_doi_use"
                        options='{"no_quick_create": True}'

--- a/addons/l10n_it_edi_sale/views/sale_order_views.xml
+++ b/addons/l10n_it_edi_sale/views/sale_order_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_reporting']" position="after">
-                <field name="l10n_it_partner_pa" invisible="1"/>
+                <field name="l10n_it_partner_pa" invisible="1"/> <!-- TODO: to be removed in master -->
                 <group name="it_edi_sale_order"
                        string="Italian Electronic Invoicing"
                        invisible="country_code != 'IT' or not l10n_it_partner_pa">

--- a/addons/l10n_it_stock_ddt/views/stock_picking_views.xml
+++ b/addons/l10n_it_stock_ddt/views/stock_picking_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='do_print_picking']" position="after">
-                <field name="l10n_it_show_print_ddt_button" invisible="1"/>
+                <field name="l10n_it_show_print_ddt_button" invisible="1"/> <!-- TODO: to be removed in master -->
                 <button name="%(l10n_it_stock_ddt.action_report_ddt)d" type="action" string="Print"
                         invisible="not l10n_it_show_print_ddt_button"
                         groups="base.group_user"/>
@@ -16,7 +16,7 @@
             </xpath>
             <group name='carrier_data' position="after">
                 <group string="DDT Information" invisible="country_code != 'IT' or picking_type_code != 'outgoing'">
-                    <field name="country_code" invisible="1"/>
+                    <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_it_ddt_number"/>
                     <field name="l10n_it_transport_reason"/>
                     <field name="l10n_it_transport_method"/>

--- a/addons/l10n_jo_edi/wizard/account_move_send_views.xml
+++ b/addons/l10n_jo_edi/wizard/account_move_send_views.xml
@@ -12,7 +12,7 @@
                 </div>
             </div>
             <xpath expr="//div[@name='advanced_options']" position="inside">
-                <field name="l10n_jo_edi_is_visible" invisible="1"/>
+                <field name="l10n_jo_edi_is_visible" invisible="1"/> <!-- TODO: to be removed in master -->
                 <div name="option_l10n_jo_edi" invisible="not l10n_jo_edi_is_visible">
                     <field name="l10n_jo_edi_is_enabled"/>
                     <b>

--- a/addons/l10n_ke_edi_tremol/views/account_move_view.xml
+++ b/addons/l10n_ke_edi_tremol/views/account_move_view.xml
@@ -7,8 +7,8 @@
             <field name="priority" eval="40"/>
             <field name="arch" type="xml">
                 <xpath expr="//header/button[@name='action_post']" position="after">
-                    <field name="l10n_ke_cu_qrcode" invisible="1"/>
-                    <field name="l10n_ke_cu_show_send_button" invisible="1"/>
+                    <field name="l10n_ke_cu_qrcode" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_ke_cu_show_send_button" invisible="1"/> <!-- TODO: to be removed in master -->
                     <button name="l10n_ke_action_cu_post" type="object"
                             class="oe_highlight"
                             groups="account.group_account_manager"

--- a/addons/l10n_latam_check/views/account_payment_view.xml
+++ b/addons/l10n_latam_check/views/account_payment_view.xml
@@ -11,8 +11,8 @@
                         <group name="latam_checks" colspan="2">
                             <field name="l10n_latam_new_check_ids" invisible="payment_method_code not in ['new_third_party_checks', 'own_checks']" nolabel="1" colspan="2" readonly="state != 'draft'">
                                 <tree name="new_checks" editable="bottom">
-                                    <field name="company_id" column_invisible="True"/>
-                                    <field name="currency_id" column_invisible="True"/>
+                                    <field name="company_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
+                                    <field name="currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                                     <field name="name" />
                                     <field name="bank_id" column_invisible="parent.payment_method_code == 'own_checks'"/>
                                     <field name="issuer_vat" column_invisible="parent.payment_method_code == 'own_checks'"/>
@@ -30,8 +30,8 @@
                                     [('payment_method_code', '=', 'new_third_party_checks'), ('current_journal_id', '=', False), ('company_id', '=', company_id)]" options="{'no_create': True}"
                                     nolabel="1" colspan="2" readonly="state != 'draft'">
                                 <tree name="existing_checks">
-                                    <field name="company_id" column_invisible="True"/>
-                                    <field name="currency_id" column_invisible="True"/>
+                                    <field name="company_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
+                                    <field name="currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                                     <field name="name" />
                                     <field name="bank_id" optional="hide"/>
                                     <field name="issuer_vat" optional="hide"/>

--- a/addons/l10n_latam_check/views/l10n_latam_check_view.xml
+++ b/addons/l10n_latam_check/views/l10n_latam_check_view.xml
@@ -67,7 +67,7 @@
                 <field name="payment_type"/>
                 <field name="journal_id"/>
                 <field name="partner_id" string="Customer"/>
-                <field name="state" column_invisible="True"/>
+                <field name="state" column_invisible="True"/> <!-- TODO: to be removed in master -->
             </tree>
         </field>
     </record>
@@ -102,7 +102,7 @@
         <field name="model">l10n_latam.check</field>
         <field name="arch" type="xml">
             <form create="false" edit="false" delete="false">
-                <field name="outstanding_line_id" invisible="True"/>
+                <field name="outstanding_line_id" invisible="True"/> <!-- TODO: to be removed in master -->
                 <header>
                     <button name="action_void" string="Void Check" invisible="issue_state != 'handed'" type="object" class="oe_highlight" confirm="Marking a check as void will cancel the check and generate a new entry that will re-open the debt."  data-hotkey="v"/>
                     <field name="issue_state" statusbar_visible="issue_state" widget="statusbar"/>
@@ -133,7 +133,7 @@
                             <field name="amount"/>
                             <field name="bank_id"  invisible="issue_state"/>
                             <field name="issuer_vat"  invisible="issue_state"/>
-                            <field name="currency_id" invisible="1"/>
+                            <field name="currency_id" invisible="1"/> <!-- TODO: to be removed in master -->
                             <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                     </group>
@@ -157,7 +157,7 @@
                     <field name="name"/>
                     <field name="original_journal_id"/>
                     <field name="company_id" optional="hide" groups="base.group_multi_company"/>
-                    <field name="payment_method_line_id" column_invisible="True"/>
+                    <field name="payment_method_line_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                     <field name="partner_id" string="Customer"/>
                     <field name="amount"  optional="show"/>
                     <field name="currency_id" string="Payment Currency" optional="hide"/>

--- a/addons/l10n_latam_check/wizards/account_payment_register_views.xml
+++ b/addons/l10n_latam_check/wizards/account_payment_register_views.xml
@@ -12,8 +12,8 @@
                         <group name="latam_checks" colspan="2">
                             <field name="l10n_latam_new_check_ids" invisible="payment_method_code not in ['new_third_party_checks', 'own_checks']" nolabel="1" colspan="2" >
                                 <tree editable="bottom">
-                                    <field name="company_id" column_invisible="True"/>
-                                    <field name="currency_id" column_invisible="True"/>
+                                    <field name="company_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
+                                    <field name="currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                                     <field name="name" />
                                     <field name="bank_id" column_invisible="parent.payment_method_code == 'own_checks'"/>
                                     <field name="issuer_vat" column_invisible="parent.payment_method_code == 'own_checks'"/>
@@ -28,8 +28,8 @@
                                     [('payment_method_code', '=', 'new_third_party_checks'), ('current_journal_id', '=', False), ('company_id', '=', company_id)]" options="{'no_create': True}"
                                     nolabel="1" colspan="2">
                                 <tree name="existing_checks">
-                                    <field name="company_id" column_invisible="True"/>
-                                    <field name="currency_id" column_invisible="True"/>
+                                    <field name="company_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
+                                    <field name="currency_id" column_invisible="True"/> <!-- TODO: to be removed in master -->
                                     <field name="name" />
                                     <field name="bank_id" optional="hide"/>
                                     <field name="issuer_vat" optional="hide"/>

--- a/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer_views.xml
+++ b/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer_views.xml
@@ -5,9 +5,9 @@
         <field name="model">l10n_latam.payment.mass.transfer</field>
         <field name="arch" type="xml">
             <form>
-                <field name="check_ids" invisible="1"/>
-                <field name="journal_id" invisible="1"/>
-                <field name="company_id" invisible="1"/>
+                <field name="check_ids" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="journal_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="company_id" invisible="1"/> <!-- TODO: to be removed in master -->
                 <group>
                     <group name="destination_journal_group">
                         <field name="destination_journal_id" options="{'no_open': True, 'no_create': True}" required="1"/>

--- a/addons/l10n_latam_invoice_document/views/account_journal_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_journal_view.xml
@@ -7,8 +7,8 @@
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
             <form>
-                <field name="country_code" invisible="1"/>
-                <field name="l10n_latam_company_use_documents" invisible="1"/>
+                <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="l10n_latam_company_use_documents" invisible="1"/> <!-- TODO: to be removed in master -->
             </form>
             <field name="type" position="after">
                 <field name="l10n_latam_use_documents" invisible="not l10n_latam_company_use_documents or type not in ['purchase', 'sale']"/>

--- a/addons/l10n_latam_invoice_document/views/account_move_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_move_view.xml
@@ -35,9 +35,9 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <form>
-                <field name="l10n_latam_available_document_type_ids" invisible="1"/>
-                <field name="l10n_latam_use_documents" invisible="1"/>
-                <field name="l10n_latam_manual_document_number" invisible="1"/>
+                <field name="l10n_latam_available_document_type_ids" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="l10n_latam_use_documents" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="l10n_latam_manual_document_number" invisible="1"/> <!-- TODO: to be removed in master -->
             </form>
 
             <xpath expr="//div[@name='journal_div']" position="after">

--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal_view.xml
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal_view.xml
@@ -7,11 +7,11 @@
         <field name="inherit_id" ref="account.view_account_move_reversal"/>
         <field name="arch" type="xml">
             <form>
-                <field name="l10n_latam_use_documents" invisible="1"/>
-                <field name="l10n_latam_manual_document_number" invisible="1"/>
+                <field name="l10n_latam_use_documents" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="l10n_latam_manual_document_number" invisible="1"/> <!-- TODO: to be removed in master -->
             </form>
             <field name="date" position="before">
-                <field name="l10n_latam_available_document_type_ids" invisible="1"/>
+                <field name="l10n_latam_available_document_type_ids" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_latam_document_type_id" invisible="not l10n_latam_use_documents" required="l10n_latam_use_documents" options="{'no_open': True, 'no_create': True}"/>
                 <field name="l10n_latam_document_number" invisible="not l10n_latam_use_documents or not l10n_latam_manual_document_number" required="l10n_latam_manual_document_number and l10n_latam_use_documents"/>
             </field>

--- a/addons/l10n_mx/views/res_bank_view.xml
+++ b/addons/l10n_mx/views/res_bank_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base.view_res_bank_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='bic']" position="after">
-                <field name="fiscal_country_codes" invisible="1"/>
+                <field name="fiscal_country_codes" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_mx_edi_code" invisible="'MX' not in fiscal_country_codes"/>
             </xpath>
         </field>
@@ -18,7 +18,7 @@
         <field name="inherit_id" ref="base.view_partner_bank_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='bank_id']" position="after">
-                <field name="fiscal_country_codes" invisible="1"/>
+                <field name="fiscal_country_codes" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_mx_edi_clabe" colspan="2" invisible="'MX' not in fiscal_country_codes"/>
             </xpath>
         </field>

--- a/addons/l10n_my_edi/views/account_move_view.xml
+++ b/addons/l10n_my_edi/views/account_move_view.xml
@@ -25,7 +25,7 @@
                     <group>
                         <group>
                             <!-- Only displayed if the invoice contains a tax of type Exempt -->
-                            <field name="l10n_my_edi_display_tax_exemption_reason" invisible="1"/>
+                            <field name="l10n_my_edi_display_tax_exemption_reason" invisible="1"/> <!-- TODO: to be removed in master -->
                             <field name="l10n_my_edi_exemption_reason" invisible="not l10n_my_edi_display_tax_exemption_reason" readonly="l10n_my_edi_state != False"/>
                             <field name="l10n_my_edi_custom_form_reference" readonly="l10n_my_edi_state != False"/>
                         </group>

--- a/addons/l10n_my_edi/views/res_config_settings_view.xml
+++ b/addons/l10n_my_edi/views/res_config_settings_view.xml
@@ -8,7 +8,7 @@
             <xpath expr="//block[@id='account_vendor_bills']" position="after">
                 <block title="Malaysian Electronic Invoicing" id='malaysian_edi' invisible="country_code != 'MY'">
                     <setting class="col-lg-12" string="MyInvois mode" company_dependent="1">
-                        <field name="l10n_my_edi_proxy_user_id" invisible="1"/>
+                        <field name="l10n_my_edi_proxy_user_id" invisible="1"/> <!-- TODO: to be removed in master -->
                         <div class="content-group">
                             <field name="l10n_my_edi_mode" widget="radio"/>
                         </div>

--- a/addons/l10n_my_edi/views/res_partner_view.xml
+++ b/addons/l10n_my_edi/views/res_partner_view.xml
@@ -6,8 +6,8 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <group name="container_row_2" position="inside">
-                <field name="l10n_my_tin_validation_state" invisible="1"/>
-                <field name="l10n_my_edi_display_tin_warning" invisible="1"/>
+                <field name="l10n_my_tin_validation_state" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="l10n_my_edi_display_tin_warning" invisible="1"/> <!-- TODO: to be removed in master -->
                 <!-- Foreigner with a tax number registered in Malaysia could be customer of an e-invoice. -->
                 <group name="l10n_my_edi" string="MyInvois Information" invisible="'MY' not in fiscal_country_codes">
                     <group colspan="2">

--- a/addons/l10n_my_edi/wizard/account_move_send_views.xml
+++ b/addons/l10n_my_edi/wizard/account_move_send_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.account_move_send_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='warnings']" position="inside">
-                    <field name="l10n_my_edi_enable" invisible="1"/>
+                    <field name="l10n_my_edi_enable" invisible="1"/> <!-- TODO: to be removed in master -->
                 </xpath>
 
                 <xpath expr="//div[@name='option_send_mail']" position='after'>

--- a/addons/l10n_my_edi_extended/views/account_move_view.xml
+++ b/addons/l10n_my_edi_extended/views/account_move_view.xml
@@ -39,7 +39,7 @@
             <button name="action_l10n_my_edi_reject_bill" position="replace">
             </button>
             <field name="l10n_my_edi_display_tax_exemption_reason" position="after">
-                    <field name="l10n_my_invoice_need_edi" invisible="1"/>
+                    <field name="l10n_my_invoice_need_edi" invisible="1"/> <!-- TODO: to be removed in master -->
             </field>
             <!-- Add the classification code to the invoice lines -->
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='name']" position="after">

--- a/addons/l10n_pe/data/res_country_data.xml
+++ b/addons/l10n_pe/data/res_country_data.xml
@@ -7,9 +7,9 @@
         <field name="arch" type="xml">
             <form>
                 <div class="o_address_format">
-                    <field name="country_enforce_cities" invisible="1"/>
-                    <field name="parent_id" invisible="1"/>
-                    <field name="type" invisible="1"/>
+                    <field name="country_enforce_cities" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="parent_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="type" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="street" placeholder="Street..." class="o_address_street"
                            readonly="type == 'contact' and parent_id"/>
                     <field name="street2" placeholder="Street 2..." class="o_address_street"

--- a/addons/l10n_pe/views/res_bank_view.xml
+++ b/addons/l10n_pe/views/res_bank_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base.view_res_bank_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='bic']" position="after">
-                <field name="country_code" invisible="1"/>
+                <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
                 <field name="l10n_pe_edi_code" invisible="country_code != 'PE'"/>
             </xpath>
         </field>

--- a/addons/l10n_ph/wizard/generate_2307_wizard_views.xml
+++ b/addons/l10n_ph/wizard/generate_2307_wizard_views.xml
@@ -13,7 +13,7 @@
                             <field name="invoice_partner_display_name" string="Vendor"/>
                             <field name="invoice_date" string="Bill Date" readonly="state != 'draft'"/>
                             <field name="invoice_date_due"/>
-                            <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'posted']"/>
+                            <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'posted']"/> <!-- TODO: to be removed in master -->
                             <field name="amount_tax_signed" string="Tax" sum="Total" optional="hide" modifiers="{'readonly':true}" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             <field name="amount_total_signed" string="Total" sum="Total" decoration-bf="1" optional="show" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             <field name="state" widget="badge" decoration-success="state == 'posted'" decoration-info="state == 'draft'" optional="show" on_change="1" modifiers="{'readonly':true, 'required':true}"/>

--- a/addons/l10n_ro_edi/views/account_move_views.xml
+++ b/addons/l10n_ro_edi/views/account_move_views.xml
@@ -27,8 +27,8 @@
                               decoration-danger="state == 'invoice_sending_failed'"
                               decoration-warning="state == 'invoice_sending'"
                               decoration-success="state == 'invoice_sent'">
-                            <field name="message" column_invisible="1"/>
-                            <field name="attachment_id" column_invisible="1"/>
+                            <field name="message" column_invisible="1"/> <!-- TODO: to be removed in master -->
+                            <field name="attachment_id" column_invisible="1"/> <!-- TODO: to be removed in master -->
                             <field name="datetime"/>
                             <field name="state" widget="account_document_state"/>
                             <field name="key_loading" optional="hide"/>

--- a/addons/l10n_ro_edi/wizard/account_move_send_views.xml
+++ b/addons/l10n_ro_edi/wizard/account_move_send_views.xml
@@ -8,8 +8,8 @@
             <field name="arch" type="xml">
 
                 <xpath expr="//div[@name='advanced_options']" position="inside">
-                    <field name="l10n_ro_edi_send_enable" invisible="1"/>
-                    <field name="l10n_ro_edi_send_readonly" invisible="1"/>
+                    <field name="l10n_ro_edi_send_enable" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_ro_edi_send_readonly" invisible="1"/> <!-- TODO: to be removed in master -->
                     <div name="option_l10n_ro_edi" invisible="not l10n_ro_edi_send_enable">
                         <field name="l10n_ro_edi_send_checkbox" readonly="l10n_ro_edi_send_readonly"/>
                         <b><label for="l10n_ro_edi_send_checkbox"/></b>

--- a/addons/l10n_ro_edi_stock/views/stock_picking_views.xml
+++ b/addons/l10n_ro_edi_stock/views/stock_picking_views.xml
@@ -6,9 +6,9 @@
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='%(stock.act_stock_return_picking)d']" position="after">
-                <field name="l10n_ro_edi_stock_enable_send" invisible="1"/>
-                <field name="l10n_ro_edi_stock_enable_fetch" invisible="1"/>
-                <field name="l10n_ro_edi_stock_enable_amend" invisible="1"/>
+                <field name="l10n_ro_edi_stock_enable_send" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="l10n_ro_edi_stock_enable_fetch" invisible="1"/> <!-- TODO: to be removed in master -->
+                <field name="l10n_ro_edi_stock_enable_amend" invisible="1"/> <!-- TODO: to be removed in master -->
 
                 <button name="action_l10n_ro_edi_stock_send_etransport"
                         string="Send eTransport"
@@ -24,7 +24,7 @@
             </xpath>
 
             <xpath expr="//field[@name='owner_id']" position="after">
-                <field name="l10n_ro_edi_stock_state" invisible="1"/>
+                <field name="l10n_ro_edi_stock_state" invisible="1"/> <!-- TODO: to be removed in master -->
 
                 <field name="l10n_ro_edi_stock_state"
                        invisible="not l10n_ro_edi_stock_enable or state != 'done' or not l10n_ro_edi_stock_state"
@@ -32,12 +32,12 @@
             </xpath>
 
             <xpath expr="//page[@name='note']" position="after">
-                <field name="l10n_ro_edi_stock_enable" invisible="1"/>
+                <field name="l10n_ro_edi_stock_enable" invisible="1"/> <!-- TODO: to be removed in master -->
 
                 <page name="etransport" string="eTransport" invisible="not l10n_ro_edi_stock_enable">
-                    <field name="l10n_ro_edi_stock_available_operation_scopes" invisible="1"/>
-                    <field name="l10n_ro_edi_stock_state" invisible="1"/>
-                    <field name="l10n_ro_edi_stock_fields_readonly" invisible="1"/>
+                    <field name="l10n_ro_edi_stock_available_operation_scopes" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_ro_edi_stock_state" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_ro_edi_stock_fields_readonly" invisible="1"/> <!-- TODO: to be removed in master -->
 
                     <group>
                         <group string="General">
@@ -56,7 +56,7 @@
                         </group>
 
                         <group string="Start Location">
-                            <field name="l10n_ro_edi_stock_available_start_loc_types" invisible="1"/>
+                            <field name="l10n_ro_edi_stock_available_start_loc_types" invisible="1"/> <!-- TODO: to be removed in master -->
                             <field name="l10n_ro_edi_stock_start_loc_type"
                                    widget="dynamic_selection"
                                    options="{'available_field': 'l10n_ro_edi_stock_available_start_loc_types'}"
@@ -67,7 +67,7 @@
                         </group>
 
                         <group string="End Location">
-                            <field name="l10n_ro_edi_stock_available_end_loc_types" invisible="1"/>
+                            <field name="l10n_ro_edi_stock_available_end_loc_types" invisible="1"/> <!-- TODO: to be removed in master -->
                             <field name="l10n_ro_edi_stock_end_loc_type"
                                    widget="dynamic_selection"
                                    options="{'available_field': 'l10n_ro_edi_stock_available_end_loc_types'}"
@@ -88,8 +88,8 @@
                               decoration-danger="state == 'stock_sending_failed'"
                               decoration-warning="state == 'stock_sent'"
                               decoration-success="state == 'stock_validated'">
-                            <field name="message" column_invisible="1"/>
-                            <field name="attachment_id" column_invisible="1"/>
+                            <field name="message" column_invisible="1"/> <!-- TODO: to be removed in master -->
+                            <field name="attachment_id" column_invisible="1"/> <!-- TODO: to be removed in master -->
                             <field name="datetime"/>
                             <field name="state" string="Status" widget="l10n_ro_edi_stock_document_state"/>
                             <field name="l10n_ro_edi_stock_uit" string="UIT"/>

--- a/addons/l10n_ro_edi_stock_batch/views/stock_picking_batch_views.xml
+++ b/addons/l10n_ro_edi_stock_batch/views/stock_picking_batch_views.xml
@@ -6,9 +6,9 @@
       <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_form"/>
       <field name="arch" type="xml">
          <xpath expr="//button[@name='action_open_label_layout']" position="after">
-             <field name="l10n_ro_edi_stock_enable_send" invisible="1"/>
-             <field name="l10n_ro_edi_stock_enable_fetch" invisible="1"/>
-             <field name="l10n_ro_edi_stock_enable_amend" invisible="1"/>
+             <field name="l10n_ro_edi_stock_enable_send" invisible="1"/> <!-- TODO: to be removed in master -->
+             <field name="l10n_ro_edi_stock_enable_fetch" invisible="1"/> <!-- TODO: to be removed in master -->
+             <field name="l10n_ro_edi_stock_enable_amend" invisible="1"/> <!-- TODO: to be removed in master -->
 
              <button name="action_l10n_ro_edi_stock_send_etransport"
                      string="Send eTransport"
@@ -24,17 +24,17 @@
          </xpath>
 
          <xpath expr="//field[@name='scheduled_date']" position="after">
-             <field name="l10n_ro_edi_stock_state" invisible="1"/>
+             <field name="l10n_ro_edi_stock_state" invisible="1"/> <!-- TODO: to be removed in master -->
              <field name="l10n_ro_edi_stock_state" invisible="state == 'draft' or not l10n_ro_edi_stock_state" readonly="1"/>
          </xpath>
 
          <xpath expr="//page[@name='page_transfers']" position="after">
-             <field name="l10n_ro_edi_stock_enable" invisible="1"/>
+             <field name="l10n_ro_edi_stock_enable" invisible="1"/> <!-- TODO: to be removed in master -->
 
              <page name="etransport" string="eTransport" invisible="not l10n_ro_edi_stock_enable">
-                 <field name="l10n_ro_edi_stock_available_operation_scopes" invisible="1"/>
-                 <field name="l10n_ro_edi_stock_state" invisible="1"/>
-                 <field name="l10n_ro_edi_stock_fields_readonly" invisible="1"/>
+                 <field name="l10n_ro_edi_stock_available_operation_scopes" invisible="1"/> <!-- TODO: to be removed in master -->
+                 <field name="l10n_ro_edi_stock_state" invisible="1"/> <!-- TODO: to be removed in master -->
+                 <field name="l10n_ro_edi_stock_fields_readonly" invisible="1"/> <!-- TODO: to be removed in master -->
 
                  <group>
                      <group string="General">
@@ -53,7 +53,7 @@
                      </group>
 
                      <group string="Start Location">
-                         <field name="l10n_ro_edi_stock_available_start_loc_types" invisible="1"/>
+                         <field name="l10n_ro_edi_stock_available_start_loc_types" invisible="1"/> <!-- TODO: to be removed in master -->
                          <field name="l10n_ro_edi_stock_start_loc_type"
                                 widget="dynamic_selection"
                                 options="{'available_field': 'l10n_ro_edi_stock_available_start_loc_types'}"
@@ -64,7 +64,7 @@
                      </group>
 
                      <group string="End Location">
-                         <field name="l10n_ro_edi_stock_available_end_loc_types" invisible="1"/>
+                         <field name="l10n_ro_edi_stock_available_end_loc_types" invisible="1"/> <!-- TODO: to be removed in master -->
                          <field name="l10n_ro_edi_stock_end_loc_type"
                                 widget="dynamic_selection"
                                 options="{'available_field': 'l10n_ro_edi_stock_available_end_loc_types'}"
@@ -85,8 +85,8 @@
                            decoration-danger="state == 'stock_sending_failed'"
                            decoration-warning="state == 'stock_sent'"
                            decoration-success="state == 'stock_validated'">
-                         <field name="message" column_invisible="1"/>
-                         <field name="attachment_id" column_invisible="1"/>
+                         <field name="message" column_invisible="1"/> <!-- TODO: to be removed in master -->
+                         <field name="attachment_id" column_invisible="1"/> <!-- TODO: to be removed in master -->
                          <field name="datetime"/>
                          <field name="state" string="Status" widget="l10n_ro_edi_stock_document_state"/>
                          <field name="l10n_ro_edi_stock_uit" string="UIT"/>

--- a/addons/l10n_rs_edi/wizard/account_move_send_views.xml
+++ b/addons/l10n_rs_edi/wizard/account_move_send_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.account_move_send_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='advanced_options']" position="inside">
-                <field name="l10n_rs_edi_send_enable" invisible="1"/>
+                <field name="l10n_rs_edi_send_enable" invisible="1"/> <!-- TODO: to be removed in master -->
                 <div name="l10n_rs_edi_send" invisible="not l10n_rs_edi_send_enable">
                     <field name="l10n_rs_edi_send_checkbox"/>
                     <b><label for="l10n_rs_edi_send_checkbox"/></b>

--- a/addons/l10n_sa_edi/data/res_country_data.xml
+++ b/addons/l10n_sa_edi/data/res_country_data.xml
@@ -7,8 +7,8 @@
         <field name="arch" type="xml">
             <form>
                 <div class="o_address_format">
-                    <field name="parent_id" invisible="1"/>
-                    <field name="type" invisible="1"/>
+                    <field name="parent_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="type" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="street" placeholder="Street" class="o_address_street"
                            readonly="type == 'contact' and parent_id"/>
                     <field name="street2" placeholder="Neighborhood" class="o_address_street"

--- a/addons/l10n_sa_edi/views/account_journal_views.xml
+++ b/addons/l10n_sa_edi/views/account_journal_views.xml
@@ -8,10 +8,10 @@
             <field name="inherit_id" ref="account.view_account_journal_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//notebook" position="inside">
-                    <field name="l10n_sa_csr" invisible="1"/>
-                    <field name="l10n_sa_compliance_csid_json" invisible="1"/>
-                    <field name="l10n_sa_production_csid_json" invisible="1"/>
-                    <field name="l10n_sa_compliance_checks_passed" invisible="1"/>
+                    <field name="l10n_sa_csr" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_sa_compliance_csid_json" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_sa_production_csid_json" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_sa_compliance_checks_passed" invisible="1"/> <!-- TODO: to be removed in master -->
                     <page name="zatca_einvoicing" string="ZATCA" invisible="country_code != 'SA' or type != 'sale'">
                         <group>
                             <group>

--- a/addons/l10n_sa_edi/views/res_config_settings_view.xml
+++ b/addons/l10n_sa_edi/views/res_config_settings_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//app[@name='account']/block" position="before">
-                <field name="country_code" invisible="1"/>
+                <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
                 <block title="ZATCA E-Invoicing Settings" name="zatca_einvoicing_setting_container" invisible="country_code != 'SA'">
                     <setting string="ZATCA E-Invoicing Settings" company_dependent="1" help="ZATCA specific settings for Saudi eInvoicing">
                         <div class="text-muted">

--- a/addons/l10n_sa_edi/wizard/account_move_reversal_views.xml
+++ b/addons/l10n_sa_edi/wizard/account_move_reversal_views.xml
@@ -7,7 +7,7 @@
             <field name="model">account.move.reversal</field>
             <field name="arch" type="xml">
                 <field name="reason" position="replace">
-                    <field name="country_code" invisible="1"/>
+                    <field name="country_code" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="reason" string="Reason" invisible="move_type == 'entry' and country_code != 'SA'" required="country_code == 'SA'"/>
                 </field>
             </field>

--- a/addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.xml
+++ b/addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.xml
@@ -8,8 +8,8 @@
             <form string="Use an OTP to request for a CSID">
                 Please, set the OTP you received from ZATCA in the input below then validate.
                 <group>
-                    <field name="journal_id" invisible="1"/>
-                    <field name="l10n_sa_renewal" invisible="1"/>
+                    <field name="journal_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_sa_renewal" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_sa_otp"/>
                 </group>
                 <footer>

--- a/addons/l10n_se/data/res_country_data.xml
+++ b/addons/l10n_se/data/res_country_data.xml
@@ -7,8 +7,8 @@
         <field name="arch" type="xml">
             <form>
                 <div class="o_address_format">
-                    <field name="parent_id" invisible="1"/>
-                    <field name="type" invisible="1"/>
+                    <field name="parent_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="type" invisible="1"/> <!-- TODO: to be removed in master -->
                     <field name="street" placeholder="Street" class="o_address_street"
                             readonly="type == 'contact' and parent_id"/>
                     <field name="street2" placeholder="Neighborhood" class="o_address_street"

--- a/addons/l10n_tr_nilvera/views/res_config_settings_views.xml
+++ b/addons/l10n_tr_nilvera/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <block name="integration" position="inside">
-                <field name="country_code" invisible="True"/>
+                <field name="country_code" invisible="True"/> <!-- TODO: to be removed in master -->
                 <setting id="nilvera_settings" string="Nilvera Electronic Document Invoicing" help="Configure Nilvera settings" invisible="country_code != 'TR'">
                     <div class="content-group">
                         <div class="row mt16">

--- a/addons/l10n_tr_nilvera_einvoice/views/account_journal_dashboard_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_journal_dashboard_views.xml
@@ -7,8 +7,8 @@
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//kanban" position="inside">
-                    <field name="is_nilvera_journal" invisible="1"/>
-                    <field name="l10n_tr_nilvera_api_key" invisible="1"/>
+                    <field name="is_nilvera_journal" invisible="1"/> <!-- TODO: to be removed in master -->
+                    <field name="l10n_tr_nilvera_api_key" invisible="1"/> <!-- TODO: to be removed in master -->
                 </xpath>
 
                 <xpath expr="//t[@id='account.JournalBodySalePurchase']//div" position="inside">

--- a/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send_views.xml
@@ -10,7 +10,7 @@
                 <field name="l10n_tr_nilvera_warnings" class="o_field_html" widget="actionable_errors"/>
             </xpath>
                 <xpath expr="//div[@name='advanced_options']" position='after'>
-                    <field name="l10n_tr_nilvera_einvoice_enable_xml" invisible="1"/>
+                    <field name="l10n_tr_nilvera_einvoice_enable_xml" invisible="1"/> <!-- TODO: to be removed in master -->
                     <div name="option_send_nilvera"
                          invisible="not l10n_tr_nilvera_einvoice_enable_xml">
                         <field name="l10n_tr_nilvera_einvoice_checkbox_xml"/>

--- a/addons/l10n_vn_edi_viettel/views/account_move_views.xml
+++ b/addons/l10n_vn_edi_viettel/views/account_move_views.xml
@@ -17,8 +17,8 @@
                       string="SInvoice"
                       invisible="move_type not in ['out_invoice', 'out_refund'] or country_code != 'VN'">
                     <group>
-                        <field name="l10n_vn_edi_replacement_origin_id" invisible="1"/>
-                        <field name="l10n_vn_edi_reversed_entry_invoice_number" invisible="1"/>
+                        <field name="l10n_vn_edi_replacement_origin_id" invisible="1"/> <!-- TODO: to be removed in master -->
+                        <field name="l10n_vn_edi_reversed_entry_invoice_number" invisible="1"/> <!-- TODO: to be removed in master -->
                         <group>
                             <field name="l10n_vn_edi_invoice_symbol" readonly="l10n_vn_edi_invoice_number"/>
                             <field name="l10n_vn_edi_issue_date" invisible="not l10n_vn_edi_invoice_number"/>

--- a/addons/l10n_vn_edi_viettel/wizard/account_move_reversal_view.xml
+++ b/addons/l10n_vn_edi_viettel/wizard/account_move_reversal_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.view_account_move_reversal"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='reason']" position="after">
-                    <field name="country_code" invisible="True"/>
+                    <field name="country_code" invisible="True"/> <!-- TODO: to be removed in master -->
                     <field name="l10n_vn_edi_adjustment_type" placeholder="Adjustment type..." invisible="country_code != 'VN'" required="country_code == 'VN'"/>
                     <field name="l10n_vn_edi_agreement_document_name" invisible="country_code != 'VN'" placeholder="Agreement document name..."/>
                     <field name="l10n_vn_edi_agreement_document_date" invisible="country_code != 'VN'" placeholder="Agreement document date..."/>

--- a/addons/l10n_vn_edi_viettel/wizard/account_move_send_views.xml
+++ b/addons/l10n_vn_edi_viettel/wizard/account_move_send_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.account_move_send_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='warnings']" position="inside">
-                    <field name="l10n_vn_edi_enable" invisible="1"/>
+                    <field name="l10n_vn_edi_enable" invisible="1"/> <!-- TODO: to be removed in master -->
                 </xpath>
 
                 <xpath expr="//div[@name='advanced_options']" position="inside">


### PR DESCRIPTION
Before this commit, several invisible fields were present in the views, whereas after https://github.com/odoo/odoo/pull/162009 these fields need to be either justified or removed.

The needed fields are fetched automatically after https://github.com/odoo/odoo/pull/137031

This commit adds a comment to each field so that the tests pass in stable versions, to avoid potential issues with inheritance in custom views.

We will removes the unnecessary invisible fields in master.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
