### PR TITLE
[FIX] barcodes_gs1_nomenclature: prevent error while creating new equipment

### DIFF
--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -168,6 +168,8 @@ class BarcodeNomenclature(models.Model):
                     return condition
 
                 # Parse the value
+                if not value:
+                    return condition
                 try:
                     parsed_data = nomenclature.parse_barcode(value) or []
                 except (ValidationError, ValueError):


### PR DESCRIPTION
This error is generated when a user tries to `create new equipment`.

Steps to Reproduce :
1. Install the `MRP` and `Maintenance` modules
2.  Go to Settings and set the `Barcode Nomenclature` to `Default GS1 Nomenclature`.
3. In  Maintenace > Equipments > Machine & Tools > New.

`TypeError: expected string or bytes-like object, got 'bool'`

The error occurs when the system attempts to parse a False value through `parse_barcode`, which expects a string.

This commit resolves the error by returning the original condition if a value is false.

Sentry:6544673924
OPW : 4725056