### PR TITLE
[IMP] point_of_sale, pos_*: persist router on all POS pages

### DIFF
--- a/addons/l10n_ar_pos/tests/test_pos_ar.py
+++ b/addons/l10n_ar_pos/tests/test_pos_ar.py
@@ -52,4 +52,4 @@ class TestPosAR(AccountTestInvoicingHttpCommon, TestAr):
         self.product_a.available_in_pos = True
         self.product_a.name = "A test product"
         self.main_pos_config.open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosARBaseFlow', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'PosARBaseFlow', login="pos_user")

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -94,7 +94,7 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
         })
 
         b_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % b_pos_config.id, 'test_pos_branch_company_access', login="pos_user")
+        self.start_tour("/pos/ui/%d" % b_pos_config.id, 'test_pos_branch_company_access', login="pos_user")
 
 
 @odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
@@ -117,4 +117,4 @@ class TestPoSSaleL10NBeNormalCompany(TestPointOfSaleHttpCommon):
             })],
         })
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderTryInvoice', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosSettleOrderTryInvoice', login="accountman")

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -91,7 +91,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         current_session.action_pos_session_closing_control()
 
         self.main_pos_config.with_user(self.pos_admin).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'l10n_es_pos_settle_account_due', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'l10n_es_pos_settle_account_due', login="accountman")
 
     def test_spanish_pos_invoice_no_certificate(self):
         """This test make sure that the invoice generated in spanish PoS are not proforma invoices when no certificate exists"""

--- a/addons/l10n_id_pos/tests/test_qris_pos.py
+++ b/addons/l10n_id_pos/tests/test_qris_pos.py
@@ -155,7 +155,7 @@ class TestPosQris(AccountTestInvoicingHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         with patch('odoo.addons.l10n_id.models.res_bank._l10n_id_make_qris_request', side_effect=_patched_make_qris_request):
-            self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenQRISPaymentFail', login="pos_user")
+            self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenQRISPaymentFail', login="pos_user")
 
     def test_tour_qris_payment_success(self):
         """ Successful fetching status should proceed next to go to receipt screen"""
@@ -182,7 +182,7 @@ class TestPosQris(AccountTestInvoicingHttpCommon):
                 }
         self.main_pos_config.with_user(self.pos_user).open_ui()
         with patch('odoo.addons.l10n_id.models.res_bank._l10n_id_make_qris_request', side_effect=_patched_make_qris_request):
-            self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenQRISPaymentSuccess', login="pos_user")
+            self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenQRISPaymentSuccess', login="pos_user")
 
     @freeze_time("2024-02-27 04:15:00")
     def test_only_call_api_call_once(self):
@@ -211,7 +211,7 @@ class TestPosQris(AccountTestInvoicingHttpCommon):
                 }
         self.main_pos_config.with_user(self.pos_user).open_ui()
         with patch('odoo.addons.l10n_id.models.res_bank._l10n_id_make_qris_request', side_effect=_patched_make_qris_request) as patched:
-            self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PayementScreenQRISFetchQR', login="pos_user")
+            self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PayementScreenQRISFetchQR', login="pos_user")
             self.assertEqual(patched.call_count, 1)
 
     @freeze_time("2024-02-27 04:15:00")
@@ -232,5 +232,5 @@ class TestPosQris(AccountTestInvoicingHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.main_pos_config.current_session_id.set_opening_control(0, 'notes')
         with patch('odoo.addons.l10n_id.models.res_bank._l10n_id_make_qris_request', side_effect=_patched_make_qris_request) as patched:
-            self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PayementScreenQRISChangeAmount', login="pos_user")
+            self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PayementScreenQRISChangeAmount', login="pos_user")
             self.assertEqual(patched.call_count, 2)

--- a/addons/l10n_test_pos_qr_payment/tests/test_pos_qr_payment.py
+++ b/addons/l10n_test_pos_qr_payment/tests/test_pos_qr_payment.py
@@ -43,7 +43,7 @@ class TestUiSEPA(TestPosQrCommon):
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
 
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentFailure', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentFailure', login="pos_user")
 
     def test_02_pos_order_with_sepa_qr_payment(self):
         """ Test Point of Sale QR Payment flow with SEPA
@@ -55,7 +55,7 @@ class TestUiSEPA(TestPosQrCommon):
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
 
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenWithQRPayment', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenWithQRPayment', login="pos_user")
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
@@ -106,7 +106,7 @@ class TestUiCH(TestPosQrCommon):
         """
         self.main_pos_config.with_user(self.pos_user).open_ui()
 
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentFailure', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentFailure', login="pos_user")
 
     def test_02_pos_order_with_swiss_qr_payment(self):
         """ Test Point of Sale QR Payment flow with Swiss QR
@@ -114,7 +114,7 @@ class TestUiCH(TestPosQrCommon):
         """
         self.main_pos_config.with_user(self.pos_user).open_ui()
 
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentSwiss', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentSwiss', login="pos_user")
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
@@ -158,7 +158,7 @@ class TestUiHK(TestPosQrCommon):
         """
         self.main_pos_config.with_user(self.pos_user).open_ui()
 
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentFailure', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentFailure', login="pos_user")
 
     def test_02_pos_order_with_emv_qr_payment(self):
         """ Test Point of Sale QR Payment flow with FPS.
@@ -173,7 +173,7 @@ class TestUiHK(TestPosQrCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
 
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenWithQRPayment', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenWithQRPayment', login="pos_user")
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
@@ -213,7 +213,7 @@ class TestUIBR(TestPosQrCommon):
         """
         self.main_pos_config.with_user(self.pos_user).open_ui()
 
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentFailure', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenWithQRPaymentFailure', login="pos_user")
 
     def test_02_pos_order_with_pix_qr_payment(self):
         """ Test Point of Sale QR Payment flow with PIX
@@ -228,4 +228,4 @@ class TestUIBR(TestPosQrCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
 
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenWithQRPayment', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenWithQRPayment', login="pos_user")

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -31,8 +31,13 @@ class PosController(PortalAccount):
             body = f.read()
             return body
 
+    # Support old routes for backward compatibility
     @http.route(['/pos/web', '/pos/ui'], type='http', auth='user')
-    def pos_web(self, config_id=False, from_backend=False, **k):
+    def old_pos_web(self, config_id=False, from_backend=False, **k):
+        return self.pos_web(config_id, from_backend, **k)
+
+    @http.route(["/pos/ui/<config_id>", "/pos/ui/<config_id>/<path:subpath>"], auth="user", type='http')
+    def pos_web(self, config_id=False, from_backend=False, subpath=None, **k):
         """Open a pos session for the given config.
 
         The right pos session will be selected to open, if non is open yet a new session will be created.

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -593,7 +593,7 @@ class PosConfig(models.Model):
     def _action_to_open_ui(self):
         if not self.current_session_id:
             self.env['pos.session'].create({'user_id': self.env.uid, 'config_id': self.id})
-        pos_url = '/pos/ui?config_id=%d&from_backend=True' % self.id
+        pos_url = '/pos/ui/%d?from_backend=True' % self.id
         debug = request and request.session.debug
         if debug:
             pos_url += '&debug=%s' % debug
@@ -604,17 +604,10 @@ class PosConfig(models.Model):
         }
 
     def _get_url_to_cache(self, debug):
-        url_to_cache = []
-        base_urls = [
-            f"/pos/ui?config_id={self.id}&from_backend=True",
-            f"/pos/ui?config_id={self.id}",
+        url_to_cache = [
+            f"/pos/ui/{self.id}?from_backend=True",
+            f"/pos/ui/{self.id}",
         ]
-
-        if not debug:
-            url_to_cache.extend(base_urls)
-        else:
-            url_to_cache.extend([f"{url}&debug={debug}" for url in base_urls])
-
         return self.env["ir.qweb"]._get_asset_links("point_of_sale.assets_prod", debug=debug) + url_to_cache
 
     def _check_before_creating_new_session(self):

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1135,6 +1135,13 @@ class PosOrder(models.Model):
         _logger.info("PoS synchronisation #%d finished", sync_token)
         return pos_order_ids.read_pos_data(orders, config_id)
 
+    @api.model
+    def read_pos_data_uuid(self, uuid):
+        order = self.search([('uuid', '=', uuid)], limit=1)
+        if not order:
+            return {}
+        return order.read_pos_data([], order.config_id.id)
+
     def read_pos_data(self, data, config_id):
         # If the previous session is closed, the order will get a new session_id due to _get_valid_session in _process_order
 

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -97,14 +97,26 @@ export class Navbar extends Component {
         this.bufferedInput = "";
     }
 
+    onClickRegister() {
+        let order = this.pos.getOrder();
+
+        if (!order) {
+            order = this.pos.addNewOrder();
+        }
+
+        this.pos.navigateToOrderScreen(order);
+    }
+
     noOpenDialogs() {
         return document.querySelectorAll(".modal-dialog, .debug-widget").length === 0;
     }
     onClickScan() {
         if (!this.pos.scanning) {
-            const screenName = this.pos.mainScreen.component.name;
+            const screenName = this.pos.router.state.current;
             if (["ProductScreen", "TicketScreen"].includes(screenName)) {
-                this.pos.showScreen(screenName);
+                const params =
+                    screenName === "ProductScreen" ? { orderUuid: this.pos.getOrder().uuid } : {};
+                this.pos.navigate(screenName, params);
             }
         }
         this.pos.mobile_pane = "right";
@@ -120,7 +132,7 @@ export class Navbar extends Component {
     get appUrl() {
         return `/scoped_app?app_id=point_of_sale&app_name=${encodeURIComponent(
             this.pos.config.display_name
-        )}&path=${encodeURIComponent(`pos/ui?config_id=${this.pos.config.id}`)}`;
+        )}&path=${encodeURIComponent(`pos/ui/${this.pos.config.id}`)}`;
     }
 
     async reloadProducts() {
@@ -192,6 +204,6 @@ export class Navbar extends Component {
 
     get mainButton() {
         const screens = ["ProductScreen", "PaymentScreen", "ReceiptScreen", "TipScreen"];
-        return screens.includes(this.pos.mainScreen.component.name) ? "register" : "order";
+        return screens.includes(this.pos.router.state.current) ? "register" : "order";
     }
 }

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -6,11 +6,11 @@
             <div class="pos-leftheader d-flex align-items-center flex-grow-1 overflow-auto" t-att-class="{'d-none': ui.isSmall and state.searchBarOpen, 'mw-100': this.pos.getOrder()}">
                 <div class="d-flex flex-shrink-0 align-items-center gap-1 position-relative pe-2" t-att-class="{ 'w-100': !ui.isSmall }">
                     <div class="navbar-menu d-flex">
-                        <button class="register-label btn btn-lg btn-light lh-lg" t-att-class="{'active': mainButton === 'register'}" t-on-click="() => this.pos.showOrderScreen(true)">
+                        <button class="register-label btn btn-lg btn-light lh-lg" t-att-class="{'active': mainButton === 'register'}" t-on-click="() => this.onClickRegister()">
                             <span t-if="!ui.isSmall">Register</span>
                             <i t-else="" class="fa fa-fw fa-pencil" t-att-class="{'fa-lg' : !ui.isSmall}"/>
                         </button>
-                        <button class="orders-button btn btn-lg btn-light lh-lg" t-att-class="{'active': mainButton === 'order'}" t-on-click="() => this.pos.showScreen('TicketScreen')">
+                        <button class="orders-button btn btn-lg btn-light lh-lg" t-att-class="{'active': mainButton === 'order'}" t-on-click="() => this.pos.navigate('TicketScreen')">
                             <t t-if="!ui.isSmall">
                                 <span>Orders</span>
                             </t>
@@ -39,7 +39,7 @@
                     getRef="(ref) => this.inputRef = ref"
                     t-if="pos.showSearchButton()"
                     isOpenCallback="(isOpen) => state.searchBarOpen = isOpen" />
-                    <button class="btn btn-light btn-lg lh-lg" t-if="isBarcodeScannerSupported() and ['ProductScreen', 'TicketScreen'].includes(pos.mainScreen.component.name) and !pos.config.module_pos_restaurant" t-on-click="onClickScan">
+                    <button class="btn btn-light btn-lg lh-lg" t-if="isBarcodeScannerSupported() and ['ProductScreen', 'TicketScreen'].includes(this.pos.router.state.current) and !pos.config.module_pos_restaurant" t-on-click="onClickScan">
                         <i class="fa fa-fw fa-lg fa-barcode" /><span t-if="this.pos.scanning" class="ms-1">Stop</span>
                     </button>
                     <div t-if="this.pos.data.network.offline or this.pos.data.network.loading" class="oe_status btn btn-light btn-lg lh-lg h-100 pe-none">
@@ -73,7 +73,7 @@
                                 <DropdownItem t-if="showCreateProductButton" onSelected="() => this.pos.editProduct()">
                                     Create Product
                                 </DropdownItem>
-                                <DropdownItem t-if="isBarcodeScannerSupported() and pos.mainScreen.component.name == 'ProductScreen' and ui.isSmall and pos.config.module_pos_restaurant" onSelected="() => this.onClickScan()">
+                                <DropdownItem t-if="isBarcodeScannerSupported() and this.pos.router.state.current == 'ProductScreen' and ui.isSmall and pos.config.module_pos_restaurant" onSelected="() => this.onClickScan()">
                                     <span t-if="this.pos.scanning">Stop Barcode Scanner</span>
                                     <span t-else="">Barcode Scanner</span>
                                 </DropdownItem>

--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -22,20 +22,18 @@ export class OrderTabs extends Component {
     }
     async newFloatingOrder() {
         const order = this.pos.addNewOrder();
-        this.pos.showScreen("ProductScreen");
+        this.pos.navigate("ProductScreen", {
+            orderUuid: order.uuid,
+        });
         this.dialog.closeAll();
         return order;
     }
     selectFloatingOrder(order) {
         this.pos.setOrder(order);
         const previousOrderScreen = order.getScreenData();
-
-        const props = {};
-        if (previousOrderScreen?.name === "PaymentScreen") {
-            props.orderUuid = order.uuid;
-        }
-
-        this.pos.showScreen(previousOrderScreen?.name || "ProductScreen", props);
+        this.pos.navigate(previousOrderScreen?.name || "ProductScreen", {
+            orderUuid: order.uuid,
+        });
         this.dialog.closeAll();
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -259,7 +259,7 @@ export class ClosePosPopup extends Component {
                 return this.handleClosingError(response);
             }
             this.pos.session.state = "closed";
-            location.reload();
+            this.pos.router.close();
         } catch (error) {
             if (error instanceof ConnectionLostError) {
                 throw error;
@@ -294,7 +294,7 @@ export class ClosePosPopup extends Component {
                                     this.pos.session.id,
                                 ]);
                                 if (session[0] && session[0].state === "closed") {
-                                    location.reload();
+                                    this.pos.router.close();
                                 } else {
                                     this.pos.redirectToBackend();
                                 }
@@ -314,7 +314,7 @@ export class ClosePosPopup extends Component {
             confirm: () => {
                 if (!response.redirect) {
                     this.props.close();
-                    this.pos.showScreen("TicketScreen");
+                    this.pos.navigate("TicketScreen");
                 }
             },
             cancel: async () => {
@@ -328,7 +328,7 @@ export class ClosePosPopup extends Component {
         });
 
         if (response.redirect) {
-            window.location.reload();
+            this.pos.router.close();
         }
     }
     getMovesTotalAmount() {

--- a/addons/point_of_sale/static/src/app/hooks/pos_hook.js
+++ b/addons/point_of_sale/static/src/app/hooks/pos_hook.js
@@ -6,3 +6,7 @@ import { useService } from "@web/core/utils/hooks";
 export function usePos() {
     return useService("pos");
 }
+
+export function usePosRouter() {
+    return useService("pos_router");
+}

--- a/addons/point_of_sale/static/src/app/hooks/pos_router_hook.js
+++ b/addons/point_of_sale/static/src/app/hooks/pos_router_hook.js
@@ -1,0 +1,19 @@
+import { registry } from "@web/core/registry";
+import { usePos, usePosRouter } from "./pos_hook";
+import { useComponent } from "@odoo/owl";
+
+export const useRouterParamsChecker = () => {
+    const component = useComponent();
+    const router = usePosRouter();
+    const pos = usePos();
+    const routeParams = registry.category("pos_pages").get(component.constructor.name);
+    const params = routeParams.params;
+
+    if (params.orderUuid) {
+        const order = pos.models["pos.order"].getBy("uuid", router.state.params.orderUuid);
+        if (!order || order.finalized !== params.orderFinalized) {
+            const params = pos.defaultPage;
+            router.navigate(params.page, params.params);
+        }
+    }
+};

--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -5,7 +5,10 @@ export class DataServiceOptions {
         return {
             "pos.order": {
                 key: "uuid",
-                condition: (record) => record.finalized && typeof record.id === "number",
+                condition: (record) =>
+                    record.finalized &&
+                    typeof record.id === "number" &&
+                    record.pos_session_id !== parseInt(odoo.pos_session_id),
             },
             "pos.order.line": {
                 key: "uuid",
@@ -65,7 +68,6 @@ export class DataServiceOptions {
             "pos.session",
             "pos.config",
             "res.users",
-            "pos.order",
             "account.tax", // Cannot be auto-loaded because the record needs adaptions
         ];
     }

--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -10,6 +10,7 @@ import { CustomerDisplayPosAdapter } from "@point_of_sale/app/customer_display/c
 import { useIdleTimer } from "./utils/use_idle_timer";
 import useTours from "./hooks/use_tours";
 import { init as initDebugFormatters } from "./utils/debug-formatter";
+
 /**
  * Chrome is the root component of the PoS App.
  */
@@ -24,10 +25,11 @@ export class Chrome extends Component {
             if (stopEventPropagation.includes(ev.type)) {
                 ev.stopPropagation();
             }
-            this.pos.showScreen(this.pos.firstScreen);
+            const page = this.pos.firstPage;
+            this.pos.navigate(page.page, page.params);
         });
+
         const reactivePos = reactive(this.pos);
-        // TODO: Should we continue on exposing posmodel as global variable?
         window.posmodel = reactivePos;
         useOwnDebugContext();
         if (this.env.debug) {

--- a/addons/point_of_sale/static/src/app/pos_app.xml
+++ b/addons/point_of_sale/static/src/app/pos_app.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-
     <t t-name="point_of_sale.Chrome">
         <div class="pos dvh-100 d-flex flex-column">
             <Navbar />
             <div class="pos-content flex-grow-1 overflow-auto bg-100">
-                <!-- FIXME POSREF: better error handling in main screens (currently, a crash in owl lifecycle of a main screen blows up the application and the error can't be displayed) -->
-                <t t-component="pos.mainScreen.component" t-props="pos.mainScreen.props"/>
+                <t t-component="this.pos.router.page.component" t-props="this.pos.router.page.params" />
             </div>
         </div>
         <MainComponentsContainer/>
     </t>
-
 </templates>

--- a/addons/point_of_sale/static/src/app/screens/action_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/action_screen.js
@@ -14,4 +14,10 @@ export class ActionScreen extends Component {
         </div>
     `;
 }
-registry.category("pos_screens").add("ActionScreen", ActionScreen);
+
+registry.category("pos_pages").add("ActionScreen", {
+    name: "ActionScreen",
+    component: ActionScreen,
+    route: `/pos/ui/${odoo.pos_config_id}/action/{string:actionName}`,
+    params: {},
+});

--- a/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.js
@@ -27,8 +27,14 @@ export class LoginScreen extends Component {
         const selectedScreen =
             this.pos.previousScreen && this.pos.previousScreen !== "LoginScreen"
                 ? this.pos.previousScreen
-                : this.pos.firstScreen;
-        this.pos.showScreen(selectedScreen);
+                : this.pos.defaultPage;
+        const order = this.pos.getOrder();
+        if (!order) {
+            this.pos.addNewOrder();
+        }
+        const params =
+            selectedScreen.page === "ProductScreen" ? { orderUuid: this.pos.getOrder().uuid } : {};
+        this.pos.navigate(selectedScreen.page, params);
         this.pos.hasLoggedIn = true;
     }
     selectOneCashier(cashier) {
@@ -43,4 +49,9 @@ export class LoginScreen extends Component {
     }
 }
 
-registry.category("pos_screens").add("LoginScreen", LoginScreen);
+registry.category("pos_pages").add("LoginScreen", {
+    name: "LoginScreen",
+    component: LoginScreen,
+    route: `/pos/ui/${odoo.pos_config_id}/login`,
+    params: {},
+});

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -105,7 +105,7 @@ export class PartnerList extends Component {
             },
             filter: partnerHasActiveOrders ? "" : "SYNCED",
         };
-        this.pos.showScreen("TicketScreen", { stateOverride });
+        this.pos.navigate("TicketScreen", { stateOverride });
     }
 
     confirm() {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -18,6 +18,7 @@ import { ask, makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dial
 import { handleRPCError } from "@point_of_sale/app/utils/error_handlers";
 import { sprintf } from "@web/core/utils/strings";
 import { serializeDateTime } from "@web/core/l10n/dates";
+import { useRouterParamsChecker } from "@point_of_sale/app/hooks/pos_router_hook";
 
 export class PaymentScreen extends Component {
     static template = "point_of_sale.PaymentScreen";
@@ -43,6 +44,7 @@ export class PaymentScreen extends Component {
             .sort((a, b) => a.sequence - b.sequence);
         this.numberBuffer = useService("number_buffer");
         this.numberBuffer.use(this._getNumberBufferConfig);
+        useRouterParamsChecker();
         useErrorHandlers();
         this.payment_interface = null;
         this.error = false;
@@ -364,7 +366,7 @@ export class PaymentScreen extends Component {
     }
     handleValidationError(error) {
         if (error instanceof ConnectionLostError) {
-            this.pos.showScreen(this.nextScreen);
+            this.pos.navigate(this.nextPage.page, this.nextPage.params);
             Promise.reject(error);
         } else if (error instanceof RPCError) {
             this.currentOrder.state = "draft";
@@ -386,11 +388,11 @@ export class PaymentScreen extends Component {
     async afterOrderValidation() {
         // Always show the next screen regardless of error since pos has to
         // continue working even offline.
-        let nextScreen = this.nextScreen;
+        let nextPage = this.nextPage;
         let switchScreen = true;
 
         if (
-            nextScreen === "ReceiptScreen" &&
+            nextPage.page === "ReceiptScreen" &&
             this.currentOrder.nb_print === 0 &&
             this.pos.config.iface_print_auto
         ) {
@@ -405,7 +407,7 @@ export class PaymentScreen extends Component {
                     this.currentOrder.setScreenData({ name: "" });
                     this.currentOrder.uiState.locked = true;
                     switchScreen = this.currentOrder.uuid === this.pos.selectedOrderUuid;
-                    nextScreen = this.pos.defaultScreen;
+                    nextPage = this.pos.defaultPage;
                     if (switchScreen) {
                         this.selectNextOrder();
                     }
@@ -414,7 +416,7 @@ export class PaymentScreen extends Component {
         }
 
         if (switchScreen) {
-            this.pos.showScreen(nextScreen);
+            this.pos.navigate(nextPage.page, nextPage.params);
         }
     }
     selectNextOrder() {
@@ -432,8 +434,15 @@ export class PaymentScreen extends Component {
     shouldDownloadInvoice() {
         return true;
     }
-    get nextScreen() {
-        return !this.error ? "ReceiptScreen" : this.pos.defaultScreen;
+    get nextPage() {
+        return !this.error
+            ? {
+                  page: "ReceiptScreen",
+                  params: {
+                      orderUuid: this.currentOrder.uuid,
+                  },
+              }
+            : this.pos.defaultPage;
     }
     paymentMethodImage(id) {
         if (this.paymentMethod.image) {
@@ -681,4 +690,12 @@ export class PaymentScreen extends Component {
     }
 }
 
-registry.category("pos_screens").add("PaymentScreen", PaymentScreen);
+registry.category("pos_pages").add("PaymentScreen", {
+    name: "PaymentScreen",
+    component: PaymentScreen,
+    route: `/pos/ui/${odoo.pos_config_id}/payment/{string:orderUuid}`,
+    params: {
+        orderUuid: true,
+        orderFinalized: false,
+    },
+});

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -119,7 +119,7 @@ export class ControlButtons extends Component {
         const order = this.pos.getOrder();
         const partner = order.getPartner();
         const searchDetails = partner ? { fieldName: "PARTNER", searchTerm: partner.name } : {};
-        this.pos.showScreen("TicketScreen", {
+        this.pos.navigate("TicketScreen", {
             stateOverride: {
                 filter: "SYNCED",
                 search: searchDetails,

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -24,6 +24,7 @@ import {
 } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
 import { BarcodeVideoScanner } from "@web/core/barcode/barcode_video_scanner";
 import { OptionalProductPopup } from "@point_of_sale/app/components/popups/optional_products_popup/optional_products_popup";
+import { useRouterParamsChecker } from "@point_of_sale/app/hooks/pos_router_hook";
 import { debounce } from "@web/core/utils/timing";
 
 const { DateTime } = luxon;
@@ -41,7 +42,9 @@ export class ProductScreen extends Component {
         ProductCard,
         BarcodeVideoScanner,
     };
-    static props = {};
+    static props = {
+        orderUuid: { type: String },
+    };
 
     setup() {
         super.setup();
@@ -55,7 +58,10 @@ export class ProductScreen extends Component {
             currentOffset: 0,
             quantityByProductTmplId: {},
         });
+
+        useRouterParamsChecker();
         onMounted(() => {
+            this.currentOrder.deselectOrderline();
             this.pos.openOpeningControl();
             this.pos.addPendingOrder([this.currentOrder.id]);
             // Call `reset` when the `onMounted` callback in `numberBuffer.use` is done.
@@ -391,4 +397,12 @@ export class ProductScreen extends Component {
     }
 }
 
-registry.category("pos_screens").add("ProductScreen", ProductScreen);
+registry.category("pos_pages").add("ProductScreen", {
+    name: "ProductScreen",
+    component: ProductScreen,
+    route: `/pos/ui/${odoo.pos_config_id}/product/{string:orderUuid}`,
+    params: {
+        orderUuid: true,
+        orderFinalized: false,
+    },
+});

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -7,15 +7,19 @@ import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { isValidEmail } from "@point_of_sale/utils";
+import { useRouterParamsChecker } from "@point_of_sale/app/hooks/pos_router_hook";
 
 export class ReceiptScreen extends Component {
     static template = "point_of_sale.ReceiptScreen";
     static components = { OrderReceipt };
-    static props = {};
+    static props = {
+        orderUuid: { type: String },
+    };
 
     setup() {
         super.setup();
         this.pos = usePos();
+        useRouterParamsChecker();
         useErrorHandlers();
         this.ui = useService("ui");
         this.renderer = useService("renderer");
@@ -64,9 +68,6 @@ export class ReceiptScreen extends Component {
         const tipAmountStr = this.env.utils.formatCurrency(tipAmount);
         return `${orderAmountStr} + ${tipAmountStr} tip`;
     }
-    get nextScreen() {
-        return this.pos.defaultScreen;
-    }
     get ticketScreen() {
         return { name: "TicketScreen" };
     }
@@ -86,7 +87,8 @@ export class ReceiptScreen extends Component {
             this.pos.addNewOrder();
         }
         this.pos.searchProductWord = "";
-        this.pos.showScreen(this.nextScreen);
+        const nextPage = this.pos.defaultPage;
+        this.pos.navigate(nextPage.page, nextPage.params);
     }
 
     generateTicketImage = async () =>
@@ -119,4 +121,12 @@ export class ReceiptScreen extends Component {
     }
 }
 
-registry.category("pos_screens").add("ReceiptScreen", ReceiptScreen);
+registry.category("pos_pages").add("ReceiptScreen", {
+    name: "ReceiptScreen",
+    component: ReceiptScreen,
+    route: `/pos/ui/${odoo.pos_config_id}/receipt/{string:orderUuid}`,
+    params: {
+        orderUuid: true,
+        orderFinalized: true,
+    },
+});

--- a/addons/point_of_sale/static/src/app/screens/saver_screen/saver_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/saver_screen/saver_screen.js
@@ -13,4 +13,9 @@ export class SaverScreen extends Component {
     }
 }
 
-registry.category("pos_screens").add("SaverScreen", SaverScreen);
+registry.category("pos_pages").add("SaverScreen", {
+    name: "SaverScreen",
+    component: SaverScreen,
+    route: `/pos/ui/${odoo.pos_config_id}/saver`,
+    params: {},
+});

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -223,7 +223,7 @@ export class TicketScreen extends Component {
         // Open the refund order.
         const refundOrder = this.pos.models["pos.order"].find((order) => order.uuid == orderUuid);
         if (refundOrder) {
-            this._setOrder(refundOrder);
+            this.setOrder(refundOrder);
         }
     }
     _onUpdateSelectedOrderline({ key, buffer }) {
@@ -356,12 +356,15 @@ export class TicketScreen extends Component {
         }
         // Set the partner to the destinationOrder.
         this.setPartnerToRefundOrder(partner, destinationOrder);
+        destinationOrder.refunded_order_id = order;
         this.pos.setOrder(destinationOrder);
         await this.addAdditionalRefundInfo(order, destinationOrder);
 
         this.postRefund(destinationOrder);
-
-        this.closeTicketScreen();
+        this.pos.ticket_screen_mobile_pane = "left";
+        this.pos.navigate("ProductScreen", {
+            orderUuid: destinationOrder.uuid,
+        });
     }
 
     async onDeleteOrder(order) {
@@ -550,7 +553,8 @@ export class TicketScreen extends Component {
     }
     closeTicketScreen() {
         this.pos.ticket_screen_mobile_pane = "left";
-        this.pos.closeScreen();
+        const next = this.pos.defaultPage;
+        this.pos.navigate(next.page, next.params);
     }
     /**
      * Find the empty order with the following priority:
@@ -644,12 +648,12 @@ export class TicketScreen extends Component {
         );
     }
 
-    async _setOrder(order) {
+    async setOrder(order) {
         if (this.pos.config.isShareable) {
             await this.pos.syncAllOrders();
         }
         this.pos.setOrder(order);
-        this.closeTicketScreen();
+        this.pos.navigateToOrderScreen(order);
     }
     _getOrderList() {
         return this.pos.models["pos.order"].getAll();
@@ -833,4 +837,9 @@ export class TicketScreen extends Component {
     }
 }
 
-registry.category("pos_screens").add("TicketScreen", TicketScreen);
+registry.category("pos_pages").add("TicketScreen", {
+    name: "TicketScreen",
+    component: TicketScreen,
+    route: `/pos/ui/${odoo.pos_config_id}/ticket`,
+    params: {},
+});

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -38,7 +38,7 @@
                                 <tbody>
                                     <t t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
                                         <tr class="order-row" t-attf-class="{{ isHighlighted(order) ? 'highlight active': '' }}"
-                                            t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => order.uiState.locked ? ()=>{} : this._setOrder(order)" >
+                                            t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => order.uiState.locked ? ()=>{} : this.setOrder(order)" >
                                             <td>
                                                 <div class="fs-6 fw-bolder"><t t-esc="this.pos.getDate(order.date_order)"></t></div>
                                                 <div class="small text-muted"><t t-esc="this.pos.getTime(order.date_order)"></t></div>
@@ -89,7 +89,7 @@
                             </table>
                             <t t-if="ui.isSmall" t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
                                 <div class="mobileOrderList order-row d-flex flex-row ps-1" t-attf-class="{{ isHighlighted(order) ? 'highlight': '' }}"
-                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() =>  order.uiState.locked ? ()=>{} : this._setOrder(order)" >
+                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() =>  order.uiState.locked ? ()=>{} : this.setOrder(order)" >
                                     <div class="p-2">
                                             <div class="fw-bolder"><t t-esc="this.pos.getDate(order.date_order)"></t></div>
                                             <div class="small text-muted"><t t-esc="this.pos.getTime(order.date_order)"></t></div>
@@ -132,7 +132,7 @@
                         <button class="btn-switchpane load-order-button primary btn btn-primary btn-lg lh-lg w-50 py-3"
                             t-att-disabled="!_selectedSyncedOrder"
                             t-if="!isOrderSynced"
-                            t-on-click="() => this._setOrder(_selectedSyncedOrder)">
+                            t-on-click="() => this.setOrder(_selectedSyncedOrder)">
                             <span class="d-block">Load Order</span>
                         </button>
                         <button class="btn-switchpane btn btn-lg lh-lg w-50 py-3 secondary review-button" t-att-class="{'btn-primary': isOrderSynced, 'btn-light': !isOrderSynced}" t-on-click="switchPane">
@@ -199,7 +199,7 @@
                                 <BackButton onClick="() => pos.onClickBackButton()"/>
                                 <button class="button validation load-order-button w-100 btn btn-lg btn-primary py-3"
                                     t-att-disabled="!_selectedSyncedOrder"
-                                    t-on-click="() => this._setOrder(_selectedSyncedOrder)">
+                                    t-on-click="() => this.setOrder(_selectedSyncedOrder)">
                                     <span class="d-block">Load Order</span>
                                 </button>
                             </div>

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -85,7 +85,7 @@ export class PosData extends Reactive {
     }
 
     get databaseName() {
-        return `config-id_${odoo.pos_config_id}_${odoo.access_token}`;
+        return `point-of-sale-${odoo.pos_config_id}-${odoo.info?.db}`;
     }
 
     get serverDateKey() {

--- a/addons/point_of_sale/static/src/app/services/pos_router_service.js
+++ b/addons/point_of_sale/static/src/app/services/pos_router_service.js
@@ -1,0 +1,161 @@
+import { registry } from "@web/core/registry";
+import { Reactive } from "@web/core/utils/reactive";
+import { browser } from "@web/core/browser/browser";
+import { escapeRegExp } from "@web/core/utils/strings";
+import { zip } from "@web/core/utils/arrays";
+
+const parseParams = (matches, paramSpecs) =>
+    Object.fromEntries(
+        zip(matches, paramSpecs).map(([match, paramSpec]) => {
+            const { type, name } = paramSpec;
+            switch (type) {
+                case "int":
+                    return [name, parseInt(match)];
+                case "string":
+                    return [name, match];
+                default:
+                    throw new Error(`Unknown type ${type}`);
+            }
+        })
+    );
+
+export class PosRouter extends Reactive {
+    static serviceDependencies = [];
+
+    constructor(...args) {
+        super(...args);
+        this.setup(...args);
+    }
+
+    setup(env) {
+        this.path = window.location.pathname;
+        this.registeredRoutes = {};
+        this.popStateCallback = null;
+        this.state = {
+            params: {},
+            current: null,
+            previous: null,
+        };
+
+        window.addEventListener("popstate", (event) => {
+            this.path = window.location.pathname;
+            this.matchURL();
+            this.popStateCallback && this.popStateCallback(event);
+        });
+
+        this.initRegisteredRoutes();
+        this.matchURL();
+    }
+
+    get page() {
+        const page = registry.category("pos_pages").get(this.state.current);
+        const params = this.state.params;
+        return {
+            name: page.name,
+            component: page.component,
+            params,
+        };
+    }
+
+    initRegisteredRoutes() {
+        const pages = registry.category("pos_pages").getAll();
+        for (const { name, route } of pages) {
+            const paramStrings = route.match(/\{\w+:\w+\}/g);
+
+            if (!paramStrings) {
+                this.registeredRoutes[name] = {
+                    route,
+                    paramSpecs: [],
+                    regex: new RegExp(`^${route}$`),
+                };
+                continue;
+            }
+
+            const paramSpecs = paramStrings.map((paramString) => {
+                const [, type, name] = paramString.match(/(\w+):(\w+)/);
+                return { type, name };
+            });
+
+            const regex = new RegExp(
+                `^${route
+                    .split(/\{\w+:\w+\}/)
+                    .map((part) => escapeRegExp(part))
+                    .join("([^/]+)")}$`
+            );
+
+            this.registeredRoutes[name] = { route, regex, paramSpecs };
+        }
+    }
+
+    back() {
+        if (!this.historyPage.length) {
+            this.navigate("LoginScreen", {
+                configId: odoo.pos_config_id,
+            });
+            return;
+        }
+
+        history.back();
+        this.path = window.location.pathname;
+        this.state.previous = window.location.pathname;
+    }
+
+    close() {
+        window.location.href = `/pos/ui/${odoo.pos_config_id}`;
+    }
+
+    matchURL(props = {}) {
+        const path = this.path;
+
+        for (const [routeName, { regex, paramSpecs }] of Object.entries(this.registeredRoutes)) {
+            const match = path.match(regex);
+            if (match) {
+                const parsedParams = parseParams(match.slice(1), paramSpecs);
+                this.state.current = routeName;
+                this.state.params = { ...props, ...parsedParams };
+                return;
+            }
+        }
+
+        // In case no route matches, we default to the LoginScreen
+        this.state.current = "LoginScreen";
+    }
+
+    getRoute(routeName) {
+        try {
+            const { route } = this.registeredRoutes[routeName];
+            return route;
+        } catch {
+            const { route } = this.registeredRoutes["ProductScreen"];
+            return route;
+        }
+    }
+
+    navigate(routeName, routeParams = {}) {
+        const route = this.getRoute(routeName);
+        const url = new URL(browser.location.href);
+
+        url.pathname = route.replace(
+            /\{\w+:(\w+)\}/g,
+            (match, paramName) => routeParams[paramName]
+        );
+
+        history.pushState({}, "", url);
+        this.path = window.location.pathname;
+        this.historyPage = this.path;
+        this.matchURL(routeParams);
+    }
+
+    registerRoutes(routes) {
+        Object.assign(this.registeredRoutes, routes);
+    }
+}
+
+export const PosRouterService = {
+    dependencies: PosRouter.serviceDependencies,
+    async start(env, deps) {
+        return new PosRouter(env, deps);
+    },
+};
+
+registry.category("services").add("pos_router", PosRouterService);

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -11,9 +11,6 @@ import { ConnectionAbortedError, ConnectionLostError, RPCError } from "@web/core
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
 import { _t } from "@web/core/l10n/translation";
 import { OpeningControlPopup } from "@point_of_sale/app/components/popups/opening_control_popup/opening_control_popup";
-import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
-import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
-import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { SelectLotPopup } from "@point_of_sale/app/components/popups/select_lot_popup/select_lot_popup";
 import { ProductConfiguratorPopup } from "@point_of_sale/app/components/popups/product_configurator_popup/product_configurator_popup";
 import { ComboConfiguratorPopup } from "@point_of_sale/app/components/popups/combo_configurator_popup/combo_configurator_popup";
@@ -27,7 +24,6 @@ import { ScaleScreen } from "../screens/scale_screen/scale_screen";
 import { computeComboItems } from "../models/utils/compute_combo_items";
 import { changesToOrder, getOrderChanges } from "../models/utils/order_change";
 import { QRPopup } from "@point_of_sale/app/components/popups/qr_code_popup/qr_code_popup";
-import { ActionScreen } from "@point_of_sale/app/screens/action_screen";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { CashMovePopup } from "@point_of_sale/app/components/popups/cash_move_popup/cash_move_popup";
 import { ClosePosPopup } from "@point_of_sale/app/components/popups/closing_popup/closing_popup";
@@ -60,6 +56,7 @@ export class PosStore extends WithLazyGetterTrap {
         "printer",
         "action",
         "alert",
+        "pos_router",
         "mail.sound_effects",
     ];
     constructor({ traps, env, deps }) {
@@ -83,6 +80,7 @@ export class PosStore extends WithLazyGetterTrap {
             pos_data,
             pos_scale,
             action,
+            pos_router,
             alert,
         }
     ) {
@@ -96,10 +94,12 @@ export class PosStore extends WithLazyGetterTrap {
         this.data = pos_data;
         this.action = action;
         this.alert = alert;
+        this.router = pos_router;
         this.sound = env.services["mail.sound_effects"];
         this.notification = notification;
         this.unwatched = markRaw({});
         this.pushOrderMutex = new Mutex();
+        this.router.popStateCallback = this.handleUrlParams.bind(this);
 
         // Object mapping the order's name (which contains the uuid) to it's server_id after
         // validation (order paid then sent to the backend).
@@ -143,6 +143,7 @@ export class PosStore extends WithLazyGetterTrap {
         this.hardwareProxy.pos = this;
         this.syncingOrders = new Set();
         await this.initServerData();
+
         if (this.config.useProxy) {
             await this.connectToProxy();
         }
@@ -151,7 +152,43 @@ export class PosStore extends WithLazyGetterTrap {
         this._searchTriggered = false;
     }
 
-    get firstScreen() {
+    navigate(routeName, routeParams = {}) {
+        const pageParams = registry.category("pos_pages").get(routeName);
+        const component = pageParams.component;
+
+        if (component.storeOnOrder ?? true) {
+            this.getOrder()?.setScreenData({ name: routeName, props: routeParams });
+        }
+
+        this.router.navigate(routeName, routeParams);
+    }
+
+    navigateToOrderScreen(order) {
+        const orderPage = order.getScreenData();
+        const page = orderPage?.name || "ProductScreen";
+        const params = orderPage?.props || {
+            orderUuid: order.uuid,
+        };
+        this.ticket_screen_mobile_pane = "left";
+        this.navigate(page, params);
+    }
+
+    get defaultPage() {
+        let openOrder = this.models["pos.order"].find((o) => o.state === "draft");
+
+        if (!openOrder) {
+            openOrder = this.addNewOrder();
+        }
+
+        return {
+            page: "ProductScreen",
+            params: {
+                orderUuid: openOrder?.uuid,
+            },
+        };
+    }
+
+    get firstPage() {
         if (odoo.from_backend) {
             // Remove from_backend params in the URL but keep the rest
             const url = new URL(window.location.href);
@@ -161,13 +198,11 @@ export class PosStore extends WithLazyGetterTrap {
             if (!this.config.module_pos_hr) {
                 this.setCashier(this.user);
             }
+        } else {
+            this.resetCashier();
         }
 
-        return !this.cashier ? "LoginScreen" : this.defaultScreen;
-    }
-
-    get defaultScreen() {
-        return "ProductScreen";
+        return !this.cashier ? { page: "LoginScreen", params: {} } : this.defaultPage;
     }
 
     get idleTimeout() {
@@ -175,14 +210,12 @@ export class PosStore extends WithLazyGetterTrap {
             {
                 timeout: 300000, // 5 minutes
                 action: () =>
-                    this.mainScreen.component.name !== "PaymentScreen" &&
-                    this.showScreen("SaverScreen"),
+                    this.router.state.current !== "PaymentScreen" && this.navigate("SaverScreen"),
             },
             {
                 timeout: 120000, // 2 minutes
                 action: () =>
-                    this.mainScreen.component.name === "LoginScreen" &&
-                    this.showScreen("SaverScreen"),
+                    this.router.state.current === "LoginScreen" && this.navigate("SaverScreen"),
             },
         ];
     }
@@ -200,7 +233,7 @@ export class PosStore extends WithLazyGetterTrap {
 
     async showLoginScreen() {
         this.resetCashier();
-        this.showScreen("LoginScreen");
+        this.navigate("LoginScreen");
         this.dialog.closeAll();
     }
 
@@ -261,8 +294,23 @@ export class PosStore extends WithLazyGetterTrap {
 
     async initServerData() {
         await this.processServerData();
+        await this.handleUrlParams();
         this.data.connectWebSocket("CLOSING_SESSION", this.closingSessionNotification.bind(this));
-        return await this.afterProcessServerData();
+        const process = await this.afterProcessServerData();
+
+        if (this.router.state.current !== "LoginScreen" && !this.config.module_pos_hr) {
+            this.setCashier(this.user);
+        }
+
+        const page =
+            this.router.state.current === "LoginScreen"
+                ? this.firstPage
+                : {
+                      page: this.router.state.current,
+                      params: this.router.state.params,
+                  };
+        this.navigate(page.page, page.params);
+        return process;
     }
 
     async closingSessionNotification(data) {
@@ -537,6 +585,24 @@ export class PosStore extends WithLazyGetterTrap {
         ]);
     }
 
+    async handleUrlParams() {
+        const orderPathUuid = this.router.state.params.orderUuid;
+        const order = this.models["pos.order"].find((order) => order.uuid === orderPathUuid);
+        if (orderPathUuid && !order) {
+            const result = await this.data.call("pos.order", "read_pos_data_uuid", [orderPathUuid]);
+            this.models.loadConnectedData(result);
+            const order = this.models["pos.order"].find((order) => order.uuid === orderPathUuid);
+            if (order) {
+                this.setOrder(order);
+            } else {
+                const next = this.defaultPage;
+                this.router.navigate(next.page, next.params);
+            }
+        } else {
+            this.setOrder(order);
+        }
+    }
+
     async afterProcessServerData() {
         // Adding the not synced paid orders to the pending orders
         const paidUnsyncedOrderIds = this.models["pos.order"]
@@ -552,16 +618,19 @@ export class PosStore extends WithLazyGetterTrap {
             .forEach((order) => (order.state = "cancel"));
 
         const openOrders = this.data.models["pos.order"].filter((order) => !order.finalized);
-        this.syncAllOrders();
+        await this.syncAllOrders();
 
         if (!this.config.module_pos_restaurant) {
-            this.selectedOrderUuid = openOrders.length
-                ? openOrders[openOrders.length - 1].uuid
-                : this.addNewOrder().uuid;
+            if (this.router.state.params.orderUuid) {
+                this.selectedOrderUuid = this.router.state.params.orderUuid;
+            } else {
+                this.selectedOrderUuid = openOrders.length
+                    ? openOrders[openOrders.length - 1].uuid
+                    : this.addNewOrder().uuid;
+            }
         }
 
         this.markReady();
-        this.showScreen(this.firstScreen);
         await this.deviceSync.readDataFromServer();
         openProxyCustomerDisplay(
             this.getDisplayDeviceIP(),
@@ -1325,13 +1394,13 @@ export class PosStore extends WithLazyGetterTrap {
             });
             if (confirmed) {
                 this.mobile_pane = "right";
-                this.showScreen("PaymentScreen", {
+                this.navigate("PaymentScreen", {
                     orderUuid: this.selectedOrderUuid,
                 });
             }
         } else {
             this.mobile_pane = "right";
-            this.showScreen("PaymentScreen", {
+            this.navigate("PaymentScreen", {
                 orderUuid: this.selectedOrderUuid,
             });
         }
@@ -1523,29 +1592,7 @@ export class PosStore extends WithLazyGetterTrap {
             true
         );
     }
-    showScreen(name, props = {}, newOrder = false) {
-        if (name === "PaymentScreen" && !props.orderUuid) {
-            name = "ProductScreen";
-        }
-        if (name === "ProductScreen") {
-            this.getOrder()?.deselectOrderline();
-        }
-        const component = registry.category("pos_screens").get(name);
-        if (
-            (component.updatePreviousScreen ?? true) &&
-            (this.mainScreen.component?.updatePreviousScreen ?? true)
-        ) {
-            this.previousScreen = this.mainScreen.component?.name;
-        }
-        this.mainScreen = { component, props };
-        // Save the screen to the order so that it is shown again when the order is selected.
-        if (component.storeOnOrder ?? true) {
-            this.getOrder()?.setScreenData({ name, props });
-        }
-        if (newOrder) {
-            this.addNewOrder();
-        }
-    }
+
     async printReceipt({
         basic = false,
         order = this.getOrder(),
@@ -1771,25 +1818,6 @@ export class PosStore extends WithLazyGetterTrap {
             cancelled: currentOrderChange["cancelled"].filter(filterFn),
             noteUpdate: currentOrderChange["noteUpdate"].filter(filterFn),
         };
-    }
-
-    closeScreen() {
-        this.showOrderScreen(false);
-    }
-
-    showOrderScreen(forceEmpty = false) {
-        this.addOrderIfEmpty(forceEmpty);
-        if (this.mainScreen.component === PaymentScreen) {
-            this.getOrder().setScreenData({ name: "PaymentScreen", props: {} });
-            this.showScreen("ProductScreen");
-            return;
-        }
-        const { name: screenName } = this.getOrder().getScreenData();
-        const props = {};
-        if (screenName === "PaymentScreen") {
-            props.orderUuid = this.selectedOrderUuid;
-        }
-        this.showScreen(screenName, props);
     }
 
     addOrderIfEmpty(forceEmpty) {
@@ -2124,7 +2152,7 @@ export class PosStore extends WithLazyGetterTrap {
                     onClose: () => {
                         if (
                             this.session.state !== "opened" &&
-                            this.mainScreen.component === ProductScreen
+                            this.router.state.current === "ProductScreen"
                         ) {
                             this.closePos();
                         }
@@ -2167,27 +2195,34 @@ export class PosStore extends WithLazyGetterTrap {
         return (
             this.ui.isSmall &&
             this.numpadMode !== "table" &&
-            (this.mainScreen.component !== ProductScreen || this.mobile_pane === "left")
+            (this.router.state.current !== "ProductScreen" || this.mobile_pane === "left")
         );
     }
     async onClickBackButton() {
-        if (this.mainScreen.component === TicketScreen) {
+        if (this.router.state.current === "TicketScreen") {
             if (this.ticket_screen_mobile_pane == "left") {
-                this.closeScreen();
+                const next = this.defaultPage;
+                this.navigate(next.page, next.params);
             } else {
                 this.ticket_screen_mobile_pane = "left";
             }
         } else if (
             this.mobile_pane == "left" ||
-            [PaymentScreen, ActionScreen].includes(this.mainScreen.component)
+            ["PaymentScreen", "ActionScreen"].includes(this.router.state.current)
         ) {
-            this.mobile_pane = this.mainScreen.component === PaymentScreen ? "left" : "right";
-            this.showScreen("ProductScreen");
+            if (this.router.state.current === "ProductScreen") {
+                this.getOrder().deselectOrderline();
+            }
+
+            this.mobile_pane = this.router.state.current === "PaymentScreen" ? "left" : "right";
+            this.navigate("ProductScreen", {
+                orderUuid: this.getOrder().uuid,
+            });
         }
     }
 
     showSearchButton() {
-        if (this.mainScreen.component === ProductScreen) {
+        if (this.router.state.current === "ProductScreen") {
             return this.ui.isSmall ? this.mobile_pane === "right" : true;
         }
         return false;
@@ -2240,7 +2275,7 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     get isTicketScreenShown() {
-        return this.mainScreen.component === TicketScreen;
+        return this.router.state.current === "TicketScreen";
     }
 
     redirectToBackend() {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -25,7 +25,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
 
     def _get_url(self, pos_config=None):
         pos_config = pos_config or self.main_pos_config
-        return f"/pos/ui?config_id={pos_config.id}"
+        return f"/pos/ui/{pos_config.id}"
 
     def start_pos_tour(self, tour_name, login="pos_user", **kwargs):
         self.start_tour(self._get_url(pos_config=kwargs.get('pos_config')), tour_name, login=login, **kwargs)
@@ -581,14 +581,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         # this you end up with js, css but no qweb.
         self.env['ir.module.module'].search([('name', '=', 'point_of_sale')], limit=1).state = 'installed'
 
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'pos_pricelist', login="pos_user")
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'pos_basic_order_01_multi_payment_and_change', login="pos_user")
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'pos_basic_order_02_decimal_order_quantity', login="pos_user")
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'pos_basic_order_03_tax_position', login="pos_user")
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FloatingOrderTour', login="pos_user")
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ProductScreenTour', login="pos_user")
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenTour', login="pos_user")
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ReceiptScreenTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'pos_pricelist', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'pos_basic_order_01_multi_payment_and_change', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'pos_basic_order_02_decimal_order_quantity', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'pos_basic_order_03_tax_position', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'FloatingOrderTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'ProductScreenTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'ReceiptScreenTour', login="pos_user")
 
         for order in self.env['pos.order'].search([]):
             self.assertEqual(order.state, 'paid', "Validated order has payment of " + str(order.amount_paid) + " and total of " + str(order.amount_total))
@@ -605,7 +605,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ChromeTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'ChromeTour', login="pos_user")
         n_invoiced = self.env['pos.order'].search_count([('account_move', '!=', False)])
         n_paid = self.env['pos.order'].search_count([('state', '=', 'paid')])
         self.assertEqual(n_invoiced, 1, 'There should be 1 invoiced order.')
@@ -649,7 +649,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             ]
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'TicketScreenTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'TicketScreenTour', login="pos_user")
 
     def test_product_information_screen_admin(self):
         '''Consider this test method to contain a test tour with miscellaneous tests/checks that require admin access.
@@ -660,7 +660,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.assertFalse(self.product_a.is_storable)
         self.main_pos_config.with_user(self.pos_admin).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CheckProductInformation', login="pos_admin")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'CheckProductInformation', login="pos_admin")
 
     def test_fixed_tax_negative_qty(self):
         """ Assert the negative amount of a negative-quantity orderline
@@ -698,7 +698,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         # We need to do this because of the fix in the "compute_all" port.
         self.main_pos_config.write({'iface_tax_included': 'total'})
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FixedTaxNegativeQty', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'FixedTaxNegativeQty', login="pos_user")
         pos_session = self.main_pos_config.current_session_id
 
         # Close the session and check the session journal entry.
@@ -727,7 +727,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.write({'payment_method_ids': [(6, 0, bank_pm.ids)], 'ship_later': True})
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenTour2', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenTour2', login="pos_user")
 
     def test_rounding_up(self):
         rouding_method = self.env['account.cash.rounding'].create({
@@ -749,7 +749,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenRoundingUp', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenRoundingUp', login="pos_user")
 
     def test_rounding_down(self):
         rouding_method = self.env['account.cash.rounding'].create({
@@ -771,9 +771,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenRoundingDown', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenRoundingDown', login="pos_user")
         self.env["pos.order"].search([]).write({'state': 'cancel'})
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenTotalDueWithOverPayment', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenTotalDueWithOverPayment', login="pos_user")
 
     def test_rounding_half_up(self):
         rouding_method = self.env['account.cash.rounding'].create({
@@ -809,7 +809,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenRoundingHalfUp', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenRoundingHalfUp', login="pos_user")
 
     def test_pos_closing_cash_details(self):
         """Test cash difference *loss* at closing.
@@ -819,7 +819,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         current_session.post_closing_cash_details(0)
         current_session.close_session_from_ui()
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashClosingDetails', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'CashClosingDetails', login="pos_user")
         cash_diff_line = self.env['account.bank.statement.line'].search([
             ('payment_ref', 'ilike', 'Cash difference observed during the counting (Loss)')
         ])
@@ -827,7 +827,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     def test_cash_payments_should_reflect_on_next_opening(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'OrderPaidInCash', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'OrderPaidInCash', login="pos_user")
 
     def test_fiscal_position_no_tax(self):
         #create a tax of 15% with price included
@@ -863,7 +863,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'pricelist_id': pricelist.id,
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionNoTax', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'FiscalPositionNoTax', login="pos_user")
 
     def test_fiscal_position_inclusive_and_exclusive_tax(self):
         """ Test the mapping of fiscal position for both Tax Inclusive ans Tax Exclusive"""
@@ -939,8 +939,8 @@ class TestUi(TestPointOfSaleHttpCommon):
                 ])],
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionIncl', login="pos_user")
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionExcl', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'FiscalPositionIncl', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'FiscalPositionExcl', login="pos_user")
 
     def test_06_pos_discount_display_with_multiple_pricelist(self):
         """ Test the discount display on the POS screen when multiple pricelists are used."""
@@ -981,7 +981,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ReceiptScreenDiscountWithPricelistTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'ReceiptScreenDiscountWithPricelistTour', login="pos_user")
 
     def test_07_product_combo(self):
         setup_product_combo_items(self)
@@ -1022,7 +1022,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         # If not, it will fail as it will mistakenly match with the product barcode "0123456789"
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'BarcodeScanningTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'BarcodeScanningTour', login="pos_user")
 
     def test_08_show_tax_excluded(self):
         # define a tax included tax record
@@ -1047,7 +1047,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ShowTaxExcludedTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'ShowTaxExcludedTour', login="pos_user")
 
     def test_chrome_without_cash_move_permission(self):
         self.env.user.write({'group_ids': [
@@ -1083,7 +1083,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'BarcodeScanningProductPackagingTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'BarcodeScanningProductPackagingTour', login="pos_user")
 
     def test_GS1_pos_barcodes_scan(self):
         barcodes_gs1_nomenclature = self.env.ref("barcodes_gs1_nomenclature.default_gs1_nomenclature")
@@ -1120,7 +1120,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'GS1BarcodeScanningTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'GS1BarcodeScanningTour', login="pos_user")
 
     def test_refund_order_with_fp_tax_included(self):
         # create a fiscal position
@@ -1161,7 +1161,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionNoTaxRefund', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'FiscalPositionNoTaxRefund', login="pos_user")
 
     def test_lot_refund(self):
 
@@ -1173,7 +1173,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'LotRefundTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'LotRefundTour', login="pos_user")
 
     def test_receipt_tracking_method(self):
         self.product_a = self.env['product.product'].create({
@@ -1183,7 +1183,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'available_in_pos': True,
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ReceiptTrackingMethodTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'ReceiptTrackingMethodTour', login="pos_user")
 
     def test_printed_receipt_tour(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
@@ -1265,7 +1265,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.pricelist_id.write({'item_ids': [(6, 0, pricelist_item.ids)]})
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'limitedProductPricelistLoading', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'limitedProductPricelistLoading', login="pos_user")
 
     def test_multi_product_options(self):
         self.pos_user.write({
@@ -1300,7 +1300,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'MultiProductOptionsTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'MultiProductOptionsTour', login="pos_user")
 
     def test_translate_product_name(self):
         self.env['res.lang']._activate_lang('fr_FR')
@@ -1315,7 +1315,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         product.update_field_translations('name', {'fr_FR': 'Testez le produit'})
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'TranslateProductNameTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'TranslateProductNameTour', login="pos_user")
 
     def test_properly_display_price(self):
         """Make sure that when the decimal separator is a comma, the shown orderline price is correct.
@@ -1331,7 +1331,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, "DecimalCommaOrderlinePrice", login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, "DecimalCommaOrderlinePrice", login="pos_user")
 
     def test_res_partner_scan_barcode(self):
         # default Customer Barcodes pattern is '042'
@@ -1340,7 +1340,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'barcode': '0421234567890',
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'BarcodeScanPartnerTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'BarcodeScanPartnerTour', login="pos_user")
 
     def test_allow_order_modification_after_validation_error(self):
         """
@@ -1362,7 +1362,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             # If there is problem in the tour, remove the log catcher to debug.
             with self.assertLogs(level="WARNING") as log_catcher:
                 self.main_pos_config.with_user(self.pos_user).open_ui()
-                self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'OrderModificationAfterValidationError', login="pos_user")
+                self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'OrderModificationAfterValidationError', login="pos_user")
 
             warning_outputs = [o for o in log_catcher.output if 'WARNING' in o]
             self.assertEqual(len(warning_outputs), 1, "Exactly one warning should be logged")
@@ -1381,7 +1381,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'RefundFewQuantities', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'RefundFewQuantities', login="pos_user")
 
     def test_product_combo_price(self):
         """ Check that the combo has the expected price """
@@ -1416,7 +1416,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         )
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductComboPriceCheckTour', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'ProductComboPriceCheckTour', login="pos_user")
         order = self.env['pos.order'].search([], limit=1)
         self.assertEqual(order.lines.filtered(lambda l: l.product_id.type == 'combo').margin, 0)
         self.assertEqual(order.lines.filtered(lambda l: l.product_id.type == 'combo').margin_percent, 0)
@@ -1484,7 +1484,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'fiscal_position_ids': [(6, 0, [fiscal_position.id])],
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductComboChangeFP', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'ProductComboChangeFP', login="pos_user")
 
     def test_cash_rounding_payment(self):
         """Verify than an error popup is shown if the payment value is more precise than the rounding method"""
@@ -1505,7 +1505,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.env['ir.config_parameter'].sudo().set_param('barcode.max_time_between_keys_in_ms', 1)
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashRoundingPayment', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'CashRoundingPayment', login="accountman")
 
     def test_product_categories_order(self):
         """ Verify that the order of categories doesnt change in the frontend """
@@ -1558,7 +1558,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             },
         ])
         self.main_pos_config.with_user(self.pos_admin).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosCategoriesOrder', login="pos_admin")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'PosCategoriesOrder', login="pos_admin")
 
     def test_product_with_dynamic_attributes(self):
         dynamic_attribute = self.env['product.attribute'].create({
@@ -1586,7 +1586,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'value_ids': [Command.set([value_1.id, value_2.id])],
         })
         self.main_pos_config.with_user(self.pos_admin).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosProductWithDynamicAttributes', login="pos_admin")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'PosProductWithDynamicAttributes', login="pos_admin")
 
     def test_autofill_cash_count(self):
         """Make sure that when the decimal separator is a comma, the shown orderline price is correct.
@@ -1602,7 +1602,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             }
         )
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, "AutofillCashCount", login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, "AutofillCashCount", login="pos_user")
 
     def test_product_search_2(self):
         self.env['product.product'].create({
@@ -1623,7 +1623,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'available_in_pos': True,
         })
         self.main_pos_config.open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'SearchProducts', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'SearchProducts', login="pos_user")
 
     def test_lot(self):
         self.product1 = self.env['product.product'].create({
@@ -1646,7 +1646,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         }).sudo().action_apply_inventory()
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'LotTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'LotTour', login="pos_user")
 
 
     def test_product_search(self):
@@ -1677,13 +1677,13 @@ class TestUi(TestPointOfSaleHttpCommon):
         ])
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ProductSearchTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'ProductSearchTour', login="pos_user")
 
     def test_customer_popup(self):
         """Verify that the customer popup search & inifnite scroll work properly"""
         self.env["res.partner"].create([{"name": "Z partner to search"}, {"name": "Z partner to scroll"}])
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CustomerPopupTour', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'CustomerPopupTour', login="pos_user")
 
     def test_pricelist_multi_items_different_qty_thresholds(self):
         """ Having multiple pricelist items for the same product tmpl with ascending `min_quantity`
@@ -1712,14 +1712,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(
-            f'/pos/ui?config_id={self.main_pos_config.id}',
+            f'/pos/ui/{self.main_pos_config.id}',
             'test_pricelist_multi_items_different_qty_thresholds',
             login='pos_user'
         )
 
     def test_tracking_number_closing_session(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_tracking_number_closing_session', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_tracking_number_closing_session', login="pos_user")
         for order in self.env['pos.order'].search([]):
             self.assertEqual(int(order.tracking_number) % 100, 1)
 
@@ -1731,14 +1731,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.write({'payment_method_ids': [(6, 0, self.customer_account_payment_method.ids)]})
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(
-            f'/pos/ui?config_id={self.main_pos_config.id}',
+            f'/pos/ui/{self.main_pos_config.id}',
             'test_reload_page_before_payment_with_customer_account',
             login='pos_user'
         )
 
     def test_product_card_qty_precision(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductCardUoMPrecision', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'ProductCardUoMPrecision', login="pos_user")
 
     def test_cash_in_out(self):
         self.pos_user.write({
@@ -1747,7 +1747,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             ]
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_cash_in_out', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_cash_in_out', login="pos_user")
 
         self.assertEqual(len(self.main_pos_config.current_session_id.statement_line_ids), 1, "There should be one cash in/out statement line")
         self.assertEqual(self.main_pos_config.current_session_id.statement_line_ids[0].amount, -5, "The cash in/out amount should be -5")
@@ -1760,7 +1760,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'available_in_pos': True,
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, "AddMultipleSerialsAtOnce", login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, "AddMultipleSerialsAtOnce", login="pos_user")
 
     def test_order_and_invoice_amounts(self):
         payment_term = self.env['account.payment.term'].create({
@@ -1791,7 +1791,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenInvoiceOrder', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PaymentScreenInvoiceOrder', login="pos_user")
 
         order = self.env['pos.order'].search([('partner_id', '=', self.partner_test_1.id)], limit=1)
         self.assertTrue(order)
@@ -1812,7 +1812,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.env['pos.category'].search([('id', '!=', self.pos_cat_chair_test.id)]).write({'sequence': 100})
         self.pos_cat_chair_test.write({'sequence': 1})
         self.main_pos_config.with_user(self.pos_admin).open_ui()
-        self.start_tour('/pos/ui?config_id=%d' % self.main_pos_config.id, 'test_product_create_update_from_frontend', login='pos_admin')
+        self.start_tour('/pos/ui/%d' % self.main_pos_config.id, 'test_product_create_update_from_frontend', login='pos_admin')
 
         # In the frontend, a product was created during the tour with the following details:
         # - Product name: Test Frontend Product
@@ -1864,7 +1864,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'fiscal_position_ids': [(6, 0, [fiscal_position.id])],
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_fiscal_position_tax_group_labels', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'test_fiscal_position_tax_group_labels', login="pos_user")
 
     def test_product_long_press(self):
         """ Test the long press on product to open the product info """
@@ -1876,7 +1876,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'available_in_pos': True,
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_product_long_press', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'test_product_long_press', login="pos_user")
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -77,7 +77,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             "iface_available_categ_ids": [(6, 0, [self.event_category.id])],
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'SellingEventInPos', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'SellingEventInPos', login="pos_user")
 
         order = self.env['pos.order'].search([], order='id desc', limit=1)
         event_registration = order.lines[0].event_registration_ids
@@ -127,7 +127,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(slot_2.seats_available, 2)
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'SellingMultiSlotEventInPos', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'SellingMultiSlotEventInPos', login="pos_user")
 
         order = self.env['pos.order'].search([], order='id desc', limit=1)
         self.assertEqual(len(order.lines), 1)

--- a/addons/pos_hr/static/src/app/services/pos_store.js
+++ b/addons/pos_hr/static/src/app/services/pos_store.js
@@ -8,7 +8,7 @@ patch(PosStore.prototype, {
         if (this.config.module_pos_hr) {
             this.login = Boolean(odoo.from_backend) && !this.config.module_pos_hr;
             if (!this.hasLoggedIn) {
-                this.showScreen("LoginScreen");
+                this.navigate("LoginScreen");
             }
         }
         this.employeeBuffer = [];

--- a/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
@@ -130,25 +130,22 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
             pos.setCashier(employee);
         }
 
-        const currentScreen = pos.mainScreen.component.name;
+        const currentScreen = pos.router.state.current;
         if (currentScreen === "LoginScreen" && login && employee) {
             const isRestaurant = pos.config.module_pos_restaurant;
-            let selectedScreen =
+            const selectedScreen =
                 pos.previousScreen && pos.previousScreen !== "LoginScreen"
                     ? pos.previousScreen
                     : isRestaurant
                     ? "FloorScreen"
                     : "ProductScreen";
-
-            const props = {};
-            if (selectedScreen === "PaymentScreen") {
-                if (!pos.selectedOrderUuid) {
-                    selectedScreen = isRestaurant ? "FloorScreen" : "ProductScreen";
-                } else {
-                    props.orderUuid = pos.selectedOrderUuid;
-                }
+            const props = {
+                orderUuid: pos.selectedOrderUuid,
+            };
+            if (selectedScreen === "FloorScreen") {
+                delete props.orderUuid;
             }
-            pos.showScreen(selectedScreen, props);
+            pos.navigate(selectedScreen, props);
         }
 
         return employee;

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -73,7 +73,7 @@ class TestUi(TestPosHrHttpCommon):
         self.main_pos_config.with_user(self.pos_admin).open_ui()
 
         self.start_tour(
-            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "CashierStayLogged",
             login="pos_admin",
         )
@@ -84,7 +84,7 @@ class TestUi(TestPosHrHttpCommon):
         self.main_pos_config.with_user(self.pos_admin).open_ui()
 
         self.start_tour(
-            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "CashierCanSeeProductInfo",
             login="pos_admin",
         )
@@ -99,7 +99,7 @@ class TestUi(TestPosHrHttpCommon):
         self.main_pos_config.with_user(self.pos_admin).open_ui()
 
         self.start_tour(
-            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "CashierCannotClose",
             login="pos_user",
         )

--- a/addons/pos_hr_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_hr_restaurant/static/src/app/services/pos_store.js
@@ -4,6 +4,8 @@ import { PosStore } from "@point_of_sale/app/services/pos_store";
 
 patch(PosStore.prototype, {
     shouldResetIdleTimer() {
-        return this.mainScreen?.name !== "LoginScreen" && super.shouldResetIdleTimer(...arguments);
+        return (
+            this.router.state.current !== "LoginScreen" && super.shouldResetIdleTimer(...arguments)
+        );
     },
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -360,7 +360,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyChangeRewardQty",
             login="pos_user",
         )
@@ -716,7 +716,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config2.with_user(self.pos_user).open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config2.id,
+            "/pos/ui/%d" % self.main_pos_config2.id,
             "PosLoyaltyTour4",
             login="pos_user",
         )
@@ -1665,7 +1665,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyTour12",
             login="pos_user",
         )
@@ -1710,7 +1710,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            '/pos/web?config_id=%d' % self.main_pos_config.id,
+            '/pos/ui/%d' % self.main_pos_config.id,
             'PosLoyaltyMinAmountAndSpecificProductTour',
             login='pos_user',
         )
@@ -1744,7 +1744,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         # Run the tour. It will use the gift card.
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "GiftCardProgramPriceNoTaxTour",
             login="pos_user"
         )
@@ -1763,7 +1763,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         # Run the tour
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PhysicalGiftCardProgramSaleTour",
             login="pos_user"
         )
@@ -1829,7 +1829,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyDontGrantPointsForRewardOrderLines",
             login="pos_user",
         )
@@ -1870,7 +1870,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyPointsGlobalDiscountProgramNoDomain",
             login="pos_user",
         )
@@ -1917,7 +1917,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyPointsDiscountNoDomainProgramNoDomain",
             login="pos_user",
         )
@@ -1974,7 +1974,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyPointsDiscountNoDomainProgramDomain",
             login="pos_user",
         )
@@ -2036,7 +2036,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyPointsDiscountWithDomainProgramDomain",
             login="pos_user",
         )
@@ -2093,7 +2093,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyPointsEwallet",
             login="pos_user",
         )
@@ -2130,7 +2130,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyPointsGiftcard",
             login="pos_user",
         )
@@ -2191,14 +2191,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         product_c.active = False
 
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyArchivedRewardProductsInactive",
             login="pos_user",
         )
 
         product_c.active = True
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyArchivedRewardProductsActive",
             login="pos_user"
         )
@@ -2241,7 +2241,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "ChangeRewardValueWithLanguage",
             login="pos_user",
         )
@@ -2278,7 +2278,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyRewardProductTag",
             login="pos_user",
         )
@@ -2306,7 +2306,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyGiftCardTaxes",
             login="accountman",
         )
@@ -2335,7 +2335,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, "CustomerLoyaltyPointsDisplayed", login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, "CustomerLoyaltyPointsDisplayed", login="pos_user")
 
     def test_cheapest_product_reward_pos_combo(self):
         self.env['product.product'].create({
@@ -2367,7 +2367,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboCheapestRewardProgram', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'PosComboCheapestRewardProgram', login="pos_user")
 
     def test_specific_product_reward_pos_combo(self):
         setup_product_combo_items(self)
@@ -2391,7 +2391,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboSpecificProductProgram', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'PosComboSpecificProductProgram', login="pos_user")
 
     def test_apply_reward_on_product_scan(self):
         """
@@ -2423,14 +2423,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosRewardProductScan",
             login="pos_admin",
         )
         # check the same flow with gs1 nomenclature
         self.env.company.nomenclature_id = self.env.ref('barcodes_gs1_nomenclature.default_gs1_nomenclature')
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosRewardProductScanGS1",
             login="pos_admin",
         )
@@ -2484,7 +2484,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         alt_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % alt_pos_config.id,
+            "/pos/ui/%d" % alt_pos_config.id,
             "PosLoyaltyPromocodePricelist",
             login="pos_user",
         )
@@ -2507,7 +2507,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "GiftCardProgramInvoice",
             login="pos_user",
         )
@@ -2537,7 +2537,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "RefundRulesProduct",
             login="pos_user",
         )
@@ -2573,7 +2573,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosCheapestProductTaxInclude', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'PosCheapestProductTaxInclude', login="pos_user")
 
     def test_next_order_coupon_program_expiration_date(self):
         self.env['loyalty.program'].search([]).write({'active': False})
@@ -2599,7 +2599,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "/pos/ui/%d" % self.main_pos_config.id,
             "PosLoyaltyNextOrderCouponExpirationDate",
             login="pos_user",
         )
@@ -2652,7 +2652,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         )
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_loyalty_on_order_with_fixed_tax', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_loyalty_on_order_with_fixed_tax', login="pos_user")
 
     def test_gift_card_no_date(self):
         """

--- a/addons/pos_mrp/tests/test_frontend.py
+++ b/addons/pos_mrp/tests/test_frontend.py
@@ -67,7 +67,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         customer.name = "AAAA Super Customer"
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        url = "/pos/ui?config_id=%d" % self.main_pos_config.id
+        url = "/pos/ui/%d" % self.main_pos_config.id
         self.start_tour(url, 'test_ship_later_kit_and_mto_manufactured_product', login="pos_user")
 
         picking = self.env['stock.picking'].search([('partner_id', '=', self.partner_full.id)], limit=1)

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -20,7 +20,7 @@ import odoo.tests
 class TestUi(TestPointOfSaleHttpCommon, OnlinePaymentCommon):
 
     def _get_url(self):
-        return f"/pos/ui?config_id={self.pos_config.id}"
+        return f"/pos/ui/{self.pos_config.id}"
 
     def start_pos_tour(self, tour_name, login="pos_user", **kwargs):
         self.start_tour(self._get_url(), tour_name, login=login, **kwargs)

--- a/addons/pos_pine_labs/static/src/app/utils/payment/payment_pine_labs.js
+++ b/addons/pos_pine_labs/static/src/app/utils/payment/payment_pine_labs.js
@@ -205,7 +205,7 @@ export class PaymentPineLabs extends PaymentInterface {
             clearTimeout(this.pollingTimeout);
 
             // If the user navigates to another screen, stop the polling
-            if (this.pos.mainScreen.component.name !== "PaymentScreen") {
+            if (this.pos.router.state.current !== "PaymentScreen") {
                 this._removePaymentHandler();
                 return;
             }

--- a/addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js
+++ b/addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js
@@ -228,7 +228,7 @@ export class PaymentRazorpay extends PaymentInterface {
             clearTimeout(this.pollingTimeout);
 
             // If the user navigates to another screen, stop the polling
-            if (this.pos.mainScreen.component.name !== "PaymentScreen") {
+            if (this.pos.router.state.current !== "PaymentScreen") {
                 return;
             }
 

--- a/addons/pos_repair/tests/test_frontend.py
+++ b/addons/pos_repair/tests/test_frontend.py
@@ -32,5 +32,5 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.repair1.sudo().action_create_sale_order()
         self.assertEqual(len(self.product_1.stock_move_ids.ids), 2, "There should be 2 stock moves for the product created by the repair order")
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosRepairSettleOrder', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosRepairSettleOrder', login="pos_user")
         self.assertEqual(len(self.product_1.stock_move_ids.ids), 2, "Paying for the order in PoS should not create new stock moves")

--- a/addons/pos_restaurant/static/src/app/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/app/components/navbar/navbar.js
@@ -29,13 +29,13 @@ patch(Navbar.prototype, {
         return true;
     },
     onTicketButtonClick() {
-        return this.canClick() && this.pos.showScreen("TicketScreen");
+        return this.canClick() && this.pos.navigate("TicketScreen");
     },
     onClickPlanButton() {
-        return this.canClick() && this.pos.showScreen("FloorScreen");
+        return this.canClick() && this.pos.navigate("FloorScreen");
     },
     get mainButton() {
-        return this.pos.mainScreen.component.name === "FloorScreen" ? "table" : super.mainButton;
+        return this.pos.router.state.current === "FloorScreen" ? "table" : super.mainButton;
     },
     get currentOrderName() {
         return this.pos.getOrder().getName().replace("T ", "");

--- a/addons/pos_restaurant/static/src/app/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/app/components/navbar/navbar.xml
@@ -2,12 +2,12 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.Navbar" t-inherit="point_of_sale.Navbar" t-inherit-mode="extension">
         <xpath expr="//DropdownItem[contains(text(), 'Backend')]" position="before">
-            <t t-if="pos.mainScreen.component.name == 'FloorScreen'">
+            <t t-if="pos.router.state.current == 'FloorScreen'">
                 <DropdownItem t-if="showEditPlanButton and this.pos.config.floor_ids.length" onSelected="() => this.pos.toggleEditMode()">
                     Edit Plan
                 </DropdownItem>
             </t>
-            <DropdownItem t-if="pos.mainScreen.component.name == 'FloorScreen'" onSelected="() => this.onSwitchButtonClick()">
+            <DropdownItem t-if="pos.router.state.current == 'FloorScreen'" onSelected="() => this.onSwitchButtonClick()">
                 Switch Floor View
             </DropdownItem>
         </xpath>

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -1114,7 +1114,9 @@ export class FloorScreen extends Component {
     }
     clickNewOrder() {
         this.pos.addNewOrder();
-        this.pos.showScreen("ProductScreen");
+        this.pos.navigate("ProductScreen", {
+            orderUuid: this.pos.selectedOrderUuid,
+        });
     }
     saveCurrentFloorScrollPosition() {
         if (!this.state.selectedFloorId) {
@@ -1133,4 +1135,9 @@ export class FloorScreen extends Component {
     }
 }
 
-registry.category("pos_screens").add("FloorScreen", FloorScreen);
+registry.category("pos_pages").add("FloorScreen", {
+    name: "FloorScreen",
+    component: FloorScreen,
+    route: `/pos/ui/${odoo.pos_config_id}/floor`,
+    params: {},
+});

--- a/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.js
@@ -2,17 +2,22 @@ import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment
 import { patch } from "@web/core/utils/patch";
 
 patch(PaymentScreen.prototype, {
-    get nextScreen() {
+    get nextPage() {
         const order = this.currentOrder;
         if (!this.pos.config.set_tip_after_payment || order.is_tipped) {
-            return super.nextScreen;
+            return super.nextPage;
         }
         // Take the first payment method as the main payment.
         const mainPayment = order.payment_ids[0];
         if (mainPayment && mainPayment.canBeAdjusted()) {
-            return "TipScreen";
+            return {
+                page: "TipScreen",
+                params: {
+                    orderUuid: order.uuid,
+                },
+            };
         }
-        return super.nextScreen;
+        return super.nextPage;
     },
     async afterOrderValidation(suggestToSync = true) {
         const changedTables = this.currentOrder?.table_id?.children?.map((table) => table.id);

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
@@ -1,6 +1,5 @@
 import { patch } from "@web/core/utils/patch";
 import { ActionpadWidget } from "@point_of_sale/app/screens/product_screen/action_pad/action_pad";
-import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
 import { _t } from "@web/core/l10n/translation";
 
 /**
@@ -20,7 +19,8 @@ patch(ActionpadWidget.prototype, {
     },
     get swapButton() {
         return (
-            this.pos.config.module_pos_restaurant && this.pos.mainScreen.component !== TicketScreen
+            this.pos.config.module_pos_restaurant &&
+            this.pos.router.state.current !== "TicketScreen"
         );
     },
     get hasChangesToPrint() {

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -85,7 +85,7 @@
                     </button>
                     <button
                         class="h-100 plan-button button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center w-50"
-                        t-on-click="() => this.pos.showScreen('FloorScreen')"
+                        t-on-click="() => this.pos.navigate('FloorScreen')"
                     >
                         <span>Plan</span>
                     </button>

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -31,6 +31,11 @@ patch(ControlButtons.prototype, {
         }
         return order.getSelectedCourse() || order.getSelectedOrderline();
     },
+    openSplitPage() {
+        this.pos.navigate("SplitBillScreen", {
+            orderUuid: this.currentOrder.uuid,
+        });
+    },
     async clickTransferCourse() {
         this.dialog.closeAll();
         await this.pos.transferLinesToCourse();

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -31,7 +31,7 @@
             <t t-if="pos.config.module_pos_restaurant">
                 <button class="btn btn-secondary btn-lg py-5"
                     t-att-disabled="pos.getOrder()?.getOrderlines()?.reduce((sum, line) => sum + line.qty, 0) lt 2"
-                    t-on-click="() => pos.showScreen('SplitBillScreen')">
+                    t-on-click="openSplitPage">
                     <i class="fa fa-files-o me-1"/>Split
                 </button>
                 <button class="btn btn-secondary btn-lg py-5" t-on-click.stop="() => this.clickTransferOrder()">

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -4,7 +4,7 @@ import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_su
 patch(OrderSummary.prototype, {
     bookTable() {
         this.pos.getOrder().setBooked(true);
-        this.pos.showScreen("FloorScreen");
+        this.pos.navigate("FloorScreen");
     },
     showBookButton() {
         if (!this.pos.selectedTable) {
@@ -24,7 +24,7 @@ patch(OrderSummary.prototype, {
         const order = this.pos.getOrder();
         await this.pos._onBeforeDeleteOrder(order);
         order.state = "cancel";
-        this.pos.showScreen("FloorScreen");
+        this.pos.navigate("FloorScreen");
     },
     showUnbookButton() {
         if (this.pos.selectedTable) {

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
@@ -50,7 +50,8 @@ patch(ProductScreen.prototype, {
     async submitOrder() {
         await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
         this.pos.addPendingOrder([this.currentOrder.id]);
-        this.pos.showScreen(this.pos.defaultScreen, {}, this.pos.defaultScreen == "ProductScreen");
+        const page = this.pos.defaultPage;
+        this.pos.navigate(page.page, page.params);
     },
     get primaryReviewButton() {
         return (

--- a/addons/pos_restaurant/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -8,7 +8,9 @@ patch(ReceiptScreen.prototype, {
         this.currentOrder.uiState.locked = true;
         this.pos.selectedOrderUuid = originalOrderUuid;
         const nextOrderScreen = this.pos.getOrder().getCurrentScreenData().name;
-        this.pos.showScreen(nextOrderScreen || "ProductScreen");
+        this.pos.navigate(nextOrderScreen || "ProductScreen", {
+            orderUuid: originalOrderUuid,
+        });
     },
     isContinueSplitting() {
         if (this.pos.config.module_pos_restaurant && !this.pos.selectedTable) {

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
@@ -4,12 +4,14 @@ import { useService } from "@web/core/utils/hooks";
 import { Component, onWillDestroy, useState } from "@odoo/owl";
 import { Orderline } from "@point_of_sale/app/components/orderline/orderline";
 import { OrderDisplay } from "@point_of_sale/app/components/order_display/order_display";
+import { useRouterParamsChecker } from "@point_of_sale/app/hooks/pos_router_hook";
 
 export class SplitBillScreen extends Component {
     static template = "pos_restaurant.SplitBillScreen";
     static components = { Orderline, OrderDisplay };
     static props = {
         disallow: { type: Boolean, optional: true },
+        orderUuid: { type: String },
     };
 
     setup() {
@@ -17,6 +19,7 @@ export class SplitBillScreen extends Component {
         this.ui = useService("ui");
         this.qtyTracker = useState({});
         this.priceTracker = useState({});
+        useRouterParamsChecker();
 
         onWillDestroy(() => {
             // Removing on all lines because the current order change during the split
@@ -204,8 +207,18 @@ export class SplitBillScreen extends Component {
     }
 
     back() {
-        this.pos.showScreen("ProductScreen");
+        this.pos.navigate("ProductScreen", {
+            orderUuid: this.pos.selectedOrderUuid,
+        });
     }
 }
 
-registry.category("pos_screens").add("SplitBillScreen", SplitBillScreen);
+registry.category("pos_pages").add("SplitBillScreen", {
+    name: "SplitBillScreen",
+    component: SplitBillScreen,
+    route: `/pos/ui/${odoo.pos_config_id}/splitting/{string:orderUuid}`,
+    params: {
+        orderUuid: true,
+        orderFinalized: false,
+    },
+});

--- a/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -34,15 +34,13 @@ patch(TicketScreen.prototype, {
         }
         return res;
     },
-    async _setOrder(order) {
+    async setOrder(order) {
         const shouldBeOverridden = this.pos.config.module_pos_restaurant && order.table_id;
-        if (!shouldBeOverridden) {
-            return super._setOrder(...arguments);
+        if (shouldBeOverridden) {
+            const orderTable = order.getTable();
+            await this.pos.setTable(orderTable, order.uuid);
         }
-        // we came from the FloorScreen
-        const orderTable = order.getTable();
-        await this.pos.setTable(orderTable, order.uuid);
-        this.closeTicketScreen();
+        return await super.setOrder(order);
     },
     async settleTips() {
         const promises = [];

--- a/addons/pos_restaurant/static/src/app/screens/tip_screen/tip_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/tip_screen/tip_screen.xml
@@ -6,7 +6,7 @@
             <div class="pos-receipt-container text-center" t-ref="pos-receipt-container"/>
             <div class="screen-content d-flex flex-column h-100">
                 <div class="top-content d-flex align-items-center p-2 border-bottom text-center">
-                    <button class="button btn btn-lg btn-outline-primary" t-on-click="() => this.pos.showScreen('FloorScreen')">
+                    <button class="button btn btn-lg btn-outline-primary" t-on-click="() => this.pos.navigate('FloorScreen')">
                         <i class="fa fa-angle-double-left me-2"/>
                         <span>Back</span>
                     </button>

--- a/addons/pos_restaurant/static/src/app/services/pos_router_service.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_router_service.js
@@ -1,0 +1,4 @@
+import { patch } from "@web/core/utils/patch";
+import { PosRouter } from "@point_of_sale/app/services/pos_router_service";
+
+patch(PosRouter.prototype, {});

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -3,7 +3,6 @@ import { PosStore } from "@point_of_sale/app/services/pos_store";
 import { ConnectionLostError } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { EditOrderNamePopup } from "@pos_restaurant/app/popup/edit_order_name_popup/edit_order_name_popup";
-import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
 import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
 import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
@@ -18,6 +17,29 @@ patch(PosStore.prototype, {
         this.tableSelectorState = false;
         await super.setup(...arguments);
     },
+    get firstPage() {
+        const screen = super.firstPage;
+
+        if (!this.config.module_pos_restaurant) {
+            return screen;
+        }
+
+        return screen.page === "LoginScreen"
+            ? { page: "LoginScreen", params: {} }
+            : this.defaultPage;
+    },
+    get defaultPage() {
+        const screen = super.defaultPage;
+        if (this.config.module_pos_restaurant) {
+            const screens = {
+                register: "ProductScreen",
+                tables: "FloorScreen",
+            };
+            screen.page = screens[this.config.default_screen];
+            screen.params = {};
+        }
+        return screen;
+    },
     get idleTimeout() {
         return [
             ...super.idleTimeout,
@@ -27,25 +49,35 @@ patch(PosStore.prototype, {
                     this.dialog.closeAll() &&
                     this.config.module_pos_restaurant &&
                     !["PaymentScreen", "TicketScreen", "ActionScreen"].includes(
-                        this.mainScreen.component.name
+                        this.router.state.current
                     ) &&
-                    this.showScreen("FloorScreen"),
+                    this.navigate("FloorScreen"),
             },
         ];
     },
     get firstScreen() {
         const screen = super.firstScreen;
+        const isFirstSession = this.config.raw.session_ids.length === 1;
+        const hasNoProducts = this.productsToDisplay.length === 0;
 
         if (!this.config.module_pos_restaurant) {
             return screen;
         }
 
-        if (screen === "LoginScreen") {
-            return screen;
+        if (screen.page === "LoginScreen") {
+            return { page: "LoginScreen", params: {} };
         }
-        const isFirstSession = this.config.raw.session_ids.length === 1;
-        const hasNoProducts = this.productsToDisplay.length === 0;
-        return isFirstSession && hasNoProducts ? "ProductScreen" : this.defaultScreen;
+
+        if (isFirstSession && hasNoProducts) {
+            return {
+                page: "ProductScreen",
+                params: {
+                    orderUuid: this.getOrder()?.uuid,
+                },
+            };
+        }
+
+        return this.defaultPage;
     },
     get defaultScreen() {
         if (this.config.module_pos_restaurant) {
@@ -57,6 +89,7 @@ patch(PosStore.prototype, {
         }
         return super.defaultScreen;
     },
+
     createNewOrder(data) {
         const order = super.createNewOrder(data);
 
@@ -79,7 +112,7 @@ patch(PosStore.prototype, {
         const guestCount = parseInt(count, 10) || 0;
         if (guestCount == 0 && currentOrder.lines.length === 0) {
             this.removeOrder(currentOrder);
-            this.showScreen("FloorScreen");
+            this.navigate("FloorScreen");
             return false;
         }
         currentOrder.setCustomerCount(guestCount);
@@ -344,9 +377,9 @@ patch(PosStore.prototype, {
         if (
             orderIsDeleted &&
             this.config.module_pos_restaurant &&
-            this.mainScreen.component.name !== "TicketScreen"
+            this.router.state.current !== "TicketScreen"
         ) {
-            this.showScreen("FloorScreen");
+            this.navigate("FloorScreen");
         }
     },
     async closingSessionNotification(data) {
@@ -424,36 +457,42 @@ patch(PosStore.prototype, {
     get selectedTable() {
         return this.getOrder()?.table_id;
     },
-    showScreen(screenName, props = {}, newOrder = false) {
+    navigate(routeName, routeParams = {}) {
         const order = this.getOrder();
         if (
             this.config.module_pos_restaurant &&
-            this.mainScreen.component === ProductScreen &&
+            this.router.state.current === "ProductScreen" &&
             order &&
             !order.isBooked
         ) {
             this.removeOrder(order);
         }
-        super.showScreen(...arguments);
-    },
-    closeScreen() {
-        if (this.config.module_pos_restaurant && !this.getOrder()) {
-            return this.showScreen("FloorScreen");
-        }
-        return super.closeScreen(...arguments);
+        super.navigate(routeName, routeParams);
     },
     showDefault() {
-        this.showScreen(this.defaultScreen, {}, this.defaultScreen == "ProductScreen");
+        const page = this.defaultPage;
+        this.navigate(page.page, page.params);
     },
     addOrderIfEmpty(forceEmpty) {
         if (!this.config.module_pos_restaurant || forceEmpty) {
             return super.addOrderIfEmpty(...arguments);
         }
     },
+    async handleUrlParams(event) {
+        await super.handleUrlParams(...arguments);
+        if (this.config.module_pos_restaurant && this.router.state.current === "ProductScreen") {
+            const orderUuid = this.router.state.params.orderUuid;
+            const order = this.models["pos.order"].getBy("uuid", orderUuid);
+            if (order && order.table_id) {
+                this.setTable(order.table_id);
+            }
+        }
+    },
     //@override
     async afterProcessServerData() {
         this.floorPlanStyle =
             localStorage.getItem("floorPlanStyle") || (this.ui.isSmall ? "kanban" : "default");
+
         if (this.config.module_pos_restaurant) {
             this.currentFloor = this.config.floor_ids?.length > 0 ? this.config.floor_ids[0] : null;
         }
@@ -571,13 +610,10 @@ patch(PosStore.prototype, {
         }
         this.setOrder(floatingOrder);
 
-        const props = {};
         const screenName = floatingOrder.getScreenData().name;
-        if (screenName === "PaymentScreen") {
-            props.orderUuid = floatingOrder.uuid;
-        }
-
-        this.showScreen(screenName || "ProductScreen", props);
+        this.navigate(screenName || "ProductScreen", {
+            orderUuid: floatingOrder.uuid,
+        });
     },
     findTable(tableNumber) {
         const find_table = (t) => t.table_number === parseInt(tableNumber);
@@ -616,14 +652,14 @@ patch(PosStore.prototype, {
             const orders = this.getTableOrders(table.id);
             if (orders.length > 0) {
                 this.setOrder(orders[0]);
-                const props = {};
-                if (orders[0].getScreenData().name === "PaymentScreen") {
-                    props.orderUuid = orders[0].uuid;
-                }
-                this.showScreen(orders[0].getScreenData().name, props);
+                this.navigate(orders[0].getScreenData().name, {
+                    orderUuid: orders[0].uuid,
+                });
             } else {
                 this.addNewOrder({ table_id: table });
-                this.showScreen("ProductScreen");
+                this.navigate("ProductScreen", {
+                    orderUuid: this.getOrder().uuid,
+                });
             }
         }
     },
@@ -657,7 +693,7 @@ patch(PosStore.prototype, {
         this.isOrderTransferMode = true;
         const orderUuid = this.getOrder().uuid;
         this.getOrder().setBooked(true);
-        this.showScreen("FloorScreen");
+        this.navigate("FloorScreen");
         const onClickWhileTransfer = async (ev) => {
             if (ev.target.closest(".button-floor")) {
                 return;

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -390,7 +390,7 @@ class TestFrontend(TestFrontendCommon):
                 'value_ids': [(6, 0, [attribute_2_value.id, attribute_2_value_2.id])],
             })
             self.main_pos_config.with_user(self.pos_user).open_ui()
-            self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")
+            self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")
 
     def test_create_floor_tour(self):
         self.pos_config.with_user(self.pos_user).open_ui()
@@ -448,7 +448,7 @@ class TestFrontend(TestFrontendCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'MultiPreparationPrinter', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'MultiPreparationPrinter', login="pos_user")
 
     def test_user_on_residual_order(self):
         self.pos_config.write({'printer_ids': False})
@@ -530,4 +530,4 @@ class TestFrontend(TestFrontendCommon):
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_multiple_preparation_printer_different_categories', login="pos_user")
+        self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'test_multiple_preparation_printer_different_categories', login="pos_user")

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -72,7 +72,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             ]
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrder', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosSettleOrder', login="pos_user")
 
         #assert that sales order qty are correctly updated
         self.assertEqual(sale_order.order_line.qty_delivered, 3)
@@ -484,7 +484,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         sale_order.action_confirm()
 
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosOrderDoesNotRemainInList', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosOrderDoesNotRemainInList', login="accountman")
 
     def test_settle_draft_order_service_product(self):
         """
@@ -516,7 +516,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.assertEqual(sale_order.state, 'draft')
 
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleDraftOrder', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosSettleDraftOrder', login="accountman")
 
     def test_settle_order_change_customer(self):
         """
@@ -540,7 +540,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         sale_order.action_confirm()
 
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleCustomPrice', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosSettleCustomPrice', login="accountman")
 
     def test_so_with_downpayment(self):
         self.product_a.available_in_pos = True
@@ -568,7 +568,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.down_payment_product_id = self.env.ref("pos_sale.default_downpayment_product")
         self.main_pos_config.down_payment_product_id.write({'active': True})
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSSaleOrderWithDownpayment', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PoSSaleOrderWithDownpayment', login="accountman")
 
     def test_downpayment_with_taxed_product(self):
         tax_1 = self.env['account.tax'].create({
@@ -635,7 +635,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             'down_payment_product_id': self.downpayment_product.id,
         })
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentLinesPerTax', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PoSDownPaymentLinesPerTax', login="accountman")
 
         # We check the content of the invoice to make sure Product A/B/C only appears only once
         invoice_pdf_content = str(self.env['pos.order'].search([]).account_move._get_invoice_legal_documents('pdf', allow_fallback=True).get('content'))
@@ -664,7 +664,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         # Apply 10% down payment
         self.main_pos_config.open_ui()
         self.main_pos_config.down_payment_product_id = self.env.ref("pos_sale.default_downpayment_product")
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSApplyDownpayment', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PoSApplyDownpayment', login="accountman")
 
         invoice = so._create_invoices(final=True)
         invoice.action_post()
@@ -691,7 +691,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         sale_order.action_confirm()
         self.main_pos_config.write({'ship_later': True})
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosShipLaterNoDefault', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosShipLaterNoDefault', login="accountman")
 
     def test_order_sale_team(self):
         self.env['product.product'].create({
@@ -703,7 +703,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         sale_team = self.env['crm.team'].create({'name': 'Test team'})
         self.main_pos_config.write({'crm_team_id': sale_team})
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSaleTeam', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosSaleTeam', login="accountman")
         order = self.env['pos.order'].search([])
         self.assertEqual(len(order), 1)
         self.assertEqual(order.crm_team_id, sale_team)
@@ -738,7 +738,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         sale_order.action_confirm()
         self.main_pos_config.with_user(self.pos_admin).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosOrdersListDifferentCurrency', login="pos_admin")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosOrdersListDifferentCurrency', login="pos_admin")
 
     def test_downpayment_amount_to_invoice(self):
         product_a = self.env['product.product'].create({
@@ -761,7 +761,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         sale_order.action_confirm()
         self.main_pos_config.down_payment_product_id = self.env.ref("pos_sale.default_downpayment_product")
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentAmount', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PoSDownPaymentAmount', login="accountman")
         self.assertEqual(sale_order.amount_to_invoice, 80.0, "Downpayment amount not considered!")
         self.assertEqual(sale_order.amount_invoiced, 20.0, "Downpayment amount not considered!")
 
@@ -842,7 +842,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.ship_later = True
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrder4', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosSettleOrder4', login="accountman")
 
         self.assertEqual(sale_order.picking_ids.state, 'cancel')
         self.assertEqual(sale_order.pos_order_line_ids.order_id.picking_ids.state, 'assigned')
@@ -854,7 +854,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             {'name': 'A Test Customer 2', 'sale_warn_msg': 'Cannot afford our services'}
         ])
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSaleWarning', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosSaleWarning', login="accountman")
 
     def test_downpayment_invoice(self):
         """This test check that users that don't have the pos user group can invoice downpayments"""
@@ -926,7 +926,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.ship_later = True
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderShipLater', login="pos_user")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosSettleOrderShipLater', login="pos_user")
 
         # The pos order is being shipped later so the qty_delivered should still be 0
         self.assertEqual(sale_order.order_line[0].qty_delivered, 0)
@@ -960,7 +960,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         sale_order.action_confirm()
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrder5', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'PosSettleOrder5', login="accountman")
         self.assertEqual(sale_order.order_line.qty_invoiced, 0)
         self.assertEqual(sale_order.order_line.qty_delivered, 0)
 
@@ -1072,7 +1072,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
 
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'POSSalePaymentScreenInvoiceOrder', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'POSSalePaymentScreenInvoiceOrder', login="accountman")
 
         order = self.env['pos.order'].search([('partner_id', '=', partner_test.id)], limit=1)
         self.assertTrue(order)
@@ -1131,4 +1131,4 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         sale_order.action_confirm()
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_settle_order_with_lot', login="accountman")
+        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'test_settle_order_with_lot', login="accountman")

--- a/addons/pos_self_order/static/src/app/services/data_service.js
+++ b/addons/pos_self_order/static/src/app/services/data_service.js
@@ -13,7 +13,7 @@ patch(PosData.prototype, {
         return await rpc(`/pos-self/relations/${parseInt(configId)}`);
     },
     get databaseName() {
-        return `self_order-${odoo.access_token}`;
+        return `pos-self-order-${odoo.pos_config_id}-${odoo.info?.db}`;
     },
     initIndexedDB() {
         return session.data.self_ordering_mode === "mobile"

--- a/addons/pos_self_order/tests/test_self_order_sequence.py
+++ b/addons/pos_self_order/tests/test_self_order_sequence.py
@@ -39,4 +39,4 @@ class TestSelfOrderSequence(SelfOrderCommonTest):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, 'SelfOrderOrderNumberTour', login="pos_admin")
-        self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'OrderNumberConflictTour', login="pos_admin")
+        self.start_tour("/pos/ui/%d" % self.pos_config.id, 'OrderNumberConflictTour', login="pos_admin")

--- a/addons/pos_viva_com/tests/test_frontend.py
+++ b/addons/pos_viva_com/tests/test_frontend.py
@@ -38,4 +38,4 @@ class TestVivaComHttpCommon(TestPointOfSaleHttpCommon):
 
         with patch.object(PosPaymentMethod, '_call_viva_com', mocked_call_viva_com_check_post_data):
             self.main_pos_config.open_ui()
-            self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'VivaComTour', login="accountman")
+            self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'VivaComTour', login="accountman")


### PR DESCRIPTION
*: l10n_be_pos_sale, l10n_es_pos, l10n_id_pos, l10n_test_pos_qr_payment, point_of_sale, pos_event, pos_hr, pos_hr_restaurant, pos_loyalty, pos_pine_labs, pos_razorpay, pos_repair, pos_restaurant, pos_sale, pos_self_order, pos_viva_com

This commit adds a new service to the POS that allows to persist the router on all POS pages.

When refreshing the page, the router will be restored to the last visited page, and the current state of the POS will be preserved.

