### PR TITLE
[IMP] im_livechat: do not show bots on dashboard

### DIFF
--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -12,6 +12,7 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     user_livechat_username = fields.Char(compute='_compute_user_livechat_username')
+    chatbot_script_ids = fields.One2many("chatbot.script", "operator_partner_id")
 
     def _search_for_channel_invite_to_store(self, store: Store, channel):
         super()._search_for_channel_invite_to_store(store, channel)

--- a/addons/spreadsheet_dashboard_im_livechat/data/files/livechat_dashboard.json
+++ b/addons/spreadsheet_dashboard_im_livechat/data/files/livechat_dashboard.json
@@ -201,7 +201,7 @@
               "context": {
                 "im_livechat.hide_partner_company": true
               },
-              "domain": [],
+              "domain": [["partner_id.chatbot_script_ids", "=", false]],
               "groupBy": ["partner_id"],
               "orderBy": []
             },
@@ -474,7 +474,7 @@
       "context": {
         "im_livechat.hide_partner_company": true
       },
-      "domain": [],
+      "domain": [["partner_id.chatbot_script_ids", "=", false]],
       "id": "3",
       "measures": [
         { "id": "nbr_channel", "fieldName": "nbr_channel" },


### PR DESCRIPTION
The live chat dashboard was recently improved. Among other things, we removed bots from the "Top Agents" and from the chat count by agent figure. However, this part was reverted when merging the channel report and operator report model. This PR restores those changes.

part of task-4589964

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
