### PR TITLE
[FIX] web: fix unclickable search panel

### DIFF
--- a/addons/web/static/src/views/view.scss
+++ b/addons/web/static/src/views/view.scss
@@ -5,7 +5,7 @@
 
 // Sample data global rules
 .o_view_sample_data {
-    .form-check {
+    > :not(.o_search_panel) .form-check {
         pointer-events: none !important;
     }
 

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -3505,4 +3505,29 @@ QUnit.module("Search", (hooks) => {
             );
         }
     );
+
+    QUnit.test("search panel with sample data", async (assert) => {
+        serverData.models.partner.records = [];
+
+        serverData.views["partner,false,kanban"] = /* xml */ `
+            <kanban sample="1">
+                <templates>
+                    <div t-name="kanban-box" class="oe_kanban_global_click">
+                        <field name="foo"/>
+                    </div>
+                </templates>
+            </kanban>`;
+        serverData.views["partner,false,list"] = /* xml */ `
+            <tree sample="1">
+                <field name="foo"/>
+            </tree>`;
+
+        const webclient = await createWebClient({ serverData });
+        await doAction(webclient, 1);
+
+        assert.deepEqual(getComputedStyle(getFilter(target, 0, "input")).pointerEvents, 'auto');
+
+        await switchView(target, "list");
+        assert.deepEqual(getComputedStyle(getFilter(target, 0, "input")).pointerEvents, 'auto');
+    });
 });


### PR DESCRIPTION
### Steps to reproduce:
- Go to Expenses > Expense Reports
- Make sure that no expenses are present to make the sample data display
- Try clicking on the left panel to change the filter on the status
- It doesn't work

### Cause:
The display of sample data adds the class "o_view_sample_data" to the `Layout` component containing the control panel, the search panel and the list ([see](https://github.com/odoo/odoo/blob/e1b6f55840c9d5e2c0f6705add8d82a311fb04a7/addons/web/static/src/views/list/list_controller.xml#L6)). When this class is added, the events are ignored for div with `form-check` ([see](https://github.com/odoo/odoo/blob/e1b6f55840c9d5e2c0f6705add8d82a311fb04a7/addons/web/static/src/views/view.scss#L7-L10)) As the `SearchPanel` component is inside the `Layout` component and contains form-check for the filters on Selection fields (state for example), this filter also gets deactivated.

### Solution:
Add the class `o_view_sample_data` in the Renderer and not the Controller component, this way we make sure that only the interactions with the sample data get deactivated. Doing this implies adding a prop in the Renderer to pass the value of `useSampleModel` to the renderer.

Fix done for the list and kanban view which are problematic with the Expense Reports page.

opw-4707016