### PR TITLE
[FIX] im_livechat: user custom live chat name for reactions

### DIFF
--- a/addons/im_livechat/models/__init__.py
+++ b/addons/im_livechat/models/__init__.py
@@ -10,6 +10,7 @@ from . import im_livechat_channel
 from . import discuss_channel
 from . import discuss_channel_member
 from . import mail_message
+from . import mail_message_reaction
 from . import res_users_settings
 from . import rating_rating
 from . import digest

--- a/addons/im_livechat/models/mail_message_reaction.py
+++ b/addons/im_livechat/models/mail_message_reaction.py
@@ -1,0 +1,25 @@
+from odoo import models
+from odoo.addons.mail.tools.discuss import Store
+
+
+class MailMessageReaction(models.Model):
+    _name = "mail.message.reaction"
+    _inherit = ["mail.message.reaction"]
+
+    def _reacting_persona_to_store(self, store: Store):
+        channel_reactions_with_partner = self.filtered(
+            lambda r: r.partner_id and r.message_id.model == "discuss.channel"
+        )
+        channel_by_message = channel_reactions_with_partner._record_by_message()
+        livechat_agent_reactions = channel_reactions_with_partner.filtered(
+            lambda r: channel_by_message.get(r.message_id, self.env["discuss.channel"]).channel_type
+            == "livechat"
+        )
+        super(MailMessageReaction, self - livechat_agent_reactions)._reacting_persona_to_store(
+            store
+        )
+        for reaction in livechat_agent_reactions:
+            store.add(
+                reaction.partner_id,
+                {"partner_id": Store.one(reaction.partner_id, fields=["avatar_128", "user_livechat_username"])},
+            )

--- a/addons/mail/models/mail_message_reaction.py
+++ b/addons/mail/models/mail_message_reaction.py
@@ -27,8 +27,7 @@ class MailMessageReaction(models.Model):
     def _to_store(self, store: Store):
         for (message_id, content), reactions in groupby(self, lambda r: (r.message_id, r.content)):
             reactions = self.env["mail.message.reaction"].union(*reactions)
-            store.add(reactions.guest_id, fields=["avatar_128", "name"])
-            store.add(reactions.partner_id, fields=["avatar_128", "name"])
+            self._reacting_persona_to_store(store)
             data = {
                 "content": content,
                 "count": len(reactions),
@@ -38,3 +37,14 @@ class MailMessageReaction(models.Model):
                 "message": Store.one_id(message_id),
             }
             store.add("MessageReactions", data)
+
+    def _reacting_persona_to_store(self, store: Store):
+        for reaction in self:
+            store.add(
+                reaction.partner_id,
+                {"partner_id": Store.one(reaction.partner_id, fields=["avatar_128", "name"])},
+            )
+            store.add(
+                reaction.guest_id,
+                {"guest_id": Store.one(reaction.guest_id, fields=["avatar_128", "name"])},
+            )


### PR DESCRIPTION
Before this PR, real user name was displayed in the message reaction summary. We should use the custom live chat name if any not to leak the real name of the agent. This PR fixes this issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
