### PR TITLE
[IMP] l10n_fr: move and rename company_id for Siret in partner form

### DIFF
--- a/addons/l10n_fr/__manifest__.py
+++ b/addons/l10n_fr/__manifest__.py
@@ -13,6 +13,7 @@
     'data': [
         'data/res_country_data.xml',
         'views/res_company_views.xml',
+        'views/res_partner_views.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_fr/models/__init__.py
+++ b/addons/l10n_fr/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import res_company
+from . import res_partner

--- a/addons/l10n_fr/models/res_partner.py
+++ b/addons/l10n_fr/models/res_partner.py
@@ -1,0 +1,12 @@
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    l10n_fr_is_french = fields.Boolean(compute='_compute_l10n_fr_is_french')
+
+    @api.depends('country_code')
+    def _compute_l10n_fr_is_french(self):
+        for partner in self:
+            partner.l10n_fr_is_french = partner.country_code in self.env['res.company']._get_france_country_codes()

--- a/addons/l10n_fr/views/res_partner_views.xml
+++ b/addons/l10n_fr/views/res_partner_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_form_inherit_l10n_fr" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit.l10n_fr</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="priority">14</field>
+        <field name="arch" type="xml">
+            <field name="company_registry" position="attributes">
+                <attribute name="invisible">parent_id or not is_company or l10n_fr_is_french</attribute>
+            </field>
+            <field name="vat" position="after">
+                <field name="company_registry" string="Siret" invisible="not l10n_fr_is_french" placeholder="33417522101010"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
We use the Company ID field to fill the Siret number in the partner form view. To make things easier, the field will be moved to the header under the VAT and renamed.

task-4724196
