### PR TITLE
[FIX] l10n_it_edi: correct error message format

### DIFF
--- a/addons/l10n_it_edi/i18n/it.po
+++ b/addons/l10n_it_edi/i18n/it.po
@@ -116,7 +116,7 @@ msgid ""
 "(%(code)s) %(message)s"
 msgstr ""
 "Si è verificato un errore duranto il download degli aggiornamenti dal server "
-"proxy:"
+"proxy: (%(code)s) %(message)s"
 
 #. module: l10n_it_edi
 #. odoo-python


### PR DESCRIPTION
This fix just add the error code and error message for IT language.

Ref: odoo/odoo#184156
Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4728595)
opw-4728595