### PR TITLE
[FIX] mail: minor discuss (style) adjustments

### DIFF
--- a/addons/mail/static/src/core/common/autoresize_input.xml
+++ b/addons/mail/static/src/core/common/autoresize_input.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.AutoresizeInput">
     <input
-        class="o-mail-AutoresizeInput px-1 border-1 text-truncate"
+        class="o-mail-AutoresizeInput px-1 border-1 text-truncate rounded"
         t-attf-class="{{ props.className }}"
         t-att-class="{'o-focused': state.isFocused}"
         t-att-placeholder="props.placeholder"

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -32,7 +32,7 @@
     <!-- @type {import("models").Message} message -->
     <t t-name="mail.message_preview_prefix">
         <t t-if="message.isSelfAuthored">
-            <i class="fa fa-mail-reply me-1"/>You:
+            <i class="fa fa-mail-reply me-1 opacity-75"/>You:
         </t>
         <t t-elif="!message.author?.eq(thread.correspondent?.persona)">
             <t t-esc="message.author?.name ?? message.email_from"/>:

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -19,7 +19,7 @@
             >
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
                     <div class="o-mail-Message-sidebar d-flex flex-shrink-0 justify-content-center" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
-                        <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view" t-att-class="getAvatarContainerAttClass()">
+                        <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view rounded-3" t-att-class="getAvatarContainerAttClass()">
                             <img class="o-mail-Message-avatar w-100 h-100 rounded-3" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
                         </div>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>

--- a/addons/mail/static/src/core/common/message_confirm_dialog.xml
+++ b/addons/mail/static/src/core/common/message_confirm_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.MessageConfirmDialog">
-    <Dialog size="props.size" title="props.title">
+    <Dialog size="props.size" title="props.title" contentClass="'bg-100'">
         <p class="mx-3 mb-3" t-esc="props.prompt"/>
         <blockquote class="mx-3 mb-3 fst-normal" style="pointer-events:none;">
             <t t-component="messageComponent" message="props.message" hasActions="false"/>

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -11,9 +11,14 @@
     transition: opacity 0.5s;
 
     span {
+        --bg-opacity: 90%;
         font-size: 0.6rem;
         clip-path: polygon(0% 50%, 15% 0%, 100% 0%, 100% 100%, 15% 100%);
     }
+}
+
+.o-mail-Thread-newMessageLine {
+    --border-opacity: .5;
 }
 
 .o_mail_notification {

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -19,8 +19,8 @@
                         <DateSection date="msg.dateDay" className="'pt-2 px-2'"/>
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
-                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1 px-2">
-                        <hr class="flex-grow-1 border-danger opacity-100"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase">New</span>
+                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bold z-1 px-2">
+                        <div class="o-mail-Thread-newMessageLine flex-grow-1 border border-danger opacity-100 shadow-sm"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase shadow-sm">New</span>
                     </div>
                     <Message
                         asCard="props.thread.model === 'mail.box'"

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -12,7 +12,7 @@
                         <img class="rounded-3 o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="!thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
-                                <a href="#" class="position-absolute z-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">
+                                <a href="#" class="position-absolute z-1 h-100 w-100 rounded-3 start-0 bottom-0" title="Upload Avatar">
                                     <i class="position-absolute top-50 start-50 fa fa-sm fa-pencil text-white"/>
                                 </a>
                             </t>

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -41,7 +41,7 @@
 }
 
 .o-mail-NotificationItem-markAsRead {
-    background-color: rgba($success, .1) !important;
+    background-color: rgba($success, .15) !important;
     font-size: 0.85rem !important;
     color: $success !important;
     outline: 1px solid rgba($success, .25);
@@ -51,6 +51,7 @@
     &:hover {
         outline-color: rgba(darken($success, 10%), .5);
         background-color: transparent !important;
+        box-shadow: $box-shadow-sm
     }
 }
 

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -13,7 +13,12 @@ threadActionsRegistry
         },
         icon: "fa fa-fw fa-phone",
         iconLarge: "fa fa-fw fa-lg fa-phone",
-        name: _t("Start a Call"),
+        name(component) {
+            if (component.thread.rtcSessions.length > 0) {
+                return _t("Join the Call");
+            }
+            return _t("Start a Call");
+        },
         open(component) {
             component.rtc.toggleCall(component.thread);
         },
@@ -30,7 +35,12 @@ threadActionsRegistry
         },
         icon: "fa fa-fw fa-video-camera",
         iconLarge: "fa fa-fw fa-lg fa-video-camera",
-        name: _t("Start a Video Call"),
+        name(component) {
+            if (component.thread.rtcSessions.length > 0) {
+                return _t("Join the Call with Camera");
+            }
+            return _t("Start a Video Call");
+        },
         open(component) {
             component.rtc.toggleCall(component.thread, { camera: true });
         },

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -35,8 +35,8 @@
     </t>
 
     <t t-name="discuss.channel_member">
-        <div class="o-discuss-ChannelMember d-flex align-items-center p-1 bg-inherit rounded" t-att-class="{ 'cursor-pointer': canOpenChatWith(member), 'o-offline': offline }" t-on-click.stop="(ev) => this.onClickAvatar(ev, member)">
-            <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex flex-shrink-0">
+        <div class="o-discuss-ChannelMember d-flex align-items-center p-1 bg-inherit rounded-3" t-att-class="{ 'cursor-pointer': canOpenChatWith(member), 'o-offline': offline }" t-on-click.stop="(ev) => this.onClickAvatar(ev, member)">
+            <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex flex-shrink-0 rounded-3">
                 <img class="w-100 h-100 rounded-3 o_object_fit_cover" t-att-src="member.persona.avatarUrl"/>
                 <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
             </div>

--- a/addons/mail/static/src/discuss/core/common/thread_patch.xml
+++ b/addons/mail/static/src/discuss/core/common/thread_patch.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-Thread')]" position="before">
-            <span t-if="!env.inChatter and props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer border-bottom border-warning smaller fw-bolder">
-                <t t-set="alertClass" t-value="'alert alert-warning m-0 border-start-0 o-mail-Thread-bannerHover rounded-0 py-1'"/>
-                <span t-attf-class="{{ alertClass }} flex-grow-1" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
-                <span t-attf-class="{{ alertClass }}" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-square"/></span>
+            <span t-if="!env.inChatter and props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm smaller fw-bolder rounded-bottom-3 rounded-top-0">
+                <t t-set="alertClass" t-value="'alert alert-warning m-0 border-start-0 o-mail-Thread-bannerHover rounded-top-0 rounded-bottom-3 py-1'"/>
+                <span t-attf-class="{{ alertClass }} flex-grow-1" style="border-bottom-right-radius: 0 !important" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
+                <span t-attf-class="{{ alertClass }}" style="border-bottom-left-radius: 0 !important" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-square"/></span>
             </span>
         </xpath>
     </t>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -67,7 +67,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 }
 
 .o-mail-DiscussSidebar-unreadIndicator {
-    font-size: 0.35rem;
+    font-size: 0.4rem;
     left: -2px;
 
     .o-mail-DiscussSidebarSubchannel &:not(.o-compact) {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -154,7 +154,7 @@
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
-                <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5" style="width:32px;height:32px;" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
+                <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-3" style="width:32px;height:32px;" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded-3 o_object_fit_cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -34,7 +34,7 @@
                                 <span class="flex-grow-1"/>
                                 <span t-if="message" class="text-muted smaller" t-esc="dateText(message)"/>
                             </div>
-                            <div class="o-mail-SubChannelList-threadLastMessage text-start text-muted fw-normal smaller overflow-hidden ms-2">
+                            <div class="o-mail-SubChannelList-threadLastMessage text-start text-muted opacity-75 fw-normal smaller overflow-hidden ms-2">
                                 <t t-if="message" t-call="mail.message_preview_prefix">
                                     <t t-set="message" t-value="message"/>
                                 </t>

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -109,7 +109,7 @@ test("keep new message separator until user goes back to the thread", async () =
     await openDiscuss(channelId);
     await contains(".o-mail-Thread");
     await contains(".o-mail-Message", { text: "hello" });
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New')");
     await hootClick(document.body); // Force "focusin" back on the textarea
     await hootClick(".o-mail-Composer-input");
     await waitNotifications([
@@ -121,7 +121,7 @@ test("keep new message separator until user goes back to the thread", async () =
     await hootClick(".o-mail-DiscussSidebar-item:contains(test)");
     await contains(".o-mail-Discuss-threadName", { value: "test" });
     await contains(".o-mail-Message", { text: "hello" });
-    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New')", { count: 0 });
 });
 
 test("show new message separator on receiving new message when out of odoo focus", async () => {
@@ -142,7 +142,7 @@ test("show new message separator on receiving new message when out of odoo focus
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Thread");
-    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New')", { count: 0 });
     // simulate receiving a message
     await withUser(userId, () =>
         rpc("/mail/message/post", {
@@ -152,7 +152,7 @@ test("show new message separator on receiving new message when out of odoo focus
         })
     );
     await contains(".o-mail-Message", { text: "hu" });
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New')");
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "hu" });
 });
 
@@ -166,11 +166,11 @@ test("keep new message separator until current user sends a message", async () =
     await contains(".o-mail-Message", { text: "hello" });
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
-    await contains(".o-mail-Thread-newMessage hr + span", { count: 1, text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New')");
     await insertText(".o-mail-Composer-input", "hey!");
     await press("Enter");
     await contains(".o-mail-Message", { count: 2 });
-    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New')", { count: 0 });
 });
 
 test("keep new message separator when switching between chat window and discuss of same thread", async () => {
@@ -233,7 +233,7 @@ test("show new message separator when message is received in chat window", async
     );
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-Message", { count: 2 });
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New'):contains('New')");
     await contains(".o-mail-Thread-newMessage + .o-mail-Message", { text: "hu" });
 });
 
@@ -283,7 +283,7 @@ test("show new message separator when message is received while chat window is c
     await contains(".o-mail-ChatBubble");
     await contains(".o-mail-ChatBubble-counter", { text: "1" });
     await click(".o-mail-ChatBubble");
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New')");
 });
 
 test("only show new message separator in its thread", async () => {

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -552,7 +552,7 @@ test("Use saved volume settings", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Start a Call']");
+    await click("[title='Join the Call']");
     await contains(".o-discuss-Call");
     await triggerEvents(`.o-discuss-CallParticipantCard[title='${partnerName}']`, ["mouseenter"]);
     await click("button[title='Participant options']");

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -325,7 +325,7 @@ test("mark channel as fetched when a new message is loaded", async () => {
     );
     await contains(".o-mail-Message");
     await waitForSteps(["rpc:channel_fetch"]);
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New')");
     await focus(".o-mail-Composer-input");
     await waitForSteps(["rpc:mark_as_read"]);
 });
@@ -664,7 +664,7 @@ test("first unseen message should be directly preceded by the new message separa
         })
     );
     await contains(".o-mail-Message", { count: 3 });
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
+    await contains(".o-mail-Thread-newMessage:contains('New')");
     await contains(".o-mail-Message[aria-label='Note'] + .o-mail-Thread-newMessage");
 });
 


### PR DESCRIPTION
- editable input in discuss header and chat window header are rounded
- avatar bg leaked some `.bg-view` in many places, fixed by `.rounded-3` on container
- "new" message separator text has weight changed from `.fw-bolder` to `.fw-bolder`
- "new" message separator line is larger but reduced opacity
- "new" message separator has `.shadow-sm`
- thread new message banner has `.shadow-sm` and bottom rounded.
- "start a call" becomes "join the call" when there's an ongoing call
- discuss sidebar unread indicator is slightly bigger
- "You:" message prefix icon has slightly reduced opacity