### PR TITLE
[FIX] point_of_sale: preserve pos category order on refresh

### DIFF
--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.js
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.js
@@ -25,9 +25,9 @@ export class CategorySelector extends Component {
     }
 
     getCategoriesAndSub() {
-        const rootCategories = this.pos.models["pos.category"].filter(
-            (category) => !category.parent_id
-        );
+        const rootCategories = this.pos.models["pos.category"]
+            .filter((category) => !category.parent_id)
+            .sort((a, b) => a.sequence - b.sequence);
         const selected = this.pos.selectedCategory ? [this.pos.selectedCategory] : [];
         const allParents = selected.concat(this.pos.selectedCategory?.allParents || []).reverse();
         return this.getCategoriesList(rootCategories, allParents, 0)


### PR DESCRIPTION
Prior to this commit, refreshing the PoS caused the category order to default to ID-based sorting from IndexedDB. This commit fixes the issue by sorting categories based on their sequence.

opw-4725408

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
