### PR TITLE
[FIX] website: keep background-color properly applied on animated text

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -555,6 +555,19 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
             selectedTextEl.classList.add(...optionClassList);
             let $snippet = null;
             try {
+                const commonAncestor = range.commonAncestorContainer;
+                const ancestorElement =
+                    commonAncestor.nodeType === 1 ? commonAncestor : commonAncestor.parentElement;
+                const backgroundColorParentEl = ancestorElement.closest(
+                    'font[style*="background-color"], font[style*="background-image"], font[class^="bg-"]'
+                );
+                if (backgroundColorParentEl?.textContent === commonAncestor.textContent) {
+                    // As long as we handle the same text content, we extend the
+                    // existing range to the `<font/>` boundaries to keep the
+                    // background color applied correctly.
+                    range.setStartBefore(backgroundColorParentEl);
+                    range.setEndAfter(backgroundColorParentEl);
+                }
                 range.surroundContents(selectedTextEl);
                 $snippet = $(selectedTextEl);
             } catch {

--- a/addons/website/static/tests/tours/text_animations.js
+++ b/addons/website/static/tests/tours/text_animations.js
@@ -35,12 +35,20 @@ wTourUtils.registerWebsitePreviewTour("text_animations", {
         isCheck: true,
     },
     {
+        content: "Open the text background color colorpicker",
+        trigger: "button#oe-fore-color",
+    },
+    {
+        content: "Add a background color on the selected text",
+        trigger: ".o_colorpicker_section [data-color='black']",
+    },
+    {
         content: "Try to apply the text animation again",
         trigger: "div.o_we_animate_text",
     },
     {
-        content: "Check that the animation was applied",
-        trigger: "iframe .s_cover:has(span.o_animated_text)",
+        content: "Check that the animation was applied and that the <font> element is inside the o_animated_text element",
+        trigger: "iframe .s_cover:has(span.o_animated_text > font.bg-black)",
         isCheck: true,
     },
 ]);


### PR DESCRIPTION
Steps to Reproduce :

- Drag and drop text snippet / or select some text.
- Apply the back-ground color to the text.
- Click on the Animate button.
- You will notice that the background got removed/misplaced.

The issue was caused because the animated text is wrapped in an element with "display: inline-block". To fix the bug, we moved the element with the background color inside the wrapper of the animated text, instead of keeping it outside.

This fix works as long as the animated text is exactly the same as the one with the background color. If only a portion of the text with a background color is animated, the fix doesn’t work. That case was too complex to handle, and in any case, the most common user scenarios are now fixed.

task-4690318
