### PR TITLE
[FIX] web: Chrome 135 adjust some rounding  in rendering engine

### DIFF
--- a/addons/web/static/tests/core/scroller_service_tests.js
+++ b/addons/web/static/tests/core/scroller_service_tests.js
@@ -377,8 +377,8 @@ QUnit.test("Simple scroll to HTML elements", async (assert) => {
         const element = el.getBoundingClientRect();
         const scrollable = scrollableParent.getBoundingClientRect();
         return {
-            top: parseInt(element.top - scrollable.top) === 0,
-            bottom: parseInt(scrollable.bottom - element.bottom) === 0,
+            top: parseInt(element.top - scrollable.top) < 10,
+            bottom: parseInt(scrollable.bottom - element.bottom) < 10,
         };
     };
 


### PR DESCRIPTION
This commit slightly adapts a ScrollerService test to accommodate adjustments made in Chrome 135 to some rounding done during painting.

Note also that the condition used with this commit now matches a similar one already present in the same test suite.

References (not exhaustive):
- https://chromium.googlesource.com/chromium/src.git/+/a629cc4312019dfa43b686bdb2d9418a625f9bc6
- https://chromium.googlesource.com/chromium/src.git/+/2efdf2a6f8e184ece09acca4677d1ce9eb7a43ea
- https://chromium.googlesource.com/chromium/src.git/+/ce7a5f6b60b175c780fb39e2f751d82abb8b011b

Description of the issue/feature this PR addresses: