### PR TITLE
[IMP] crm: select company and contact separately in kanban

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -429,13 +429,17 @@ class CrmLead(models.Model):
     @api.depends('partner_id')
     def _compute_contact_name(self):
         """ compute the new values when partner_id has changed """
-        for lead in self:
+        to_reset = self.filtered(lambda l: not l.partner_id)
+        to_reset.contact_name = False
+        for lead in (self - to_reset):
             lead.update(lead._prepare_contact_name_from_partner(lead.partner_id))
 
     @api.depends('partner_id')
     def _compute_partner_name(self):
         """ compute the new values when partner_id has changed """
-        for lead in self:
+        to_reset = self.filtered(lambda l: not l.partner_id)
+        to_reset.partner_name = False
+        for lead in (self - to_reset):
             lead.update(lead._prepare_partner_name_from_partner(lead.partner_id))
 
     @api.depends('partner_id')

--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -28,7 +28,7 @@ registry.category("web_tour.tours").add('crm_tour', {
     tooltipPosition: 'bottom',
     run: "click",
 }, {
-    trigger: ".o_kanban_quick_create .o_field_widget[name='partner_id'] input",
+    trigger: ".o_kanban_quick_create .o_field_widget[name='commercial_partner_id'] input",
     content: markup(_t('<b>Write a few letters</b> to look for a company, or create a new one.')),
     tooltipPosition: "top",
     run: "edit Brandon Freeman",

--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -1,3 +1,16 @@
 .crm_lead_merge_summary blockquote {
     font-style: normal;
 }
+
+.crm_quick_create_opportunity_form_group {
+
+    padding-bottom: 0.5rem;
+
+    i.fa {
+        text-align: center;
+        min-width: 2rem;
+    }
+    .crm_revenues .o_row {
+        margin-left: 1.75rem;
+    }
+}

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -79,6 +79,37 @@ class TestCRMLead(TestCrmCommon):
             self.assertEqual(lead.lang_id, self.lang_en)
 
     @users('user_sales_leads')
+    def test_crm_lead_compute_commercial_partner(self):
+        company_partner, child_partner, orphan_partner = self.env['res.partner'].create([
+            {
+                'name': 'test_crm_lead_compute_commercial_partner',
+                'is_company': True,
+                'email': 'test_crm_lead_compute_commercial_partner@test.lan',
+            },
+            {'name': 'Test Child'},
+            {'name': 'Test Orphan'},
+        ])
+        child_partner.parent_id = company_partner
+        lead = self.env['crm.lead'].create({
+            'name': 'Test Lead',
+            'partner_name': 'test_crm_lead_compute_commercial_partner',
+        })
+        self.assertEqual(lead.commercial_partner_id, company_partner)
+        lead.partner_id = orphan_partner
+        self.assertFalse(lead.commercial_partner_id)
+        lead.partner_id = child_partner
+        self.assertEqual(lead.commercial_partner_id, company_partner)
+        lead.write({
+            'partner_id': False,
+            'partner_name': False,
+        })
+        self.assertFalse(lead.commercial_partner_id)
+        lead.partner_id = company_partner
+        # this is mostly because we use it to set "parent_id" in most flows
+        # and it doesn't really make sense to have it be its own parent
+        self.assertFalse(lead.commercial_partner_id, "If a partner is its own commercial_partner_id, the lead is considered to have none.")
+
+    @users('user_sales_leads')
     def test_crm_lead_creation_no_partner(self):
         lead_data = {
             'name': 'Test',

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from itertools import product
 
 from odoo import SUPERUSER_ID
 from odoo.addons.crm.tests import common as crm_common
@@ -334,24 +333,6 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         self.assertEqual(self.lead_1.partner_id, self.contact_1)
 
     @users('user_sales_manager')
-    def test_lead_convert_action_nothing(self):
-        """ Test specific use case of 'nothing' action in conver wizard """
-        self.lead_1.write({'contact_name': False})
-
-        convert = self.env['crm.lead2opportunity.partner'].with_context({
-            'active_model': 'crm.lead',
-            'active_id': self.lead_1.id,
-            'active_ids': self.lead_1.ids,
-        }).create({})
-        self.assertEqual(convert.action, 'nothing')
-        convert.action_apply()
-        self.assertEqual(self.lead_1.type, 'opportunity')
-        self.assertEqual(self.lead_1.user_id, self.user_sales_leads)
-        self.assertEqual(self.lead_1.team_id, self.sales_team_1)
-        self.assertEqual(self.lead_1.stage_id, self.stage_team1_1)
-        self.assertEqual(self.lead_1.partner_id, self.env['res.partner'])
-
-    @users('user_sales_manager')
     def test_lead_convert_contact_mutlicompany(self):
         """ Check the wizard convert to opp don't find contact
         You are not able to see because they belong to another company """
@@ -431,6 +412,58 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         self.lead_1.convert_opportunity(False, user_ids=self.user_sales_salesman.ids)
         self.assertNotEqual(self.lead_1.team_id, initial_team)
         self.assertFalse(self.lead_1.lead_properties)
+
+    @users('user_sales_manager')
+    def test_lead_convert_wizard_new_partner(self):
+        no_partner = self.env['res.partner']
+        test_partner_lead, test_partner_wizard, commercial_partner = self.env['res.partner'].create([
+            {'name': 'Lead Test Partner'},
+            {'name': 'Wizard Test Partner'},
+            {'name': 'Company Partner', 'is_company': True},
+        ])
+        case_values = product(
+            [no_partner, test_partner_lead],
+            [False, 'New Company'],
+            [no_partner, commercial_partner],
+            [no_partner, test_partner_wizard],
+            ['create', 'exist'],
+        )
+        for (lead_partner, lead_company_name, wizard_company, wizard_contact, wizard_action) in case_values:
+            (test_partner_lead + test_partner_wizard).parent_id = False
+            commercial_partner.invalidate_recordset()
+            lead_contact_name = lead_partner.name or 'Test Contact Name'
+            lead = self.env['crm.lead'].create({
+                'name': 'Test Lead',
+                'contact_name': lead_contact_name,
+                'partner_id': lead_partner.id,
+                'partner_name': lead_company_name,
+            })
+            wizard = self.env['crm.lead2opportunity.partner'].with_context({
+                'active_model': 'crm.lead',
+                'active_id': lead.id,
+                'active_ids': lead.ids,
+            }).create({})
+            wizard.write({'action': wizard_action, 'name': 'convert'})
+            if wizard_contact:
+                wizard.partner_id = wizard_contact
+            if wizard_company:
+                wizard.commercial_partner_id = wizard_company
+            with self.subTest(
+                lead_company_name=lead_company_name, lead_partner=lead_partner.name,
+                wizard_company=wizard_company.name, wizard_contact=wizard_contact.name, wizard_action=wizard_action
+            ):
+                wizard.action_apply()
+                self.assertEqual(lead.type, 'opportunity')
+                self.assertEqual(bool(lead.partner_id), bool(wizard_action == 'create' or lead_partner or wizard_contact))
+                if wizard_action == 'exist' and (lead_partner or wizard_contact):
+                    self.assertEqual(lead.partner_id, wizard_contact or lead_partner)
+                if wizard_action == 'create' and not lead_partner and not wizard_contact and wizard_company:
+                    self.assertTrue(lead.partner_id)
+                    self.assertEqual(lead.partner_id.name, lead_contact_name)
+                    self.assertEqual(lead.partner_id.parent_id, wizard_company)
+                if wizard_action == 'create' and (wizard_contact or lead_partner):
+                    self.assertEqual(lead.partner_id, wizard_contact or lead_partner)
+                    self.assertFalse(lead.partner_id.parent_id)
 
     @users('user_sales_manager')
     def test_lead_merge(self):

--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.crm.tests.common import TestCrmCommon
-from odoo.tests import HttpCase
+from odoo.tests import Form, HttpCase, TransactionCase
 from odoo.tests.common import tagged
 
 
@@ -86,3 +86,110 @@ class TestUi(HttpCase, TestCrmCommon):
         self.assertEqual(lead.phone, '+32 494 44 44 44', 'Should not have changed the lead phone')
         self.assertEqual(partner.email, 'test@example.com', 'Should have propagated the lead email on the partner')
         self.assertEqual(partner.phone, '+32 494 44 44 44', 'Should have propagated the lead phone on the partner')
+
+
+class TestCrmKanbanUI(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.child_contact_1, cls.child_contact_2, cls.orphan_contact = cls.env['res.partner'].create([
+            {'name': 'Child Contact 1'}, {'name': 'Child Contact 2'}, {'name': 'Orphan Contact'},
+        ])
+        cls.parent_company, cls.childless_company = cls.env['res.partner'].create([
+            {'name': 'Parent Company', 'is_company': True},
+            {'name': 'Childless Company', 'is_company': True},
+        ])
+        (cls.child_contact_1 + cls.child_contact_2).parent_id = cls.parent_company
+        cls.quick_create_form_view = cls.env.ref('crm.quick_create_opportunity_form', raise_if_not_found=False)
+
+    def test_kanban_quick_create_form(self):
+        """Check major state transitions when picking a company or a partner from the quick_create form."""
+        lead_form = Form(self.env['crm.lead'], self.quick_create_form_view)
+        self.assertFalse(lead_form._get_context('partner_id')['default_parent_id'])
+
+        lead_form.partner_id = self.orphan_contact
+        self.assertFalse(lead_form.commercial_partner_id)
+        self.assertFalse(lead_form._get_context('partner_id')['default_parent_id'])
+
+        # set contact, updates commercial partner
+        lead_form.partner_id = self.child_contact_1
+        self.assertEqual(lead_form.commercial_partner_id, self.parent_company)
+        self.assertEqual(lead_form._get_context('partner_id')['default_parent_id'], self.parent_company.id)
+        lead_form.partner_id = self.child_contact_2
+        self.assertEqual(lead_form.commercial_partner_id, self.parent_company)
+        self.assertEqual(lead_form.partner_id, self.child_contact_2)
+
+        # set company, resets partner
+        lead_form.commercial_partner_id = self.childless_company
+        self.assertEqual(lead_form.commercial_partner_id, self.childless_company)
+        self.assertFalse(lead_form.partner_id)
+        self.assertEqual(lead_form._get_context('partner_id')['default_parent_id'], self.childless_company.id)
+
+        lead_form.commercial_partner_id = self.parent_company
+        self.assertEqual(lead_form.commercial_partner_id, self.parent_company)
+        self.assertFalse(lead_form.partner_id)
+        self.assertEqual(lead_form._get_context('partner_id')['default_parent_id'], self.parent_company.id)
+
+    def test_kanban_quick_create_partner_inherited_details(self):
+        """Check behavior of setting the quick create "company" field at create time.
+
+        It should link the company as the partner if there's no contact
+        and the contact details are either empty or match the company's.
+        Otherwise it will simply be added as the partner_name, if there is none.
+        """
+        no_partner = self.env['res.partner']
+        company = self.childless_company
+        company.write({
+            'email': 'childless@test.lan',
+            'phone': '+32 499 00 00 00'
+        })
+
+        test_cases = [
+            ({'email_from': False, 'phone': False}, {'partner_id': company, 'email_from': company.email, 'phone': company.phone}),
+            ({'email_from': company.email, 'phone': False}, {'partner_id': no_partner, 'email_from': company.email, 'phone': False}),
+            (
+                {'email_from': company.email, 'phone': company.phone[:-1] + '1'},
+                {'partner_id': no_partner, 'email_from': company.email, 'phone': company.phone[:-1] + '1'},
+            ),
+            (
+                {'email_from': company.email, 'phone': company.phone},
+                {'partner_id': company, 'email_from': company.email, 'phone': company.phone}
+            ),
+            (
+                {'email_from': company.email + 'n', 'phone': company.phone},
+                {'partner_id': no_partner, 'email_from': company.email + 'n', 'phone': company.phone}
+            ),
+            (
+                {'partner_id': self.child_contact_1, 'email_from': company.email, 'phone': company.phone},
+                {'partner_name': self.parent_company.name, 'partner_id': self.child_contact_1, 'email_from': company.email, 'phone': company.phone}
+            ),
+        ]
+        for form_values, expected_lead_values in test_cases:
+            lead_form = Form(self.env['crm.lead'], self.quick_create_form_view)
+            lead_form.commercial_partner_id = self.childless_company
+            self.assertFalse(lead_form.phone)
+            self.assertFalse(lead_form.email_from)
+            expected_lead_values = {'partner_name': company.name} | expected_lead_values
+            with self.subTest(form_values=form_values):
+                for field_name, input_value in form_values.items():
+                    lead_form[field_name] = input_value
+                lead = lead_form.save()
+                for field_name, expected_value in expected_lead_values.items():
+                    self.assertEqual(lead[field_name], expected_value)
+
+        # sanity check, nothing was synced
+        self.assertEqual(company.email, 'childless@test.lan')
+        self.assertEqual(company.phone, '+32 499 00 00 00')
+
+        # check that it behaves reasonably if used without form too
+        lead = self.env['crm.lead'].create({
+            'commercial_partner_id': self.childless_company.id,
+            'name': "Childless Company's lead",
+        })
+        self.assertEqual(lead.partner_id, self.childless_company)
+
+        lead = self.env['crm.lead'].with_context(default_partner_id=self.parent_company).create({
+            'commercial_partner_id': self.childless_company.id,
+            'name': "Childless Company's lead",
+        })
+        self.assertEqual(lead.partner_id, self.parent_company, 'Default partner should take precedence over commercial_partner_id')

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -89,6 +89,7 @@
                                 <field name="is_partner_visible" invisible='1'/>
                                 <field name="partner_id" widget="res_partner_many2one"
                                     context="{
+                                        'default_parent_id': commercial_partner_id,
                                         'default_name': contact_name,
                                         'default_street': street,
                                         'default_street2': street2,
@@ -408,33 +409,72 @@
             <field name="priority">1000</field>
             <field name="arch" type="xml">
                 <form>
-                    <group>
-                        <field name="partner_id" widget="res_partner_many2one"
-                            class="o_field_highlight"
-                            string='Contact'
-                            context="{
-                            'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
-                            'default_name': contact_name or partner_name,
-                            'default_is_company': type == 'opportunity' and contact_name == False,
-                            'default_company_name': type == 'opportunity' and partner_name,
-                            'default_type': 'contact',
-                            'default_phone': phone,
-                            'default_email': email_from,
-                            'default_user_id': user_id,
-                            'default_team_id': team_id,
-                            'show_vat': True}"/>
-                        <field name="name" placeholder="e.g. Product Pricing" />
-                        <field name="email_from" string="Email" placeholder='e.g. "email@address.com"' />
-                        <field name="phone" string="Phone" placeholder='e.g. "0123456789"' />
-                        <label for="expected_revenue"/>
-                        <div>
-                            <div class="o_row">
-                                <field name="expected_revenue" class="oe_inline me-5 o_field_highlight" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                                <field name="priority" class="oe_inline" nolabel="1" widget="priority"/>
+                    <group class="crm_quick_create_opportunity_form_group">
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-building" title="Company"/>
+                            <field name="commercial_partner_id" widget="res_partner_many2one"
+                                placeholder="Company"
+                                string="Company"
+                                nolabel="1"
+                                class="o_field_highlight w-100 mb-0"
+                                context="{
+                                'default_is_company': True,
+                                'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
+                                'default_type': 'contact',
+                                'default_user_id': user_id,
+                                'default_team_id': team_id,
+                                'default_child_ids': partner_id and [(4, partner_id)] or False,
+                        }"/>
+                        </div>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-user" title="Contact"/>
+                            <field name="partner_id"
+                                nolabel="1"
+                                class="o_field_highlight w-100 mb-0"
+                                placeholder='Contact'
+                                string='Contact'
+                                context="{
+                                'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
+                                'partner_display_name_hide_company': commercial_partner_id,
+                                'default_company_name': not commercial_partner_id and type == 'opportunity' and partner_name,
+                                'default_name': contact_name or partner_name,
+                                'default_is_company': False,
+                                'default_type': 'contact',
+                                'default_phone': phone,
+                                'default_email': email_from,
+                                'default_parent_id': commercial_partner_id,
+                                'default_user_id': user_id,
+                                'default_team_id': team_id,
+                                'show_vat': True}"
+                                domain="[('is_company', '!=', True)] + (
+                                    [('id', 'child_of', commercial_partner_id)] if commercial_partner_id else []
+                                )"
+                            />
+                        </div>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-briefcase" title="Opportunity Name"/>
+                            <field name="name" nolabel="1" placeholder="Opportunity's Name" class="o_field_highlight w-100 mb-0"/>
+                        </div>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-envelope" title="Contact Email"/>
+                            <field name="email_from" string="Contact Email" placeholder='Contact Email' nolabel="1" class="o_field_highlight w-100 mb-0"/>
+                        </div>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-mobile fa-lg" title="Contact Phone"/>
+                            <field name="phone" string="Contact Phone" placeholder='Contact Phone' nolabel="1" class="o_field_highlight w-100 mb-0"/>
+                        </div>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-money" title="Expected Revenue"/>
+                            <div class="mb-0">
+                                <field name="expected_revenue" class="oe_inline me-5 o_field_highlight mb-0" widget="monetary" options="{'currency_field': 'company_currency'}"/>
+                                <field name="priority" class="oe_inline mb-0" nolabel="1" widget="priority"/>
                             </div>
-                            <div class="o_row" groups="crm.group_use_recurring_revenues">
-                                <field name="recurring_revenue" class="oe_inline o_field_highlight" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                                <field name="recurring_plan" class="oe_inline" placeholder='e.g. "Monthly"'
+                        </div>
+                        <div class="d-flex align-items-center" colspan="2">
+                            <i class="fa fa-refresh" title="Recurring Revenue"/>
+                            <div class="o_row">
+                                <field name="recurring_revenue" class="oe_inline mb-0 o_field_highlight" widget="monetary" options="{'currency_field': 'company_currency'}"/>
+                                <field name="recurring_plan" class="oe_inline mb-0" placeholder='e.g. "Monthly"'
                                     required="recurring_revenue != 0" options="{'no_create': True, 'no_open': True}"/>
                             </div>
                         </div>

--- a/addons/crm/wizard/crm_lead_to_opportunity_mass.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass.py
@@ -39,6 +39,10 @@ class CrmLead2opportunityPartnerMass(models.TransientModel):
         for convert in self:
             convert.partner_id = False
 
+    def _compute_commercial_partner_id(self):
+        """Setting a company for each lead in mass mode is not supported."""
+        self.commercial_partner_id = False
+
     @api.depends('user_ids')
     def _compute_team_id(self):
         """ When changing the user, also set a team_id or restrict team id

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -29,12 +29,31 @@
                         </list>
                     </field>
                 </group>
-                <group name="action" invisible="name != 'convert'" string="Customer" col="1">
-                    <field name="action" nolabel="1" widget="radio"/>
-                    <group col="2">
-                        <field name="partner_id" widget="res_partner_many2one" context="{'res_partner_search_mode': 'customer', 'show_vat': True}" invisible="action != 'exist'" required="action == 'exist'"/>
-                    </group>
-                </group>
+                <div name="action" invisible="name != 'convert'" class="row">
+                    <div class="col-3">
+                        <field name="action" nolabel="1" widget="radio"/>
+                    </div>
+                    <div class="col-4">
+                        <div class="row h-50">
+                            <t invisible="lead_partner_name or action != 'create'">
+                                <label for="commercial_partner_id" class="col-3 p-0"/>
+                                <field name="commercial_partner_id" class="col p-0" string="Company" placeholder="Don't link to a company"/>
+                            </t>
+                            <t invisible="not lead_partner_name or not lead_contact_name or action != 'create'">
+                                <label for="lead_partner_name" class="col-3 p-0"/>
+                                <field name="lead_partner_name" class="col p-0" string="Company" placeholder="Don't link to a company"/>
+                            </t>
+                        </div>
+                        <div class="row h-50">
+                            <t invisible="action != 'exist'">
+                                <label for="partner_id" class="col-3 p-0"/>
+                                <field name="partner_id" class="col p-0" widget="res_partner_many2one" 
+                                    context="{'res_partner_search_mode': 'customer', 'show_vat': True}"
+                                    required="action == 'exist'"/>
+                            </t>
+                        </div>
+                    </div>
+                </div>
                 <footer>
                     <button name="action_apply" string="Create Opportunity" type="object" class="btn-primary" data-hotkey="q"/>
                     <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -354,7 +354,7 @@ class ResPartner(models.Model):
         if self.company_name or self.parent_id:
             if not name and self.type in displayed_types:
                 name = type_description[self.type]
-            if not self.is_company:
+            if not self.is_company and not self.env.context.get('partner_display_name_hide_company'):
                 name = f"{self.commercial_company_name or self.sudo().parent_id.name}, {name}"
         return name.strip()
 
@@ -954,7 +954,10 @@ class ResPartner(models.Model):
                 }
 
     @api.depends('complete_name', 'email', 'vat', 'state_id', 'country_id', 'commercial_company_name')
-    @api.depends_context('show_address', 'partner_show_db_id', 'address_inline', 'show_email', 'show_vat', 'lang')
+    @api.depends_context(
+        'show_address', 'partner_display_name_hide_company', 'partner_show_db_id', 'address_inline',
+        'show_email', 'show_vat', 'lang',
+    )
     def _compute_display_name(self):
         for partner in self:
             name = partner.with_context(lang=self.env.lang)._get_complete_name()


### PR DESCRIPTION
### Opportunity quick create functionality
Kanban quick create now lets you pick a "company", which restricts the contacts you can pick to children of that company. If no contact is picked and there's no default partner, then the company itself will be the contact.

To avoid any accidental update of details, company details are not set in the quick create.
If the details are fill in anyway, we consider this is a lead for a new contact of the company for which we don't want a partner. Then only the company name is set.

If a partner is created later on either via setting one from the form view or by sending a message in the chatter, we try to link them to an existing company partner of the same name.

### Opportunity quick create design

We now use icons and placeholders instead of field labels to keep the view compact

### Lead to opportunity conversion wizard

To align with the separation of company and contact in quick create, we allow users to pick a parent company when creating a new contact from the wizard.

task-4568114