### PR TITLE
[FIX] tools: diff header text color

### DIFF
--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1755,7 +1755,7 @@ def get_diff(data_from, data_to, custom_style=False, dark_color_scheme=False):
         For the table to fit the modal width, some custom style is needed.
         """
         to_append = {
-            'diff_header': 'bg-600 text-center align-top px-2',
+            'diff_header': 'bg-600 text-light text-center align-top px-2',
             'diff_next': 'd-none',
         }
         for old, new in to_append.items():


### PR DESCRIPTION
Steps:
- Compare 2 views

Actual result:
- Header text color is dark with dark background
![image](https://github.com/user-attachments/assets/23a28f3d-0dc1-4fd0-addd-38a0f900094a)

Expected result:
- Header text color is light with dark background
![image](https://github.com/user-attachments/assets/0293e4d6-c100-45a5-b5a3-d4bd2d5d838d)
