### PR TITLE
[FIX] ir_asset: prevent error when adding custom asset paths

### DIFF
--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -210,6 +210,8 @@ class IrAsset(models.Model):
             return
         if can_aggregate(path_def):
             paths = self._get_paths(path_def, installed)
+            if paths is None:
+                return
         else:
             paths = [(path_def, EXTERNAL_ASSET, -1)]  # external urls
 


### PR DESCRIPTION
This error occurs when a user adds a custom path to assets.

Steps to Reproduce :

1. Install moudule POS.
2. Activate the developer mode (with tests assets)
3. Go to Settings > Techncial > Database Structer > Assets
4. Create a new asset. Set the path as `custom_pos_receipt/static/src/**/*`, Bundle name as `point_of_sale._assets_pos`.
5. Open POS Session.

`TypeError: 'NoneType' object is not iterable`

This error happens when the system tries to append paths and encounters a `None` value for the `paths` variable.

This commit resolves the error by ensuring that a logger warning is raised when paths is not found.

Sentry: 6499122709