### PR TITLE
[IMP] web: add missing Domain operators in js

### DIFF
--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -315,6 +315,7 @@ function matchCondition(record, condition) {
         ilikeRegexp = new RegExp(`(.*)${escapeRegExp(value).replaceAll("%", "(.*)")}(.*)`, "gi");
     }
     const fieldValue = typeof field === "number" ? field : record[field];
+    const isNot = operator.startsWith("not ");
     switch (operator) {
         case "=?":
             if ([false, null].includes(value)) {
@@ -329,7 +330,7 @@ function matchCondition(record, condition) {
             return fieldValue === value;
         case "!=":
         case "<>":
-            return !matchCondition(record, [field, "==", value]);
+            return !matchCondition(record, [field, "=", value]);
         case "<":
             return fieldValue < value;
         case "<=":
@@ -338,48 +339,38 @@ function matchCondition(record, condition) {
             return fieldValue > value;
         case ">=":
             return fieldValue >= value;
-        case "in": {
-            const val = Array.isArray(value) ? value : [value];
-            const fieldVal = Array.isArray(fieldValue) ? fieldValue : [fieldValue];
-            return fieldVal.some((fv) => val.includes(fv));
-        }
+        case "in":
         case "not in": {
             const val = Array.isArray(value) ? value : [value];
             const fieldVal = Array.isArray(fieldValue) ? fieldValue : [fieldValue];
-            return !fieldVal.some((fv) => val.includes(fv));
+            return Boolean(fieldVal.some((fv) => val.includes(fv))) != isNot;
         }
         case "like":
-            if (fieldValue === false) {
-                return false;
-            }
-            return Boolean(fieldValue.match(likeRegexp));
         case "not like":
             if (fieldValue === false) {
-                return false;
+                return isNot;
             }
-            return Boolean(!fieldValue.match(likeRegexp));
+            return Boolean(fieldValue.match(likeRegexp)) != isNot;
         case "=like":
+        case "not =like":
             if (fieldValue === false) {
-                return false;
+                return isNot;
             }
-            return new RegExp(escapeRegExp(value).replace(/%/g, ".*")).test(fieldValue);
+            return Boolean(new RegExp(escapeRegExp(value).replace(/%/g, ".*")).test(fieldValue)) != isNot;
         case "ilike":
-            if (fieldValue === false) {
-                return false;
-            }
-            return Boolean(fieldValue.match(ilikeRegexp));
         case "not ilike":
             if (fieldValue === false) {
-                return false;
+                return isNot;
             }
-            return Boolean(!fieldValue.match(ilikeRegexp));
+            return Boolean(fieldValue.match(ilikeRegexp)) != isNot;
         case "=ilike":
+        case "not =ilike":
             if (fieldValue === false) {
-                return false;
+                return isNot;
             }
-            return new RegExp(escapeRegExp(value).replace(/%/g, ".*"), "i").test(fieldValue);
+            return Boolean(new RegExp(escapeRegExp(value).replace(/%/g, ".*"), "i").test(fieldValue)) != isNot;
         case "any":
-        case "not_any":
+        case "not any":
             return true;
     }
     throw new InvalidDomainError("could not match domain");

--- a/addons/web/static/tests/core/domain.test.js
+++ b/addons/web/static/tests/core/domain.test.js
@@ -99,8 +99,8 @@ describe("Basic Properties", () => {
         expect(new Domain(["!", ["group_method", "=", "count"]]).contains(record)).toBe(true);
     });
 
-    test("like, =like, ilike, =ilike, not like and not ilike", () => {
-        expect.assertions(28);
+    test("like, =like, ilike, =ilike and not likes", () => {
+        expect.assertions(34);
 
         expect(new Domain([["a", "like", "value"]]).contains({ a: "value" })).toBe(true);
         expect(new Domain([["a", "like", "value"]]).contains({ a: "some value" })).toBe(true);
@@ -129,14 +129,22 @@ describe("Basic Properties", () => {
         expect(new Domain([["a", "not like", "value"]]).contains({ a: "Some Value" })).toBe(true);
         expect(new Domain([["a", "not like", "value"]]).contains({ a: "something" })).toBe(true);
         expect(new Domain([["a", "not like", "value"]]).contains({ a: "Something" })).toBe(true);
-        expect(new Domain([["a", "not like", "value"]]).contains({ a: false })).toBe(false);
+        expect(new Domain([["a", "not like", "value"]]).contains({ a: false })).toBe(true);
 
         expect(new Domain([["a", "not ilike", "value"]]).contains({ a: "value" })).not.toBe(true);
         expect(new Domain([["a", "not ilike", "value"]]).contains({ a: "some value" })).toBe(false);
         expect(new Domain([["a", "not ilike", "value"]]).contains({ a: "Some Value" })).toBe(false);
         expect(new Domain([["a", "not ilike", "value"]]).contains({ a: "something" })).toBe(true);
         expect(new Domain([["a", "not ilike", "value"]]).contains({ a: "Something" })).toBe(true);
-        expect(new Domain([["a", "not ilike", "value"]]).contains({ a: false })).toBe(false);
+        expect(new Domain([["a", "not ilike", "value"]]).contains({ a: false })).toBe(true);
+
+        expect(new Domain([["a", "not =like", "%value"]]).contains({ a: "some value" })).toBe(false);
+        expect(new Domain([["a", "not =like", "%value"]]).contains({ a: "Some Value" })).not.toBe(false);
+
+        expect(new Domain([["a", "not =ilike", "%value"]]).contains({ a: "value" })).toBe(false);
+        expect(new Domain([["a", "not =ilike", "%value"]]).contains({ a: "some value" })).toBe(false);
+        expect(new Domain([["a", "not =ilike", "%value"]]).contains({ a: "Some Value" })).toBe(false);
+        expect(new Domain([["a", "not =ilike", "%value"]]).contains({ a: false })).toBe(true);
     });
 
     test("complex domain", () => {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Some new operators were added after 18.0 such as "not =like". We add support for them in the javascript code.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
