### PR TITLE
[FIX] website: fix hidden snippet forced visibility

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2711,7 +2711,9 @@ options.registry.DeviceVisibility = options.Class.extend({
      * @override
      */
     async onTargetHide() {
+        this.options.wysiwyg.odooEditor.observerUnactive("onTargetHide");
         this.$target[0].classList.remove('o_snippet_override_invisible');
+        this.options.wysiwyg.odooEditor.observerActive("onTargetHide");
     },
     /**
      * @override
@@ -2722,7 +2724,9 @@ options.registry.DeviceVisibility = options.Class.extend({
         if ((this.$target[0].classList.contains('o_snippet_mobile_invisible')
                 || this.$target[0].classList.contains('o_snippet_desktop_invisible')
             ) && isMobilePreview === isMobileHidden) {
+            this.options.wysiwyg.odooEditor.observerUnactive("onTargetShow");
             this.$target[0].classList.add('o_snippet_override_invisible');
+            this.options.wysiwyg.odooEditor.observerActive("onTargetShow");
         }
     },
     /**


### PR DESCRIPTION
Steps to Reproduce :

- Drag and drop a "Text" snippet.
- Click on "Hide on desktop".
- Toggle on the eye button to force its visibility.
- Click on a text outside the snippet & press enter.
- Bug: the invisible snippet disappears.

The issue comes from the fact that when we press Enter, a new paragraph is created and a history rollback is triggered at that moment. So when we go back in the history because of that rollback, the invisible snippet loses the "o_snippet_override_invisible" class that had just been applied.

Actually, adding and removing this class should not be inside the observer. This commit prevents that from happening.

task-4690318