### PR TITLE
[FIX] website: ensure robots.txt matches domain with punycode support

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -326,6 +326,9 @@ class Website(models.Model):
         configurator_action_todo = self.env.ref('website.website_configurator_todo')
         return configurator_action_todo.action_launch()
 
+    def _idna_url(self, url):
+        return get_base_domain(url.lower(), True).encode('idna').decode('ascii')
+
     def _is_indexable_url(self, url):
         """
         Returns True if the given url has to be indexed by search engines.
@@ -338,7 +341,7 @@ class Website(models.Model):
         :param url: the url to check
         :return: True if the url has to be indexed, False otherwise
         """
-        return get_base_domain(url.lower(), True) == get_base_domain(self.domain.lower(), True)
+        return self._idna_url(url) == self._idna_url(self.domain)
 
     # ----------------------------------------------------------
     # Configurator


### PR DESCRIPTION
When the website domain is defined using punycode (e.g., `xn--ingenieurbro-mlb.localhost`), navigating to the Unicode URL (e.g., `Ingenieurbüro.localhost`) would not reflect the updated `robots.txt`.

Steps to reproduce the issue:

- Navigate to Website > Configuration > Website.
- Set a domain name with punycode (e.g., http://xn--ingenieurbro-mlb.localhost:8069).
- Go to settings and modify the robots.txt file.
- Visit http://Ingenieurbüro.localhost:8069 and notice that the changes are not reflected.

This commit ensures the correct handling of punycode domains so that the robots.txt is properly served, regardless of whether the domain is accessed in Unicode or punycode form.

opw-4641081
