### PR TITLE
[FIX] sale_loyalty: remove `website_sale_loyalty` method from test

### DIFF
--- a/addons/sale_loyalty/tests/test_buy_gift_card.py
+++ b/addons/sale_loyalty/tests/test_buy_gift_card.py
@@ -59,7 +59,6 @@ class TestBuyGiftCard(TestSaleCouponCommon):
             'order_line': [Command.create({'product_id': self.product_gift_card.id})],
         })
         order._update_programs_and_rewards()
-        order._auto_apply_rewards()
 
         # Create an order without salesman to test company-based fallback
         orders = order + order.copy({'user_id': None})


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Run the `test_gift_card_email_sender` without `website_sale_loyalty`.

Issue
-----
`AttributeError`

Cause
-----
The `sale_loyalty` test calls `_auto_apply_rewards`, which is defined in `website_sale_loyalty`.

Solution
--------
The test works just as well without the method call, so we can simply remove it.

runbot-163194