### PR TITLE
[FIX] pos_mrp: error when trying to set product_id on boms

### DIFF
--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -41,7 +41,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         })
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.kit
         bom_product_form.product_tmpl_id = self.kit.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -147,7 +146,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         })
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.subkit1
         bom_product_form.product_tmpl_id = self.subkit1.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -157,7 +155,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         self.bom_a = bom_product_form.save()
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.subkit2
         bom_product_form.product_tmpl_id = self.subkit2.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -170,7 +167,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         self.bom_b = bom_product_form.save()
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.kit
         bom_product_form.product_tmpl_id = self.kit.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -183,7 +179,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         self.final_bom = bom_product_form.save()
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.kit_2
         bom_product_form.product_tmpl_id = self.kit_2.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -284,7 +279,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         })
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = self.kit
         bom_product_form.product_tmpl_id = self.kit.product_tmpl_id
         bom_product_form.product_qty = 2.0
         bom_product_form.type = 'phantom'
@@ -384,7 +378,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         })
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = kit_1
         bom_product_form.product_tmpl_id = kit_1.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -397,7 +390,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         self.bom_a = bom_product_form.save()
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = kit_2
         bom_product_form.product_tmpl_id = kit_2.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -489,7 +481,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         })
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = kit_1
         bom_product_form.product_tmpl_id = kit_1.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -499,7 +490,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         self.bom_a = bom_product_form.save()
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = kit_2
         bom_product_form.product_tmpl_id = kit_2.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'
@@ -509,7 +499,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         self.bom_b = bom_product_form.save()
 
         bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_id = kit_3
         bom_product_form.product_tmpl_id = kit_3.product_tmpl_id
         bom_product_form.product_qty = 1.0
         bom_product_form.type = 'phantom'


### PR DESCRIPTION
Similar to #206050, sale_mrp has a bunch of forms which try to set the `product_id` on a bom without product variants being enabled, in which case the field is invisible and setting it fails.

Since they don't seem to really care for variants, and the products are not created with variants, as in #206050 just don't set `product_id`.

https://runbot.odoo.com/odoo/error/163112
