### PR TITLE
[REV] core: avoid sending invalid json-rpc responses

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1923,7 +1923,7 @@ class JsonRPCDispatcher(Dispatcher):
         response = {'jsonrpc': '2.0', 'id': self.request_id}
         if error is not None:
             response['error'] = error
-        else:
+        if result is not None:
             response['result'] = result
 
         return self.request.make_json_response(response)


### PR DESCRIPTION
This reverts commit 4c7942e6bd0459fc9014d2af4a67a68c8334bca4.

Steps to reproduce
==================

- Install account_accountant
- Go to accounting
- Close the onboarding banner

=> TypeError: Cannot read properties of null (reading 'context')
    at _preprocessAction

Cause of the issue
==================

With commit 4c7942e6bd04, the response when calling the action changed

```diff
- {"jsonrpc": "2.0", "id": 10}
+ {"jsonrpc": "2.0", "id": 10, result: null}
```

https://github.com/odoo/odoo/blob/c412f11c028a8c7ff6e6c10da0e3f9dbc55e8e80/addons/web/static/src/views/view_hook.js#L86-L89

The condition `action !== undefined` is no longer met since the result is null.

Solution
========

Since this can happen anywhere we make an RPC call and there's no easy way to detect it, we revert the commit in stable.