### PR TITLE
[FIX] website_sale: fix shop redirects test

### DIFF
--- a/addons/website_sale/tests/test_website_sale_shop_redirects.py
+++ b/addons/website_sale/tests/test_website_sale_shop_redirects.py
@@ -13,7 +13,9 @@ class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
         category_a = self.env['product.public.category'].create({'name': "Category A"})
         category_b = self.env['product.public.category'].create({'name': "Category B"})
         test_product = self.env['product.template'].create({
-            'name': "Test product", 'public_categ_ids': [Command.link(category_a.id)]
+            'name': "Test product",
+            'public_categ_ids': [Command.link(category_a.id)],
+            'website_published': True,
         })
         slug = self.env['ir.http']._slug
 


### PR DESCRIPTION
Incorrect test setup: the test product wasn't published. As a result, the test would pass when run with an internal user but not when run with a public user.

See https://runbot.odoo.com/odoo/runbot.build.error/163440