### PR TITLE
[FIX] spreadsheet: 'falsy' odoo.pivot.position are skipped

### DIFF
--- a/addons/spreadsheet/static/tests/utils/data.js
+++ b/addons/spreadsheet/static/tests/utils/data.js
@@ -61,9 +61,9 @@ export function getBasicGraphArch() {
 /**
  * @returns {ServerData}
  */
-export function getBasicServerData() {
+export function getBasicServerData(params = {}) {
     return {
-        models: getBasicData(),
+        models: params.data || getBasicData(),
         views: {
             "partner,false,list": getBasicListArch(),
             "partner,false,pivot": getBasicPivotArch(),
@@ -113,6 +113,24 @@ export function getBasicListArchs() {
         "partner,false,search": /* xml */ `<search/>`,
         "partner,false,form": /* xml */ `<form/>`,
     };
+}
+
+export function getBasicDataWithEmptyRecords() {
+    const data = getBasicData();
+    data.partner.records.push({
+        id: 5,
+        foo: 2,
+        bar: true,
+        date: "2016-12-11",
+        create_date: "2016-12-10 21:59:59",
+        product_id: false,
+        probability: 15,
+        field_with_array_agg: 4,
+        tag_ids: [42],
+        currency_id: 2,
+        pognon: 1000,
+    });
+    return data;
 }
 
 export function getBasicData() {


### PR DESCRIPTION
How to reproduce:

    Go to CRM,
    Create a pivot with one of the group by set to an empty M2O field
    insert the pivot in a new spreadsheet, you should have a group by "None"
    Create a template from that spreadsheet
    Create a new spreadsheet from the template
    The reference to the new "None" group by is not present in the spreadsheet

Task: 4342966

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
