### PR TITLE
[FIX] resource : Get correct hours for flexible employees

### DIFF
--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -557,7 +557,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                          "All the remaining days of the allocation will expire")
 
         # Days between the target date and the expiration date (accrual_plan's carryover date)
-        remaining_days_before_expiration = (allocation._get_carryover_date(target_date) - target_date).days + 1
+        remaining_days_before_expiration = (allocation._get_carryover_date(target_date) - target_date).days
         working_days_equivalent_needed = remaining_days_before_expiration * 24 / self.flex_40h_calendar.hours_per_day
     
         # Assert the closest allocation duration (number of working days equivalent (8 hours/day) remaining before the allocation expires)

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -208,8 +208,11 @@ class ResourceMixin(models.AbstractModel):
             for record in records:
                 intervals = all_intervals[record.resource_id.id]
                 record_result = defaultdict(float)
-                for start, stop, _meta in intervals:
-                    record_result[start.date()] += (stop - start).total_seconds() / 3600
+                for start, stop, meta in intervals:
+                    if calendar.flexible_hours:
+                        record_result[start.date()] = meta.duration_hours
+                    else:
+                        record_result[start.date()] += (stop - start).total_seconds() / 3600
                 result[record.id] = sorted(record_result.items())
         return result
 


### PR DESCRIPTION
### Steps to reproduce:
	- Create a leave type that creates timesheet
	- Create a leave for a flexible employee for 4 days
	- Check the timesheet created for this leave
	- Notice the amount of this timesheet is 83 hours not 32

### Cause:
When creating a timesheet or a work entry for a leave we get the difference between the start and the end date in milliseconds and divide it by 3600 to get the hours.

Timesheet:

https://github.com/odoo/odoo/blob/c3c63c3d00852010be4fe61a6f2314a099d99215/addons/resource/models/resource_mixin.py#L208-L213

Work entry:

https://github.com/odoo/odoo/blob/c3c63c3d00852010be4fe61a6f2314a099d99215/addons/resource/models/resource_calendar.py#L522-L525

This doesn't work for flexible hours as when fetching attendance intervals for flexible employee we return one big block for the whole period as there is no attendance intervals for the flexible employees.

https://github.com/odoo/odoo/blob/c3c63c3d00852010be4fe61a6f2314a099d99215/addons/resource/models/resource_calendar.py#L370-L376

### Fix:
When fetching the attendance intervals for flexible employee we return the hours per day as duration hours not the diff between the start and the end date of the period. We only use the diff between the dates in case of fully flexible. Then we use this duration hours in timesheet and work entry creation

opw-4628296