### PR TITLE
[FIX] web, website: fix popup expiration delay

### DIFF
--- a/addons/web/static/src/core/browser/cookie.js
+++ b/addons/web/static/src/core/browser/cookie.js
@@ -30,7 +30,7 @@ export const cookie = {
         if (value !== undefined) {
             fullCookie.push(`${key}=${value}`);
         }
-        fullCookie = fullCookie.concat(["path=/", `max-age=${ttl}`]);
+        fullCookie = fullCookie.concat(["path=/", `max-age=${Math.floor(ttl)}`]);
         this._cookieMonster = fullCookie.join("; ");
     },
     delete(key) {


### PR DESCRIPTION
Steps to reproduce the issue:

- Add a popup with a 0.0001 days config.
- Visit the page as a non-connected user.
- The popup opens at some point.
- Close the popup.
- Wait 10 seconds.
- Refresh the page ---> The popup never reappears.

This issue comes from the fact that we were setting a non-integer value for the cookie expiration. The "max-age" attribute does not accept float values, so the cookie is treated as a "session" cookie. It only expires when the session ends, which can be effectively "never" on some browsers that keep sessions open indefinitely.

This used to work before commit [1] because we were also setting an "expires" attribute. When the "max-age" attribute was invalid, the browser would fallback to the "expires" attribute. Since that commit removed the "expires" attribute, the only remaining value (max-age) is invalid, and the popup never reappears as expected.

This fix ensures the value used in "max-age" is always an integer, avoiding any invalid cookie behavior.

[1]: https://github.com/odoo/odoo/commit/006ee1fc470eabdcbde68077259cf543633d6490

task-4690318
