### PR TITLE
[REF] web_tour: use step_delay only in debug mode

### DIFF
--- a/addons/web/static/tests/core/macro.test.js
+++ b/addons/web/static/tests/core/macro.test.js
@@ -7,9 +7,8 @@ import { Macro } from "@web/core/macro";
 
 let macro;
 async function waitForMacro() {
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 100; i++) {
         await animationFrame();
-        await advanceTime(265);
         if (macro.isComplete) {
             return;
         }

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -44,9 +44,6 @@ export class TourAutomatic {
                         } else {
                             console.log(step.describeMe);
                         }
-                        // This delay is important for making the current set of tour tests pass.
-                        // IMPROVEMENT: Find a way to remove this delay.
-                        await new Promise((resolve) => requestAnimationFrame(resolve));
                         if (stepDelay > 0) {
                             await hoot.delay(stepDelay);
                         }

--- a/addons/web_tour/static/tests/tour_automatic.test.js
+++ b/addons/web_tour/static/tests/tour_automatic.test.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { afterEach, beforeEach, describe, expect, test } from "@odoo/hoot";
-import { advanceTime, animationFrame, queryFirst } from "@odoo/hoot-dom";
+import { animationFrame, queryFirst } from "@odoo/hoot-dom";
 import { Component, xml } from "@odoo/owl";
 import {
     getService,
@@ -20,9 +20,8 @@ describe.current.tags("desktop");
 const tourRegistry = registry.category("web_tour.tours");
 let macro;
 async function waitForMacro() {
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 100; i++) {
         await animationFrame();
-        await advanceTime(265);
         if (macro.isComplete) {
             return;
         }


### PR DESCRIPTION
In this commit, we move step_delay so that it can only be used in debug mode. So, for step_delay to be effective, the tour must be launched in watch=True or debug=True mode.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
