### PR TITLE
[IMP] web: add skip_thousands_separator to IntegerField

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -485,7 +485,7 @@
                                     <field name="allow_milestones" column_invisible="True"/>
                                     <field name="display_in_project" column_invisible="True" force_save="1"/>
                                     <field name="sequence" widget="handle"/>
-                                    <field name="id" optional="hide" options="{'enable_formatting': False}"/>
+                                    <field name="id" optional="hide" options="{'skip_thousands_separator': True}"/>
                                     <field name="parent_id" column_invisible="True"/>
                                     <field name="priority" widget="priority" nolabel="1" width="20px"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
@@ -532,7 +532,7 @@
                                     <field name="parent_id" column_invisible="True" />
                                     <field name="subtask_count" column_invisible="True"/>
                                     <field name="closed_subtask_count" column_invisible="True"/>
-                                    <field name="id" optional="hide" options="{'enable_formatting': False}"/>
+                                    <field name="id" optional="hide" options="{'skip_thousands_separator': True}"/>
                                     <field name="priority" widget="priority" nolabel="1" width="20px"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
                                     <field name="name" widget="name_with_subtask_count"/>
@@ -741,7 +741,7 @@
                     <field name="allow_milestones" column_invisible="True"/>
                     <field name="subtask_count" column_invisible="True"/>
                     <field name="closed_subtask_count" column_invisible="True"/>
-                    <field name="id" optional="hide" options="{'enable_formatting': False}"/>
+                    <field name="id" optional="hide" options="{'skip_thousands_separator': True}"/>
                     <field name="priority" widget="priority" nolabel="1" width="20px"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
                     <field name="name" string="Title" widget="name_with_subtask_count"/>

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -230,6 +230,7 @@ formatFloatTime.extractOptions = ({ options }) => {
  * @param {boolean} [options.humanReadable] if true, large numbers are formatted
  *   to a human readable format.
  * @param {boolean} [options.isPassword=false] if returns true, acts like
+ * @param {boolean} [options.skipThousands] if true, disables thousands separator.
  * @param {string} [options.thousandsSep] thousands separator to insert
  * @param {number[]} [options.grouping] array of relative offsets at which to
  * @param {number} [options.decimals] used for humanNumber formmatter
@@ -246,6 +247,9 @@ export function formatInteger(value, options = {}) {
     if (options.humanReadable) {
         return humanNumber(value, options);
     }
+    if (options.skipThousands) {
+        return value.toString();
+    }
     const grouping = options.grouping || l10n.grouping;
     const thousandsSep = "thousandsSep" in options ? options.thousandsSep : l10n.thousandsSep;
     return insertThousandsSep(value.toFixed(0), thousandsSep, grouping);
@@ -254,6 +258,7 @@ formatInteger.extractOptions = ({ attrs, options }) => {
     return {
         decimals: options.decimals || 0,
         humanReadable: !!options.human_readable,
+        skipThousands: !!options.skip_thousands_separator,
         isPassword: exprToBoolean(attrs.password),
     };
 };

--- a/addons/web/static/src/views/fields/integer/integer_field.js
+++ b/addons/web/static/src/views/fields/integer/integer_field.js
@@ -14,6 +14,7 @@ export class IntegerField extends Component {
         ...standardFieldProps,
         formatNumber: { type: Boolean, optional: true },
         humanReadable: { type: Boolean, optional: true },
+        skipThousands: { type: Boolean, optional: true },
         decimals: { type: Number, optional: true },
         inputType: { type: String, optional: true },
         step: { type: Number, optional: true },
@@ -21,6 +22,7 @@ export class IntegerField extends Component {
     };
     static defaultProps = {
         formatNumber: true,
+        skipThousands: false,
         humanReadable: false,
         inputType: "text",
         decimals: 0,
@@ -57,9 +59,10 @@ export class IntegerField extends Component {
             return formatInteger(this.value, {
                 humanReadable: true,
                 decimals: this.props.decimals,
+                skipThousands: this.props.skipThousands,
             });
         } else {
-            return formatInteger(this.value, { humanReadable: false });
+            return formatInteger(this.value, { humanReadable: false, skipThousands: this.props.skipThousands });
         }
     }
 
@@ -104,6 +107,13 @@ export const integerField = {
             default: 0,
             help: _t("Use it with the 'User-friendly format' option to customize the formatting."),
         },
+        {
+            label: _t("Skip thousand separator"),
+            name: "skip_thousands_separator",
+            type: "boolean",
+            help: _t("Disable comma (thousands) formatting while keeping other formatting."),
+            default: false,
+        },
     ],
     supportedTypes: ["integer"],
     isEmpty: (record, fieldName) => record.data[fieldName] === false,
@@ -113,6 +123,7 @@ export const integerField = {
         humanReadable: !!options.human_readable,
         inputType: options.type,
         step: options.step,
+        skipThousands: !!options.skip_thousands_separator,
         placeholder: attrs.placeholder,
         decimals: options.decimals || 0,
     }),

--- a/addons/web/static/tests/views/fields/integer_field.test.js
+++ b/addons/web/static/tests/views/fields/integer_field.test.js
@@ -170,6 +170,20 @@ test("without input type option", async () => {
     expect(".o_field_widget input").toHaveValue("1,234,567,890");
 });
 
+test("with skip_thousands_separator only", async () => {
+    Product._records = [{ id: 1, price: 1234567 }];
+    await mountView({
+        type: "form",
+        resModel: "product",
+        resId: 1,
+        arch: `<form><field name="price" options="{'skip_thousands_separator': true}"/></form>`,
+    });
+
+    expect(".o_field_widget input").toHaveValue("1234567", {
+        message: "Should not format with comma when skipThousands is true.",
+    });
+});
+
 test("is formatted by default", async () => {
     // `localization > grouping` required for this test is [3, 0], which is the default in mock server
     Product._records = [{ id: 1, price: 8069 }];


### PR DESCRIPTION
Steps:
Set enable_formatting to false on an Integer field (ex. ID).
Turn the ID column to be visible in subtask list view.
Add a new record using list view.

Issue:
The ID field displays false till saved.

Reason:
enable_formatting: false was used to remove regional formatting 
 (e.g., thousand separators) for the ID field. But this also disabled all other
formatters, including null value handling, resulting in false value in ID field.

Fix:
Introduced a new option skip_thousands_separator under the IntegerField
formatting logic.When enabled, it disables only the thousands separator 
while preserving other formatting behaviors.

task-4700791
