### PR TITLE
[IMP] base: Ensure deterministic _order for all base models

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -53,7 +53,7 @@ class IrActionsActions(models.Model):
     _name = 'ir.actions.actions'
     _description = 'Actions'
     _table = 'ir_actions'
-    _order = 'name'
+    _order = 'name, id'
     _allow_sudo_commands = False
 
     _path_unique = models.Constraint(
@@ -260,7 +260,7 @@ class IrActionsAct_Window(models.Model):
     _description = 'Action Window'
     _table = 'ir_act_window'
     _inherit = ['ir.actions.actions']
-    _order = 'name'
+    _order = 'name, id'
     _allow_sudo_commands = False
 
     @api.constrains('res_model', 'binding_model_id')
@@ -444,7 +444,7 @@ class IrActionsAct_Url(models.Model):
     _description = 'Action URL'
     _table = 'ir_act_url'
     _inherit = ['ir.actions.actions']
-    _order = 'name'
+    _order = 'name, id'
     _allow_sudo_commands = False
 
     type = fields.Char(default='ir.actions.act_url')
@@ -1271,7 +1271,7 @@ class IrActionsClient(models.Model):
     _description = 'Client Action'
     _inherit = ['ir.actions.actions']
     _table = 'ir_act_client'
-    _order = 'name'
+    _order = 'name, id'
     _allow_sudo_commands = False
 
     type = fields.Char(default='ir.actions.client')

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -68,7 +68,7 @@ class IrCron(models.Model):
     # loaded yet or was already unloaded (e.g. 'force_db_wakeup' or something)
     # See also odoo.cron
     _name = 'ir.cron'
-    _order = 'cron_name'
+    _order = 'cron_name, id'
     _description = 'Scheduled Actions'
     _allow_sudo_commands = False
 

--- a/odoo/addons/base/models/ir_exports.py
+++ b/odoo/addons/base/models/ir_exports.py
@@ -7,7 +7,7 @@ from odoo import fields, models
 class IrExports(models.Model):
     _name = 'ir.exports'
     _description = 'Exports'
-    _order = 'name'
+    _order = 'name, id'
 
     name = fields.Char(string='Export Name')
     resource = fields.Char(index=True)

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -500,7 +500,7 @@ FIELD_TYPES = [(key, key) for key in sorted(fields.Field.by_type)]
 class IrModelFields(models.Model):
     _name = 'ir.model.fields'
     _description = "Fields"
-    _order = "name"
+    _order = "name, id"
     _rec_name = 'field_description'
     _allow_sudo_commands = False
 

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -71,7 +71,7 @@ def assert_log_admin_access(method):
 class IrModuleCategory(models.Model):
     _name = 'ir.module.category'
     _description = "Application"
-    _order = 'name'
+    _order = 'name, id'
     _allow_sudo_commands = False
 
     name = fields.Char(string='Name', required=True, translate=True, index=True)

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -88,7 +88,7 @@ class IrSequence(models.Model):
     """
     _name = 'ir.sequence'
     _description = 'Sequence'
-    _order = 'name'
+    _order = 'name, id'
     _allow_sudo_commands = False
 
     def _get_number_next_actual(self):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -67,7 +67,7 @@ def att_names(name):
 class IrUiViewCustom(models.Model):
     _name = 'ir.ui.view.custom'
     _description = 'Custom View'
-    _order = 'create_date desc'  # search(limit=1) should return the last customization
+    _order = 'create_date desc, id desc'  # search(limit=1) should return the last customization
     _rec_name = 'user_id'
     _allow_sudo_commands = False
 

--- a/odoo/addons/base/models/report_layout.py
+++ b/odoo/addons/base/models/report_layout.py
@@ -7,7 +7,7 @@ from odoo import fields, models
 class ReportLayout(models.Model):
     _name = 'report.layout'
     _description = 'Report Layout'
-    _order = 'sequence'
+    _order = 'sequence, id'
 
     view_id = fields.Many2one('ir.ui.view', 'Document Template', required=True)
     image = fields.Char(string="Preview image src")

--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -15,7 +15,7 @@ def sanitize_account_number(acc_number):
 class ResBank(models.Model):
     _name = 'res.bank'
     _description = 'Bank'
-    _order = 'name'
+    _order = 'name, id'
     _rec_names_search = ['name', 'bic']
 
     name = fields.Char(required=True)

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -31,7 +31,7 @@ NO_FLAG_COUNTRIES = [
 class ResCountry(models.Model):
     _name = 'res.country'
     _description = 'Country'
-    _order = 'name'
+    _order = 'name, id'
     _rec_names_search = ['name', 'code']
 
     name = fields.Char(
@@ -190,7 +190,7 @@ class ResCountryGroup(models.Model):
 class ResCountryState(models.Model):
     _name = 'res.country.state'
     _description = "Country state"
-    _order = 'code'
+    _order = 'code, id'
     _rec_names_search = ['name', 'code']
 
     country_id = fields.Many2one('res.country', string='Country', required=True, index=True)

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -344,7 +344,7 @@ class ResCurrencyRate(models.Model):
     _name = 'res.currency.rate'
     _description = "Currency Rate"
     _rec_names_search = ['name', 'rate']
-    _order = "name desc"
+    _order = "name desc, id"
     _check_company_domain = models.check_company_domain_parent_of
 
     name = fields.Date(string='Date', required=True, index=True,

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -131,7 +131,7 @@ class FormatAddressMixin(models.AbstractModel):
 class ResPartnerCategory(models.Model):
     _name = 'res.partner.category'
     _description = 'Partner Tags'
-    _order = 'name'
+    _order = 'name, id'
     _parent_store = True
 
     def _get_default_color(self):
@@ -1102,7 +1102,7 @@ class ResPartner(models.Model):
 class ResPartnerIndustry(models.Model):
     _name = 'res.partner.industry'
     _description = 'Industry'
-    _order = "name"
+    _order = "name, id"
 
     name = fields.Char('Name', translate=True)
     full_name = fields.Char('Full Name', translate=True)

--- a/odoo/addons/base/models/res_users_view.py
+++ b/odoo/addons/base/models/res_users_view.py
@@ -4,7 +4,7 @@ from odoo import api, fields, models, tools
 
 class ResGroups(models.Model):
     _inherit = 'res.groups'
-    _order = 'category_id,sequence,name'
+    _order = 'category_id, sequence, name, id'
 
     sequence = fields.Integer(string='Sequence')
     visible = fields.Boolean(related='category_id.visible', readonly=True)

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1702,7 +1702,7 @@ class TestQueries(TransactionCase):
             SELECT "res_country"."id"
             FROM "res_country"
             WHERE COALESCE("res_country"."name"->>%s, "res_country"."name"->>%s) LIKE %s
-            ORDER BY COALESCE("res_country"."name"->>%s, "res_country"."name"->>%s)
+            ORDER BY COALESCE("res_country"."name"->>%s, "res_country"."name"->>%s), "res_country"."id"
         ''']):
             Model.search([('name', 'like', 'foo')])
 

--- a/odoo/addons/base/tests/test_search.py
+++ b/odoo/addons/base/tests/test_search.py
@@ -296,7 +296,7 @@ class test_search(TransactionCase):
         with self.assertQueries(["""
             SELECT "res_country"."id"
             FROM "res_country"
-            ORDER BY "res_country"."name"->>%s
+            ORDER BY "res_country"."name"->>%s, "res_country"."id"
         """]):
             Model.search([('code', 'ilike', '')])
             Model.search([('code', 'not ilike', '')])


### PR DESCRIPTION
Currently, without a specified `order`, the `search` result order depends on PostgreSQL statistics, leading to inconsistencies that hinder testing and bug reproducibility.

This commit enforces a deterministic order (typically by 'id') on all base module models to guarantee consistent `search` results.
