### PR TITLE
[FIX] web: adapts plus & minus OI icons

### DIFF
--- a/addons/web/static/lib/odoo_ui_icons/style.css
+++ b/addons/web/static/lib/odoo_ui_icons/style.css
@@ -77,8 +77,8 @@
 .oi-users:before { content: '\e807'; }
 .oi-ellipsis-h:before { content: '\e867'; }
 .oi-ellipsis-v:before { content: '\e868'; }
-.oi-plus:before { content: '\e87b'; }
-.oi-minus:before { content: '\e87a'; }
+.oi-plus:before { content: '\e809'; }
+.oi-minus:before { content: '\e80b'; }
 
 /* RTL adaptations. */
 /* Flip directional icons by 180 degree. */


### PR DESCRIPTION
Since commit e1e118d2361148c64db1d32074f0d2652c8522a2, the code for `oi-plus` and `oi-minus` seems to have been modified in the font files, which breaks these icons.
This commit adapts these icons to display them correctly.

task-4735707



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
