### PR TITLE
[FIX] l10n_in_ewaybill_stock: allow e-Waybill to print without company logo

### DIFF
--- a/addons/l10n_in_ewaybill_stock/report/ewaybill_report.xml
+++ b/addons/l10n_in_ewaybill_stock/report/ewaybill_report.xml
@@ -19,7 +19,7 @@
                             <table class="border-bottom border-dark">
                                 <tr class="d-flex justify-content-between align-items-center px-4 py-3">
                                     <td style="width: 8rem;">
-                                        <img t-att-src="image_data_uri(doc.company_id.logo)"
+                                        <img t-if="doc.company_id.logo" t-att-src="image_data_uri(doc.company_id.logo)"
                                              style="max-width: 8rem; height: auto;" alt="Company Logo"/>
                                     </td>
                                     <td>


### PR DESCRIPTION
Printing the E-Way Bill failed if the company logo was not configured, as the QWeb template attempted to render an image using a non-existent logo.

Steps to reproduce:
- Remove the company logo from the company settings
- Try to print an E-Way Bill for any invoice

Expected:
- The E-Way Bill should be printed successfully without a logo

Actual:
- PDF generation fails due to a template rendering error

Now:
- The template checks for the presence of a logo before rendering it, allowing the E-Way Bill to print even if the logo is not set.


opw-4709233


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
