### PR TITLE
[FIX] stock: Fix and improve lot/SN smart button on partner

### DIFF
--- a/addons/stock/models/res_partner.py
+++ b/addons/stock/models/res_partner.py
@@ -20,7 +20,5 @@ class ResPartner(models.Model):
 
     def action_view_stock_serial(self):
         action = self.env["ir.actions.act_window"]._for_xml_id("stock.action_production_lot_form")
-        action.update({
-            'domain': [('partner_ids', '=', self.id)],
-        })
+        action['domain'] = [('partner_ids', 'child_of', self.ids)]
         return action

--- a/addons/stock/models/res_partner.py
+++ b/addons/stock/models/res_partner.py
@@ -22,8 +22,5 @@ class ResPartner(models.Model):
         action = self.env["ir.actions.act_window"]._for_xml_id("stock.action_production_lot_form")
         action.update({
             'domain': [('partner_ids', '=', self.id)],
-            'context': {
-                'default_partner_ids': self.id,
-            }
         })
         return action


### PR DESCRIPTION
**[FIX] stock: remove partner_ids from context for new lot**

Steps to reproduce:
- Go to a partner;
- Click on Lot/Serial Number smart button;
- Click on New to create a stock lot;
-> Traceback: ValueError: Wrong value for stock.lot.partner_ids: 57

This comes from the context provided to the action: `default_partner_ids` is set to `self.id`. In addition to being wrong, it makes little sense. The partners linked to a lot are computed from partners linked to the moves in which the lot/SN is added.

This commit therefore removes the context from the action, so that a new lot can be created without any partner linked to it.

**[IMP] stock: link all lots/SN of commercial partner from smart button**

Before this commit, the smart button "Lots/Serial Number" on res.partner was not taking into account the possible hierarchy between partners.

This commit improves this be displaying all lots/SN delivered to the partner or to the children partners of a commercial partner.

Simple example: Odoo has 2 addresses (GR2 and GR3). Clicking on the smart button from Odoo was not displaying the deliveries to GR2 or GR3. Now it does. While clicking on the button from GR2 is unchanged.