### PR TITLE
[FIX] discuss: faster SFU fallback if no TURN server

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1061,7 +1061,7 @@ export class Rtc extends Record {
                     return;
                 }
                 this._p2pRecoveryCount++;
-                if (this._p2pRecoveryCount > 1) {
+                if (this._p2pRecoveryCount > 1 || !hasTurn(this.iceServers)) {
                     this.upgradeConnectionDebounce();
                 }
             }


### PR DESCRIPTION
Before this commit, falling back to the SFU in case of p2p connection issue would take 2 recovery cycles (±10s), which can be a bit long. This commit makes the fallback happen faster if the client does not have TURN servers, which indicates that the connection is unlikely to be recoverable if it failed.


