### PR TITLE
[IMP] web, *: clean user menu

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu.xml
+++ b/addons/web/static/src/core/debug/debug_menu.xml
@@ -21,7 +21,7 @@
                                 onSelected="element.callback"
                                 attrs="{ href: element.href }"
                             >
-                                <span t-att-style="entry[0] and 'padding-left: 12px;'" t-esc="element.description"/>
+                                <span t-att-class="entry[0] and 'ps-3'" t-esc="element.description"/>
                             </DropdownItem>
                             <t t-if="element.type == 'component'" t-component="element.Component" t-props="element.props"/>
                         </t>

--- a/addons/web/static/src/core/debug/debug_menu_basic.js
+++ b/addons/web/static/src/core/debug/debug_menu_basic.js
@@ -14,7 +14,7 @@ debugSectionRegistry
     .add("records", { label: _t("Records"), sequence: 10 })
     .add("ui", { label: _t("User Interface"), sequence: 20 })
     .add("security", { label: _t("Security"), sequence: 30 })
-    .add("testing", { label: _t("Testing"), sequence: 40 })
+    .add("testing", { label: _t("Tours & Testing"), sequence: 40 })
     .add("tools", { label: _t("Tools"), sequence: 50 });
 
 export class DebugMenuBasic extends Component {

--- a/addons/web/static/src/webclient/debug/profiling/profiling_item.scss
+++ b/addons/web/static/src/webclient/debug/profiling/profiling_item.scss
@@ -1,12 +1,3 @@
-.o_debug_profiling_item {
-    cursor: auto;
-    padding-left: 12px;
-
-    .o_profiling_switch .form-switch {
-        cursor: pointer;
-    }
-}
-
 .o_debug_recording {
     animation: 2s flash infinite;
 }

--- a/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.DebugMenu.ProfilingItem">
         <DropdownItem class="o_debug_profiling_item_wrapper">
-            <div class="o_debug_profiling_item d-flex justify-content-between">
+            <div class="d-flex justify-content-between ps-3">
                 <div class="align-self-center">
                     <div t-if="profiling.state.isEnabled" class="alert alert-info py-2 me-3">Recording...</div>
                     <span class="o_profiling_switch">

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -8,26 +8,12 @@ import { session } from "@web/session";
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
 
-function documentationItem(env) {
-    const documentationURL = "https://www.odoo.com/documentation/master";
-    return {
-        type: "item",
-        id: "documentation",
-        description: _t("Documentation"),
-        href: documentationURL,
-        callback: () => {
-            browser.open(documentationURL, "_blank");
-        },
-        sequence: 10,
-    };
-}
-
 function supportItem(env) {
     const url = session.support_url;
     return {
         type: "item",
         id: "support",
-        description: _t("Support"),
+        description: _t("Help"),
         href: url,
         callback: () => {
             browser.open(url, "_blank");
@@ -89,7 +75,7 @@ export function odooAccountItem(env) {
     return {
         type: "item",
         id: "account",
-        description: _t("My Odoo.com account"),
+        description: _t("My Odoo.com Account"),
         callback: () => {
             rpc("/web/session/account")
                 .then((url) => {
@@ -151,7 +137,6 @@ function logOutItem(env) {
 
 registry
     .category("user_menuitems")
-    .add("documentation", documentationItem)
     .add("support", supportItem)
     .add("shortcuts", shortCutsItem)
     .add("separator", separator)

--- a/addons/web/static/tests/webclient/user_menu.test.js
+++ b/addons/web/static/tests/webclient/user_menu.test.js
@@ -159,7 +159,7 @@ test("click on odoo account item", async () => {
     stepAllNetworkCalls();
     await contains("button.dropdown-toggle").click();
     expect(".o-dropdown--menu .dropdown-item").toHaveCount(1);
-    expect(".o-dropdown--menu .dropdown-item").toHaveText("My Odoo.com account");
+    expect(".o-dropdown--menu .dropdown-item").toHaveText("My Odoo.com Account");
     await contains(".o-dropdown--menu .dropdown-item").click();
     expect.verifySteps(["/web/session/account", "open https://account-url.com"]);
 });


### PR DESCRIPTION
This commits aims to improve the UserMenu experience by renaming or removing some items from the list.

For example, the 'Onboarding Item' has been moved to the debug menu instead.

task-4649510