### PR TITLE
[IMP] auth_top: prevent replay attacks for TOTP

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -24,6 +24,7 @@ class ResUsers(models.Model):
     _inherit = 'res.users'
 
     totp_secret = fields.Char(copy=False, groups=fields.NO_ACCESS, compute='_compute_totp_secret', inverse='_inverse_token')
+    totp_last_counter = fields.Integer(copy=False, groups=fields.NO_ACCESS)
     totp_enabled = fields.Boolean(string="Two-factor authentication", compute='_compute_totp_enabled', search='_totp_enable_search')
     totp_trusted_device_ids = fields.One2many('auth_totp.device', 'user_id', string="Trusted Devices")
 
@@ -71,14 +72,19 @@ class ResUsers(models.Model):
             if match is None:
                 _logger.info("2FA check: FAIL for %s %r", self, sudo.login)
                 raise AccessDenied(_("Verification failed, please double-check the 6-digit code"))
+
+            if sudo.totp_last_counter and match <= sudo.totp_last_counter:
+                _logger.warning("2FA check: REUSE for %s %r", self, sudo.login)
+                raise AccessDenied(_("Verification failed, please use the latest 6-digit code"))
+
+            sudo.totp_last_counter = match
             _logger.info("2FA check: SUCCESS for %s %r", self, sudo.login)
             return {
                 'uid': self.env.user.id,
                 'auth_method': 'totp',
                 'mfa': 'default',
             }
-        else:
-            return super()._check_credentials(credentials, env)
+        return super()._check_credentials(credentials, env)
 
     def _totp_try_setting(self, secret, code):
         if self.totp_enabled or self != self.env.user:
@@ -92,6 +98,7 @@ class ResUsers(models.Model):
             return False
 
         self.sudo().totp_secret = secret
+        self.sudo().totp_last_counter = match
         if request:
             self.env.flush_all()
             # update session token so the user does not get logged out (cache cleared by change)
@@ -175,6 +182,7 @@ class ResUsers(models.Model):
             user.totp_secret = self.env.cr.fetchone()[0]
 
     def _inverse_token(self):
+        self.sudo().totp_last_counter = False
         for user in self:
             secret = user.totp_secret if user.totp_secret else None
             self.env.cr.execute('UPDATE res_users SET totp_secret = %s WHERE id=%s', (secret, user.id))

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -109,7 +109,8 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
             copyBtn.remove();
         }
         const token = await rpc('/totphook', {
-            secret: secret.textContent
+            secret: secret.textContent,
+            offset: 0,
         });
         await helpers.edit(token, '[name=code] input');
         document.querySelector("body").classList.add("got-token");
@@ -157,18 +158,45 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
     trigger: 'label:contains(Authentication Code)',
     run: "click",
 }, {
+    content: "input incorrect code",
+    trigger: 'input[name=totp_token]',
+    async run(helpers) {
+        // set the offset in the past, so the token will be always wrong
+        await rpc("/totphook", { offset: -2 });
+        helpers.edit("123456");
+    }
+}, {
+    trigger: `button:contains("Log in")`,
+    run: "click",
+}, {
+    content: "using an incorrect token should fail",
+    trigger: "p.alert.alert-danger:contains(Verification failed, please double-check the 6-digit code)",
+}, {
+    content: "reuse same code",
+    trigger: 'input[name=totp_token]',
+    async run(helpers) {
+        // send the same token as the one last one from the setup tour
+        const token = await rpc("/totphook", { offset: 0 });
+        helpers.edit(token);
+    }
+}, {
+    trigger: `button:contains("Log in")`,
+    run: "click",
+}, {
+    content: "reusing the same token should fail",
+    trigger: "p.alert.alert-danger:contains(Verification failed, please use the latest 6-digit code)",
+}, {
     content: "input code",
     trigger: 'input[name=totp_token]',
     async run(helpers) {
-        const token = await rpc('/totphook');
+        const token = await rpc('/totphook', { offset: 1 });
         helpers.edit(token);
     }
 },
 {
     trigger: `button:contains("Log in")`,
     run: "click",
-},
-{
+}, {
     content: "check we're logged in",
     trigger: ".o_user_menu .dropdown-toggle",
 }]});
@@ -203,7 +231,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
     content: "input code",
     trigger: 'input[name=totp_token]',
     async run(helpers) {
-        const token = await rpc('/totphook')
+        const token = await rpc('/totphook', { offset: 2 });
         helpers.edit(token);
     }
 },

--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -9,9 +9,12 @@ from odoo import http
 from odoo.tests import tagged, get_db_name, new_test_user, HttpCase
 from odoo.tools import mute_logger
 
+from odoo.addons.auth_totp.models.totp import TOTP as auth_TOTP
+
 from ..controllers.home import Home
 
 _logger = logging.getLogger(__name__)
+
 
 class TestTOTPMixin:
     @classmethod
@@ -22,30 +25,43 @@ class TestTOTPMixin:
         )
 
     def install_totphook(self):
+        baseline_time = time.time()
+        last_offset = 0
         totp = None
+
         # might be possible to do client-side using `crypto.subtle` instead of
         # this horror show, but requires working on 64b integers, & BigInt is
         # significantly less well supported than crypto
-        def totp_hook(self, secret=None):
-            nonlocal totp
+        def totp_hook(self, secret=None, offset=0):
+            nonlocal totp, last_offset
+            last_offset = offset * 30
             if totp is None:
                 totp = TOTP(secret)
-            if secret:
-                return totp.generate().token
-            else:
-                # on check, take advantage of window because previous token has been
-                # "burned" so we can't generate the same, but tour is so fast
-                # we're pretty certainly within the same 30s
-                return totp.generate(time.time() + 30).token
+
+            # generate the token for the given time offset
+            # we can't generate the same token twice, but tour is so fast
+            # we're pretty certainly within the same 30s
+            token = totp.generate(baseline_time + last_offset).token
+            _logger.info("TOTP secret:%s offset:%s token:%s", secret, offset, token)
+            return token
         # because not preprocessed by ControllerType metaclass
         totp_hook.routing_type = 'json'
         self.env.registry.clear_cache('routing')
         # patch Home to add test endpoint
         Home.totp_hook = http.route('/totphook', type='jsonrpc', auth='none')(totp_hook)
+
+        def totp_match(self, code, t=None, **kwargs):
+            # Allow going beyond the 30s window
+            return origin_match(self, code, t=baseline_time + last_offset, **kwargs)
+
+        origin_match = auth_TOTP.match
+        auth_TOTP.match = totp_match
+
         # remove endpoint and destroy routing map
         @self.addCleanup
         def _cleanup():
             del Home.totp_hook
+            auth_TOTP.match = origin_match
             self.env.registry.clear_cache('routing')
 
 
@@ -77,7 +93,11 @@ class TestTOTP(TestTOTPMixin, HttpCase):
             )
 
         # 3. Check 2FA is required
-        self.start_tour('/', 'totp_login_enabled', login=None)
+        with self.assertLogs("odoo.addons.auth_totp.models.res_users", "WARNING") as cm:
+            self.start_tour('/', 'totp_login_enabled', login=None)
+
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("2FA check: REUSE", cm.output[0])
 
         # 4. Check 2FA is not requested on saved device and disable it
         self.start_tour('/', 'totp_login_device', login=None)
@@ -93,7 +113,6 @@ class TestTOTP(TestTOTPMixin, HttpCase):
             'res.users', 'read', [uid, ['login']]
         )
         self.assertEqual(r['login'], 'test_user')
-
 
     def test_totp_administration(self):
         self.start_tour('/web', 'totp_tour_setup', login='test_user')

--- a/addons/auth_totp_portal/static/tests/totp_portal.js
+++ b/addons/auth_totp_portal/static/tests/totp_portal.js
@@ -28,8 +28,9 @@ registry.category("web_tour.tours").add('totportal_tour_setup', {
         const secret = this.anchor
             .closest("div")
             .querySelector('span[name="secret"]').textContent;
-        const token = await rpc('/totphook', {
-            secret
+        const token = await rpc("/totphook", {
+            secret,
+            offset: 0,
         });
         await helpers.edit(token, 'input[name="code"]');
         await helpers.click("button.btn-primary:contains(Activate)");
@@ -65,7 +66,7 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
     content: "input code",
     trigger: 'input[name=totp_token]',
     run: async function (helpers) {
-        const token = await rpc('/totphook');
+        const token = await rpc('/totphook', { offset: 1 });
         await helpers.edit(token);
         // FIXME: is there a way to put the button as its own step trigger without
         //        the tour straight blowing through and not waiting for this?


### PR DESCRIPTION
Ensure that successfully used TOTP tokens cannot be reused, hardening security against replay attacks.

task-4174506