### PR TITLE
[FIX] account: Added force_delete in action_cancel payments method

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1187,7 +1187,7 @@ class AccountPayment(models.Model):
     def action_cancel(self):
         self.state = 'canceled'
         draft_moves = self.move_id.filtered(lambda m: m.state == 'draft')
-        draft_moves.unlink()
+        draft_moves.with_context(force_delete=True).unlink()
         (self.move_id - draft_moves).button_cancel()
 
     def button_request_cancel(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When you try to cancel a payment in draft (which move_id is in draft too) and you are not an Administrator, the restriction to eliminate moves is shoot "You cannot delete this entry, as it has already consumed a sequence number and is not the last one in the chain. You should probably revert it instead."

Current behavior before PR:
You can´t cancel a payment in draft

Desired behavior after PR is merged:
Now you can cancel the payment and the move_id is correctly removed



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
