### PR TITLE
[FIX] web: daterange_field: set default value on reset

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker_popover.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker_popover.xml
@@ -6,7 +6,7 @@
                 <button
                     class="btn btn-secondary btn-sm h-100 w-100 w-md-auto d-flex align-items-center justify-content-center gap-1"
                     tabindex="-1"
-                    t-on-click="() => props.pickerProps.range ? props.pickerProps.onSelect([false, false]) : props.pickerProps.onSelect(false)"
+                    t-on-click="() => props.pickerProps.range || props.pickerProps.focusedDateIndex ? props.pickerProps.onSelect([false, false]) : props.pickerProps.onSelect(false)"
                 >
                     <i class="fa fa-eraser" />
                     <span>Clear</span>

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1098,6 +1098,31 @@ test("update the selected input date after removing the existing date", async ()
     expect("input[data-field=date]").toHaveValue("02/12/2017");
 });
 
+test("update the selected input datetime after clearing the existing date", async () => {
+    Partner._fields.date_end = fields.Date({ string: "Date end" });
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="datetime" widget="daterange" options="{'start_date_field': 'date_end'}" />
+            </form>`,
+        resId: 1,
+    });
+    await contains("input[data-field=datetime]").click();
+    await contains(".o_datetime_buttons button.btn-secondary:contains('Clear')").click();
+    expect(".o_time_picker_input").toHaveCount(1);
+
+    await contains(getPickerCell("12")).click();
+    await click(".o_time_picker:eq(0) .o_time_picker_input");
+    await animationFrame();
+    await edit("15:35", { confirm: "enter" });
+    await animationFrame();
+
+    expect("input[data-field=datetime]").toHaveValue("03/12/2019 15:35");
+});
+
 test("daterange with inverted start date and end date", async () => {
     Partner._records[0].datetime_end = "2017-02-01 00:00:00";
 


### PR DESCRIPTION
This bug occured with daterange field with an optional start date.

Even if users only see only one field and ´range´ props value is set to false, this should be considered as a range. It's why we have to send [false, false] if we want to clear it.

The traceback occured because the default value wasn't set in ´getTimeValues´ for the end date (´focusedDateIndex´ = 1).

Steps to reproduce:
- Open project > task
- Select planned date
- Open date range widget
- When clicking on the clear button then select the date  -> Traceback

opw-4714457

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
