### PR TITLE
[FIX] l10n_it_edi: fix for import vendor bill with scontomaggiorazione

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1314,19 +1314,30 @@ class AccountMove(models.Model):
                 move_line.tax_ids = [Command.set(fitting_taxes)]
 
         # Discounts
-        if elements := element.xpath('.//ScontoMaggiorazione'):
-            # Special case of only 1 percentage discount
-            if len(elements) == 1:
-                element = elements[0]
-                if discount_percentage := get_float(element, './/Percentuale'):
-                    discount_type = get_text(element, './/Tipo')
-                    discount_sign = -1 if discount_type == 'MG' else 1
-                    move_line.discount = discount_sign * discount_percentage
-            # Discounts in cascade summarized in 1 percentage
-            else:
-                total = get_float(element, './/PrezzoTotale')
-                discount = 100 - (100 * total) / (move_line.quantity * move_line.price_unit)
-                move_line.discount = discount
+        if discounts := element.xpath('.//ScontoMaggiorazione'):
+            current_unit_price = move_line.price_unit
+            # We apply the discounts in the order they are found in the XML.
+            # The first discount is applied to the unit price, the second to the result of the first, etc.
+            # If the discount is a percentage, it is applied to the unit price.
+            # If the discount is an amount, it is subtracted from the unit price.
+            # If the computed amount is different than the expected one, we log a message.
+            for discount in discounts:
+                discount_type = get_text(discount, './/Tipo')
+                discount_sign = -1 if discount_type == 'MG' else 1
+                if discount_percentage := get_float(discount, './/Percentuale'):
+                    current_unit_price *= discount_sign * (100 - discount_percentage) / 100
+                elif discount_amount := get_float(discount, './/Importo'):
+                    current_unit_price -= discount_sign * discount_amount
+            expected_total = get_float(element, './/PrezzoTotale')
+            current_total = current_unit_price * move_line.quantity
+            if float_compare(expected_total, current_total, precision_rounding=move_line.currency_id.rounding) != 0:
+                message = Markup("<br/>").join((
+                    _("The amount_total %(current_total)s is different than PrezzoTotale %(expected_total)s for '%(move_name)s'", current_total=current_total, expected_total=expected_total, move_name=move_line.name),
+                    self._compose_info_message(element, '.')
+                ))
+                message_to_log.append(message)
+            discount = 100 - (100 * current_unit_price) / move_line.price_unit
+            move_line.discount = discount
 
         return message_to_log
 

--- a/addons/l10n_it_edi/tests/import_xmls/IT01234567890_DISC1.xml
+++ b/addons/l10n_it_edi/tests/import_xmls/IT01234567890_DISC1.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<p:FatturaElettronica versione="FPR12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                      xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+        <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>00001</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>ABC1234</CodiceDestinatario>
+            <ContattiTrasmittente/>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>01234560157</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF19</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIALE ROMA 543</Indirizzo>
+                <CAP>07100</CAP>
+                <Comune>SASSARI</Comune>
+                <Provincia>SS</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>DITTA BETA</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIA TORINO 38-B</Indirizzo>
+                <CAP>00145</CAP>
+                <Comune>ROMA</Comune>
+                <Provincia>RM</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2014-12-18</Data>
+                <Numero>01234567890</Numero>
+                <Causale>
+                    LA FATTURA FA RIFERIMENTO AD UNA OPERAZIONE AAAA BBBBBBBBBBBBBBBBBB CCC DDDDDDDDDDDDDDD 
+                </Causale>                      
+                <ImportoTotaleDocumento>35.07</ImportoTotaleDocumento>
+            </DatiGeneraliDocumento>
+            <DatiOrdineAcquisto>
+                <RiferimentoNumeroLinea>1</RiferimentoNumeroLinea>
+                <IdDocumento>66685</IdDocumento>
+                <NumItem>1</NumItem>
+            </DatiOrdineAcquisto>
+            <DatiContratto>
+                <RiferimentoNumeroLinea>1</RiferimentoNumeroLinea>
+                <IdDocumento>01234567890</IdDocumento>
+                <Data>2012-09-01</Data>
+                <NumItem>5</NumItem>
+                <CodiceCUP>01234567890abc</CodiceCUP>
+                <CodiceCIG>456def</CodiceCIG>
+            </DatiContratto>
+            <DatiTrasporto>
+                <DatiAnagraficiVettore>
+                    <IdFiscaleIVA>
+                        <IdPaese>IT</IdPaese>
+                        <IdCodice>24681012141</IdCodice>
+                    </IdFiscaleIVA>
+                    <Anagrafica>
+                        <Denominazione>Trasporto spa</Denominazione>
+                    </Anagrafica>
+                </DatiAnagraficiVettore>
+                <DataOraConsegna>2012-10-22T16:46:12.000+02:00</DataOraConsegna>
+            </DatiTrasporto>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>DESCRIZIONE DELLA FORNITURA</Descrizione>
+                <Quantita>5.00</Quantita>
+                <PrezzoUnitario>1.00</PrezzoUnitario>
+                <PrezzoTotale>5.00</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>2</NumeroLinea>
+                <Descrizione>DESCRIZIONE DELLA FORNITURA 2</Descrizione>
+                <Quantita>5.00</Quantita>
+                <PrezzoUnitario>10.00</PrezzoUnitario>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Importo>5.00</Importo>
+                </ScontoMaggiorazione>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Percentuale>5.00</Percentuale>
+                </ScontoMaggiorazione>
+                <PrezzoTotale>23.75</PrezzoTotale>
+                <AliquotaIVA>22</AliquotaIVA>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>28.75</ImponibileImporto>
+                <Imposta>6.32</Imposta>
+                <EsigibilitaIVA>I</EsigibilitaIVA>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP01</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP01</ModalitaPagamento>
+                <DataScadenzaPagamento>2015-01-30</DataScadenzaPagamento>
+                <ImportoPagamento>35.07</ImportoPagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -69,6 +69,29 @@ class TestItEdiImport(TestItEdi):
             }],
         }])
 
+    def test_receive_vendor_bill_sconto_maggiorazione(self):
+        """ Test a sample e-invoice file with
+        ScontoMaggiorazione on lines
+        """
+        self._assert_import_invoice('IT01234567890_DISC1.xml', [{
+            'move_type': 'in_invoice',
+            'invoice_date': fields.Date.from_string('2014-12-18'),
+            'amount_untaxed': 28.75,
+            'amount_tax': 6.32,
+            'invoice_line_ids': [{
+                'quantity': 5.0,
+                'price_unit': 1.0,
+                'discount': 0,
+                'debit': 5.0,
+            },
+            {
+                'quantity': 5.0,
+                'price_unit': 10.0,
+                'discount': 52.5,
+                'debit': 23.75,
+            }],
+        }])
+
     def test_receive_negative_vendor_bill(self):
         """ Same vendor bill as test_receive_vendor_bill but negative unit price """
         self._assert_import_invoice('IT01234567890_FPR02.xml', [{


### PR DESCRIPTION
Fix the import of vendor bills that use per-line ScontoMaggiorazione.
The discount/surcharge should be applied to the price unit before taxes, instead of summed and subtracted from the total.

#### Correct
| Product   | Qty | Unit Price | Discount | VAT % | Formula                          | Total     |
|-----------|-----|------------|----------|-------|----------------------------------|-----------|
| Product 1 | 2   | 5.00       | 3.00     | 22%   | `2 * (5 - 3) * 1.22`             | 4.88      |
| Product 2 | 1   | 10.00      | 3.00     | 10%   | `1 * (10 - 3) * 1.10`            | 7.70      |
|           |     |            |          |       |                                  | **12.58** |


#### Before 
the scontomaggiorazione is not managed line by line.
We have to manage line by line because the ScontoMaggiorazione should decrease the "Imponibile" and than calculate the amount tax line by line because each line can have different tax % .

ATTENTION: the ScontoMaggiorazione on ImportoTotaleDocumento is not the sum of the ScontoMaggiorazione on the lines. It is a discount on the amount tax included
