### PR TITLE
[FIX] website: no gap for on hover mega menu


### DIFF
--- a/addons/website/static/src/interactions/dropdown/hoverable_dropdown.js
+++ b/addons/website/static/src/interactions/dropdown/hoverable_dropdown.js
@@ -10,6 +10,11 @@ export class HoverableDropdown extends Interaction {
             "t-on-mouseenter.withTarget": this.onMouseEnter,
             "t-on-mouseleave.withTarget": this.onMouseLeave,
         },
+        ".o_mega_menu": {
+            "t-att-style": () => ({
+                "top": this.isSmall() ? "" : "unset",
+            }),
+        },
         _window: {
             "t-on-resize": this.onResize,
         },


### PR DESCRIPTION
Scenario:

- go on website and edit navbar and set option "Sub Menus" to "On Hover"
- save and edit menu to add a mega menu
- hover on a mega menu

Result: there is a gap and you can't reach the mega menu from the menu
item.

Cause:

The commit https://github.com/odoo/odoo/commit/ddf071267bd8aca341cb9b7481f3153a254212e7 removed the gap for
dropdown menu by removing the CSS that was applying it since it was no
longer necessary since saas-15.5 version.

But the CSS was still necessary for mega menu, that uses this attribute:

data-bs-display="static"

which makes boostrap not apply inline style to position the menu, see
"Responsive Alignment" in the dropdown component documentation:

https://getbootstrap.com/docs/5.0/components/dropdowns/#responsive-alignment

This attribute adds the attribute data-bs-popper="static" on the mega
menu dropdown, which has the CSS (for .dropdown-menu[data-bs-popper]):

top: 100%;
left: 0;
margin-top: .125rem;

The "top: 100%" makes its height be that of the first positionned
ancestor (nav.navbar) which has a padding, so there is a gap between the
drodown menu and the menu item.

Fix: revert https://github.com/odoo/odoo/commit/ddf071267bd8aca341cb9b7481f3153a254212e7 but only apply it
to mega menu dropdown (margin-top: 0px !important is already in CSS for
.o_mega_menu).

opw-[4715301](https://www.odoo.com/web#id=4715301&view_type=form&model=project.task)