### PR TITLE
[IMP] website,website_sale: search bar result template

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
@@ -11,6 +11,7 @@ import { HeaderFontOption } from "./header_font_option";
 import { HeaderTemplateOption } from "./header_template_option";
 import { HeaderIconBackgroundOption } from "./header_icon_background_option";
 import { HeaderTopOptions } from "./header_top_options";
+// import { SearchbarOption } from "../searchbar_option";
 
 const [
     HEADER_TEMPLATE,
@@ -40,11 +41,11 @@ export const basicHeaderOptionSettings = {
     editableOnly: false,
     selector: "#wrapwrap > header",
     groups: ["website.group_website_designer"],
-}
+};
 
 class HeaderOptionPlugin extends Plugin {
     static id = "headerOption";
-    static dependencies = ["customizeWebsite", "menuDataPlugin"];
+    static dependencies = ["customizeWebsite", "menuDataPlugin", "searchbarOption"]; // remove searchbarOption from dependencies
 
     resources = {
         builder_header_middle_buttons: [
@@ -74,8 +75,21 @@ class HeaderOptionPlugin extends Plugin {
                 ...basicHeaderOptionSettings,
                 OptionComponent: HeaderIconBackgroundOption,
             }),
+            // {
+            //     editableOnly: false,
+            //     // selector: "#wrapwrap > header",
+            //     groups: ["website.group_website_designer"],
+            //     OptionComponent: SearchbarOption,
+            //     selector: "#wrapwrap > header .s_searchbar_input", // <-- make sure `.qwerty` matches your <li>
+            //     applyTo: ".search-query",
+            //     props: {
+            //         getOrderByItems: () => this.getResource("searchbar_option_order_by_items"),
+            //         getDisplayItems: () => this.getResource("searchbar_option_display_items"),
+            //         getTemplates: () => this.getResource("searchbar_option_templates"),
+            //     },
+            // },
         ],
     };
-};
+}
 
 registry.category("website-plugins").add(HeaderOptionPlugin.id, HeaderOptionPlugin);

--- a/addons/website/static/src/builder/plugins/options/searchbar_option.js
+++ b/addons/website/static/src/builder/plugins/options/searchbar_option.js
@@ -5,6 +5,7 @@ export class SearchbarOption extends BaseOptionComponent {
     static props = {
         getOrderByItems: Function,
         getDisplayItems: Function,
+        getTemplates: Function,
     };
 
     setup() {
@@ -13,5 +14,6 @@ export class SearchbarOption extends BaseOptionComponent {
 
         this.orderByItems = this.props.getOrderByItems();
         this.displayItems = this.props.getDisplayItems();
+        this.templates = this.props.getTemplates();
     }
 }

--- a/addons/website/static/src/builder/plugins/options/searchbar_option.xml
+++ b/addons/website/static/src/builder/plugins/options/searchbar_option.xml
@@ -24,6 +24,23 @@
         </BuilderSelect>
     </BuilderRow>
 
+    <BuilderRow label.translate="Template">
+        <BuilderSelect id="'template_opt'" dataAttributeAction="'templateId'">
+            <t t-foreach="this.templates" t-as="item" t-key="item_index">
+                <BuilderSelectItem t-if="!item.dependency or this.isActiveItem(item.dependency)"
+                    actionValue="item.templateId"
+                    dataAttributeActionValue="item.templateId"
+                    id="item.id">
+                    <Img src="item.image" alt="item.label"/>
+                </BuilderSelectItem>
+            </t>
+        </BuilderSelect>
+    </BuilderRow>
+
+    <BuilderRow label.translate="Placeholder">
+        <BuilderTextInput id="'placeholder_opt'" action="'setPlaceholder'" />
+    </BuilderRow>
+
     <BuilderRow label.translate="Suggestions">
         <BuilderNumberInput id="'limit_opt'" dataAttributeAction="'limit'" min="0"/>
         <span class="flex-grow-1 w-100">results</span>

--- a/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
@@ -3,25 +3,41 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { SearchbarOption } from "./searchbar_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
-
+import { SNIPPET_SPECIFIC_NEXT } from "@html_builder/utils/option_sequence";
+import { withSequence } from "@html_editor/utils/resource";
 class SearchbarOptionPlugin extends Plugin {
     static id = "searchbarOption";
     resources = {
         builder_options: [
-            {
+            withSequence(SNIPPET_SPECIFIC_NEXT, {
                 OptionComponent: SearchbarOption,
-                selector: ".s_searchbar_input",
+                template: "website.SearchbarOption",
+                selector: "#wrapwrap > header .s_searchbar_input, .s_searchbar_input",
+                title: _t("Search"),
+                editableOnly: false,
                 applyTo: ".search-query",
                 props: {
                     getOrderByItems: () => this.getResource("searchbar_option_order_by_items"),
                     getDisplayItems: () => this.getResource("searchbar_option_display_items"),
+                    getTemplates: () => this.getResource("searchbar_option_templates"),
                 },
-            },
+            }),
+            // {
+            //     OptionComponent: SearchbarOption,
+            //     selector: ".s_searchbar_input",
+            //     applyTo: ".search-query",
+            //     props: {
+            //         getOrderByItems: () => this.getResource("searchbar_option_order_by_items"),
+            //         getDisplayItems: () => this.getResource("searchbar_option_display_items"),
+            //         getTemplates: () => this.getResource("searchbar_option_templates"),
+            //     },
+            // },
         ],
         builder_actions: {
             SetSearchTypeAction,
             SetOrderByAction,
             SetSearchbarStyleAction,
+            SetPlaceholderAction,
             // This resets the data attribute to an empty string on clean.
             // TODO: modify the Python `_search_get_detail()` (grep
             // `with_description = options['displayDescription']`) so we can use
@@ -60,6 +76,18 @@ class SearchbarOptionPlugin extends Plugin {
                 label: _t("Image"),
                 dataAttribute: "displayImage",
                 dependency: "search_all_opt",
+            },
+        ],
+        searchbar_option_templates: [
+            {
+                label: _t("Default Template"),
+                templateId: "website.s_searchbar.autocomplete",
+                image: "/website/static/src/img/snippets_options/searchbar_template_default.svg",
+            },
+            {
+                label: _t("Second Template"),
+                templateId: "website.s_searchbar.autocomplete_second",
+                image: "/website/static/src/img/snippets_options/searchbar_template_second.svg",
             },
         ],
     };
@@ -146,6 +174,17 @@ export class SetSearchbarStyleAction extends BaseSearchBarAction {
         searchButtonEl?.classList.toggle("btn-primary", !isLight);
     }
 }
+class SetPlaceholderAction extends BaseSearchBarAction {
+    static id = "setPlaceholder";
+    getValue({ editingElement }) {
+        return editingElement.getAttribute("placeholder");
+    }
+    apply({ editingElement, value: widgetValue }) {
+        editingElement.setAttribute("placeholder", widgetValue);
+        editingElement.dataset.placeholder = widgetValue;
+    }
+}
+
 // This resets the data attribute to an empty string on clean.
 // TODO: modify the Python `_search_get_detail()` (grep
 // `with_description = options['displayDescription']`) so we can use

--- a/addons/website/static/src/img/snippets_options/searchbar_template_default.svg
+++ b/addons/website/static/src/img/snippets_options/searchbar_template_default.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="100" viewBox="0 0 720 90">
+  <defs>
+    <g id="product_card_layout_v2">
+      <!-- Image Box (Smaller Width) -->
+      <clipPath id="clip-octagon-small">
+        <polygon points="15,0 105,0 120,15 120,105 105,120 15,120 0,105 0,15" />
+      </clipPath>
+      <g id="image-box-small">
+        <rect width="120" height="120" rx="0" fill="#cceeff"/>
+        <g clip-path="url(#clip-octagon-small)">
+          <rect width="120" height="120" fill="#cceeff"/>
+          <circle cx="35" cy="30" r="10" fill="#e6f6fc"/>
+          <circle cx="50" cy="35" r="7" fill="#e6f6fc"/>
+          <path d="M0 80 Q40 75 65 85 Q90 95 120 90 V120 H0 Z" fill="#74a719"/>
+          <path d="M0 70 Q30 68 60 75 Q85 80 120 75 V90 H0 Z" fill="#aad77c"/>
+        </g>
+      </g>
+
+      <!-- Title -->
+      <rect x="140" y="10" rx="10" ry="10" width="400" height="20" fill="#e1f3fd"/>
+
+      <!-- Content Lines -->
+      <rect x="140" y="40" width="460" height="6" rx="3" fill="#a6d9eb"/>
+      <rect x="140" y="50" width="420" height="6" rx="3" fill="#a6d9eb"/>
+      <rect x="140" y="60" width="390" height="6" rx="3" fill="#a6d9eb"/>
+      <rect x="140" y="70" width="440" height="6" rx="3" fill="#a6d9eb"/>
+      <rect x="140" y="80" width="360" height="6" rx="3" fill="#a6d9eb"/>
+
+      <!-- Main Button (bottom-right) -->
+      <rect x="580" y="15" rx="10" ry="10" width="120" height="20" fill="#b7e1f3"/>
+
+      <!-- Little Rectangle (Label/Tag) -->
+      <rect x="140" y="95" rx="5" ry="5" width="60" height="10" fill="#ffcc80"/>
+    </g>
+  </defs>
+
+  <!-- Use the layout -->
+  <use href="#product_card_layout_v2" x="0" y="-10"/>
+</svg>

--- a/addons/website/static/src/img/snippets_options/searchbar_template_second.svg
+++ b/addons/website/static/src/img/snippets_options/searchbar_template_second.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="100" viewBox="0 0 720 90">
+  <defs>
+    <g id="product_card_layout">
+      <!-- Image Box -->
+      <clipPath id="clip-octagon">
+        <polygon points="20,0 100,0 120,20 120,100 100,120 20,120 0,100 0,20" />
+      </clipPath>
+      <g id="image-box">
+        <rect width="120" height="120" rx="0" fill="#cceeff"/>
+        <g clip-path="url(#clip-octagon)">
+          <rect width="120" height="120" fill="#cceeff"/>
+          <circle cx="35" cy="30" r="10" fill="#e6f6fc"/>
+          <circle cx="50" cy="35" r="7" fill="#e6f6fc"/>
+          <path d="M0 80 Q40 75 65 85 Q90 95 120 90 V120 H0 Z" fill="#74a719"/>
+          <path d="M0 70 Q30 68 60 75 Q85 80 120 75 V90 H0 Z" fill="#aad77c"/>
+        </g>
+      </g>
+
+      <!-- Title and Subtitle -->
+      <rect x="140" y="10" rx="10" ry="10" width="560" height="20" fill="#e1f3fd"/>
+      <rect x="140" y="35" rx="10" ry="10" width="360" height="20" fill="#b7e1f3"/>
+
+      <!-- Content Lines -->
+      <rect x="140" y="60" width="540" height="6" rx="3" fill="#a6d9eb"/>
+      <rect x="140" y="70" width="500" height="6" rx="3" fill="#a6d9eb"/>
+      <rect x="140" y="80" width="460" height="6" rx="3" fill="#a6d9eb"/>
+      <rect x="140" y="90" width="420" height="6" rx="3" fill="#a6d9eb"/>
+
+      <!-- Button -->
+      <rect x="600" y="105" rx="10" ry="10" width="120" height="20" fill="#b7e1f3"/>
+    </g>
+  </defs>
+
+  <!-- Use the layout -->
+  <use href="#product_card_layout" x="0" y="-10"/>
+</svg>

--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-<!-- Search Bar autocomplete item -->
-<div t-name="website.s_searchbar.autocomplete"
+<!-- Search Bar autocomplete template -->
+<div t-name="website.s_searchbar.autocomplete_layout"
     class="o_dropdown_menu show position-absolute w-100">
     <t t-if="fuzzySearch and results.length">
         <span class="dropdown-item-text">
@@ -14,42 +14,97 @@
             <span class="text-muted">No results found. Please try another search.</span>
         </span>
     </t>
-    <a t-foreach="results" t-as="result" t-key="result_index"
-        t-att-href="result['website_url']" class="dropdown-item p-2 text-wrap">
-        <div class="d-flex align-items-center flex-wrap o_search_result_item">
-            <t t-if="widget.displayImage">
-                <img t-if="result['image_url']" t-att-src="result['image_url']" class="flex-shrink-0 o_image_64_contain"/>
-                <i t-else="" t-attf-class="o_image_64_contain text-center pt16 fa #{result['_fa']}" style="font-size: 34px;"/>
-            </t>
-            <div class="o_search_result_item_detail px-3">
-                <t t-set="description" t-value="parts['description'] and widget.displayDescription and result['description']"/>
-                <t t-set="extra_link" t-value="parts['extra_link'] and widget.displayExtraLink and result['extra_link_url'] and result['extra_link']"/>
-                <t t-set="extra_link_html" t-value="parts['extra_link'] and widget.displayExtraLink and !result['extra_link_url'] and result['extra_link']"/>
-                <div t-attf-class="h6 fw-bold #{description ? '' : 'mb-0'}" t-out="result['name']"/>
-                <p t-if="description" class="mb-0" t-out="description"/>
-                <button t-if="extra_link" class="extra_link btn btn-link btn-sm" t-att-data-target="result['extra_link_url']" t-out="extra_link"/>
-                <t t-if="extra_link_html" t-out="extra_link_html"/>
-            </div>
-            <div t-if="parts['detail'] and widget.displayDetail" class="flex-shrink-0 ms-auto">
-                <t t-if="result['detail_strike']">
-                    <span class="text-muted text-nowrap" style="text-decoration: line-through;">
-                        <t t-out="result['detail_strike']"/>
-                    </span>
-                    <br/>
-                </t>
-                <b t-if="result['detail']" class="text-nowrap">
-                    <t t-out="result['detail']"/>
-                </b>
-                <t t-if="result['detail_extra']">
-                    <br/>
-                    <span class="text-nowrap" t-out="result['detail_extra']"/>
-                </t>
-            </div>
-        </div>
-    </a>
+    <t t-out="0"/>
     <t t-if="hasMoreResults">
         <button type="submit" class="dropdown-item text-center text-primary-emphasis">All results</button>
     </t>
 </div>
 
+<!-- Search bar default template -->
+<t t-name="website.s_searchbar.autocomplete">
+    <t t-call="website.s_searchbar.autocomplete_layout">
+        <a t-foreach="results" t-as="result" t-key="result_index"
+            t-att-href="result['website_url']" class="dropdown-item p-2 text-wrap">
+            <div class="d-flex align-items-center flex-wrap o_search_result_item">
+                <t t-if="widget.displayImage">
+                    <img t-if="result['image_url']" t-att-src="result['image_url']" class="flex-shrink-0 o_image_64_contain"/>
+                    <p t-elif="result['icon'] and result['icon'] != 'False'" t-attf-class="o_image_64_contain text-center pt16 fa" style="font-size: 34px;"><t t-out="result['icon']"/></p>
+                    <i t-else="" t-attf-class="o_image_64_contain text-center pt16 fa #{result['_fa']}" style="font-size: 34px;"/>
+                </t>
+                <div class="o_search_result_item_detail px-3">
+                    <t t-set="description" t-value="parts['description'] and widget.displayDescription and result['description']"/>
+                    <t t-set="extra_link" t-value="parts['extra_link'] and widget.displayExtraLink and result['extra_link_url'] and result['extra_link']"/>
+                    <t t-set="extra_link_html" t-value="parts['extra_link'] and widget.displayExtraLink and !result['extra_link_url'] and result['extra_link']"/>
+
+                    <div t-attf-class="h6 fw-bold #{description ? '' : 'mb-0'}" t-out="result['name']"/>
+                    <p t-if="description" class="mb-0" t-out="description"/>
+
+                    <!-- Extra items hook -->
+                    <t id="extra_items_hook"/>
+
+                    <button t-if="extra_link" class="extra_link btn btn-link btn-sm" t-att-data-target="result['extra_link_url']" t-out="extra_link"/>
+                    <t t-if="extra_link_html" t-out="extra_link_html"/>
+                </div>
+                <div t-if="parts['detail'] and widget.displayDetail" class="flex-shrink-0 ms-auto">
+                    <span t-if="result['detail_strike']" class="text-muted text-nowrap" style="text-decoration: line-through;">
+                        <t t-out="result['detail_strike']"/>
+                    </span>
+                    <br/>
+                    <b t-if="result['detail']" class="text-nowrap">
+                        <t t-out="result['detail']"/>
+                    </b>
+                    <t t-if="result['detail_extra']">
+                        <br/>
+                        <span class="text-nowrap" t-out="result['detail_extra']"/>
+                    </t>
+                </div>
+            </div>
+        </a>
+    </t>
+</t>
+
+<!-- Search bar second template -->
+<t t-name="website.s_searchbar.autocomplete_second">
+    <t t-call="website.s_searchbar.autocomplete_layout">
+        <a t-foreach="results" t-as="result" t-key="result_index"
+           t-att-href="result['website_url']" class="dropdown-item p-2 text-wrap">
+            <div class="d-flex align-items-start o_search_result_item rounded bg-light border p-2" t-if="widget.displayImage or result['icon']">
+                <div class="flex-shrink-0 me-2">
+                    <img t-if="result['image_url']" t-att-src="result['image_url']" class="flex-shrink-0 o_image_64_contain"/>
+                    <p t-elif="result['icon']" t-attf-class="o_image_64_contain text-center pt16 fa" style="font-size: 34px;"><t t-out="result['icon']"/></p>
+                    <i t-else="" t-attf-class="o_image_64_contain text-center pt16 fa #{result['_fa']}" style="font-size: 34px;"/>
+                </div>
+
+                <div class="flex-grow-1">
+                    <h6 class="fw-bold mb-0 me-2" t-out="result['name']"/>
+                    <t t-set="description"
+                        t-value="parts['description'] and widget.displayDescription and result['description']"/>
+                    <p t-if="description" class="mb-1 small text-muted" t-out="description"/>
+
+                    <t t-set="extra_link" t-value="parts['extra_link'] and widget.displayExtraLink and result['extra_link_url'] and result['extra_link']"/>
+                    <t t-set="extra_link_html" t-value="parts['extra_link'] and widget.displayExtraLink and !result['extra_link_url'] and result['extra_link']"/>
+                    <p t-if="extra_info" class="mb-0 me-2 small" t-out="extra_info"/>
+                    <button t-if="extra_link" class="extra_link btn btn-link btn-sm me-2 small" t-att-data-target="result['extra_link_url']" t-out="extra_link"/>
+                    <span t-if="extra_link_html" class="small ps-0" t-out="extra_link_html"/>
+
+                    <!-- Extra items hook -->
+                    <t id="extra_items_hook"/>
+
+                    <div t-if="parts['detail'] and widget.displayDetail and result['detail_strike']" class="text-nowrap">
+                        <span class="text-muted me-2 small" style="text-decoration: line-through;">
+                            <t t-out="result['detail_strike']"/>
+                        </span>
+                        <b t-if="result['detail']" class="small">
+                            <t t-out="result['detail']"/>
+                        </b>
+                        <span t-if="result['detail_extra']" class="text-muted small">
+                            <br/>
+                            <t t-out="result['detail_extra']"/>
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </a>
+    </t>
+</t>
 </templates>

--- a/addons/website/static/src/snippets/s_searchbar/search_bar.edit.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.edit.js
@@ -1,0 +1,211 @@
+import { SearchBar } from "@website/snippets/s_searchbar/search_bar";
+import { registry } from "@web/core/registry";
+import { markup } from "@odoo/owl";
+import { MacroMutationObserver } from "@web/core/macro";
+
+const SearchBarEdit = (I) =>
+    class extends I {
+        dynamicContent = {
+            ...this.dynamicContent,
+            _root: {
+                ...this.dynamicContent._root,
+                "t-on-click": this.debounced(this.onClick, 100),
+            },
+        };
+        start() {
+            super.start();
+            this.inputEl = this.el.querySelector(".search-query");
+            this.isDropdownVisible = false;
+            this.websiteEditService = this.services.website_edit;
+            this.observedState = {
+                templateId: this.inputEl.dataset.templateId,
+                displayDescription: this.inputEl.dataset.displayDescription,
+                displayImage: this.inputEl.dataset.displayImage,
+                displayExtraLink: this.inputEl.dataset.displayExtraLink,
+                displayDetail: this.inputEl.dataset.displayDetail,
+            };
+        }
+        temp() {
+            this.templateObserver = new MacroMutationObserver(() => {
+                const newState = {
+                    templateId: this.inputEl.dataset.templateId,
+                    displayDescription: this.inputEl.dataset.displayDescription,
+                    displayImage: this.inputEl.dataset.displayImage,
+                    displayExtraLink: this.inputEl.dataset.displayExtraLink,
+                    displayDetail: this.inputEl.dataset.displayDetail,
+                };
+
+                const hasChanged = Object.keys(newState).some(
+                    (key) => newState[key] !== this.observedState[key]
+                );
+
+                if (hasChanged && this.isDropdownVisible) {
+                    this.observedState = newState;
+                    this.render();
+                }
+            });
+        }
+        onClick() {
+            this.websiteEditService.callShared("history", "ignoreDOMMutations", () => {
+                if (!this.isDropdownVisible) {
+                    this.render();
+                }
+                if (this.templateObserver) {
+                    this.templateObserver.disconnect();
+                    this.templateObserver = null;
+                }
+                this.temp();
+
+                this.observedState = {
+                    templateId: this.inputEl.dataset.templateId,
+                    displayDescription: this.inputEl.dataset.displayDescription,
+                    displayImage: this.inputEl.dataset.displayImage,
+                    displayExtraLink: this.inputEl.dataset.displayExtraLink,
+                    displayDetail: this.inputEl.dataset.displayDetail,
+                };
+
+                this.templateObserver.observe(this.inputEl, {
+                    attributes: true,
+                    attributeFilter: [
+                        "data-template-id",
+                        "data-display-description",
+                        "data-display-image",
+                        "data-display-extra-link",
+                        "data-display-detail",
+                    ],
+                });
+                this.inputEl = this.el.querySelector(".search-query");
+
+                // Bind the document click handler
+                this.onDocumentClick = this.handleDocumentClick.bind(this);
+                window.addEventListener("click", this.onDocumentClick);
+            });
+        }
+        handleDocumentClick(ev) {
+            if (this.isDropdownVisible) {
+                const clickedInside = this.el.contains(ev.target);
+                if (!clickedInside) {
+                    this.hideDropdown();
+                }
+            }
+        }
+        hideDropdown() {
+            if (this.menuEl) {
+                this.menuEl.remove();
+                this.menuEl = null;
+            }
+            if (this.templateObserver) {
+                this.templateObserver.disconnect();
+                this.templateObserver = null;
+            }
+            this.isDropdownVisible = false;
+            window.removeEventListener("click", this.onDocumentClick);
+        }
+        getResults(displayImage) {
+            return [
+                {
+                    attributes: "AA: Wooden",
+                    barcode: "1111225331",
+                    colors: "Red",
+                    default_code: "None",
+                    description: "Description",
+                    detail: markup("$ 252.0"),
+                    detail_strike: markup("$ 280.0"),
+                    extra_link: "Category",
+                    image_url: displayImage === "true",
+                    name: markup('<span class="text-primary-emphasis">Dum</span><span>my</span>'),
+                    "product_variant_ids.default_code": "None",
+                    rating: "3",
+                    website_url: "#",
+                    _fa: displayImage === "true",
+                },
+            ];
+        }
+
+        getParts({ displayDescription, displayImage, displayExtraLink, displayDetail }) {
+            return {
+                attributes: true,
+                barcode: true,
+                body: true,
+                colors: true,
+                default_code: true,
+                description: displayDescription === "true",
+                detail: displayDetail === "true",
+                detail_strike: true,
+                extra_link: displayExtraLink === "true",
+                icon: displayImage === "true",
+                image_url: displayImage === "true",
+                name: true,
+                "product_variant_ids.default_code": true,
+                rating: true,
+                website_url: true,
+            };
+        }
+
+        getWidgetConfig() {
+            return {
+                allowFuzzy: true,
+                displayDescription: "true",
+                displayDetail: "true",
+                displayExtraLink: "true",
+                displayImage: "true",
+                order: "name asc",
+            };
+        }
+        render() {
+            this.websiteEditService.callShared("history", "ignoreDOMMutations", () => {
+                if (this.menuEl) {
+                    this.menuEl.remove();
+                    this.menuEl = null;
+                }
+                if (document.querySelector(".o_dropdown_menu")) {
+                    document.querySelector(".o_dropdown_menu").remove();
+                }
+                const {
+                    templateId,
+                    displayDescription,
+                    displayImage,
+                    displayExtraLink,
+                    displayDetail,
+                } = this.observedState;
+                if (!templateId) {
+                    return;
+                }
+                this.menuEl = this.renderAt(
+                    templateId,
+                    {
+                        results: this.getResults(displayImage),
+                        parts: this.getParts({
+                            displayDescription,
+                            displayImage,
+                            displayExtraLink,
+                            displayDetail,
+                        }),
+                        hasMoreResults: false,
+                        search: "war",
+                        fuzzySearch: false,
+                        widget: this.getWidgetConfig(),
+                    },
+                    this.el
+                )[0];
+                this.isDropdownVisible = true;
+            });
+        }
+        destroy() {
+            if (this.menuEl) {
+                this.menuEl.remove();
+                this.menuEl = null;
+            }
+            if (this.templateObserver) {
+                this.templateObserver.disconnect();
+                this.templateObserver = null;
+            }
+            this.isDropdownVisible = false;
+            window.removeEventListener("click", this.onDocumentClick);
+        }
+    };
+
+registry.category("public.interactions.edit").add("website.search_bar", {
+    Interaction: SearchBar,
+    mixin: SearchBarEdit,
+});

--- a/addons/website/static/src/snippets/s_searchbar/search_bar.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.js
@@ -30,7 +30,9 @@ export class SearchBar extends Interaction {
         this.inputEl = this.el.querySelector(".search-query");
         this.menuEl = null;
         this.searchType = this.inputEl.dataset.searchType;
+        this.template = this.inputEl.dataset.templateId || "website.s_searchbar.autocomplete";
         const orderByEl = this.el.querySelector(".o_search_order_by");
+        this.totalSearchCountEl = this.el.querySelector(".o_total_search_count");
         const form = orderByEl.closest("form");
         this.order = orderByEl.value;
         this.limit = parseInt(this.inputEl.dataset.limit) || 5;
@@ -83,6 +85,8 @@ export class SearchBar extends Interaction {
     }
 
     destroy() {
+        this.inputEl.value = "";
+        this.totalSearchCountEl.textContent = "";
         this.render(null);
     }
 
@@ -115,8 +119,13 @@ export class SearchBar extends Interaction {
         }
         const prevMenuEl = this.menuEl;
         if (res && this.limit) {
+            if (this.totalSearchCountEl) {
+                this.totalSearchCountEl.textContent = `(${res["results_count"]} result${
+                    res["results_count"] > 1 ? "s)" : ")"
+                }`;
+            }
             const results = res["results"];
-            let template = "website.s_searchbar.autocomplete";
+            let template = this.template;
             const candidate = template + "." + this.searchType;
             if (getTemplate(candidate)) {
                 template = candidate;
@@ -146,6 +155,9 @@ export class SearchBar extends Interaction {
     }
 
     async onInput() {
+        if (!this.inputEl.value.trim().length) {
+            this.totalSearchCountEl.textContent = "";
+        }
         if (!this.limit) {
             return;
         }
@@ -159,6 +171,8 @@ export class SearchBar extends Interaction {
 
     onFocusOut() {
         if (!this.linkHasFocus && document.activeElement?.closest(".o_searchbar_form") !== this.el) {
+            this.totalSearchCountEl.textContent = "";
+            this.inputEl.value = "";
             this.render();
         }
     }
@@ -169,6 +183,7 @@ export class SearchBar extends Interaction {
     onKeydown(ev) {
         switch (ev.key) {
             case "Escape":
+                this.totalSearchCountEl.textContent = "";
                 this.render();
                 break;
             case "ArrowUp":

--- a/addons/website/static/src/snippets/s_searchbar/search_bar_results.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar_results.js
@@ -139,3 +139,7 @@ export class SearchBarResults extends Interaction {
 registry
     .category("public.interactions")
     .add("website.search_bar_results", SearchBarResults);
+
+registry.category("public.interactions.edit").add("website.search_bar_results", {
+    Interaction: SearchBarResults,
+});

--- a/addons/website/static/tests/interactions/snippets/search_bar.edit.test.js
+++ b/addons/website/static/tests/interactions/snippets/search_bar.edit.test.js
@@ -1,0 +1,45 @@
+import { queryOne, click, press } from "@odoo/hoot-dom";
+import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
+import { switchToEditMode } from "../../helpers";
+import { describe, expect, test } from "@odoo/hoot";
+
+setupInteractionWhiteList("website.search_bar");
+describe.current.tags("interaction_dev");
+
+const searchTemplate = /* html */ `
+    <form method="get" class="o_searchbar_form s_searchbar_input" action="/website/search" data-snippet="s_searchbar_input">
+        <div role="search" class="input-group input-group-lg">
+            <input type="search" name="search" class="search-query form-control oe_search_box o_translatable_attribute" placeholder="Search..."
+                    data-search-type="test"
+                    data-limit="3"
+                    data-display-image="false"
+                    data-display-description="false"
+                    data-display-extra-link="true"
+                    data-display-detail="false"
+                    data-order-by="name asc"
+                    autocomplete="off"/>
+                    <button type="submit" aria-label="Search" title="Search" class="btn oe_search_button border border-start-0 px-4 bg-o-color-4">
+                <span class="o_total_search_count"></span>
+                <i class="oi oi-search"></i>
+            </button>
+        </div>
+        <input name="order" type="hidden" class="o_search_order_by" value="test desc"/>
+    </form>
+`;
+
+test("searchbar placeholder can be customized", async () => {
+    const { core } = await startInteractions(searchTemplate, {
+        waitForStart: true,
+        editMode: true,
+    });
+    await switchToEditMode(core);
+    expect(core.interactions).toHaveLength(1);
+    const inputEl = queryOne(".search-query");
+    await click(inputEl);
+    await press("x");
+});
+
+// test("searchbar placeholder can be customized", async () => {
+//     await setupWebsiteBuilderWithSnippet("s_searchbar_input");
+//     debugger;
+// })

--- a/addons/website/static/tests/interactions/snippets/search_bar.test.js
+++ b/addons/website/static/tests/interactions/snippets/search_bar.test.js
@@ -25,7 +25,8 @@ const searchTemplate = /* html */ `
                     data-display-detail="false"
                     data-order-by="name asc"
                     autocomplete="off"/>
-            <button type="submit" aria-label="Search" title="Search" class="btn oe_search_button border border-start-0 px-4 bg-o-color-4">
+                    <button type="submit" aria-label="Search" title="Search" class="btn oe_search_button border border-start-0 px-4 bg-o-color-4">
+                <span class="o_total_search_count"></span>
                 <i class="oi oi-search"></i>
             </button>
         </div>
@@ -75,6 +76,7 @@ function supportAutocomplete() {
 test("searchbar triggers a search when text is entered", async () => {
     supportAutocomplete();
     const { core } = await startInteractions(searchTemplate);
+    const totalSearchCountEl = queryOne(".o_total_search_count");
     expect(core.interactions).toHaveLength(1);
     await click("form input[type=search]");
     await press("x");
@@ -84,12 +86,14 @@ test("searchbar triggers a search when text is entered", async () => {
     await press("z");
     await advanceTime(400);
     expect(queryAll("form .o_search_result_item")).toHaveLength(3);
+    expect(totalSearchCountEl).toHaveText("(3 results)");
 });
 
 test("searchbar selects first result on cursor down", async () => {
     supportAutocomplete();
     await startInteractions(searchTemplate);
     const inputEl = queryOne("form input[type=search]");
+    const totalSearchCountEl = queryOne(".o_total_search_count");
     await click(inputEl);
     await press("x");
     await press("y");
@@ -97,6 +101,7 @@ test("searchbar selects first result on cursor down", async () => {
     await advanceTime(400);
     const resultEls = queryAll("form a:has(.o_search_result_item)");
     expect(resultEls).toHaveLength(3);
+    expect(totalSearchCountEl).toHaveText("(3 results)");
     expect(document.activeElement).toBe(inputEl);
     await press("down");
     expect(document.activeElement).toBe(resultEls[0]);
@@ -106,6 +111,7 @@ test("searchbar selects last result on cursor up", async () => {
     supportAutocomplete();
     await startInteractions(searchTemplate);
     const inputEl = queryOne("form input[type=search]");
+    const totalSearchCountEl = queryOne(".o_total_search_count");
     await click(inputEl);
     await press("x");
     await press("y");
@@ -113,6 +119,7 @@ test("searchbar selects last result on cursor up", async () => {
     await advanceTime(400);
     const resultEls = queryAll("form a:has(.o_search_result_item)");
     expect(resultEls).toHaveLength(3);
+    expect(totalSearchCountEl).toHaveText("(3 results)");
     expect(document.activeElement).toBe(inputEl);
     await press("up");
     expect(document.activeElement).toBe(resultEls[2]);
@@ -121,12 +128,15 @@ test("searchbar selects last result on cursor up", async () => {
 test("searchbar removes results on escape", async () => {
     supportAutocomplete();
     await startInteractions(searchTemplate);
+    const totalSearchCountEl = queryOne(".o_total_search_count");
     await click("form input[type=search]");
     await press("x");
     await press("y");
     await press("z");
     await advanceTime(400);
     expect(queryAll("form a:has(.o_search_result_item)")).toHaveLength(3);
+    expect(totalSearchCountEl).toHaveText("(3 results)");
     await press("escape");
     expect(queryAll("form a:has(.o_search_result_item)")).toHaveLength(0);
+    expect(totalSearchCountEl).toHaveText("");
 });

--- a/addons/website/static/tests/tours/website_searchbar_template_option.js
+++ b/addons/website/static/tests/tours/website_searchbar_template_option.js
@@ -1,0 +1,64 @@
+import {
+    changeOption,
+    changeOptionInPopover,
+    clickOnSnippet,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "website_searchbar_template_option",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({
+            id: "s_searchbar_input",
+            name: "Search",
+        }),
+        {
+            content: "Check default template id",
+            trigger:
+                ":iframe input[type='search'][data-template-id='website.s_searchbar.autocomplete']",
+        },
+        ...clickOnSnippet({ id: "s_searchbar_input", name: "Search" }),
+        ...changeOptionInPopover("Search", "Search within", "Everything"),
+        {
+            content: "Limit search to 'Knowledge Articles'",
+            trigger: ':iframe .s_searchbar_input[action="/website/search"]',
+        },
+        changeOption("Search", "[id='template_opt']"),
+        {
+            trigger: "[data-action-value='website.s_searchbar.autocomplete_second']",
+            run: "hover",
+        },
+        {
+            trigger: ":iframe input[data-template-id='website.s_searchbar.autocomplete_second']",
+        },
+        {
+            content: "Select second template option",
+            trigger: "div[data-action-value='website.s_searchbar.autocomplete_second']",
+            run: "click",
+        },
+        {
+            content: "Check second template id",
+            trigger:
+                ":iframe input[type='search'][data-template-id='website.s_searchbar.autocomplete_second']",
+        },
+        changeOption("Search", "[data-action-param='displayDescription']"),
+        {
+            content: "Check second template id",
+            trigger: ":iframe .o_search_result_item:not(:contains(Description))",
+        },
+        {
+            content: "Set placeholder",
+            trigger: "[data-action-id='setPlaceholder'] input",
+            run: "edit Hello",
+        },
+        {
+            content: "Check placeholder value",
+            trigger: ":iframe input[placeholder='Hello']",
+        },
+    ]
+);

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -40,3 +40,4 @@ from . import test_website_reset_password
 from . import test_website_visitor
 from . import test_website_technical_page
 from . import test_website_website_builder_assets_bundle
+from . import test_website_sale_searchbar_template_option

--- a/addons/website/tests/test_website_sale_searchbar_template_option.py
+++ b/addons/website/tests/test_website_sale_searchbar_template_option.py
@@ -1,0 +1,11 @@
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleSearchbarTemplateOptions(HttpCase):
+    def test_website_searchbar_template_option(self):
+        self.start_tour(
+            self.env["website"].get_client_action_url("/"),
+            "website_searchbar_template_option",
+            login="admin",
+        )

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -3013,8 +3013,9 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
 <template id="website_search_box" name="Website Searchbox">
     <div t-attf-class="input-group #{_classes}" role="search">
         <t t-set="search_placeholder">Search...</t>
-        <input type="search" name="search" t-att-class="'search-query form-control oe_search_box %s %s' % (_input_classes or '', '' if default_style else 'border-0 bg-light')" t-att-placeholder="placeholder if placeholder else search_placeholder" t-att-value="search"/>
+        <input type="search" name="search" t-att-class="'search-query form-control oe_search_box %s %s' % (_input_classes or '', '' if default_style else 'border-0 bg-light')" t-att-placeholder="placeholder if placeholder else search_placeholder" t-att-value="search" t-att-data-placeholder="placeholder" t-att-data-template-id="'website.s_searchbar.autocomplete'"/>
         <button type="submit" t-att-class="'btn oe_search_button %s' % (_submit_classes or ('btn-primary' if default_style else 'btn-light'))" aria-label="Search" title="Search">
+            <span class="o_total_search_count"></span>
             <i class="oi oi-search"/>
             <span t-if="search" class="oe_search_found">
                 <small>(<t t-out="search_count or 0"/> found)</small>

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -91,6 +91,7 @@
         'web.assets_frontend': [
             'website_sale/static/src/interactions/**/*',
             'website_sale/static/src/snippets/**/*.js',
+            'website_sale/static/src/snippets/s_searchbar/000.xml',
             'website_sale/static/src/js/tours/tour_utils.js',
             'website_sale/static/src/scss/product_tile.scss',
             'website_sale/static/src/scss/website_sale.scss',

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -42,6 +42,14 @@ class ProductTemplate(models.Model):
     _mail_post_access = 'read'
     _check_company_auto = True
 
+    rating_ids = fields.One2many(
+        comodel_name='rating.rating',
+        inverse_name='res_id',
+        domain=lambda self: [('res_model', '=', 'product.template')],
+        string='Ratings',
+        groups="base.group_user,base.group_portal,base.group_public",  # ← Make it readable by portal/public
+    )
+
     #=== DEFAULT METHODS ===#
 
     @api.model
@@ -871,13 +879,17 @@ class ProductTemplate(models.Model):
             domains.append([('list_price', '<=', max_price)])
         if attribute_value_dict:
             domains.extend(self._get_attribute_value_domain(attribute_value_dict))
-        search_fields = ['name', 'default_code', 'variants_default_code']
-        fetch_fields = ['id', 'name', 'website_url']
+        search_fields = ['name', 'default_code', 'variants_default_code', 'product_variant_ids.default_code', 'product_variant_ids.barcode', 'attribute_line_ids.attribute_id.name', 'attribute_line_ids.value_ids.name']
+        fetch_fields = ['id', 'name', 'website_url', 'product_variant_id', 'rating_ids', 'attribute_line_ids']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'default_code': {'name': 'default_code', 'type': 'text', 'match': True},
             'product_variant_ids.default_code': {'name': 'product_variant_ids.default_code', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
+            'rating': {'name': 'rating', 'match': False, 'skip_markup': True},
+            'barcode': {'name': 'barcode', 'type': 'text', 'match': True, 'truncate': False},
+            'attributes': {'name': 'attributes', 'type': 'text', 'match': True},
+            'colors': {'name': 'colors', 'type': 'text', 'match': False, 'skip_markup': True, 'truncate': False},
         }
         if with_image:
             mapping['image_url'] = {'name': 'image_url', 'type': 'html'}
@@ -889,10 +901,12 @@ class ProductTemplate(models.Model):
             fetch_fields.append('description_sale')
             mapping['description'] = {'name': 'description_sale', 'type': 'text', 'match': True}
         if with_price:
-            mapping['detail'] = {'name': 'price', 'type': 'html', 'display_currency': options['display_currency']}
-            mapping['detail_strike'] = {'name': 'list_price', 'type': 'html', 'display_currency': options['display_currency']}
+            search_fields.append('list_price')
+            mapping['detail'] = {'name': 'price', 'type': 'text', 'match': True, 'display_currency': options['display_currency']}
+            mapping['detail_strike'] = {'name': 'list_price', 'type': 'text', 'match': False, 'display_currency': options['display_currency']}
         if with_category:
-            mapping['extra_link'] = {'name': 'category', 'type': 'html'}
+            mapping['extra_link'] = {'name': 'category', 'type': 'text', 'match': True}
+
         return {
             'model': 'product.template',
             'base_domain': domains,
@@ -903,51 +917,165 @@ class ProductTemplate(models.Model):
         }
 
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
+        """
+        Constructs and returns enriched search result entries for product templates,
+        based on search term relevance and configuration.
+
+        This method processes product templates and enriches each search result with
+        structured data such as title, price, image, rating, barcode, attributes,
+        color swatches, and public categories, depending on the context and the fields requested.
+
+        The method also identifies which part of the product data best matches the user's
+        search term and sets that field's content, while defaulting others to empty to
+        reduce clutter and noise in the result set. Rating is always computed and included.
+
+        :param fetch_fields: list of fields fetched for each product
+        :param mapping: dictionary specifying which additional fields to render (image, detail, etc.)
+        :param icon: icon to associate with results (unused in this method, passed through)
+        :param limit: maximum number of search results to return
+
+        :return: a list of dictionaries, each representing a product template with
+                relevant metadata and the best-matching content populated
+        """
+        term = (request.params.get('term') or "").strip().lower()
+
         with_image = 'image_url' in mapping
         with_category = 'extra_link' in mapping
         with_price = 'detail' in mapping
+        with_rating = 'rating_ids' in fetch_fields
+        with_attributes = 'attribute_line_ids' in fetch_fields
+        with_barcode = 'product_variant_ids.barcode' in fetch_fields or 'barcode' in mapping
+
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
         current_website = self.env['website'].get_current_website()
+
         for product, data in zip(self, results_data):
-            categ_ids = product.public_categ_ids.filtered(lambda c: not c.website_id or c.website_id == current_website)
+            data['title'] = product.name or ''
             if with_price:
                 combination_info = product._get_combination_info(only_template=True)
-                data['price'], list_price = self._search_render_results_prices(
-                    mapping, combination_info
-                )
-                if list_price:
-                    data['list_price'] = list_price
+                data['price'], list_price = self._search_render_results_prices(mapping, combination_info)
+                data['list_price'] = list_price or ''
 
             if with_image:
-                data['image_url'] = '/web/image/product.template/%s/image_128' % data['id']
-            if with_category and categ_ids:
-                data['category'] = self.env['ir.ui.view'].sudo()._render_template(
-                    "website_sale.product_category_extra_link",
-                    {
-                        'categories': categ_ids,
-                        'slug': self.env['ir.http']._slug,
-                        'shop_path': SHOP_PATH,
-                    }
-                )
+                data['image_url'] = f'/web/image/product.template/{product.id}/image_128'
+
+            # Always compute and pass rating
+            data['rating'] = ''
+            if with_rating and product.rating_ids:
+                data['rating'] = sum(product.rating_ids.mapped('rating')) / len(product.rating_ids)
+
+            # Default all optional fields to ''
+            data.update({
+                'description_sale': '',
+                'barcode': '',
+                'attributes': '',
+                'colors': '',
+                'category': ''
+            })
+
+            matched_group = None
+
+            for group in ["title", "description", "rating", "barcode", "attributes", "category"]:
+                match group:
+                    case "title":
+                        if term in (product.name or "").lower():
+                            matched_group = "title"
+                    case "description":
+                        desc = product.description_sale or ""
+                        if term in desc.lower():
+                            data["description_sale"] = desc
+                            matched_group = "description_sale"
+                    case "rating":
+                        if data["rating"] and term in str(data["rating"]):
+                            matched_group = "rating"
+                    case "barcode":
+                        if with_barcode:
+                            barcode = product.barcode or product.product_variant_id.barcode or ""
+                            if term in barcode.lower():
+                                data["barcode"] = barcode
+                                matched_group = "barcode"
+                    case "attributes":
+                        if with_attributes and product.attribute_line_ids:
+                            attr_blocks, color_blocks = [], []
+                            matched_attr, matched_color = False, False
+
+                            for line in product.attribute_line_ids:
+                                attr_name = line.attribute_id.name
+                                is_color = "color" in attr_name.lower()
+                                values = []
+
+                                for val in line.value_ids:
+                                    val_name = val.name.lower()
+
+                                    if not matched_attr and (term in attr_name.lower() or term in val_name):
+                                        if not is_color:
+                                            matched_attr = True
+
+                                    if not is_color:
+                                        values.append(val.name)
+
+                                    if is_color and term in val_name:
+                                        matched_color = True
+
+                                    if is_color:
+                                        if val.html_color:
+                                            color_blocks.append({"type": "color", "value": val.html_color})
+                                        elif val.image:
+                                            color_blocks.append({"type": "image", "value": f"/web/image/product.attribute.value/{val.id}/image"})
+
+                                if matched_attr and values:
+                                    attr_blocks.append(f"{attr_name}: {', '.join(values)}")
+
+                            if matched_attr:
+                                data["attributes"] = " | ".join(attr_blocks)
+                                matched_group = "attribute"
+                            elif matched_color:
+                                data["colors"] = color_blocks
+                                matched_group = "color"
+                    case "category":
+                        if with_category:
+                            categs = product.public_categ_ids.filtered(
+                                lambda c: not c.website_id or c.website_id == current_website
+                            )
+                            if any(term in cat.name.lower() for cat in categs):
+                                data["category"] = ", ".join(categs.mapped("name"))
+                                matched_group = "category"
+
+                if matched_group:
+                    break
+
+            # Clear description if not matched
+            if matched_group != 'description_sale':
+                data['description_sale'] = ''
         return results_data
 
     def _search_render_results_prices(self, mapping, combination_info):
+        """
+        This method avoids displaying prices when zero-price sales are disabled and ensures
+        proper formatting based on the display currency. It also handles regular prices,
+        discounted prices, and comparative list prices (e.g., crossed-out prices in case of promotions).
+
+        :param mapping: dictionary containing display settings, including display_currency
+        :param combination_info: dictionary with computed pricing data from `_get_combination_info`
+
+        :return: tuple of (formatted price, formatted list_price) or (None, None) if display is not allowed
+        """
+
         if combination_info.get('prevent_zero_price_sale'):
             return None, None
 
-        monetary_options = {'display_currency': mapping['detail']['display_currency']}
-        price = self.env['ir.qweb.field.monetary'].value_to_html(
-            combination_info['price'], monetary_options
-        )
+        currency = mapping['detail']['display_currency']
+
+        def _format_price(amount):
+            return f"{currency.symbol} {amount}"
+
+        price = _format_price(combination_info['price'])
         list_price = None
-        if combination_info['has_discounted_price']:
-            list_price = self.env['ir.qweb.field.monetary'].value_to_html(
-                combination_info['list_price'], monetary_options
-            )
+
         if combination_info.get('compare_list_price'):
-            list_price = self.env['ir.qweb.field.monetary'].value_to_html(
-                combination_info['compare_list_price'], monetary_options
-            )
+            list_price = _format_price(combination_info['compare_list_price'])
+        elif combination_info.get('has_discounted_price'):
+            list_price = _format_price(combination_info['list_price'])
 
         return price, list_price
 

--- a/addons/website_sale/static/src/interactions/search_bar.js
+++ b/addons/website_sale/static/src/interactions/search_bar.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { SearchBar } from "@website/snippets/s_searchbar/search_bar";
+
+// Fetch the original getFieldsNames method from SearchBar
+const originalGetFieldsNames = SearchBar.prototype.getFieldsNames;
+
+patch(SearchBar.prototype, {
+    getFieldsNames() {
+        const baseFields = originalGetFieldsNames ? originalGetFieldsNames.call(this) : [];
+        return [...new Set([...baseFields, "barcode", "attributes"])];
+    },
+});

--- a/addons/website_sale/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website_sale/static/src/snippets/s_searchbar/000.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+    <t t-inherit="website.s_searchbar.autocomplete" t-name="website_searchbar_autocomplete_extension" t-inherit-mode="extension">
+        <xpath expr="//t[@id='extra_items_hook']" position="replace">
+            <t t-if="result['rating']">
+                <t t-call="portal_rating.rating_stars_static">
+                    <t t-set="val" t-value="result['rating']"/>
+                    <t t-set="inline_mode" t-value="True"/>
+                </t>
+            </t>
+            <div class="d-flex align-items-center flex-wrap mt-1" t-if="result['colors']">
+                <t t-foreach="result['colors']" t-as="color" t-key="color['value']">
+                    <t t-if="color['type'] == 'color'">
+                        <span class="color_preview border" t-attf-style="display:inline-block; width:12px; height:12px; border-radius:50%; background-color:{{color['value']}}; margin-right:4px;"></span>
+                    </t>
+                    <t t-if="color['type'] == 'image'">
+                        <img t-att-src="color['value']" style="width:12px; height:12px; border-radius:50%; margin-right:4px; object-fit:cover;"/>
+                    </t>
+                </t>
+            </div>
+            <div t-if="result['barcode']" class="mb-0">
+                Barcode: <t t-out="result['barcode']"/>
+            </div>
+            <div t-if="result['category']" class="mb-0">
+                Category: <t t-out="result['category']"/>
+            </div>
+            <div t-if="result['attributes']" class="mb-0">
+                <t t-out="result['attributes']"/>
+            </div>
+        </xpath>
+    </t>
+
+    <t t-inherit="website.s_searchbar.autocomplete_second" t-name="website_searchbar_autocomplete_extension" t-inherit-mode="extension">
+        <xpath expr="//t[@id='extra_items_hook']" position="replace">
+            <t t-if="result['rating']">
+                        <t t-call="portal_rating.rating_stars_static">
+                            <t t-set="val" t-value="result['rating']"/>
+                            <t t-set="inline_mode" t-value="True"/>
+                        </t>
+                    </t>
+                <t t-if="result['colors']">
+                    <t t-foreach="result['colors']" t-as="color" t-key="color['value']">
+                        <t t-if="color['type'] == 'color'">
+                            <span class="color_preview border" t-attf-style="display:inline-block; width:12px; height:12px; border-radius:50%; background-color:{{color['value']}}; margin-right:4px;"></span>
+                        </t>
+                        <t t-if="color['type'] == 'image'">
+                            <img t-att-src="color['value']" style="width:12px; height:12px; border-radius:50%; margin-right:4px; object-fit:cover;"/>
+                        </t>
+                    </t>
+                </t>
+                <div t-if="result['barcode']" class="mb-0">
+                    <strong>Barcode:</strong> <t t-out="result['barcode']"/>
+                </div>
+                <div t-if="result['category']" class="mb-0">
+                    <strong>Category:</strong> <t t-out="result['category']"/>
+                </div>
+                <div t-if="result['attributes']" class="mb-0">
+                    <t t-out="result['attributes']"/>
+                </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/website_sale/static/tests/tours/website_sale_searchbar.js
+++ b/addons/website_sale/static/tests/tours/website_sale_searchbar.js
@@ -1,0 +1,63 @@
+// import { registry } from "@web/core/registry";
+import {
+    changeOption,
+    changeOptionInPopover,
+    clickOnElement,
+    clickOnSave,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+function makeAndCheckSearch(word, color = null) {
+    return [
+        {
+            trigger: ":iframe input.search-query",
+            run: `edit ${word}`,
+        },
+        {
+            trigger: `:iframe span.text-primary-emphasis:contains(${word})`,
+        },
+    ];
+}
+
+registerWebsitePreviewTour(
+    "test_searchbar_search_functionality",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({
+            id: "s_searchbar_input",
+            name: "Search",
+        }),
+        clickOnElement("Searchbar", ":iframe .s_searchbar_input[data-snippet='s_searchbar_input']"),
+        ...changeOptionInPopover("Search", "Search within", "Products"),
+        changeOption(
+            "Search",
+            "[data-label='Description'] [data-action-id='setNonEmptyDataAttribute']"
+        ),
+        {
+            trigger:
+                ":iframe .o_search_result_item .o_search_result_item_detail:not(:contains(Description))",
+        },
+        ...clickOnSave(),
+        {
+            trigger: ":iframe input.search-query",
+            run: `edit red`,
+        },
+        {
+            trigger: `:iframe .color_preview`,
+            run(helper) {
+                if (helper.anchor.style.backgroundColor !== "rgb(255, 0, 0)") {
+                    throw new Error("Error in previewing color");
+                }
+            },
+        },
+        ...makeAndCheckSearch("200"),
+        ...makeAndCheckSearch("111111111"),
+        ...makeAndCheckSearch("BMW"),
+        ...makeAndCheckSearch("Mercedes"),
+        ...makeAndCheckSearch("Hundai"),
+    ]
+);

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -40,3 +40,4 @@ from . import test_website_sale_visitor
 from . import test_website_sale_technical_page
 from . import test_website_sequence
 from . import test_website_sale_product_ribbon
+from . import test_website_sale_searchbar

--- a/addons/website_sale/tests/test_website_sale_searchbar.py
+++ b/addons/website_sale/tests/test_website_sale_searchbar.py
@@ -1,0 +1,26 @@
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleSearchbar(HttpCase):
+    def test_searchbar(self):
+        self.car = self.env['product.template'].create({
+            'name': 'Car',
+            'barcode': '111111111',
+            'list_price': '200',
+            'description_sale': 'BMW Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took Mercedes a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Hundai Aldus PageMaker including versions of Lorem Ipsum.',
+            'is_published': True
+        })
+        self.color_attribute = self.env['product.attribute'].create({'name': 'Color', 'sequence': 1, 'display_type': 'color'})
+        self.color_red = self.env['product.attribute.value'].create({
+            'name': 'Red',
+            'attribute_id': self.color_attribute.id,
+            'sequence': 1,
+            'html_color': '#ff0000'
+        })
+        self.car_color_attribute_line = self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': self.car.id,
+            'attribute_id': self.color_attribute.id,
+            'value_ids': [(6, 0, [self.color_red.id])],
+        })
+        self.start_tour("/", 'test_searchbar_search_functionality', login="admin")


### PR DESCRIPTION
Before this commit
==================
- The placeholder text in the website search bar snippet was hardcoded
  and could not be changed through the website editor.
- When searching for a keyword, the matched term in the description was
  only highlighted if it appeared near the beginning of the text. As a
  result, relevant matches deeper in the content were harder to locate,
  reducing user clarity and search result usefulness.
- Only default search result template was available.
- Search was only limited to title and description for products.

After this commit
=================
- The search bar snippet's placeholder is now editable from the website
  editor.
- Search descriptions now automatically shift to show the first
  occurrence of the matched word in context. The result still
  highlights the matching keyword, but now shows the surrounding
  sentence snippet, starting with an ellipsis (`...`) when the match is
  not at the beginning.
- Multiple search result templates made available
- Search for products can be made across:
  - Title
  - Price
  - Description
  - Barcode
  - Attributes

task-4029264