### PR TITLE
[FIX] l10n_hu_edi: prevent error on send & print button

### DIFF
--- a/addons/l10n_hu_edi/data/template_invoice.xml
+++ b/addons/l10n_hu_edi/data/template_invoice.xml
@@ -120,15 +120,17 @@
     </template>
 
     <template id="nav_online_invoice_xml_3_0_tax_number" xmlns:base="http://schemas.nav.gov.hu/OSA/3.0/base">
-        <t t-if="'-' in vat">
-            <base:taxpayerId t-out="vat[:8]"/>
-            <base:vatCode t-out="vat[9:10]"/>
-            <base:countyCode t-out="vat[11:13]"/>
-        </t>
-        <t t-else="else">
-            <base:taxpayerId t-out="vat[:8]"/>
-            <base:vatCode t-out="vat[8:9]"/>
-            <base:countyCode t-out="vat[9:11]"/>
+        <t t-if="vat">
+            <t t-if="'-' in vat">
+                <base:taxpayerId t-out="vat[:8]"/>
+                <base:vatCode t-out="vat[9:10]"/>
+                <base:countyCode t-out="vat[11:13]"/>
+            </t>
+            <t t-else="else">
+                <base:taxpayerId t-out="vat[:8]"/>
+                <base:vatCode t-out="vat[8:9]"/>
+                <base:countyCode t-out="vat[9:11]"/>
+            </t>
         </t>
     </template>
 

--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -25,7 +25,7 @@
                             <span t-else="else" t-out="o.company_id.vat"/>
                         </li>
                         <li t-if="not o.fiscal_position_id.foreign_vat and o.company_id.partner_id.l10n_hu_group_vat">Group Member Tax ID: <span t-field="o.company_id.partner_id.l10n_hu_group_vat"/></li>
-                        <li t-if="o.partner_id.commercial_partner_id.country_id and o.partner_id.commercial_partner_id.country_id.code!='HU'">
+                        <li t-if="o.partner_id.commercial_partner_id.country_id and o.partner_id.commercial_partner_id.country_id.code!='HU' and o.company_id.vat">
                             EU Tax ID: <span t-out="'HU%s' % o.company_id.vat[:8]"/>
                         </li>
                         <li t-if="o.move_type in ['out_invoice', 'out_receipt'] and o.partner_bank_id">Bank Account: <span t-field="o.partner_bank_id.acc_number"/></li>


### PR DESCRIPTION
When vat is unset in Company and user tries to send & print invoice,
a traceback will appear.

Steps to reproduce the error:
- Install ``l10n_hu_edi`` module > Switch to ``HU Company``
- Open ``HU Company`` > Unset vat field > Save
- Go to Invoicing > Configuration > Settings > NAV Credentials > Mode: Demo > Save
- Create a new invoice > Confirm > Send & Print > Send & Print

Traceback:
```
QWebException: Error while render the template
TypeError: argument of type 'bool' is not iterable
Template: ir.ui.view(2872,)
Path: /t/t[1]/base:taxpayerId
Node: <ns0:taxpayerId xmlns:ns0="http://schemas.nav.gov.hu/OSA/3.0/base" t-out="vat[:8]"/>
```

https://github.com/odoo/odoo/blob/33b728c5917b06dd8ab46c48b160e3cf24ddc1ba/addons/l10n_hu_edi/models/res_company.py#L95-L96
For NAV Credentials(Mode: Demo), Credentials are not required.

https://github.com/odoo/odoo/blob/33b728c5917b06dd8ab46c48b160e3cf24ddc1ba/addons/l10n_hu_edi/data/template_invoice.xml#L124-L131
When user unset the vat field , ``vat`` will be False.
It will lead to the above traceback.

sentry-6242690591

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
