### PR TITLE
[FIX] html_editor: prevent border from scrolling when height is set

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -319,6 +319,7 @@ export const htmlField = {
         }
         if (options.height) {
             editorConfig.height = `${options.height}px`;
+            editorConfig.classList = ["overflow-auto"];
         }
         if ("disableImage" in options) {
             editorConfig.disableImage = Boolean(options.disableImage);

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -102,9 +102,12 @@ export class PowerButtonsPlugin extends Plugin {
         }
         const block = closestBlock(editableSelection.anchorNode);
         const element = closestElement(editableSelection.anchorNode);
+        const blockRect = block.getBoundingClientRect();
+        const editableRect = this.editable.getBoundingClientRect();
         if (
             editableSelection.isCollapsed &&
             element?.matches(baseContainerGlobalSelector) &&
+            editableRect.bottom > blockRect.top &&
             isEmptyBlock(block) &&
             !this.services.ui.isSmall &&
             !closestElement(editableSelection.anchorNode, "td") &&
@@ -121,7 +124,7 @@ export class PowerButtonsPlugin extends Plugin {
                 const shouldHide = Boolean(isAvailable && !isAvailable(editableSelection));
                 buttonElement.classList.toggle("d-none", shouldHide); // 2nd arg must be a boolean
             }
-            this.setPowerButtonsPosition(block, direction);
+            this.setPowerButtonsPosition(block, blockRect, direction);
         }
     }
 
@@ -143,12 +146,11 @@ export class PowerButtonsPlugin extends Plugin {
      * @param {HTMLElement} block
      * @param {string} direction
      */
-    setPowerButtonsPosition(block, direction) {
+    setPowerButtonsPosition(block, blockRect, direction) {
         const overlayStyles = this.powerButtonsOverlay.style;
         // Resetting the position of the power buttons.
         overlayStyles.top = "0px";
         overlayStyles.left = "0px";
-        const blockRect = block.getBoundingClientRect();
         const buttonsRect = this.powerButtonsContainer.getBoundingClientRect();
         const placeholderWidth = this.getPlaceholderWidth(block) + 20;
         if (direction === "rtl") {


### PR DESCRIPTION
**Current behavior before PR:**

- When the height option is passed to the editor and the content exceeds that fixed height, the bottom border scrolls along with the content instead of staying anchored at the bottom.
- When Enter was pressed at the bottom of a fixed-height editor, the newly inserted block was positioned outside the editable area. As a result, power buttons were also shown outside the editor until the block was scrolled into view.

**Desired behavior after PR is merged:**

- The bottom border now remains fixed at the bottom of the editor when the height option is set, even if the content overflows and becomes scrollable.
- Power buttons are no longer displayed while the block is outside the visible editable area.

task: 4718217