### PR TITLE
[FIX] sale_mrp: error when trying to set product_id on boms

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -26,7 +26,6 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
     def test_sale_mrp_kit_bom_cogs(self):
         """Check invoice COGS aml after selling and delivering a product
         with Kit BoM having another product with Kit BoM as component"""
-
         # ----------------------------------------------
         # BoM of Kit A:
         #   - BoM Type: Kit
@@ -56,7 +55,6 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
 
         # Create BoM for Kit A
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.kit_a
         bom_product_form.product_tmpl_id = self.kit_a.product_tmpl_id
         bom_product_form.product_qty = 3.0
         bom_product_form.type = 'phantom'
@@ -70,7 +68,6 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
 
         # Create BoM for Kit B
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.kit_b
         bom_product_form.product_tmpl_id = self.kit_b.product_tmpl_id
         bom_product_form.product_qty = 10.0
         bom_product_form.type = 'phantom'

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -158,7 +158,6 @@ class TestSaleMrpKitBom(TransactionCase):
 
         # Create BoM for Kit
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.kit
         bom_product_form.product_tmpl_id = self.kit.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -206,7 +205,6 @@ class TestSaleMrpKitBom(TransactionCase):
 
         # Create BoM for KitB
         bom_product_formA = Form(self.env['mrp.bom'])
-        bom_product_formA.product_id = self.kitB
         bom_product_formA.product_tmpl_id = self.kitB.product_tmpl_id
         bom_product_formA.product_qty = 1.0
         bom_product_formA.type = 'phantom'
@@ -220,7 +218,6 @@ class TestSaleMrpKitBom(TransactionCase):
 
         # Create BoM for KitA
         bom_product_formB = Form(self.env['mrp.bom'])
-        bom_product_formB.product_id = self.kitA
         bom_product_formB.product_tmpl_id = self.kitA.product_tmpl_id
         bom_product_formB.product_qty = 1.0
         bom_product_formB.type = 'phantom'
@@ -273,7 +270,6 @@ class TestSaleMrpKitBom(TransactionCase):
 
         # Create BoM for KitB
         bom_product_formA = Form(self.env['mrp.bom'])
-        bom_product_formA.product_id = kitA
         bom_product_formA.product_tmpl_id = kitA.product_tmpl_id
         bom_product_formA.product_qty = 1.0
         bom_product_formA.type = 'phantom'
@@ -330,7 +326,6 @@ class TestSaleMrpKitBom(TransactionCase):
 
         # Create BoM for KitB
         bom_product_formA = Form(self.env['mrp.bom'])
-        bom_product_formA.product_id = kitAB
         bom_product_formA.product_tmpl_id = kitAB.product_tmpl_id
         bom_product_formA.product_qty = 1.0
         bom_product_formA.type = 'phantom'
@@ -344,7 +339,6 @@ class TestSaleMrpKitBom(TransactionCase):
 
         # Create BoM for KitA
         bom_product_formB = Form(self.env['mrp.bom'])
-        bom_product_formB.product_id = kitABC
         bom_product_formB.product_tmpl_id = kitABC.product_tmpl_id
         bom_product_formB.product_qty = 1.0
         bom_product_formB.type = 'phantom'


### PR DESCRIPTION
Issue started popping up on runbot on March 26th, after the change to demo data in tests, so this is likely because demo data enabled the `group_product_variant` somehow on the current user.

The issue of these tests is that they try to set the `product_id` on an `mrp.bom`, but in the view `mrp.mrp_bom_form_view` which they auto-resolve to the field is declared as:

    <field name="product_id" groups="product.group_product_variant" context="{'default_is_storable': True}"/>
    <field name="product_id" groups="!product.group_product_variant" invisible="1"/>

Thus without variants management enabled the field is not visible and can not be set, triggering an error.

There are two possible fixes for the issue and both seem to work fine:

1. Enable variants for the user.
2. Don't set the `product_id` on the bom.

While the test probably originally used (1) implicitly, the tests don't seem to do care about variants at all, they only seem to manipulate single-variant products. Thus we can just stop setting the `product_id` and rely solely on the `product_tmpl_id`.

https://runbot.odoo.com/odoo/error/161643
