### PR TITLE
[IMP] pos_event : support event slots in pos_event

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -25,6 +25,7 @@ Key Features
         'views/event_ticket_views.xml',
         'views/event_mail_views.xml',
         'views/event_registration_views.xml',
+        'views/event_slot_views.xml',
         'views/event_type_views.xml',
         'views/event_event_views.xml',
         'views/event_stage_views.xml',
@@ -58,7 +59,7 @@ Key Features
             'event/static/src/icon_selection_field/icon_selection_field.xml',
             'event/static/src/template_reference_field/*',
             'event/static/src/js/tours/**/*',
-            'event/static/src/views/*',
+            'event/static/src/views/**/*',
         ],
         'web.assets_frontend': [
             'event/static/src/js/tours/**/*',

--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -17,7 +17,8 @@ class EventController(Controller):
         if request.env.user._is_public():
             lang = request.cookies.get('frontend_lang')
         event = event.with_context(lang=lang)
-        files = event._get_ics_file()
+        slot_id = int(kwargs['slot_id']) if kwargs.get('slot_id') else False
+        files = event._get_ics_file(slot=request.env['event.slot'].sudo().browse(slot_id))
         if not event.id in files:
             return NotFound()
         content = files[event.id]
@@ -52,7 +53,7 @@ class EventController(Controller):
 
         event_registrations_sudo = event_sudo.registration_ids.filtered(lambda reg: reg.id in registration_ids)
         report_name_prefix = _("Ticket") if responsive_html else _("Badges") if badge_mode else _("Tickets")
-        report_date = format_datetime(request.env, event_sudo.date_begin, tz=event_sudo.date_tz, dt_format='medium')
+        report_date = format_datetime(request.env, event_registrations_sudo[0].event_begin_date, tz=event_sudo.date_tz, dt_format='medium')
         report_name = f"{report_name_prefix} - {event_sudo.name} ({report_date})"
         if len(event_registrations_sudo) == 1:
             report_name += f" - {event_registrations_sudo[0].name}"

--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -12,8 +12,8 @@
             <field name="description">Sent automatically to someone after they registered to an event</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
-<t t-set="date_begin" t-value="format_datetime(object.event_id.date_begin, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
-<t t-set="date_end" t-value="format_datetime(object.event_id.date_end, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
+<t t-set="date_begin" t-value="format_datetime(object.event_begin_date, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
+<t t-set="date_end" t-value="format_datetime(object.event_end_date, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
 <t t-set="is_online" t-value="'is_published' in object.event_id and object.event_id.is_published"/>
 <t t-set="event_organizer" t-value="object.event_id.organizer_id"/>
 <t t-set="event_address" t-value="object.event_id.address_id"/>
@@ -67,8 +67,8 @@
                         <br />
                         <strong>Add this event to your calendar</strong>
                         <a t-attf-href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text={{ object.event_id.name }}&amp;dates={{ date_begin }}/{{ date_end }}&amp;location={{ location }}&amp;details={{ object.event_id._get_external_description() }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Google</a>
-                        <a t-attf-href="/event/{{ slug(object.event_id) }}/ics" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> iCal/Outlook</a>
-                        <a t-attf-href="https://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title={{ object.event_id.name }}&amp;in_loc={{ location }}&amp;st={{ format_datetime(object.event_id.date_begin, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}&amp;et={{ format_datetime(object.event_id.date_end, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
+                        <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> iCal/Outlook</a>
+                        <a t-attf-href="https://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title={{ object.event_id.name }}&amp;in_loc={{ location }}&amp;st={{ format_datetime(object.event_begin_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}&amp;et={{ format_datetime(object.event_end_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
                             <img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Yahoo
                         </a>
                         <br /><br />
@@ -104,16 +104,16 @@
                             </td>
                             <td style="padding: 0px 10px 0px 10px;width:50%;line-height:20px;vertical-align:top;">
                                 <div t-if="object.event_id.is_one_day">
-                                    <t t-out="object.event_id.date_begin" t-options='{"widget": "datetime", "date_only": True, "tz_name": object.event_id.date_tz, "format": "long"}'>May 4, 2021</t>
-                                    <t t-out="object.event_id.date_begin" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>7:00 AM</t>
-                                     - <t t-out="object.event_id.date_end" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>5:00 PM</t>
+                                    <t t-out="object.event_begin_date" t-options='{"widget": "datetime", "date_only": True, "tz_name": object.event_id.date_tz, "format": "long"}'>May 4, 2021</t>
+                                    <t t-out="object.event_begin_date" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>7:00 AM</t>
+                                     - <t t-out="object.event_end_date" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>5:00 PM</t>
                                 </div>
                                 <div t-else="">
                                     <strong>From</strong>
-                                    <t t-out="object.event_id.date_begin" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 4, 2021 - 7:00 AM</t>
+                                    <t t-out="object.event_begin_date" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 4, 2021 - 7:00 AM</t>
                                     <br/>
                                     <strong>To</strong>
-                                    <t t-out="object.event_id.date_end" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 6, 2021 - 5:00 PM</t>
+                                    <t t-out="object.event_end_date" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 6, 2021 - 5:00 PM</t>
                                 </div>
                                 <div style="font-size:12px;color:#9e9e9e"><i>(<t t-out="object.event_id.date_tz or ''">Europe/Brussels</t>)</i></div>
                             </td>
@@ -259,8 +259,8 @@
             <field name="description">Sent to attendees after registering to an event</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
-<t t-set="date_begin" t-value="format_datetime(object.event_id.date_begin, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
-<t t-set="date_end" t-value="format_datetime(object.event_id.date_end, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
+<t t-set="date_begin" t-value="format_datetime(object.event_begin_date, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
+<t t-set="date_end" t-value="format_datetime(object.event_end_date, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
 <t t-set="is_online" t-value="'is_published' in object.event_id and object.event_id.is_published"/>
 <t t-set="is_sale" t-value="'sale_order_id' in object and object.sale_order_id"/>
 <t t-set="event_organizer" t-value="object.event_id.organizer_id"/>
@@ -337,8 +337,8 @@
                         <br />
                         <strong>Add this event to your calendar</strong>
                         <a t-attf-href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text={{ object.event_id.name }}&amp;dates={{ date_begin }}/{{ date_end }}&amp;location={{ location }}&amp;details={{ object.event_id._get_external_description() }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Google</a>
-                        <a t-attf-href="/event/{{ slug(object.event_id) }}/ics" t-attf-style="padding:3px 5px; ;color:{{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> iCal/Outlook</a>
-                        <a t-attf-href="https://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title={{ object.event_id.name }}&amp;in_loc={{ location }}&amp;st={{ format_datetime(object.event_id.date_begin, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}&amp;et={{ format_datetime(object.event_id.date_end, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
+                        <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}" t-attf-style="padding:3px 5px; ;color:{{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> iCal/Outlook</a>
+                        <a t-attf-href="https://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title={{ object.event_id.name }}&amp;in_loc={{ location }}&amp;st={{ format_datetime(object.event_begin_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}&amp;et={{ format_datetime(object.event_end_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
                             <img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Yahoo
                         </a>
                         <br /><br />
@@ -374,16 +374,16 @@
                             </td>
                             <td style="padding: 0px 10px 0px 10px;width:50%;line-height:20px;vertical-align:top;">
                                 <div t-if="object.event_id.is_one_day">
-                                    <t t-out="object.event_id.date_begin" t-options='{"widget": "datetime", "date_only": True, "tz_name": object.event_id.date_tz, "format": "long"}'>May 4, 2021</t>
-                                    <t t-out="object.event_id.date_begin" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>7:00 AM</t>
-                                     - <t t-out="object.event_id.date_end" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>5:00 PM</t>
+                                    <t t-out="object.event_begin_date" t-options='{"widget": "datetime", "date_only": True, "tz_name": object.event_id.date_tz, "format": "long"}'>May 4, 2021</t>
+                                    <t t-out="object.event_begin_date" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>7:00 AM</t>
+                                     - <t t-out="object.event_end_date" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>5:00 PM</t>
                                 </div>
                                 <div t-else="">
                                     <strong>From</strong>
-                                    <t t-out="object.event_id.date_begin" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 4, 2021 - 7:00 AM</t>
+                                    <t t-out="object.event_begin_date" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 4, 2021 - 7:00 AM</t>
                                     <br/>
                                     <strong>To</strong>
-                                    <t t-out="object.event_id.date_end" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 6, 2021 - 5:00 PM</t>
+                                    <t t-out="object.event_end_date" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 6, 2021 - 5:00 PM</t>
                                 </div>
                                 <div style="font-size:12px;color:#9e9e9e"><i>(<t t-out="object.event_id.date_tz or ''">Europe/Brussels</t>)</i></div>
                             </td>
@@ -528,8 +528,8 @@
             <field name="description">Sent automatically to attendees if there is a reminder defined on the event</field>
             <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
-<t t-set="date_begin" t-value="format_datetime(object.event_id.date_begin, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
-<t t-set="date_end" t-value="format_datetime(object.event_id.date_end, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
+<t t-set="date_begin" t-value="format_datetime(object.event_begin_date, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
+<t t-set="date_end" t-value="format_datetime(object.event_end_date, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
 <t t-set="is_online" t-value="'is_published' in object.event_id and object.event_id.is_published"/>
 <t t-set="is_sale" t-value="'sale_order_id' in object and object.sale_order_id"/>
 <t t-set="event_organizer" t-value="object.event_id.organizer_id"/>
@@ -594,8 +594,8 @@
                         <br />
                         <strong>Add this event to your calendar</strong>
                         <a t-attf-href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text={{ object.event_id.name }}&amp;dates={{ date_begin }}/{{ date_end }}&amp;location={{ location }}&amp;details={{ object.event_id._get_external_description() }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Google</a>
-                        <a t-attf-href="/event/{{ slug(object.event_id) }}/ics" t-attf-style="padding:3px 5px; color:{{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> iCal/Outlook</a>
-                        <a t-attf-href="https://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title={{ object.event_id.name }}&amp;in_loc={{ location }}&amp;st={{ format_datetime(object.event_id.date_begin, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}&amp;et={{ format_datetime(object.event_id.date_end, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
+                        <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}" t-attf-style="padding:3px 5px; color:{{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> iCal/Outlook</a>
+                        <a t-attf-href="https://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title={{ object.event_id.name }}&amp;in_loc={{ location }}&amp;st={{ format_datetime(object.event_begin_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}&amp;et={{ format_datetime(object.event_end_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
                             <img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Yahoo
                         </a>
                         <br /><br />
@@ -631,16 +631,16 @@
                             </td>
                             <td style="padding: 0px 10px 0px 10px;width:50%;line-height:20px;vertical-align:top;">
                                 <div t-if="object.event_id.is_one_day">
-                                    <t t-out="object.event_id.date_begin" t-options='{"widget": "datetime", "date_only": True, "tz_name": object.event_id.date_tz, "format": "long"}'>May 4, 2021</t>
-                                    <t t-out="object.event_id.date_begin" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>7:00 AM</t>
-                                     - <t t-out="object.event_id.date_end" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>5:00 PM</t>
+                                    <t t-out="object.event_begin_date" t-options='{"widget": "datetime", "date_only": True, "tz_name": object.event_id.date_tz, "format": "long"}'>May 4, 2021</t>
+                                    <t t-out="object.event_begin_date" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>7:00 AM</t>
+                                     - <t t-out="object.event_end_date" t-options='{"widget": "datetime", "time_only": True, "tz_name": object.event_id.date_tz, "hide_seconds": True, "format": "short"}'>5:00 PM</t>
                                 </div>
                                 <div t-else="">
                                     <strong>From</strong>
-                                    <t t-out="object.event_id.date_begin" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 4, 2021 - 7:00 AM</t>
+                                    <t t-out="object.event_begin_date" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 4, 2021 - 7:00 AM</t>
                                     <br/>
                                     <strong>To</strong>
-                                    <t t-out="object.event_id.date_end" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 6, 2021 - 5:00 PM</t>
+                                    <t t-out="object.event_end_date" t-options='{"widget": "datetime", "show_seconds": False, "tz_name": object.event_id.date_tz, "format": "medium"}'>May 6, 2021 - 5:00 PM</t>
                                 </div>
                                 <div style="font-size:12px;color:#9e9e9e"><i>(<t t-out="object.event_id.date_tz or ''">Europe/Brussels</t>)</i></div>
                             </td>

--- a/addons/event/models/__init__.py
+++ b/addons/event/models/__init__.py
@@ -9,7 +9,9 @@ from . import event_type_ticket
 from . import event_event
 from . import event_mail
 from . import event_mail_registration
+from . import event_mail_slot
 from . import event_registration
+from . import event_slot
 from . import event_stage
 from . import event_tag
 from . import event_ticket

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -108,7 +108,8 @@ class EventEvent(models.Model):
     seats_max = fields.Integer(
         string='Maximum Attendees',
         compute='_compute_seats_max', readonly=False, store=True,
-        help="For each event you can define a maximum registration of seats(number of attendees), above this numbers the registrations are not accepted.")
+        help="For each event you can define a maximum registration of seats(number of attendees), above this number the registrations are not accepted. "
+        "If the event has multiple slots, this maximum number is applied per slot.")
     seats_limited = fields.Boolean('Limit Attendees', required=True, compute='_compute_seats_limited',
                                    precompute=True, readonly=False, store=True)
     seats_reserved = fields.Integer(
@@ -125,6 +126,12 @@ class EventEvent(models.Model):
         store=False, readonly=True, compute='_compute_seats')
     # Registration fields
     registration_ids = fields.One2many('event.registration', 'event_id', string='Attendees')
+    is_multi_slots = fields.Boolean("Is Multi Slots", copy=True,
+        help="Allow multiple time slots. "
+        "The communications, the maximum number of attendees and the maximum number of tickets registrations "
+        "are defined for each time slot instead of the whole event.")
+    event_slot_ids = fields.One2many("event.slot", "event_id", "Slots", copy=True)
+    event_slot_count = fields.Integer("Slots Count", compute="_compute_event_slot_count")
     event_ticket_ids = fields.One2many(
         'event.event.ticket', 'event_id', string='Event Ticket', copy=True,
         compute='_compute_event_ticket_ids', readonly=False, store=True, precompute=True)
@@ -253,7 +260,7 @@ class EventEvent(models.Model):
             else:
                 event.kanban_state_label = event.stage_id.legend_done
 
-    @api.depends('seats_max', 'registration_ids.state', 'registration_ids.active')
+    @api.depends('event_slot_count', 'is_multi_slots', 'seats_max', 'registration_ids.state', 'registration_ids.active')
     def _compute_seats(self):
         """ Determine available, reserved, used and taken seats. """
         # initialize fields to 0
@@ -281,8 +288,9 @@ class EventEvent(models.Model):
         # compute seats_available and expected
         for event in self:
             event.update(results.get(event._origin.id or event.id, base_vals))
-            if event.seats_max > 0:
-                event.seats_available = event.seats_max - (event.seats_reserved + event.seats_used)
+            seats_max = event.seats_max * event.event_slot_count if event.is_multi_slots else event.seats_max
+            if seats_max > 0:
+                event.seats_available = seats_max - (event.seats_reserved + event.seats_used)
 
             event.seats_taken = event.seats_reserved + event.seats_used
 
@@ -315,7 +323,25 @@ class EventEvent(models.Model):
             event.event_registrations_open = event.event_registrations_started and \
                 (date_end_tz >= current_datetime if date_end_tz else True) and \
                 (not event.seats_limited or not event.seats_max or event.seats_available) and \
-                (not event.event_ticket_ids or any(ticket.sale_available for ticket in event.event_ticket_ids))
+                (
+                    # Not multi slots: open if no tickets or at least a sale available ticket
+                    (not event.is_multi_slots and
+                        (not event.event_ticket_ids or any(ticket.sale_available for ticket in event.event_ticket_ids)))
+                    or
+                    # Multi slots: open if at least a slot and no tickets or at least an ongoing ticket with availability
+                    (event.is_multi_slots and event.event_slot_count and (
+                        not event.event_ticket_ids or any(
+                            ticket.is_launched and not ticket.is_expired and (
+                                any(availability is None or availability > 0
+                                    for availability in event._get_seats_availability([
+                                        (slot, ticket)
+                                        for slot in event.event_slot_ids
+                                    ])
+                                )
+                            ) for ticket in event.event_ticket_ids
+                        )
+                    ))
+                )
 
     @api.depends('event_ticket_ids.start_sale_datetime')
     def _compute_start_sale_date(self):
@@ -325,18 +351,30 @@ class EventEvent(models.Model):
             start_dates = [ticket.start_sale_datetime for ticket in event.event_ticket_ids if not ticket.is_expired]
             event.start_sale_datetime = min(start_dates) if start_dates and all(start_dates) else False
 
-    @api.depends('event_ticket_ids.sale_available', 'seats_available', 'seats_limited')
+    @api.depends('event_slot_ids', 'event_ticket_ids.sale_available', 'seats_available', 'seats_limited')
     def _compute_event_registrations_sold_out(self):
         """Note that max seats limits for events and sum of limits for all its tickets may not be
         equal to enable flexibility.
         E.g. max 20 seats for ticket A, 20 seats for ticket B
             * With max 20 seats for the event
             * Without limit set on the event (=40, but the customer didn't explicitly write 40)
+        When the event is multi slots, instead of checking if every tickets is sold out,
+        checking if every slot-ticket combination is sold out.
         """
         for event in self:
             event.event_registrations_sold_out = (
-                (event.seats_limited and event.seats_max and not event.seats_available)
-                or (event.event_ticket_ids and all(ticket.is_sold_out for ticket in event.event_ticket_ids))
+                (event.seats_limited and event.seats_max and not event.seats_available > 0)
+                or (event.event_ticket_ids and (
+                    not any(availability is None or availability > 0
+                        for availability in event._get_seats_availability([
+                            (slot, ticket)
+                            for slot in event.event_slot_ids
+                            for ticket in event.event_ticket_ids
+                        ])
+                    )
+                    if event.is_multi_slots else
+                    all(ticket.is_sold_out for ticket in event.event_ticket_ids)
+                ))
             )
 
     @api.depends('date_begin', 'date_end')
@@ -384,6 +422,16 @@ class EventEvent(models.Model):
                 event.date_tz = event.event_type_id.default_timezone
             if not event.date_tz:
                 event.date_tz = self.env.user.tz or 'UTC'
+
+    @api.depends("event_slot_ids")
+    def _compute_event_slot_count(self):
+        slot_count_per_event = dict(self.env['event.slot']._read_group(
+            domain=[('event_id', 'in', self.ids)],
+            groupby=['event_id'],
+            aggregates=['__count']
+        ))
+        for event in self:
+            event.event_slot_count = slot_count_per_event.get(event, 0)
 
     @api.depends('address_id')
     def _compute_address_search(self):
@@ -534,19 +582,29 @@ class EventEvent(models.Model):
         """Reset url field as it should only be used for events with no physical location."""
         self.filtered('address_id').event_url = ''
 
-    @api.constrains('seats_max', 'seats_limited', 'registration_ids')
-    def _check_seats_availability(self, minimal_availability=0):
-        sold_out_events = []
-        for event in self:
-            if event.seats_limited and event.seats_max and event.seats_available < minimal_availability:
-                sold_out_events.append(_(
-                    '- "%(event_name)s": Missing %(nb_too_many)i seats.',
-                    event_name=event.name,
-                    nb_too_many=minimal_availability - event.seats_available,
-                ))
-        if sold_out_events:
-            raise ValidationError(_('There are not enough seats available for:')
-                                  + '\n%s\n' % '\n'.join(sold_out_events))
+    @api.constrains("date_begin", "date_end", "event_slot_ids", "is_multi_slots")
+    def _check_slots_dates(self):
+        multi_slots_event_ids = self.filtered(lambda event: event.is_multi_slots).ids
+        if not multi_slots_event_ids:
+            return
+        min_max_slot_dates_per_event = {
+            event: (min_start, max_end)
+            for event, min_start, max_end in self.env['event.slot']._read_group(
+                domain=[('event_id', 'in', multi_slots_event_ids)],
+                groupby=['event_id'],
+                aggregates=['start_datetime:min', 'end_datetime:max']
+            )
+        }
+        events_w_slots_outside_bounds = []
+        for event, (min_start, max_end) in min_max_slot_dates_per_event.items():
+            if (not (event.date_begin <= min_start <= event.date_end) or
+                not (event.date_begin <= max_end <= event.date_end)):
+                events_w_slots_outside_bounds.append(event)
+        if events_w_slots_outside_bounds:
+            raise ValidationError(_(
+                "These events cannot have slots scheduled outside of their time range:\n%(event_names)s",
+                event_names="\n".join(f"- {event.name}" for event in events_w_slots_outside_bounds)
+            ))
 
     @api.constrains('date_begin', 'date_end')
     def _check_closing_date(self):
@@ -568,6 +626,19 @@ class EventEvent(models.Model):
             parsed_url = urlparse(event.event_url)
             if parsed_url.scheme not in ('http', 'https'):
                 event.event_url = 'https://' + event.event_url
+
+    @api.onchange('seats_max')
+    def _onchange_seats_max(self):
+        for event in self:
+            if event.seats_limited and event.seats_max and event.seats_available <= 0 and \
+                (event.event_slot_ids if event.is_multi_slots else True):
+                return {
+                    'warning': {
+                        'title': _("Update the limit of registrations?"),
+                        'message': _("There are more registrations than this limit, "
+                                    "the event will be sold out and the extra registrations will remain."),
+                    }
+                }
 
     def write(self, vals):
         if 'stage_id' in vals and 'kanban_state' not in vals:
@@ -616,6 +687,86 @@ class EventEvent(models.Model):
         self.ensure_one()
         return self.with_context(tz=self.date_tz or 'UTC')
 
+    def _get_seats_availability(self, slot_tickets):
+        """ Get availabilities for given combinations of slot / ticket. Returns
+        a list following input order. None denotes no limit. """
+        self.ensure_one()
+        if not (all(len(item) == 2 for item in slot_tickets)):
+            raise ValueError('Input should be a list of tuples containing slot, ticket')
+
+        if any(slot for (slot, _ticket) in slot_tickets):
+            slot_tickets_nb_registrations = {
+                (slot.id, ticket.id): count
+                for (slot, ticket, count) in self.env['event.registration'].sudo()._read_group(
+                    domain=[('event_slot_id', '!=', False), ('event_id', 'in', self.ids),
+                            ('state', 'in', ['open', 'done']), ('active', '=', True)],
+                    groupby=['event_slot_id', 'event_ticket_id'],
+                    aggregates=['__count']
+                )
+            }
+
+        availabilities = []
+        for slot, ticket in slot_tickets:
+            available = None
+            # event is constrained: max stands for either each slot, either global (no slots)
+            if self.seats_limited and self.seats_max:
+                if slot:
+                    available = slot.seats_available
+                else:
+                    available = self.seats_available
+            # ticket is constrained: max standard for either each slot / ticket, either global (no slots)
+            if available != 0 and ticket and ticket.seats_max:
+                if slot:
+                    ticket_available = ticket.seats_max - slot_tickets_nb_registrations.get((slot.id, ticket.id), 0)
+                else:
+                    ticket_available = ticket.seats_available
+                available = ticket_available if available is None else min(available, ticket_available)
+            availabilities.append(available)
+        return availabilities
+
+    def _verify_seats_availability(self, slot_tickets):
+        """ Check event seats availability, for combinations of slot / ticket.
+
+        :slot_tickets: a list of tuples(slot, ticket, count). SLot and ticket
+          are optional, depending on event configuration. If count is 0
+          it is a simple check current values do not overflow limit. If count
+          is given, it serves as a check there are enough remaining seats.
+
+        Raises:
+            ValidationError: if the event / slot / ticket do not have enough
+            available seats
+        """
+        self.ensure_one()
+        if not (all(len(item) == 3 for item in slot_tickets)):
+            raise ValueError('Input should be a list of tuples containing slot, ticket, count')
+
+        sold_out = []
+        availabilities = self._get_seats_availability([(item[0], item[1]) for item in slot_tickets])
+        for (slot, ticket, count), available in zip(slot_tickets, availabilities, strict=True):
+            if available is None:  # unconstrained
+                continue
+            if available < count:
+                if slot and ticket:
+                    name = f'{ticket.name} - {slot.display_name}'
+                elif slot:
+                    name = slot.display_name
+                elif ticket:
+                    name = ticket.name
+                else:
+                    name = self.name
+                sold_out.append((name, count - available))
+
+        if sold_out:
+            info = []  # note: somehow using list comprehension make translate.py crash in default lang
+            for item in sold_out:
+                info.append(_('%(slot_name)s: missing %(count)s seat(s)', slot_name=item[0], count=item[1]))
+            raise ValidationError(
+                _('There are not enough seats available for %(event_name)s:\n%(sold_out_info)s',
+                  event_name=self.name,
+                  sold_out_info='\n'.join(info),
+                )
+            )
+
     # ------------------------------------------------------------
     # ACTIONS
     # ------------------------------------------------------------
@@ -630,10 +781,11 @@ class EventEvent(models.Model):
         if first_ended_stage:
             self.write({'stage_id': first_ended_stage.id})
 
-    def _get_date_range_str(self, lang_code=False):
+    def _get_date_range_str(self, start_datetime=False, lang_code=False):
         self.ensure_one()
+        datetime = start_datetime or self.date_begin
         today_tz = pytz.utc.localize(fields.Datetime.now()).astimezone(pytz.timezone(self.date_tz))
-        event_date_tz = pytz.utc.localize(self.date_begin).astimezone(pytz.timezone(self.date_tz))
+        event_date_tz = pytz.utc.localize(datetime).astimezone(pytz.timezone(self.date_tz))
         diff = (event_date_tz.date() - today_tz.date())
         if diff.days <= 0:
             return _('today')
@@ -645,7 +797,7 @@ class EventEvent(models.Model):
             return _('next week')
         if event_date_tz.month == (today_tz + relativedelta(months=+1)).month:
             return _('next month')
-        return _('on %(date)s', date=format_date(self.env, self.date_begin, lang_code=lang_code, date_format='medium'))
+        return _('on %(date)s', date=format_date(self.env, datetime, lang_code=lang_code, date_format='medium'))
 
     def _get_external_description(self):
         """
@@ -662,8 +814,9 @@ class EventEvent(models.Model):
         description += textwrap.shorten(html_to_inner_content(self.description), 1900)
         return description
 
-    def _get_ics_file(self):
+    def _get_ics_file(self, slot=False):
         """ Returns iCalendar file for the event invitation.
+            :param slot: If a slot is given, schedule with the given slot datetimes
             :returns a dict of .ics file content for each event
         """
         result = {}
@@ -674,10 +827,12 @@ class EventEvent(models.Model):
             cal = vobject.iCalendar()
             cal.add('method').value = 'PUBLISH'
             cal_event = cal.add('vevent')
+            start = slot.start_datetime or event.date_begin
+            end = slot.end_datetime or event.date_end
 
             cal_event.add('created').value = fields.Datetime.now().replace(tzinfo=pytz.timezone('UTC'))
-            cal_event.add('dtstart').value = event.date_begin.astimezone(pytz.timezone(event.date_tz))
-            cal_event.add('dtend').value = event.date_end.astimezone(pytz.timezone(event.date_tz))
+            cal_event.add('dtstart').value = start.astimezone(pytz.timezone(event.date_tz))
+            cal_event.add('dtend').value = end.astimezone(pytz.timezone(event.date_tz))
             cal_event.add('summary').value = event.name
             cal_event.add('description').value = event._get_external_description()
             if event.address_id:

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -47,7 +47,9 @@ class EventMail(models.Model):
         # event based: end date
         ('after_event', 'After the event ended'),
         ('before_event_end', 'Before the event ends')],
-        string='Trigger ', default="before_event", required=True)
+        string='Trigger ', default="before_event", required=True,
+        help="Indicates when the communication is sent. "
+        "If the event has multiple slots, the interval is related to each time slot instead of the whole event.")
     scheduled_date = fields.Datetime('Schedule Date', compute='_compute_scheduled_date', store=True)
     error_datetime = fields.Datetime('Last Error')
     # contact and status
@@ -55,6 +57,9 @@ class EventMail(models.Model):
     mail_registration_ids = fields.One2many(
         'event.mail.registration', 'scheduler_id',
         help='Communication related to event registrations')
+    mail_slot_ids = fields.One2many(
+        'event.mail.slot', 'scheduler_id',
+        help='Slot-based communication')
     mail_done = fields.Boolean("Sent", copy=False, readonly=True)
     mail_state = fields.Selection(
         [('running', 'Running'), ('scheduled', 'Scheduled'), ('sent', 'Sent'), ('error', 'Error')],
@@ -104,6 +109,8 @@ class EventMail(models.Model):
         for scheduler in self._filter_template_ref():
             if scheduler.interval_type == 'after_sub':
                 scheduler._execute_attendee_based()
+            elif scheduler.event_id.is_multi_slots:
+                scheduler._execute_slot_based()
             else:
                 # before or after event -> one shot communication, once done skip
                 if scheduler.mail_done:
@@ -114,11 +121,17 @@ class EventMail(models.Model):
             scheduler.error_datetime = False
         return True
 
-    def _execute_event_based(self):
+    def _execute_event_based(self, mail_slot=False):
         """ Main scheduler method when running in event-based mode aka
         'after_event' or 'before_event' (and their negative counterparts).
         This is a global communication done once i.e. we do not track each
-        registration individually. """
+        registration individually.
+
+        :param mail_slot: optional <event.mail.slot> slot-specific event communication,
+          when event uses slots. In that case, it works like the classic event
+          communication (iterative, ...) but information is specific to each
+          slot (last registration, scheduled datetime, ...)
+        """
         auto_commit = not modules.module.current_test
         batch_size = int(
             self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
@@ -126,19 +139,22 @@ class EventMail(models.Model):
         cron_limit = int(
             self.env['ir.config_parameter'].sudo().get_param('mail.render.cron.limit')
         ) or 1000  # be sure to not have 0, as otherwise we will loop
+        scheduler_record = mail_slot or self
 
         # fetch registrations to contact
         registration_domain = [
             ('event_id', '=', self.event_id.id),
             ('state', 'not in', ["draft", "cancel"]),
         ]
-        if self.last_registration_id:
+        if mail_slot:
+            registration_domain += [('event_slot_id', '=', mail_slot.event_slot_id.id)]
+        if scheduler_record.last_registration_id:
             registration_domain += [('id', '>', self.last_registration_id.id)]
         registrations = self.env["event.registration"].search(registration_domain, limit=(cron_limit + 1), order="id ASC")
 
         # no registrations -> done
         if not registrations:
-            self.mail_done = True
+            scheduler_record.mail_done = True
             return
 
         # there are more than planned for the cron -> reschedule
@@ -148,9 +164,9 @@ class EventMail(models.Model):
 
         for registrations_chunk in tools.split_every(batch_size, registrations.ids, self.env["event.registration"].browse):
             self._execute_event_based_for_registrations(registrations_chunk)
-            self.last_registration_id = registrations_chunk[-1]
+            scheduler_record.last_registration_id = registrations_chunk[-1]
 
-            self._refresh_mail_count_done()
+            self._refresh_mail_count_done(mail_slot=mail_slot)
             if auto_commit:
                 self.env.cr.commit()
                 # invalidate cache, no need to keep previous content in memory
@@ -166,6 +182,29 @@ class EventMail(models.Model):
         if self.notification_type == "mail":
             self._send_mail(registrations)
         return True
+
+    def _execute_slot_based(self):
+        """ Main scheduler method when running in slot-based mode aka
+        'after_event' or 'before_event' (and their negative counterparts) on
+        events with slots. This is a global communication done once i.e. we do
+        not track each registration individually. """
+        # create slot-specific schedulers if not existing
+        missing_slots = self.event_id.event_slot_ids - self.mail_slot_ids.event_slot_id
+        if missing_slots:
+            self.write({'mail_slot_ids': [
+                (0, 0, {'event_slot_id': slot.id})
+                for slot in missing_slots
+            ]})
+
+        # filter slots to contact
+        now = fields.Datetime.now()
+        for mail_slot in self.mail_slot_ids:
+            # before or after event -> one shot communication, once done skip
+            if mail_slot.mail_done:
+                continue
+            # do not send emails if the mailing was scheduled before the slot but the slot is over
+            if mail_slot.scheduled_date <= now and (self.interval_type not in ('before_event', 'after_event_start') or mail_slot.event_slot_id.end_datetime > now):
+                self._execute_event_based(mail_slot=mail_slot)
 
     def _execute_attendee_based(self):
         """ Main scheduler method when running in attendee-based mode aka
@@ -254,7 +293,7 @@ class EventMail(models.Model):
                 } for registration in registrations])
         return new
 
-    def _refresh_mail_count_done(self):
+    def _refresh_mail_count_done(self, mail_slot=False):
         for scheduler in self:
             if scheduler.interval_type == "after_sub":
                 total_sent = self.env["event.mail.registration"].search_count([
@@ -262,6 +301,17 @@ class EventMail(models.Model):
                     ("mail_sent", "=", True),
                 ])
                 scheduler.mail_count_done = total_sent
+            elif mail_slot and mail_slot.last_registration_id:
+                total_sent = self.env["event.registration"].search_count([
+                    ("id", "<=", mail_slot.last_registration_id.id),
+                    ("event_id", "=", scheduler.event_id.id),
+                    ("event_slot_id", "=", mail_slot.event_slot_id.id),
+                    ("state", "not in", ["draft", "cancel"]),
+                ])
+                mail_slot.mail_count_done = total_sent
+                mail_slot.mail_done = total_sent >= mail_slot.event_slot_id.seats_taken
+                scheduler.mail_count_done = sum(scheduler.mail_slot_ids.mapped('mail_count_done'))
+                scheduler.mail_done = scheduler.mail_count_done >= scheduler.event_id.seats_taken
             elif scheduler.last_registration_id:
                 total_sent = self.env["event.registration"].search_count([
                     ("id", "<=", self.last_registration_id.id),

--- a/addons/event/models/event_mail_slot.py
+++ b/addons/event/models/event_mail_slot.py
@@ -1,0 +1,31 @@
+from odoo import api, fields, models
+from odoo.addons.event.models.event_mail import _INTERVALS
+
+
+class EventMailRegistration(models.Model):
+    _name = 'event.mail.slot'
+    _description = 'Slot Mail Scheduler'
+    _rec_name = 'scheduler_id'
+    _order = 'scheduled_date DESC, id ASC'
+
+    event_slot_id = fields.Many2one('event.slot', 'Slot', ondelete='cascade', required=True)
+    scheduled_date = fields.Datetime('Schedule Date', compute='_compute_scheduled_date', store=True)
+    scheduler_id = fields.Many2one('event.mail', 'Mail Scheduler', ondelete='cascade', required=True)
+    # contact and status
+    last_registration_id = fields.Many2one('event.registration', 'Last Attendee')
+    mail_count_done = fields.Integer('# Sent', copy=False, readonly=True)
+    mail_done = fields.Boolean("Sent", copy=False, readonly=True)
+
+    @api.depends('event_slot_id.start_datetime', 'event_slot_id.end_datetime', 'scheduler_id.interval_unit', 'scheduler_id.interval_type')
+    def _compute_scheduled_date(self):
+        for mail_slot in self:
+            scheduler = mail_slot.scheduler_id
+            if scheduler.interval_type in ('before_event', 'after_event_start'):
+                date, sign = mail_slot.event_slot_id.start_datetime, (scheduler.interval_type == 'before_event' and -1) or 1
+            else:
+                date, sign = mail_slot.event_slot_id.end_datetime, (scheduler.interval_type == 'after_event' and 1) or -1
+            mail_slot.scheduled_date = date.replace(microsecond=0) + _INTERVALS[scheduler.interval_unit](sign * scheduler.interval_nbr) if date else False
+
+        next_schedule = self.filtered('scheduled_date').mapped('scheduled_date')
+        if next_schedule and (cron := self.env.ref('event.event_mail_scheduler', raise_if_not_found=False)):
+            cron._trigger(next_schedule)

--- a/addons/event/models/event_slot.py
+++ b/addons/event/models/event_slot.py
@@ -1,0 +1,144 @@
+import pytz
+from datetime import datetime
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools.date_intervals import float_to_time
+from odoo.tools import (
+    format_date,
+    format_datetime,
+    formatLang,
+    format_time,
+)
+
+
+class EventSlot(models.Model):
+    _name = "event.slot"
+    _description = "Event Slot"
+    _order = "event_id, date, start_hour, end_hour, id"
+
+    event_id = fields.Many2one("event.event", "Event", required=True, ondelete="cascade")
+    color = fields.Integer("Color", default=0)
+    date = fields.Date("Date", required=True)
+    date_tz = fields.Selection(related="event_id.date_tz")
+    start_hour = fields.Float("Starting Hour", required=True, help="Expressed in the event timezone.")
+    end_hour = fields.Float("Ending Hour", required=True, help="Expressed in the event timezone.")
+    start_datetime = fields.Datetime("Start Datetime", compute="_compute_datetimes", store=True)
+    end_datetime = fields.Datetime("End Datetime", compute="_compute_datetimes", store=True)
+
+    # Registrations
+    is_sold_out = fields.Boolean(
+        "Sold Out", compute="_compute_is_sold_out",
+        help="Whether seats are sold out for this slot.")
+    registration_ids = fields.One2many("event.registration", "event_slot_id", string="Attendees")
+    seats_available = fields.Integer(
+        string="Available Seats",
+        store=False, readonly=True, compute="_compute_seats")
+    seats_reserved = fields.Integer(
+        string="Number of Registrations",
+        store=False, readonly=True, compute="_compute_seats")
+    seats_taken = fields.Integer(
+        string="Number of Taken Seats",
+        store=False, readonly=True, compute="_compute_seats")
+    seats_used = fields.Integer(
+        string="Number of Attendees",
+        store=False, readonly=True, compute="_compute_seats")
+
+    @api.constrains("start_hour", "end_hour")
+    def _check_hours(self):
+        for slot in self:
+            if not (0 <= slot.start_hour <= 23.99 and 0 <= slot.end_hour <= 23.99):
+                raise ValidationError(_("A slot hour must be between 0:00 and 23:59."))
+            if slot.end_hour <= slot.start_hour:
+                raise ValidationError(_("A slot end hour must be later than its start hour.\n%s", slot.display_name))
+
+    @api.constrains("date", "start_hour", "end_hour")
+    def _check_time_range(self):
+        for slot in self:
+            event_start = slot.event_id.date_begin
+            event_end = slot.event_id.date_end
+            if not (event_start <= slot.start_datetime <= event_end) or not (event_start <= slot.end_datetime <= event_end):
+                raise ValidationError(_(
+                    "A slot cannot be scheduled outside of its event time range.\n\n"
+                    "Event:\t\t%(event_start)s - %(event_end)s\n"
+                    "Slot:\t\t%(slot_name)s",
+                    event_start=format_datetime(self.env, event_start, tz=slot.date_tz, dt_format='medium'),
+                    event_end=format_datetime(self.env, event_end, tz=slot.date_tz, dt_format='medium'),
+                    slot_name=slot.display_name,
+                ))
+
+    @api.depends("date", "date_tz", "start_hour", "end_hour")
+    def _compute_datetimes(self):
+        for slot in self:
+            event_tz = pytz.timezone(slot.date_tz)
+            start = datetime.combine(slot.date, float_to_time(slot.start_hour))
+            end = datetime.combine(slot.date, float_to_time(slot.end_hour))
+            slot.start_datetime = event_tz.localize(start).astimezone(pytz.UTC).replace(tzinfo=None)
+            slot.end_datetime = event_tz.localize(end).astimezone(pytz.UTC).replace(tzinfo=None)
+
+    @api.depends("seats_available")
+    @api.depends_context('name_with_seats_availability')
+    def _compute_display_name(self):
+        """Adds slot seats availability if requested by context.
+        Always display the name without availabilities if the event is multi slots
+        because the availability displayed won't be relative to the possible ticket combinations
+        but only relative to the event and this will confuse the user.
+        """
+        for slot in self:
+            date = format_date(self.env, slot.date, date_format="medium")
+            start = format_time(self.env, float_to_time(slot.start_hour), time_format="short")
+            end = format_time(self.env, float_to_time(slot.end_hour), time_format="short")
+            name = f"{date}, {start} - {end}"
+            if (
+                self.env.context.get('name_with_seats_availability') and slot.event_id.seats_limited
+                and not slot.event_id.is_multi_slots
+            ):
+                name = _('%(slot_name)s (Sold out)', slot_name=name) if not slot.seats_available else \
+                    _(
+                        '%(slot_name)s (%(count)s seats remaining)',
+                        slot_name=name,
+                        count=formatLang(self.env, slot.seats_available, digits=0),
+                    )
+            slot.display_name = name
+
+    @api.depends("event_id.seats_limited", "seats_available")
+    def _compute_is_sold_out(self):
+        for slot in self:
+            slot.is_sold_out = slot.event_id.seats_limited and not slot.seats_available
+
+    @api.depends("event_id", "event_id.seats_max", "registration_ids.state", "registration_ids.active")
+    def _compute_seats(self):
+        # initialize fields to 0
+        for slot in self:
+            slot.seats_reserved = slot.seats_used = slot.seats_available = 0
+        # aggregate registrations by slot and by state
+        state_field = {
+            'open': 'seats_reserved',
+            'done': 'seats_used',
+        }
+        base_vals = dict.fromkeys(state_field.values(), 0)
+        results = {slot_id: dict(base_vals) for slot_id in self.ids}
+        if self.ids:
+            query = """ SELECT event_slot_id, state, count(event_slot_id)
+                        FROM event_registration
+                        WHERE event_slot_id IN %s AND state IN ('open', 'done') AND active = true
+                        GROUP BY event_slot_id, state
+                    """
+            self.env['event.registration'].flush_model(['event_slot_id', 'state', 'active'])
+            self._cr.execute(query, (tuple(self.ids),))
+            res = self._cr.fetchall()
+            for slot_id, state, num in res:
+                results[slot_id][state_field[state]] = num
+        # compute seats_available
+        for slot in self:
+            slot.update(results.get(slot._origin.id or slot.id, base_vals))
+            if slot.event_id.seats_max > 0:
+                slot.seats_available = slot.event_id.seats_max - (slot.seats_reserved + slot.seats_used)
+            slot.seats_taken = slot.seats_reserved + slot.seats_used
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_if_registrations(self):
+        if self.registration_ids:
+            raise UserError(_(
+                "The following slots cannot be deleted while they have one or more registrations linked to them:\n- %s",
+                '\n- '.join(self.mapped('display_name'))))

--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -193,7 +193,13 @@
                                 <div class="col-md-6 col-12 mb-3 o_event_full_page_ticket_column">
                                     <div class="d-flex">
                                         <i class="fa fa-calendar fa-2x fa-fw me-2 mt-1"/>
-                                        <div t-if="event.is_one_day">
+                                        <div t-if="attendee">
+                                            <span t-field="attendee.event_begin_date" class="text-nowrap"
+                                                t-options='{"widget": "datetime", "tz_name": event.date_tz, "format": "short"}'/><br/>
+                                            <span class="me-1">to</span><span t-field="attendee.event_end_date" class="text-nowrap"
+                                                t-options='{"widget": "datetime", "tz_name": event.date_tz, "format": "short"}'/>
+                                        </div>
+                                        <div t-elif="event.is_one_day">
                                             <span t-field="event.date_begin" class="text-nowrap"
                                                 t-options='{"widget": "datetime", "date_only": True, "tz_name": event.date_tz}'/><br/>
                                             <span class="me-1">from</span><span t-field="event.date_begin" class="text-nowrap"
@@ -312,20 +318,37 @@
         <div class="position-relative h-100">
             <h3 class="fw-bold text-center" t-field="event.name"/>
             <div class="text-center o_event_badge_font_small">
-                <span itemprop="startDate" t-field="event.date_begin"
-                    t-options='{"widget": "datetime", "date_only": True, "tz_name": event.date_tz}'
-                    class="fw-bold"/>
-                <span itemprop="startDateTime" t-field="event.date_begin"
-                    class="fw-bold"
-                    t-options='{"widget": "datetime", "time_only": True, "tz_name": event.date_tz, "hide_seconds": True}'/>
-                <span class="fa fa-arrow-right o_event_badge_font_faded"/>
-                <span t-if="not event.is_one_day"
-                    itemprop="endDate" t-field="event.date_end"
-                    t-options='{"widget": "datetime", "date_only": True, "tz_name": event.date_tz}'
-                    class="fw-bold"/>
-                <span itemprop="endDateTime" t-field="event.date_end"
-                    class="fw-bold"
-                    t-options='{"widget": "datetime", "time_only": True, "tz_name": event.date_tz, "hide_seconds": True}'/>
+                <t t-if="attendee">
+                    <span itemprop="startDate" t-field="attendee.event_begin_date"
+                        t-options='{"widget": "datetime", "date_only": True, "tz_name": event.date_tz}'
+                        class="fw-bold"/>
+                    <span itemprop="startDateTime" t-field="attendee.event_begin_date"
+                        class="fw-bold"
+                        t-options='{"widget": "datetime", "time_only": True, "tz_name": event.date_tz, "hide_seconds": True}'/>
+                    <span class="fa fa-arrow-right o_event_badge_font_faded"/>
+                    <span itemprop="endDate" t-field="attendee.event_end_date"
+                        t-options='{"widget": "datetime", "date_only": True, "tz_name": event.date_tz}'
+                        class="fw-bold"/>
+                    <span itemprop="endDateTime" t-field="attendee.event_end_date"
+                        class="fw-bold"
+                        t-options='{"widget": "datetime", "time_only": True, "tz_name": event.date_tz, "hide_seconds": True}'/>
+                </t>
+                <t t-else="">
+                    <span itemprop="startDate" t-field="event.date_begin"
+                        t-options='{"widget": "datetime", "date_only": True, "tz_name": event.date_tz}'
+                        class="fw-bold"/>
+                    <span itemprop="startDateTime" t-field="event.date_begin"
+                        class="fw-bold"
+                        t-options='{"widget": "datetime", "time_only": True, "tz_name": event.date_tz, "hide_seconds": True}'/>
+                    <span class="fa fa-arrow-right o_event_badge_font_faded"/>
+                    <span t-if="not event.is_one_day"
+                        itemprop="endDate" t-field="event.date_end"
+                        t-options='{"widget": "datetime", "date_only": True, "tz_name": event.date_tz}'
+                        class="fw-bold"/>
+                    <span itemprop="endDateTime" t-field="event.date_end"
+                        class="fw-bold"
+                        t-options='{"widget": "datetime", "time_only": True, "tz_name": event.date_tz, "hide_seconds": True}'/>
+                </t>
             </div>
             <div t-if="event.address_id" class="o_event_badge_font_faded o_event_badge_font_small text-center">
                 <t t-call="event.event_report_template_formatted_event_address">

--- a/addons/event/security/ir.model.access.csv
+++ b/addons/event/security/ir.model.access.csv
@@ -16,8 +16,12 @@ access_event_mail_registration,event.mail.registration,model_event_mail,event.gr
 access_event_mail_user,event.mail.user,model_event_mail,event.group_event_user,1,1,1,1
 access_event_mail_registration_registration,event.mail.registration.registration,model_event_mail_registration,event.group_event_registration_desk,1,0,0,0
 access_event_mail_registration_manager,event.mail.registration.manager,model_event_mail_registration,event.group_event_manager,1,1,1,1
+access_event_mail_slot_registration,event.mail.slot.registration,model_event_mail_slot,event.group_event_registration_desk,1,0,0,0
+access_event_mail_slot_manager,event.mail.slot.manager,model_event_mail_slot,event.group_event_manager,1,1,1,1
 access_event_type_mail_registration,event.type.mail.registration,model_event_type_mail,event.group_event_registration_desk,1,0,0,0
 access_event_type_mail_manager,event.type.mail.manager,model_event_type_mail,event.group_event_manager,1,1,1,1
+access_event_slot_registration,event.slot.registration,model_event_slot,event.group_event_registration_desk,1,0,0,0
+access_event_slot_user,event.slot.user,model_event_slot,event.group_event_user,1,1,1,1
 access_event_stage_registration,event.stage.registration,model_event_stage,event.group_event_registration_desk,1,0,0,0
 access_event_stage_manager,event.stage.manager,model_event_stage,event.group_event_manager,1,1,1,1
 access_event_tag_category_registration,event.tag.category.registration,model_event_tag_category,event.group_event_registration_desk,1,0,0,0

--- a/addons/event/static/src/client_action/event_registration_summary_dialog.xml
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.xml
@@ -46,6 +46,7 @@
                     <table class="table table-striped fs-4">
                         <tr t-if="registration.company_name"><td>Company</td><td><t t-out="registration.company_name"/></td></tr>
                         <tr><td>Event</td><td><t t-out="registration.event_display_name"/></td></tr>
+                        <tr t-if="registration.slot_name"><td>Slot</td><td><t t-out="registration.slot_name"/></td></tr>
                         <tr t-if="registration.ticket_name"><td>Ticket Type</td><td><t t-out="registration.ticket_name"/></td></tr>
                         <tr t-if="registration.registration_answers &amp;&amp; registration.registration_answers.length > 0">
                             <td class="d-flex">Answers</td>

--- a/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_common_renderer.xml
+++ b/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_common_renderer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="event.EventSlotCalendarCommonRenderer.event">
+        <!-- Display end time and hide title on the full calendar library event. -->
+        <span t-if="!isTimeHidden" class="fc-time">
+            <t t-out="startTime"/> - <t t-out="endTime"/>
+        </span>
+    </t>
+
+</templates>

--- a/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_model.js
+++ b/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_model.js
@@ -1,0 +1,30 @@
+import { CalendarModel } from "@web/views/calendar/calendar_model";
+import { serializeDate } from "@web/core/l10n/dates";
+
+export class EventSlotCalendarModel extends CalendarModel {
+
+    /**
+     * @override
+     * Save slot date and hours from selected datetimes
+     */
+    buildRawRecord(partialRecord, options = {}) {
+        const rawRecord = super.buildRawRecord(partialRecord, options)
+        rawRecord["date"] = serializeDate(partialRecord.start);
+        rawRecord["start_hour"] = partialRecord.start.hour + partialRecord.start.minute / 60;
+        rawRecord["end_hour"] = partialRecord.end.hour + partialRecord.end.minute / 60;
+        return rawRecord;
+    }
+
+    /**
+     * @override
+     * Instead of the local tz, express the times in the related event tz or fallback on utc.
+     */
+    normalizeRecord(rawRecord) {
+        const normalizedRecord = super.normalizeRecord(rawRecord);
+        const tz = rawRecord.date_tz || 'utc';
+        normalizedRecord.start = normalizedRecord.start.setZone(tz);
+        normalizedRecord.end = normalizedRecord.end.setZone(tz);
+        return normalizedRecord;
+    }
+
+}

--- a/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_renderer.js
+++ b/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_renderer.js
@@ -1,0 +1,18 @@
+import { CalendarCommonRenderer } from "@web/views/calendar/calendar_common/calendar_common_renderer";
+import { CalendarRenderer } from "@web/views/calendar/calendar_renderer";
+import { CalendarYearRenderer } from "@web/views/calendar/calendar_year/calendar_year_renderer";
+
+export class EventSlotCalendarCommonRenderer extends CalendarCommonRenderer {
+    // Display end time and hide title on the full calendar library event.
+    static eventTemplate = "event.EventSlotCalendarCommonRenderer.event";
+}
+
+export class EventSlotCalendarRenderer extends CalendarRenderer {
+    static components = {
+        ...CalendarRenderer.components,
+        day: EventSlotCalendarCommonRenderer,
+        week: EventSlotCalendarCommonRenderer,
+        month: EventSlotCalendarCommonRenderer,
+        year: CalendarYearRenderer,
+    };
+}

--- a/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_view.js
+++ b/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_view.js
@@ -1,0 +1,13 @@
+import { calendarView } from "@web/views/calendar/calendar_view";
+import { EventSlotCalendarModel } from "@event/views/event_slot_calendar/event_slot_calendar_model";
+import { EventSlotCalendarRenderer } from "@event/views/event_slot_calendar/event_slot_calendar_renderer";
+import { registry } from "@web/core/registry";
+
+
+export const EventSlotCalendarView = {
+    ...calendarView,
+    Model: EventSlotCalendarModel,
+    Renderer: EventSlotCalendarRenderer,
+};
+
+registry.category("views").add("event_slot_calendar", EventSlotCalendarView);

--- a/addons/event/tests/__init__.py
+++ b/addons/event/tests/__init__.py
@@ -3,4 +3,5 @@
 
 from . import test_event_internals
 from . import test_event_mail_schedule
+from . import test_event_slot
 from . import test_mailing

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from odoo import exceptions
 from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.event.tests.common import EventCase
+from odoo.addons.event.models.event_mail import EventMail
 from odoo.addons.mail.tests.common import MailCase
 from odoo.tests import tagged, users, warmup
 from odoo.tools import formataddr, mute_logger
@@ -47,7 +48,7 @@ class EventMailCommon(EventCase, MailCase, CronMixinCase):
         cls._setup_test_reports()
         with cls.mock_datetime_and_now(cls, cls.reference_now):
             # create with admin to force create_date
-            cls.test_event = cls.env['event.event'].create({
+            cls.test_event = cls.env['event.event'].with_user(cls.user_eventmanager).create({
                 'name': 'TestEventMail',
                 'user_id': cls.user_eventmanager.id,
                 'date_begin': cls.event_date_begin,
@@ -108,6 +109,9 @@ class TestMailSchedule(EventMailCommon):
 
         # event data
         self.assertEqual(test_event.create_date, self.reference_now)
+        self.assertEqual(test_event.date_begin, self.event_date_begin, 'Expressed in current user TZ')
+        self.assertEqual(test_event.date_end, self.event_date_end, 'Expressed in current user TZ')
+        self.assertEqual(test_event.date_tz, 'Europe/Brussels')
         self.assertEqual(test_event.organizer_id, self.user_eventmanager.company_id.partner_id)
         self.assertEqual(test_event.user_id, self.user_eventmanager)
 
@@ -602,6 +606,117 @@ class TestMailSchedule(EventMailCommon):
         self.assertTrue(after_sub_scheduler)
         self.template_subscription.sudo().unlink()
         self.assertFalse(after_sub_scheduler.exists(), "When removing template, scheduler should be removed")
+
+    @users('user_eventmanager')
+    def test_event_mail_schedule_on_slot(self):
+        """ Test emails sent globally on slots, notably to test iterative job
+
+        Expected behavior
+         - event date_begin: 22 08AM
+         - event date_end:   24 18AM
+         - schedulers: 1 day before start, immediately after end
+         - slots begin:      23 08AM and 24 08AM
+         - Nothing happens before (23 - 1) 08AM, as what matters are the slots, not the event
+         - Two executions: on 22 08 AM and on 23 08 AM
+        """
+        test_event = self.test_event.with_env(self.env)
+
+        # check iterative work, update params to check call count
+        batch_size, render_limit = 2, 4
+        self.env['ir.config_parameter'].sudo().set_param('mail.batch_size', batch_size)
+        self.env['ir.config_parameter'].sudo().set_param('mail.render.cron.limit', render_limit)
+
+        # find slot-based schedulers, remove other to avoid noise
+        event_prev_scheduler = self.env['event.mail'].search([('event_id', '=', test_event.id), ('interval_type', '=', 'before_event')])
+        event_after_scheduler = self.env['event.mail'].search([('event_id', '=', test_event.id), ('interval_type', '=', 'after_event')])
+        (test_event.event_mail_ids - (event_prev_scheduler + event_after_scheduler)).unlink()
+
+        with self.mock_datetime_and_now(self.reference_now):
+            test_event = self.test_event.with_env(self.env)
+            test_event.write({
+                'is_multi_slots': True,
+                # Start and end hours expressed in event tz
+                # The slots datetimes will be saved in utc
+                'event_slot_ids': [
+                    (0, 0, {
+                        'date': self.event_date_end.date() - relativedelta(days=1),
+                        'end_hour': 18,
+                        'start_hour': 8,
+                    }),
+                    (0, 0, {
+                        'date': self.event_date_end.date(),
+                        'end_hour': 18,
+                        'start_hour': 8,
+                    }),
+                ],
+            })
+        # Verify datetimes in UTC
+        self.assertEqual(test_event.date_tz, 'Europe/Brussels')
+        self.assertEqual(
+            test_event.event_slot_ids.mapped('start_datetime'),
+            [datetime(2021, 3, 23, 7, 0, 0), datetime(2021, 3, 24, 7, 0, 0)])
+        self.assertEqual(
+            test_event.event_slot_ids.mapped('end_datetime'),
+            [datetime(2021, 3, 23, 17, 0, 0), datetime(2021, 3, 24, 17, 0, 0)])
+
+        # create some registrations
+        with self.mock_datetime_and_now(self.reference_now):
+            registrations = self.env['event.registration'].with_user(self.user_eventuser).create([
+                {
+                    'email': f'reg.{idx}.{slot.id}@test.example.com',
+                    'event_id': test_event.id,
+                    'name': f'Reg-{idx} in {slot.id}',
+                    'event_slot_id': slot.id,
+                }
+                for slot in [test_event.event_slot_ids[0], test_event.event_slot_ids[1]]
+                for idx in range(5)
+            ])
+        self.assertEqual(len(registrations), 10)
+        registrations_slot_1 = registrations.filtered(lambda r: r.event_slot_id == test_event.event_slot_ids[0])
+
+        # simulate cron: ok for event-begin, but not for slots -> should not send communication
+        current = self.event_date_begin - relativedelta(hours=2)
+        self.execute_event_cron(freeze_date=current)
+        self.assertFalse(event_prev_scheduler.mail_done)
+        self.assertEqual(event_prev_scheduler.mail_state, 'scheduled')
+        self.assertEqual(event_prev_scheduler.mail_count_done, 0)
+        self.assertEqual(len(self._new_mails), 0)
+
+        # created missing mail.slot
+        self.assertEqual(len(event_prev_scheduler.mail_slot_ids), 2)
+        self.assertEqual(event_prev_scheduler.mail_slot_ids.event_slot_id, test_event.event_slot_ids)
+        for mail_slot in event_prev_scheduler.mail_slot_ids:
+            self.assertEqual(mail_slot.mail_count_done, 0)
+            self.assertEqual(mail_slot.mail_done, 0)
+        mail_slot_1 = event_prev_scheduler.mail_slot_ids.filtered(lambda s: s.event_slot_id.date == self.event_date_end.date() - relativedelta(days=1))
+        self.assertEqual(mail_slot_1.scheduled_date, datetime(2021, 3, 22, 7, 0, 0))
+        mail_slot_2 = event_prev_scheduler.mail_slot_ids.filtered(lambda s: s.event_slot_id.date == self.event_date_end.date())
+        self.assertEqual(mail_slot_2.scheduled_date, datetime(2021, 3, 23, 7, 0, 0))
+
+        # execute cron to run scheduler on first slot
+        slot1_before_oneday = datetime(2021, 3, 23, 7, 0, 0) - relativedelta(days=1)
+        exec_origin = EventMail._execute_event_based_for_registrations
+        with patch.object(
+            EventMail, '_execute_event_based_for_registrations', autospec=True, wraps=EventMail, side_effect=exec_origin,
+        ) as mock_exec:
+            capture = self.execute_event_cron(freeze_date=slot1_before_oneday)
+        # produced content
+        self.assertEqual(len(self._new_mails), 4, 'Cron limited to size of 2x2')
+        self.assertEqual(mock_exec.call_count, 2, '2 calls: 2x2registrations, limit of 4')
+        self.assertMailMailWEmails(
+            [formataddr((reg.name, reg.email)) for reg in registrations_slot_1[:4]],
+            'outgoing',
+            content=None,
+            fields_values={
+                'email_from': self.user_eventmanager.company_id.email_formatted,
+                'subject': f'Reminder for {test_event.name}: tomorrow',
+            })
+        # updated info
+        self.assertEqual(mail_slot_1.mail_count_done, 4)
+        self.assertFalse(mail_slot_1.mail_done)
+        self.assertEqual(event_prev_scheduler.mail_count_done, 4)
+        self.assertFalse(event_prev_scheduler.mail_done)
+        self.assertSchedulerCronTriggers(capture, [slot1_before_oneday])
 
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
     @users('user_eventmanager')

--- a/addons/event/tests/test_event_slot.py
+++ b/addons/event/tests/test_event_slot.py
@@ -1,0 +1,245 @@
+from datetime import date, datetime
+
+from odoo.addons.event.tests.common import EventCase
+from odoo import exceptions
+from odoo.tests import tagged
+
+
+class TestEventSlotsCommon(EventCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Mock dates to have reproducible computed fields based on time
+        cls.reference_now = datetime(2025, 4, 15, 10, 0, 0)
+        cls.reference_beg = datetime(2025, 4, 21, 6, 30, 0)
+        cls.reference_end = datetime(2025, 8, 21, 17, 45, 0)
+
+        with cls.mock_datetime_and_now(cls, cls.reference_now):
+            cls.test_event = cls.env['event.event'].create({
+                'date_begin': cls.reference_beg,
+                'date_end': cls.reference_end,
+                'date_tz': 'Europe/Brussels',
+                'event_ticket_ids': [
+                    (0, 0, {
+                        'name': 'Classic',
+                        'seats_limited': False,
+                        'seats_max': 0,
+                    }), (0, 0, {
+                        'name': 'Better',
+                        'seats_limited': True,
+                        'seats_max': 3,
+                    }), (0, 0, {
+                        'name': 'VIP',
+                        'seats_limited': True,
+                        'seats_max': 1,
+                    }),
+                ],
+                'name': 'Test Event',
+                'seats_limited': True,
+                'seats_max': 5,
+                'event_slot_ids': [
+                    (0, 0, {
+                        'date': date(2025, 4, 21),
+                        'end_hour': 12,
+                        'start_hour': 9,
+                    }),
+                    (0, 0, {
+                        'date': date(2025, 4, 21),
+                        'end_hour': 16,
+                        'start_hour': 13,
+                    }),
+                ],
+                'user_id': cls.user_eventuser.id,
+            })
+
+            first_slot = cls.test_event.event_slot_ids.filtered(lambda s: s.start_hour == 9)
+            second_slot = cls.test_event.event_slot_ids.filtered(lambda s: s.start_hour == 13)
+            first_ticket = cls.test_event.event_ticket_ids.filtered(lambda t: t.name == 'Classic')
+            second_ticket = cls.test_event.event_ticket_ids.filtered(lambda t: t.name == 'Better')
+
+            # already existing registrations
+            cls._create_registrations_for_slot_and_ticket(cls.test_event, first_slot, first_ticket, 3)
+            cls._create_registrations_for_slot_and_ticket(cls.test_event, second_slot, second_ticket, 1)
+
+
+@tagged('event_slot', 'event_seats')
+class TestEventSlotSeats(TestEventSlotsCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.test_event_slot_noticket = cls.test_event.copy({'event_ticket_ids': False})
+
+        first_slot = cls.test_event_slot_noticket.event_slot_ids.filtered(lambda s: s.start_hour == 9)
+        second_slot = cls.test_event_slot_noticket.event_slot_ids.filtered(lambda s: s.start_hour == 13)
+
+        # already existing registrations: 3 on first slot (1 archived), 1 on second slot (2 archived)
+        with cls.mock_datetime_and_now(cls, cls.reference_now):
+            cls._create_registrations_for_slot_and_ticket(cls.test_event_slot_noticket, first_slot, False, 1, state='open')
+            cls._create_registrations_for_slot_and_ticket(cls.test_event_slot_noticket, first_slot, False, 2, state='done')
+            cls._create_registrations_for_slot_and_ticket(cls.test_event_slot_noticket, first_slot, False, 1, active=False)
+            cls._create_registrations_for_slot_and_ticket(cls.test_event_slot_noticket, second_slot, False, 1)
+            cls._create_registrations_for_slot_and_ticket(cls.test_event_slot_noticket, second_slot, False, 2, active=False)
+            cls._create_registrations_for_slot_and_ticket(cls.test_event_slot_noticket, second_slot, False, 1, state='cancel')
+            cls._create_registrations_for_slot_and_ticket(cls.test_event_slot_noticket, second_slot, False, 1, state='draft')
+
+    def test_assert_initial_values(self):
+        """ Check initial values, ensure test conditions """
+        test_event = self.test_event.with_user(self.user_eventregistrationdesk)
+        first_slot = test_event.event_slot_ids.filtered(lambda s: s.start_hour == 9)
+        second_slot = test_event.event_slot_ids.filtered(lambda s: s.start_hour == 13)
+        self.assertTrue(first_slot)
+        self.assertTrue(second_slot)
+        self.assertEqual(first_slot.seats_available, 2)
+        self.assertEqual(first_slot.seats_reserved, 3)
+        self.assertEqual(second_slot.seats_available, 4)
+        self.assertEqual(second_slot.seats_reserved, 1)
+
+        test_event_nt = self.test_event_slot_noticket.with_user(self.user_eventregistrationdesk)
+        first_slot = test_event_nt.event_slot_ids.filtered(lambda s: s.start_hour == 9)
+        second_slot = test_event_nt.event_slot_ids.filtered(lambda s: s.start_hour == 13)
+        self.assertTrue(first_slot)
+        self.assertTrue(second_slot)
+        self.assertEqual(first_slot.seats_available, 2)
+        self.assertEqual(first_slot.seats_reserved, 1)
+        self.assertEqual(second_slot.seats_available, 4)
+        self.assertEqual(second_slot.seats_reserved, 1)
+
+    def test_seats_slots_notickets(self):
+        """ Test: slots, no tickets -> limits come from event itself """
+        # self.test_event_slot_noticket.with_user(self.user_eventuser).write({'event_ticket_ids': [(5, 0)]})
+        test_event = self.test_event_slot_noticket.with_user(self.user_eventregistrationdesk)
+        first_slot = test_event.event_slot_ids.filtered(lambda s: s.start_hour == 9)
+        second_slot = test_event.event_slot_ids.filtered(lambda s: s.start_hour == 13)
+
+        Registration = self.env['event.registration'].with_user(self.user_eventregistrationdesk)
+
+        # check ``_get_seats_availability`` tool, giving availabilities for slot / ticket combinations
+        res = test_event._get_seats_availability([(first_slot, False), (second_slot, False)])
+        self.assertEqual(res, [first_slot.seats_available, second_slot.seats_available])
+
+        # check constraints at registration creation
+        for create_input, should_crash in [
+            # ok for event max seats for both slots
+            (((first_slot, 2), (second_slot, 2)), False),
+            # not enough seats on first slot
+            (((first_slot, 3),), True),
+            # not enough seats on second slot
+            (((second_slot, 5),), True),
+        ]:
+            with self.subTest(create_input=create_input, should_crash=should_crash):
+                create_values = []
+                for slot, count in create_input:
+                    create_values += [
+                        {
+                            'email': f'{slot.display_name}.{idx}@test.example.com',
+                            'event_id': test_event.id,
+                            'event_slot_id': slot.id,
+                            'name': f'{slot.display_name} {idx}',
+                        } for idx in range(count)
+                    ]
+                if should_crash:
+                    with self.assertRaises(exceptions.ValidationError):
+                        new = Registration.create(create_values)
+                else:
+                    new = Registration.create(create_values)
+                    self.assertEqual(len(new), sum(count for _slot, count in create_input))
+                    new.with_user(self.user_eventmanager).unlink()
+
+        # check ``_verify_seats_availability`` itself
+        for check_input, should_crash in [
+            # ok for event max seats for both slots
+            (((first_slot, False, 2), (second_slot, False, 4)), False),
+            # not enough seats on first slot
+            (((first_slot, False, 3),), True),
+            # not enough seats on second slot
+            (((second_slot, False, 5),), True),
+        ]:
+            with self.subTest(check_input=check_input, should_crash=should_crash):
+                if should_crash:
+                    with self.assertRaises(exceptions.ValidationError):
+                        test_event._verify_seats_availability(check_input)
+                else:
+                    test_event._verify_seats_availability(check_input)
+
+        # check constraint at write (active change) -> ok, check count
+        all_slot2 = test_event.with_context(active_test=False).registration_ids.filtered(lambda r: r.event_slot_id == second_slot)
+        self.assertEqual(len(all_slot2), 5, 'Test setup data: 3 active, 2 inactive')
+        all_slot2.active = True
+        self.assertEqual(second_slot.seats_available, 2)
+        self.assertEqual(second_slot.seats_reserved, 3)
+
+        # move them on first slot -> crash as it would be out of limits
+        with self.assertRaises(exceptions.ValidationError):
+            all_slot2.event_slot_id = first_slot.id
+
+    def test_seats_slots_tickets(self):
+        """ Test: slots and tickets -> limits come from event (global) and tickets """
+        test_event = self.test_event.with_user(self.user_eventregistrationdesk)
+        first_slot = test_event.event_slot_ids.filtered(lambda s: s.start_hour == 9)
+        second_slot = test_event.event_slot_ids.filtered(lambda s: s.start_hour == 13)
+        first_ticket = test_event.event_ticket_ids.filtered(lambda t: t.name == 'Classic')
+        second_ticket = test_event.event_ticket_ids.filtered(lambda t: t.name == 'Better')
+        third_ticket = test_event.event_ticket_ids.filtered(lambda t: t.name == 'VIP')
+
+        Registration = self.env['event.registration'].with_user(self.user_eventregistrationdesk)
+
+        # check ``_get_seats_availability`` tool, giving availabilities for slot / ticket combinations
+        res = test_event._get_seats_availability([
+            (first_slot, first_ticket), (first_slot, second_ticket), (first_slot, third_ticket),
+            (second_slot, first_ticket), (second_slot, second_ticket), (second_slot, third_ticket),
+        ])
+        # first slot: 2 seats available, and VIP ticket has 1 seat anyway
+        # second slot: 4 seats available, Better has 3 max and 1 taken and VIP 1 max
+        self.assertEqual(res, [2, 2, 1, 4, 2, 1])
+
+        # check constraints at registration creation
+        for create_input, should_crash in [
+            (((first_slot, second_ticket, 2),), False),
+            # not enough seats for first slot
+            (((first_slot, first_ticket, 5),), True),
+            # not enough seats on VIP ticket
+            (((second_slot, third_ticket, 2),), True),
+        ]:
+            with self.subTest(create_input=create_input, should_crash=should_crash):
+                create_values = []
+                for slot, ticket, count in create_input:
+                    create_values += [
+                        {
+                            'email': f'{slot.display_name}.{ticket.name}.{idx}@test.example.com',
+                            'event_id': test_event.id,
+                            'event_slot_id': slot.id,
+                            'event_ticket_id': ticket.id,
+                            'name': f'{slot.display_name} {ticket.name} {idx}',
+                        } for idx in range(count)
+                    ]
+                if should_crash:
+                    with self.assertRaises(exceptions.ValidationError):
+                        new = Registration.create(create_values)
+                else:
+                    new = Registration.create(create_values)
+                    self.assertEqual(len(new), sum(count for _slot, _ticket, count in create_input))
+                    new.with_user(self.user_eventmanager).unlink()
+
+        # check create constraint through embed 2many: 2 VIPs is not possible
+        with self.assertRaises(exceptions.ValidationError):
+            test_event.with_user(self.user_eventmanager).write({
+                'registration_ids': [
+                    (0, 0, {'event_slot_id': second_slot.id, 'event_ticket_id': third_ticket.id}),
+                    (0, 0, {'event_slot_id': second_slot.id, 'event_ticket_id': third_ticket.id}),
+                ],
+            })
+        # one of them is archived, ok for limit
+        test_event.with_user(self.user_eventmanager).write({
+            'registration_ids': [
+                (0, 0, {'event_slot_id': second_slot.id, 'event_ticket_id': third_ticket.id, 'active': False}),
+                (0, 0, {'event_slot_id': second_slot.id, 'event_ticket_id': third_ticket.id}),
+            ],
+        })
+        archived_vip = test_event.with_context(active_test=False).registration_ids.filtered(lambda r: r.event_slot_id == second_slot and r.event_ticket_id == third_ticket and not r.active)
+        self.assertTrue(archived_vip)
+        # writing on active triggers constraint on VIP
+        with self.assertRaises(exceptions.ValidationError):
+            archived_vip.active = True

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -40,6 +40,13 @@
                                 help="Total Registrations for this Event">
                             <field name="seats_taken" widget="statinfo" string="Attendees"/>
                         </button>
+                        <button name="%(event.act_event_slot_from_event)d"
+                                type="action"
+                                class="oe_stat_button"
+                                icon="fa-calendar"
+                                invisible="not is_multi_slots">
+                            <field name="event_slot_count" widget="statinfo" string="Slots"/>
+                        </button>
                     </div>
                     <field name="active" invisible="1"/>
                     <field name="company_id" invisible="1"/>
@@ -58,6 +65,7 @@
                             <field name="date_begin" string="Date" widget="daterange" options="{'end_date_field': 'date_end'}" />
                             <field name="date_end" invisible="1" />
                             <field name="date_tz"/>
+                            <field name="is_multi_slots" string="Multiple Slots"/>
                             <field name="lang"/>
                             <field name="event_type_id" string="Template"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}"/>
@@ -71,7 +79,10 @@
                             <label for="seats_limited" string="Limit Registrations"/>
                             <div>
                                 <field name="seats_limited"/>
-                                <span invisible="not seats_limited" required="not seats_limited">to <field name="seats_max" class="oe_inline o_input_9ch"/> Attendees</span>
+                                <span invisible="not seats_limited" required="not seats_limited">
+                                    to <field name="seats_max" class="oe_inline o_input_9ch"/> Attendees
+                                    <span invisible="not is_multi_slots"> per slot</span>
+                                </span>
                             </div>
                         </group>
                     </group>
@@ -79,6 +90,7 @@
                         <page string="Tickets" name="tickets">
                             <field name="event_ticket_ids" context="{
                                 'default_event_name': name,
+                                'is_event_multi_slots': is_multi_slots,
                                 'list_view_ref': 'event.event_event_ticket_view_tree_from_event',
                                 'form_view_ref': 'event.event_event_ticket_view_form_from_event',
                                 'kanban_view_ref': 'event.event_event_ticket_view_kanban_from_event'}" mode="list,kanban"/>

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -18,6 +18,7 @@
                 <field name="phone" optional="show"/>
                 <field name="company_name" optional="hide"/>
                 <field name="event_id" column_invisible="context.get('default_event_id')"/>
+                <field name="event_slot_id" domain="[('event_id', '=', event_id)]"/>
                 <field name="event_ticket_id" domain="[('event_id', '=', event_id)]"/>
                 <field name="activity_ids" widget="list_activity"/>
                 <field name="state" decoration-info="state in ('draft', 'open')"
@@ -68,10 +69,14 @@
                         <group string="Event Information" name="event">
                             <field class="text-break" name="event_id"
                                    context="{'name_with_seats_availability': True}" options="{'no_create': True}"/>
-                            <field name="barcode" groups="base.group_no_one"/>
-                            <field name="event_ticket_id" invisible="not event_id"
+                            <field name="event_slot_id" invisible="not is_multi_slots" required="is_multi_slots"
                                    context="{'name_with_seats_availability': True}" options="{'no_open': True, 'no_create': True}"
                                    domain="[('event_id', '=', event_id)]"/>
+                            <field name="event_ticket_id" invisible="not event_id"
+                                   context="{'name_with_seats_availability': True, 'is_event_multi_slots': is_multi_slots}"
+                                   options="{'no_open': True, 'no_create': True}"
+                                   domain="[('event_id', '=', event_id)]"/>
+                            <field name="barcode" groups="base.group_no_one"/>
                             <field name="partner_id"/>
                             <field name="create_date" string="Registration Date" groups="base.group_no_one"/>
                             <field name="date_closed" groups="base.group_no_one"/>
@@ -142,10 +147,14 @@
                             </span>
                             <div id="event_ticket_id">
                                 <field name="registration_properties"/>
-                                <t t-if="record.event_ticket_id.raw_value">
+                                <div t-if="record.event_slot_id.raw_value">
+                                    <i class="fa fa-calendar" title="Slot"/>
+                                    <field name="event_slot_id" class="fw-bold text-truncate ms-1"/>
+                                </div>
+                                <div t-if="record.event_ticket_id.raw_value">
                                     <i class="fa fa-ticket" title="Ticket type"/>
                                     <field name="event_ticket_id" class="fw-bold text-truncate ms-1"/>
-                                </t>
+                                </div>
                             </div>
                         </div>
                     </t>

--- a/addons/event/views/event_slot_views.xml
+++ b/addons/event/views/event_slot_views.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<odoo><data>
+
+    <record id="view_event_slot_form" model="ir.ui.view">
+        <field name="name">event.slot.form</field>
+        <field name="model">event.slot</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <group>
+                        <field name="start_hour" string="From" widget="float_time"/>
+                        <field name="color" widget="color_picker"/>
+                    </group>
+                    <group>
+                        <field name="end_hour" string="To" widget="float_time"/>
+                    </group>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_event_slot_multi_create_form" model="ir.ui.view">
+        <field name="name">event.slot.form</field>
+        <field name="model">event.slot</field>
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <form>
+                <div class="row">
+                    <label class="col-4" for="color" string="Color"/>
+                    <field class="col-8" name="color" widget="color_picker"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_event_slot_tree" model="ir.ui.view">
+        <field name="name">event.slot.list</field>
+        <field name="model">event.slot</field>
+        <field name="arch" type="xml">
+            <list string="Slots" editable="bottom" multi_edit="1">
+                <field name="date"/>
+                <field name="start_hour" string="From" widget="float_time"/>
+                <button name="durationArrow" width="20px" title="Until"
+                    class="fa fa-long-arrow-right text-center text-secondary pe-none"/>
+                <field name="end_hour" string="To" widget="float_time"/>
+                <field name="color" widget="color_picker"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_event_slot_calendar" model="ir.ui.view">
+        <field name="name">event.slot.calendar</field>
+        <field name="model">event.slot</field>
+        <field name="arch" type="xml">
+            <calendar js_class="event_slot_calendar" date_start="start_datetime" date_stop="end_datetime"
+                string="Slots" scales="month" color="color" multi_create_view="event.view_event_slot_multi_create_form">
+                <field name="start_datetime" invisible="1"/>
+                <field name="end_datetime" invisible="1"/>
+                <field name="date_tz" invisible="1"/>
+            </calendar>
+        </field>
+    </record>
+
+    <record id="act_event_slot_from_event" model="ir.actions.act_window">
+        <field name="name">Slots</field>
+        <field name="res_model">event.slot</field>
+        <field name="view_mode">calendar,list,form</field>
+        <field name="domain">[('event_id', '=', active_id)]</field>
+        <field name="context">{'default_event_id': active_id}</field>
+    </record>
+
+</data></odoo>

--- a/addons/event/views/event_ticket_views.xml
+++ b/addons/event/views/event_ticket_views.xml
@@ -76,8 +76,10 @@
                 <field name="description" optional="hide"/>
                 <field name="start_sale_datetime" optional="show"/>
                 <field name="end_sale_datetime" optional="show"/>
-                <field name="seats_max" sum="Total" width="105px" string="Maximum"/>
-                <field name="seats_taken" sum="Total" width="105px" string="Registration"/>
+                <field name="seats_max" sum="Total" width="120px" string="Maximum" column_invisible="context.get('is_event_multi_slots')"/>
+                <field name="seats_max" sum="Total" width="120px" string="Maximum per slot" column_invisible="not context.get('is_event_multi_slots')"/>
+                <field name="seats_taken" sum="Total" width="120px" string="Registration" column_invisible="context.get('is_event_multi_slots')"/>
+                <field name="seats_taken" sum="Total" width="120px" string="Total Registration" column_invisible="not context.get('is_event_multi_slots')"/>
                 <field name="color" widget="color" optional="hidden"/>
             </list>
         </field>

--- a/addons/event_sale/data/mail_templates.xml
+++ b/addons/event_sale/data/mail_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<template id="event_ticket_id_change_exception" name="Message: Alert on event ticket id change">
+<template id="event_registration_change_exception" name="Message: Alert on event registration data change">
     <div>
         <p>
             <span>Registration modification for attendee:</span>
@@ -13,7 +13,7 @@
             <ul>
                 <li>
                     <a href="#" data-oe-model="event.registration" t-att-data-oe-id="registration.id"><t t-out="registration.name"/></a>:
-                    <span>Ticket changed from <strong><t t-out="old_ticket_name"/></strong> to <strong><t t-out="new_ticket_name"/></strong></span>
+                    <span><t t-out="record_type"/> changed from <strong><t t-out="old_name"/></strong> to <strong><t t-out="new_name"/></strong></span>
                 </li>
             </ul>
         </div>

--- a/addons/event_sale/models/sale_order_line.py
+++ b/addons/event_sale/models/sale_order_line.py
@@ -11,18 +11,29 @@ class SaleOrderLine(models.Model):
         'event.event', string='Event',
         compute="_compute_event_id", store=True, readonly=False, precompute=True, index='btree_not_null',
         help="Choose an event and it will automatically create a registration for this event.")
+    event_slot_id = fields.Many2one(
+        'event.slot', string='Slot',
+        compute="_compute_event_related", store=True, readonly=False, precompute=True,
+        help="Choose an event slot and it will automatically create a registration for this event slot.")
     event_ticket_id = fields.Many2one(
         'event.event.ticket', string='Ticket Type',
-        compute="_compute_event_ticket_id", store=True, readonly=False, precompute=True,
+        compute="_compute_event_related", store=True, readonly=False, precompute=True,
         help="Choose an event ticket and it will automatically create a registration for this event ticket.")
+    is_multi_slots = fields.Boolean(related="event_id.is_multi_slots")
     registration_ids = fields.One2many('event.registration', 'sale_order_line_id', string="Registrations")
 
-    @api.constrains('event_id', 'event_ticket_id', 'product_id')
+    @api.constrains('event_id', 'event_slot_id', 'event_ticket_id', 'product_id')
     def _check_event_registration_ticket(self):
         for so_line in self:
-            if so_line.product_id.service_tracking == "event" and (not so_line.event_id or not so_line.event_ticket_id):
-                raise ValidationError(
-                    _("The sale order line with the product %(product_name)s needs an event and a ticket.", product_name=so_line.product_id.name))
+            if so_line.product_id.service_tracking == "event" and (
+                not so_line.event_id or
+                not so_line.event_ticket_id or
+                (so_line.is_multi_slots and not so_line.event_slot_id)
+            ):
+                raise ValidationError(_(
+                    "The sale order line with the product %(product_name)s needs an event,"
+                    " a ticket and a slot in case the event has multiple time slots.",
+                    product_name=so_line.product_id.name))
 
     @api.depends('state', 'event_id')
     def _compute_product_uom_readonly(self):
@@ -59,10 +70,13 @@ class SaleOrderLine(models.Model):
                 line.event_id = False
 
     @api.depends('event_id')
-    def _compute_event_ticket_id(self):
+    def _compute_event_related(self):
         event_lines = self.filtered('event_id')
+        (self - event_lines).event_slot_id = False
         (self - event_lines).event_ticket_id = False
         for line in event_lines:
+            if line.event_id != line.event_slot_id.event_id:
+                line.event_slot_id = False
             if line.event_id != line.event_ticket_id.event_id:
                 line.event_ticket_id = False
 
@@ -70,7 +84,7 @@ class SaleOrderLine(models.Model):
     def _compute_price_unit(self):
         super()._compute_price_unit()
 
-    @api.depends('event_ticket_id')
+    @api.depends('event_slot_id', 'event_ticket_id')
     def _compute_name(self):
         """Override to add the compute dependency.
 
@@ -85,7 +99,9 @@ class SaleOrderLine(models.Model):
                 We need this override to be defined here in sales order line (and not in product) because here is the only place where the event_ticket_id is referenced.
         """
         if self.event_ticket_id:
-            return self.event_ticket_id._get_ticket_multiline_description() + self._get_sale_order_line_multiline_description_variants()
+            return self.event_ticket_id._get_ticket_multiline_description() + \
+                ('\n%s' % self.event_slot_id.display_name if self.event_slot_id else '') + \
+                self._get_sale_order_line_multiline_description_variants()
         else:
             return super()._get_sale_order_line_multiline_description_sale()
 

--- a/addons/event_sale/report/event_sale_report.py
+++ b/addons/event_sale/report/event_sale_report.py
@@ -17,6 +17,7 @@ class EventSaleReport(models.Model):
     event_id = fields.Many2one('event.event', string='Event', readonly=True)
     event_date_begin = fields.Date(string='Event Start Date', readonly=True)
     event_date_end = fields.Date(string='Event End Date', readonly=True)
+    event_slot_id = fields.Many2one('event.slot', string='Event Slot', readonly=True)
     event_ticket_id = fields.Many2one('event.event.ticket', string='Event Ticket', readonly=True)
     event_ticket_price = fields.Float(string='Ticket price', readonly=True)
     event_registration_create_date = fields.Date(string='Registration Date', readonly=True)
@@ -73,6 +74,7 @@ SELECT
     event_registration.id AS event_registration_id,
     event_registration.company_id AS company_id,
     event_registration.event_id AS event_id,
+    event_registration.event_slot_id AS event_slot_id,
     event_registration.event_ticket_id AS event_ticket_id,
     event_registration.create_date AS event_registration_create_date,
     event_registration.name AS event_registration_name,
@@ -115,6 +117,7 @@ SELECT
         return """
 FROM event_registration
 LEFT JOIN event_event ON event_event.id = event_registration.event_id
+LEFT JOIN event_slot ON event_slot.id = event_registration.event_slot_id
 LEFT JOIN event_event_ticket ON event_event_ticket.id = event_registration.event_ticket_id
 LEFT JOIN sale_order ON sale_order.id = event_registration.sale_order_id
 LEFT JOIN sale_order_line ON sale_order_line.id = event_registration.sale_order_line_id

--- a/addons/event_sale/report/event_sale_report_views.xml
+++ b/addons/event_sale/report/event_sale_report_views.xml
@@ -28,6 +28,7 @@
                             <field name="event_registration_id"/>
                             <field name="event_registration_name"/>
                             <field name="event_registration_create_date"/>
+                            <field name="event_slot_id"/>
                             <field name="event_ticket_id"/>
                             <field name="event_registration_state"/>
                         </group>
@@ -69,6 +70,7 @@
         <field name="arch" type="xml">
             <list string="Revenues" edit="false" create="false">
                 <field name="event_id"/>
+                <field name="event_slot_id"/>
                 <field name="event_ticket_id"/>
                 <field name="product_id" optional="hide"/>
                 <field name="event_ticket_price"/>
@@ -113,6 +115,7 @@
                     <filter string="Event" name="group_by_event_id" context="{'group_by': 'event_id' }"/>
                     <separator/>
                     <filter string="Product" name="group_by_product_id" context="{'group_by': 'product_id'}"/>
+                    <filter string="Slot" name="group_by_slot_id" context="{'group_by': 'event_slot_id'}"/>
                     <filter string="Ticket" name="group_by_ticket_id" context="{'group_by': 'event_ticket_id'}"/>
                     <separator/>
                     <filter string="Registration Status" name="group_by_registration_state"

--- a/addons/event_sale/static/src/js/event_configurator_controller.js
+++ b/addons/event_sale/static/src/js/event_configurator_controller.js
@@ -7,7 +7,7 @@ import { formView } from "@web/views/form/form_view";
  * window when a service product linked to events is selected.
  *
  * This allows keeping an editable list view for sales order and remove the noise of
- * those 2 fields ('event_id' + 'event_ticket_id')
+ * those 3 fields ('event_id' + 'event_slot_id' + 'event_ticket_id')
  */
 
 export class EventConfiguratorController extends formView.Controller {
@@ -26,12 +26,13 @@ export class EventConfiguratorController extends formView.Controller {
      */
     async onRecordSaved(record) {
         await super.onRecordSaved(...arguments);
-        const { event_id, event_ticket_id } = record.data;
+        const { event_id, event_slot_id, event_ticket_id } = record.data;
         return this.action.doAction({
             type: "ir.actions.act_window_close",
             infos: {
                 eventConfiguration: {
                     event_id,
+                    event_slot_id,
                     event_ticket_id,
                 },
             },

--- a/addons/event_sale/static/src/js/sale_product_field.js
+++ b/addons/event_sale/static/src/js/sale_product_field.js
@@ -34,6 +34,9 @@ patch(SaleOrderLineProductField.prototype, {
         if (this.props.record.data.event_id) {
             actionContext.default_event_id = this.props.record.data.event_id[0];
         }
+        if (this.props.record.data.event_slot_id) {
+            actionContext.default_event_slot_id = this.props.record.data.event_slot_id[0];
+        }
         if (this.props.record.data.event_ticket_id) {
             actionContext.default_event_ticket_id = this.props.record.data.event_ticket_id[0];
         }

--- a/addons/event_sale/views/sale_order_views.xml
+++ b/addons/event_sale/views/sale_order_views.xml
@@ -26,6 +26,12 @@
                     required="service_tracking == 'event'"
                     options="{'no_open': True, 'no_create': True}"/>
                 <field
+                    name="event_slot_id"
+                    domain="[('event_id','=', event_id)]"
+                    invisible="not is_multi_slots or service_tracking != 'event'"
+                    required="is_multi_slots and service_tracking == 'event'"
+                    options="{'no_open': True, 'no_create': True}"/>
+                <field
                     name="event_ticket_id"
                     domain="[
                         ('event_id', '=', event_id), ('product_id','=',product_id),
@@ -46,6 +52,12 @@
                     required="service_tracking == 'event'"
                     options="{'no_open': True, 'no_create': True}"
                     placeholder="All Events"/>
+                <field
+                    name="event_slot_id"
+                    column_invisible="True"
+                    domain="[('event_id','=', event_id)]"
+                    required="is_multi_slots and service_tracking == 'event'"
+                    options="{'no_open': True, 'no_create': True}"/>
                 <field name="event_ticket_id"
                     column_invisible="True"
                     domain="[

--- a/addons/event_sale/wizard/event_configurator.py
+++ b/addons/event_sale/wizard/event_configurator.py
@@ -11,17 +11,23 @@ class EventEventConfigurator(models.TransientModel):
 
     product_id = fields.Many2one('product.product', string="Product", readonly=True)
     event_id = fields.Many2one('event.event', string="Event")
-    event_ticket_id = fields.Many2one('event.event.ticket', string="Ticket Type",
+    event_slot_id = fields.Many2one('event.slot', string="Slot", domain="[('event_id', '=', event_id)]",
+        compute="_compute_event_slot_id", readonly=False, store=True)
+    event_ticket_id = fields.Many2one('event.event.ticket', string="Ticket Type", domain="[('event_id', '=', event_id)]",
         compute="_compute_event_ticket_id", readonly=False, store=True)
+    is_multi_slots = fields.Boolean(related="event_id.is_multi_slots")
     has_available_tickets = fields.Boolean("Has Available Tickets", compute="_compute_has_available_tickets")
 
-    @api.constrains('event_id', 'event_ticket_id')
+    @api.constrains('event_id', 'event_slot_id', 'event_ticket_id')
     def check_event_id(self):
         error_messages = []
         for record in self:
             if record.event_id.id != record.event_ticket_id.event_id.id:
                 error_messages.append(
                     _('Invalid ticket choice "%(ticket_name)s" for event "%(event_name)s".'))
+            if record.event_slot_id and record.event_id.id != record.event_slot_id.event_id.id:
+                error_messages.append(
+                    _('Invalid slot choice "%(slot_name)s" for event "%(event_name)s".'))
         if error_messages:
             raise ValidationError('\n'.join(error_messages))
 
@@ -35,6 +41,17 @@ class EventEventConfigurator(models.TransientModel):
         mapped_data = {product: ticket_count for product, ticket_count in product_ticket_data}
         for configurator in self:
             configurator.has_available_tickets = bool(mapped_data.get(configurator.product_id, 0))
+
+    @api.depends("is_multi_slots")
+    def _compute_event_slot_id(self):
+        """ Pre-select the slot of the multi slots event selected if it is the only one """
+        for configurator in self:
+            if not configurator.is_multi_slots:
+                configurator.event_slot_id = False
+            else:
+                event_slot_ids = self.env['event.slot'].search([
+                    ('event_id', '=', configurator.event_id.id)], limit=2)
+                configurator.event_slot_id = event_slot_ids if len(event_slot_ids) == 1 else False
 
     @api.depends('event_id')
     def _compute_event_ticket_id(self):

--- a/addons/event_sale/wizard/event_configurator_views.xml
+++ b/addons/event_sale/wizard/event_configurator_views.xml
@@ -25,6 +25,12 @@
                         options="{'no_open': True, 'no_create': True}"
                         placeholder="All Events"
                     />
+                    <field name="event_slot_id"
+                        domain="[('event_id', '=', event_id)]"
+                        invisible="not is_multi_slots"
+                        required="is_multi_slots"
+                        context="{'name_with_seats_availability': True}"
+                        options="{'no_open': True, 'no_create': True}"/>
                     <field
                         name="event_ticket_id"
                         domain="[('event_id', '=', event_id), ('product_id', '=', product_id)]"

--- a/addons/event_sale/wizard/event_edit_registration.py
+++ b/addons/event_sale/wizard/event_edit_registration.py
@@ -22,6 +22,7 @@ class RegistrationEditor(models.TransientModel):
         sale_order = self.env['sale.order'].browse(res.get('sale_order_id'))
         registrations = self.env['event.registration'].search([
             ('sale_order_id', '=', sale_order.id),
+            ('event_slot_id', 'in', sale_order.mapped('order_line.event_slot_id').ids or [False]),
             ('event_ticket_id', 'in', sale_order.mapped('order_line.event_ticket_id').ids),
             ('state', '!=', 'cancel')])
 
@@ -33,6 +34,7 @@ class RegistrationEditor(models.TransientModel):
             # Add existing registrations
             attendee_list += [[0, 0, {
                 'event_id': reg.event_id.id,
+                'event_slot_id': reg.event_slot_id.id,
                 'event_ticket_id': reg.event_ticket_id.id,
                 'registration_id': reg.id,
                 'name': reg.name,
@@ -43,6 +45,7 @@ class RegistrationEditor(models.TransientModel):
             # Add new registrations
             attendee_list += [[0, 0, {
                 'event_id': so_line.event_id.id,
+                'event_slot_id': so_line.event_slot_id.id,
                 'event_ticket_id': so_line.event_ticket_id.id,
                 'sale_order_line_id': so_line.id,
                 'name': so_line.order_partner_id.name,
@@ -78,6 +81,7 @@ class RegistrationEditorLine(models.TransientModel):
     event_id = fields.Many2one('event.event', string='Event', required=True)
     company_id = fields.Many2one(related="event_id.company_id")
     registration_id = fields.Many2one('event.registration', 'Original Registration')
+    event_slot_id = fields.Many2one('event.slot', string='Event Slot')
     event_ticket_id = fields.Many2one('event.event.ticket', string='Event Ticket')
     email = fields.Char(string='Email')
     phone = fields.Char(string='Phone')
@@ -94,6 +98,7 @@ class RegistrationEditorLine(models.TransientModel):
         if include_event_values:
             registration_data.update({
                 'event_id': self.event_id.id,
+                'event_slot_id': self.event_slot_id.id,
                 'event_ticket_id': self.event_ticket_id.id,
                 'sale_order_id': self.editor_id.sale_order_id.id,
                 'sale_order_line_id': self.sale_order_line_id.id,

--- a/addons/event_sale/wizard/event_edit_registration.xml
+++ b/addons/event_sale/wizard/event_edit_registration.xml
@@ -13,6 +13,7 @@
                             <list string="Registration" editable="top" create="false" delete="false">
                                 <field name="event_id" readonly='1' force_save="1"/>
                                 <field name="registration_id" readonly='1' force_save="1"/>
+                                <field name="event_slot_id" domain="[('event_id', '=', event_id)]" readonly='1' force_save="1"/>
                                 <field name="event_ticket_id" domain="[('event_id', '=', event_id)]" readonly='1' force_save="1"/>
                                 <field name="name"/>
                                 <field name="email"/>

--- a/addons/pos_event/models/__init__.py
+++ b/addons/pos_event/models/__init__.py
@@ -3,6 +3,7 @@ from . import pos_config
 from . import event_ticket
 from . import pos_session
 from . import event_event
+from . import event_slot
 from . import pos_order
 from . import pos_order_line
 from . import event_registration

--- a/addons/pos_event/models/event_event.py
+++ b/addons/pos_event/models/event_event.py
@@ -14,4 +14,16 @@ class EventEvent(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'seats_available', 'event_ticket_ids', 'registration_ids', 'seats_limited', 'write_date',
-                'question_ids', 'general_question_ids', 'specific_question_ids', 'badge_format']
+                'question_ids', 'general_question_ids', 'specific_question_ids', 'badge_format', 'seats_max',
+                'is_multi_slots', 'event_slot_ids']
+
+    def get_slot_tickets_availability_pos(self, slot_ticket_ids):
+        self.ensure_one()
+        slot_tickets = [
+            (
+                self.event_slot_ids.filtered(lambda slot: slot.id == slot_id) if slot_id else self.env['event.slot'],
+                self.event_ticket_ids.filtered(lambda ticket: ticket.id == ticket_id) if ticket_id else self.env['event.event.ticket']
+            )
+            for slot_id, ticket_id in slot_ticket_ids
+        ]
+        return self._get_seats_availability(slot_tickets)

--- a/addons/pos_event/models/event_registration.py
+++ b/addons/pos_event/models/event_registration.py
@@ -34,7 +34,8 @@ class EventRegistration(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'event_id', 'event_ticket_id', 'pos_order_line_id', 'pos_order_id', 'phone', 'email', 'name', 'registration_answer_ids', 'registration_answer_choice_ids']
+        return ['id', 'event_id', 'event_ticket_id', 'event_slot_id', 'pos_order_line_id', 'pos_order_id', 'phone',
+                'email', 'name', 'registration_answer_ids', 'registration_answer_choice_ids']
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/pos_event/models/event_slot.py
+++ b/addons/pos_event/models/event_slot.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models, api, fields
+
+
+class EventSlot(models.Model):
+    _name = 'event.slot'
+    _inherit = ['event.slot', 'pos.load.mixin']
+
+    @api.model
+    def _load_pos_data_domain(self, data):
+        return [
+            ('event_id.is_finished', '=', False),
+            ('event_id.company_id', '=', data['pos.config'][0]['company_id']),
+            ('event_id', 'in', [event['id'] for event in data['event.event']]),
+            ('start_datetime', '>=', fields.Datetime.now()),
+        ]
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return ['id', 'date', 'display_name', 'event_id', 'registration_ids', 'seats_available', 'start_datetime']

--- a/addons/pos_event/models/pos_config.py
+++ b/addons/pos_event/models/pos_config.py
@@ -14,7 +14,11 @@ class PosConfig(models.Model):
                 'event_ticket_ids': [{
                     'ticket_id': ticket.id,
                     'seats_available': ticket.seats_available
-                } for ticket in event.event_ticket_ids]
+                } for ticket in event.event_ticket_ids],
+                'event_slot_ids': [{
+                    'slot_id': slot.id,
+                    'seats_available': slot.seats_available
+                } for slot in event.event_slot_ids]
             })
 
         for record in self:

--- a/addons/pos_event/models/pos_order.py
+++ b/addons/pos_event/models/pos_order.py
@@ -27,11 +27,13 @@ class PosOrder(models.Model):
         lines_with_event = paid_orders.mapped('lines').filtered(lambda line: line.event_ticket_id)
         event_event_fields = self.env['event.event']._load_pos_data_fields(paid_orders[0].config_id.id)
         event_ticket_fields = self.env['event.event.ticket']._load_pos_data_fields(paid_orders[0].config_id.id)
+        event_slot_fields = self.env['event.slot']._load_pos_data_fields(paid_orders[0].config_id.id)
         event_registrations_fields = self.env['event.registration']._load_pos_data_fields(paid_orders[0].config_id.id)
         event_registrations_answer_fields = self.env['event.registration.answer']._load_pos_data_fields(paid_orders[0].config_id.id)
         results['event.registration'] = lines_with_event.event_registration_ids.read(event_registrations_fields, load=False)
         results['event.event'] = lines_with_event.event_registration_ids.mapped('event_id').read(event_event_fields, load=False)
         results['event.event.ticket'] = lines_with_event.event_registration_ids.mapped('event_ticket_id').read(event_ticket_fields, load=False)
+        results['event.slot'] = lines_with_event.event_registration_ids.mapped('event_slot_id').read(event_slot_fields, load=False)
         results['event.registration.answer'] = lines_with_event.event_registration_ids.mapped('registration_answer_ids').read(event_registrations_answer_fields, load=False)
 
         for registration in lines_with_event.event_registration_ids:

--- a/addons/pos_event/models/pos_session.py
+++ b/addons/pos_event/models/pos_session.py
@@ -8,7 +8,7 @@ class PosSession(models.Model):
     @api.model
     def _load_pos_data_models(self, config_id):
         models = super()._load_pos_data_models(config_id)
-        models += ['event.event.ticket', 'event.event', 'event.registration', 'event.question', 'event.question.answer', 'event.registration.answer']
+        models += ['event.event.ticket', 'event.event', 'event.slot', 'event.registration', 'event.question', 'event.question.answer', 'event.registration.answer']
         return models
 
     @api.model
@@ -19,4 +19,5 @@ class PosSession(models.Model):
             relations['email']['compute'] = False
             relations['phone']['compute'] = False
             relations['name']['compute'] = False
+            relations['event_slot_id']['compute'] = False
         return relations

--- a/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.xml
@@ -3,17 +3,26 @@
     <t t-name="pos_event.EventConfiguratorPopup">
         <Dialog title="dialogTitle">
             <div class="o_event_configurator_popup">
+                <div t-if="this.props.slotResult?.slotName"
+                    class="d-flex justify-content-center text-primary fs-3 pt-2 pb-3">
+                    <span class="ms-1" t-esc="this.props.slotResult?.slotName"/>
+                </div>
                 <t t-foreach="this.props.tickets" t-as="ticket" t-key="ticket.id">
                     <div class="d-flex justify-content-between">
                         <div class="d-flex flex-column">
                             <div class="fs-5">
                                 <span t-esc="ticket.name"/>
-                             </div>
-                            <span t-if="ticket.seats_max === 0 and !ticket.event_id.seats_limited" class="fs-6 text-success">
-                                Unlimited
-                            </span>
-                            <span t-else="" t-attf-class="{{ this.ticketIsAvailable(ticket) ? 'text-success' : 'text-danger'}} fs-6">
-                                <t t-esc="this.getTicketMaxQty(ticket)" /> left
+                            </div>
+                            <span t-attf-class="{{ this.ticketIsAvailable(ticket) ? 'text-success' : 'text-danger'}} fs-6">
+                                <t t-if="this.getTicketMaxQty(ticket) === 'unlimited'">
+                                    Unlimited
+                                </t>
+                                <t t-elif="this.getTicketMaxQty(ticket) > 0">
+                                    <t t-esc="this.getTicketMaxQty(ticket)"/> left
+                                </t>
+                                <t t-else="">
+                                    Sold out
+                                </t>
                             </span>
                         </div>
                         <div class="d-flex align-items-center gap-3">

--- a/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.js
+++ b/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.js
@@ -1,0 +1,86 @@
+// Part of Odoo. See LICENSE file for full copyright and licensing details.
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { Dialog } from "@web/core/dialog/dialog";
+import { Component, useState } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+import { formatDate } from "@web/core/l10n/dates";
+import { localization } from "@web/core/l10n/localization";
+import { NumericInput } from "@point_of_sale/app/components/inputs/numeric_input/numeric_input";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+const { DateTime } = luxon;
+
+export class EventSlotSelectionPopup extends Component {
+    static template = "pos_event.EventSlotSelectionPopup";
+    static props = ["getPayload", "close", "event", "availabilityPerSlot"];
+    static components = {
+        Dialog,
+        NumericInput,
+    };
+    setup() {
+        this.pos = usePos();
+        this.dialog = useService("dialog");
+        this.slotId = false;
+        this.state = useState({
+            selectedSlotDisplay: "",
+        });
+    }
+    get dialogTitle() {
+        return _t("Select a slot for %(event)s", { event: this.props.event.name });
+    }
+    get slots() {
+        const slots = {};
+        this.props.event.event_slot_ids.forEach((slot) => {
+            if (slot.start_datetime < DateTime.now()) {
+                return false;
+            }
+            const date = formatDate(slot.date, { format: "MMM dd yyyy, EEEE" });
+            if (!slots[date]) {
+                slots[date] = [];
+            }
+            slots[date].push({
+                availability: this.props.availabilityPerSlot[slot.id],
+                slotId: slot.id,
+                startDatetime: slot.start_datetime.toFormat(
+                    localization.timeFormat.replace(":ss", "")
+                ),
+            });
+        });
+        return slots;
+    }
+    select(ev) {
+        this.slotId = parseInt(ev.currentTarget.dataset.slotId);
+        const selectedSlot = this.pos.models["event.slot"].get(this.slotId);
+        // Return if not available
+        if (!selectedSlot || !this.props.availabilityPerSlot[this.slotId]) {
+            return;
+        }
+        // Visually select the button and update displayed datetime
+        document.querySelectorAll(".o_event_slot_btn").forEach((btn) => {
+            btn.classList.replace("btn-primary", "btn-secondary");
+        });
+        ev.currentTarget.classList.replace("btn-secondary", "btn-primary");
+        this.state.selectedSlotDisplay = selectedSlot.start_datetime.toFormat(
+            "MMM dd yyyy, EEEE, h:mm a"
+        );
+    }
+    confirm() {
+        if (!this.slotId) {
+            this.dialog.add(AlertDialog, {
+                title: "Error",
+                body: "Please select a slot.",
+            });
+            return;
+        }
+        this.props.getPayload({
+            slotAvailability: this.props.availabilityPerSlot[this.slotId],
+            slotId: this.slotId,
+            slotName: this.state.selectedSlotDisplay,
+        });
+        this.props.close();
+    }
+    cancel() {
+        this.props.close();
+    }
+}

--- a/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_event.EventSlotSelectionPopup">
+        <Dialog title="dialogTitle">
+            <div class="text-center pt-2 pb-3">
+                <h3 t-if="!this.state.selectedSlotDisplay" class="text-primary">No Slot Selected</h3>
+                <h3 t-else="" class="text-primary" t-out="this.state.selectedSlotDisplay"/>
+            </div>
+            <div class="row">
+                <div t-foreach="slots" t-as="date" t-key="date" class="col col-sm-6 col-lg-4 pb-3">
+                    <span class="mb-1" t-out="date"/>
+                    <div class="d-flex flex-wrap gap-2 mt-1">
+                        <t t-foreach="slots[date]" t-as="slot" t-key="slot_index">
+                            <t t-set="isAvailable" t-value="slot.availability === 'unlimited' || slot.availability > 0"/>
+                            <button type="button"
+                                t-attf-class="o_event_slot_btn lh-1 btn btn-sm btn-secondary {{isAvailable ? '' : 'text-muted'}}"
+                                t-att-data-slot-id="slot.slotId"
+                                t-attf-disabled="{{isAvailable ? false : true}}"
+                                t-on-click="select">
+                                <span t-attf-class="" t-out="slot.startDatetime" class="lh-1"/>
+                            </button>
+                        </t>
+                    </div>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-secondary o-default-button" t-on-click="cancel">Cancel</button>
+                <button class="btn btn-primary o-default-button" t-on-click="confirm">Confirm</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/pos_event/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_event/static/src/app/components/product_card/product_card.js
@@ -2,16 +2,35 @@
 import { ProductCard } from "@point_of_sale/app/components/product_card/product_card";
 import { patch } from "@web/core/utils/patch";
 
+const { DateTime } = luxon;
+
 patch(ProductCard.prototype, {
     get displayRemainingSeats() {
         return Boolean(this.props.product.event_id);
     },
-    get totalTicketSeats() {
+    get isEventMultiSlot() {
+        return Boolean(this.props.product.event_id) && this.props.product.event_id.is_multi_slots;
+    },
+    get totalFutureSlots() {
         return (
-            this.props.product.event_id?.event_ticket_ids?.reduce(
-                (acc, ticket) => acc + ticket.seats_available,
-                0
-            ) || 0
+            this.props.product.event_id?.event_slot_ids?.filter(
+                (slot) => slot.start_datetime > DateTime.now()
+            )?.length || 0
         );
+    },
+    get totalTicketSeats() {
+        const event = this.props.product.event_id;
+        const eventTickets = event?.event_ticket_ids;
+
+        if (
+            !eventTickets?.length ||
+            (!event.seats_limited && eventTickets?.some((ticket) => ticket.seats_max === 0))
+        ) {
+            return 0;
+        }
+        if (event.seats_limited && !event.seats_max) {
+            return -1;
+        }
+        return eventTickets.reduce((acc, ticket) => acc + ticket.seats_available, 0) || -1;
     },
 });

--- a/addons/pos_event/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_event/static/src/app/components/product_card/product_card.xml
@@ -3,11 +3,21 @@
     <t t-name="pos_event.ProductCard" t-inherit="point_of_sale.ProductCard" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('product-img')]" position="before">
             <t t-set="availableSeats" t-value="this.totalTicketSeats" />
-            <div t-if="displayRemainingSeats" class="shadow-sm m-1 py-1 px-2 rounded position-absolute top-0 end-0 bg-white">
-                <span t-if="availableSeats > 0">
-                    <t t-esc="availableSeats" /> left
-                </span>
-                <span t-else="">Unlimited</span>
+            <t t-set="futureSlots" t-value="this.totalFutureSlots" />            
+            <div t-if="displayRemainingSeats" class="shadow-sm m-1 py-1 px-2 z-1 rounded position-absolute top-0 end-0 bg-white">
+                <t t-if="isEventMultiSlot">
+                    <span t-if="futureSlots > 0">
+                        <t t-esc="futureSlots" /> <t t-if="futureSlots > 1">slots</t><t t-else="">slot</t>
+                    </span>
+                    <span t-else="">No slots</span>
+                </t>
+                <t t-else="">
+                    <span t-if="availableSeats > 0">
+                        <t t-esc="availableSeats" /> left
+                    </span>
+                    <span t-elif="availableSeats === 0">Unlimited</span>
+                    <span t-else="">Sold out</span>
+                </t>
             </div>
         </xpath>
     </t>

--- a/addons/pos_event/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_event/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -4,7 +4,7 @@
 		<xpath expr="//Orderline" position="inside" >
             <t t-if="line.event_ticket_id">
                 <li class="info ms-2">
-                    <i class="fa fa-ticket me-1" role="img" aria-label="Event name" title="Event name"/>
+                    <i class="fa fa-ticket me-2" role="img" aria-label="Event name" title="Event name"/>
                     <t t-esc="line.event_ticket_id.event_id.name" />
                 </li>
             </t>

--- a/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
@@ -4,6 +4,9 @@ import { patch } from "@web/core/utils/patch";
 import { EventConfiguratorPopup } from "@pos_event/app/components/popup/event_configurator_popup/event_configurator_popup";
 import { _t } from "@web/core/l10n/translation";
 import { EventRegistrationPopup } from "../../components/popup/event_registration_popup/event_registration_popup";
+import { EventSlotSelectionPopup } from "../../components/popup/event_slot_selection_popup/event_slot_selection_popup";
+
+const { DateTime } = luxon;
 
 patch(ProductScreen.prototype, {
     get products() {
@@ -41,10 +44,109 @@ patch(ProductScreen.prototype, {
             (ticket) => ticket.product_id && ticket.product_id.service_tracking === "event"
         );
 
+        // Multi Slot
+        let avaibilityByTicket = {};
+        let slotResult = {};
+        let slotSelected;
+        let slotTicketAvailabilities = {};
+        if (event.is_multi_slots) {
+            // Updating data in case of event change
+            await this.pos.data.read(
+                "event.event",
+                [event.id],
+                ["event_slot_ids", "seats_available", "seats_limited"]
+            );
+            await this.pos.data.read(
+                "event.slot",
+                event.event_slot_ids.map((slot) => slot.id)
+            );
+            const slotTickets = [];
+            const slots = event.event_slot_ids.filter(
+                (slot) => slot.start_datetime > DateTime.now()
+            );
+            for (const ticket of tickets) {
+                for (const slot of slots) {
+                    slotTickets.push([slot.id, ticket.id]);
+                }
+            }
+            slotTicketAvailabilities = await this.pos.data.call(
+                "event.event",
+                "get_slot_tickets_availability_pos",
+                [event.id, slotTickets]
+            );
+            const eventSeats = event.seats_limited ? event.seats_available : "unlimited";
+            avaibilityByTicket = slotTicketAvailabilities.reduce((acc, availability, idx) => {
+                const ticketsData = slotTickets[idx];
+                const slotId = ticketsData[0];
+                const ticketId = ticketsData[1];
+                if (!acc[ticketId]) {
+                    acc[ticketId] = {};
+                }
+                if (!acc[ticketId][slotId]) {
+                    acc[ticketId][slotId] = {};
+                }
+                if (availability === null) {
+                    acc[ticketId][slotId] = "unlimited";
+                } else if (typeof availability === "number") {
+                    acc[ticketId][slotId] = availability;
+                } else {
+                    acc[ticketId][slotId] = 0;
+                }
+                return acc;
+            }, {});
+            const isAvailable = Object.values(avaibilityByTicket).some((av) =>
+                Object.values(av).some((a) => typeof a === "number" && a > 0)
+            );
+            if (!isAvailable || eventSeats === 0) {
+                this.notification.add("All slots are booked out for this event.", {
+                    type: "danger",
+                });
+                return;
+            }
+            const availabilityPerSlot = Object.values(avaibilityByTicket).reduce(
+                (acc, ticketAvailability) => {
+                    Object.entries(ticketAvailability).forEach(([slotId, availability]) => {
+                        if (!acc[slotId]) {
+                            acc[slotId] = 0;
+                        } else if (acc[slotId] === "unlimited") {
+                            return acc;
+                        }
+                        if (availability === "unlimited") {
+                            acc[slotId] = "unlimited";
+                        } else if (typeof availability === "number") {
+                            acc[slotId] = Math.max(acc[slotId], availability);
+                        } else {
+                            acc[slotId] = Math.max(acc[slotId], 0);
+                        }
+                    });
+                    return acc;
+                },
+                {}
+            );
+            slotResult = await makeAwaitable(this.dialog, EventSlotSelectionPopup, {
+                availabilityPerSlot: availabilityPerSlot,
+                event: event,
+            });
+            if (!slotResult?.slotId) {
+                return;
+            }
+            slotSelected = this.pos.models["event.slot"].get(slotResult.slotId);
+        } else {
+            avaibilityByTicket = tickets.reduce((acc, ticket) => {
+                if (ticket.seats_max === 0 && !event.seats_limited) {
+                    acc[ticket.id] = "unlimited";
+                } else {
+                    acc[ticket.id] = ticket.seats_available;
+                }
+                return acc;
+            }, {});
+        }
+
         const ticketResult = await makeAwaitable(this.dialog, EventConfiguratorPopup, {
+            availabilityPerTicket: avaibilityByTicket,
+            slotResult: slotResult,
             tickets: tickets,
         });
-
         if (!ticketResult || !ticketResult.length) {
             return;
         }
@@ -83,6 +185,7 @@ patch(ProductScreen.prototype, {
                 price_unit: ticket.price,
                 qty: data.length,
                 event_ticket_id: ticket,
+                event_slot_id: slotSelected,
             });
 
             for (const registration of data) {
@@ -123,11 +226,12 @@ patch(ProductScreen.prototype, {
                     },
                     { simpleChoice: {}, textAnswer: {} }
                 );
-
+                // This will throw an error on creation if not possible (python constraint)
                 this.pos.models["event.registration"].create({
                     ...userData,
                     event_id: event,
                     event_ticket_id: ticket,
+                    event_slot_id: slotSelected,
                     pos_order_line_id: line,
                     partner_id: this.pos.getOrder().partner_id,
                     registration_answer_ids: Object.entries({
@@ -159,6 +263,11 @@ patch(ProductScreen.prototype, {
                 });
             }
         }
+    },
+    getSlotTicketAvailability(slotId, ticketId, slotTickets, slotTicketAvailabilities) {
+        const idx = slotTickets.findIndex((st) => st[0] === slotId && st[1] === ticketId);
+        const availability = idx === undefined ? undefined : slotTicketAvailabilities[idx]; // Support 0 index
+        return availability === null ? "unlimited" : availability; // null in slotTicketAvailabilities <-> no limit
     },
     onMouseDown(event, product) {
         if (product.event_id) {

--- a/addons/pos_event/static/src/app/services/pos_store.js
+++ b/addons/pos_event/static/src/app/services/pos_store.js
@@ -20,6 +20,13 @@ patch(PosStore.prototype, {
                         eventTicket.seats_available = ticket.seats_available;
                     }
                 }
+
+                for (const slot of ev.event_slot_ids) {
+                    const eventSlot = this.models["event.slot"].get(slot.slot_id);
+                    if (eventSlot) {
+                        eventSlot.seats_available = slot.seats_available;
+                    }
+                }
             }
         });
 

--- a/addons/pos_event/static/tests/tours/pos_multi_slot_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_multi_slot_event_tour.js
@@ -1,0 +1,56 @@
+// Part of Odoo. See LICENSE file for full copyright and licensing details.
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as SlotSelectionScreen from "@pos_event/../tests/tours/utils/slot_selection_screen_utils";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as EventTourUtils from "@pos_event/../tests/tours/utils/event_tour_utils";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("SellingMultiSlotEventInPos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            // Confirm popup - Not enough tickets available for this choice
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            SlotSelectionScreen.clickDisplayedSlot("08:00"),
+            Dialog.confirm(),
+            EventTourUtils.increaseQuantityOfTicket("Ticket Basic"),
+            Dialog.confirm(),
+            Dialog.confirm(),
+
+            // Confirm popup - Not enough tickets available for this ticket
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            SlotSelectionScreen.clickDisplayedSlot("10:00"),
+            Dialog.confirm(),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            Dialog.confirm(),
+            Dialog.confirm(),
+
+            // Confirm popup - Enough availability
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            SlotSelectionScreen.clickDisplayedSlot("08:00"),
+            Dialog.confirm(),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            Dialog.confirm(),
+            EventTourUtils.answerTicketSelectQuestion("1", "Question1", "Q1-Answer1"),
+            EventTourUtils.answerGlobalSelectQuestion("Question2", "Q2-Answer1"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("200.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            EventTourUtils.printTicket("full"),
+            EventTourUtils.printTicket("badge"),
+            ReceiptScreen.clickNextOrder(),
+
+            // Slot is now unavailable
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            SlotSelectionScreen.assertDisabledSlot("08:00"),
+        ].flat(),
+});

--- a/addons/pos_event/static/tests/tours/utils/slot_selection_screen_utils.js
+++ b/addons/pos_event/static/tests/tours/utils/slot_selection_screen_utils.js
@@ -1,0 +1,19 @@
+// Part of Odoo. See LICENSE file for full copyright and licensing details.
+export function assertDisabledSlot(slot) {
+    return [
+        {
+            content: `Assert that slot ${slot} is disabled`,
+            trigger: `.modal .o_event_slot_btn:disabled:contains('${slot}')`,
+        },
+    ];
+}
+
+export function clickDisplayedSlot(slot) {
+    return [
+        {
+            content: `Select slot ${slot}`,
+            trigger: `.modal .o_event_slot_btn:contains('${slot}')`,
+            run: "click",
+        },
+    ];
+}

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -473,9 +473,16 @@ class EventEvent(models.Model):
             return self.env.ref('website_event.mt_event_unpublished', raise_if_not_found=False)
         return super()._track_subtype(init_values)
 
-    def _get_event_resource_urls(self):
-        url_date_start = self.date_begin.astimezone(timezone(self.date_tz)).strftime('%Y%m%dT%H%M%S')
-        url_date_stop = self.date_end.astimezone(timezone(self.date_tz)).strftime('%Y%m%dT%H%M%S')
+    def _get_event_resource_urls(self, slot=False):
+        """ Prepare the Google and iCal urls for the event.
+        :param slot: If a slot is given, prepare the urls for the given slot.
+        Returns:
+            The google and iCal url in a dictionnary
+        """
+        start = slot.start_datetime if slot else self.date_begin
+        end = slot.end_datetime if slot else self.date_end
+        url_date_start = start.astimezone(timezone(self.date_tz)).strftime('%Y%m%dT%H%M%S')
+        url_date_stop = end.astimezone(timezone(self.date_tz)).strftime('%Y%m%dT%H%M%S')
         params = {
             'action': 'TEMPLATE',
             'text': self.name,
@@ -488,6 +495,8 @@ class EventEvent(models.Model):
         encoded_params = werkzeug.urls.url_encode(params)
         google_url = GOOGLE_CALENDAR_URL + encoded_params
         iCal_url = f'/event/{self.id:d}/ics'
+        if slot:
+            iCal_url += '?' + werkzeug.urls.url_encode({'slot_id': slot.id})
         return {'google_url': google_url, 'iCal_url': iCal_url}
 
     def _default_website_meta(self):

--- a/addons/website_event/models/event_registration.py
+++ b/addons/website_event/models/event_registration.py
@@ -9,4 +9,4 @@ class EventRegistration(models.Model):
     visitor_id = fields.Many2one('website.visitor', string='Visitor', ondelete='set null', index='btree_not_null')
 
     def _get_website_registration_allowed_fields(self):
-        return {'name', 'phone', 'email', 'company_name', 'event_id', 'partner_id', 'event_ticket_id'}
+        return {'name', 'phone', 'email', 'company_name', 'event_id', 'partner_id', 'event_slot_id', 'event_ticket_id'}

--- a/addons/website_event/security/event_security.xml
+++ b/addons/website_event/security/event_security.xml
@@ -34,6 +34,17 @@
         <field name="perm_unlink" eval="False"/>
     </record>
 
+    <record id="ir_rule_event_slot_public" model="ir.rule">
+        <field name="name">Event Slot: public/portal: published read</field>
+        <field name="model_id" ref="event.model_event_slot"/>
+        <field name="domain_force">[('event_id.website_published', '=', True)]</field>
+        <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
     <record id="ir_rule_event_question_published" model="ir.rule">
         <field name="name">Event Question: not event groups: event published read</field>
         <field name="model_id" ref="event.model_event_question"/>

--- a/addons/website_event/security/ir.model.access.csv
+++ b/addons/website_event/security/ir.model.access.csv
@@ -5,6 +5,9 @@ access_event_event_employee,event.event,model_event_event,base.group_user,1,0,0,
 access_event_event_ticket_public,event.event.ticket,event.model_event_event_ticket,base.group_public,1,0,0,0
 access_event_event_ticket_portal,event.event.ticket,event.model_event_event_ticket,base.group_portal,1,0,0,0
 access_event_event_ticket_employee,event.event.ticket,event.model_event_event_ticket,base.group_user,1,0,0,0
+access_event_event_slot_public,event.slot,event.model_event_slot,base.group_public,1,0,0,0
+access_event_event_slot_portal,event.slot,event.model_event_slot,base.group_portal,1,0,0,0
+access_event_event_slot_employee,event.slot,event.model_event_slot,base.group_user,1,0,0,0
 access_event_type,event.type,event.model_event_type,,0,0,0,0
 access_event_tag_category_public,event.tag.category,event.model_event_tag_category,base.group_public,1,0,0,0
 access_event_tag_category_portal,event.tag.category,event.model_event_tag_category,base.group_portal,1,0,0,0

--- a/addons/website_event/static/src/interactions/modal_registration.js
+++ b/addons/website_event/static/src/interactions/modal_registration.js
@@ -4,14 +4,14 @@ import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { Interaction } from "@web/public/interaction";
 
-export class ModalAttendeesRegistration extends Interaction {
-    static selector = "#modal_attendees_registration";
+export class ModalRegistration extends Interaction {
+    static selector = "#modal_attendees_registration,.o_wevent_modal_slot_ticket_registration";
     dynamicContent = {
         "form": {
             "t-on-submit": this.onSubmit,
         },
         ".js_goto_event, .btn-close": {
-            "t-on-click.once": this.onClick,
+            "t-on-click": this.onClick,
         },
     };
 
@@ -107,4 +107,4 @@ export class ModalAttendeesRegistration extends Interaction {
 
 registry
     .category("public.interactions")
-    .add("website_event.modal_attendees_registration", ModalAttendeesRegistration);
+    .add("website_event.modal_registration", ModalRegistration);

--- a/addons/website_event/static/src/interactions/website_event_slot_details.js
+++ b/addons/website_event/static/src/interactions/website_event_slot_details.js
@@ -1,0 +1,146 @@
+import { deserializeDateTime } from "@web/core/l10n/dates";
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+import { rpc } from "@web/core/network/rpc";
+
+const { DateTime } = luxon;
+
+const MAX_DATES_PER_PAGE = 6;
+
+export class SlotDetails extends Interaction {
+    static selector = ".o_wevent_js_slot_details";
+    dynamicSelectors = {
+        ...this.dynamicSelectors,
+        _envBus: () => this.env.bus,
+    };
+    dynamicContent = {
+        _envBus: {
+            "t-on-websiteEvent.enableSubmit": () => this.buttonDisabled = false,
+        },
+        ".a-submit": {
+            "t-on-click.prevent.stop": this._onSubmitClick,
+            "t-att-disabled": () => !this.selectedSlotId || this.buttonDisabled,
+        },
+        "li.page-item": {
+            "t-on-click.prevent.stop": this._onChangePageClick,
+        },
+        ".o_wevent_slot_btn": {
+            "t-on-click.prevent.stop": this._onSlotSelected,
+            "t-att-class": (el) => ({
+                "btn-light": el.dataset.slotId !== this.selectedSlotId,
+                "btn-primary": el.dataset.slotId === this.selectedSlotId,
+            })
+        },
+        ".o_wevent_slot_btn_cancel, .btn-close": {
+            "t-on-click": this._onClose,
+        },
+        ".o_wevent_selected_slot" : {
+            "t-out": () => this.selectedSlotDatetime,
+        },
+        ".o_wevent_selected_slot_title": {
+            "t-out": () => this.selectedSlotId ? "Selected Date: " : "Select a Date: ",
+        },
+    };
+
+    setup() {
+        this.currentSlotPage = 0;
+        this.form = this.el.querySelector("#slot_registration_form");
+        this.selectedSlotDatetime = "";
+        // Init first slot page
+        if (this.el.querySelector(".pagination")) {
+            this._changePage(0);
+        }
+    }
+
+    get selectedSlotId() {
+        return this.form.getAttribute("data-selected-slot-id");
+    }
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Update the displayed slots page.
+     * @param {MouseEvent} ev
+     */
+    _onChangePageClick(ev) {
+        const numPage = ev.currentTarget.classList.contains("o_wevent_slot_next") ? this.currentSlotPage + 1 : this.currentSlotPage - 1;
+        const maxNumPage = Math.ceil(this.el.querySelectorAll(".o_wevent_slot_date").length / MAX_DATES_PER_PAGE) - 1;
+        if (numPage < 0 || numPage > maxNumPage) {
+            return;
+        }
+        this._changePage(numPage);
+    }
+
+    /**
+     * Reset slot selection and pagination
+     * @param {MouseEvent} ev
+     */
+    _onClose(ev) {
+        this.form.removeAttribute("data-selected-slot-id");
+        this.selectedSlotDatetime = "";
+        this._changePage(0);
+    }
+
+    /**
+     * Select a slot
+     * @param {MouseEvent} ev
+     */
+    _onSlotSelected(ev) {
+        this.selectedSlotDatetime = deserializeDateTime(
+            ev.currentTarget.dataset.slotStart).toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY);
+        this.form.setAttribute("data-selected-slot-id", parseInt(ev.currentTarget.dataset.slotId));
+    }
+
+    /**
+     * @param {MouseEvent} ev
+     */
+    async _onSubmitClick(ev) {
+        const formEl = ev.currentTarget.closest("form");
+        this.buttonDisabled = true;
+        const modal = await this.waitFor(rpc(
+            formEl.action.replace("slot_id", this.selectedSlotId),
+        ));
+        const modalEl = new DOMParser().parseFromString(modal, "text/html").body.firstChild;
+        this.insert(modalEl, document.body);
+    }
+
+    //--------------------------------------------------------------------------
+    // Methods
+    //--------------------------------------------------------------------------
+
+    /**
+     * Display the specified slot page. Index starting at 0.
+     * @param {Integer} numPage
+     */
+    _changePage(numPage) {
+        this.currentSlotPage = numPage;
+        const dates = this.el.querySelectorAll(".o_wevent_slot_date");
+        dates.forEach((date) => date.classList.add("d-none"));
+        const min = MAX_DATES_PER_PAGE * this.currentSlotPage;
+        const max = MAX_DATES_PER_PAGE * (this.currentSlotPage + 1);
+        Array.from(dates).slice(min, max).forEach(
+            date => date.classList.remove("d-none")
+        );
+        // Handle previous/next buttons display
+        const previousBtn = this.el.querySelector(".o_wevent_slot_previous button");
+        const nextBtn = this.el.querySelector(".o_wevent_slot_next button");
+        if (dates.length <= MAX_DATES_PER_PAGE) {
+            [previousBtn, nextBtn].forEach((button) => button.classList.add("d-none"));
+        } else {
+            [previousBtn, nextBtn].forEach((button) => {
+                button.classList.remove("disabled");
+            });
+            if (this.currentSlotPage === 0) {
+                previousBtn.classList.add("disabled");
+            } else if(max >= dates.length) {
+                nextBtn.classList.add("disabled");
+            }
+        }
+    }
+}
+
+registry
+    .category("public.interactions")
+    .add("website_event.slot_details", SlotDetails);

--- a/addons/website_event/static/src/interactions/website_event_ticket_details.js
+++ b/addons/website_event/static/src/interactions/website_event_ticket_details.js
@@ -21,17 +21,12 @@ export class TicketDetails extends Interaction {
         },
     };
 
-    get post() {
-        const post = {};
-        const selectEls = this.el.querySelectorAll("select");
-        selectEls.forEach((selectEl) => {
-            post[selectEl.name] = selectEl.value;
-        });
-        return post;
-    }
-
     get noTicketsOrdered() {
-        return Object.values(this.post).every((value) => parseInt(value) === 0);
+        return Boolean(
+            !Array.from(this.el.querySelectorAll("select").values()).find(
+                (select) => select.value > 0
+            )
+        );
     }
 
     /**
@@ -40,7 +35,10 @@ export class TicketDetails extends Interaction {
     async onSubmitClick(ev) {
         const formEl = ev.currentTarget.closest("form");
         this.buttonDisabled = true;
-        const modal = await this.waitFor(rpc(formEl.action, this.post));
+        const modal = await this.waitFor(rpc(
+            formEl.action,
+            Object.fromEntries(new FormData(formEl)),
+        ));
 
         const modalEl = new DOMParser().parseFromString(modal, "text/html").body.firstChild;
         this.insert(modalEl, document.body);

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -323,7 +323,7 @@
                                 <meta itemprop="startDate" t-att-content="event.date_begin.isoformat()"/>
                                 <!-- Short date + Country Flag -->
                                 <div t-if="opt_events_event_location" t-attf-class="o_wevent_date_with_flag o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
-                                    <div class="o_wevent_event_date_text">
+                                    <div t-if="not event.is_multi_slots" class="o_wevent_event_date_text">
                                         <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
                                         <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
                                     </div>
@@ -333,7 +333,7 @@
                                     </div>
                                 </div>
                                 <!-- Short Date -->
-                                <div t-else="" t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
+                                <div t-elif="not event.is_multi_slots" t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
                                 </div>

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -13,7 +13,8 @@
         </div>
 
         <!-- The registration modal is available in any event page  -->
-        <t t-call="website_event.modal_ticket_registration"/>
+        <t t-if="event.is_multi_slots" t-call="website_event.modal_slot_registration"/>
+        <t t-else="" t-call="website_event.modal_ticket_registration"/>
     </t>
 </template>
 

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -168,7 +168,16 @@
 <!-- Event - Registration -->
 <!-- cta_additional_classes {string} - classes applied to the main CTA   -->
 <template id="registration_template" name="Registration">
-    <button t-if="event.event_registrations_open" type="button" data-bs-toggle="modal" data-bs-target="#modal_ticket_registration" t-attf-class="btn btn-primary {{cta_additional_classes}}">Register</button>
+    <a t-if="event_page and event.event_registrations_open" type="button"
+        t-attf-class="btn btn-primary {{cta_additional_classes}}"
+        t-att-href="'/event/%s/register' % (slug(event))">
+        Register
+    </a>
+    <button t-elif="event.event_registrations_open" type="button"
+        data-bs-toggle="modal" t-attf-class="btn btn-primary {{cta_additional_classes}}"
+        t-attf-data-bs-target="#modal_{{'slot' if event.is_multi_slots else 'ticket'}}_registration">
+        Register
+    </button>
     <div t-if="registration_error_code == 'insufficient_seats'" class="alert alert-danger my-3" role="alert">
         Registration failed! These tickets are not available anymore.
     </div>
@@ -194,11 +203,58 @@
     </t>
 </template>
 
+<!-- Event - Calendar Links -->
+<template id="event_calendar_links">
+    <h5>Add to your calendar</h5>
+    <div id="add_to_calendar" class="o_event_add_to_calendar_btns d-flex flex-wrap gap-3 mt-2">
+        <a role="button" class="o_outlook_calendar btn btn-block bg-white"
+            t-att-href="iCal_url">
+            <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" loading="lazy"/>
+            Add to iCal/Outlook
+        </a>
+        <a role="button" class="o_google_calendar btn btn-block bg-white"
+            t-att-href="google_url">
+            <img src="/event/static/src/img/google-calendar.svg" alt="Google Agenda" loading="lazy"/>
+            Add to Google Agenda
+        </a>
+    </div>
+</template>
+
 <!-- Event - Description Dates -->
 <template id="event_description_dates" name="Event Description Dates">
-    <div t-attf-class="o_wevent_dates_block {{event.is_one_day and 'd-flex flex-wrap justify-content-between align-items-center gap-2'}}">
+    <t t-set="is_one_day_without_slots" t-value="not event.is_multi_slots and event.is_one_day"/>
+    <div t-attf-class="o_wevent_dates_block {{is_one_day_without_slots and 'd-flex flex-wrap justify-content-between align-items-center gap-2'}}">
         <div t-if="opt_event_dates_block" class="pb-3 flex-wrap gap-3 w-lg-100">
-            <div t-if="event.is_one_day" class="card bg-transparent d-inline-flex align-items-end flex-row flex-grow-1 w-lg-100 gap-2 p-2 p-md-3">
+            <div t-if="event.is_multi_slots">
+                <small class="fw-bold">Next Dates</small>
+                <div class="card bg-transparent py-3 px-2 px-md-3">
+                    <!-- Up to the next 3 closest dates -->
+                    <t t-set="slots_to_preview" t-value="dict(list(slots.items())[:3])"/>
+                    <t t-if="slots_to_preview">
+                        <div class="row">
+                            <div t-foreach="slots_to_preview" t-as="date" class="col d-flex flex-column align-items-start gap-1 pb-2">
+                                <time t-out="date" class="text-nowrap" t-options="{'widget': 'date', 'format': 'full'}"/>
+                                <div class="d-flex flex-wrap gap-2">
+                                    <button t-foreach="slots_to_preview[date]" t-as="slot" t-attf-class="btn btn-sm text-nowrap pe-none
+                                        #{'bg-danger text-white' if slot.is_sold_out else 'btn-light'}">
+                                        <span t-if="slot.is_sold_out" class="lh-1">Sold Out</span>
+                                        <time t-else="" t-out="slot.start_datetime" t-att-datetime="slot.start_datetime" class="lh-1"
+                                            t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'time_only': 'true', 'format': 'short'}"/>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <button t-if="event.event_registrations_open" type="button" data-bs-toggle="modal" data-bs-target="#modal_slot_registration"
+                            t-attf-class="btn btn-link text-decoration-none pb-0 {{cta_additional_classes}}">
+                            View More
+                        </button>
+                    </t>
+                    <t t-else="">
+                        No Future Dates Available
+                    </t>
+                </div>
+            </div>
+            <div t-elif="event.is_one_day" class="card bg-transparent d-inline-flex align-items-end flex-row flex-grow-1 w-lg-100 gap-2 p-2 p-md-3">
                 <time t-out="event.date_begin" t-att-datetime="event.date_begin" class="o_wevent_day_header_number lh-1" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd', 'date_only': 'true'}"/>
                 <div class="small">
                     <time t-out="event.date_begin" t-att-datetime="event.date_begin" class="d-block lh-1" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'MMMM Y', 'date_only': 'true'}"/>
@@ -237,9 +293,9 @@
             </t>
         </div>
 
-        <div t-if="opt_event_calendar_block" t-attf-class="d-flex align-items-center flex-wrap gap-2 {{'flex-basis-50 flex-basis-md-auto' if event.is_one_day else ''}}">
+        <div t-if="opt_event_calendar_block" t-attf-class="d-flex align-items-center flex-wrap gap-2 {{'flex-basis-50 flex-basis-md-auto' if is_one_day_without_slots else ''}}">
             <small class="text-muted">Add to calendar:</small>
-            <div t-attf-class="d-flex align-items-center flex-shrink-0 flex-grow-1 {{'gap-1 gap-md-2' if event.is_one_day else 'gap-2'}}">
+            <div t-attf-class="d-flex align-items-center flex-shrink-0 flex-grow-1 {{'gap-1 gap-md-2' if is_one_day_without_slots else 'gap-2'}}">
                 <a t-att-href="iCal_url" class="btn btn-light o_wevent_add_to_ical" title="Add to iCal">
                     <img src="/event/static/src/img/apple-calendar.svg" alt="iCal" loading="lazy"/>
                 </a>
@@ -270,6 +326,7 @@
                     <t t-if="availability_check" t-foreach="tickets" t-as="ticket">
                         <t t-foreach="range(1, ticket['quantity'] + 1)" t-as="att_counter" name="attendee_loop">
                             <t t-set="counter" t-value="counter + 1"/>
+                            <input t-if="event_slot_id" type="hidden" t-attf-name="#{counter}-event_slot_id" t-att-value="event_slot_id"/>
                             <input class="d-none" type="text" t-attf-name="#{counter}-event_ticket_id" t-attf-value="#{ticket['id']}"/>
                             <div t-if="event.specific_question_ids" class="modal-body">
                                 <h5 t-attf-class="mt-1 pb-2 #{'border-bottom' if event.question_ids else ''}">Ticket #<span t-out="counter"/> <small class="text-muted">- <span t-out="ticket['name']"/></small></h5>
@@ -347,17 +404,7 @@
                 <div>
                     <t t-if="attendees" t-call="website_event.registration_ticket_access"/>
                     <div class="mt-4">
-                        <h5>Add to your calendar</h5>
-                        <div id="add_to_calendar" class="o_event_add_to_calendar_btns d-flex flex-wrap gap-3 mt-2">
-                            <a role="button" class="o_outlook_calendar btn btn-block bg-white" t-att-href="iCal_url">
-                                <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" loading="lazy"/>
-                                Add to iCal/Outlook
-                            </a>
-                            <a role="button" class="o_google_calendar btn btn-block bg-white" t-att-href="google_url">
-                                <img src="/event/static/src/img/google-calendar.svg" alt="Google Agenda" loading="lazy"/>
-                                Add to Google Agenda
-                            </a>
-                        </div>
+                        <t t-call="website_event.event_calendar_links"/>
                     </div>
                 </div>
                 <div class="mt-4 mt-lg-0">
@@ -367,7 +414,7 @@
                             <b>Start</b>
                         </div>
                         <div class="col-auto ps-0">
-                            <span t-out="event.date_begin"
+                            <span t-out="slot.start_datetime if event.is_multi_slots else event.date_begin"
                                 t-options='{"widget": "datetime", "show_seconds": False, "tz_name": event.date_tz, "format": "medium"}'/>
                         </div>
                     </div>
@@ -376,7 +423,7 @@
                             <b>End</b>
                         </div>
                         <div class="col-auto ps-0">
-                            <span t-out="event.date_end"
+                            <span t-out="slot.end_datetime if event.is_multi_slots else event.date_end"
                                 t-options='{"widget": "datetime", "show_seconds": False, "tz_name": event.date_tz, "format": "medium"}'/>
                         </div>
                     </div>
@@ -428,11 +475,12 @@
 
 <template id="modal_ticket_registration" name="Modal for tickets registration">
     <!-- Modal -->
-    <div class="modal fade" id="modal_ticket_registration" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+    <div id="modal_ticket_registration" t-attf-class="modal fade {{'o_wevent_modal_slot_ticket_registration' if event.is_multi_slots else ''}}"
+        data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabelTicket" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
             <div class="modal-header">
-                <div class="o_wevent_registration_title modal-title fs-5" id="staticBackdropLabel">Tickets</div>
+                <div class="o_wevent_registration_title modal-title fs-5" id="staticBackdropLabelTicket">Tickets</div>
                 <div t-if="len(event.event_ticket_ids) &gt; 2" class="o_wevent_price_range ms-2"/>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
@@ -442,6 +490,7 @@
                 t-attf-action="/event/#{slug(event)}/registration/new" method="post"
                 itemscope="itemscope" itemprop="offers" itemtype="http://schema.org/AggregateOffer">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                <input t-if="event_slot" type="hidden" name="event_slot_id" t-att-value="event_slot.id"/>
                 <div id="o_wevent_tickets" class="shadow-sm o_wevent_js_ticket_details">
                     <div t-if="registration_error_code == 'insufficient_seats'" class="alert alert-danger" role="alert">
                         <p class="mb-0">
@@ -480,12 +529,17 @@
                                 <div class="d-flex flex-column flex-md-row align-items-center justify-content-between gap-2">
                                     <div class="o_wevent_registration_multi_select flex-md-grow-1 text-end"/>
                                     <div class="ms-auto">
-                                        <select t-if="not ticket.is_expired and ticket.sale_available"
+                                        <t t-set="seats_available_slot_ticket" t-value="seats_available_slot_tickets and seats_available_slot_tickets.get(ticket.id, 0) or 0"/>
+                                        <t t-set="seats_available_slot" t-value="event_slot and event_slot.seats_available or 0"/>
+                                        <t t-set="seats_max_slot_ticket" t-value="((not event.seats_limited and not ticket.seats_limited) or seats_available_slot_ticket &gt; 9) and 10 or seats_available_slot_ticket + 1"/>
+                                        <t t-set="seats_max_slot" t-value="(not event.seats_limited or seats_available_slot &gt; 9) and 10 or seats_available_slot + 1"/>
+                                        <t t-set="seats_max_ticket" t-value="(not ticket.seats_limited or ticket.seats_available &gt; 9) and 10 or ticket.seats_available + 1"/>
+                                        <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
+                                        <t t-set="seats_max_event_or_slot" t-value="seats_max_slot if event_slot else seats_max_event"/>
+                                        <t t-set="seats_max" t-value="seats_available_slot_tickets and seats_max_slot_ticket or min(seats_max_ticket, seats_max_event_or_slot)"/>
+                                        <select t-if="(not ticket.is_expired and ticket.sale_available) or seats_available_slot_ticket"
                                             t-attf-name="nb_register-#{ticket.id}"
                                             class="w-auto form-select">
-                                            <t t-set="seats_max_ticket" t-value="(not ticket.seats_limited or ticket.seats_available &gt; 9) and 10 or ticket.seats_available + 1"/>
-                                            <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
-                                            <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event)"/>
                                             <t t-foreach="range(0, seats_max)" t-as="nb">
                                                 <option t-out="nb" t-att-selected="len(ticket) == 0 and nb == 0 and 'selected'"/>
                                             </t>
@@ -499,7 +553,10 @@
                             </div>
                         </div>
                         <div class="modal-footer flex-lg-row border-top">
-                            <button type="button" class="btn btn-light" data-bs-dismiss="modal">Close</button>
+                            <button type="button" class="btn btn-light js_goto_event" data-bs-dismiss="modal">
+                                <t t-if="event.is_multi_slots">Cancel</t>
+                                <t t-else="">Close</t>
+                            </button>
                             <button type="submit" class="btn btn-primary a-submit" disabled="" t-attf-id="#{event.id}">
                                 Register
                                 <t t-if="event.seats_limited and event.seats_max and event.seats_available &lt;= (event.seats_max * 0.2)">
@@ -531,10 +588,15 @@
                                 <t t-if="event.event_registrations_open">
                                     <link itemprop="availability" content="http://schema.org/InStock"/>
                                     <div class="o_wevent_registration_single_select w-auto ms-auto">
+                                        <t t-set="seats_available_slot_ticket" t-value="seats_available_slot_tickets and tickets and seats_available_slot_tickets.get(tickets.id, 0) or 0"/>
+                                        <t t-set="seats_max_slot_ticket" t-value="((not event.seats_limited and not tickets.seats_limited) or seats_available_slot_ticket &gt; 9) and 10 or seats_available_slot_ticket + 1"/>
+                                        <t t-set="seats_available_slot" t-value="event_slot and event_slot.seats_available or 0"/>
+                                        <t t-set="seats_max_slot" t-value="(not event.seats_limited or seats_available_slot &gt; 9) and 10 or seats_available_slot + 1"/>
+                                        <t t-set="seats_max_ticket" t-value="(not tickets or not tickets.seats_limited or tickets.seats_available &gt; 9) and 10 or tickets.seats_available + 1"/>
+                                        <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
+                                        <t t-set="seats_max_event_or_slot" t-value="seats_max_slot if event_slot else seats_max_event"/>
+                                        <t t-set="seats_max" t-value="(seats_available_slot_tickets and seats_max_slot_ticket or min(seats_max_ticket, seats_max_event_or_slot)) if tickets else seats_max_event_or_slot"/>
                                         <select t-att-name="'nb_register-%s' % (tickets.id if tickets else 0)" class="d-inline w-auto form-select">
-                                            <t t-set="seats_max_ticket" t-value="(not tickets or not tickets.seats_limited or tickets.seats_available &gt; 9) and 10 or tickets.seats_available + 1"/>
-                                            <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
-                                            <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event) if tickets else seats_max_event"/>
                                             <t t-foreach="range(0, seats_max)" t-as="nb">
                                                 <option t-out="nb" t-att-selected="nb == 1 and 'selected'"/>
                                             </t>
@@ -549,7 +611,10 @@
                             </div>
                         </div>
                         <div class="modal-footer flex-lg-row border-top">
-                            <button type="button" class="btn btn-light" data-bs-dismiss="modal">Close</button>
+                            <button type="button" class="btn btn-light js_goto_event" data-bs-dismiss="modal">
+                                <t t-if="event.is_multi_slots">Cancel</t>
+                                <t t-else="">Close</t>
+                            </button>
                             <button type="submit" class="btn btn-primary a-submit" t-attf-id="#{event.id}" disabled="disabled">
                                 Register
                                 <t t-if="event.seats_limited and event.seats_max and event.seats_available &lt;= (event.seats_max * 0.2)">
@@ -565,6 +630,60 @@
     </div>
 </template>
 
+<template id="modal_slot_registration" name="Modal for slots registration">
+    <div class="modal fade" id="modal_slot_registration" data-bs-backdrop="static" data-bs-keyboard="false"
+        tabindex="-1" aria-labelledby="staticBackdropLabelSlot" aria-hidden="true">
+        <div class="modal-dialog modal-lg o_wevent_js_slot_details">
+            <form id="slot_registration_form" t-attf-action="/event/#{slug(event)}/registration/slot/slot_id/tickets" method="post">
+                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                <div class="modal-content">
+                <div class="modal-header">
+                    <div class="o_wevent_registration_title modal-title fs-5" id="staticBackdropLabelSlot">Slots</div>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="d-flex flex-column flex-sm-row gap-sm-3">
+                        <h5 class="o_wevent_selected_slot_title">Select a Date:</h5>
+                        <span class="o_wevent_selected_slot text-primary fw-bold"/>
+                    </div>
+                    <nav class="mt-2">
+                        <ul class="pagination d-flex flex-nowrap gap-3 user-select-none">
+                            <li class="o_wevent_slot_previous page-item">
+                                <button class="btn btn-link text-decoration-none p-1">
+                                    <i class="fa fa-caret-left me-2"/><small>Previous</small>
+                                </button>
+                            </li>
+                            <li class="o_wevent_slot_next page-item">
+                                <button class="btn btn-link text-decoration-none p-1">
+                                    <small>Next</small><i class="fa fa-caret-right ms-2"/>
+                                </button>
+                            </li>
+                        </ul>
+                    </nav>
+                    <div class="o_wevent_slot_dates row px-2">
+                        <div t-foreach="slots" t-as="date" t-attf-class="o_wevent_slot_date col col-sm-6 col-lg-4 px-3 pb-4">
+                            <time t-out="date" class="text-nowrap pe-5 me-5" t-options="{'widget': 'date', 'format': 'full'}"/>
+                            <div class="d-flex flex-wrap gap-2">
+                                <button type="button" t-foreach="slots[date]" t-as="slot" class="o_wevent_slot_btn btn btn-sm btn-light"
+                                    t-att-data-slot-id="slot.id" t-att-data-slot-start="slot.start_datetime">
+                                    <time t-out="slot.start_datetime" class="lh-1"
+                                        t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'time_only': 'true', 'format': 'short'}"/>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer flex-lg-row border-top">
+                    <button type="button" class="btn btn-light o_wevent_slot_btn_cancel" data-bs-dismiss="modal">Close</button>
+                    <button type="submit" class="btn btn-primary a-submit" disabled="" t-attf-id="#{event.id}">
+                        Next
+                    </button>
+                </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</template>
 
 <!-- Cover Options -->
 <template id="opt_event_description_cover_hidden" name="Event Description Cover Hidden Option" inherit_id="website_event.event_description_full" active="False"/>

--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -35,26 +35,29 @@ class WebsiteEventSaleController(WebsiteEventController):
         order_sudo = request.cart or request.website._create_cart()
         tickets_data = defaultdict(int)
         for data in registration_data:
-            event_ticket_id = data.get('event_ticket_id')
+            event_slot_id = data.get('event_slot_id', False)
+            event_ticket_id = data.get('event_ticket_id', False)
             if event_ticket_id:
-                tickets_data[event_ticket_id] += 1
+                tickets_data[event_slot_id, event_ticket_id] += 1
 
         cart_data = {}
-        for ticket_id, count in tickets_data.items():
+        for (slot_id, ticket_id), count in tickets_data.items():
             ticket_sudo = event_ticket_by_id.get(ticket_id)
             cart_values = order_sudo._cart_add(
                 product_id=ticket_sudo.product_id.id,
                 quantity=count,
                 event_ticket_id=ticket_id,
+                event_slot_id=slot_id,
             )
-            cart_data[ticket_id] = cart_values['line_id']
+            cart_data[slot_id, ticket_id] = cart_values['line_id']
 
         for data in registration_data:
-            event_ticket_id = data.get('event_ticket_id')
+            event_slot_id = data.get('event_slot_id', False)
+            event_ticket_id = data.get('event_ticket_id', False)
             event_ticket = event_ticket_by_id.get(event_ticket_id)
             if event_ticket:
                 data['sale_order_id'] = order_sudo.id
-                data['sale_order_line_id'] = cart_data[event_ticket_id]
+                data['sale_order_line_id'] = cart_data[event_slot_id, event_ticket_id]
 
         return super()._create_attendees_from_registration_post(event, registration_data)
 

--- a/addons/website_event_sale/views/website_sale_templates.xml
+++ b/addons/website_event_sale/views/website_sale_templates.xml
@@ -26,6 +26,12 @@
         </xpath>
     </template>
 
+    <template id="cart_summary_inherit_website_event_sale" inherit_id="website_sale.checkout_layout">
+        <xpath expr="//td[@name='website_sale_cart_summary_product_name']/h6" position="after">
+            <span t-if="line.event_slot_id" class="text-muted" t-out="line.event_slot_id.display_name"/>
+        </xpath>
+    </template>
+
     <template id="event_confirmation" inherit_id="website_sale.confirmation">
         <div id="order_name" position="after">
             <t t-if="events">
@@ -41,7 +47,7 @@
                             <t t-set="additionnal_classes" t-value="'o_wevent_event_main_cover o_wevent_event_main_cover_top overflow-hidden h-auto'"/>
 
                             <a class="text-decoration-none" t-att-href="event.event_url or event.website_url">
-                                <div t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable">
+                                <div t-if="not event.is_multi_slots" t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable">
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
                                 </div>
@@ -59,20 +65,52 @@
                                 </div>
                             </a>
                         </t>
-                        <div class="m-3">
-                            <t t-if="attendees" t-call="website_event.registration_ticket_access"/>
-                            <div class="row my-3">
-                                <h5>Add to your calendar</h5>
-                                <div id="add_to_calendar" class="o_event_add_to_calendar_btns d-flex flex-wrap gap-3 mt-2">
-                                    <a role="button" class="o_outlook_calendar btn btn-block bg-white" t-att-href="urls_per_event.get(event.id, {}).get('iCal_url', '')">
-                                        <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" loading="lazy"/>
-                                        Add to iCal/Outlook
-                                    </a>
-                                    <a role="button" class="o_google_calendar btn btn-block bg-white" t-att-href="urls_per_event.get(event.id, {}).get('google_url', '')">
-                                        <img src="/event/static/src/img/google-calendar.svg" alt="Google Agenda" loading="lazy"/>
-                                        Add to Google Agenda
-                                    </a>
+                        <t t-set="event_attendees" t-value="attendee_ids_per_event.get(event, [])"/>
+                        <div t-if="event_attendees or not event.is_multi_slots" class="m-3">
+                            <t t-if="event_attendees and not event.is_multi_slots">
+                                <t t-call="website_event.registration_ticket_access">
+                                    <t t-set="attendees" t-value="event_attendees"/>
+                                </t>
+                            </t>
+                            <div t-elif="event_attendees" t-foreach="event_attendees" t-as="slot" class="mb-4">
+                                <div t-attf-class="d-flex flex-column flex-md-row justify-content-between mt-2">
+                                    <div class="mb-3">
+                                        <div class="row">
+                                            <div class="col-auto">
+                                                <b>Start</b>
+                                            </div>
+                                            <div class="col-auto ps-0">
+                                                <span t-out="slot.start_datetime"
+                                                    t-options='{"widget": "datetime", "show_seconds": False, "tz_name": event.date_tz, "format": "medium"}'/>
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-auto">
+                                                <b>End</b>
+                                            </div>
+                                            <div class="col-auto ps-0">
+                                                <span t-out="slot.end_datetime"
+                                                    t-options='{"widget": "datetime", "show_seconds": False, "tz_name": event.date_tz, "format": "medium"}'/>
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <span t-if="website_visitor_timezone != event.date_tz" class="small">(<t t-out="event.date_tz"/>)</span>
+                                        </div>
+                                    </div>
+                                    <div t-if="event_attendees[slot]" t-call="website_event.registration_ticket_access">
+                                        <t t-set="attendees" t-value="event_attendees[slot]"/>
+                                    </div>
                                 </div>
+                                <t t-call="website_event.event_calendar_links">
+                                    <t t-set="iCal_url" t-value="urls_per_event.get(event.id, {}).get(slot.id, {}).get('iCal_url', '')"/>
+                                    <t t-set="google_url" t-value="urls_per_event.get(event.id, {}).get(slot.id, {}).get('google_url', '')"/>
+                                </t>
+                            </div>
+                            <div t-if="not event.is_multi_slots" class="row my-3">
+                                <t t-call="website_event.event_calendar_links">
+                                    <t t-set="iCal_url" t-value="urls_per_event.get(event.id, {}).get('iCal_url', '')"/>
+                                    <t t-set="google_url" t-value="urls_per_event.get(event.id, {}).get('google_url', '')"/>
+                                </t>
                             </div>
                             <t t-call="website_event.event_confirmation_end_page_hook"/>
                         </div>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2287,7 +2287,7 @@
                     </div>
                     <div class="d-flex flex-column flex-grow-1 gap-3 min-w-0">
                         <div class="d-flex gap-3">
-                            <div class="flex-grow-1 text-wrap">
+                            <div class="flex-grow-1 text-wrap w-100">
                                 <div class="d-flex justify-content-between">
                                     <t t-call="website_sale.cart_line_product_link">
                                         <h6


### PR DESCRIPTION

LAST COMMIT ONLY -> pos part of event slots:

PURPOSE
=======

In this task, we add a new feature allowing events to be
'multi slots', which means an attendee can now chose a slot
in addition to a ticket. This commit adds the pos part to
this new feature.

CHANGES
=======

Now, when the event is multi slot, the first popup will
be the one for slot selection. Sold out slots will not
be selectable and will be disabled on that screen.

The availabilities for tickets will be computed based on
the selection made on that screen, and ticket popup will
be opened in turn. Those consider the various configurations
with slot and its seats_max, the tickets and their seats_max,
and the minimum between slot and sum of tickets availabilities.

- We include the new model event.slot and associated fields
in the loaded pos data.
- In order to support the new handling of availabilities,
the config popup is slightly modified. Also, we now use a
litteral 'unlimited' value for availability, which also
improves clarity as availability computation can be a bit heavy.
- A few display improvements are done in the product card.
This part was 'hidden' and is brought back at the same time.
- We only show future slots.
- Pos order lines will show the event and the slot. They will
be merged only if both are the same.

Task-4307566