### PR TITLE
[IMP] mail: limit visible threads per channel to improve sidebar usability

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -4,6 +4,7 @@ import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { discussSidebarItemsRegistry } from "@mail/core/public_web/discuss_sidebar";
 import { DiscussSidebarChannelActions } from "@mail/discuss/core/public_web/discuss_sidebar_channel_actions";
 import { useHover } from "@mail/utils/common/hooks";
+import { threadCompareRegistry } from "@mail/core/common/thread_compare";
 
 import { Component, useSubEnv } from "@odoo/owl";
 
@@ -134,7 +135,14 @@ export class DiscussSidebarChannel extends Component {
     }
 
     get subChannels() {
-        return this.env.filteredThreads?.(this.thread.sub_channel_ids) ?? [];
+        const sortedThreads = (this.env.filteredThreads?.(this.thread.sub_channel_ids) ?? []).sort(
+            threadCompareRegistry.get("mail.last-interest")
+        );
+        const currentThread = this.store.discuss.thread;
+        if (sortedThreads.findIndex((t) => t.eq(currentThread)) > 4) {
+            return [...sortedThreads.slice(0, 4), currentThread];
+        }
+        return sortedThreads.slice(0, 5);
     }
 
     showThread(sub) {


### PR DESCRIPTION
**Before this PR,**

All threads in a channel were displayed in the sidebar. 
This caused usability issues by pushing other sections like 
channels, chats and live chat out of view when many threads were present.

**After this PR:**

The sidebar shows a maximum of 5 threads per channel, sorted by `last_interest_dt`.
If the currently selected thread is not among the top 5, 
it is shown at the top, followed by the next top 4 threads.

task-[4207854](https://www.odoo.com/odoo/project/1519/tasks/4207854)