### PR TITLE
[FIX] html_editor: unwrap nested formatting tags

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -12,11 +12,12 @@ import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import {
     isContentEditable,
     isEmptyBlock,
+    isRedundantElement,
     isTextNode,
     isWhitespace,
     isZwnbsp,
 } from "@html_editor/utils/dom_info";
-import { closestElement, descendants } from "@html_editor/utils/dom_traversal";
+import { closestElement, descendants, selectElements } from "@html_editor/utils/dom_traversal";
 import { isCSSColor } from "@web/core/utils/colors";
 import { ColorSelector } from "./color_selector";
 import { reactive } from "@odoo/owl";
@@ -65,6 +66,7 @@ export class ColorPlugin extends Plugin {
         /** Handlers */
         selectionchange_handlers: this.updateSelectedColor.bind(this),
         remove_format_handlers: this.removeAllColor.bind(this),
+        normalize_handlers: this.normalize.bind(this),
     };
 
     setup() {
@@ -72,6 +74,14 @@ export class ColorPlugin extends Plugin {
         this.previewableApplyColor = this.dependencies.history.makePreviewableOperation(
             (color, mode, previewMode) => this._applyColor(color, mode, previewMode)
         );
+    }
+
+    normalize(root) {
+        for (const el of selectElements(root, "font")) {
+            if (isRedundantElement(el)) {
+                unwrapContents(el);
+            }
+        }
     }
 
     /**

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -1,12 +1,13 @@
 import { Plugin } from "@html_editor/plugin";
 import { isBlock, closestBlock } from "@html_editor/utils/blocks";
-import { fillEmpty } from "@html_editor/utils/dom";
+import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
-import { isVisibleTextNode } from "@html_editor/utils/dom_info";
+import { isRedundantElement, isVisibleTextNode } from "@html_editor/utils/dom_info";
 import {
     closestElement,
     createDOMPathGenerator,
     descendants,
+    selectElements,
 } from "@html_editor/utils/dom_traversal";
 import {
     convertNumericToUnit,
@@ -261,6 +262,7 @@ export class FontPlugin extends Plugin {
             this.updateFontSelectorParams.bind(this),
             this.updateFontSizeSelectorParams.bind(this),
         ],
+        normalize_handlers: this.normalize.bind(this),
 
         /** Overrides */
         split_element_block_overrides: [
@@ -275,6 +277,14 @@ export class FontPlugin extends Plugin {
     setup() {
         this.fontSize = reactive({ displayName: "" });
         this.font = reactive({ displayName: "" });
+    }
+
+    normalize(root) {
+        for (const el of selectElements(root, "strong, b, span[style*='font-weight: bolder']")) {
+            if (isRedundantElement(el)) {
+                unwrapContents(el);
+            }
+        }
     }
 
     get fontName() {

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -137,7 +137,7 @@ test("should get ready to type in not bold", async () => {
 test("should remove a bold tag that was redondant while performing the command", async () => {
     for (const tag of BOLD_TAGS) {
         await testEditor({
-            contentBefore: `<p>a${tag(`b${tag(`[c]`)}d`)}e</p>`,
+            contentBefore: `<p>a${tag(`b[c]d`)}e</p>`,
             stepFunction: bold,
             contentAfter: `<p>a${tag("b")}[c]${tag("d")}e</p>`,
         });

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -899,6 +899,21 @@ describe("Unwrapping html element", () => {
             },
             contentAfter: "<h1>mnabc</h1><h1>def</h1><h1>ghi[]op</h1>",
         });
+        await testEditor({
+            contentBefore: "<p><strong>test []</strong></p>",
+            stepFunction: async (editor) => {
+                pasteHtml(editor, "<strong>paste</strong>");
+            },
+            contentAfter: "<p><strong>test paste[]</strong></p>",
+        });
+        await testEditor({
+            contentBefore: '<p><font style="background-color: rgb(255, 0, 0);">[]test</font></p>',
+            stepFunction: async (editor) => {
+                pasteHtml(editor, '<font style="background-color: rgb(255, 0, 0);">nested </font>');
+            },
+            contentAfter:
+                '<p><font style="background-color: rgb(255, 0, 0);">nested []test</font></p>',
+        });
     });
     test("should not unwrap a node when pasting at start of different node", async () => {
         await testEditor({


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- When pasting formatted content (like `<strong>` or `<font>`) into a region that already had same formatting, it caused nested identical tags, leading to exaggerated styling (e.g., "double bold").

```html
<!-- User pastes <strong>text</strong> inside <strong> -->
<p><strong>text []</strong></p>

<!-- Resulting HTML -->
<p><strong>text <strong>text</strong>[]</strong></p>
```

### Desired behavior after PR is merged:

- Prevents unwanted style amplification by unwrapping nested identical formatting tags.

```html
<!-- Resulting HTML -->
<p><strong>text text[]</strong></p>
```

task-4715409

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
