### PR TITLE
[FIX] base: generate a unique key on duplication of the view

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -553,7 +553,8 @@ actual arch.
     @api.returns('self', lambda value: value.id)
     def copy(self, default=None):
         self.ensure_one()
-        if self.key and default and 'key' not in default:
+        default = default or {}
+        if self.key and 'key' not in default:
             new_key = self.key + '_%s' % str(uuid.uuid4())[:6]
             default = dict(default or {}, key=new_key)
         return super(View, self).copy(default)


### PR DESCRIPTION
Currently, an error occurs if multiple views share the same key, which can happen when duplicating a view.

**Steps to reproduce:**
- Install the `website` module.
- Navigate to `Settings > Technical > User Interface > Views`.
- Duplicate the **Home** view for **My Website**.
- Open the website home page in **Editor** mode.

**Error:**
`ValueError - Expected singleton: ir.ui.view(1755, 1757, 1758, 1756)`

Here, when `default` is `None` or an empty dictionary, or `key` is already provided, the logic that generates 
a new key is skipped - [1]. As a result, the duplicated view inherits the same key, leading to conflicts.

[1] - https://github.com/odoo/odoo/blob/33b728c5917b06dd8ab46c48b160e3cf24ddc1ba/odoo/addons/base/models/ir_ui_view.py#L554-L559

This commit ensures that `default` is always initialized to a dictionary before checking for 'key'.  If no key is passed, a unique key will be generated and assigned when duplicating a view.

Related Enterprise PR: https://github.com/odoo/enterprise/pull/83491

sentry-6466843507, 6654957361