### PR TITLE
[FIX] point_of_sale: display on-hand quantity for product variants

### DIFF
--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -159,11 +159,11 @@ export class ProductConfiguratorPopup extends Component {
     computeProductProduct() {
         let product = this.props.product;
         const formattedPayload = this.computePayload();
-        const alwaysVariants = this.props.product.attribute_line_ids.every(
-            (line) => line.attribute_id.create_variant === "always"
+        const hasVariants = this.props.product.attribute_line_ids.some(
+            (line) => line.attribute_id.create_variant !== "no_variant"
         );
 
-        if (alwaysVariants) {
+        if (hasVariants) {
             const newProduct = this.pos.models["product.product"]
                 .filter((p) => p.raw?.product_template_variant_value_ids?.length > 0)
                 .find((p) =>


### PR DESCRIPTION
Prior to this fix, the product configurator did not display the on-hand quantities of product variants as shown on the product page, when an attribute’s variant creation was set to 'never'.

Steps to reproduce:
1. Create a product with variants.
2. Add multiple attributes and values.
3. Set the variant creation to 'never' for one attribute.
4. Add stock for the product and make it available in POS.
5. Open POS, select the product, and switch between variants.

The quantity displayed was only for one variant.

This commit ensures that the correct on-hand quantity is shown for each selected variant in POS.

opw-4685882

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
