### PR TITLE
[IMP] point_of_sale: order search by customer selection on ticket screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -102,6 +102,7 @@ export class PartnerList extends Component {
             search: {
                 fieldName: "PARTNER",
                 searchTerm: partner.name,
+                partnerId: partner.id,
             },
             filter: partnerHasActiveOrders ? "" : "SYNCED",
         };

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -419,6 +419,9 @@ export class TicketScreen extends Component {
             const repr = this._getSearchFields()[this.state.search.fieldName].repr;
             orders = fuzzyLookup(this.state.search.searchTerm, orders, repr);
         }
+        if (this.state.search.partnerId && this.state.search.fieldName === "PARTNER") {
+            orders = orders.filter((order) => order.partner_id?.id === this.state.search.partnerId);
+        }
 
         if (this.state.selectedPreset) {
             orders = orders.filter((order) => order.preset_id?.id === this.state.selectedPreset.id);
@@ -763,6 +766,9 @@ export class TicketScreen extends Component {
                 if (domain.length > 1) {
                     domain.unshift("|");
                 }
+            }
+            if (this.state.search.partnerId && this.state.search.fieldName === "PARTNER") {
+                domain.unshift(["partner_id.id", "in", [this.state.search.partnerId]]);
             }
             return domain;
         } else {


### PR DESCRIPTION
Before this commit:
====================
When filtering orders from the partner list on the POS ticket screen, the search matched only by partner name. If multiple customers shared the same name, the ticket screen displayed all matching customers' orders, making it difficult to identify the exact customer intended.

After this commit:
==================
Orders can now be searched using both the partner name and partner ID when the search is triggered via the partner list. This ensures that when customers have the same name, the system returns orders for the exact customer selected from the partner list.

Task-4715151

