### PR TITLE
[FIX] stock: fix “_search_rule_for_warehouses” with product categ

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -722,7 +722,8 @@ class ProductTemplate(models.Model):
         default=lambda self: self.env['stock.route'].search_count([('product_selectable', '=', True)]))
     route_ids = fields.Many2many(
         'stock.route', 'stock_route_product', 'product_id', 'route_id', 'Routes',
-        domain=[('product_selectable', '=', True)], depends_context=['company', 'allowed_companies'],
+        domain="(company_id and ['|', ('company_id', '=', False), ('company_id', 'in', [company_id])] or [] )+ [('product_selectable', '=', True)]",
+        depends_context=['company', 'allowed_companies'],
         help="Depending on the modules installed, this will allow you to define the route of the product: whether it will be bought, manufactured, replenished on order, etc.")
     nbr_moves_in = fields.Integer(compute='_compute_nbr_moves', compute_sudo=False, help="Number of incoming stock moves in the past 12 months")
     nbr_moves_out = fields.Integer(compute='_compute_nbr_moves', compute_sudo=False, help="Number of outgoing stock moves in the past 12 months")
@@ -1063,7 +1064,7 @@ class ProductCategory(models.Model):
     filter_for_stock_putaway_rule = fields.Boolean('stock.putaway.rule', store=False, search='_search_filter_for_stock_putaway_rule')
 
     def _search_total_route_ids(self, operator, value):
-        categories = self.env['product.category'].sudo().search([])
+        categories = self.env['product.category'].search([])
         categ_ids = categories.filtered_domain([('total_route_ids', operator, value)]).ids
         return [('id', 'in', categ_ids)]
 

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -76,7 +76,9 @@ class StockWarehouseOrderpoint(models.Model):
     rule_ids = fields.Many2many('stock.rule', string='Rules used', compute='_compute_rules')
     lead_days_date = fields.Date(compute='_compute_lead_days')
     route_id = fields.Many2one(
-        'stock.route', string='Route', domain="[('product_selectable', '=', True)]")
+        'stock.route', string='Route',
+        domain="(company_id and ['|', ('company_id', '=', False), ('company_id', 'in', [company_id])] or [] )+ [('product_selectable', '=', True)]",
+    )
     qty_on_hand = fields.Float('On Hand', readonly=True, compute='_compute_qty', digits='Product Unit of Measure')
     qty_forecast = fields.Float('Forecast', readonly=True, compute='_compute_qty', digits='Product Unit of Measure')
     qty_to_order = fields.Float('To Order', compute='_compute_qty_to_order', inverse='_inverse_qty_to_order', search='_search_qty_to_order', digits='Product Unit of Measure')

--- a/addons/stock/tests/test_multicompany.py
+++ b/addons/stock/tests/test_multicompany.py
@@ -712,3 +712,37 @@ class TestMultiCompany(TransactionCase):
                     'picking_type_id': self.warehouse_b.in_type_id.id,
                 })
             ]})
+
+    def test_multiple_routes_different_company_product_categories(self):
+        route_1 = self.env['stock.route'].create({
+            'name': 'Test Route',
+            'company_id': self.company_a.id,
+            'product_categ_selectable': True,
+            'product_selectable': True,
+        })
+        route_2 = self.env['stock.route'].create({
+            'name': 'Test Route',
+            'company_id': self.company_b.id,
+            'product_categ_selectable': True,
+            'product_selectable': True,
+        })
+        product_category = self.env['product.category'].create({
+            'name': 'Test Category',
+            'route_ids': [(6, 0, [route_1.id, route_2.id])],
+        })
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'categ_id': product_category.id,
+            'company_id': self.company_a.id,
+        })
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': product.id,
+            'location_id': self.stock_location_a.id,
+            'company_id': self.company_a.id,
+        })
+        # product_category.invalidate_recordset(['total_route_ids'])
+        # self.assertEqual(product_category.total_route_ids, (route_1 | route_2))
+        self.env.invalidate_all()
+        # orderpoint.with_context(allowed_company_ids=self.company_b.ids)._compute_rules()
+        # self.assertEqual(orderpoint.with_user(self.user_a).with_company(self.company_a).rule_ids)
+        self.assertEqual(product_category.with_user(self.user_a).with_company(self.company_a).total_route_ids, route_1)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create two companies:
    - Company 1 and Company 2

- Create Route 1:
    - Applicable on: Product Categories and Products
    - Assigned to: Company 1

- Create a route 2:
    - Applicable on: Product Categories and Products
    - Assigned to: Company 2

- In the company selector, select only Company 1
- Create a storable product “P1”
    - Try to create an orderpoint for this product

Problem:
An access error is raised:

```
Sorry, Mitchell Admin (id=2) doesn't have 'read' access to:
- Inventory Routes, Manufacture (copy) (stock.route: 11, company=My
Company (Chicago))

Blame the following rules:
- stock_route multi-company
```

opw-4682685
