### PR TITLE
[FIX] payment, payment_custom: test dependencies on non dependencies

### DIFF
--- a/addons/payment/tests/test_payment_transaction.py
+++ b/addons/payment/tests/test_payment_transaction.py
@@ -14,6 +14,8 @@ class TestPaymentTransaction(PaymentCommon):
 
     def test_capture_allowed_for_authorized_users(self):
         """ Test that users who have access to a transaction can capture it. """
+        if not self.env.ref('account.group_account_invoice', raise_if_not_found=False):
+            self.skipTest("account needed for test")
         self.provider.support_manual_capture = 'full_only'
         tx = self._create_transaction('redirect', state='authorized')
         user = self._prepare_user(self.internal_user, 'account.group_account_invoice')
@@ -21,6 +23,8 @@ class TestPaymentTransaction(PaymentCommon):
 
     def test_void_allowed_for_authorized_users(self):
         """ Test that users who have access to a transaction can void it. """
+        if not self.env.ref('account.group_account_invoice', raise_if_not_found=False):
+            self.skipTest("account needed for test")
         self.provider.support_manual_capture = 'full_only'
         tx = self._create_transaction('redirect', state='authorized')
         user = self._prepare_user(self.internal_user, 'account.group_account_invoice')
@@ -28,6 +32,8 @@ class TestPaymentTransaction(PaymentCommon):
 
     def test_refund_allowed_for_authorized_users(self):
         """ Test that users who have access to a transaction can refund it. """
+        if not self.env.ref('account.group_account_invoice', raise_if_not_found=False):
+            self.skipTest("account needed for test")
         self.provider.support_refund = 'full_only'
         tx = self._create_transaction('redirect', state='done')
         user = self._prepare_user(self.internal_user, 'account.group_account_invoice')

--- a/addons/payment_custom/tests/test_payment_transaction.py
+++ b/addons/payment_custom/tests/test_payment_transaction.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import unittest
 
 from odoo import Command, fields
 from odoo.tests import tagged
@@ -8,10 +9,12 @@ from odoo.addons.payment.tests.common import PaymentCommon
 
 @tagged('-at_install', 'post_install')
 class TestPaymentTransaction(PaymentCommon):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        if 'product.product' not in cls.env:
+            raise unittest.SkipTest("requires product")
 
         cls.provider = cls._prepare_provider(code='custom')
         cls.product = cls.env['product.product'].create({


### PR DESCRIPTION
`payment` does not depend on `account`, it thus can't unconditionally use `account` groups. Skip tests if `account` is not installed (matches `account_custom` behaviour).

`account_custom` does not depend on `product`, so can't use `product.product` unconditionally. `setUpClass` doesn't seem useful so just remove it entirely.
