### PR TITLE
[IMP] web: use nav hook in tag nav hook

### DIFF
--- a/addons/mail/static/src/core/web/recipients_input.js
+++ b/addons/mail/static/src/core/web/recipients_input.js
@@ -25,7 +25,9 @@ export class RecipientsInput extends Component {
         this.action = useService("action");
         this.store = useService("mail.store");
         this.popover = usePopover(RecipientsPopover, { position: "bottom-middle" });
-        this.onKeydown = useTagNavigation("recipientsInputRef", this.deleteTagByIndex.bind(this));
+        useTagNavigation("recipientsInputRef", {
+            delete: this.deleteTagByIndex.bind(this),
+        });
 
         this.openListViewToSelectResPartner = useSelectCreate({
             resModel: "res.partner",
@@ -207,7 +209,6 @@ export class RecipientsInput extends Component {
                             additionalOrSuggestedRecipient.email !== recipient.email
                     );
                 },
-                onKeydown: this.onKeydown.bind(this),
             });
         };
         for (const recipient of this.props.thread.suggestedRecipients) {

--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -16,7 +16,7 @@ import { getVisibleElements } from "../utils/ui";
  *  allow registration to perform no matter the UI active element
  * @property {() => HTMLElement} [area]
  *  adds a restricted operating area for this hotkey
- * @property {() => boolean} [isAvailable]
+ * @property {(target: HTMLElement) => boolean} [isAvailable]
  *  adds a validation before calling the hotkey registration's callback
  * @property {() => HTMLElement} [withOverlay]
  *  provides the element on which the overlay should be displayed
@@ -240,7 +240,7 @@ export const hotkeyService = {
                     (reg.allowRepeat || !isRepeated) &&
                     (reg.bypassEditableProtection || !shouldProtectEditable) &&
                     (reg.global || reg.activeElement === activeElement) &&
-                    (!reg.isAvailable || reg.isAvailable()) &&
+                    (!reg.isAvailable || reg.isAvailable(target)) &&
                     (!reg.area || (target && reg.area() && reg.area().contains(target)))
             );
 

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -198,7 +198,7 @@ export class Navigator {
             this._hotkeyRemoves.push(
                 this._hotkeyService.add(hotkey, () => callback(this), {
                     allowRepeat,
-                    isAvailable: () => isAvailable(this),
+                    isAvailable: (target) => isAvailable(this, target),
                     bypassEditableProtection,
                 })
             );
@@ -289,7 +289,14 @@ export class Navigator {
             this.activeItemIndex < this.items.length &&
             oldActiveItem !== this.items[this.activeItemIndex]
         ) {
-            this.items[this.activeItemIndex]?.setActive();
+            const index = elements.indexOf(oldActiveItem?.el);
+            if (index < 0) {
+                this.items[this.activeItemIndex]?.setActive();
+            } else {
+                // set the new active item's index
+                this.activeItemIndex = index;
+                this.activeItem = this.items[this.activeItemIndex];
+            }
         }
     }
 

--- a/addons/web/static/src/core/record_selectors/multi_record_selector.js
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.js
@@ -22,7 +22,9 @@ export class MultiRecordSelector extends Component {
 
     setup() {
         this.nameService = useService("name");
-        this.onTagKeydown = useTagNavigation("multiRecordSelector", this.deleteTag.bind(this));
+        useTagNavigation("multiRecordSelector", {
+            delete: (index) => this.deleteTag(index),
+        });
         onWillStart(() => this.computeDerivedParams());
         onWillUpdateProps((nextProps) => this.computeDerivedParams(nextProps));
     }
@@ -68,7 +70,6 @@ export class MultiRecordSelector extends Component {
                 onDelete: () => {
                     this.deleteTag(index);
                 },
-                onKeydown: this.onTagKeydown,
                 img:
                     this.isAvatarModel &&
                     isId(id) &&

--- a/addons/web/static/src/core/record_selectors/tag_navigation_hook.js
+++ b/addons/web/static/src/core/record_selectors/tag_navigation_hook.js
@@ -1,6 +1,4 @@
-import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
-
-import { useEffect, useRef } from "@odoo/owl";
+import { useNavigation } from "../navigation/navigation";
 
 /**
  * This hook allows to navigate between tags in a record selector. It also
@@ -9,127 +7,72 @@ import { useEffect, useRef } from "@odoo/owl";
  * `Autocomplete` and `TagList`.
  *
  * @param {string} refName Name of the t-ref which contains the `Autocomplete` and `TagList` components.
- * @param {Function} deleteTag Function to be called when a tag is deleted. It should take the index of the tag to delete as parameter.
- * @returns {Function} Function to be called when a tag is focused and a key is pressed. It should be passed to the `onKeydown` prop of the `Tag` component.
+ * @param {object} [options]
+ * @param {() => boolean} [options.isEnabled]
+ * @param {(index: number) => void} [options.delete] Function to be called when a tag is deleted. It should take the index of the tag to delete as parameter.
  */
-export function useTagNavigation(refName, deleteTag) {
-    const ref = useRef(refName);
+export function useTagNavigation(refName, options = {}) {
+    const isEnabled = options.isEnabled ?? (() => true);
 
-    useEffect(
-        (autocomplete) => {
-            if (!autocomplete) {
-                return;
+    const isNavigationAvailable = (navigator, target) => {
+        return isEnabled() && navigator.items.some((item) => item.target === target);
+    };
+
+    const canRemoveTag = (target) => {
+        return options.delete && (target.tagName.toLowerCase() !== "input" || !target.value);
+    };
+
+    const onBackspaceKeydown = (navigator) => {
+        const el = navigator.activeItem.el;
+        if (el.classList.contains("o-autocomplete--input")) {
+            if (!el.value && navigator.items.length > 1) {
+                options.delete(navigator.items.length - 2);
             }
-            autocomplete.addEventListener("keydown", onAutoCompleteKeydown);
-            return () => {
-                autocomplete.removeEventListener("keydown", onAutoCompleteKeydown);
-            };
+        } else {
+            options.delete(navigator.activeItemIndex);
+        }
+        navigator.items.at(-1).setActive();
+    };
+
+    const canNavigateFromInput = (navigator, navNext) => {
+        const el = navigator.activeItem.el;
+        if (el.classList.contains("o-autocomplete--input")) {
+            const menu = navigator.containerRef.el.querySelector(".o-autocomplete--dropdown-menu");
+            const index = navNext ? el.value.length : 0;
+            if (el.selectionStart !== index || menu) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    useNavigation(refName, {
+        itemsSelector: ":scope .o_tag, :scope .o-autocomplete--input",
+        onEnabled() {}, // prevent auto focus
+        focusInitialElementOnDisabled: () => false,
+        hotkeys: {
+            tab: null,
+            "shift+tab": null,
+            home: null,
+            end: null,
+            enter: null,
+            arrowup: null,
+            arrowdown: null,
+            backspace: {
+                bypassEditableProtection: true,
+                isAvailable: (navigator, target) => isNavigationAvailable(navigator, target) && canRemoveTag(target),
+                callback: (navigator) => onBackspaceKeydown(navigator),
+            },
+            arrowleft: {
+                bypassEditableProtection: true,
+                isAvailable: (navigator, target) => isNavigationAvailable(navigator, target) && canNavigateFromInput(navigator, false),
+                callback: (navigator) => navigator.previous(),
+            },
+            arrowright: {
+                bypassEditableProtection: true,
+                isAvailable: (navigator, target) => isNavigationAvailable(navigator, target) && canNavigateFromInput(navigator, true),
+                callback: (navigator) => navigator.next(),
+            },
         },
-        () => [ref.el?.querySelector(".o-autocomplete")]
-    );
-
-    /**
-     * Focus the tag at the given index. If no index is given, focus the rightmost tag.
-     * @param {number|undefined} index Index of the tag to focus. If undefined, focus the rightmost tag.
-     */
-    function focusTag(index) {
-        const tags = ref.el.getElementsByClassName("o_tag");
-        if (tags.length) {
-            if (index === undefined) {
-                tags[tags.length - 1].focus();
-            } else {
-                tags[index].focus();
-            }
-        }
-    }
-
-    /**
-     * Function to be called when a key is pressed in the `Autocomplete` component.
-     *
-     * @param {Event} ev
-     */
-    function onAutoCompleteKeydown(ev) {
-        if (ev.isComposing) {
-            // This case happens with an IME for example: we let it handle all key events.
-            return;
-        }
-        const hotkey = getActiveHotkey(ev);
-        const input = ev.target.closest(".o-autocomplete--input");
-        const autoCompleteMenuOpened = !!ref.el.querySelector(".o-autocomplete--dropdown-menu");
-        switch (hotkey) {
-            case "arrowleft": {
-                if (input.selectionStart || autoCompleteMenuOpened) {
-                    return;
-                }
-                // focus rightmost tag if any.
-                focusTag();
-                break;
-            }
-            case "arrowright": {
-                if (input.selectionStart !== input.value.length || autoCompleteMenuOpened) {
-                    return;
-                }
-                // focus leftmost tag if any.
-                focusTag(0);
-                break;
-            }
-            case "backspace": {
-                if (input.value) {
-                    return;
-                }
-                const tags = ref.el.getElementsByClassName("o_tag");
-                if (tags.length) {
-                    deleteTag(tags.length - 1);
-                }
-                break;
-            }
-            default:
-                return;
-        }
-        ev.preventDefault();
-        ev.stopPropagation();
-    }
-
-    /**
-     * Function to be called when a key is pressed in the `Tag` component.
-     * It should be passed to the `onKeydown` prop of the `Tag` component.
-     *
-     * @param {Event} ev
-     */
-    function onTagKeydown(ev) {
-        const hotkey = getActiveHotkey(ev);
-        const tags = [...ref.el.getElementsByClassName("o_tag")];
-        const closestTag = ev.target.closest(".o_tag");
-        const tagIndex = tags.indexOf(closestTag);
-        const input = ref.el.querySelector(".o-autocomplete--input");
-        switch (hotkey) {
-            case "arrowleft": {
-                if (tagIndex === 0) {
-                    input.focus();
-                } else {
-                    focusTag(tagIndex - 1);
-                }
-                break;
-            }
-            case "arrowright": {
-                if (tagIndex === tags.length - 1) {
-                    input.focus();
-                } else {
-                    focusTag(tagIndex + 1);
-                }
-                break;
-            }
-            case "backspace": {
-                input.focus();
-                deleteTag(tagIndex);
-                break;
-            }
-            default:
-                return;
-        }
-        ev.preventDefault();
-        ev.stopPropagation();
-    }
-
-    return onTagKeydown;
+    });
 }

--- a/addons/web/static/src/core/tags_list/tags_list.xml
+++ b/addons/web/static/src/core/tags_list/tags_list.xml
@@ -16,7 +16,7 @@
                 t-att-aria-label="tag.title || tag.text"
                 t-att-data-tooltip="tag.title || tag.text"
                 t-on-click="(ev) => tag.onClick and tag.onClick(ev)"
-                t-on-keydown="tag.onKeydown">
+            >
 
                 <!-- Avatar's :hover backdrop -->
                 <span
@@ -60,7 +60,7 @@
     </t>
 
     <t t-name="web.TagsList.Tooltip">
-        <t t-foreach="tags" t-as="tag" t-key="tag.id">
+        <t t-foreach="tags" t-as="tag" t-key="tag.id or tag_index">
             <div t-esc="tag.text"/>
         </t>
     </t>

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -73,10 +73,10 @@ export class Many2ManyTagsField extends Component {
         this.popover = usePopover(this.constructor.components.Popover);
         this.dialog = useService("dialog");
         this.dialogClose = [];
-        this.onTagKeydown = useTagNavigation(
-            "many2ManyTagsField",
-            this.deleteTagByIndex.bind(this)
-        );
+        useTagNavigation("many2ManyTagsField", {
+            isEnabled: () => !this.props.readonly,
+            delete: (index) => this.deleteTagByIndex(index),
+        });
         this.autoCompleteRef = useRef("autoComplete");
         this.mutex = new Mutex();
 
@@ -152,12 +152,6 @@ export class Many2ManyTagsField extends Component {
             colorIndex: record.data[this.props.colorField],
             canEdit: this.props.canEditTags,
             onDelete: !this.props.readonly ? () => this.deleteTag(record.id) : undefined,
-            onKeydown: (ev) => {
-                if (this.props.readonly) {
-                    return;
-                }
-                this.onTagKeydown(ev);
-            },
         };
     }
 


### PR DESCRIPTION
Before this commit, the tag navigation hook didn't use the navigation hook. The tag nav hook also returned a callback to use with keydown events. Now that the tag nav hook uses nav hook, it doesn't need to return the callback anymore.

task-4660359