### PR TITLE
[IMP] pos: add manual retry for failed KOT

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/confirmation_dialog/confirmation_dialog.js
+++ b/addons/point_of_sale/static/src/app/components/popups/confirmation_dialog/confirmation_dialog.js
@@ -1,0 +1,27 @@
+import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { patch } from "@web/core/utils/patch";
+
+patch(ConfirmationDialog.prototype, {
+    async _cancel() {
+        this.props.getPayload && this.props.getPayload(false);
+        return this.execButton(this.props.cancel);
+    },
+    async _confirm() {
+        this.props.getPayload && this.props.getPayload(true);
+        return this.execButton(this.props.confirm);
+    },
+    async _dismiss() {
+        this.props.getPayload && this.props.getPayload(false);
+        return this.execButton(this.props.dismiss || this.props.cancel);
+    },
+});
+
+ConfirmationDialog.props = {
+    ...ConfirmationDialog.props,
+    getPayload: { type: Function, optional: true },
+};
+
+AlertDialog.props = {
+    ...AlertDialog.props,
+    getPayload: { type: Function, optional: true },
+};

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -33,7 +33,7 @@ import { CashMovePopup } from "@point_of_sale/app/components/popups/cash_move_po
 import { ClosePosPopup } from "@point_of_sale/app/components/popups/closing_popup/closing_popup";
 import { SelectionPopup } from "../components/popups/selection_popup/selection_popup";
 import { user } from "@web/core/user";
-import { unaccent } from "@web/core/utils/strings";
+import { sprintf, unaccent } from "@web/core/utils/strings";
 import { WithLazyGetterTrap } from "@point_of_sale/lazy_getter";
 import { debounce } from "@web/core/utils/timing";
 import DevicesSynchronisation from "../utils/devices_synchronisation";
@@ -1929,11 +1929,16 @@ export class PosStore extends WithLazyGetterTrap {
         return receiptsData;
     }
 
-    async printChanges(order, orderChange, reprint = false) {
-        let isPrinted = false;
-        const unsuccedPrints = [];
+    async printChanges(
+        order,
+        orderChange,
+        reprint = false,
+        printers = this.unwatched.printers,
+        isPrinted = false
+    ) {
+        const unsuccedPrinters = [];
 
-        for (const printer of this.unwatched.printers) {
+        for (const printer of printers) {
             const { orderData, changes } = this.generateOrderChange(
                 order,
                 orderChange,
@@ -1948,22 +1953,48 @@ export class PosStore extends WithLazyGetterTrap {
             for (const data of receiptsData) {
                 const result = await this.printOrderChanges(data, printer);
                 if (!result.successful) {
-                    unsuccedPrints.push(printer.config.name);
+                    unsuccedPrinters.push(printer);
                 } else {
                     isPrinted = true;
                 }
             }
         }
 
-        // printing errors
-        if (unsuccedPrints.length) {
-            const failedReceipts = unsuccedPrints.join(", ");
-            this.dialog.add(AlertDialog, {
-                title: _t("Printing failed"),
-                body: _t("Failed in printing %s changes of the order", failedReceipts),
-            });
-        }
+        if (unsuccedPrinters.length) {
+            const printerNames = unsuccedPrinters
+                .map(
+                    (printer) =>
+                        `\n\t${printer.config.name} (${
+                            printer.config.printer_type === "iot"
+                                ? printer.config.proxy_ip
+                                : printer.config.epson_printer_ip
+                        })`
+                )
+                .join("");
 
+            const retry = await makeAwaitable(this.dialog, AlertDialog, {
+                title: _t("Printing failed"),
+                body: sprintf(
+                    _t(
+                        "Please note that some printers could not be contacted. The changes will be taken into account locally, but a preparation ticket may be missing. Here is the list of printers with errors: %s\nDo you want to retry ?"
+                    ),
+                    printerNames
+                ),
+                confirmLabel: _t("Retry"),
+                cancelLabel: _t("Discard"),
+                cancel: () => {},
+            });
+
+            if (retry) {
+                return await this.printChanges(
+                    order,
+                    orderChange,
+                    reprint,
+                    unsuccedPrinters,
+                    isPrinted
+                );
+            }
+        }
         return isPrinted;
     }
 

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -217,10 +217,7 @@ registry.category("web_tour.tours").add("TableMergeUnmergeTour", {
             FloorScreen.clickTable("4"),
             inLeftSide(ProductScreen.orderLineHas("Coca-Cola", "1")),
             ProductScreen.clickOrderButton(),
-            {
-                ...Dialog.confirm(),
-                content: "Acknowledge printing error (test does not use a printer).",
-            },
+            Chrome.closePrintingWarning(),
             ProductScreen.orderlinesHaveNoChange(),
             Chrome.clickPlanButton(),
             FloorScreen.isShown(),
@@ -229,10 +226,7 @@ registry.category("web_tour.tours").add("TableMergeUnmergeTour", {
             FloorScreen.clickTable("5"),
             inLeftSide(ProductScreen.orderLineHas("Minute Maid", "1")),
             ProductScreen.clickOrderButton(),
-            {
-                ...Dialog.confirm(),
-                content: "Acknowledge printing error (test does not use a printer).",
-            },
+            Chrome.closePrintingWarning(),
             ProductScreen.orderlinesHaveNoChange(),
             Chrome.clickPlanButton(),
             FloorScreen.isShown(),
@@ -247,10 +241,7 @@ registry.category("web_tour.tours").add("TableMergeUnmergeTour", {
             ProductScreen.clickDisplayedProduct("Minute Maid"),
             ProductScreen.orderlineIsToOrder("Minute Maid"),
             ProductScreen.clickOrderButton(),
-            {
-                ...Dialog.confirm(),
-                content: "Acknowledge printing error (test does not use a printer).",
-            },
+            Chrome.closePrintingWarning(),
             ProductScreen.orderlinesHaveNoChange(),
 
             // Unlink tables again and verify restoration

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -449,16 +449,14 @@ registry.category("web_tour.tours").add("test_course_restaurant_preparation_tour
                 }
             ),
             ProductScreen.clickOrderButton(),
-            Dialog.bodyIs("Failed in printing Preparation Printer, Printer changes of the order"),
-            Dialog.confirm(),
+            ...checkPrinterRetryDialog(["Preparation Printer (127.0.0.1)", "Printer (0.0.0.0)"]),
             FloorScreen.clickTable("5"),
             checkPreparationTicketData([], {
                 visibleInDom: ["Course 2"],
                 fireCourse: true,
             }),
             ProductScreen.fireCourseButton(),
-            Dialog.bodyIs("Failed in printing Preparation Printer, Printer changes of the order"),
-            Dialog.confirm(),
+            ...checkPrinterRetryDialog(["Preparation Printer (127.0.0.1)", "Printer (0.0.0.0)"]),
             FloorScreen.clickTable("5"),
             ProductScreen.selectCourseLine("Course 3"),
             checkPreparationTicketData([{ name: "Product Test", qty: 1, attribute: ["Value 1"] }], {
@@ -509,8 +507,7 @@ registry.category("web_tour.tours").add("MultiPreparationPrinter", {
             FloorScreen.clickTable("5"),
             ProductScreen.clickDisplayedProduct("Product 1"),
             ProductScreen.clickOrderButton(),
-            Dialog.bodyIs("Failed in printing Printer 2 changes of the order"),
-            Dialog.confirm(),
+            ...checkPrinterRetryDialog(["Printer 2 (0.0.0.0)"]),
         ].flat(),
 });
 
@@ -563,8 +560,7 @@ registry.category("web_tour.tours").add("test_multiple_preparation_printer_diffe
             ProductScreen.clickDisplayedProduct("Product 1"),
             ProductScreen.clickDisplayedProduct("Product 2"),
             ProductScreen.clickOrderButton(),
-            Dialog.bodyIs("Failed in printing Printer 1, Printer 2 changes of the order"),
-            Dialog.confirm(),
+            ...checkPrinterRetryDialog(["Printer 1 (0.0.0.0)", "Printer 2 (0.0.0.0)"]),
         ].flat(),
 });
 
@@ -779,6 +775,17 @@ registry.category("web_tour.tours").add("test_direct_sales", {
             ReceiptScreen.discardOrderWarningDialog(),
         ].flat(),
 });
+
+function checkPrinterRetryDialog(printer_names) {
+    const commonSteps = [
+        Dialog.bodyIs(
+            "Please note that some printers could not be contacted. The changes will be taken into account locally, but a preparation ticket may be missing. Here is the list of printers with errors:"
+        ),
+        ...printer_names.map((printer_name) => Dialog.bodyIs(printer_name)),
+        Dialog.bodyIs("Do you want to retry ?"),
+    ];
+    return [...commonSteps, Dialog.confirm("retry"), ...commonSteps, Dialog.discard()];
+}
 
 registry.category("web_tour.tours").add("test_sync_lines_qty_update", {
     steps: () =>

--- a/addons/pos_restaurant/static/tests/tours/utils/chrome.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/chrome.js
@@ -12,7 +12,7 @@ export function isTabActive(tabText) {
 export function closePrintingWarning() {
     return [
         {
-            ...Dialog.confirm(),
+            ...Dialog.discard(),
             content: "acknowledge printing error ( because we don't have printer in the test. )",
         },
     ];


### PR DESCRIPTION
Before this commit:
=
- There was no option to retry printing kitchen receipts if a printer failed.

After this commit:
=
- Users can now manually retry printing kitchen receipts that failed due to printer issues.
- The `Retry` button targets only the printers that previously failed, ensuring other successful prints are not repeated.

Task: 4717776
