### PR TITLE
[IMP] web: Keep control panel and headers fixed in select_create_dialog

### DIFF
--- a/addons/web/static/src/views/view_dialogs/select_create_dialog.scss
+++ b/addons/web/static/src/views/view_dialogs/select_create_dialog.scss
@@ -1,0 +1,8 @@
+.o_select_create_dialog_content {
+    height: 100%;
+    .o_list_view {
+        height: 100%;
+        display: flex;
+        flex-flow: column;
+    }
+}

--- a/addons/web/static/src/views/view_dialogs/select_create_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/select_create_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.SelectCreateDialog">
-        <Dialog title="props.title" withBodyPadding="false">
+        <Dialog title="props.title" withBodyPadding="false" contentClass="'o_select_create_dialog_content'">
             <t t-set-slot="header" t-slot-scope="scope">
                 <t t-call="web.Dialog.header">
                     <t t-set="dismiss" t-value="scope.close"/>


### PR DESCRIPTION
This commit adds desktop-specific styling to the select_create_dialog to ensure that the control panel and list headers remain fixed at the top while scrolling through the modal body. This improves usability, especially when dealing with long lists. As a side-effect, every select_create_dialog will take the whole screen height no matter their content.

task-4578925
