### PR TITLE
[IMP] base: single savepoint for import

### DIFF
--- a/addons/test_import_export/tests/test_load.py
+++ b/addons/test_import_export/tests/test_load.py
@@ -1789,5 +1789,5 @@ class CheckSavepoint(ImporterCase):
             data = [[str(i)] for i in range(100)] + [[str(i)] for i in range(20)]
             self.import_(['value'], data)
             self.assertLess(sp_mock.call_count, 100, "Too many savepoints in the same transaction, load method should not create a savepoint for each record")
-            self.assertEqual(sp_mock.call_count, 3, "Too many savepoints in the same transaction")
+            self.assertEqual(sp_mock.call_count, 2, "Too many savepoints in the same transaction")
             self.assertGreater(sp_flush.call_count, 120, "We should flush after each record to bind errors to the record")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The import either succeeds or fails altogether. To avoid creating savepoints per records, we will start only one and use it throughout the import process: including conversion of file to values.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
