### PR TITLE
[FIX] sale: remove catalog tour race conditions

### DIFF
--- a/addons/sale/static/tests/tours/sale_catalog.js
+++ b/addons/sale/static/tests/tours/sale_catalog.js
@@ -45,9 +45,17 @@ registry.category("web_tour.tours").add('sale_catalog', {
             run: 'click',
         },
         {
+            content: "Wait for filtering",
+            trigger: '.o_kanban_renderer:not(:has(.o_kanban_record:contains("AAA Product")))',
+        },
+        {
             content: "Add the product to the SO",
             trigger: '.o_kanban_record:contains("Restricted Product") .fa-shopping-cart',
             run: 'click',
+        },
+        {
+            content: "Wait for product to be added",
+            trigger: '.o_kanban_record:contains("Restricted Product"):not(:has(.fa-shopping-cart))',
         },
         {
             content: "Input a custom quantity",

--- a/addons/sale/tests/test_sale_order_product_catalog.py
+++ b/addons/sale/tests/test_sale_order_product_catalog.py
@@ -22,6 +22,10 @@ class TestSaleOrderProductCatalog(HttpCase):
             'parent_id': self.env.company.id,
         })
         admin.company_id = branch
+        self.env['product.template'].create({
+            'name': "AAA Product",
+            'company_id': admin.company_id.id,
+        })
         self.start_tour(
             '/web#action=sale.action_quotations',
             'sale_catalog',


### PR DESCRIPTION
The test introduced in 5734ba9 opens the product catalog, filters it, then adds a product and updates its quantity. The problem is that when the product is already visible in the catalog (before filtering), the next steps can be triggerred while the filtering is still being processed. Once the filtering is done, the state of the product in the catalog is "reverted" to how it was when the filtering was called. This might be inconsistent with the state expected by the step the tour is currently in.

We can solve this by adding a different product to be filtered out. This allows to add a blocking step that just waits for the catalog not to include the new product.

Fixes runbot errors:
[162099](https://runbot.odoo.com/odoo/error/162099)
[163417](https://runbot.odoo.com/odoo/error/163417)
