### PR TITLE
[IMP] *: deprecate lazy_property for cached_property

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -33,7 +33,7 @@ from odoo.modules.registry import Registry
 from odoo.service import model as service_model
 from odoo.service.server import CommonServer
 from odoo.service.security import check_session
-from odoo.tools import config, lazy_property
+from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
 
@@ -938,7 +938,7 @@ class WebsocketRequest:
         """
         self.update_env(context=dict(self.env.context, **overrides))
 
-    @lazy_property
+    @functools.cached_property
     def cookies(self):
         cookies = MultiDict(self.httprequest.cookies)
         if self.registry:

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -18,7 +18,7 @@ except ImportError:
 from odoo import http
 from odoo.exceptions import UserError
 from odoo.http import content_disposition, request
-from odoo.tools import lazy_property, osutil
+from odoo.tools import osutil
 
 
 _logger = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ class GroupsTreeNode:
         return aggregated_field_names
 
     # Lazy property to memoize aggregated values of children nodes to avoid useless recomputations
-    @lazy_property
+    @functools.cached_property
     def aggregated_values(self):
 
         aggregated_values = {}

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -1,7 +1,4 @@
-from contextlib import closing
-from collections import OrderedDict
-from lxml import etree
-from subprocess import Popen, PIPE
+import functools
 import hashlib
 import io
 import logging
@@ -9,8 +6,13 @@ import os
 import re
 import textwrap
 import uuid
+from collections import OrderedDict
+from contextlib import closing
+from subprocess import Popen, PIPE
 
+from lxml import etree
 from rjsmin import jsmin as rjsmin
+
 try:
     import sass as libsass
 except ImportError:
@@ -21,7 +23,7 @@ except ImportError:
 from odoo import release
 from odoo.api import SUPERUSER_ID
 from odoo.http import request
-from odoo.tools import (func, misc, transpile_javascript,
+from odoo.tools import (misc, transpile_javascript,
     is_odoo_module, SourceMapGenerator, profiler, OrderedSet)
 from odoo.tools.json import scriptsafe as json
 from odoo.tools.constants import SCRIPT_EXTENSIONS, STYLE_EXTENSIONS
@@ -732,16 +734,16 @@ class WebAsset(object):
         _logger.error(msg)  # log it in the python console in all cases.
         return msg
 
-    @func.lazy_property
+    @functools.cached_property
     def id(self):
         if self._id is None: self._id = str(uuid.uuid4())
         return self._id
 
-    @func.lazy_property
+    @functools.cached_property
     def unique_descriptor(self):
         return f'{self.url or self.inline},{self.last_modified}'
 
-    @func.lazy_property
+    @functools.cached_property
     def name(self):
         return '<inline asset>' if self.inline else self.url
 
@@ -928,7 +930,7 @@ class StylesheetAsset(WebAsset):
     def bundle_version(self):
         return self.bundle.get_version('css')
 
-    @func.lazy_property
+    @functools.cached_property
     def unique_descriptor(self):
         direction = (self.rtl and 'rtl') or 'ltr'
         autoprefixed = (self.autoprefix and 'autoprefixed') or ''

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -8,7 +8,6 @@ import logging
 import pprint
 import re
 import uuid
-import warnings
 
 from lxml import etree
 from lxml.etree import LxmlError
@@ -22,7 +21,7 @@ from odoo.fields import Domain
 from odoo.http import request
 from odoo.modules.module import get_resource_from_path
 from odoo.service.model import get_public_method
-from odoo.tools import _, config, lazy_property, frozendict, SQL
+from odoo.tools import _, config, frozendict, SQL
 from odoo.tools.convert import _fix_multiple_roots
 from odoo.tools.misc import file_path, get_diff, ConstantMapping
 from odoo.tools.template_inheritance import apply_inheritance_specs, locate_node
@@ -3027,7 +3026,7 @@ class NameManager:
         # this maps field names to the group of users that have access to the field
         self.field_groups = {}
 
-    @lazy_property
+    @functools.cached_property
     def field_info(self):
         field_info = self.model.fields_get(attributes=['readonly', 'required'])
         if not (self.model.has_access('write') or self.model.has_access('create')):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -131,14 +131,12 @@ endpoint
 import odoo.init  # import first for core setup
 
 import base64
-import collections
 import collections.abc
 import contextlib
 import functools
 import glob
 import hashlib
 import hmac
-import importlib
 import importlib.metadata
 import inspect
 import json
@@ -206,7 +204,7 @@ from .service import security, model as service_model
 from .service.server import thread_local
 from .tools import (config, consteq, file_path, get_lang, json_default,
                     parse_version, profiler, unique, exception_to_unicode)
-from .tools.func import filter_kwargs, lazy_property
+from .tools.func import filter_kwargs
 from .tools.misc import submap, real_time
 from .tools._vendor import sessions
 from .tools._vendor.useragents import UserAgent
@@ -1225,7 +1223,7 @@ class GeoIP(collections.abc.Mapping):
     def __init__(self, ip):
         self.ip = ip
 
-    @lazy_property
+    @functools.cached_property
     def _city_record(self):
         try:
             return root.geoip_city_db.city(self.ip)
@@ -1234,7 +1232,7 @@ class GeoIP(collections.abc.Mapping):
         except geoip2.errors.AddressNotFoundError:
             return GEOIP_EMPTY_CITY
 
-    @lazy_property
+    @functools.cached_property
     def _country_record(self):
         if '_city_record' in vars(self):
             # the City class inherits from the Country class and the
@@ -1597,7 +1595,7 @@ class Request:
 
     _cr = cr
 
-    @lazy_property
+    @functools.cached_property
     def best_lang(self):
         lang = self.httprequest.accept_languages.best
         if not lang:
@@ -1613,7 +1611,7 @@ class Request:
         except (ValueError, KeyError):
             return None
 
-    @lazy_property
+    @functools.cached_property
     def cookies(self):
         cookies = werkzeug.datastructures.MultiDict(self.httprequest.cookies)
         if self.registry:
@@ -2307,7 +2305,7 @@ class Application:
         from odoo.service.server import load_server_wide_modules  # noqa: PLC0415
         load_server_wide_modules()
 
-    @lazy_property
+    @functools.cached_property
     def statics(self):
         """
         Map module names to their absolute ``static`` path on the file
@@ -2354,7 +2352,7 @@ class Application:
         except FileNotFoundError:
             return None
 
-    @lazy_property
+    @functools.cached_property
     def nodb_routing_map(self):
         nodb_routing_map = werkzeug.routing.Map(strict_slashes=False, converters=None)
         for url, endpoint in _generate_routing_rules([''] + config['server_wide_modules'], nodb_only=True):
@@ -2367,7 +2365,7 @@ class Application:
 
         return nodb_routing_map
 
-    @lazy_property
+    @functools.cached_property
     def session_store(self):
         path = odoo.tools.config.session_dir
         _logger.debug('HTTP sessions stored in: %s', path)
@@ -2378,7 +2376,7 @@ class Application:
             return self.nodb_routing_map
         return request.env['ir.http'].routing_map()
 
-    @lazy_property
+    @functools.cached_property
     def geoip_city_db(self):
         try:
             return geoip2.database.Reader(config['geoip_city_db'])
@@ -2389,7 +2387,7 @@ class Application:
             )
             raise
 
-    @lazy_property
+    @functools.cached_property
     def geoip_country_db(self):
         try:
             return geoip2.database.Reader(config['geoip_country_db'])

--- a/odoo/modules/module_graph.py
+++ b/odoo/modules/module_graph.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 import typing
 
@@ -158,7 +159,7 @@ class ModuleNode:
         self.depends: OrderedSet[ModuleNode] = OrderedSet()
         self.module_graph: ModuleGraph = module_graph
 
-    @lazy_property
+    @functools.cached_property
     def order_name(self) -> str:
         if self.name.startswith('test_'):
             # The 'space' was chosen because it's smaller than any character that can be used by the module name.
@@ -167,7 +168,7 @@ class ModuleNode:
 
         return self.name
 
-    @lazy_property
+    @functools.cached_property
     def depth(self) -> int:
         """ Return the longest distance from self to module 'base' along dependencies. """
         if self.name.startswith('test_'):
@@ -176,7 +177,7 @@ class ModuleNode:
 
         return max(module.depth for module in self.depends) + 1 if self.depends else 0
 
-    @lazy_property
+    @functools.cached_property
     def phase(self) -> int:
         if self.name == 'base':
             return 0
@@ -242,7 +243,7 @@ class ModuleGraph:
         self._update_depth(names)
         self._update_from_database(names)
 
-    @lazy_property
+    @functools.cached_property
     def _imported_modules(self) -> OrderedSet[str]:
         result = ['studio_customization']
         if column_exists(self._cr, 'ir_module_module', 'imported'):

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -4,6 +4,7 @@
 """
 from __future__ import annotations
 
+import functools
 import logging
 import typing
 import warnings
@@ -184,28 +185,28 @@ class Environment(Mapping[str, "BaseModel"]):
             superuser mode. """
         return self.su or self.user._is_system()
 
-    @lazy_property
+    @functools.cached_property
     def registry(self) -> Registry:
         """Return the registry associated with the transaction."""
         return self.transaction.registry
 
-    @lazy_property
+    @functools.cached_property
     def _protected(self):
         """Return the protected map of the transaction."""
         return self.transaction.protected
 
-    @lazy_property
+    @functools.cached_property
     def cache(self):
         """Return the cache object of the transaction."""
         return self.transaction.cache
 
-    @lazy_property
+    @functools.cached_property
     def _cache_key(self) -> dict[Field, typing.Any]:
         """Return an empty key for the cache"""
         # memo {field: cache_key}
         return {}
 
-    @lazy_property
+    @functools.cached_property
     def user(self) -> BaseModel:
         """Return the current user (as an instance).
 
@@ -213,7 +214,7 @@ class Environment(Mapping[str, "BaseModel"]):
         :rtype: :class:`res.users record<~odoo.addons.base.models.res_users.ResUsers>`"""
         return self(su=True)['res.users'].browse(self.uid)
 
-    @lazy_property
+    @functools.cached_property
     def company(self) -> BaseModel:
         """Return the current company (as an instance).
 
@@ -243,7 +244,7 @@ class Environment(Mapping[str, "BaseModel"]):
             return self['res.company'].browse(company_ids[0])
         return self.user.company_id.with_env(self)
 
-    @lazy_property
+    @functools.cached_property
     def companies(self) -> BaseModel:
         """Return a recordset of the enabled companies by the user.
 
@@ -283,7 +284,7 @@ class Environment(Mapping[str, "BaseModel"]):
         #   - when loading an binary image on a template
         return self['res.company'].browse(user_company_ids)
 
-    @lazy_property
+    @functools.cached_property
     def lang(self) -> str | None:
         """Return the current language code."""
         lang = self.context.get('lang')
@@ -292,7 +293,7 @@ class Environment(Mapping[str, "BaseModel"]):
             raise UserError(f'Invalid language code: {lang}')  # pylint: disable=missing-gettext
         return lang or None
 
-    @lazy_property
+    @functools.cached_property
     def _lang(self) -> str:
         """Return the technical language code of the current context for **model_terms** translated field
         """

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -3,6 +3,7 @@
 """ High-level objects for fields. """
 from __future__ import annotations
 
+import functools
 import itertools
 import logging
 import typing
@@ -12,7 +13,7 @@ from operator import attrgetter
 from psycopg2.extras import Json as PsycopgJson
 
 from odoo.exceptions import AccessError, MissingError
-from odoo.tools import Query, SQL, lazy_property, sql
+from odoo.tools import Query, SQL, sql
 from odoo.tools.constants import PREFETCH_MAX
 from odoo.tools.misc import SENTINEL, OrderedSet, Sentinel, unique
 
@@ -779,7 +780,7 @@ class Field(typing.Generic[T]):
     _related_groups = property(attrgetter('groups'))
     _related_aggregator = property(attrgetter('aggregator'))
 
-    @lazy_property
+    @functools.cached_property
     def column_type(self) -> tuple[str, str] | None:
         """ Return the actual column type for this field, if stored as a column. """
         return ('jsonb', 'jsonb') if self.company_dependent or self.translate else self._column_type

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import base64
 import binascii
 import contextlib
+import functools
 import itertools
-import reprlib
 import typing
 import warnings
 from operator import attrgetter
@@ -12,10 +12,10 @@ from operator import attrgetter
 import psycopg2
 
 from odoo.exceptions import CacheMiss, UserError
-from odoo.tools import SQL, human_size, image_process, lazy_property
+from odoo.tools import SQL, human_size, image_process
 from odoo.tools.mimetypes import guess_mimetype
 
-from .fields import Field, _logger
+from .fields import Field
 from .utils import SQL_OPERATORS
 
 if typing.TYPE_CHECKING:
@@ -40,7 +40,7 @@ class Binary(Field):
     _depends_context = ('bin_size',)    # depends on context (content or size)
     attachment = True                   # whether value is stored in attachment
 
-    @lazy_property
+    @functools.cached_property
     def column_type(self):
         return None if self.attachment else ('bytea', 'bytea')
 

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -5,6 +5,7 @@
 """
 from __future__ import annotations
 
+import functools
 import inspect
 import logging
 import os
@@ -395,7 +396,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
                 model._register_hook()
             env.flush_all()
 
-    @lazy_property
+    @functools.cached_property
     def field_computed(self) -> dict[Field, list[Field]]:
         """ Return a dict mapping each field to the fields computed by the same method. """
         computed: dict[Field, list[Field]] = {}
@@ -522,7 +523,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
 
         return tree
 
-    @lazy_property
+    @functools.cached_property
     def _field_triggers(self) -> defaultdict[Field, defaultdict[tuple[str, ...], OrderedSet[Field]]]:
         """ Return the field triggers, i.e., the inverse of field dependencies,
         as a dictionary like ``{field: {path: fields}}``, where ``field`` is a


### PR DESCRIPTION
`functools.cached_property` is functionally the same thing as `lazy_property`, and was introduced in Python 3.8.

It does not provide a way to reset all cached properties so a helper for this usage is necessary.
