### PR TITLE
[FIX] website: fix scrolling blocked on mobile

### DIFF
--- a/addons/website/static/src/interactions/header/header_standard.js
+++ b/addons/website/static/src/interactions/header/header_standard.js
@@ -65,10 +65,10 @@ export class HeaderStandard extends BaseHeader {
                 : this.transformShow()
         void this.el.offsetWidth; // Force a paint refresh
 
-        this.el.classList.remove("o_transformed_not_affixed");
         this.hideEl?.classList.toggle("hidden", reachHeaderBottom);
 
         this.toggleCSSAffixed(reachHeaderBottom);
+        this.el.classList.remove("o_transformed_not_affixed");
         this.isScrolled = reachTransitionPoint;
     }
 


### PR DESCRIPTION
Steps to reproduce:

- Go to a website with "e-commerce" installed.
- Use the devtools to display the website on a mobile device (note that the bug may only occur on certain mobile devices, so it might be necessary to test several to reproduce it).
- Add a product to the cart and go to the "/shop/checkout" page.
- Try scrolling down.
- Bug: scrolling is blocked.

The same bug was already fixed in this commit [1] but the fix was lost during the conversion of public widgets to the new interaction system with this commit [2].

[1]: https://github.com/odoo/odoo/commit/dca8bdd79a634974a9e15ac1117fddc471147882
[2]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f

opw-4716373
task-4727630
