### PR TITLE
[IMP] base:  prevent duplication of `ir.model` records

### DIFF
--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -4,7 +4,7 @@
         <record id="view_model_form" model="ir.ui.view">
             <field name="model">ir.model</field>
             <field name="arch" type="xml">
-                <form string="Model Description">
+                <form string="Model Description" duplicate="0">
                   <header><!-- used for override --></header>
                   <sheet>
                     <group>
@@ -187,7 +187,7 @@
         <record id="view_model_tree" model="ir.ui.view">
             <field name="model">ir.model</field>
             <field name="arch" type="xml">
-                <list string="Model Description">
+                <list string="Model Description" duplicate="0">
                     <field name="model"/>
                     <field name="name"/>
                     <field name="state"/>


### PR DESCRIPTION
Before this commit:
- The `Duplicate` option was visible in both the form and list views of the `ir.model` model. Attempting to duplicate a record would result in a unique constraint violation. Moreover, duplicating a model serves no practical purpose.

After this commit:
- The `Duplicate` option is no longer visible for `ir.model` records.

task-4283392
