### PR TITLE
[FIX] l10n_it_edi: fix async multi-company send to SDI

### DIFF
--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -8,15 +8,15 @@ from odoo.addons.l10n_it_edi.tests.common import TestItEdi
 @tagged('post_install_l10n', 'post_install', '-at_install')
 class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
 
-    def init_invoice(self, partners):
+    def init_invoice(self, partners, company=None, taxes=None):
         invoices = self.env['account.move']
         for partner in partners:
             invoices |= super().init_invoice(
                 "out_invoice",
                 partner=partner,
-                company=self.company,
+                company=company or self.company,
                 amounts=[1000],
-                taxes=self.default_tax,
+                taxes=taxes or self.default_tax,
                 post=True)
         return invoices
 
@@ -121,3 +121,45 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
             self.assertIn('move_missing_origin_document_field', cig)
             self.assertIn('move_missing_origin_document_field', cup)
             self.assertIn('move_missing_origin_document_field', cig_cup)
+
+    def test_invoice_send_with_multiple_company(self):
+        second_company = self.company_data['company']
+        second_company.write({
+            'vat': 'IT12345670017',
+            'phone': '0266766700',
+            'mobile': '+393288088988',
+            'email': 'test@test.it',
+            'street': '1234 Test Street',
+            'zip': '12345',
+            'city': 'Prova',
+            'l10n_it_codice_fiscale': '12345670017',
+            'l10n_it_tax_system': 'RF01'
+        })
+
+        second_proxy = self.env['account_edi_proxy_client.user'].create({
+            'proxy_type': 'l10n_it_edi',
+            'id_client': 'l10n_it_edi_test_second_company',
+            'company_id': second_company.id,
+            'edi_identification': 'l10n_it_edi_test_second_company',
+            'private_key_id': self.private_key_id.id,
+            'edi_mode': 'demo',
+        })
+
+        self.proxy_user.edi_mode = 'demo'
+
+        invoice1 = self.init_invoice(self.italian_partner_a)
+        invoice2 = self.init_invoice(
+            self.italian_partner_a,
+            second_company,
+            self.company_data['default_tax_sale']
+        )
+
+        with patch('odoo.addons.l10n_it_edi.models.account_move.AccountMove._l10n_it_edi_upload', return_value={}, autospec=True) as mock_check:
+            self.env['account.move.send'].with_context(allowed_company_ids=[second_company.id, self.company.id])._generate_and_send_invoices(invoice2 + invoice1)
+            self.assertEqual(mock_check.call_count, 2)
+            res_call_invoice1, res_call_invoice2 = mock_check.call_args_list
+            res_invoice1, res_invoice2 = res_call_invoice2[0][0], res_call_invoice1[0][0]
+            self.assertEqual(res_invoice1, invoice1)
+            self.assertEqual(res_invoice2, invoice2)
+            self.assertEqual(res_invoice1.company_id.l10n_it_edi_proxy_user_id, self.proxy_user)
+            self.assertEqual(res_invoice2.company_id.l10n_it_edi_proxy_user_id, second_proxy)


### PR DESCRIPTION
Fix an issue when sending invoices asynchronously to SDI from multiple companies.

Steps to reproduce:
- Setup two Italian companies, A and B
- Create and post one invoice in each company
- From the list view, batch send both invoices
- Run the “Send invoices automatically” scheduled action

An error occurs:
ValueError: Expected singleton: account_edi_proxy_client.user(4, 3)

This happens because both companies try to send their moves simultaneously, but the proxy client is company-specific.

This fix groups the invoices by company before sending them.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4725653)
opw-4725653