### PR TITLE
[FIX] project: fix progress bar display in shared project

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -197,6 +197,7 @@
             'project/static/src/components/project_task_state_selection/*',
             'project/static/src/components/project_many2one_field/*',
             'project/static/src/views/project_task_form/*.scss',
+            'project/static/src/views/project_task_kanban/*.scss',
 
             'project/static/src/project_sharing/search/favorite_menu/custom_favorite_item.xml',
             'project/static/src/project_sharing/**/*',

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -42,7 +42,7 @@
                 <field name="subtask_count"/>
                 <field name="allow_milestones" />
                 <field name="has_late_and_unreached_milestone"/>
-                <progressbar field="state" colors='{"1_done": "success", "03_approved": "success", "02_changes_requested": "warning", "1_canceled": "danger", "04_waiting_normal": "200", "01_in_progress": "200"}'/>
+                <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "200"}'/>
                 <templates>
                 <t t-name="kanban-menu" t-if="!selection_mode">
                     <div invisible="1" role="separator" class="dropdown-divider"></div>


### PR DESCRIPTION
### Issue
   In project sharing, tasks in the "Done" and "Approved" stages were not shown with distinct progress in the Kanban progress bar. As a result, users were unable to identify the task status easily.

### Reason:
   The color class was set incorrectly.

### Fix:
   We have updated the color class in this commit to correctly reflect the  task stages.
  issue-https://github.com/odoo/odoo/commit/1a44b849970d3e39111a99ea35db5b586b184dd3

### Steps to Reproduce:
  - Create a project with 2 tasks:
      - Task 1 in the "Done" stage
      - Task 2 in the "Approved" stage
  - Share the project with a portal user
  - Open the project in the portal
  - Navigate to the project sharing Kanban view and check the progress bar

task-4551177
