### PR TITLE
[FIX] sale_mrp: don't try to set invisible field `uom_po_id`

### DIFF
--- a/addons/sale_mrp/tests/test_multistep_manufacturing.py
+++ b/addons/sale_mrp/tests/test_multistep_manufacturing.py
@@ -33,7 +33,6 @@ class TestMultistepManufacturing(TestMrpCommon):
         product_form = Form(cls.env['product.product'])
         product_form.name = 'Stick'
         product_form.uom_id = cls.uom_unit
-        product_form.uom_po_id = cls.uom_unit
         product_form.route_ids.clear()
         product_form.route_ids.add(cls.warehouse.manufacture_pull_id.route_id)
         product_form.route_ids.add(cls.warehouse.mto_pull_id.route_id)
@@ -43,12 +42,10 @@ class TestMultistepManufacturing(TestMrpCommon):
         product_form = Form(cls.env['product.product'])
         product_form.name = 'Raw Stick'
         product_form.uom_id = cls.uom_unit
-        product_form.uom_po_id = cls.uom_unit
         cls.product_raw = product_form.save()
 
         # Create bom for manufactured product
         bom_product_form = Form(cls.env['mrp.bom'])
-        bom_product_form.product_id = cls.product_manu
         bom_product_form.product_tmpl_id = cls.product_manu.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'normal'
@@ -121,7 +118,6 @@ class TestMultistepManufacturing(TestMrpCommon):
 
         # New BoM for raw material product, it will generate another Production order i.e. child Production order
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.product_raw
         bom_product_form.product_tmpl_id = self.product_raw.product_tmpl_id
         bom_product_form.product_qty = 1.0
         with bom_product_form.bom_line_ids.new() as bom_line:

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -165,7 +165,6 @@ class TestSaleMrpFlowCommon(ValuationReconciliationTestCommon):
         p.name = name
         p.is_storable = True
         p.uom_id = uom_id
-        p.uom_po_id = uom_id
         p.route_ids.clear()
         for r in routes:
             p.route_ids.add(r)

--- a/addons/sale_mrp/tests/test_sale_mrp_procurement.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_procurement.py
@@ -42,7 +42,6 @@ class TestSaleMrpProcurement(TransactionCase):
         product.name = 'Slider Mobile'
         product.is_storable = True
         product.uom_id = uom_unit
-        product.uom_po_id = uom_unit
         product.route_ids.clear()
         product.route_ids.add(warehouse0.manufacture_pull_id.route_id)
         product.route_ids.add(warehouse0.mto_pull_id.route_id)
@@ -104,14 +103,12 @@ class TestSaleMrpProcurement(TransactionCase):
         product_form.name = 'Raw Stick'
         product_form.is_storable = True
         product_form.uom_id = self.uom_unit
-        product_form.uom_po_id = self.uom_unit
         self.raw_product = product_form.save()
 
         # Create manufactured product
         product_form = Form(self.env['product.product'])
         product_form.name = 'Stick'
         product_form.uom_id = self.uom_unit
-        product_form.uom_po_id = self.uom_unit
         product_form.is_storable = True
         product_form.route_ids.clear()
         product_form.route_ids.add(self.warehouse.manufacture_pull_id.route_id)
@@ -132,12 +129,10 @@ class TestSaleMrpProcurement(TransactionCase):
         product_form.name = 'Raw Iron'
         product_form.is_storable = True
         product_form.uom_id = self.uom_unit
-        product_form.uom_po_id = self.uom_unit
         self.raw_product_2 = product_form.save()
 
         # Create bom for manufactured product
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.finished_product
         bom_product_form.product_tmpl_id = self.finished_product.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'normal'
@@ -149,7 +144,6 @@ class TestSaleMrpProcurement(TransactionCase):
 
         ## Create bom for manufactured product
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.complex_product
         bom_product_form.product_tmpl_id = self.complex_product.product_tmpl_id
         with bom_product_form.bom_line_ids.new() as line:
             line.product_id = self.finished_product


### PR DESCRIPTION
Revealed by the changes to single app tests (which now test every module).

While at it, remove a few unnecessary setting of product-id on non-variant scenarios, they don't blow up but they look a lot like odoo/odoo#206050 and why bother?

https://runbot.odoo.com/odoo/error/163244
