### PR TITLE
[FIX] im_livechat: show custom agent name in start call notification

### DIFF
--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -25,3 +25,27 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
         channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         channel.add_members(partner_ids=john.partner_id.ids)
         self.assertEqual(channel.message_ids[-1].body, f"<div class=\"o_mail_notification\">invited <a href=\"#\" data-oe-model=\"res.partner\" data-oe-id=\"{john.partner_id.id}\">@ELOPERADOR</a> to the channel</div>")
+
+    def test_user_livechat_username_start_call_notification(self):
+        john = self._create_operator("fr_FR")
+        john.partner_id.user_livechat_username = "ELOPERADOR"
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {
+                "name": "Livechat Channel",
+                "user_ids": [john.id],
+            }
+        )
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Visitor",
+                "channel_id": livechat_channel.id,
+                "persisted": True,
+            },
+        )
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
+        self.make_jsonrpc_request("/mail/rtc/channel/join_call", {"channel_id": channel.id})
+        self.assertEqual(
+            channel.message_ids[-1].body,
+            "<div class=\"o_mail_notification\">started a live conference</div>",
+        )

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -329,7 +329,11 @@ class DiscussChannelMember(models.Model):
                 },
             )
         if len(self.channel_id.rtc_session_ids) == 1 and self.channel_id.channel_type != "channel":
-            self.channel_id.message_post(body=_("%s started a live conference", self.partner_id.name or self.guest_id.name), message_type='notification')
+            self.channel_id.message_post(
+                body=Markup("<div class='o_mail_notification'>%s</div>")
+                % self.env._("started a live conference"),
+                message_type="notification",
+            )
             self._rtc_invite_members()
 
     def _join_sfu(self, ice_servers=None, force=False):


### PR DESCRIPTION
Before this PR, the live chat user name of the agent was not used in the call start notification. This PR fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
