### PR TITLE
[FIX] website_mass_mailing: deconstructing error

### DIFF
--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
@@ -21,8 +21,7 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
         this.rpc = this.bindService("rpc");
         this.notification = this.bindService("notification");
         if (session.turnstile_site_key) {
-            const { turnStile } = odoo.loader.modules.get('@website_cf_turnstile/js/turnstile');
-            this._turnstile = turnStile;
+            this._turnstile = odoo.loader.modules.get('@website_cf_turnstile/js/turnstile')?.turnStile;
         }
     },
     /**


### PR DESCRIPTION
When Turnstile was not installed, JS would try to deconstruct an undefined value, resulting in an error.

Introduced in: https://github.com/odoo/odoo/pull/200158/files :see_no_evil: 

opw-4625786
