### PR TITLE
[FIX] website_sale: missing class in breadcrumb

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1533,7 +1533,7 @@
                     <div class="row align-items-center">
                         <div class="col d-flex align-items-center order-1 order-lg-0">
                             <ol class="o_wsale_breadcrumb breadcrumb p-0 mb-4 m-lg-0">
-                                <li class="o_not_editable d-none d-lg-inline-block">
+                                <li class="o_not_editable breadcrumb-item d-none d-lg-inline-block">
                                     <a t-att-href="shop_path">
                                         <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/>All Products
                                     </a>


### PR DESCRIPTION
After commit 8d8b8f95cd7e018afe09a8fbba6184c9c2bf1038, the divider between breadcrumbs was missing because the class 'breadcrumb-item' was removed from the 'All Products' breadcrumb.

The class was removed to avoid showing the separator on mobile but in fact there was css that was misplaced in commit 158f99de69eb5f8356afc9771d5bfcbd0f8293e9 when the outer selector was changed but now fixed in b1ba323a9965255b1ebcf07567a300bb0c560ebe

![image](https://github.com/user-attachments/assets/eba1b12f-d424-4e5d-8b98-2f00734f0e1f)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
