### PR TITLE
[IMP] web, stock: Persist search panel expand state using localStorage

### DIFF
--- a/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
+++ b/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
@@ -9,7 +9,6 @@ export class StockOrderpointSearchPanel extends SearchPanel {
     setup() {
         this.orm = useService("orm");
         super.setup(...arguments);
-        this.state.sidebarExpanded = false;
         this.globalVisibilityDays = useState({value: 0});
         onWillStart(this.getVisibilityParameter);
     }

--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -2,7 +2,6 @@ import { makeContext } from "@web/core/context";
 import { _t } from "@web/core/l10n/translation";
 import { evaluateBooleanExpr, evaluateExpr } from "@web/core/py_js/py";
 import { clamp } from "@web/core/utils/numbers";
-import { exprToBoolean } from "@web/core/utils/strings";
 import { visitXML } from "@web/core/utils/xml";
 import { DEFAULT_INTERVAL, toGeneratorId } from "@web/search/utils/dates";
 
@@ -47,7 +46,6 @@ export class SearchArchParser {
         this.preSearchItems = [];
         this.searchPanelInfo = {
             className: "",
-            fold: false,
             viewTypes: DEFAULT_VIEWS_WITH_SEARCH_PANEL,
         };
         this.sections = [];
@@ -315,9 +313,6 @@ export class SearchArchParser {
 
         if (searchPanelNode.hasAttribute("class")) {
             this.searchPanelInfo.className = searchPanelNode.getAttribute("class");
-        }
-        if (searchPanelNode.hasAttribute("fold")) {
-            this.searchPanelInfo.fold = exprToBoolean(searchPanelNode.getAttribute("fold"));
         }
         if (searchPanelNode.hasAttribute("view_types")) {
             this.searchPanelInfo.viewTypes = searchPanelNode.getAttribute("view_types").split(",");

--- a/addons/web/static/src/search/search_panel/search_panel.js
+++ b/addons/web/static/src/search/search_panel/search_panel.js
@@ -11,6 +11,8 @@ import {
     useRef,
     useState,
 } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { useSetupAction } from "@web/search/action_hook";
 
 //-------------------------------------------------------------------------
@@ -56,11 +58,12 @@ export class SearchPanel extends Component {
     };
 
     setup() {
+        this.keyExpandSidebar = `search_panel_expanded,${this.env.config.viewId},${this.env.config.actionId}`;
         this.state = useState({
             active: {},
             expanded: {},
             showMobileSearch: false,
-            sidebarExpanded: !this.env.searchModel.searchPanelInfo.fold,
+            sidebarExpanded: true,
         });
         this.hasImportedState = false;
         this.root = useRef("root");
@@ -69,6 +72,10 @@ export class SearchPanel extends Component {
         this.width = "10px";
 
         this.importState(this.env.searchPanelState);
+        const sidebarExpandedPreference = browser.localStorage.getItem(this.keyExpandSidebar);
+        if (sidebarExpandedPreference !== null) {
+            this.state.sidebarExpanded = exprToBoolean(sidebarExpandedPreference);
+        }
 
         useBus(this.env.searchModel, "update", async () => {
             await this.env.searchModel.sectionsPromise;
@@ -312,6 +319,7 @@ export class SearchPanel extends Component {
 
     toggleSidebar() {
         this.state.sidebarExpanded = !this.state.sidebarExpanded;
+        browser.localStorage.setItem(this.keyExpandSidebar, this.state.sidebarExpanded);
     }
 
     /**

--- a/addons/web/static/tests/webclient/actions/push_state.test.js
+++ b/addons/web/static/tests/webclient/actions/push_state.test.js
@@ -615,7 +615,7 @@ test(`properly push globalState`, async () => {
             },
         ],
         globalState: {
-            searchModel: `{"nextGroupId":2,"nextGroupNumber":1,"nextId":2,"query":[{"searchItemId":1,"autocompleteValue":{"label":"blip","operator":"ilike","value":"blip"}}],"searchItems":{"1":{"type":"field","fieldName":"foo","fieldType":"char","description":"Foo","groupId":1,"id":1}},"searchPanelInfo":{"className":"","fold":false,"viewTypes":["kanban","list"],"loaded":false,"shouldReload":true},"sections":[]}`,
+            searchModel: `{"nextGroupId":2,"nextGroupNumber":1,"nextId":2,"query":[{"searchItemId":1,"autocompleteValue":{"label":"blip","operator":"ilike","value":"blip"}}],"searchItems":{"1":{"type":"field","fieldName":"foo","fieldType":"char","description":"Foo","groupId":1,"id":1}},"searchPanelInfo":{"className":"","viewTypes":["kanban","list"],"loaded":false,"shouldReload":true},"sections":[]}`,
         },
     });
 
@@ -660,7 +660,7 @@ test(`properly push globalState`, async () => {
             },
         ],
         globalState: {
-            searchModel: `{"nextGroupId":2,"nextGroupNumber":1,"nextId":2,"query":[{"searchItemId":1,"autocompleteValue":{"label":"blip","operator":"ilike","value":"blip"}}],"searchItems":{"1":{"type":"field","fieldName":"foo","fieldType":"char","description":"Foo","groupId":1,"id":1}},"searchPanelInfo":{"className":"","fold":false,"viewTypes":["kanban","list"],"loaded":false,"shouldReload":true},"sections":[]}`,
+            searchModel: `{"nextGroupId":2,"nextGroupNumber":1,"nextId":2,"query":[{"searchItemId":1,"autocompleteValue":{"label":"blip","operator":"ilike","value":"blip"}}],"searchItems":{"1":{"type":"field","fieldName":"foo","fieldType":"char","description":"Foo","groupId":1,"id":1}},"searchPanelInfo":{"className":"","viewTypes":["kanban","list"],"loaded":false,"shouldReload":true},"sections":[]}`,
         },
     });
 });


### PR DESCRIPTION
This commit enhances the user experience by remembering the state of the search panel across sessions using localStorage.

- When a user visits a screen for the first time, the search panel uses the arch's information to set its expand state.
- If the user folds the panel, it remains folded the next time they return.
- Likewise, if the panel is unfolded, that preference is preserved.

This behavior aligns with how list view column preferences are already stored.

As this should become the default behavior everywhere, the arch's fold attribute is removed (as it was not used anyway) and the diff from https://github.com/odoo/odoo/commit/f0c9d3ced97351a0b23254bab0fc11a94c7d981f is reverted.

task-4665085