### PR TITLE
[IMP] sale: add method to fetch default sale order IDs

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -9,6 +9,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
     _name = 'sale.advance.payment.inv'
     _description = "Sales Advance Payment Invoice"
 
+
     advance_payment_method = fields.Selection(
         selection=[
             ('delivered', "Regular invoice"),


### PR DESCRIPTION
in this commit:

- added a  helper function to get sale order ids which can be override in inherited models.

Enterprise PR: https://github.com/odoo/enterprise/pull/83561
