### PR TITLE
[FIX] base: prevent wkhtmltopdf deadlock

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -30905,6 +30905,15 @@ msgid ""
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/ir_actions_report.py:0
+#, python-format
+msgid ""
+"We're short on system resources right now, please try again in a few "
+"seconds."
+msgstr ""
+
+#. module: base
 #: model:ir.module.module,shortdesc:base.module_web
 msgid "Web"
 msgstr ""


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Start a server with `--workers=2` (or use runbot);
2. have `payment_demo` published as payment provider;
3. create 2 sale orders;
4. generate payment links for each, and open in separate sessions;
5. click both payment buttons as fast as possible[^1].

[^1]: easier if you use this JS function in the console:
    ```javascript
    while (true)
        if (new Date().getSeconds() % 20 === 0) {
            document.querySelector('button[name=o_payment_submit_button]').click();
            break;
        }
    ```

Issue
-----
The entire server becomes unresponsive for several minutes.

Cause
-----
The default mode for SaaS, odoo.sh & runbot is a prefork server with 2 workers. When two actions that generate PDFs (like mailing sale orders) happen at the same time, both workers will start a subprocess, calling on `wkhtmltopdf`.

The HTML passed to `wkhtmltopdf` contains `link` elements, linking to assets on the server itself. The presents an issue, as both workers are waiting for `wkhtmltopdf` to finish rendering, while `wkhtmltopdf` is waiting for a worker to handle its HTTP GET requests, so it can finish rendering a PDF, resulting in a deadlock.

Solution
--------
When starting in prefork mode, create a semaphore that can be acquired $\\#{workers} - 1$ times, ensuring one workers always remains available to process HTTP GET requests from `wkhtmltopdf`. If it cannot be acquired when `wkhtmltopdf` is about to be called, raise an error, telling the user to try again in a few seconds to avoid a deadlocked server.

opw-4616053
