### PR TITLE
[FIX] web: Chrome 135 adjust some rounding in rendering engine

### DIFF
--- a/addons/web/static/tests/legacy/core/utils/sortable_tests.js
+++ b/addons/web/static/tests/legacy/core/utils/sortable_tests.js
@@ -55,9 +55,9 @@ QUnit.module("Draggable", ({ beforeEach }) => {
 
         const scrollParentX = target.querySelector(".root");
         const scrollParentY = target.querySelector(".scroll_parent_y");
-        const assertScrolling = (top, left) => {
-            assert.strictEqual(scrollParentY.scrollTop, top);
-            assert.strictEqual(scrollParentX.scrollLeft, left);
+        const assertScrolling = (top, left, tolerance=1) => {
+            assert.ok(Math.abs(scrollParentY.scrollTop - top) <= tolerance, `${scrollParentY.scrollTop} and ${top} should be almost equal`);
+            assert.ok(Math.abs(scrollParentX.scrollLeft - left) <= tolerance, `${scrollParentX.scrollLeft} and ${left} should be almost equal`);
         };
         const cancelDrag = async (cancel) => {
             await cancel();


### PR DESCRIPTION
This commit slightly adapts a Sortable test to accommodate adjustments made in Chrome 135 to some rounding done during painting.

References (not exhaustive):
- https://chromium.googlesource.com/chromium/src.git/+/a629cc4312019dfa43b686bdb2d9418a625f9bc6
- https://chromium.googlesource.com/chromium/src.git/+/2efdf2a6f8e184ece09acca4677d1ce9eb7a43ea
- https://chromium.googlesource.com/chromium/src.git/+/ce7a5f6b60b175c780fb39e2f751d82abb8b011b

