### PR TITLE
[FIX] l10n_in_edi_ewaybill: correct actual UOM used on the move line

### DIFF
--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -506,7 +506,7 @@ class AccountEdiFormat(models.Model):
             "hsnCode": extract_digits(line.product_id.l10n_in_hsn_code),
             "productDesc": line.name,
             "quantity": line.quantity,
-            "qtyUnit": line.product_id.uom_id.l10n_in_code and line.product_id.uom_id.l10n_in_code.split("-")[0] or "OTH",
+            "qtyUnit": line.product_uom_id.l10n_in_code and line.product_uom_id.l10n_in_code.split("-")[0] or "OTH",
             "taxableAmount": self._l10n_in_round_value(line.balance * sign),
         }
         gst_types = {'cgst', 'sgst', 'igst'}

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -81,6 +81,39 @@ class TestEdiEwaybillJson(TestEdiJson):
         }
         self.assertDictEqual(json_value, expected, "Indian EDI send json value is not matched")
 
+        # =================================== Different UOM Test ===========================================
+        self.invoice.button_draft()
+        self.invoice.invoice_line_ids.product_uom_id = self.env.ref('uom.product_uom_dozen')
+        self.invoice.action_post()
+        json_value = self.env["account.edi.format"]._l10n_in_edi_ewaybill_generate_json(self.invoice)
+        self.assertListEqual(
+            json_value['itemList'],
+            [
+                {
+                  "productName": "product_a",
+                  "hsnCode": "01111",
+                  "productDesc": "product_a",
+                  "quantity": 1.0,
+                  "qtyUnit": "DOZ",
+                  "taxableAmount": 900.0 * 12,
+                  "cgstRate": 2.5,
+                  "sgstRate": 2.5
+                },
+                {
+                  "productName": "product_with_cess",
+                  "hsnCode": "02222",
+                  "productDesc": "product_with_cess",
+                  "quantity": 1.0,
+                  "qtyUnit": "DOZ",
+                  "taxableAmount": 900.0 * 12,
+                  "cgstRate": 6.0,
+                  "sgstRate": 6.0,
+                  "cessRate": 5.0
+                }
+            ],
+            "Indian EDI send json UOM value is not matched"
+        )
+
         # =================================== Credit Note Test =============================================
         credit_note_expected = expected.copy()
         credit_note_expected.update({


### PR DESCRIPTION
Steps to reproduce:
1. Install Indian E-waybill(`l10n_in_edi_ewaybill`)
2. Activate Unit of Measures
3. Create a Invoice with a move line product as default UOM as units.
4. Change the UOM on line to Dozens
5. Confirm and send the E-waybill

On portal the E-waybill for that line is Unit instead of Dozens

In this commit we fix the issue

opw-4728253


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
