### PR TITLE
[FIX] test_website_modules: make test consider shape on default image

### DIFF
--- a/addons/test_website_modules/tests/test_controllers.py
+++ b/addons/test_website_modules/tests/test_controllers.py
@@ -12,15 +12,29 @@ from odoo.tools.json import scriptsafe as json_safe
 class TestWebEditorController(HttpCaseWithUserDemo):
 
     def test_modify_image(self):
-        gif_base64 = b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs="
         attachment = self.env['ir.attachment'].create({
             'name': 'test.gif',
             'mimetype': 'image/gif',
-            'datas': gif_base64,
+            'type': 'binary',
+            'datas': b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=",
             'public': True,
             'res_model': 'ir.ui.view',
             'res_id': 0,
         })
+        self._test_modify_image(attachment)
+
+    def test_modify_default_image(self):
+        attachment = self.env['ir.attachment'].create({
+            'name': 'test.gif',
+            'mimetype': 'image/gif',
+            'type': 'url',
+            'url': '/website/static/src/img/something.jpg',
+            'public': True,
+        })
+        self._test_modify_image(attachment)
+
+    def _test_modify_image(self, attachment):
+        gif_base64 = attachment.datas or b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs="
 
         def modify(login, name, expect_fail=False):
             self.authenticate(login, login)


### PR DESCRIPTION
Follow-up of [1]. It introduced a fix for restricted users to be allowed to add shapes on images. However, starting from Odoo 18.1, the fix stopped working when applying shapes on *default* images.

This is apparently because of [2], which was now fixed by [3].

This commit extends the test that was made in [1] to take that extra case that got broken into account.

[1]: https://github.com/odoo/odoo/commit/9c9c58a5a10101532cbf046d21d4a63c2b7d2838
[2]: https://github.com/odoo/odoo/commit/57a72d2e9a9a3d6e9f4724848813cad1ff2f9230
[3]: TODO

