### PR TITLE
[FIX] pos_hr: not use employee rights from cached data.

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/backend_utils.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/backend_utils.js
@@ -1,0 +1,25 @@
+export function editShopConfiguration(shop) {
+    return [
+        {
+            trigger: ".o_main_navbar span:contains('Configuration')",
+            run: "click",
+        },
+        {
+            trigger: ".dropdown-item:contains('Point of Sales')",
+            run: "click",
+        },
+        {
+            trigger: `.o_data_cell[data-tooltip=${shop}]`,
+            run: "click",
+        },
+    ];
+}
+
+export function saveShopConfiguration() {
+    return [
+        {
+            trigger: ".o_form_button_save",
+            run: "click",
+        },
+    ];
+}

--- a/addons/pos_hr/static/src/app/models/data_service_options.js
+++ b/addons/pos_hr/static/src/app/models/data_service_options.js
@@ -1,0 +1,8 @@
+import { DataServiceOptions } from "@point_of_sale/app/models/data_service_options";
+import { patch } from "@web/core/utils/patch";
+
+patch(DataServiceOptions.prototype, {
+    get uniqueModels() {
+        return [...super.uniqueModels, "hr.employee"];
+    },
+});

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -5,6 +5,8 @@ import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as NumberPopup from "@point_of_sale/../tests/generic_helpers/number_popup_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selection_popup_util";
+import * as BackendUtils from "@point_of_sale/../tests/pos/tours/utils/backend_utils";
+import * as Utils from "@point_of_sale/../tests/generic_helpers/utils";
 import { registry } from "@web/core/registry";
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
@@ -135,5 +137,35 @@ registry.category("web_tour.tours").add("CashierCannotClose", {
             {
                 trigger: negate(`span.dropdown-item:contains("Close Register")`),
             },
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_change_on_rights_reflected_directly", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Dialog.confirm("Open Register"),
+            Chrome.clickMenuOption("Backend"),
+            BackendUtils.editShopConfiguration("Shop"),
+            {
+                trigger: ".o_tag:contains('Pos Employee1') .o_delete",
+                run: "click",
+            },
+            BackendUtils.saveShopConfiguration(),
+            {
+                trigger: ".o_main_navbar .o-dropdown-item:contains('Dashboard')",
+                run: "click",
+            },
+            {
+                trigger: ".btn:contains('Continue Selling')",
+                run: "click",
+            },
+            Chrome.clickBtn("Unlock Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            Utils.negateStep(...SelectionPopup.has("Pos Employee1")),
         ].flat(),
 });

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -103,3 +103,15 @@ class TestUi(TestPosHrHttpCommon):
             "CashierCannotClose",
             login="pos_user",
         )
+
+    def test_change_on_rights_reflected_directly(self):
+        """When changes in employee rights (advanced/basic/minimal) should
+        be reflected directly and not read from the cache."""
+
+        self.main_pos_config.advanced_employee_ids = self.pos_admin.employee_id
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_change_on_rights_reflected_directly",
+            login="pos_admin",
+        )


### PR DESCRIPTION
Currently, since we read most data from cache, if an employee right was changed, it is not reflected in the pos.

Steps to reproduce:
-------------------
* Enable "Log in with employees" and set some records for each field.
* Open session, make a sale, close register
* Edit employees configuration, delete one, change rights advanced -> minimal
* Reopen the session
> Observation: The employee deleted is still visible in the list of cashiers
and the employee that has now minimal rights is still having advanced rights.

Why the fix:
------------
When removing rights from an employee it is important to have it reflected as soon as possible.

A possible solution would have been to recompute `last_data_change` when making any modification on the employee rights but this would recompute everything and we lose the performance added by the caching feature.

Instead, by adding the model to `uniqueModels` we ensure that anytime we reload the pos, all `hr.employee` records will be dropped from the indexedDB, which ends up using the data loaded.

https://github.com/odoo/odoo/blob/5d52373b4c9d64968316c4e883d6b49c7cd1d048/addons/point_of_sale/static/src/app/services/data_service.js#L246-L251

opw-4699241