### PR TITLE
[FIX] point_of_sale: correctly search contacts by phone without spaces

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -193,8 +193,7 @@ export class PartnerListScreen extends Component {
             const search_fields = [
                 "name",
                 "parent_name",
-                "phone",
-                "mobile",
+                ...this.pos.getPhoneSearchFields(),
                 "email",
                 "barcode",
                 "street",

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -2199,6 +2199,10 @@ export class PosStore extends Reactive {
         const { start_category, iface_start_categ_id } = this.config;
         this.selectedCategoryId = (start_category && iface_start_categ_id?.[0]) || 0;
     }
+
+    getPhoneSearchFields() {
+        return ["phone", "mobile"];
+    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};

--- a/addons/pos_hr/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_store.js
@@ -113,4 +113,7 @@ patch(PosStore.prototype, {
         }
         return super.closePos(...arguments);
     },
+    getPhoneSearchFields() {
+        return ["phone_mobile_search"];
+    },
 });


### PR DESCRIPTION
Before this commit, searching for a customer in the PoS using a phone number without spaces (e.g. "0612345678") would return no results if the number was stored with spaces (e.g. "06 12 34 56 78").

opw-4683209

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
