### PR TITLE
[FIX] mail: fix confusion between record.id/resId in email tags

### DIFF
--- a/addons/mail/static/src/core/web/recipients_input.js
+++ b/addons/mail/static/src/core/web/recipients_input.js
@@ -8,6 +8,7 @@ import { useSelectCreate } from "@web/views/fields/relational_utils";
 import { rpc } from "@web/core/network/rpc";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useTagNavigation } from "@web/core/record_selectors/tag_navigation_hook";
+import { uniqueId } from "@web/core/utils/functions";
 import { RecipientsPopover } from "./recipients_popover";
 import { RecipientsInputTagsList } from "./recipients_input_tags_list";
 
@@ -181,7 +182,8 @@ export class RecipientsInput extends Component {
                 }
             );
             tags.push({
-                id: recipient.partner_id,
+                id: uniqueId("tag_"),
+                resId: recipient.partner_id,
                 canEdit: true,
                 text: recipient.name || recipient.email,
                 name: recipient.name,

--- a/addons/mail/static/src/core/web/recipients_input_tags_list.js
+++ b/addons/mail/static/src/core/web/recipients_input_tags_list.js
@@ -56,10 +56,7 @@ export class RecipientsInputTagsList extends TagsList {
         this.popover.open(this.tagToUpdateRef.el, {
             tagToUpdate: this.state.tagToUpdate,
             onUpdateTag: (newEmail) =>
-                this.props.updateRecipient(
-                    newEmail,
-                    this.state.tagToUpdate.resId ?? this.state.tagToUpdate.id
-                ),
+                this.props.updateRecipient(newEmail, this.state.tagToUpdate.resId),
         });
     }
 }

--- a/addons/mail/static/src/core/web/recipients_input_tags_list_popover.js
+++ b/addons/mail/static/src/core/web/recipients_input_tags_list_popover.js
@@ -28,8 +28,11 @@ export class RecipientsInputTagsListPopover extends Component {
         });
     }
 
+    /**
+     * @deprecated
+     */
     get id() {
-        return this.props.tagToUpdate.id;
+        return this.props.tagToUpdate.resId;
     }
 
     onKeydown(ev) {

--- a/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
+++ b/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
@@ -74,7 +74,6 @@ export class FieldMany2ManyTagsEmail extends Many2ManyTagsField {
         );
         tags.forEach((tag) => {
             tag.email = emailByResId[tag.resId];
-            tag.id = tag.resId;
             tag.name = tag.text;
             tag.title = tag.text;
         });

--- a/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.xml
+++ b/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.xml
@@ -5,7 +5,7 @@
             <div t-attf-class="badge rounded-pill dropdown o_tag o_tag_color_0 #{tag.email.indexOf('@') &lt; 0 ? 'o_tag_error' : ''}"
                  t-att-data-color="tag.colorIndex"
                  t-att-data-index="tag_index"
-                 t-att-data-id="tag.id"
+                 t-att-data-id="tag.resId"
                  t-att-title="tag.text"
                  t-on-click="(ev) => tag.onClick and tag.onClick(ev)" t-ref="{{tagEquals(tag, state.tagToUpdate) ? 'tagToUpdate' : `tag_${tag_index}`}}">
                 <span class="o_badge_text" t-att-title="tag.email"><t t-esc="tag.text"/></span>


### PR DESCRIPTION
[This commit] used `record.id` as if they were `record.resId` resulting in an
issue when trying to delete a tag.

How to reproduce:
- Use the chatter to send an email using the full composer
- add some email recipients
- try to remove them using backspace -> traceback

This fix correctly renames properties that should be `resId`, and removes the
`id` override (`record.id` is a value specific to the relational model from
`/web/`).

[This commit]: https://github.com/odoo/odoo/commit/1f34abc173f07b6d20c08a27ec57c7025cb20562

task-4731774

Co-authored-by: Damien Abeloos <abd@odoo.com>
Co-authored-by: Kadam Darji <kmdi@odoo.com>