### PR TITLE
[FIX] web: set the prewrap to the tooltip of kanban header

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -41,7 +41,7 @@
     </t>
 
     <t t-name="web.KanbanGroupTooltip">
-        <div class="o-tooltip px-2 py-1">
+        <div class="o-tooltip text-prewrap px-2 py-1">
             <t t-foreach="props.tooltip" t-as="entry" t-key="entry_index">
                 <t t-esc="entry.title"/>
                 <br/>


### PR DESCRIPTION
<b>Steps to produce:</b>

1) Install CRM
2) In debug mode, open the stages from the crm configuration 
3) Give a long text to Requirements with spaces to the stage 'new'
4) Now open my pipeline and hover on the new stage

<b>Issue:-</b>

When the user gives a long text with spaces to the requirements in
 the first stage, It is overflowing the screen.

<b>Solution:-</b>

 Add the class text-prewrap to the tooltip of the kanban header.
 So the "formatted text" is respected for the kanban stage.

opw-4623639
