### PR TITLE
[FIX] tests: watch=True working for chrome 135+


### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1886,7 +1886,8 @@ class HttpCase(TransactionCase):
         if watch and self.browser.dev_tools_frontend_url:
             _logger.warning('watch mode is only suitable for local testing - increasing tour timeout to 3600')
             timeout = max(timeout*10, 3600)
-            debug_front_end = f'http://127.0.0.1:{self.browser.devtools_port}{self.browser.dev_tools_frontend_url}'
+            devtool_query_string = self.browser.dev_tools_frontend_url.partition('/inspector.html')[2]
+            debug_front_end = f'http://127.0.0.1:{self.browser.devtools_port}/devtools/inspector.html{devtool_query_string}'
             self.browser._chrome_without_limit([self.browser.executable, debug_front_end])
             time.sleep(3)
         try:


### PR DESCRIPTION
Scenario: run a tour with watch=True on a test with chrome at least 135

Result: the tour runs, but is not shown in the browser

Issue: since https://github.com/chromium/chromium/commit/17ee927a3b7f8641ec1f44e1c6190dcca3acf416
the full appspot URL is priviledged for devtool URL instead of the
local browser bundled ones. So we get an url like
[https://chrome-devtools-frontend.appspot.com/serve_rev/…/inspector.html?…](https://chrome-devtools-frontend.appspot.com/serve_rev/%E2%80%A6/inspector.html?%E2%80%A6)
instead of /devtools/inspector.html?… and we get a wrong URL when doing
the concatenation with localhost and port.

Fix: use the full appspot URL to get the query string for local dev
tools.

Note: issue not present in 17.0 since watch=True uses headful browser

__PR Note:__ using hardcoded `/devtools/inspector.html` is a little more ugly but has not changed since 7 years ago https://github.com/chromium/chromium/commit/c8a484b5f69327d05a95c0298b1ef2a18f192532

an alternative would be to just use the full appspot URL but then it would not work without internet:

```diff
-            debug_front_end = f'http://127.0.0.1:{self.browser.devtools_port}{self.browser.dev_tools_frontend_url}'
+            if self.browser.dev_tools_frontend_url.startswith('https://'):
+                debug_front_end = self.browser.dev_tools_frontend_url
+            else:
+                debug_front_end = f'http://127.0.0.1:{self.browser.devtools_port}{self.browser.dev_tools_frontend_url}'
```