### PR TITLE
[REF] product: move tags fields from website_sale to product

### DIFF
--- a/addons/product/models/product_tag.py
+++ b/addons/product/models/product_tag.py
@@ -36,6 +36,12 @@ class ProductTag(models.Model):
         'product.product', string='All Product Variants using this Tag',
         compute='_compute_product_ids', search='_search_product_ids'
     )
+    visible_to_customers = fields.Boolean(
+        string="Visible to customers",
+        help="Whether the tag is displayed to customers.",
+        default=True,
+    )
+    image = fields.Image(string="Image", max_width=200, max_height=200)
 
     _name_uniq = models.Constraint(
         'unique (name)',

--- a/addons/product/views/product_tag_views.xml
+++ b/addons/product/views/product_tag_views.xml
@@ -9,24 +9,15 @@
                 <sheet>
                     <group>
                         <field name="name"/>
+                        <field name="visible_to_customers"/>
+                        <field name="color"
+                               widget='color'
+                               invisible="not visible_to_customers"/>
+                        <field name="image"
+                               widget="image"
+                               options="{'size': [0, 55]}"
+                               invisible="not visible_to_customers"/>
                     </group>
-                    <notebook>
-                        <page string="Product Templates" name="page_product_templates">
-                            <field name="product_template_ids"
-                                   context="{'list_view_ref':'product.product_template_view_tree_tag'}"
-                            />
-                        </page>
-                        <page string="Product Variants" name="page_product_variants">
-                            <field name="product_product_ids"
-                                   context="{'list_view_ref':'product.product_product_view_tree_tag'}"
-                            />
-                        </page>
-                        <page string="All Products" name="page_all_products" invisible="not product_ids">
-                            <field name="product_ids"
-                                   context="{'list_view_ref':'product.product_product_view_tree_tag'}"
-                            />
-                        </page>
-                    </notebook>
                 </sheet>
             </form>
         </field>
@@ -38,6 +29,17 @@
             <list string="Product Tags" multi_edit="1">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
+                <field name="visible_to_customers" optional="show"/>
+                <field name="color"
+                       widget="color"
+                       optional="hide"
+                       readonly="1"
+                       invisible="not visible_to_customers"/>
+                <field name="image"
+                       widget="image"
+                       options="{'size': [0, 30]}"
+                       optional="hide"
+                       invisible="not visible_to_customers"/>
                 <field name="product_template_ids" widget="many2many_tags" optional="show"/>
                 <field name="product_product_ids" widget="many2many_tags" string="Product Variant" optional="show"/>
             </list>

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -375,7 +375,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if filter_by_tags_enabled and search_product:
             all_tags = ProductTag.search(
                 expression.AND([
-                    [('product_ids.is_published', '=', True), ('visible_on_ecommerce', '=', True)],
+                    [('product_ids.is_published', '=', True), ('visible_to_customers', '=', True)],
                     website_domain
                 ])
             )

--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -53,7 +53,7 @@ class WebsiteSaleVariantController(Controller):
         if product and request.website.is_view_active('website_sale.product_tags'):
             combination_info['product_tags'] = request.env['ir.ui.view']._render_template(
                 'website_sale.product_tags', values={
-                    'all_product_tags': product.all_product_tag_ids.filtered('visible_on_ecommerce')
+                    'all_product_tags': product.all_product_tag_ids.filtered('visible_to_customers')
                 }
             )
         return combination_info

--- a/addons/website_sale/models/product_tag.py
+++ b/addons/website_sale/models/product_tag.py
@@ -1,15 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import models
 
 
 class ProductTag(models.Model):
     _name = 'product.tag'
     _inherit = ['website.multi.mixin', 'product.tag']
-
-    visible_on_ecommerce = fields.Boolean(
-        string="Visible on eCommerce",
-        help="Whether the tag is displayed on the eCommerce.",
-        default=True,
-    )
-    image = fields.Image(string="Image", max_width=200, max_height=200)

--- a/addons/website_sale/views/product_tag_views.xml
+++ b/addons/website_sale/views/product_tag_views.xml
@@ -7,41 +7,12 @@
         <field name="model">product.tag</field>
         <field name="inherit_id" ref="product.product_tag_form_view"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field name="visible_on_ecommerce"/>
-                <field name="color"
-                       widget='color'
-                       invisible="not visible_on_ecommerce"/>
-                <field name="image"
-                       widget="image"
-                       options="{'size': [0, 55]}"
-                       invisible="not visible_on_ecommerce"/>
-                <p class="text-muted" colspan="2" invisible="not visible_on_ecommerce">
+            <field name="image" position="after">
+                <p class="text-muted" colspan="2" invisible="not visible_to_customers">
                     If an image is set, the color will not be used on eCommerce.
                 </p>
             </field>
         </field>
     </record>
-
-    <record id="product_tag_tree_view_inherit_website_sale" model="ir.ui.view">
-        <field name="name">product.tag.list.inherit.website.sale</field>
-        <field name="model">product.tag</field>
-        <field name="inherit_id" ref="product.product_tag_tree_view"/>
-        <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field name="visible_on_ecommerce" optional="show"/>
-                <field name="color"
-                       widget="color"
-                       optional="hide"
-                       readonly="1"
-                       invisible="not visible_on_ecommerce"/>
-                <field name="image"
-                       widget="image"
-                       options="{'size': [0, 30]}"
-                       optional="hide"
-                       invisible="not visible_on_ecommerce"/>
-            </field>
-        </field>
-    </record>
-
+    
 </odoo>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1939,7 +1939,7 @@
     <template id="product_tags" name="Product Tags" active="True">
         <div class="o_product_tags o_field_tags d-flex flex-wrap align-items-center gap-2 mb-2 mt-1">
             <t t-foreach="all_product_tags" t-as="tag">
-                <t t-if="tag.visible_on_ecommerce">
+                <t t-if="tag.visible_to_customers">
                     <span t-if="tag.image"
                           class="order-0"
                           t-field="tag.image"


### PR DESCRIPTION
To prevent redundant field definitions, this commit moves the tag fields 'image' and 'visible_on_ecommerce', which are required by both website_sale and point_of_sale, into the product module. The notebooks (Product Templates, Product Variants, All Products)  have been removed from the product_tag form view to simplify the UI.

Task 4735789 
(Suggested by fp) 
