### PR TITLE
[FIX] hr: avoid access error if an assigned employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -237,7 +237,7 @@ class HrEmployeePrivate(models.Model):
         self._check_private_fields(field_names)
         self.flush_recordset(field_names)
         public = self.env['hr.employee.public'].browse(self._ids)
-        public.fetch(field_names)
+        public.sudo().fetch(field_names)
         self._copy_cache_from(public, field_names)
 
     def _check_private_fields(self, field_names):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Avoid access error if an assigned employee is from another company where the user has no access to.

This happens for example if the manager of a linked user in an expense report is from another company and therefore the fields would not be accessible at all. As we access here in this HACK "only" the public employee information we accept the risk of leakage in the cache. In the UI the user will be stopped by clicking on the user which is not in the the list of allowed companies.

**Current behavior before PR:**
Access error to an expense report where the manager to whom we have access has a manager which is from a company the user has no access to.

**Desired behavior after PR is merged:**
Allow such a setting especially it is a very indirect link through a hack of the public employee information.

Info: @wt-io-it

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
