### PR TITLE
[FIX] pos_self_order: wait till product loads before clicking on attribute

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -56,6 +56,7 @@ registry.category("web_tour.tours").add("self_multi_attribute_selector", {
 registry.category("web_tour.tours").add("selfAlwaysAttributeVariants", {
     steps: () => [
         Utils.clickBtn("Order Now"),
+        ProductPage.waitProduct("Chair"),
         ProductPage.clickProduct("Chair"),
         ...ProductPage.setupAttribute([{ name: "Color", value: "White" }]),
         Utils.clickBtn("Order"),

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -6,6 +6,13 @@ export function clickProduct(productName) {
     };
 }
 
+export function waitProduct(productName) {
+    return {
+        content: `Wait for product '${productName}'`,
+        trigger: `.self_order_product_card span:contains('${productName}')`,
+    };
+}
+
 export function checkReferenceNotInProductName(productName, reference) {
     return {
         content: `Check product label has '${productName}' and not ${reference}`,

--- a/addons/pos_self_order/tests/test_self_order_attribute.py
+++ b/addons/pos_self_order/tests/test_self_order_attribute.py
@@ -85,6 +85,10 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
         pos_categ_chairs = self.env['pos.category'].create({
             'name': 'Chairs',
         })
+        self.pos_config.write({
+            'iface_available_categ_ids': [(4, pos_categ_chairs.id)]
+        })
+
         color_attribute = self.env['product.attribute'].create({
             'name': 'Color',
             'create_variant': 'always',


### PR DESCRIPTION

since the product page is loaded asynchronously, we need to wait for the product page to be loaded before clicking on the attribute this is to avoid the issue where the attribute is not clickable and the test fails

![image](https://github.com/user-attachments/assets/9097821b-aa2d-4cd0-9201-02c397a4aa1a)

as you can see in the screenshot products are not loaded yet !

build_error-163168