### PR TITLE
[FIX] l10n_in_*_stock: price unit compute

### DIFF
--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -504,7 +504,7 @@ class Ewaybill(models.Model):
             "hsnCode": AccountEDI._l10n_in_edi_extract_digits(product.l10n_in_hsn_code),
             "productDesc": product.name,
             "quantity": line.quantity,
-            "qtyUnit": product.uom_id.l10n_in_code and product.uom_id.l10n_in_code.split("-")[
+            "qtyUnit": line.product_uom.l10n_in_code and line.product_uom.l10n_in_code.split("-")[
                 0] or "OTH",
             "taxableAmount": AccountEDI._l10n_in_round_value(tax_details['total_excluded']),
         }

--- a/addons/l10n_in_purchase_stock/models/stock_move.py
+++ b/addons/l10n_in_purchase_stock/models/stock_move.py
@@ -12,7 +12,7 @@ class StockMove(models.Model):
             if qty := line_id.product_qty:
                 company_id = line_id.company_id
                 return line_id.currency_id._convert(
-                    line_id.price_subtotal / qty,
+                    line_id.product_uom._compute_price(line_id.price_subtotal / qty, self.product_uom),
                     company_id.currency_id,
                     company_id,
                     self.date,

--- a/addons/l10n_in_sale_stock/models/stock_move.py
+++ b/addons/l10n_in_sale_stock/models/stock_move.py
@@ -12,7 +12,7 @@ class StockMove(models.Model):
             if qty := line_id.product_uom_qty:
                 company_id = line_id.company_id
                 return line_id.currency_id._convert(
-                    line_id.price_subtotal / qty,
+                    line_id.product_uom._compute_price(line_id.price_subtotal / qty, self.product_uom),
                     company_id.currency_id,
                     company_id,
                     self.date,


### PR DESCRIPTION
Steps to reproduce:
1. Install `l10n_in_ewaybill_stock` and `sale_management`
2. Activate Units of measure
3. Create SO and add SO line with a product uom having units
4. Set this parameter `Quantity -> 1`, `UoM -> Dozen`, `Price Unit -> 12`
5. Confirm SO and related picking delivery
6. Create and generate E-waybill
7. Print Receipt

The actual Taxable amount should be Rs. 12 but instead it shows 144

In this commit we fix the following issue

opw-4728253



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
