### PR TITLE
[FIX] account,l10n_ch: skip_create also skips the search

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -435,8 +435,6 @@ class AccountBankStatementLine(models.Model):
 
     def _find_or_create_bank_account(self):
         self.ensure_one()
-        if str2bool(self.env['ir.config_parameter'].sudo().get_param("account.skip_create_bank_account_on_reconcile")):
-            return self.env['res.partner.bank']
 
         # There is a sql constraint on res.partner.bank ensuring an unique pair <partner, account number>.
         # Since it's not dependent of the company, we need to search on others company too to avoid the creation
@@ -447,7 +445,9 @@ class AccountBankStatementLine(models.Model):
             ('acc_number', '=', self.account_number),
             ('partner_id', '=', self.partner_id.id),
         ])
-        if not bank_account:
+        if not bank_account and not str2bool(
+                self.env['ir.config_parameter'].sudo().get_param("account.skip_create_bank_account_on_reconcile")
+        ):
             bank_account = self.env['res.partner.bank'].create({
                 'acc_number': self.account_number,
                 'partner_id': self.partner_id.id,

--- a/addons/l10n_ch/models/account_bank_statement.py
+++ b/addons/l10n_ch/models/account_bank_statement.py
@@ -11,14 +11,14 @@ class AccountBankStatementLine(models.Model):
     _inherit = "account.bank.statement.line"
 
     def _find_or_create_bank_account(self):
-        if str2bool(self.env['ir.config_parameter'].sudo().get_param("account.skip_create_bank_account_on_reconcile")):
-            return self.env['res.partner.bank']
         if self.company_id.account_fiscal_country_id.code in ('CH', 'LI') and _is_l10n_ch_postal(self.account_number):
             bank_account = self.env['res.partner.bank'].search(
                 [('company_id', '=', self.company_id.id),
                  ('sanitized_acc_number', 'like', self.account_number + '%'),
                  ('partner_id', '=', self.partner_id.id)])
-            if not bank_account:
+            if not bank_account and not str2bool(
+                    self.env['ir.config_parameter'].sudo().get_param("account.skip_create_bank_account_on_reconcile")
+            ):
                 bank_account = self.env['res.partner.bank'].create({
                     'company_id': self.company_id.id,
                     'acc_number': self.account_number + " " + self.partner_id.name,


### PR DESCRIPTION
The config param skip_create_bank_account_on_reconcile currently also skips the search.
In the original commit https://github.com/odoo/odoo/commit/62354663c6622f6d059e36097f0455ab5890b616, it was not the case. It was a mistake during the fw-port

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
