### PR TITLE
[FIX] hw_posbox_homepage: add non-error certificate status

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -95,9 +95,13 @@ export class Homepage extends Component {
             <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
                 <h4 class="text-center m-0">IoT Box - <t t-esc="this.data.hostname" /></h4>
             </div>
-            <div t-if="this.store.advanced" class="alert alert-warning" role="alert">
-                <p class="m-0 fw-bold">HTTPS certificate</p>
-                <small>Error code: <t t-esc="this.data.certificate_details" /></small>
+            <div t-if="this.store.advanced" t-att-class="'alert ' + (this.data.is_certificate_ok === true ? 'alert-info' : 'alert-warning')" role="alert">
+                <p class="m-0 fw-bold">HTTPS Certificate</p>
+                <small>
+                    <t t-if="this.data.is_certificate_ok === true">Status: </t>
+                    <t t-else="">Error Code: </t>
+                    <t t-esc="this.data.certificate_details" />
+                </small>
             </div>
             <SingleData name="'Name'" value="this.data.hostname" icon="'fa-id-card'">
 				<t t-set-slot="button">


### PR DESCRIPTION
This commit is a backport of commit 1f761a3.
The original commit message follows:

Certificate banner in "advanced view" on the homepage could only display an "error" message, even when the message was not an error.
This is not the case anymore.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
