### PR TITLE
[FIX] website_event_booth: Public user no longer able to buy a booth

### DIFF
--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -139,7 +139,7 @@ class WebsiteEventBoothController(WebsiteEventController):
         if request.env.user._is_public():
             contact_email_normalized = tools.email_normalize(kwargs['contact_email'])
             if contact_email_normalized:
-                partner = event._partner_find_from_emails_single(
+                partner = event.sudo()._partner_find_from_emails_single(
                     [contact_email_normalized],
                     additional_values={contact_email_normalized: {
                         'phone': kwargs.get('contact_phone'),


### PR DESCRIPTION
While attempting to buy a booth as the public user, the interface would freeze when proceeding to the payment part.

This was because `_prepare_booth_registration_partner_values` would actually encounter an AccessError while calling
`_partner_find_from_emails_single` because the public user can't access the `res.partners` records by itself.

With fac6ddfe12b567acc876232c74c1a6868f6b9341 in mind, it seems that the original `sudo()` got forgotten during the refactor, so we simply add it back.

