### PR TITLE
[IMP] web: add preview for text, xml, json

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -111,12 +111,12 @@ class IrAttachment(models.Model):
         return fname, full_path
 
     @api.model
-    def _file_read(self, fname):
+    def _file_read(self, fname, size=None):
         assert isinstance(self, IrAttachment)
         full_path = self._full_path(fname)
         try:
             with open(full_path, 'rb') as f:
-                return f.read()
+                return f.read(size)
         except OSError:
             _logger.info("_read_file reading %s", full_path, exc_info=True)
         return b''


### PR DESCRIPTION
Introduce to text-like preview sandbox attributes to ensure security and isolate content.

Added size parameter to `_file_read` inside of `ir_attachment.py` to allow reading a limited number of bytes from an attachment.

see PR [83485](https://github.com/odoo/enterprise/pull/83485) for more context

task-4236987
