### PR TITLE
[FIX] project: activate tasks when copying archived template project

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -576,6 +576,7 @@ class Project(models.Model):
             'stage_id': task.stage_id.id,
             'name': task.name,
             'company_id': project.company_id.id,
+            'active': project.active,
         }
 
     def map_tasks(self, new_project_id):


### PR DESCRIPTION
**Context**
When a service product is linked to a project template (which has been archived along with its tasks), confirming a Sale Order creates a new project and a corresponding task based on the sale order line. However, the tasks from the template project do not appear in the new project's task list.

**Cause**
During the duplication of the template project, the tasks are copied with their original active status preserved. Since the template tasks are archived (active=False), the copied tasks are also archived. This leads users to mistakenly think that the system failed to copy the template tasks.

**Solution**
Update the duplication logic so that all tasks copied from the template project are explicitly set to active=True. This ensures that the new project contains all relevant tasks in an active state, ready for immediate use in planning and execution, as expected when using a template.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
