### PR TITLE
[FIX] account_check_printing: access error with branch

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -169,7 +169,7 @@ class AccountPayment(models.Model):
             # The wizard asks for the number printed on the first pre-printed check
             # so payments are attributed the number of the check the'll be printed on.
             self.env.cr.execute("""
-                  SELECT payment.id
+                  SELECT payment.check_number
                     FROM account_payment payment
                     JOIN account_move move ON move.id = payment.move_id
                    WHERE move.journal_id = %(journal_id)s
@@ -179,9 +179,9 @@ class AccountPayment(models.Model):
             """, {
                 'journal_id': self.journal_id.id,
             })
-            last_printed_check = self.browse(self.env.cr.fetchone())
-            number_len = len(last_printed_check.check_number or "")
-            next_check_number = '%0{}d'.format(number_len) % (int(last_printed_check.check_number) + 1)
+            last_check_number = (self.env.cr.fetchone() or (False,))[0]
+            number_len = len(last_check_number or "")
+            next_check_number = f'{int(last_check_number) + 1:0{number_len}}'
 
             return {
                 'name': _('Print Pre-numbered Checks'),

--- a/addons/account_check_printing/tests/test_print_check.py
+++ b/addons/account_check_printing/tests/test_print_check.py
@@ -196,3 +196,35 @@ class TestPrintCheck(AccountTestInvoicingCommon):
         payment_2.action_post()
         action_window = payment_2.print_checks()
         self.assertEqual(action_window['context']['default_next_check_number'], '2147483649', "Check number should have been incremented without error.")
+
+    def test_print_check_with_branch(self):
+        """
+        Test that we don't get access error when printing a check with a branch
+        """
+        company = self.env.company
+        branch = self.env['res.company'].create({
+            'name': 'Branch',
+            'parent_id': company.id,
+        })
+        self.cr.precommit.run()  # load the CoA
+        self.env.user.write({'company_id': company.id, 'company_ids': [Command.set(company.ids)]})
+
+        vals = {
+            'payment_type': 'outbound',
+            'partner_type': 'supplier',
+            'amount': 100.0,
+            'journal_id': self.company_data['default_journal_bank'].id,
+            'payment_method_line_id': self.payment_method_line_check.id,
+        }
+        payment = self.env['account.payment'].create(vals)
+        payment.action_post()
+        self.assertTrue(payment.write({'check_number': '00001'}))
+        payment.invalidate_recordset(['check_number'])
+
+        self.env.user.write({'company_id': branch.id, 'company_ids': [Command.set(branch.ids)]})
+
+        payment_2 = self.env['account.payment'].create(vals)
+        payment_2.action_post()
+
+        action_window = payment_2.print_checks()
+        self.assertTrue(action_window)


### PR DESCRIPTION
We get an Access Error when trying to print check from
a journal that is shared between branches.

Steps:

- Have a company X and a branch Y
- Make a vendor payment with only X selected in company selector,
  set payment method as 'Checks'
- Confirm and print check
- Now select only branch Y in company selector
- Create a vendor payment with same config as previous one
- Condirm, and try to print check
-> Access Error

This is because we try to get the previous check number from
the last payment of the journal, but even if the record shares
the same journal, we don't necessary have access to it.

Fix:

Get `check_number` directly from the SQL query instead of a record

opw-4520708
