### PR TITLE
[IMP] point_of_sale: company_registry field from res.partner as one of loaded and searched fields

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -32,7 +32,7 @@ class ResPartner(models.Model):
         return [
             'id', 'name', 'street', 'city', 'state_id', 'country_id', 'vat', 'lang', 'phone', 'zip', 'mobile', 'email',
             'barcode', 'write_date', 'property_account_position_id', 'property_product_pricelist', 'parent_name', 'contact_address',
-            'company_type',
+            'company_type', 'company_registry',
         ]
 
     def _compute_pos_order(self):

--- a/addons/point_of_sale/static/src/app/models/res_partner.js
+++ b/addons/point_of_sale/static/src/app/models/res_partner.js
@@ -14,6 +14,7 @@ export class ResPartner extends Base {
             "vat",
             "parent_name",
             "contact_address",
+            "company_registry",
         ];
         return fields
             .map((field) => {

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -137,6 +137,7 @@ export class PartnerList extends Component {
                 "state_id",
                 "country_id",
                 "vat",
+                "company_registry"
             ];
             domain = [
                 ...Array(search_fields.length - 1).fill("|"),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Wouldn't it be smart to add `company_registry` (or company code as I will refer to it) as one of loaded and searched fields?
For one Lithuanian localizations (and I bet some others) require you to use `company_registry` frequently, to the point some clients prefer to sometimes ask the code of the company instead of it's vat or name.
IMO this would save a decent amount of code lines for other localizations (or customizations) and it's a really nice feature.
In the end there's nothing to loose but a lot to gain, if a client doesn't use this field - no impact, if a client uses it to enter company codes - awesome, if a client uses this for some other purposes - might also be great.

So i'm suggesting to add this here, there's even barely any affected lines :relieved: 

Current behavior before PR:
**Can't** find partners by `company_registry`

Desired behavior after PR is merged:
**Can** find partners by `company_registry` :relieved: 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
