### PR TITLE
[FIX] core: fix language in export list of selection fields

### DIFF
--- a/addons/test_import_export/tests/test_export_impex.py
+++ b/addons/test_import_export/tests/test_export_impex.py
@@ -237,9 +237,9 @@ class test_selection_function(CreatorCase):
 
     def test_value(self):
         # selection functions export the *value* itself
-        self.assertEqual(self.export('1'), [['1']])
-        self.assertEqual(self.export('3'), [['3']])
-        self.assertEqual(self.export('0'), [['0']])
+        self.assertEqual(self.export('1'), [['Grault']])
+        self.assertEqual(self.export('3'), [['Moog']])
+        self.assertEqual(self.export('0'), [['Corge']])
 
 
 class test_m2o(CreatorCase):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2992,13 +2992,10 @@ class Selection(Field[str | typing.Literal[False]]):
         raise ValueError("Wrong value for %s: %r" % (self, value))
 
     def convert_to_export(self, value, record):
-        if not isinstance(self.selection, list):
-            # FIXME: this reproduces an existing buggy behavior!
-            return value if value else ''
         for item in self._description_selection(record.env):
             if item[0] == value:
                 return item[1]
-        return ''
+        return value or ''
 
 
 class Reference(Selection):


### PR DESCRIPTION
Reproduce:
18.0 and 18.1
Switch your language to French
Go to employee and export one record
You will see not translated value of État civil

Solution:
Modified the convert_to_export function for selection field

Description of the issue/feature this PR addresses: In the selection field selection list is defined by a method then instead of exporting the localized label, it exports the raw value

this is backport of #192095

opw-4715430