### PR TITLE
[FIX] mail: check allowUpload flag in composer actions

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -164,7 +164,7 @@ export class Composer extends Component {
                     extraClass: "o-mail-Composer-dropzone",
                     onDrop: this.onDropFile,
                 },
-                () => this.allowUpload
+                () => this.props.allowUpload
             );
         }
         if (this.props.messageEdition) {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -90,7 +90,7 @@
             </div>
             <div class="o-mail-Composer-footer overflow-auto">
                 <AttachmentList
-                    t-if="allowUpload and props.composer.attachments.length > 0"
+                    t-if="props.composer.attachments.length > 0"
                     attachments="props.composer.attachments"
                     unlinkAttachment.bind="(...args) => attachmentUploader.unlink(...args)"
                     imagesHeight="75"/>

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -101,15 +101,7 @@ composerActionsRegistry
         sequenceQuick: 20,
     })
     .add("upload-files", {
-        condition: (component) => {
-            const thread = component.thread ?? component.message?.thread;
-            return (
-                !(
-                    thread?.channel_type === "whatsapp" &&
-                    component.props.composer.attachments.length > 0
-                ) && !component.props.composer.portalComment
-            );
-        },
+        condition: (component) => component.allowUpload,
         icon: "fa fa-paperclip",
         name: _t("Attach Files"),
         onClick: (component, action, ev) => {


### PR DESCRIPTION
## Description

In spreadsheet cell thread, setting `allowUpload` to false did not hide the file upload button in the composer. This was due to missing `allowUpload` checks within the composer actions logic.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
