### PR TITLE
[FIX] project: prevent project users from creating stages in list view

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -687,7 +687,8 @@
                     <field name="date_deadline" optional="hide" widget="remaining_days" invisible="state in ['1_done', '1_canceled']"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
                     <field name="date_last_stage_update" optional="hide"/>
-                    <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show"/>
+                    <field name="stage_id" column_invisible="context.get('set_visible', False)" context="{'default_project_id': project_id}" groups="project.group_project_manager" optional="show"/>
+                    <field name="stage_id" column_invisible="context.get('set_visible', False)" groups="!project.group_project_manager" options="{'no_create': True}" optional="show"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Steps to reproduce:
- Go to a project
- Open the task list view
- Select a task
- In the `Stage` field, attempt to create a new stage

Issue:
- Project users were able to create new task stages from the task list view, despite not having the required permissions.

Cause:
- The `_default_user_id` method assigns the current user as the owner `user_id` of a new stage only when `default_project_id` is not present in the context. As a result, the method returned the current user’s ID, unintentionally making them the owner of the stage. This allowed project users to bypass the intended access rules and create new stages.

Solution:
- Use the `no_create` option for users outside the project manager group to prevent them from creating new stages.
- Updated the `stage_id` field in the task list view to explicitly include `default_project_id` in the context, ensuring proper access control of that stage.

task-4628666

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
