### PR TITLE
[FIX] {stock,mrp}_account: unbuild after return

### DIFF
--- a/addons/mrp_account/models/__init__.py
+++ b/addons/mrp_account/models/__init__.py
@@ -10,3 +10,4 @@ from . import product
 from . import stock_move
 from . import stock_rule
 from . import account_move
+from . import stock_valuation_layer

--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -117,15 +117,6 @@ class ProductProduct(models.Model):
                 total *= float_round(1 - byproduct_cost_share / 100, precision_rounding=0.0001)
             return bom.product_uom_id._compute_price(total / bom.product_qty, self.uom_id)
 
-    def _get_fifo_candidates_domain(self, company):
-        fifo_candidates_domain = super()._get_fifo_candidates_domain(company)
-        if self in self.env.context.get('product_unbuild_map', ()):
-            fifo_candidates_domain = expression.AND([
-                fifo_candidates_domain,
-                [('stock_move_id', 'in', self.env.context['product_unbuild_map'][self].mo_id.move_finished_ids.ids)]
-            ])
-        return fifo_candidates_domain
-
 
 class ProductCategory(models.Model):
     _inherit = 'product.category'

--- a/addons/mrp_account/models/stock_valuation_layer.py
+++ b/addons/mrp_account/models/stock_valuation_layer.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockValuationLayer(models.Model):
+    _inherit = 'stock.valuation.layer'
+
+    def _candidate_sort_key(self):
+        self.ensure_one()
+        res = super()._candidate_sort_key()
+        if self.product_id in self.env.context.get('product_unbuild_map', ()):
+            unbuild = self.env.context['product_unbuild_map'][self.product_id]
+            # Give priority to the SVL that produced `self.product_id`
+            res += (self.stock_move_id.id not in unbuild.mo_id.move_finished_ids.ids,)
+        return res

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -333,7 +333,7 @@ class ProductProduct(models.Model):
 
     def _get_fifo_candidates(self, company):
         candidates_domain = self._get_fifo_candidates_domain(company)
-        return self.env["stock.valuation.layer"].sudo().search(candidates_domain)
+        return self.env["stock.valuation.layer"].sudo().search(candidates_domain).sorted(lambda svl: svl._candidate_sort_key())
 
     def _get_qty_taken_on_candidate(self, qty_to_take_on_candidates, candidate):
         return min(qty_to_take_on_candidates, candidate.remaining_qty)

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -62,6 +62,10 @@ class StockValuationLayer(models.Model):
         ]).ids
         return [('id', 'in', layer_ids)]
 
+    def _candidate_sort_key(self):
+        self.ensure_one()
+        return tuple()
+
     def _validate_accounting_entries(self):
         am_vals = []
         aml_to_reconcile = defaultdict(set)


### PR DESCRIPTION
Unbuilding a returned product will break the stock valuations.

To reproduce the issue:
1. Create a FIFO product
2. Produce
3. Deliver
4. Return
5. Unbuild

Issue: Looking at the remaining qties of the SVL, we see that the
layer of the unbuild didn't consume the quantity of the return. This
may lead to more important issues in the stock valuation.

When processing the unbuild, we `_run_fifo` to consume the existing
SVLs. To do so, we first try to find the candidates. Here is the
problem: since [1], in case of an unbuild, we force to use the SVL
of the MO only. This will not work with the above use case: the SVL
of the MO has been consumed by the delivery. Therefore, we don't
find any candidate. This is the reason why we have some
inconsistencies on the layers.

Instead of getting the SVL of the MO only, we should simply give it
the priority and be able to find some other candidates.

[1] https://github.com/odoo/odoo/commit/49565cdd9007ac66a3b835dc073777e2e6c48f2c

OPW-4683083