### PR TITLE
[FIX] point_of_sale: correctly compute extra price for attributes

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -708,6 +708,7 @@ export class PosStore extends WithLazyGetterTrap {
                 // Find candidate based on instantly created variants.
                 const attributeValues = this.models["product.template.attribute.value"]
                     .readMany(payload.attribute_value_ids)
+                    .filter((value) => value.attribute_id.create_variant !== "no_variant")
                     .map((value) => value.id);
 
                 let candidate = productTemplate.product_variant_ids.find((variant) => {
@@ -889,16 +890,6 @@ export class PosStore extends WithLazyGetterTrap {
                 false,
                 values.product_id
             );
-        }
-        const isScannedProduct = opts.code && opts.code.type === "product";
-        if (values.price_extra && !isScannedProduct) {
-            const price = values.product_tmpl_id.getPrice(
-                order.pricelist_id,
-                values.qty,
-                values.price_extra
-            );
-
-            values.price_unit = price;
         }
 
         const line = this.data.models["pos.order.line"].create({ ...values, order_id: order });


### PR DESCRIPTION
Before this fix, when a product had multiple attributes with extra prices and differing creation modes (e.g. pills with instant creation and checkboxes with never creation), the extra price of attributes created instantly (like "pills") was not taken into account in the PoS.

To reproduce:
- Create two attribute lines with extra prices:
  1. Display = Pills (creation = instantly)
  2. Display = Multi-checkbox (creation = never)
- Make the product available in the PoS and select it.

Only the extra price from the multi-checkbox attribute was applied, leading to an incorrect total.

opw-4684979

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
