### PR TITLE
[FIX] hr_fleet: correctly update `work_contact_id`

### DIFF
--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
@@ -23,7 +22,7 @@ class Employee(models.Model):
             "type": "ir.actions.act_window",
             "res_model": "fleet.vehicle.assignation.log",
             "views": [[self.env.ref("hr_fleet.fleet_vehicle_assignation_log_employee_view_list").id, "tree"], [False, "form"]],
-            "domain": [("driver_employee_id", "in", self.ids)],
+            "domain": [("driver_employee_id", "in", self.ids), ("driver_id", "in", self.work_contact_id.ids)],
             "context": dict(self._context, default_driver_id=self.user_id.partner_id.id, default_driver_employee_id=self.id),
             "name": "History Employee Cars",
         }
@@ -32,7 +31,7 @@ class Employee(models.Model):
     def _compute_license_plate(self):
         for employee in self:
             if employee.private_car_plate and employee.car_ids.license_plate:
-                employee.license_plate = ' '.join([employee.car_ids.license_plate, employee.private_car_plate])
+                employee.license_plate = f'{employee.car_ids.license_plate} {employee.private_car_plate}'
             else:
                 employee.license_plate = employee.car_ids.license_plate or employee.private_car_plate
 
@@ -42,7 +41,7 @@ class Employee(models.Model):
 
     def _compute_employee_cars_count(self):
         rg = self.env['fleet.vehicle.assignation.log']._read_group([
-            ('driver_employee_id', 'in', self.ids),
+            ('driver_employee_id', 'in', self.ids), ('driver_id', 'in', self.work_contact_id.ids),
         ], ['driver_employee_id'], ['__count'])
         cars_count = {driver_employee.id: count for driver_employee, count in rg}
         for employee in self:
@@ -59,31 +58,27 @@ class Employee(models.Model):
             raise ValidationError(_('Cannot remove address from employees with linked cars.'))
 
     def write(self, vals):
-        if 'user_id' in vals:
-            self._sync_employee_cars(self.env['res.users'].browse(vals['user_id']))
         res = super().write(vals)
-        #Update car partner when it is changed on the employee
+        # Update car partner when it is changed on the employee
         if 'work_contact_id' in vals:
             car_ids = self.env['fleet.vehicle'].sudo().search([
-                ('driver_employee_id', 'in', self.ids),
-                ('driver_id', 'in', self.mapped('work_contact_id').ids),
+                '|',
+                    ('driver_employee_id', 'in', self.ids),
+                    ('future_driver_employee_id', 'in', self.ids),
             ])
             if car_ids:
-                car_ids.write({'driver_id': vals['work_contact_id']})
+                car_ids.filtered(lambda c: c.driver_employee_id.id in self.ids).write({
+                    'driver_id': vals['work_contact_id'],
+                })
+                car_ids.filtered(lambda c: c.future_driver_employee_id.id in self.ids).write({
+                    'future_driver_id': vals['work_contact_id'],
+                })
         if 'mobility_card' in vals:
-            #NOTE: keeping it as a search on driver_id but we might be able to use driver_employee_id in the future
-            vehicles = self.env['fleet.vehicle'].search([('driver_id', 'in', (self.user_id.partner_id | self.sudo().work_contact_id).ids)])
-            vehicles._compute_mobility_card()
+            car_ids = self.env['fleet.vehicle'].sudo().search([
+                ('driver_employee_id', 'in', self.ids),
+            ])
+            car_ids._compute_mobility_card()
         return res
-
-    def _sync_employee_cars(self, user):
-        if self.work_contact_id and self.work_contact_id != user.partner_id:
-            cars = self.env['fleet.vehicle'].search(['|', ('future_driver_id', '=', self.work_contact_id.id), ('driver_id', '=', self.work_contact_id.id), ('company_id', '=', self.company_id.id)])
-            for car in cars:
-                if car.future_driver_id == self.work_contact_id:
-                    car.future_driver_id = user.partner_id
-                if car.driver_id == self.work_contact_id:
-                    car.driver_id = user.partner_id
 
 
 class EmployeePublic(models.Model):


### PR DESCRIPTION
ISSUE: When you remove the user from an employee
all the linked vehicles are removed as `work_contact_id` is written by the new value before updating the fleet model

REPRODUCE:
- create a vehicle and link it an employee with user
- remove the user from the employee
- employee and driver is removed from the vehicle

As the issue of persistent 'work_contact_id' on employee has been fixed, all the updates are made auto and these extra code interduce the wrong behavior

Task: 4680261

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
