### PR TITLE
[FIX] im_livechat: negative session durations in demo data

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
             <field name="name">Visitor #234, Odoo</field>
             <field name="anonymous_name">Visitor #234</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_chatbot_session_1_member_bot_demo" model="discuss.channel.member">
             <field name="partner_id" ref="welcome_bot_operator_partner_demo"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
             <field name="name">Visitor #235, Odoo</field>
             <field name="anonymous_name">Visitor #235</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_chatbot_session_2_member_bot_demo" model="discuss.channel.member">
             <field name="partner_id" ref="welcome_bot_operator_partner_demo"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
             <field name="name">Visitor #236, Odoo</field>
             <field name="anonymous_name">Visitor #235</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_member_bot_demo" model="discuss.channel.member">
             <field name="partner_id" ref="welcome_bot_operator_partner_demo"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="name">Visitor #234, Mitchell Admin</field>
             <field name="anonymous_name">Visitor #234</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_1_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="base.partner_demo"/>
             <field name="name">Visitor #323, Marc Demo</field>
             <field name="anonymous_name">Visitor #323</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-1)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_2_member_demo" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="name">Joel Willis, Mitchell Admin</field>
             <field name="anonymous_name">Joel Willis</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-2)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_3_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="base.partner_demo"/>
             <field name="name">Joel Willis, Marc Demo</field>
             <field name="anonymous_name">Joel Willis</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-3)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_4_member_demo" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="name">Visitor #532, Mitchell Admin</field>
             <field name="anonymous_name">Visitor #532</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-4)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_5_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="name">Visitor #649, Mitchell Admin</field>
             <field name="anonymous_name">Visitor #649</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-5)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_6_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="name">Joel Willis, Mitchell Admin</field>
             <field name="anonymous_name">Joel Willis</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-6)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_7_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -7,6 +7,7 @@
             <field name="livechat_operator_id" ref="base.partner_demo"/>
             <field name="name">Visitor #722, Marc Demo</field>
             <field name="anonymous_name">Visitor #722</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-7)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_8_member_demo" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo"/>


### PR DESCRIPTION
**Current behavior before PR:**

Live chat sessions in the demo data could show a negative duration. This occurred because the `create_date`—now used as the session start time—was set to the time the demo data was installed, while the session end time was computed to a date earlier.

**Desired behavior after PR is merged:**

The issue is fixed by explicitly setting the `create_date` in the demo data to match the intended session start time.

**Task**-4728159


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
