### PR TITLE
[FIX] project: set the is_from_recurrence context during recurring task creation

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -70,7 +70,7 @@ class ProjectTaskRecurrence(models.Model):
             self.repeat_type != 'until' or not occurrence_from.date_deadline or
             self.repeat_until and (occurrence_from.date_deadline + self._get_recurrence_delta()).date() <= self.repeat_until
         ):
-            occurrence_from.with_context(copy_project=True).sudo().copy(
+            occurrence_from.with_context(copy_project=True, is_from_recurrence=True).sudo().copy(
                 self._create_next_occurrence_values(occurrence_from)
             )
 


### PR DESCRIPTION
  This context is used in the FSM task's copy_data method.

Enterprise: https://github.com/odoo/enterprise/pull/83424
task-4595587


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
