### PR TITLE
[FIX] mail: livechat from visitor stays open in mobile

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -8,6 +8,7 @@ import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { ChatBubble } from "./chat_bubble";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class ChatHub extends Component {
     static components = { ChatBubble, ChatWindow, Dropdown };
@@ -44,6 +45,10 @@ export class ChatHub extends Component {
             onDrop: ({ top, left }) =>
                 Object.assign(this.compactPosition, { left: `${left}px`, top: `${top}px` }),
         });
+    }
+
+    get isMobileOS() {
+        return isMobileOS();
     }
 
     onResize() {

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -8,7 +8,7 @@
 }
 
 .o-mail-ChatHub-bubbleBtn {
-    padding: 0;
+    padding: 0 !important;
     border: none !important;
     border-radius: 50%;
     box-shadow: $box-shadow-sm;

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -8,14 +8,14 @@
                 <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
             </t>
         </t>
-        <div t-if="!store.discuss.isActive and !ui.isSmall" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
+        <div class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
                 <t t-if="store.chatHub.compact">
                     <t t-call="mail.ChatHub.compactButton"/>
                 </t>
                 <t t-else="">
                     <Dropdown t-if="chatHub.folded.length gt 1" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
-                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !chatHub.folded.length or !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" aria-label="Chat Hub Options"/>
+                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !chatHub.folded.length or !bubblesHover.isHover and !options.isOpen and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" aria-label="Chat Hub Options"/>
                         <t t-set-slot="content">
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -128,7 +128,7 @@ export class ChatWindow extends Component {
 
     toggleFold() {
         const chatWindow = toRaw(this.props.chatWindow);
-        if (this.ui.isSmall || this.state.actionsMenuOpened) {
+        if (this.state.actionsMenuOpened) {
             return;
         }
         chatWindow.fold();

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -9,7 +9,11 @@ export const threadActionsRegistry = registry.category("mail.thread/actions");
 threadActionsRegistry
     .add("fold-chat-window", {
         condition(component) {
-            return !component.ui.isSmall && component.props.chatWindow;
+            return (
+                component.props.chatWindow &&
+                (component.env.services["im_livechat.livechat"] ||
+                    !component.env.services.ui.isSmall)
+            );
         },
         icon: "fa fa-fw fa-minus",
         name(component) {
@@ -102,6 +106,9 @@ function transformAction(component, id, action) {
         },
         /** Condition to display this action. */
         get condition() {
+            if (action.condition === undefined) {
+                return true;
+            }
             return action.condition(component);
         },
         /** Condition to disable the button of this action (but still display it). */

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -45,15 +45,20 @@ export class Thread extends Record {
     static new() {
         const thread = super.new(...arguments);
         Record.onChange(thread, ["state"], () => {
+            if (
+                thread.state === "folded" ||
+                (thread.state === "open" &&
+                    this.store.env.services.ui.isSmall &&
+                    this.store.env.services["im_livechat.livechat"])
+            ) {
+                const cw = this.store.ChatWindow?.insert({ thread });
+                thread.store.chatHub.folded.delete(cw);
+                thread.store.chatHub.folded.unshift(cw);
+            }
             if (thread.state === "open" && !this.store.env.services.ui.isSmall) {
                 const cw = this.store.ChatWindow?.insert({ thread });
                 thread.store.chatHub.opened.delete(cw);
                 thread.store.chatHub.opened.unshift(cw);
-            }
-            if (thread.state === "folded") {
-                const cw = this.store.ChatWindow?.insert({ thread });
-                thread.store.chatHub.folded.delete(cw);
-                thread.store.chatHub.folded.unshift(cw);
             }
         });
         return thread;

--- a/addons/mail/static/src/discuss/core/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/core/common/composer_patch.js
@@ -3,10 +3,10 @@ import { patch } from "@web/core/utils/patch";
 
 patch(Composer.prototype, {
     get allowUpload() {
-        const thread = this.thread ?? this.message.thread;
+        const thread = this.thread ?? this.message?.thread;
         return (
             super.allowUpload &&
-            (thread.model !== "discuss.channel" ||
+            ((thread && thread.model !== "discuss.channel") ||
                 thread?.allow_public_upload ||
                 this.store.self.isInternalUser)
         );


### PR DESCRIPTION
Before this commit, when using livechat by visitor in mobile, any page reload would remove access to the livechat.

Steps to reproduce:
- access to website with livechat installed on mobile
- click on livechat button (bubble icon in bottom right)
- send a message
- reload the page

=> the livechat is not open, not even as a chat bubble.

This prevents visitor from access the livechat again, except if user finds a workaround to open the same page in non-mobile mode (e.g. landscape mode or disabling high-dpi).

This happens because livechat relies on discuss chat hub, and there's some code to prevent server-side synchronisation of chat windows and bubbles in mobile. As a reminder, conversation in mobile are shown as fullscreen chat windows.
This code was preventing the opening of chat window on livechat for visitor, leading to prevention of continuing to live chat on the device.

This commit fixes by adding fold action to chat windows in mobile specifically for livechat visitors, thus allowing to have chat bubbles in mobile. This fixes allow to show chat windows as bubbles to livechat visitors, which is the primary fix of these changes.

Due to chat windows being server-synced, we made sure to not sync chat windows in the backend. To do so, we rely on presence of livechat service to determine when the chat bubble feature should work in mobile.

opw-4423556
opw-4488830

closes odoo/odoo#194363
