### PR TITLE
[FIX] web_editor: traceback when applying gradient color

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -716,7 +716,7 @@ export const editorCommands = {
                     // Partially selected <font>: split it.
                     const selectedChildren = children.filter(child => selectedNodes.includes(child));
                     if (selectedChildren.length) {
-                        const closestGradientEl = closestElement(node, '[style*="background-image"]');
+                        const closestGradientEl = closestElement(node, 'font[style*="background-image"], span[style*="background-image"]');
                         const isGradientBeingUpdated = closestGradientEl && isColorGradient(color);
                         const splitnode = isGradientBeingUpdated ? closestGradientEl : font;
                         font = splitAroundUntil(selectedChildren, splitnode);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
@@ -255,6 +255,20 @@ describe('applyColor', () => {
                         '<font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);"><span class="a">bc</span></font></p>',
         });
     });
+    it("should apply gradient color on selected text", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<div style="background-image:none"><p>[ab<strong>cd</strong>ef]</p></div>',
+            stepFunction: setColor("linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%)", "backgroundColor"),
+            contentAfter: '<div style="background-image:none"><p><font style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);">[ab<strong>cd</strong>ef]</font></p></div>'
+        });
+    });
+    it("should apply gradient text color on selected text", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<div style="background-image:none"><p>[ab<strong>cd</strong>ef]</p></div>',
+            stepFunction: setColor("linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%)", "color"),
+            contentAfter: '<div style="background-image:none"><p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);">[ab<strong>cd</strong>ef]</font></p></div>'
+        });
+    });
 });
 describe('rgbToHex', () => {
     it('should convert an rgb color to hexadecimal', async () => {


### PR DESCRIPTION
**Current behavior before PR:**

- When gradient image is applied on element other than font or span, applying a gradient color to its child text would trigger a traceback.

**Desired behavior after PR is merged:**

- Now, if the gradient image is applied on element other than font or span, applying gradient color on its child text will applied gradient color properly.

task:4730500
