### PR TITLE
[IMP] website_sale_(loyalty): strikethrough pricelist

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -866,21 +866,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         return request.redirect(redirect_url or self._get_shop_path())
 
-    @route('/shop/pricelist', type='http', auth='public', website=True, sitemap=False)
-    def pricelist(self, promo, **post):
-        redirect = post.get('r', '/shop/cart')
-        if promo:
-            pricelist_sudo = request.env['product.pricelist'].sudo().search([('code', '=', promo)], limit=1)
-            if not (pricelist_sudo and request.website.is_pricelist_available(pricelist_sudo.id)):
-                return request.redirect("%s?code_not_available=1" % redirect)
-
-            self._apply_pricelist(pricelist=pricelist_sudo)
-        else:
-            # Reset the pricelist if empty promo code is given
-            self._apply_pricelist(pricelist=None)
-
-        return request.redirect(redirect)
-
     def _apply_selectable_pricelist(self, pricelist_id):
         """ Change the request pricelist if selectable on the website.
 

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -357,6 +357,15 @@ class ProductTemplate(models.Model):
                     round=False,
                 )
 
+            if (
+                'base_price' in template_price_vals
+                and template_price_vals['base_price'] > template_price_vals['price_reduce']
+            ):
+                template_price_vals['price_reduce_percentage'] = (
+                    round(template_price_vals['base_price'] - template_price_vals['price_reduce'], 2)
+                ) * 100 / template_price_vals['base_price']
+                template_price_vals['price_reduce_percentage'] = int(template_price_vals['price_reduce_percentage'])
+            template_price_vals['pricelist_comparison'] = pricelist.comparison
             res[template.id] = template_price_vals
 
         return res
@@ -539,6 +548,7 @@ class ProductTemplate(models.Model):
             'has_discounted_price': has_discounted_price,
             'discount_start_date': pricelist_item.date_start,
             'discount_end_date': pricelist_item.date_end,
+            'pricelist_comparison': pricelist.comparison,
         }
 
         if (
@@ -557,6 +567,18 @@ class ProductTemplate(models.Model):
                 date=date,
                 round=False,
             )
+            combination_info['price_reduce_percentage'] = (
+                round(combination_info['compare_list_price'] - combination_info['list_price'], 2)
+            ) * 100 / combination_info["compare_list_price"]
+            combination_info['price_reduce_percentage'] = int(combination_info['price_reduce_percentage'])
+        elif (
+                combination_info.get('list_price')
+                and combination_info['list_price'] > combination_info['price']
+            ):
+            combination_info['price_reduce_percentage'] = (
+                round(combination_info['list_price'] - combination_info['price'], 2)
+            ) * 100 / combination_info['list_price']
+            combination_info['price_reduce_percentage'] = int(combination_info['price_reduce_percentage'])
 
         # Apply taxes
         product_taxes = product_or_template.sudo().taxes_id._filter_taxes_by_company(self.env.company)

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -390,7 +390,6 @@ class Website(models.Model):
         :param str country_code: code iso or False, If set, we search only price list available for this country
         :param bool show_visible: if True, we don't display pricelist where selectable is False (Eg: Code promo)
         :param int current_pl_id: The current pricelist used on the website
-            (If not selectable but currently used anyway, e.g. pricelist with promo code)
         :param tuple website_pricelist_ids: List of ids of pricelists available for this website
         :param int partner_pl_id: the partner pricelist
         :returns: list of product.pricelist ids
@@ -443,7 +442,7 @@ class Website(models.Model):
     def get_pricelist_available(self, show_visible=False):
         """ Return the list of pricelists that can be used on website for the current user.
         Country restrictions will be detected with GeoIP (if installed).
-        :param bool show_visible: if True, we don't display pricelist where selectable is False (Eg: Code promo)
+        :param bool show_visible: if True, we don't display pricelist where selectable is False
         :returns: pricelist recordset
         """
         self.ensure_one()

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -172,23 +172,6 @@ class TestCheckoutAddress(WebsiteSaleCommon):
                 msg="The recalculated delivery price must be updated on the order.",
             )
 
-    def test_04_apply_empty_pl(self):
-        ''' Ensure empty pl code reset the applied pl '''
-        self._enable_pricelists()
-        so = self._create_so(partner_id=self.env.user.partner_id.id)
-        eur_pl = self.env['product.pricelist'].create({
-            'name': 'EUR_test',
-            'website_id': self.website.id,
-            'code': 'EUR_test',
-        })
-
-        with MockRequest(self.env, website=self.website, sale_order_id=so.id):
-            self.WebsiteSaleController.pricelist('EUR_test')
-            self.assertEqual(so.pricelist_id, eur_pl, "Ensure EUR_test is applied")
-
-            self.WebsiteSaleController.pricelist('')
-            self.assertNotEqual(so.pricelist_id, eur_pl, "Pricelist should be removed when sending an empty pl code")
-
     def test_04_pl_reset_on_login(self):
         self._enable_pricelists()
         """Check that after login, the SO pricelist is correctly recomputed."""
@@ -200,7 +183,6 @@ class TestCheckoutAddress(WebsiteSaleCommon):
         pl_with_code = self.env['product.pricelist'].create({
             'name': 'EUR_test',
             'website_id': self.website.id,
-            'code': 'EUR_test',
         })
         self.website.user_id.partner_id.property_product_pricelist = self.pricelist
         test_user.partner_id.property_product_pricelist = pl_with_code

--- a/addons/website_sale/views/product_pricelist_views.xml
+++ b/addons/website_sale/views/product_pricelist_views.xml
@@ -14,7 +14,7 @@
                             options="{'no_create': True}"
                             placeholder="Select a website"/>
                         <field name="selectable"/>
-                        <field name="code"/>
+                        <field name="comparison"/>
                     </group>
                 </page>
             </notebook>

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -531,10 +531,6 @@
                          data-customize-website-views="website_sale.suggested_products_list"
                          data-no-preview="true"
                          data-reload="/"/>
-            <we-checkbox string="Promo Code"
-                         data-customize-website-views="website_sale.reduction_code"
-                         data-no-preview="true"
-                         data-reload="/"/>
             <we-checkbox string="Accept Terms &amp; Conditions"
                          data-customize-website-views="website_sale.accept_terms_and_conditions"
                          data-no-preview="true"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -346,7 +346,7 @@
                 </div>
                 <div class="o_wsale_product_sub d-flex align-items-center justify-content-between flex-nowrap gap-3">
                     <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
-                    <div t-attf-class="product_price d-flex align-items-baseline w-100 {{'justify-content-between' if layout_mode == 'grid' else 'gap-1'}}">
+                    <div t-attf-class="product_price d-sm-flex flex-wrap align-items-center w-100 {{'justify-content-between' if layout_mode == 'grid' else 'gap-1'}}">
                         <span
                             name="product_price_reduce"
                             class="h6 mb-0"
@@ -357,27 +357,24 @@
                                 t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                             />
                         </span>
-                        <div>
+                        <div
+                            t-if="template_price_vals.get('pricelist_comparison') != 'none' and 'base_price' in template_price_vals and (template_price_vals['base_price'] &gt; template_price_vals['price_reduce']) and (template_price_vals['price_reduce'] or not website.prevent_zero_price_sale)"
+                            name="product_base_price"
+                            class="h6 mb-0 d-flex align-items-center"
+                        >
+                            <del
+                                class="me-2 small text-muted"
+                                t-out="template_price_vals['base_price']"
+                                t-options="{
+                                    'widget': 'monetary',
+                                    'display_currency': website.currency_id
+                                }"
+                            />
                             <span
-                                t-if="template_price_vals.get('pricelist_comparison') != 'none' and 'base_price' in template_price_vals and (template_price_vals['base_price'] &gt; template_price_vals['price_reduce']) and (template_price_vals['price_reduce'] or not website.prevent_zero_price_sale)"
-                                name="product_base_price"
+                                t-if="template_price_vals.get('pricelist_comparison') == 'strike_and_percentage' and template_price_vals.get('price_reduce_percentage')"
+                                class="badge text-bg-success"
                             >
-                                <del t-attf-class="text-muted me-1 h6 mb-0" style="white-space: nowrap;">
-                                    <span
-                                        class="small"
-                                        t-out="template_price_vals['base_price']"
-                                        t-options="{
-                                            'widget': 'monetary',
-                                            'display_currency': website.currency_id
-                                        }"
-                                    />
-                                </del>
-                                <span
-                                    t-if="template_price_vals.get('pricelist_comparison') == 'strike_and_percentage' and template_price_vals.get('price_reduce_percentage')"
-                                    class="text-muted h6 bg-primary text-white rounded p-1"
-                                >
-                                    <t t-out="template_price_vals['price_reduce_percentage']"/>%
-                                </span>
+                                - <t t-out="template_price_vals['price_reduce_percentage']"/> %
                             </span>
                         </div>
                     </div>
@@ -2553,27 +2550,27 @@
         >
             <div
                 name="product_price_container"
-                class="css_editable_mode_hidden d-flex align-items-center justify-content-end gap-2 flex-wrap h4 mb-0 text-wrap w-100"
+                class="css_editable_mode_hidden d-flex align-items-center gap-2 flex-wrap h4 mb-0 text-wrap w-100"
             >
                 <span class="oe_price"
                       style="white-space: nowrap;"
                       t-out="combination_info['price']"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
-                <div>
+                <div class="d-flex justify-content-between align-items-center gap-3 h5-fs">
                     <span
                         t-if="combination_info.get('pricelist_comparison') != 'none'"
-                        t-attf-class="text-muted oe_default_price ms-1 h5 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
+                        t-attf-class="oe_default_price ms-1 mb-0 text-muted {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
                         style="text-decoration: line-through; white-space: nowrap;"
                         t-esc="combination_info['list_price']"
                         t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                         name="product_list_price"
                     />
-                    <em
+                    <span
                         t-if="combination_info['has_discounted_price'] and combination_info.get('pricelist_comparison') == 'strike_and_percentage' and combination_info.get('price_reduce_percentage')"
-                        class="text-muted h5 bg-primary text-light rounded p-1"
+                        class="badge text-bg-success"
                     >
-                        <t t-out="combination_info['price_reduce_percentage']"/>%
-                    </em>
+                        - <t t-out="combination_info['price_reduce_percentage']"/> %
+                    </span>
                 </div>
                 <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>
                 <div t-if="combination_info.get('pricelist_comparison') != 'none' and combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -346,19 +346,40 @@
                 </div>
                 <div class="o_wsale_product_sub d-flex align-items-center justify-content-between flex-nowrap gap-3">
                     <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
-                    <div class="product_price">
-                        <span class="h6 mb-0"
-                              t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale"
-                              t-out="template_price_vals['price_reduce']"
-                              t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
-                        <t
-                            t-if="'base_price' in template_price_vals and (template_price_vals['base_price'] &gt; template_price_vals['price_reduce']) and (template_price_vals['price_reduce'] or not website.prevent_zero_price_sale)"
-                            name="product_base_price"
+                    <div t-attf-class="product_price d-flex align-items-baseline w-100 {{'justify-content-between' if layout_mode == 'grid' else 'gap-1'}}">
+                        <span
+                            name="product_price_reduce"
+                            class="h6 mb-0"
                         >
-                            <del t-attf-class="text-muted me-1 h6 mb-0" style="white-space: nowrap;">
-                                <em class="small" t-esc="template_price_vals['base_price']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}" />
-                            </del>
-                        </t>
+                            <span
+                                t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale"
+                                t-out="template_price_vals['price_reduce']"
+                                t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+                            />
+                        </span>
+                        <div>
+                            <span
+                                t-if="template_price_vals.get('pricelist_comparison') != 'none' and 'base_price' in template_price_vals and (template_price_vals['base_price'] &gt; template_price_vals['price_reduce']) and (template_price_vals['price_reduce'] or not website.prevent_zero_price_sale)"
+                                name="product_base_price"
+                            >
+                                <del t-attf-class="text-muted me-1 h6 mb-0" style="white-space: nowrap;">
+                                    <span
+                                        class="small"
+                                        t-out="template_price_vals['base_price']"
+                                        t-options="{
+                                            'widget': 'monetary',
+                                            'display_currency': website.currency_id
+                                        }"
+                                    />
+                                </del>
+                                <span
+                                    t-if="template_price_vals.get('pricelist_comparison') == 'strike_and_percentage' and template_price_vals.get('price_reduce_percentage')"
+                                    class="text-muted h6 bg-primary text-white rounded p-1"
+                                >
+                                    <t t-out="template_price_vals['price_reduce_percentage']"/>%
+                                </span>
+                            </span>
+                        </div>
                     </div>
                     <div
                         t-if="layout_mode == 'list'"
@@ -2528,49 +2549,75 @@
     <template id="product_price">
         <div
             name="product_price"
-            t-attf-class="product_price text-end {{'' if is_view_active('website_sale.cta_wrapper_boxed') else 'mt-2'}} {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-block'}}"
+            t-attf-class="w-100 product_price text-end {{'' if is_view_active('website_sale.cta_wrapper_boxed') else 'mt-2'}} {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-block'}}"
         >
             <div
                 name="product_price_container"
-                class="css_editable_mode_hidden d-flex align-items-center justify-content-end gap-2 flex-wrap h4 mb-0 text-wrap"
+                class="css_editable_mode_hidden d-flex align-items-center justify-content-end gap-2 flex-wrap h4 mb-0 text-wrap w-100"
             >
                 <span class="oe_price"
                       style="white-space: nowrap;"
                       t-out="combination_info['price']"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
-                <span t-attf-class="text-muted oe_default_price ms-1 h5 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
-                      style="text-decoration: line-through; white-space: nowrap;"
-                      t-esc="combination_info['list_price']"
-                      t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
-                      name="product_list_price"
-                />
+                <div>
+                    <span
+                        t-if="combination_info.get('pricelist_comparison') != 'none'"
+                        t-attf-class="text-muted oe_default_price ms-1 h5 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
+                        style="text-decoration: line-through; white-space: nowrap;"
+                        t-esc="combination_info['list_price']"
+                        t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+                        name="product_list_price"
+                    />
+                    <em
+                        t-if="combination_info['has_discounted_price'] and combination_info.get('pricelist_comparison') == 'strike_and_percentage' and combination_info.get('price_reduce_percentage')"
+                        class="text-muted h5 bg-primary text-light rounded p-1"
+                    >
+                        <t t-out="combination_info['price_reduce_percentage']"/>%
+                    </em>
+                </div>
                 <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>
-                <del
-                    name="product_price_strikethrough"
-                    t-if="combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])"
-                    class="text-muted ms-1 h5 oe_compare_list_price"
-                >
-                    <bdi dir="inherit">
-                    <span t-esc="combination_info['compare_list_price']"
-                          t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
-                    </bdi>
-                </del>
+                <div t-if="combination_info.get('pricelist_comparison') != 'none' and combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])">
+                    <del
+                        name="product_price_strikethrough"
+                        t-if="combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])"
+                        class="text-muted ms-1 h5 oe_compare_list_price"
+                    >
+                        <bdi dir="inherit">
+                        <span t-esc="combination_info['compare_list_price']"
+                            t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
+                        </bdi>
+                    </del>
+                    <em
+                        t-if="combination_info.get('pricelist_comparison') == 'strike_and_percentage' and combination_info.get('price_reduce_percentage')"
+                        class="text-muted h6 bg-primary text-light rounded p-1"
+                    >
+                        <t t-out="combination_info['price_reduce_percentage']"/>%
+                    </em>
+                </div>
             </div>
             <div
                 t-if="editable"
                 name="product_list_price_container"
-                class="css_non_editable_mode_hidden decimal_precision h4"
+                class="css_non_editable_mode_hidden decimal_precision h4 d-flex justify-content-between"
                 t-att-data-precision="str(website.currency_id.decimal_places)"
             >
                 <span t-field="product.list_price"
                       t-options="{'widget': 'monetary', 'display_currency': product.currency_id}"/>
                 <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>
-                <del t-if="combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])">
-                    <bdi dir="inherit">
-                    <span t-field="product.compare_list_price"
-                          t-options="{'widget': 'monetary', 'display_currency': product.currency_id}"/>
-                    </bdi>
-                </del>
+                <div t-if="combination_info.get('pricelist_comparison') != 'none' and combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])">
+                    <del>
+                        <bdi dir="inherit">
+                        <span t-field="product.compare_list_price"
+                            t-options="{'widget': 'monetary', 'display_currency': product.currency_id}"/>
+                        </bdi>
+                    </del>
+                    <em
+                        t-if="combination_info.get('pricelist_comparison') == 'strike_and_percentage' and combination_info.get('price_reduce_percentage')"
+                        class="text-muted h6 bg-primary text-light rounded px-2"
+                    >
+                        <t t-out="combination_info['price_reduce_percentage']"/>%
+                    </em>
+                </div>
             </div>
             <small t-if="combination_info.get('tax_disclaimer')" class="text-muted">
                 <t t-out="combination_info['tax_disclaimer']"/>
@@ -3019,18 +3066,24 @@
                                     t-set="combination_info"
                                     t-value="product._get_combination_info_variant()"
                                 />
-                                <del
-                                    name="suggested_product_list_price"
-                                    t-attf-class="me-2 text-nowrap text-muted {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
-                                    t-esc="combination_info['list_price']"
-                                    t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
-                                />
                                 <span
                                     name="suggested_product_price"
-                                    class="text-nowrap"
+                                    class="text-nowrap me-2"
                                     t-esc="combination_info['price']"
                                     t-options="{'widget': 'monetary','display_currency': website.currency_id}"
                                 />
+                                <del
+                                    name="suggested_product_list_price"
+                                    t-attf-class="me-2 text-nowrap text-muted {{'' if (combination_info.get('pricelist_comparison') != 'none' and combination_info['has_discounted_price']) else 'd-none'}}"
+                                    t-esc="combination_info['list_price']"
+                                    t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+                                />
+                                <em
+                                    t-if="combination_info.get('pricelist_comparison') == 'strike_and_percentage' and combination_info.get('price_reduce_percentage')"
+                                    class="text-muted h6"
+                                >
+                                    <span class="bg-primary text-light rounded px-2"><t t-out="combination_info['price_reduce_percentage']"/>%</span>
+                                </em>
                             </h6>
                         </div>
                         <div class="d-flex justify-content-md-end">
@@ -3050,29 +3103,6 @@
                 </div>
             </div>
         </xpath>
-    </template>
-
-    <!-- Called in `website_sale.reduction_code`. -->
-    <template id='coupon_form' name='Coupon form'>
-        <!-- Checkout context:
-            - redirect: The route to redirect to when a customer enters a coupon; default: `None`.
-            - website_sale_order: The current order.
-        -->
-        <form
-            class="mb-3"
-            t-attf-action="/shop/pricelist#{redirect and '?r=' + redirect or ''}"
-            method="post"
-            name="coupon_code"
-        >
-            <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
-            <div class="input-group w-100">
-                <input name="promo" class="form-control" type="text" placeholder="Discount code..." t-att-value="website_sale_order.pricelist_id.code or None"/>
-                <a href="#" role="button" class="btn btn-light a-submit border">Apply</a>
-            </div>
-        </form>
-        <t t-if="request.params.get('code_not_available')" name="code_not_available">
-            <div class="alert alert-danger text-start" role="alert">This promo code is not available.</div>
-        </t>
     </template>
 
     <!-- Called in `website_sale.checkout_layout`. -->
@@ -3787,27 +3817,6 @@
                 </tr>
             </table>
         </div>
-    </template>
-
-    <!-- Deactivatable through the website editor. -->
-    <template id="reduction_code" inherit_id="website_sale.total" name="Promo Code">
-        <!-- Checkout context:
-            - hide_promotions: Whether to hide promotion input; default: `None`.
-            - redirect: The route to redirect to when a customer enters a coupon; default: `None`.
-            - website_sale_order: The current order.
-        -->
-        <xpath expr="//div[contains(@t-attf-class, 'o_cart_total')]//table/tr[last()]" position="after">
-            <tr t-if="not hide_promotions">
-                <td colspan="3" class="text-end text-xl-end border-0 p-0">
-                <span>
-                    <t t-set="force_coupon" t-value="website_sale_order.pricelist_id.code"/>
-                    <div t-if="not force_coupon" class="coupon_form">
-                        <t t-call="website_sale.coupon_form"/>
-                    </div>
-                </span>
-                </td>
-            </tr>
-        </xpath>
     </template>
 
     <!-- Called in `website_sale.confirmation`. -->

--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -11,13 +11,13 @@ from odoo.addons.website_sale.controllers import main
 
 class WebsiteSale(main.WebsiteSale):
 
-    @route()
-    def pricelist(self, promo, reward_id=None, **post):
+    @route('/shop/promo', type='http', auth='public', website=True, sitemap=False)
+    def promo(self, promo, reward_id=None, **post):
         if not (order_sudo := request.cart):
             return request.redirect('/shop')
         coupon_status = order_sudo._try_apply_code(promo)
         if coupon_status.get('not_found'):
-            return super().pricelist(promo, **post)
+            return request.redirect("%s?code_not_available=1" % post.get('r', '/shop/cart'))
         elif coupon_status.get('error'):
             request.session['error_promo_code'] = coupon_status['error']
         elif 'error' not in coupon_status:
@@ -95,7 +95,7 @@ class WebsiteSale(main.WebsiteSale):
                         and program_sudo.applies_on == 'future'
                         and program_sudo.program_type not in ('ewallet', 'loyalty'))
                 ):
-                    return self.pricelist(code, reward_id=reward_id)
+                    return self.promo(code, reward_id=reward_id)
         if coupon:
             self._apply_reward(order_sudo, reward_sudo, coupon)
         return request.redirect(redirect)

--- a/addons/website_sale_loyalty/tests/test_apply_pending_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_apply_pending_coupon.py
@@ -55,7 +55,7 @@ class TestSaleCouponApplyPending(TestSaleCouponNumbersCommon, WebsiteSaleCommon)
                 product_id=self.largeCabinet.id,
                 quantity=2,
             )
-            self.WebsiteSaleController.pricelist(self.global_program.rule_ids.code)
+            self.WebsiteSaleController.promo(self.global_program.rule_ids.code)
             self.assertEqual(
                 order.amount_total,
                 576,
@@ -94,7 +94,7 @@ class TestSaleCouponApplyPending(TestSaleCouponNumbersCommon, WebsiteSaleCommon)
                 product_id=self.largeCabinet.id,
                 quantity=1,
             )
-            self.WebsiteSaleController.pricelist(self.global_program.rule_ids.code)
+            self.WebsiteSaleController.promo(self.global_program.rule_ids.code)
             self.assertEqual(self.largeCabinet.lst_price, 320)
             cabinet_sol = order.order_line.filtered(lambda sol: sol.product_id == self.largeCabinet)
             promo_sol = (order.order_line - cabinet_sol)

--- a/addons/website_sale_loyalty/tests/test_shop_multi_reward.py
+++ b/addons/website_sale_loyalty/tests/test_shop_multi_reward.py
@@ -107,7 +107,7 @@ class TestClaimReward(WebsiteSaleCommon):
         discount_reward = self.coupon_program.reward_ids.filtered('discount')
 
         with MockRequest(website.env, website=website, sale_order_id=cart.id):
-            self.WebsiteSaleController.pricelist(promo=self.coupon.code)
+            self.WebsiteSaleController.promo(promo=self.coupon.code)
             self.assertFalse(cart.order_line.reward_id)
 
             self.WebsiteSaleController.claim_reward(discount_reward.id, code=self.coupon.code)

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -136,7 +136,7 @@ class WebsiteSaleLoyaltyTestUi(TestSaleCommon, HttpCase):
             'points': 371.03,
         })
 
-        self.env.ref("website_sale.reduction_code").write({"active": True})
+        self.env.ref("website_sale_loyalty.reduction_code").write({"active": True})
         self.start_tour("/", 'shop_sale_loyalty', login="admin")
 
     def test_02_admin_shop_gift_card_tour(self):
@@ -205,7 +205,7 @@ class WebsiteSaleLoyaltyTestUi(TestSaleCommon, HttpCase):
             'code': 'GIFT_CARD',
         })
 
-        self.env.ref("website_sale.reduction_code").write({"active": True})
+        self.env.ref("website_sale_loyalty.reduction_code").write({"active": True})
         self.start_tour('/', 'shop_sale_gift_card', login='admin')
 
         self.assertEqual(len(gift_card_program.coupon_ids), 2, 'There should be two coupons, one with points, one without')
@@ -418,13 +418,13 @@ class TestWebsiteSaleCoupon(HttpCase, WebsiteSaleCommon):
             self.assertEqual(order.amount_total, 100.0, "The base cart value is incorrect.")
 
             # Apply coupon for the first time
-            WebsiteSaleController.pricelist(promo=self.coupon.code)
+            WebsiteSaleController.promo(promo=self.coupon.code)
 
             # Check that the coupon has been applied
             self.assertEqual(order.amount_total, 90.0, "The coupon is not applied.")
 
             # Apply the coupon again
-            WebsiteSaleController.pricelist(promo=self.coupon.code)
+            WebsiteSaleController.promo(promo=self.coupon.code)
             Cart().cart()
             error_msg = request.session.get('error_promo_code')
 

--- a/addons/website_sale_loyalty/views/snippets.xml
+++ b/addons/website_sale_loyalty/views/snippets.xml
@@ -10,6 +10,14 @@
                          data-reload="/"/>
         </div>
     </xpath>
+    <div name="o_wsale_checkout_pages" position="inside">
+        <we-checkbox
+            string="Promo Code"
+            data-customize-website-views="website_sale_loyalty.reduction_code"
+            data-no-preview="true"
+            data-reload="/"
+        />
+    </div>
 </template>
 
 </odoo>

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -1,10 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="sale_coupon_result" inherit_id="website_sale.coupon_form">
-        <xpath expr="//form[@name='coupon_code']//input[@name='promo']" position="attributes">
-            <attribute name="placeholder">Gift card or discount code...</attribute>
+
+    <!-- Deactivatable through the website editor. -->
+    <template id="reduction_code" inherit_id="website_sale.total" name="Promo Code">
+        <!-- Checkout context:
+            - hide_promotions: Whether to hide promotion input; default: `None`.
+            - redirect: The route to redirect to when a customer enters a coupon; default: `None`.
+            - website_sale_order: The current order.
+        -->
+        <xpath expr="//div[@id='cart_total']//table/tr[last()]" position="after">
+            <tr t-if="not hide_promotions">
+                <td colspan="3" class="text-end text-xl-end border-0 p-0">
+                <span>
+                    <div class="coupon_form">
+                        <form
+                            name="coupon_code"
+                            t-attf-action="/shop/promo#{redirect and '?r=' + redirect or ''}"
+                            method="post"
+                        >
+                            <input
+                                name="csrf_token"
+                                type="hidden"
+                                t-att-value="request.csrf_token()"
+                                t-nocache="The csrf token must always be up to date."
+                            />
+                            <div class="input-group w-100 my-2">
+                                <input
+                                    name="promo"
+                                    class="form-control"
+                                    type="text"
+                                    placeholder="Gift card or discount code..."
+                                />
+                                <a
+                                    href="#"
+                                    role="button"
+                                    class="btn btn-secondary a-submit"
+                                >
+                                    Apply
+                                </a>
+                            </div>
+                        </form>
+                        <t
+                            t-if="request.params.get('code_not_available')"
+                            name="code_not_available"
+                        >
+                            <div
+                                class="alert alert-danger text-start"
+                                role="alert"
+                            >
+                                This promo code is not available.
+                            </div>
+                        </t>
+                    </div>
+                </span>
+                </td>
+            </tr>
         </xpath>
-        <xpath expr="//t[@name='code_not_available']" position="replace"/>
     </template>
 
     <template id="modify_code_form" inherit_id="website_sale.total" name="Loyalty, coupon, gift card">
@@ -189,12 +240,6 @@
                     }'/>
             </td>
             </tr>
-        </xpath>
-    </template>
-
-    <template id="reduction_coupon_code" inherit_id="website_sale.reduction_code">
-        <xpath expr="//t[@t-set='force_coupon']" position="after">
-            <t t-set="_placeholder" t-value="'Discount code or gift card'"/>
         </xpath>
     </template>
 


### PR DESCRIPTION
Prior this commit:
- Pricelists display strikethrough prices as soon as they are less than the sales price for discounts and formulas

Post this commit:
- Removed ecommerce promotional code field and moved the promo code input to website_sale_loyalty
- Pricelists will display strikethrough prices based on selection field in pricelist

task-4613393

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
