### PR TITLE
[FIX] pos_hr: correct manager role assignment logic

### DIFF
--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -31,7 +31,7 @@ class HrEmployee(models.Model):
 
         employees = employees.read(fields, load=False)
         for employee in employees:
-            if employee['user_id'] and employee['user_id'] in manager_ids or employee['id'] in data['pos.config']['data'][0]['advanced_employee_ids']:
+            if employee['id'] and employee['id'] in manager_ids or employee['id'] in data['pos.config']['data'][0]['advanced_employee_ids']:
                 role = 'manager'
             else:
                 role = 'cashier'


### PR DESCRIPTION
Fix the condition to assign 'manager' role by checking employee ID instead of user_id in manager_ids. This aligns with the actual filtering done earlier where manager_ids contains employee IDs.

Original condition could incorrectly assign roles when user_id was set but didn't match the manager group check.

---

**Description of the issue/feature this PR addresses:**

1. Set user as Point of Sale manager
2. Open Point of Sale with user having a closed cash register
3. Start sale by selecting product
4. Change product price

**Current behavior before PR:**
- Error appears stating "Price change not allowed"

**Desired behavior after PR is merged:**
- Allow price change

**Screenshoot**
![Captura de pantalla de 2025-04-15 15-58-09](https://github.com/user-attachments/assets/30881b91-2b7f-4432-b7bd-02e580e35cdd)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
