### PR TITLE
[FIX] product: allow product_manager to access UoMs

### DIFF
--- a/addons/product/security/ir.model.access.csv
+++ b/addons/product/security/ir.model.access.csv
@@ -36,3 +36,4 @@ access_product_document_manager,access_product_document_manager,model_product_do
 access_update_product_attribute_value_manager,update.product.attribute.value,model_update_product_attribute_value,group_product_manager,1,1,1,0
 access_product_uom_manager,product.uom manager,model_product_uom,group_product_manager,1,1,1,1
 access_product_uom_user,product.uom user,model_product_uom,base.group_user,1,0,0,0
+access_uom_uom_product_manager,uom.uom.product.manager,model_uom_uom,group_product_manager,1,1,1,1


### PR DESCRIPTION
Admins of various applications (e.g. stock, sale, purchase, etc.) recently had their product + uom write/delete/create access rights removed so that the `product_manager` role can handle the modification of products/uoms and decouple manager roles for more granular access control. Unfortunately we forgot to give `product_manager` access rights over the uom model so no one but admins could modify them, therefore we update the uom access rights so `product_manager`s can edit them as well.

Followup to task: 4578961

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
