### PR TITLE
[IMP] web: stylized dropdown item on m2o

### DIFF
--- a/addons/account/static/src/components/tax_autocomplete/tax_autocomplete.xml
+++ b/addons/account/static/src/components/tax_autocomplete/tax_autocomplete.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="account.TaxAutoComplete" t-inherit="web.AutoComplete">
-        <xpath expr="//t[@t-esc='option.label']" position="replace">
+        <xpath expr="//t[@t-out='option.label']" position="replace">
             <t t-if="option.tax_scope">
                 <div class="tax_autocomplete_grid">
-                    <div t-esc="option.label"/>
+                    <div t-out="option.label"/>
                     <div t-esc="option.tax_scope" class="text-muted"/>
                 </div>
             </t>
             <t t-else="">
-                <span t-esc="option.label"/>
+                <span t-out="option.label"/>
             </t>
         </xpath>
     </t>

--- a/addons/hr_holidays/static/src/fields/avatar_many2x_autocomplete.xml
+++ b/addons/hr_holidays/static/src/fields/avatar_many2x_autocomplete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="web.Many2ManyTagsAvatarField.option" t-inherit-mode="extension">
-        <xpath expr="//span[@t-esc='autoCompleteItemScope.label']" position="after">
+        <xpath expr="//span[@t-out='autoCompleteItemScope.label']" position="after">
             <span t-if="autoCompleteItemScope.outOfOffice" class="text-warning ms-1 small">
                 <i class="fa fa-plane" role="img"/> <t t-esc="autoCompleteItemScope.outOfOffice"/>
             </span>

--- a/addons/uom/static/src/components/uom_autocomplete/uom_autocomplete.xml
+++ b/addons/uom/static/src/components/uom_autocomplete/uom_autocomplete.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="uom.UomAutoComplete" t-inherit="web.AutoComplete">
-        <xpath expr="//t[@t-esc='option.label']" position="replace">
+        <xpath expr="//t[@t-out='option.label']" position="replace">
             <t t-if="option.relative_info">
                 <div class="uom_autocomplete_grid">
-                    <div t-esc="option.label"/>
+                    <div t-out="option.label"/>
                     <div t-esc="option.relative_info" class="text-muted"/>
                 </div>
             </t>
             <t t-else="">
-                <span t-esc="option.label"/>
+                <span t-out="option.label"/>
             </t>
         </xpath>
     </t>

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -54,7 +54,7 @@ class Base(models.AbstractModel):
     def web_name_search(self, name, specification, domain=None, operator='ilike', limit=100):
         id_name_pairs = self.name_search(name, domain, operator, limit)
         if len(specification) == 1 and 'display_name' in specification:
-            return [{ 'id': id, 'display_name': name } for id, name in id_name_pairs]
+            return [{'id': id, 'display_name': name, '__formatted_display_name': self.with_context(formatted_display_name=True).browse(id).display_name} for id, name in id_name_pairs]
         records = self.browse([id for id, _ in id_name_pairs])
         return records.web_read(specification)
 

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -66,7 +66,7 @@
                                         t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
                                     >
                                         <t t-slot="{{ source.optionSlot }}" option="Object.getPrototypeOf(option)">
-                                            <t t-esc="option.label"/>
+                                            <t t-out="option.label"/>
                                         </t>
                                     </t>
                                 </li>

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -1,4 +1,5 @@
 import { isObject } from "./objects";
+import { markup } from "@odoo/owl";
 
 export const nbsp = "\u00a0";
 
@@ -115,6 +116,37 @@ export function sprintf(s, ...values) {
  */
 export function capitalize(s) {
     return s ? s[0].toUpperCase() + s.slice(1) : "";
+}
+
+/**
+ * Format the text as follow:
+ *      \*\*text\*\* => Put the text in bold.
+ *      --text-- => Put the text in muted.
+ *      \`text\` => Put the text in a rounded badge (bg-primary).
+ *      \<br> => Insert a breakline.
+ *      \<tab> => Insert 4 spaces.
+ *
+ * @param {string} text **will be escaped**
+ * @returns {ReturnType<markup>} the formatted text
+ */
+export function odoomark(text) {
+    const boldEx = /\*\*(.+?)\*\*/g;
+    const textMutedEx = /--(.+?)--/g;
+    const tagEx = /&#x60;(.+?)&#x60;/g;
+    const brEx = /&lt;br&gt;/g;
+    const tabEx = /&lt;tab&gt;/g;
+
+    return markup(
+        escape(text)
+            .replaceAll(boldEx, `<b>$1</b>`)
+            .replaceAll(textMutedEx, `<span class='text-muted'>$1</span>`)
+            .replaceAll(
+                tagEx,
+                `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 text-white bg-primary">$1</span>`
+            )
+            .replaceAll(brEx, `<br/>`)
+            .replaceAll(tabEx, `&nbsp;&nbsp;&nbsp;&nbsp;`)
+        );
 }
 
 /* eslint-disable */

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -34,7 +34,7 @@
         <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
             <img t-if="autoCompleteItemScope.value" class="rounded me-1"
                 t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.value}}/avatar_128"/>
-            <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record) }" t-esc="autoCompleteItemScope.label">
+            <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record) }" t-out="autoCompleteItemScope.label">
                 <t t-out="autoCompleteItemScope.label"/>
             </span>
         </span>

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -47,6 +47,7 @@ import {
     useState,
     useSubEnv,
 } from "@odoo/owl";
+import { odoomark } from "@web/core/utils/strings";
 
 //
 // Commons
@@ -358,11 +359,13 @@ export class Many2XAutocomplete extends Component {
         });
     }
     mapRecordToOption(record) {
+        const label = record.__formatted_display_name || record.display_name;
         return {
             value: record.id,
-            label: record.display_name ? record.display_name.split("\n")[0] : _t("Unnamed"),
+            label: label ? odoomark(label.split("\n")[0]) : _t("Unnamed"),
         };
     }
+
     async loadOptionsSource(request) {
         if (this.lastProm) {
             this.lastProm.abort(false);
@@ -379,7 +382,10 @@ export class Many2XAutocomplete extends Component {
         if (request.length < this.props.searchThreshold) {
             if (!this.props.value) {
                 options.push({
-                    label: this.props.searchThreshold > 1 ? _t("Start typing %s characters", this.props.searchThreshold) : _t("Start typing..."),
+                    label:
+                        this.props.searchThreshold > 1
+                            ? _t("Start typing %s characters", this.props.searchThreshold)
+                            : _t("Start typing..."),
                     classList: "o_m2o_start_typing",
                     unselectable: true,
                 });
@@ -405,12 +411,11 @@ export class Many2XAutocomplete extends Component {
         }
 
         if (request.length) {
-            const slowCreate = () => {
-                return this.openMany2X({
+            const slowCreate = () =>
+                this.openMany2X({
                     context: this.getCreationContext(request),
                     nextRecordsContext: this.props.context,
                 });
-            };
 
             if (this.props.quickCreate) {
                 options.push({
@@ -631,11 +636,11 @@ export class X2ManyFieldDialog extends Component {
                             elementToFocus = this.modalRef.el.querySelector(`#${id}`);
                             if (elementToFocus) {
                                 break;
-                            };
-                        };
-                        elementToFocus = elementToFocus || this.modalRef.el.querySelector(
-                            ".o_field_widget input"
-                        );
+                            }
+                        }
+                        elementToFocus =
+                            elementToFocus ||
+                            this.modalRef.el.querySelector(".o_field_widget input");
                     } else {
                         elementToFocus = this.modalRef.el.querySelector("button.btn-primary");
                     }

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -2448,7 +2448,11 @@ export class Model extends Array {
 
         const idNamePairs = this.name_search(name, domain, operator, limit, kwargs);
         if (Object.keys(specification).length === 1 && "display_name" in specification) {
-            return idNamePairs.map(([id, name]) => ({ id, display_name: name }));
+            return idNamePairs.map(([id, name]) => ({
+                id,
+                display_name: name,
+                __formatted_display_name: name,
+            }));
         }
 
         return this.web_read(

--- a/addons/web/static/tests/core/utils/strings.test.js
+++ b/addons/web/static/tests/core/utils/strings.test.js
@@ -10,6 +10,7 @@ import {
     isNumeric,
     sprintf,
     unaccent,
+    odoomark,
 } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 
@@ -136,4 +137,16 @@ test("isNumeric", () => {
     expect(isNumeric("12.34")).toBe(false);
 
     expect(isNumeric("1234")).toBe(true);
+});
+
+test("odoomark", () => {
+    expect(odoomark("").toString()).toBe("");
+    expect(odoomark("**test**").toString()).toBe("<b>test</b>");
+    expect(odoomark("**test** something else **test**").toString()).toBe("<b>test</b> something else <b>test</b>");
+    expect(odoomark("--test--").toString()).toBe("<span class='text-muted'>test</span>");
+    expect(odoomark("--test-- something else --test--").toString()).toBe("<span class='text-muted'>test</span> something else <span class='text-muted'>test</span>");
+    expect(odoomark("`test`").toString()).toBe(`<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 text-white bg-primary">test</span>`);
+    expect(odoomark("`test` something else `test`").toString()).toBe(`<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 text-white bg-primary">test</span> something else <span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 text-white bg-primary">test</span>`);
+    expect(odoomark("test<tab>test2").toString()).toBe("test&nbsp;&nbsp;&nbsp;&nbsp;test2");
+    expect(odoomark("test<br>test2").toString()).toBe("test<br/>test2");
 });

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -1934,7 +1934,7 @@ export class MockServer {
             Object.keys(kwargs.specification).length === 1 &&
             "display_name" in kwargs.specification
         ) {
-            return idNamePairs.map(([id, name]) => ({ id, display_name: name }));
+            return idNamePairs.map(([id, name]) => ({ id, display_name: name, __formatted_display_name: name }));
         }
         const ids = idNamePairs.map(([id]) => id);
         return this.mockWebRead(modelName, [ids], kwargs);

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -148,8 +148,7 @@ test("Many2ManyTagsField with and without color on desktop", async () => {
     expect("[name=timmy] .o_tag").toHaveCount(0);
     await clickFieldDropdown("timmy");
     expect("[name='timmy'] .o-autocomplete.dropdown li").toHaveCount(3, {
-        message:
-            "autocomplete dropdown should have 3 entries (2 values + 'Search more...')",
+        message: "autocomplete dropdown should have 3 entries (2 values + 'Search more...')",
     });
     await clickFieldDropdownItem("timmy", "gold");
     expect("[name=timmy] .o_tag").toHaveCount(1);
@@ -1632,6 +1631,7 @@ test("Many2ManyTagsField with arch context in form view on desktop", async () =>
             expect.step("name search with context given");
             for (const res of result) {
                 res.display_name += " coucou";
+                res.__formatted_display_name += " coucou";
             }
         }
         return result;
@@ -1696,6 +1696,7 @@ test("Many2ManyTagsField with arch context in list view on desktop", async () =>
             expect.step("name search with context given");
             for (const res of result) {
                 res.display_name += " coucou";
+                res.__formatted_display_name += " coucou";
             }
         }
         return result;

--- a/addons/web/tests/test_web_search_read.py
+++ b/addons/web/tests/test_web_search_read.py
@@ -35,3 +35,8 @@ class TestWebSearchRead(common.TransactionCase):
         self.assert_web_search_read(2, 2, limit=2, count_limit=2, expected_search_count_called=False)
         self.assert_web_search_read(20, 2, limit=2, offset=10, count_limit=20)
         self.assert_web_search_read(12, 2, limit=2, offset=10, count_limit=12, expected_search_count_called=False)
+
+    def test_web_name_search(self):
+        result = self.env["res.partner"].web_name_search("", {"display_name": {}})[0]
+        self.assertTrue("display_name" in result)
+        self.assertTrue("__formatted_display_name" in result)

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -254,9 +254,10 @@ class ResCountryState(models.Model):
         return Domain.FALSE
 
     @api.depends('country_id')
+    @api.depends_context('formatted_display_name')
     def _compute_display_name(self):
-        if self.env.context.get('hide_country_from_state'):
-            return super()._compute_display_name()
-
         for record in self:
-            record.display_name = f"{record.name} ({record.country_id.code})"
+            if self.env.context.get('formatted_display_name'):
+                record.display_name = f"{record.name} <tab> --{record.country_id.code}--"
+            else:
+                record.display_name = f"{record.name} ({record.country_id.code})"

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -987,7 +987,7 @@ class ResPartner(models.Model):
             if partner._context.get('show_vat') and partner.vat:
                 name = f"{name} ‒ {partner.vat}"
             if partner._context.get("formatted_display_name") and (partner.parent_id or partner.company_name):
-                name = f"{partner.name}<tab>--{partner.company_name or partner.parent_id.name}--"
+                name = f"{partner.company_name or partner.parent_id.name}<tab>--{partner.name}--"
 
             partner.display_name = name.strip()
 

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -969,7 +969,7 @@ class ResPartner(models.Model):
     @api.depends('complete_name', 'email', 'vat', 'state_id', 'country_id', 'commercial_company_name')
     @api.depends_context(
         'show_address', 'partner_display_name_hide_company', 'partner_show_db_id', 'address_inline',
-        'show_email', 'show_vat', 'lang',
+        'show_email', 'show_vat', 'lang', 'formatted_display_name'
     )
     def _compute_display_name(self):
         for partner in self:
@@ -986,6 +986,8 @@ class ResPartner(models.Model):
                 name = f"{name} <{partner.email}>"
             if partner._context.get('show_vat') and partner.vat:
                 name = f"{name} ‒ {partner.vat}"
+            if partner._context.get("formatted_display_name") and (partner.parent_id or partner.company_name):
+                name = f"{partner.name}<tab>--{partner.company_name or partner.parent_id.name}--"
 
             partner.display_name = name.strip()
 

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -187,7 +187,7 @@
 
                     <notebook colspan="4">
                         <page string="Contacts" name="contact_addresses" autofocus="autofocus">
-                            <field name="child_ids" mode="kanban" context="{'hide_country_from_state':1, 'default_parent_id': id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_lang': lang, 'default_user_id': user_id, 'default_type': is_company and 'contact' or 'other'}">
+                            <field name="child_ids" mode="kanban" context="{'default_parent_id': id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_lang': lang, 'default_user_id': user_id, 'default_type': is_company and 'contact' or 'other'}">
                                 <kanban color="color">
                                     <field name="color"/>
                                     <field name="type"/>


### PR DESCRIPTION
Now you can use syntaxes in the _compute_display_name when
there is 'name_search_format' in the context. This syntax allow
you to format the text that will be shown in the dropdown-item
of the Many2XAutocomplete.

Here are the different syntaxes:
\*\*text\*\* => Put the text in bold
--text-- => Put the text in muted
\`text\` => Put the text in a rounded badge (bg-primary) 
\<br> => Insert a breakline
\<tab> => Insert 4 spaces

Task-ID: 4610814

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
