### PR TITLE
[FIX] pos_loyalty: Block edition of physical gift card in POS

### DIFF
--- a/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -3,7 +3,7 @@ import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_su
 import { patch } from "@web/core/utils/patch";
 import { ask } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { useService } from "@web/core/utils/hooks";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { ManageGiftCardPopup } from "@pos_loyalty/app/components/popups/manage_giftcard_popup/manage_giftcard_popup";
 
 patch(OrderSummary.prototype, {
@@ -62,7 +62,30 @@ patch(OrderSummary.prototype, {
      */
     _setValue(val) {
         const selectedLine = this.currentOrder.getSelectedOrderline();
+        const { numpadMode } = this.pos;
+        const isPhysicalGiftCard = selectedLine.gift_code?.length > 0;
         if (!selectedLine) {
+            return;
+        }
+        if (isPhysicalGiftCard && numpadMode == "quantity" && !["", "remove"].includes(val)) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Gift Card Error"),
+                body: _t("You cannot change the quantity of a physical gift card."),
+            });
+            return;
+        }
+        if (isPhysicalGiftCard && numpadMode == "discount") {
+            this.dialog.add(AlertDialog, {
+                title: _t("Gift Card Error"),
+                body: _t("You cannot change the discount of a physical gift card."),
+            });
+            return;
+        }
+        if (isPhysicalGiftCard && numpadMode == "price") {
+            this.dialog.add(AlertDialog, {
+                title: _t("Gift Card Error"),
+                body: _t("You cannot change the price of a physical gift card."),
+            });
             return;
         }
         if (selectedLine.is_reward_line && val === "remove") {

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -7,6 +7,8 @@ import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_sc
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
+import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 
 registry.category("web_tour.tours").add("GiftCardProgramTour1", {
     steps: () =>
@@ -119,6 +121,19 @@ registry.category("web_tour.tours").add("PhysicalGiftCardProgramSaleTour", {
             PosLoyalty.createManualGiftCard("test-card-0001", 100),
             PosLoyalty.clickPhysicalGiftCard("test-card-0001"),
             ProductScreen.selectedOrderlineHas("Gift Card", "1", "100"),
+            inLeftSide([
+                // Cannot modifiy quantity on physical gift card
+                Numpad.click("4"),
+                Dialog.confirm(),
+                // Cannot modifiy discount on physical gift card
+                Numpad.click("%"),
+                Numpad.click("5"),
+                Dialog.confirm(),
+                // Connot modifiy price on physical gift card
+                Numpad.click("Price"),
+                Numpad.click("5"),
+                Dialog.confirm(),
+            ]),
             ProductScreen.addOrderline("Gift Card", "1", "50", "50"),
             PosLoyalty.createManualGiftCard("new-card-0001", 250),
             PosLoyalty.clickPhysicalGiftCard("new-card-0001"),

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1718,7 +1718,8 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour(
             "/pos/web?config_id=%d" % self.main_pos_config.id,
             "PhysicalGiftCardProgramSaleTour",
-            login="pos_user"
+            login="pos_user",
+            debug=True
         )
 
         expected_coupons = {


### PR DESCRIPTION
Before this commit it was possible to edit a physical gift card in the POS, which was not the expected behavior. This commit adds a check to prevent the edition of physical gift cards.


