### PR TITLE
[FIX] web: datetime_picker: show selected inverted range

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -30,12 +30,12 @@
         ;
     }
 
-    .o_select_start {
+    :nth-child(1 of .o_selected) {
         border-top-left-radius: 50%;
         border-bottom-left-radius: 50%;
     }
 
-    .o_select_end  {
+    :nth-last-child(1 of .o_selected) {
         border-top-right-radius: 50%;
         border-bottom-right-radius: 50%;
     }

--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -200,13 +200,13 @@ export function isInRange(value, range) {
         return false;
     }
     if (Array.isArray(value)) {
-        const actualValues = value.filter(Boolean);
+        const actualValues = value.filter(Boolean).sort();
         if (actualValues.length < 2) {
             return isInRange(actualValues[0], range);
         }
         return (
-            (value[0] <= range[0] && range[0] <= value[1]) ||
-            (range[0] <= value[0] && value[0] <= range[1])
+            (actualValues[0] <= range[0] && range[0] <= actualValues[1]) ||
+            (range[0] <= actualValues[0] && actualValues[0] <= range[1])
         );
     } else {
         return range[0] <= value && value <= range[1];

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1098,6 +1098,29 @@ test("update the selected input date after removing the existing date", async ()
     expect("input[data-field=date]").toHaveValue("02/12/2017");
 });
 
+test("daterange with inverted start date and end date", async () => {
+    Partner._records[0].datetime_end = "2017-02-01 00:00:00";
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end'}"/>
+            </form>`,
+        resId: 1,
+    });
+
+    expect(".o_field_daterange input:eq(0)").toHaveValue("02/08/2017 15:30");
+    expect(".o_field_daterange input:eq(1)").toHaveValue("02/01/2017 05:30");
+
+    await contains("input[data-field=datetime]").click();
+
+    expect(".o_selected").toHaveCount(8, {
+        message: "should correctly display the range even if invalid",
+    });
+});
+
 test("daterange field in kanban with show_time option", async () => {
     mockTimeZone(+2);
     Partner._records[0].datetime_end = "2017-03-13 00:00:00";


### PR DESCRIPTION
Before this commit, only one date was selected if the end date was before the start date.
Even if we all agree that this shouldn't pass the form validation, the range should be able to display it without weirdness.

Note that ´isInRange()´ utility is sometimes called with arguments in the wrong order. This function seems resilient and we had to deal with it for this fix. We will see later to change this.

Steps to reproduce:
- Open Calendar
- New
- In "Start" range field, manually enter the end date and then the start date. => Reopen the picker to see the result

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
