### PR TITLE
[FIX] web: prevent cursor change in emoji search

### DIFF
--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -481,6 +481,15 @@ export class EmojiPicker extends Component {
         }
     }
 
+    onKeydownSearch(ev) {
+        if (
+            ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(ev.key) &&
+            this.itemsNumber > 0
+        ) {
+            ev.preventDefault();
+        }
+    }
+
     getAllCategories() {
         const res = [...this.categories];
         if (this.recentEmojis.length > 0) {

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -116,7 +116,7 @@
 </t>
 
 <t t-name="web.EmojiPicker.searchInput">
-    <input class="form-control border-0 flex-grow-1 rounded-3 rounded-end-0 o-active lh-1" placeholder="Search emoji" t-model="localState.searchTerm" t-ref="autofocus" t-att-model="localState.searchTerm" t-on-input="() => this.state.activeEmojiIndex = 0" t-att-tabindex="isMobileOS ? -1 : 0"/>
+    <input class="form-control border-0 flex-grow-1 rounded-3 rounded-end-0 o-active lh-1" placeholder="Search emoji" t-model="localState.searchTerm" t-ref="autofocus" t-att-model="localState.searchTerm" t-on-keydown="onKeydownSearch" t-on-input="() => this.state.activeEmojiIndex = 0" t-att-tabindex="isMobileOS ? -1 : 0"/>
 </t>
 
 </templates>


### PR DESCRIPTION
When having emojis in the picker and text in search input, the cursor moves when navigating with the arrow keys and the selected emoji is changed as well.

This commit fixes this by preventing the default behavior of the arrow keys when the search input is focused. This way, the cursor of the search input is not changed and the emoji picker can be navigated.

When the search result is empty, the search input cursor should be able to move with the arrow keys as usual.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
