### PR TITLE
[FIX] mail: no traceback reading 'getWhenReady' on call join

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -978,7 +978,9 @@ export class Rtc extends Record {
                     if (!sequence) {
                         return;
                     }
-                    const session = await this.store.RtcSession.getWhenReady(senderId);
+                    const session = await this.store["discuss.channel.rtc.session"].getWhenReady(
+                        senderId
+                    );
                     if (!session) {
                         return;
                     }
@@ -2006,7 +2008,9 @@ export const rtcService = {
         const rtc = env.services["mail.store"].rtc;
         rtc.p2pService = services["discuss.p2p"];
         rtc.p2pService.acceptOffer = async (id, sequence) => {
-            const session = await this.store.RtcSession.getWhenReady(Number(id));
+            const session = await this.store["discuss.channel.rtc.session"].getWhenReady(
+                Number(id)
+            );
             /**
              * We only accept offers for new connections (higher sequence),
              * or offers that renegotiate an existing connection (same sequence).


### PR DESCRIPTION
Before this commit, when joining a call, all call participants received the following traceback:

```
UncaughtPromiseError > TypeError
Uncaught Promise > Cannot read properties of undefined (reading 'getWhenReady')
```

This happens due to a typo in fw-port commit: `RtcSession` model was renamed to `discuss.channel.rtc.session` in 18.2, to match with the python model, but the fw-port kept the wrong `RtcSession` name, thus the static method `getWhenReady` was accessed on non-existing model name `RtcSession`.

[1]: https://github.com/odoo/odoo/pull/205662