### PR TITLE
[FIX] website_sale: ensure product exists on reorder check

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -571,7 +571,9 @@ class SaleOrder(models.Model):
 
     def _is_reorder_allowed(self):
         self.ensure_one()
-        return self.state == 'sale' and any(line._is_reorder_allowed() for line in self.order_line if not line.display_type)
+        return self.state == 'sale' and any(
+            line._is_reorder_allowed() for line in self.order_line if line.product_id
+        )
 
     def _filter_can_send_abandoned_cart_mail(self):
         self.website_id.ensure_one()

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -59,4 +59,4 @@ class SaleOrderLine(models.Model):
 
     def _is_reorder_allowed(self):
         self.ensure_one()
-        return self.product_id._is_add_to_cart_allowed()
+        return bool(self.product_id) and self.product_id._is_add_to_cart_allowed()

--- a/addons/website_sale/tests/test_website_sale_reorder_from_portal.py
+++ b/addons/website_sale/tests/test_website_sale_reorder_from_portal.py
@@ -2,18 +2,27 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.fields import Command
-from odoo.tests import HttpCase, tagged
+from odoo.tests import tagged
+
+from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 
 
 @tagged('post_install', '-at_install')
-class TestWebsiteSaleReorderFromPortal(HttpCase):
+class TestWebsiteSaleReorderFromPortal(HttpCaseWithUserPortal):
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env['website'].get_current_website().enabled_portal_reorder_button = True
 
-    def test_website_sale_reorder_from_portal(self):
-        product_1, product_2 = self.env['product.product'].create([
+        cls.website = cls.env['website'].get_current_website()
+        cls.website.write({
+            'enabled_portal_reorder_button': True,
+            'prevent_zero_price_sale': False,
+        })
+        cls.empty_cart = cls.env['sale.order'].create({
+            'partner_id': cls.partner_portal.id,
+        })
+        cls.product_1, cls.product_2 = cls.env['product.product'].create([
             {
                 'name': 'Reorder Product 1',
                 'sale_ok': True,
@@ -25,6 +34,8 @@ class TestWebsiteSaleReorderFromPortal(HttpCase):
                 'website_published': True,
             },
         ])
+
+    def test_website_sale_reorder_from_portal(self):
         no_variant_attribute = self.env['product.attribute'].create({
             'name': 'Size',
             'create_variant': 'no_variant',
@@ -46,15 +57,15 @@ class TestWebsiteSaleReorderFromPortal(HttpCase):
         ptav_s = ptavs.filtered(lambda ptav: ptav.product_attribute_value_id == s)
         ptav_l = ptavs.filtered(lambda ptav: ptav.product_attribute_value_id == l)
         user_admin = self.env.ref('base.user_admin')
-        order = self.env['sale.order'].create({
+        order = self.empty_cart
+        order.write({
             'partner_id': user_admin.partner_id.id,
-            'state': 'sale',
             'order_line': [
                 Command.create({
-                    'product_id': product_1.id,
+                    'product_id': self.product_1.id,
                 }),
                 Command.create({
-                    'product_id': product_2.id,
+                    'product_id': self.product_2.id,
                 }),
                 Command.create({
                     'product_id': no_variant_template.product_variant_id.id,
@@ -70,6 +81,7 @@ class TestWebsiteSaleReorderFromPortal(HttpCase):
                 })
             ],
         })
+        order.action_confirm()
         order.message_subscribe(user_admin.partner_id.ids)
 
         self.start_tour("/", 'website_sale_reorder_from_portal', login='admin')
@@ -83,4 +95,60 @@ class TestWebsiteSaleReorderFromPortal(HttpCase):
         self.assertEqual(
             previous_lines.product_no_variant_attribute_value_ids,
             order_lines.product_no_variant_attribute_value_ids,
+        )
+
+    def test_is_reorder_allowed(self):
+        line_published_product = Command.create({
+            'product_id': self.product_1.id,
+        })
+        self.product_2.active = False
+        line_archived_product = Command.create({
+            'product_id': self.product_2.id,
+        })
+        line_section = Command.create({
+            'name': "Free line",
+            'display_type': 'line_section',
+        })
+        line_downpayment = Command.create({
+            'name': "Down with the Payment",
+            'is_downpayment': True,
+            'price_unit': 5,
+        })
+
+        order = self.empty_cart.with_user(self.user_portal).sudo()
+        order.order_line = [line_section]
+        order.action_confirm()
+        self.assertFalse(
+            order._is_reorder_allowed(),
+            "Reordering a line section should not be allowed",
+        )
+
+        order.order_line = [line_archived_product]
+        self.assertFalse(
+            order._is_reorder_allowed(),
+            "Reordering an archived product should not be allowed",
+        )
+
+        order.order_line = [line_published_product]
+        self.assertTrue(
+            order._is_reorder_allowed(),
+            "Reordering a published product should be allowed",
+        )
+
+        self.product_1.website_published = False
+        self.assertFalse(
+            order._is_reorder_allowed(),
+            "Reordering an unpublished product should not be allowed",
+        )
+
+        order.order_line = [line_downpayment]
+        self.assertFalse(
+            order._is_reorder_allowed(),
+            "Reordering a down payment should not be allowed",
+        )
+
+        self.product_2.write({'active': True, 'list_price': 0.0})
+        self.assertTrue(
+            order._is_reorder_allowed(),
+            "Reordering a zero-priced product should be allowed when enabled",
         )


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Create a SO for non-user client;
2. add a product that isn't published on the website;
3. confirm SO;
4. create downpayment;
5. copy share SO link;
6. open link in private window.

Issue
-----
> 500: Internal Server Error
> Error while render the template
> ValueError: Expected singleton: product.product()

Cause
-----
Commit 9aa52dd6418e removed the creation of a "Down payment" product. Before it, order lines were either of type `display_section` or they had a `product_id` value. After the commit, a third option is for `is_downpayment` to be true.

This regressed the fix to this issue added by 34d4ffa01d57d, as instead of ensuring lines have a `product_id` value before checking if reorder is allowed, it decided to check whether they're not of `display_type`.

Solution
--------
Ensure there's a `product_id` in `sale.order.line` instead of only relying on the caller to filter those out beforehand.

opw-4711297