### PR TITLE
[FIX] payment_worldline, payment_asiapay: don't use accounting test things

### DIFF
--- a/addons/payment_asiapay/tests/common.py
+++ b/addons/payment_asiapay/tests/common.py
@@ -1,12 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import Command
 
 from odoo.addons.payment.tests.common import PaymentCommon
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
-class AsiaPayCommon(AccountTestInvoicingCommon, PaymentCommon):
+class AsiaPayCommon(PaymentCommon):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/payment_asiapay/tests/test_payment_transaction.py
+++ b/addons/payment_asiapay/tests/test_payment_transaction.py
@@ -26,6 +26,13 @@ class TestPaymentTransaction(AsiaPayCommon, PaymentHttpCommon):
     def test_reference_is_computed_based_on_document_name(self):
         """ Test the computation of reference prefixes based on the provided invoice. """
         self._skip_if_account_payment_is_not_installed()
+        company = self.env.company
+        Account = self.env['account.account']
+        default_account_revenue = Account.with_company(company).search([
+            *Account._check_company_domain(company),
+            ('account_type', '=', 'income'),
+            ('id', '!=', company.account_journal_early_pay_discount_gain_account_id.id)
+        ], limit=1)
 
         invoice = self.env['account.move'].create({
             'move_type': 'entry',
@@ -33,7 +40,7 @@ class TestPaymentTransaction(AsiaPayCommon, PaymentHttpCommon):
             'line_ids': [
                 Command.create({
                     'name': 'line',
-                    'account_id': self.company_data['default_account_revenue'].id,
+                    'account_id': default_account_revenue.id,
                 }),
             ]
         })

--- a/addons/payment_worldline/tests/common.py
+++ b/addons/payment_worldline/tests/common.py
@@ -1,10 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.payment.tests.common import PaymentCommon
 
 
-class WorldlineCommon(AccountTestInvoicingCommon, PaymentCommon):
+class WorldlineCommon(PaymentCommon):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
It doesn't seem to be of any use, and neither module depends on account.

It happens to pass if enterprise is available because avatax is `auto_install=['payment']` and has a dependency on `account`, so you install a payment module which installs `payment` which auto_installs avatax which installs `account` and you have account's groups available for `account`'s test utilities to resolve.

If you only have community tho, it blows up in your face. Which I guess is what happens in the single app tests.

https://runbot.odoo.com/odoo/error/163117
