### PR TITLE
[FIX] html_editor: prevent column selection on table border double-click

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -794,9 +794,10 @@ export class TablePlugin extends Plugin {
         this._currentMouseState = ev.type;
         this._lastMousedownPosition = [ev.x, ev.y];
         this.deselectTable();
+        const isPointerInsideCell = this.isPointerInsideCell(ev);
         const td = closestElement(ev.target, "td");
         if (
-            td &&
+            isPointerInsideCell &&
             !isProtected(td) &&
             !isProtecting(td) &&
             ((isEmptyBlock(td) && ev.detail === 2) || ev.detail === 3)
@@ -816,7 +817,7 @@ export class TablePlugin extends Plugin {
                 this._isTripleClickInTable = true;
             }
         }
-        if (this.isPointerInsideCell(ev)) {
+        if (isPointerInsideCell) {
             this.editable.addEventListener("mousemove", this.onMousemove);
             const currentSelection = this.dependencies.selection.getEditableSelection();
             // disable dragging on table

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1651,11 +1651,22 @@ describe("single cell selection", () => {
             )
         );
 
+        const BORDER_SENSITIVITY = 5;
         const firstTd = el.querySelector("td");
-        manuallyDispatchProgrammaticEvent(firstTd, "mousedown", { detail: 2 });
+        const offset = BORDER_SENSITIVITY + 1;
+
+        manuallyDispatchProgrammaticEvent(firstTd, "mousedown", {
+            detail: 2,
+            clientX: offset,
+            clientY: offset,
+        });
         await animationFrame();
 
-        manuallyDispatchProgrammaticEvent(firstTd, "mouseup", { detail: 2 });
+        manuallyDispatchProgrammaticEvent(firstTd, "mouseup", {
+            detail: 2,
+            clientX: offset,
+            clientY: offset,
+        });
         await animationFrame();
 
         expectContentToBe(
@@ -1681,18 +1692,29 @@ describe("single cell selection", () => {
             )
         );
 
+        const BORDER_SENSITIVITY = 5;
         const firstTd = el.querySelector("td");
-        manuallyDispatchProgrammaticEvent(firstTd, "mousedown", { detail: 3 });
+        const offset = BORDER_SENSITIVITY + 1;
+
+        manuallyDispatchProgrammaticEvent(firstTd, "mousedown", {
+            detail: 3,
+            clientX: offset,
+            clientY: offset,
+        });
         await animationFrame();
 
-        manuallyDispatchProgrammaticEvent(firstTd, "mouseup", { detail: 3 });
+        manuallyDispatchProgrammaticEvent(firstTd, "mouseup", {
+            detail: 3,
+            clientX: offset,
+            clientY: offset,
+        });
         await animationFrame();
 
         expectContentToBe(
             el,
             `<table class="table table-bordered o_table o_selected_table">
                 <tbody>
-                    <tr><td class="o_selected_td">ab[]c<br></td><td><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td">[]abc<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
             </table>`
@@ -1723,6 +1745,37 @@ describe("single cell selection", () => {
             `<table class="table table-bordered o_table">
                 <tbody>
                     <tr><td>ab[]c<br></td><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+    });
+
+    test("should not select cell when double-click occurs on table border", async () => {
+        const { el } = await setupEditor(
+            unformat(
+                `<table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td>[]<br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>`
+            )
+        );
+
+        const firstTd = el.querySelector("td");
+
+        manuallyDispatchProgrammaticEvent(firstTd, "mousedown", { detail: 2 });
+        await animationFrame();
+
+        manuallyDispatchProgrammaticEvent(firstTd, "mouseup", { detail: 2 });
+        await animationFrame();
+
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table">
+                <tbody>
+                    <tr><td>[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
             </table>`


### PR DESCRIPTION
**Current behavior before PR:**

- Double-clicking on a table border would select the table column if the selection was inside a table cell.
- If the selection was outside the table, a traceback will occur.

**Desired behavior after PR is merged:**

- Now, a table cell is now only selected when the double-click is performed inside the cell, not on its border.

task:4730234
