### PR TITLE
[FIX] purchase_stock: remove bottom margin in modal widget

### DIFF
--- a/addons/purchase_stock/static/src/css/purchase_stock.scss
+++ b/addons/purchase_stock/static/src/css/purchase_stock.scss
@@ -1,7 +1,12 @@
-.o_purchase_order_suggest .o_field_widget.o_small {
-    display: inline;
+.o_purchase_order_suggest {
+    .o_field_widget.o_small {
+        display: inline;
 
-    input {
-        width: 40px;
+        input {
+            width: 40px;
+        }
+    }
+    .o_field_widget.o_field_many2one {
+        margin-bottom: 0;
     }
 }


### PR DESCRIPTION
The many2one widget on the Suggest modal has a margin-bottom that adds a pixel or 2 of additional space between 2 lines of text.

This creates an imbalance between the first and the second paragraph, completely ruining the feeling of precision so inherent to Odoo. Also, it destroys the Feng Shui of the modal and probably kills a kitten every time someone opens the view.

For all those reasons, the bottom margin has to be hidden so that balance can be brought back to Odoo.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
