### PR TITLE
[FIX] mrp: avoid validation error when switching views

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -923,9 +923,9 @@ class MrpProduction(models.Model):
             action['domain'] = [('id', 'in', self.picking_ids.ids)]
         elif self.picking_ids:
             action['res_id'] = self.picking_ids.id
-            action['views'] = [(self.env.ref('stock.view_picking_form').id, 'form')]
-            if 'views' in action:
-                action['views'] += [(state, view) for state, view in action['views'] if view != 'form']
+            picking_form = self.env.ref('stock.view_picking_form', False)
+            picking_form_view = [(picking_form and picking_form.id or False, 'form')]
+            action['views'] = picking_form_view + [(state, view) for state, view in action.get('views', []) if view != 'form']
         action['context'] = dict(self._context, default_origin=self.name)
         return action
 


### PR DESCRIPTION
Issue:
------------------------------------------
When we create MO having one picking, open this picking via Studio and switching 
to other view giving a ValidationError: `The modes in view_mode must not be 
duplicated: ['tree', 'kanban', 'form', 'calendar', 'map', 'kanban']` instead of 
switching to the selected view.

How to reproduce:
------------------------------------------
1.Install Manufacturing,
2.Enable 2-step manufacturing,
3.Create MO for any product, e.g.Wood Panel
4.Go to the Transfers(having 1 picking),
5.Open Studio -> views -> Activate list view,
Switching to Studio list view giving a ValidationError.

Cause of the issue:
------------------------------------------
In the `action_view_mo_delivery` method when there is a single picking for the MO, only form 
view is passed in views, so it is not able to open other views.

Solution:
------------------------------------------
In action_view_mo_delivery for single picking passes the form view and append
the other views. This prevents the ValidationError and opens the 
selected view in Studio.

This is similar to the issue previously fixed in:
https://github.com/odoo/odoo/pull/37582