### PR TITLE
[IMP] account: Ease receipt UI/UX

### DIFF
--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -38,6 +38,7 @@ from . import digest
 from . import res_users
 from . import ir_attachment
 from . import ir_actions_report
+from . import ir_http
 from . import ir_module
 from . import mail_message
 from . import mail_template

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5748,6 +5748,9 @@ class AccountMove(models.Model):
     def is_entry(self):
         return self.move_type == 'entry'
 
+    def is_receipt(self):
+        return self.move_type in ['out_receipt', 'in_receipt']
+
     @api.model
     def get_sale_types(self, include_receipts=False):
         return ['out_invoice', 'out_refund'] + (include_receipts and ['out_receipt'] or [])

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -886,18 +886,24 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
 
         company_domain = self.env['account.tax']._check_company_domain(self.move_id.company_id)
-        if self.move_id.is_sale_document(include_receipts=True):
-            # Out invoice.
-            filtered_taxes_id = self.product_id.taxes_id.filtered_domain(company_domain)
-            tax_ids = filtered_taxes_id or self.account_id.tax_ids.filtered(lambda tax: tax.type_tax_use == 'sale')
+        tax_ids = self.env['account.tax']
 
-        elif self.move_id.is_purchase_document(include_receipts=True):
-            # In invoice.
-            filtered_supplier_taxes_id = self.product_id.supplier_taxes_id.filtered_domain(company_domain)
-            tax_ids = filtered_supplier_taxes_id or self.account_id.tax_ids.filtered(lambda tax: tax.type_tax_use == 'purchase')
+        if self.move_id.is_receipt():
+            tax_ids = self.company_id.account_purchase_receipt_tax_id if self.move_id.move_type == 'in_receipt' else self.company_id.account_sale_receipt_tax_id
 
-        else:
-            tax_ids = False if self.env.context.get('skip_computed_taxes') or self.move_id.is_entry() else self.account_id.tax_ids
+        if not tax_ids:
+            if self.move_id.is_sale_document(include_receipts=True):
+                # Out invoice.
+                filtered_taxes_id = self.product_id.taxes_id.filtered_domain(company_domain)
+                tax_ids = filtered_taxes_id or self.account_id.tax_ids.filtered(lambda tax: tax.type_tax_use == 'sale')
+
+            elif self.move_id.is_purchase_document(include_receipts=True):
+                # In invoice.
+                filtered_supplier_taxes_id = self.product_id.supplier_taxes_id.filtered_domain(company_domain)
+                tax_ids = filtered_supplier_taxes_id or self.account_id.tax_ids.filtered(lambda tax: tax.type_tax_use == 'purchase')
+
+            else:
+                tax_ids = False if self.env.context.get('skip_computed_taxes') or self.move_id.is_entry() else self.account_id.tax_ids
 
         if self.company_id and tax_ids:
             tax_ids = tax_ids._filter_taxes_by_company(self.company_id)

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -122,6 +122,8 @@ class ResCompany(models.Model):
     transfer_account_code_prefix = fields.Char(string='Prefix of the transfer accounts')
     account_sale_tax_id = fields.Many2one('account.tax', string="Default Sale Tax", check_company=True)
     account_purchase_tax_id = fields.Many2one('account.tax', string="Default Purchase Tax", check_company=True)
+    account_sale_receipt_tax_id = fields.Many2one('account.tax', string="Default Sale Receipt Tax", check_company=True)
+    account_purchase_receipt_tax_id = fields.Many2one('account.tax', string="Default Purchase Receipt Tax", check_company=True)
     tax_calculation_rounding_method = fields.Selection([
         ('round_per_line', 'Round per Line'),
         ('round_globally', 'Round Globally'),

--- a/addons/account/models/ir_http.py
+++ b/addons/account/models/ir_http.py
@@ -1,0 +1,11 @@
+from odoo import api, models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @api.model
+    def lazy_session_info(self):
+        res = super().lazy_session_info()
+        res['show_sale_receipts'] = self.env['ir.config_parameter'].sudo().get_param('account.show_sale_receipts')
+        return res

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -78,10 +78,7 @@ class ResConfigSettings(models.TransientModel):
         help="Intermediary account used when moving from a liquidity account to another.")
     module_account_accountant = fields.Boolean(string='Accounting')
     group_cash_rounding = fields.Boolean(string="Cash Rounding", implied_group='account.group_cash_rounding')
-    group_show_sale_receipts = fields.Boolean(string='Sale Receipt',
-        implied_group='account.group_sale_receipts')
-    group_show_purchase_receipts = fields.Boolean(string='Purchase Receipt',
-        implied_group='account.group_purchase_receipts')
+    show_sale_receipts = fields.Boolean(string='Sale Receipt', config_parameter='account.show_sale_receipts')
     module_account_budget = fields.Boolean(string='Budget Management')
     module_account_payment = fields.Boolean(string='Invoice Online Payment')
     module_account_reports = fields.Boolean("Dynamic Reports")

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -87,13 +87,6 @@
         <field name="name">Allow the cash rounding management</field>
     </record>
 
-    <record id="group_sale_receipts" model="res.groups">
-        <field name="name">Sale Receipt</field>
-    </record>
-    <record id="group_purchase_receipts" model="res.groups">
-        <field name="name">Purchase Receipt</field>
-    </record>
-
     <!-- Add a new setting that can be enabled to allow the user to "trust" a partner bank account -->
     <record model="res.groups.privilege" id="res_group_privilege_accounting_bank">
         <field name="name">Bank</field>

--- a/addons/account/static/src/components/receipt_selector/receipt_selector.js
+++ b/addons/account/static/src/components/receipt_selector/receipt_selector.js
@@ -1,0 +1,93 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { radioField, RadioField } from "@web/views/fields/radio/radio_field";
+import { onWillStart, useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { deepCopy } from "@web/core/utils/objects";
+
+
+const labels = {
+    'in_invoice': _t("Bill"),
+    'out_invoice': _t("Invoice"),
+    'in_receipt': _t("Receipt"),
+    'out_receipt': _t("Receipt"),
+};
+
+const in_move_types = ['in_invoice', 'in_receipt']
+const out_move_types = ['out_invoice', 'out_receipt']
+
+
+export class ReceiptSelector extends RadioField {
+    static template = "account.ReceiptSelector";
+    static props = {
+        ...RadioField.props,
+    };
+
+    setup() {
+        super.setup();
+        this.lazySession = useService("lazy_session");
+        this.show_sale_receipts = useState({ value: false });
+        onWillStart(()=> {
+            this.lazySession.getValue("show_sale_receipts", (show_sale_receipts) => {
+                this.show_sale_receipts.value = show_sale_receipts;
+            })
+        });
+    }
+
+    /**
+     * Remove the unwanted options and update the English labels
+     * @override
+     */
+    get items() {
+        const original_items = super.items;
+        if ( this.type !== 'selection' ) {
+            return original_items;
+        }
+
+        // Use a copy to avoid updating the original selection labels
+        let items = deepCopy(original_items)
+
+        let allowedValues = [];
+        if ( in_move_types.includes(this.value) ) {
+            allowedValues = in_move_types
+        } else if (out_move_types.includes(this.value) && this.show_sale_receipts.value ) {
+            allowedValues = out_move_types
+        }
+
+        if ( allowedValues.length > 1 ) {
+            // Filter only the wanted items
+            items = items.filter((item) => {
+                return (allowedValues.includes(item[0]));
+            });
+
+            // Update the label of the wanted items
+            items.forEach((item) => {
+                if (item[0] in labels) {
+                    item[1] = labels[item[0]];
+                }
+            });
+        }
+        return items;
+    }
+
+    get string() {
+        if ( this.type === 'selection' ) {
+            // Use the original labels and not the modified ones
+            return this.value !== false
+                ? this.props.record.fields[this.props.name].selection.find((i) => i[0] === this.value)[1]
+                : "";
+        }
+        return "";
+    }
+}
+
+export const receiptSelector = {
+    ...radioField,
+    additionalClasses: ['o_field_radio'],
+    component: ReceiptSelector,
+    extractProps() {
+        return radioField.extractProps(...arguments);
+    },
+};
+
+registry.category("fields").add("receipt_selector", receiptSelector);

--- a/addons/account/static/src/components/receipt_selector/receipt_selector.xml
+++ b/addons/account/static/src/components/receipt_selector/receipt_selector.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="account.ReceiptSelector">
+        <div>
+            <t t-if="props.readonly || (!show_sale_receipts.value and ['out_invoice', 'out_receipt'].includes(value))">
+                <span t-esc="string" t-att-raw-value="value" />
+            </t>
+            <t t-else="">
+                <t t-call="web.RadioField"/>
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -10,7 +10,6 @@
         <menuitem id="menu_finance_receivables" name="Customers" sequence="2">
             <menuitem id="menu_action_move_out_invoice_type" action="action_move_out_invoice" sequence="1"/>
             <menuitem id="menu_action_move_out_refund_type" action="action_move_out_refund_type_non_legacy" sequence="2"/>
-            <menuitem id="menu_action_move_out_receipt_type" action="action_move_out_receipt_type" groups="account.group_sale_receipts" sequence="3"/>
             <menuitem id="menu_action_account_payments_receivable" name="Payments" action="action_account_payments" sequence="15"/>
             <menuitem id="product_product_menu_sellable" name="Products" action="product_product_action_sellable" sequence="100"/>
             <menuitem id="menu_account_customer" name="Customers" action="res_partner_action_customer" sequence="110"/>
@@ -18,7 +17,6 @@
         <menuitem id="menu_finance_payables" name="Vendors" sequence="3">
             <menuitem id="menu_action_move_in_invoice_type" action="action_move_in_invoice" sequence="1"/>
             <menuitem id="menu_action_move_in_refund_type" action="action_move_in_refund_type" sequence="2"/>
-            <menuitem id="menu_action_move_in_receipt_type" action="action_move_in_receipt_type" groups="account.group_purchase_receipts" sequence="3"/>
             <menuitem id="menu_action_account_payments_payable" name="Payments" action="action_account_payments_payable" sequence="20"/>
             <menuitem id="product_product_menu_purchasable" name="Products" action="product_product_action_purchasable" sequence="100"/>
             <menuitem id="menu_account_supplier" name="Vendors" action="account.res_partner_action_supplier" sequence="200"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -653,18 +653,6 @@
             </field>
         </record>
 
-        <record id="view_in_invoice_receipt_tree" model="ir.ui.view">
-            <field name="name">account.out.invoice.list</field>
-            <field name="model">account.move</field>
-            <field name="inherit_id" ref="account.view_in_invoice_tree"/>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <field name="currency_id" position="attributes">
-                    <attribute name="string">Receipt Currency</attribute>
-                </field>
-            </field>
-        </record>
-
         <record id="view_account_move_kanban" model="ir.ui.view">
             <field name="name">account.move.kanban</field>
             <field name="model">account.move</field>
@@ -977,7 +965,16 @@
                         <field name="show_update_fpos" invisible="1"/>
 
                         <div class="oe_title">
-                            <span class="o_form_label"><field name="move_type" readonly="1" invisible="move_type == 'entry'" nolabel="1"/></span>
+                            <span class="o_form_label">
+                                <field 
+                                    name="move_type"
+                                    invisible="move_type == 'entry'"
+                                    widget="receipt_selector"
+                                    options="{'horizontal': true}"
+                                    nolabel="1"
+                                    readonly="state != 'draft'"
+                                />
+                            </span>
 
                             <div class="text-warning" invisible="not show_name_warning">The current highest number is <field class="oe_inline" name="highest_name"/>. You might want to put a higher number here.</div>
 
@@ -1023,7 +1020,7 @@
                                 <label for="ref" string="Bill Reference"
                                        invisible="move_type not in ('in_invoice', 'in_receipt', 'in_refund')" />
                                 <field name="ref" default_focus="1" nolabel="1" invisible="move_type not in ('in_invoice', 'in_receipt', 'in_refund')"/>
-                                <field name="ref" default_focus="1" invisible="move_type in ('in_invoice', 'in_receipt', 'in_refund', 'out_invoice', 'out_refund')"/>
+                                <field name="ref" default_focus="1" invisible="move_type != 'entry'"/>
                                 <field name="tax_cash_basis_origin_move_id" invisible="not tax_cash_basis_origin_move_id"/>
                                 <label name="invoice_vendor_bill_id_label" for="invoice_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
                                        invisible="state != 'draft' or move_type != 'in_invoice'"/>
@@ -1050,7 +1047,7 @@
                                        invisible="move_type in ('out_invoice', 'out_refund', 'out_receipt') and not quick_edit_mode and not (state == 'posted' and date != invoice_date)"
                                        readonly="state != 'draft'"/>
                                 <field name="payment_reference"
-                                       invisible="move_type not in ('in_invoice', 'in_refund', 'out_receipt', 'in_receipt')"
+                                       invisible="move_type not in ('in_invoice', 'in_refund', 'in_receipt')"
                                        readonly="inalterable_hash != False"
                                        placeholder="Use Bill Reference"/>
                                 <field name="partner_bank_id"
@@ -1645,6 +1642,10 @@
                             string="Invoices"
                             domain="[('move_type', '=', 'out_invoice')]"
                     />
+                    <filter name="out_receipt"
+                            string="Receipts"
+                            domain="[('move_type', '=', 'out_receipt')]"
+                    />
                     <filter name="out_refund"
                             string="Credit Notes"
                             domain="[('move_type', '=', 'out_refund')]"
@@ -1719,6 +1720,12 @@
                     <filter name="in_invoice"
                             string="Bills"
                             domain="[('move_type', '=', 'in_invoice')]"
+                    />
+                </filter>
+                <filter name="out_receipt" position="replace">
+                    <filter name="in_receipt"
+                            string="Receipt"
+                            domain="[('move_type', '=', 'in_receipt')]"
                     />
                 </filter>
                 <filter name="out_refund" position="replace">
@@ -1897,7 +1904,7 @@
             <field name="view_mode">list,kanban,form,activity</field>
             <field name="view_id" ref="view_out_invoice_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
-            <field name="domain">[('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
+            <field name="domain">[('move_type', 'in', ['out_invoice', 'out_refund', 'out_receipt'])]</field>
             <field name="context">{'default_move_type': 'out_invoice'}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
@@ -1916,7 +1923,7 @@
             <field name="view_mode">list,kanban,form,activity</field>
             <field name="view_id" ref="view_out_invoice_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
-            <field name="domain">[('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
+            <field name="domain">[('move_type', 'in', ['out_invoice', 'out_refund', 'out_receipt'])]</field>
             <field name="context">{'search_default_out_invoice': 1, 'default_move_type': 'out_invoice'}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
@@ -1953,7 +1960,7 @@
             <field name="view_mode">list,kanban,form,activity</field>
             <field name="view_id" ref="view_in_invoice_bill_tree"/>
             <field name="search_view_id" ref="view_account_bill_filter"/>
-            <field name="domain">[('move_type', 'in', ['in_invoice', 'in_refund'])]</field>
+            <field name="domain">[('move_type', 'in', ['in_invoice', 'in_refund', 'in_receipt'])]</field>
             <field name="context">{'default_move_type': 'in_invoice', 'display_account_trust': True}</field>
             <field name="help" type="html">
                 <!-- An owl component should be displayed instead -->
@@ -1973,7 +1980,7 @@
             <field name="view_mode">list,kanban,form,activity</field>
             <field name="view_id" ref="view_in_invoice_bill_tree"/>
             <field name="search_view_id" ref="view_account_bill_filter"/>
-            <field name="domain">[('move_type', 'in', ['in_invoice', 'in_refund'])]</field>
+            <field name="domain">[('move_type', 'in', ['in_invoice', 'in_refund', 'in_receipt'])]</field>
             <field name="context">{'search_default_in_invoice': 1, 'default_move_type': 'in_invoice', 'display_account_trust': True}</field>
             <field name="help" type="html">
                 <!-- An owl component should be displayed instead -->
@@ -2016,44 +2023,6 @@
                 </p><p>
                     Cool, it looks like you don't have any amount to settle.
                 </p>
-            </field>
-        </record>
-
-        <record id="action_move_out_receipt_type" model="ir.actions.act_window">
-            <field name="name">Receipts</field>
-            <field name="res_model">account.move</field>
-            <field name="path">customer-receipts</field>
-            <field name="view_mode">list,kanban,form,activity</field>
-            <field name="view_id" ref="view_invoice_tree"/>
-            <field name="search_view_id" ref="view_account_invoice_filter"/>
-            <field name="domain">[('move_type', '=', 'out_receipt')]</field>
-            <field name="context">{'default_move_type': 'out_receipt'}</field>
-            <field name="help" type="html">
-              <p class="o_view_nocontent_smiling_face">
-                Create a new sales receipt
-              </p><p>
-                When the sale receipt is confirmed, you can record the customer
-                payment related to this sales receipt.
-              </p>
-            </field>
-        </record>
-
-        <record id="action_move_in_receipt_type" model="ir.actions.act_window">
-            <field name="name">Receipts</field>
-            <field name="res_model">account.move</field>
-            <field name="path">vendor-receipts</field>
-            <field name="view_mode">list,kanban,form,activity</field>
-            <field name="view_id" ref="view_in_invoice_receipt_tree"/>
-            <field name="search_view_id" ref="view_account_invoice_filter"/>
-            <field name="domain">[('move_type', '=', 'in_receipt')]</field>
-            <field name="context">{'default_move_type': 'in_receipt', 'display_account_trust': True}</field>
-            <field name="help" type="html">
-              <p class="o_view_nocontent_smiling_face">
-                Register a new purchase receipt
-              </p><p>
-                When the purchase receipt is confirmed, you can record the
-                vendor payment related to this purchase receipt.
-              </p>
             </field>
         </record>
 

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -136,7 +136,7 @@
                                 <field name="incoterm_id"/>
                             </setting>
                             <setting id="show_sale_receipts" help="Activate to create sale receipt">
-                                <field name="group_show_sale_receipts"/>
+                                <field name="show_sale_receipts"/>
                             </setting>
                             <setting id="use_invoice_terms" company_dependent="1" help="Add your terms &amp; conditions at the bottom of invoices/orders/quotations">
                                 <field name="use_invoice_terms"/>
@@ -224,9 +224,6 @@
                             </setting>
                         </block>
                         <block title="Vendor Bills" id="account_vendor_bills">
-                            <setting id="show_purchase_receipts" help="Activate to create purchase receipt">
-                                <field name="group_show_purchase_receipts"/>
-                            </setting>
                             <setting id="autopost_bills" help="Propose to validate bills automatically when AI accuracy is right 3 times in a row for a vendor.">
                                 <field name="autopost_bills"/>
                             </setting>

--- a/addons/l10n_be/models/template_be.py
+++ b/addons/l10n_be/models/template_be.py
@@ -33,6 +33,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_journal_early_pay_discount_gain_account_id': 'a757000',
                 'account_sale_tax_id': 'attn_VAT-OUT-21-L',
                 'account_purchase_tax_id': 'attn_VAT-IN-V81-21',
+                'account_purchase_receipt_tax_id': 'attn_VAT-IN-V82-00-S',
                 'default_cash_difference_income_account_id': 'a757100',
                 'default_cash_difference_expense_account_id': 'a657100',
                 'transfer_account_id': 'a58',


### PR DESCRIPTION
Problem
---------
Currently, receipts are well implemented but highly hidden in the depth of Odoo. Users are required to activate the option to see and create receipts.

Objective
---------
Make it easier for users to create and use receipts.

Solution
---------
- Create a new JS widget that mixes the `dynamic_selection` and the radio widgets to only display possible move types on the move form:
    - From `in_invoice` to `in_receipt` and inversely;
    - From `out_invoice` to `out_receipt` and inversely.
And another `receipt_selector`, that is based on the aforementioned component which dynamically re-label selection values for English only; and remove the old views as those are not necessary anymore.
- Add filters to the list view to easily retrieve the receipts.
- Remove the two different security groups; receipts are now always
available.
- Add company default receipt taxes that will be used by default on sale receipts (over product and account default taxes) to, once again, ease the user experience. This default tax is not available from the UI because we don't want to cumbersome the settings any more; instead, it shall be set up in the localization company templates.
For purchase receipts, we introduce a banner that is shown when the bill contains taxes. The reason is that most country don't allow tax deduction for bill receipts. To emphasis this behavior, when switching from bill to receipts, all default taxes are removed.

task-4677472

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
