### PR TITLE
[IMP] pos*: click on open session shows user modal

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -643,7 +643,9 @@ class PosConfig(models.Model):
             raise UserError(_("You do not have permission to open a POS session. Please try opening a session with a different user"))
 
         if not self.current_session_id:
-            self._check_before_creating_new_session()
+            res = self._check_before_creating_new_session()
+            if res:
+                return res
         self._validate_fields(self._fields)
 
         return self._action_to_open_ui()

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -358,7 +358,9 @@ class PosConfig(models.Model):
         self.ensure_one()
 
         if not self.current_session_id:
-            self._check_before_creating_new_session()
+            res = self._check_before_creating_new_session()
+            if res:
+                return res
             session = self.env['pos.session'].create({'user_id': self.env.uid, 'config_id': self.id})
             session.set_opening_control(0, "")
             self._notify('STATUS', {'status': 'open'})


### PR DESCRIPTION
pos*: point_of_sale, pos_self_order

With changes in the enterprise commit, clicking on open session can now return an action so we need to propagate this to the whole stack to make sure we are displaying the modal we want to show.

task-id: 4643331

Enterprise PR: https://github.com/odoo/enterprise/pull/83498

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
