### PR TITLE
[FIX] account: prevent DivisionByZero in average price aggregation

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -162,7 +162,7 @@ class AccountInvoiceReport(models.Model):
         if aggregate_spec != 'price_average:avg':
             return super()._read_group_select(aggregate_spec, query)
         return SQL(
-            'SUM(%(f_price)s) / SUM(%(f_qty)s)',
+            'COALESCE(SUM(%(f_price)s) / NULLIF(SUM(%(f_qty)s), 0.0), 0)',
             f_qty=self._field_to_sql(self._table, 'quantity', query),
             f_price=self._field_to_sql(self._table, 'price_subtotal', query),
         )


### PR DESCRIPTION
Currently, an error occurs when the sum of the quantity is zero, and user analyzes invoice data using the `Average Price` measure.

**Steps to produce:**

- Install the account module.
- Navigate to `Invoicing > Customers > Invoices > New`.
- Add required fields and set `quantity to zero` and confirm the invoice.
- Navigate to `Reporting > Invoice Analysis`, Switch to `Graph or Pivot view` and set measure to Average Price.

**Error:**
`DivisionByZero: division by zero`

**Root Cause:**
At [1], the `_read_group_select` method for computing average price, divides the sum of price_subtotal by the sum of quantity. If sum of the quantity is zero, it leads to a division by zero error.

[1] https://github.com/odoo/odoo/blob/97c2381aaeb1cca56288a1cca3c8359ea712ab6e/addons/account/report/account_invoice_report.py#L165

This commit ensures that the average price calculation safely returns 0 when the total quantity is zero.

Sentry - 6358566076