### PR TITLE
[FIX] account_peppol: add mock for set_webhook route in demo

### DIFF
--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -80,6 +80,7 @@ def _mock_call_peppol_proxy(func, self, *args, **kwargs):
         'cancel_peppol_registration': lambda _user, _args, _kwargs: {},
         'migrate_peppol_registration': lambda _user, _args, _kwargs: {'migration_key': 'demo_migration_key'},
         'participant_status': lambda _user, _args, _kwargs: {'peppol_state': 'receiver'},
+        'set_webhook': lambda _user, _args, _kwargs: {},
         # document routes
         'get_all_documents': _mock_get_all_documents,
         'get_document': _mock_get_document,


### PR DESCRIPTION
When we added the webhooks for Peppol we forgot to mock the route that sets the webhook. This now causes a silent traceback (unmocked call in demo) when the keepalive cron `_cron_peppol_webhook_keepalive` runs.

task-no
