### PR TITLE
[FIX] mrp_subcontracting: move test_bom_overview

### DIFF
--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1111,60 +1111,6 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
             {'qty_producing': 10.0, 'product_qty': 10.0, 'state': 'to_close'},
         ])
 
-    @freeze_time('2024-01-01')
-    def test_bom_overview_availability(self):
-        # Create routes for components and the main product
-        self.env['product.supplierinfo'].create({
-            'product_tmpl_id': self.finished.product_tmpl_id.id,
-            'partner_id': self.subcontractor_partner1.id,
-            'price': 1.0,
-            'delay': 10
-        })
-        self.env['product.supplierinfo'].create({
-            'product_tmpl_id': self.comp1.product_tmpl_id.id,
-            'partner_id': self.subcontractor_partner1.id,
-            'price': 648.0,
-            'delay': 5
-        })
-        self.env['product.supplierinfo'].create({
-            'product_tmpl_id': self.comp2.product_tmpl_id.id,
-            'partner_id': self.subcontractor_partner1.id,
-            'price': 648.0,
-            'delay': 5
-        })
-
-        self.bom.produce_delay = 1
-        self.bom.days_to_prepare_mo = 3
-
-        # Add 4 units of each component to subcontractor's location
-        subcontractor_location = self.env.company.subcontracting_location_id
-        self.env['stock.quant']._update_available_quantity(self.comp1, subcontractor_location, 4)
-        self.env['stock.quant']._update_available_quantity(self.comp2, subcontractor_location, 4)
-
-        # Generate a report for 3 products: all products should be ready for production
-        bom_data = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, 3)
-
-        self.assertTrue(bom_data['lines']['components_available'])
-        for component in bom_data['lines']['components']:
-            self.assertEqual(component['quantity_on_hand'], 4)
-            self.assertEqual(component['availability_state'], 'available')
-        self.assertEqual(bom_data['lines']['earliest_capacity'], 3)
-        self.assertEqual(bom_data['lines']['earliest_date'], '01/11/2024')
-        self.assertTrue('leftover_capacity' not in bom_data['lines']['earliest_date'])
-        self.assertTrue('leftover_date' not in bom_data['lines']['earliest_date'])
-
-        # Generate a report for 5 products: only 4 products should be ready for production
-        bom_data = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, 5)
-
-        self.assertFalse(bom_data['lines']['components_available'])
-        for component in bom_data['lines']['components']:
-            self.assertEqual(component['quantity_on_hand'], 4)
-            self.assertEqual(component['availability_state'], 'estimated')
-        self.assertEqual(bom_data['lines']['earliest_capacity'], 4)
-        self.assertEqual(bom_data['lines']['earliest_date'], '01/11/2024')
-        self.assertEqual(bom_data['lines']['leftover_capacity'], 1)
-        self.assertEqual(bom_data['lines']['leftover_date'], '01/16/2024')
-
 
 @tagged('post_install', '-at_install')
 class TestSubcontractingTracking(TransactionCase):


### PR DESCRIPTION
moving it to the module mrp_subcontracting_purchase is the correct module, as it depends on the override of _get_resupply_availability happening in mrp_subcontracting_purchase module accorinding to this PR (https://github.com/odoo/odoo/pull/144702/files#diff-54bc40f604ca24cec75d6f7473d21d1d2d0300576456026fe63164daf7cd5149)  and fails as a single app test in  mrp_subcontracting

build_error-163126

