### PR TITLE
[FIX] hw_drivers: download certificate issue

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -338,14 +338,15 @@ def load_certificate():
     if response.status != 200:
         return "ERR_IOT_HTTPS_LOAD_REQUEST_STATUS %s\n\n%s" % (response.status, response.reason)
 
-    response = json.loads(response.data.decode('utf8'))
+    response = json.loads(response.data.decode())
     error = response.get('error')
-    if error or not response.get('data') or not json.loads(response.data.decode('utf8')).get('result'):
-        _logger.warning("An error received from odoo.com while trying to get the certificate: %s", error or 'Empty response')
+    if error or not response.get('result'):
+        _logger.error(
+            "An error received from odoo.com while trying to get the certificate: %s", error or 'Empty response'
+        )
         return "ERR_IOT_HTTPS_LOAD_REQUEST_NO_RESULT"
 
-    result = json.loads(response.data.decode('utf8'))['result']
-
+    result = response['result']
     write_file('odoo-subject.conf', result['subject_cn'])
     if platform.system() == 'Linux':
         with writable():


### PR DESCRIPTION
A check on the object received by the IoT Box containing certificate keys was always returning `False`, resulting in the certificate never being applied to the box in addition to an excessive amount of requests to odoo.com.
