### PR TITLE
[IMP] l10n_au: enable integer rounding on bas report

### DIFF
--- a/addons/l10n_au/data/account_tax_report_data.xml
+++ b/addons/l10n_au/data/account_tax_report_data.xml
@@ -6,6 +6,7 @@
         <field name="country_id" ref="base.au"/>
         <field name="filter_fiscal_position" eval="True"/>
         <field name="availability_condition">country</field>
+        <field name="integer_rounding">DOWN</field>
         <field name="column_ids">
             <record id="tax_report_balance" model="account.report.column">
                 <field name="name">Balance</field>


### PR DESCRIPTION
As per the ATO guidelines, the BAS should be rounded down to whole dollars.

task-4734528


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
