### PR TITLE
[FIX] discuss: increase spacing of the call view

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -7,7 +7,7 @@
             'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen,
             'o-compact': props.compact and !isMobileOs,
             'o-minimized': minimized,
-            'position-relative': !state.isFullscreen,
+            'position-relative rounded-2 mx-1 mt-1 p-1': !state.isFullscreen,
         }">
             <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-on-mouseleave="onMouseleaveMain">
                 <div


### PR DESCRIPTION
Before this commit, the spacing around the call view was too narrow, which could lead to a degraded user experience, for example on mobile devices with curved screen where having elements too close to the sides could hide them or cause involuntary touch interactions.

This commit also adds a slight curve to the call view to better match the overall style of discuss.

| Before | After |
|--------|--------|
| <img width="753" alt="Screenshot 2025-04-16 at 14 14 29" src="https://github.com/user-attachments/assets/b5bbc1f3-3b1d-420e-ac45-6f05edf6c75a" /> | <img width="959" alt="Screenshot 2025-04-16 at 14 34 21" src="https://github.com/user-attachments/assets/a42e2e3f-83df-49fe-86ac-1848ff68bb47" /> |
| <img width="387" alt="Screenshot 2025-04-16 at 14 15 33" src="https://github.com/user-attachments/assets/8262f3d3-bab0-47df-8ca4-2942887680c4" /> | <img width="387" alt="Screenshot 2025-04-16 at 14 34 44" src="https://github.com/user-attachments/assets/03e813cd-9a5a-4e7d-87ef-364058016d6a" /> | 

