### PR TITLE
[FIX] point_of_sale: Fix number buffer error

### DIFF
--- a/addons/pos_loyalty/static/src/tours/EWalletProgramTours.js
+++ b/addons/pos_loyalty/static/src/tours/EWalletProgramTours.js
@@ -23,14 +23,14 @@ ProductScreen.do.clickPayButton(false);
 Chrome.do.confirmPopup();
 PartnerListScreen.check.isShown();
 PartnerListScreen.do.clickPartner('AAAAAAA');
-PosLoyalty.exec.finalizeOrder('Cash', '50');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Topup 10$ for partner_bbb
 ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer('BBBBBBB');
 ProductScreen.exec.addOrderline('Top-up eWallet', '1', '10');
 PosLoyalty.check.orderTotalIs('10.00');
-PosLoyalty.exec.finalizeOrder('Cash', '10');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('EWalletProgramTour1', { test: true, url: '/pos/web' }, getSteps());
 
@@ -49,7 +49,7 @@ ProductScreen.do.clickCustomer('AAAAAAA');
 PosLoyalty.check.eWalletButtonState({ highlighted: true, text: getEWalletText('Pay') });
 PosLoyalty.do.clickEWalletButton(getEWalletText('Pay'));
 PosLoyalty.check.orderTotalIs('0.00');
-PosLoyalty.exec.finalizeOrder('Cash', '0');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Consume partner_bbb's full eWallet.
 ProductScreen.do.clickPartnerButton();
@@ -59,7 +59,7 @@ ProductScreen.exec.addOrderline('Desk Pad', '6', '6', '36.00');
 PosLoyalty.check.eWalletButtonState({ highlighted: true, text: getEWalletText('Pay') });
 PosLoyalty.do.clickEWalletButton(getEWalletText('Pay'));
 PosLoyalty.check.orderTotalIs('26.00');
-PosLoyalty.exec.finalizeOrder('Cash', '26');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Switching partners should work.
 ProductScreen.do.clickPartnerButton();
@@ -80,7 +80,7 @@ ProductScreen.do.clickCustomer('AAAAAAA');
 PosLoyalty.check.eWalletButtonState({ highlighted: true, text: getEWalletText('Pay') });
 PosLoyalty.do.clickEWalletButton(getEWalletText('Pay'));
 PosLoyalty.check.orderTotalIs('0.00');
-PosLoyalty.exec.finalizeOrder('Cash', '0');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Refund with eWallet.
 // - Make an order to refund.
@@ -88,7 +88,7 @@ ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer('BBBBBBB');
 ProductScreen.exec.addOrderline('Whiteboard Pen', '1', '20', '20.00');
 PosLoyalty.check.orderTotalIs('20.00');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 // - Refund order.
 ProductScreen.do.clickRefund();
 TicketScreen.check.filterIs('Paid');
@@ -99,7 +99,7 @@ ProductScreen.check.isShown();
 PosLoyalty.check.eWalletButtonState({ highlighted: true, text: getEWalletText('Refund') });
 PosLoyalty.do.clickEWalletButton(getEWalletText('Refund'));
 PosLoyalty.check.orderTotalIs('0.00');
-PosLoyalty.exec.finalizeOrder('Cash', '0');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('EWalletProgramTour2', { test: true, url: '/pos/web' }, getSteps());
 

--- a/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
+++ b/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
@@ -12,7 +12,7 @@ ProductScreen.do.confirmOpeningPopup();
 ProductScreen.do.clickHomeCategory();
 ProductScreen.do.clickDisplayedProduct('Gift Card');
 PosLoyalty.check.orderTotalIs('50.00');
-PosLoyalty.exec.finalizeOrder('Cash', '50');
+PosLoyalty.exec.finalizeOrder('Cash');
 Tour.register('GiftCardProgramCreateSetTour1', { test: true, url: '/pos/web' }, getSteps());
 //#endregion
 
@@ -22,7 +22,7 @@ ProductScreen.do.clickHomeCategory();
 ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
 PosLoyalty.do.enterCode('044123456');
 PosLoyalty.check.orderTotalIs('0.00');
-PosLoyalty.exec.finalizeOrder('Cash', '0');
+PosLoyalty.exec.finalizeOrder('Cash');
 Tour.register('GiftCardProgramCreateSetTour2', { test: true, url: '/pos/web' }, getSteps());
 //#endregion
 
@@ -36,17 +36,17 @@ TextInputPopup.check.isShown();
 TextInputPopup.do.inputText('044123456');
 TextInputPopup.do.clickConfirm();
 PosLoyalty.check.orderTotalIs('5.00');
-PosLoyalty.exec.finalizeOrder('Cash', '5');
+PosLoyalty.exec.finalizeOrder('Cash');
 // Partially use the gift card. (4$)
 ProductScreen.exec.addOrderline('Desk Pad', '2', '2', '4.0');
 PosLoyalty.do.enterCode('044123456');
 PosLoyalty.check.orderTotalIs('0.00');
-PosLoyalty.exec.finalizeOrder('Cash', '0');
+PosLoyalty.exec.finalizeOrder('Cash');
 // Use the remaining of the gift card. (5$ - 4$ = 1$)
 ProductScreen.exec.addOrderline('Whiteboard Pen', '6', '6', '36.0');
 PosLoyalty.do.enterCode('044123456');
 PosLoyalty.check.orderTotalIs('35.00');
-PosLoyalty.exec.finalizeOrder('Cash', '35');
+PosLoyalty.exec.finalizeOrder('Cash');
 Tour.register('GiftCardProgramScanUseTour', { test: true, url: '/pos/web' }, getSteps());
 //#endregion
 
@@ -58,7 +58,7 @@ TextInputPopup.check.isShown();
 TextInputPopup.do.inputText('044123456');
 TextInputPopup.do.clickConfirm();
 PosLoyalty.check.orderTotalIs('50.00');
-PosLoyalty.exec.finalizeOrder('Cash', '50');
+PosLoyalty.exec.finalizeOrder('Cash');
 ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer("partner_a");
 ProductScreen.exec.addOrderline("product_a", "1");
@@ -76,7 +76,7 @@ TextInputPopup.check.isShown();
 TextInputPopup.do.inputText('044123456');
 TextInputPopup.do.clickConfirm();
 PosLoyalty.check.orderTotalIs('50.00');
-PosLoyalty.exec.finalizeOrder('Cash', '50');
+PosLoyalty.exec.finalizeOrder('Cash');
 ProductScreen.do.clickDisplayedProduct("Test Product A");
 PosLoyalty.do.enterCode("044123456");
 PosLoyalty.check.orderTotalIs("50.00");
@@ -93,5 +93,5 @@ TextInputPopup.do.clickConfirm();
 PosLoyalty.check.orderTotalIs('0.00');
 ProductScreen.do.pressNumpad("Price 5");
 PosLoyalty.check.orderTotalIs('5.00');
-PosLoyalty.exec.finalizeOrder('Cash', '5');
+PosLoyalty.exec.finalizeOrder('Cash');
 Tour.register("PosLoyaltyGiftCardNoPoints", { test: true }, getSteps());

--- a/addons/pos_loyalty/static/src/tours/MultipleGiftWalletProgramsTour.js
+++ b/addons/pos_loyalty/static/src/tours/MultipleGiftWalletProgramsTour.js
@@ -19,14 +19,14 @@ SelectionPopup.do.clickItem('gift_card_1');
 ProductScreen.do.pressNumpad('Price');
 ProductScreen.do.pressNumpad('1 0');
 PosLoyalty.check.orderTotalIs('10.00');
-PosLoyalty.exec.finalizeOrder('Cash', '10');
+PosLoyalty.exec.finalizeOrder('Cash');
 // One card for gift_card_1.
 ProductScreen.do.clickDisplayedProduct('Gift Card');
 SelectionPopup.do.clickItem('gift_card_2');
 ProductScreen.do.pressNumpad('Price');
 ProductScreen.do.pressNumpad('2 0');
 PosLoyalty.check.orderTotalIs('20.00');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 // Top up ewallet_1 for AAAAAAA.
 ProductScreen.do.clickDisplayedProduct('Top-up eWallet');
 SelectionPopup.check.hasSelectionItem('ewallet_1');
@@ -37,7 +37,7 @@ ProductScreen.do.clickCustomer('AAAAAAA');
 ProductScreen.do.pressNumpad('Price');
 ProductScreen.do.pressNumpad('3 0');
 PosLoyalty.check.orderTotalIs('30.00');
-PosLoyalty.exec.finalizeOrder('Cash', '30');
+PosLoyalty.exec.finalizeOrder('Cash');
 // Top up ewallet_2 for AAAAAAA.
 ProductScreen.do.clickDisplayedProduct('Top-up eWallet');
 SelectionPopup.do.clickItem('ewallet_2');
@@ -46,14 +46,14 @@ ProductScreen.do.clickCustomer('AAAAAAA');
 ProductScreen.do.pressNumpad('Price');
 ProductScreen.do.pressNumpad('4 0');
 PosLoyalty.check.orderTotalIs('40.00');
-PosLoyalty.exec.finalizeOrder('Cash', '40');
+PosLoyalty.exec.finalizeOrder('Cash');
 // Top up ewallet_1 for BBBBBBB.
 ProductScreen.do.clickDisplayedProduct('Top-up eWallet');
 SelectionPopup.do.clickItem('ewallet_1');
 ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer('BBBBBBB');
 PosLoyalty.check.orderTotalIs('50.00');
-PosLoyalty.exec.finalizeOrder('Cash', '50');
+PosLoyalty.exec.finalizeOrder('Cash');
 // Consume 12$ from ewallet_1 of AAAAAAA.
 ProductScreen.exec.addOrderline('Whiteboard Pen', '2', '6', '12.00');
 PosLoyalty.check.eWalletButtonState({ highlighted: false });
@@ -65,6 +65,6 @@ SelectionPopup.check.hasSelectionItem('ewallet_1');
 SelectionPopup.check.hasSelectionItem('ewallet_2');
 SelectionPopup.do.clickItem('ewallet_1');
 PosLoyalty.check.orderTotalIs('0.00');
-PosLoyalty.exec.finalizeOrder('Cash', '0');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('MultipleGiftWalletProgramsTour', { test: true, url: '/pos/web' }, getSteps());

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -15,7 +15,7 @@ ProductScreen.exec.addOrderline('Whiteboard Pen', '2');
 ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer('Test Partner AAA');
 PosLoyalty.check.orderTotalIs('6.40');
-PosLoyalty.exec.finalizeOrder('Cash', '10');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Order2: Consumes points to get free product.
 ProductScreen.do.clickPartnerButton();
@@ -31,7 +31,7 @@ ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '3.00');
 PosLoyalty.check.hasRewardLine('Free Product - Whiteboard Pen', '-3.20', '1.00');
 PosLoyalty.check.isRewardButtonHighlighted(false);
 PosLoyalty.check.orderTotalIs('6.40');
-PosLoyalty.exec.finalizeOrder('Cash', '10');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Order3: Generate 4 points.
 // - Initially gets free product, but was removed automatically by changing the
@@ -63,7 +63,7 @@ ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '4.00');
 PosLoyalty.check.isRewardButtonHighlighted(true);
 
 PosLoyalty.check.orderTotalIs('12.80');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyLoyaltyProgram1', { test: true, url: '/pos/web' }, getSteps());
 
@@ -85,7 +85,7 @@ ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
 PosLoyalty.check.hasRewardLine('Free Product - Whiteboard Pen', '-3.20', '1.00');
 PosLoyalty.check.isRewardButtonHighlighted(false);
 PosLoyalty.check.orderTotalIs('3.20');
-PosLoyalty.exec.finalizeOrder('Cash', '10');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Order2: Generate 4 points for Test Partner CCC.
 // - Reference: Order2_CCC
@@ -107,7 +107,7 @@ ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer('Test Partner CCC');
 PosLoyalty.check.customerIs('Test Partner CCC');
 PosLoyalty.check.orderTotalIs('12.80');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Order3: Generate 3 points for Test Partner BBB.
 // - Reference: Order3_BBB
@@ -120,7 +120,7 @@ ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer('Test Partner BBB');
 PosLoyalty.check.customerIs('Test Partner BBB');
 PosLoyalty.check.orderTotalIs('9.60');
-PosLoyalty.exec.finalizeOrder('Cash', '10');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Order4: Should not have reward because the customer will be removed.
 // - Reference: Order4_no_reward
@@ -137,7 +137,7 @@ ProductScreen.do.clickPartnerButton();
 PosLoyalty.do.unselectPartner();
 PosLoyalty.check.customerIs('Customer');
 PosLoyalty.check.orderTotalIs('6.40');
-PosLoyalty.exec.finalizeOrder('Cash', '10');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyLoyaltyProgram2', { test: true, url: '/pos/web' }, getSteps());
 

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
@@ -34,7 +34,7 @@ ProductScreen.do.clickDisplayedProduct('Desk Organizer');
 PosLoyalty.check.isRewardButtonHighlighted(false);
 PosLoyalty.check.orderTotalIs('25.50');
 // Finalize order that consumed a reward.
-PosLoyalty.exec.finalizeOrder('Cash', '30');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 ProductScreen.do.clickDisplayedProduct('Desk Organizer');
 ProductScreen.check.selectedOrderlineHas('Desk Organizer', '1.00');
@@ -52,7 +52,7 @@ PosLoyalty.check.isRewardButtonHighlighted(true);
 // Finalize order but without the reward.
 // This step is important. When syncing the order, no reward should be synced.
 PosLoyalty.check.orderTotalIs('10.20');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 
 ProductScreen.exec.addOrderline('Magnetic Board', '2');
@@ -72,7 +72,7 @@ PosLoyalty.check.isRewardButtonHighlighted(false);
 PosLoyalty.check.hasRewardLine('Free Product - Whiteboard Pen', '-6.40', '2.00');
 // Finalize order that consumed a reward.
 PosLoyalty.check.orderTotalIs('11.88');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 ProductScreen.exec.addOrderline('Magnetic Board', '6');
 ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
@@ -94,7 +94,7 @@ PosLoyalty.check.hasRewardLine('Free Product - Whiteboard Pen', '-3.20', '1.00')
 PosLoyalty.check.isRewardButtonHighlighted(false);
 
 PosLoyalty.check.orderTotalIs('5.94');
-PosLoyalty.exec.finalizeOrder('Cash', '10');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Promotion: 2 items of shelves, get desk_pad/monitor_stand free
 // This is the 5th order.
@@ -127,7 +127,7 @@ PosLoyalty.check.isRewardButtonHighlighted(false);
 ProductScreen.check.selectedOrderlineHas('Monitor Stand', '1.00', '3.19');
 PosLoyalty.check.hasRewardLine('Free Product', '-3.19', '1.00');
 PosLoyalty.check.orderTotalIs('4.81');
-PosLoyalty.exec.finalizeOrder('Cash', '10');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyFreeProductTour', { test: true, url: '/pos/web' }, getSteps());
 

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
@@ -20,7 +20,7 @@ ProductScreen.exec.addOrderline('Whiteboard Pen', '5');
 PosLoyalty.check.hasRewardLine('90% on the cheapest product', '-2.88');
 PosLoyalty.do.selectRewardLine('on the cheapest product');
 PosLoyalty.check.orderTotalIs('13.12');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // remove the reward from auto promo program
 // no applied programs
@@ -29,7 +29,7 @@ PosLoyalty.check.hasRewardLine('on the cheapest product', '-2.88');
 PosLoyalty.check.orderTotalIs('16.32');
 PosLoyalty.exec.removeRewardLine('90% on the cheapest product');
 PosLoyalty.check.orderTotalIs('19.2');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // order with coupon code from coupon program
 // applied programs:
@@ -41,7 +41,7 @@ PosLoyalty.check.orderTotalIs('45.90');
 PosLoyalty.do.enterCode('invalid_code');
 PosLoyalty.do.enterCode('1234');
 PosLoyalty.check.hasRewardLine('Free Product - Desk Organizer', '-15.30');
-PosLoyalty.exec.finalizeOrder('Cash', '50');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Use coupon but eventually remove the reward
 // applied programs:
@@ -55,7 +55,7 @@ PosLoyalty.check.hasRewardLine('Free Product - Desk Organizer', '-15.30');
 PosLoyalty.check.orderTotalIs('46.97');
 PosLoyalty.exec.removeRewardLine('Free Product');
 PosLoyalty.check.orderTotalIs('62.27');
-PosLoyalty.exec.finalizeOrder('Cash', '90');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // specific product discount
 // applied programs:
@@ -69,7 +69,7 @@ PosLoyalty.check.orderTotalIs('54.44')
 PosLoyalty.do.enterCode('promocode')
 PosLoyalty.check.hasRewardLine('50% on specific products', '-16.66') // 17.55 - 1.78*0.5
 PosLoyalty.check.orderTotalIs('37.78')
-PosLoyalty.exec.finalizeOrder('Cash', '50')
+PosLoyalty.exec.finalizeOrder('Cash')
 
 Tour.register('PosLoyaltyTour1', { test: true, url: '/pos/web' }, getSteps());
 
@@ -91,7 +91,7 @@ PosLoyalty.do.enterCode('123456');
 PosLoyalty.check.hasRewardLine('10% on your order', '-5.10');
 PosLoyalty.check.hasRewardLine('10% on your order', '-1.64');
 PosLoyalty.check.orderTotalIs('60.63'); //SUBTOTAL
-PosLoyalty.exec.finalizeOrder('Cash', '70');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Scanning coupon twice.
 // Also apply global discount on top of free product to check if the
@@ -120,7 +120,7 @@ PosLoyalty.check.hasRewardLine('Free Product - Desk Organizer', '-20.40');
 // scan the code again and check notification
 PosLoyalty.do.enterCode('5678');
 PosLoyalty.check.orderTotalIs('60.13');
-PosLoyalty.exec.finalizeOrder('Cash', '65');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Specific products discount (with promocode) and free product (1357)
 // Applied programs:
@@ -135,7 +135,7 @@ PosLoyalty.do.enterCode('1357');
 PosLoyalty.check.hasRewardLine('Free Product - Desk Organizer', '-10.20');
 PosLoyalty.check.hasRewardLine('50% on specific products', '-10.20');
 PosLoyalty.check.orderTotalIs('10.20');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Check reset program
 // Enter two codes and reset the programs.
@@ -153,7 +153,7 @@ PosLoyalty.check.orderTotalIs('17.23');
 PosLoyalty.do.resetActivePrograms();
 PosLoyalty.check.hasRewardLine('90% on the cheapest product', '-2.87');
 PosLoyalty.check.orderTotalIs('16.27');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyTour2', { test: true, url: '/pos/web' }, getSteps());
 
@@ -308,7 +308,7 @@ PosLoyalty.do.clickRewardButton();
 PosLoyalty.check.hasRewardLine('Free Product', '-3.00');
 PosLoyalty.check.isRewardButtonHighlighted(false);
 ProductScreen.check.totalAmountIs('50.00');
-PosLoyalty.exec.finalizeOrder('Cash', '50');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyTour11.2', { test: true, url: '/pos/web' }, getSteps());
 

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyValidityTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyValidityTour.js
@@ -14,7 +14,7 @@ ProductScreen.do.clickHomeCategory();
 // Not valid -> date
 ProductScreen.exec.addOrderline('Whiteboard Pen', '5');
 PosLoyalty.check.checkNoClaimableRewards();
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyValidity1', { test: true, url: '/pos/web' }, getSteps());
 
@@ -26,11 +26,11 @@ ProductScreen.do.clickHomeCategory();
 // Valid
 ProductScreen.exec.addOrderline('Whiteboard Pen', '5');
 PosLoyalty.check.hasRewardLine('90% on the cheapest product', '-2.88');
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 // Not valid -> usage
 ProductScreen.exec.addOrderline('Whiteboard Pen', '5');
 PosLoyalty.check.checkNoClaimableRewards();
-PosLoyalty.exec.finalizeOrder('Cash', '20');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyValidity2', { test: true, url: '/pos/web' }, getSteps());


### PR DESCRIPTION
During tests some components were unmounted before the number buffer finished handling the input. This was causing an error in the order object which was finalized.

Runbot error: 163213
