### PR TITLE
[FIX] l10n_in_pos: blocked opening session

### DIFF
--- a/addons/l10n_in_pos/__manifest__.py
+++ b/addons/l10n_in_pos/__manifest__.py
@@ -24,6 +24,9 @@
             'l10n_in/static/src/helpers/hsn_summary.js',
             'l10n_in_pos/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'l10n_in_pos/static/tests/**/*'
+        ]
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/l10n_in_pos/static/src/app/models/pos_order_line.js
+++ b/addons/l10n_in_pos/static/src/app/models/pos_order_line.js
@@ -5,7 +5,4 @@ patch(PosOrderline.prototype, {
     setup(vals) {
         return super.setup(...arguments);
     },
-    get l10n_in_hsn_code() {
-        return this.product_id?.l10n_in_hsn_code || "";
-    },
 });

--- a/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/app/screens/receipt_screen/pos_receipt.xml
@@ -28,7 +28,7 @@
         </xpath>
         <xpath expr="//div[@class='before-footer']" position="after">
             <t t-set="l10n_in_hsn_summary" t-value="order._prepareL10nInHsnSummary()"/>
-            <table t-if="l10n_in_hsn_summary and header.company.country_id?.code === 'IN' and l10n_in_hsn_summary.items.length > 0" class="pt-3 w-100">
+            <table t-if="l10n_in_hsn_summary and header.company.country_id?.code === 'IN' and l10n_in_hsn_summary.items.length > 0" class="hsn-summary-table pt-3 w-100">
               <tr>
                     <th class="text-center fw-bolder" colspan="6">HSN Summary</th>
                 </tr>

--- a/addons/l10n_in_pos/static/tests/tours/test_indian_pos_tour.js
+++ b/addons/l10n_in_pos/static/tests/tours/test_indian_pos_tour.js
@@ -1,0 +1,35 @@
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("ReceiptWithHSNSummaryTour", {
+    checkDelay: 50,
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Magnetic Board"),
+            ProductScreen.clickDisplayedProduct("Monitor Stand"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.receiptIsThere(),
+            // First order line contains HSN Code
+            {
+                trigger: ".orderline:eq(0) .pos-receipt-left-padding span:contains('HSN Code:')",
+            },
+            // Second order line does not contain HSN Code
+            {
+                trigger:
+                    ".orderline:eq(1):not(:has(.pos-receipt-left-padding span:contains('HSN Code:'))",
+            },
+            {
+                trigger: "table.hsn-summary-table",
+            },
+        ].flat(),
+});

--- a/addons/l10n_in_pos/tests/__init__.py
+++ b/addons/l10n_in_pos/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_in_pos

--- a/addons/l10n_in_pos/tests/test_in_pos.py
+++ b/addons/l10n_in_pos/tests/test_in_pos.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestL10nInPos(TestPointOfSaleHttpCommon):
+
+    @classmethod
+    @TestPointOfSaleHttpCommon.setup_country('in')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.magnetic_board.write({'l10n_in_hsn_code': 1234})
+
+    def test_pos_receipt_with_hsn_summary(self):
+        """ Test PoS receipt displays HSN summary when a product with an HSN code is added. """
+        self.main_pos_config.open_ui()
+        self.start_pos_tour('ReceiptWithHSNSummaryTour', login="accountman")
+        last_order = self.env['pos.order'].search([], limit=1, order='id desc')
+        self.assertEqual(last_order.state, 'paid', "The last order should be paid successfully.")


### PR DESCRIPTION
Steps:
-----------
- Install the l10n_in_pos module.
- Open a POS session with products added `l10n_in_hsn_code`.

Issue:
-------------
- The session was not opening and was continuously loading.

Cause:
----------
- Orderline class has a getter with the same name as the field `l10n_in_hsn_code`.

FIX:
-----------
- Removed `l10n_in_hsn_code`  getter from Orderline class.

task-4719868
