### PR TITLE
[FIX] bus: detect lost notifications when gc runs during disconnection

### DIFF
--- a/addons/bus/controllers/main.py
+++ b/addons/bus/controllers/main.py
@@ -12,6 +12,12 @@ class BusController(Controller):
             request.env['ir.model']._get_model_definitions(json.loads(model_names_to_fetch)),
         ))
 
+    @route("/bus/has_missed_notifications", type="json", auth="public")
+    def has_missed_notifications(self, last_notification_id):
+        # sudo - bus.bus: checking if a notification still exists in order to
+        # detect missed notification during disconnect is allowed.
+        return request.env["bus.bus"].sudo().search_count([("id", "=", last_notification_id)]) == 0
+
     @route("/bus/get_autovacuum_info", type="json", auth="public")
     def get_autovacuum_info(self):
         # sudo - ir.cron: lastcall and nextcall of the autovacuum is not sensitive

--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -37,6 +37,7 @@ export const busService = {
         let workerState;
         let isActive = false;
         let isInitialized = false;
+        let lastNotificationId = null;
         let isUsingSharedWorker = browser.SharedWorker && !isIosApp();
         let backOnlineTimeout;
         const startedAt = luxon.DateTime.now().set({ milliseconds: 0 });
@@ -74,7 +75,8 @@ export const busService = {
             switch (type) {
                 case "notification": {
                     const notifications = data.map(({ id, message }) => ({ id, ...message }));
-                    multiTab.setSharedValue("last_notification_id", notifications.at(-1).id);
+                    lastNotificationId = notifications.at(-1).id;
+                    multiTab.setSharedValue("last_notification_id", lastNotificationId);
                     for (const { id, type, payload } of notifications) {
                         notificationBus.trigger(type, { id, payload });
                         busService._onMessage(id, type, payload);
@@ -280,6 +282,10 @@ export const busService = {
             startedAt,
             get workerState() {
                 return workerState;
+            },
+            /** The id of the last notification received by this tab. */
+            get lastNotificationId() {
+                return lastNotificationId;
             },
         };
     },

--- a/addons/bus/static/tests/mock_server/bus_mock_server.js
+++ b/addons/bus/static/tests/mock_server/bus_mock_server.js
@@ -1,7 +1,10 @@
 import { serializeDateTime } from "@web/core/l10n/dates";
 import { registry } from "@web/core/registry";
 
-registry.category("mock_rpc").add("/bus/get_autovacuum_info", () => ({
-    lastcall: serializeDateTime(luxon.DateTime.now().minus({ days: 1 }).toUTC()),
-    nextcall: serializeDateTime(luxon.DateTime.now().plus({ days: 1 }).toUTC()),
-}));
+registry
+    .category("mock_rpc")
+    .add("/bus/get_autovacuum_info", () => ({
+        lastcall: serializeDateTime(luxon.DateTime.now().minus({ days: 1 }).toUTC()),
+        nextcall: serializeDateTime(luxon.DateTime.now().plus({ days: 1 }).toUTC()),
+    }))
+    .add("/bus/has_missed_notifications", () => false);


### PR DESCRIPTION
In [1], a mechanism was introduced to detect when notifications were lost due to the bus table being cleared during a disconnection.

However, this approach used the autovacuum cron dates to detect this scenario. Other actions can clear the bus table, which is typically the case on odoo.com where another cron runs more frequently.

This PR fixes the issue by comparing the disconnection time with the oldest bus notification's create date.

[1]: https://github.com/odoo/odoo/pull/188003

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
