### PR TITLE
[FIX] l10n_es_edi_tbai: pass correct xmlns for LROE 140

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
+++ b/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
@@ -14,11 +14,11 @@
                 t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
             <lrpjfecsgap:LROEPJ240FacturasEmitidasConSGAnulacionPeticion
                 xmlns:lrpjfecsgap="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PJ_240_1_1_FacturasEmitidas_ConSG_AnulacionPeticion_V1_0_0.xsd"
-                t-elif="not is_emission and not is_freelancer"
+                t-elif="not is_emission and not freelancer"
                 t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
             <lrpficfcsgap:LROEPF140IngresosConFacturaConSGAnulacionPeticion
                 xmlns:lrpficfcsgap="https://www.batuz.eus/fitxategiak/batuz/LROE/esquemas/LROE_PF_140_1_1_Ingresos_ConfacturaConSG_AnulacionPeticion_V1_0_0.xsd"
-                t-elif="not is_emission and is_freelancer"
+                t-elif="not is_emission and freelancer"
                 t-call="l10n_es_edi_tbai.template_LROE_240_inner"/>
         </template>
 

--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -296,6 +296,7 @@ class L10nEsEdiTbaiDocument(models.Model):
             'sender_vat': sender.vat[2:] if sender.vat.startswith('ES') else sender.vat,
             'fiscal_year': str(self.date.year),
             'freelancer': freelancer,
+            'is_freelancer': freelancer,  # For bugfix, will be removed in master
             'epigrafe': self.env['ir.config_parameter'].sudo().get_param('l10n_es_edi_tbai.epigrafe', '')
         }
         lroe_values.update({'tbai_b64_list': [base64.b64encode(self.xml_attachment_id.raw).decode()]})


### PR DESCRIPTION
is_freelancer is not passed, but freelancer is as value to the XML

opw-4634677

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
