### PR TITLE
[FIX] orm: Fix LRU size with unlimited memory soft.

### DIFF
--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -101,7 +101,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
                 # A registry takes 10MB of memory on average, so we reserve
                 # 10Mb (registry) + 5Mb (working memory) per registry
                 avgsz = 15 * 1024 * 1024
-                size = int(config['limit_memory_soft'] / avgsz)
+                limit_memory_soft = config['limit_memory_soft'] if config['limit_memory_soft'] > 0 else (2048 * 1024 * 1024)
+                size = (limit_memory_soft // avgsz) or 1
         return LRU(size)
 
     def __new__(cls, db_name: str):


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/205866, we added a assert to in the LRU class to force size to be bigger than 0 (instead of max with 1).

Sadly, the LRU of registries is computed depending of `limit-memory-soft` config that may be set to 0 to force unlimited memory. Because of that server cannot be launched anymore with 0 as `limit-memory-soft` (or with a very small number).

Fall back to the default value of `limit_memory_soft` in that case.

