### PR TITLE
[FIX] core: ignore vobject warning

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -205,6 +205,9 @@ def init_logger():
     # need to be adapted later but too muchwork for this pr.
     warnings.filterwarnings('ignore', r'^datetime.datetime.utcnow\(\) is deprecated and scheduled for removal in a future version.*', category=DeprecationWarning)
 
+    # This warning is triggered library only during the python precompilation which does not occur on readonly filesystem
+    warnings.filterwarnings("ignore", r'invalid escape sequence', category=DeprecationWarning, module=".*vobject")
+    warnings.filterwarnings("ignore", r'invalid escape sequence', category=SyntaxWarning, module=".*vobject")
     from .tools.translate import resetlocale
     resetlocale()
 


### PR DESCRIPTION
Until version 0.9.8 of vobject we need to ignore:
-  DeprecationWarning in python 3.6 and after
- SyntaxWarning since python 3.12
See https://github.com/py-vobject/vobject/commit/da50fdb5fa871e4c5c3420d1e2e34e7c9ce6bb30

The warning occurs only during the first precompilation of the library.
It does not occur on readonly filesystem, ie runbot



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
