### PR TITLE
[FIX] l10n_in_ewaybill: product description is wrong

### DIFF
--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -542,7 +542,7 @@ class L10nInEwaybill(models.Model):
         line_details = {
             'productName': line.product_id.name,
             'hsnCode': extract_digits(line.l10n_in_hsn_code),
-            'productDesc': line.product_id.name,
+            'productDesc': line.name,
             'quantity': line.quantity,
             'qtyUnit': line.product_id.uom_id.l10n_in_code and line.product_id.uom_id.l10n_in_code.split('-')[0] or 'OTH',
             'taxableAmount': round_value(line.balance * sign),


### PR DESCRIPTION
During this fw-port https://github.com/odoo/odoo/commit/ca0d42f01e76387da4c5a24a0b48fe3e3a346936, the ProductDesc was wrongly put.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
