### PR TITLE
[IMP] mail: delete thread action

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -209,3 +209,10 @@ class ChannelController(http.Controller):
             "store_data": Store().add(sub_channels).add(sub_channels._get_last_messages()).get_result(),
             "sub_channel_ids": sub_channels.ids,
         }
+
+    @http.route("/discuss/channel/sub_channel/delete", methods=["POST"], type="jsonrpc", auth="user")
+    def discuss_delete_sub_channel(self, sub_channel_id, **kwargs):
+        channel = request.env["discuss.channel"].search([("id", "=", sub_channel_id)])
+        if not channel and not channel.parent_channel_id:
+            raise NotFound()
+        channel._delete_sub_channel()

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -18,6 +18,7 @@ import { useService } from "@web/core/utils/hooks";
 import { Typing } from "@mail/discuss/typing/common/typing";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { isMobileOS } from "@web/core/browser/feature_detection";
+import { assignGetter } from "@mail/utils/common/misc";
 
 /**
  * @typedef {Object} Props
@@ -42,7 +43,6 @@ export class ChatWindow extends Component {
 
     setup() {
         super.setup();
-        useSubEnv({ inChatWindow: true });
         this.store = useService("mail.store");
         this.messageHighlight = useMessageScrolling();
         this.state = useState({
@@ -50,6 +50,9 @@ export class ChatWindow extends Component {
             jumpThreadPresent: 0,
             editingGuestName: false,
             editingName: false,
+        });
+        useSubEnv({
+            inChatWindow: assignGetter(this.state, { thread: () => this.props.chatWindow.thread }),
         });
         this.ui = useService("ui");
         this.contentRef = useRef("content");

--- a/addons/mail/static/src/discuss/core/common/delete_thread_dialog.js
+++ b/addons/mail/static/src/discuss/core/common/delete_thread_dialog.js
@@ -1,0 +1,37 @@
+import { ActionPanel } from "@mail/discuss/core/common/action_panel";
+
+import { Component } from "@odoo/owl";
+
+import { rpc } from "@web/core/network/rpc";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+export class DeleteThreadDialog extends Component {
+    static components = { ActionPanel };
+    static props = ["thread", "close"];
+    static template = "discuss.DeleteThreadDialog";
+
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+    }
+
+    async onConfirmation() {
+        let toOpenThread;
+        const threadName = this.props.thread.name;
+        if (this.store.discuss?.thread?.eq(this.props.thread) || this.env.inChatWindow.thread) {
+            toOpenThread = this.props.thread.parent_channel_id;
+        }
+        await rpc("/discuss/channel/sub_channel/delete", {
+            sub_channel_id: this.props.thread.id,
+        });
+        if (toOpenThread?.exists()) {
+            toOpenThread.open();
+        }
+        this.props.close();
+        this.env.services.notification.add(
+            _t('Thread "%(thread_name)s" has been deleted', { name: threadName }),
+            { type: "warning" }
+        );
+    }
+}

--- a/addons/mail/static/src/discuss/core/common/delete_thread_dialog.xml
+++ b/addons/mail/static/src/discuss/core/common/delete_thread_dialog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="discuss.DeleteThreadDialog">
+        <ActionPanel title.translate="Delete Thread" icon="'fa fa-trash'" resizable="false">
+            <div class="d-flex justify-content-between align-items-center">
+                <p class="fs-5 mb-0">Permanently delete this thread?</p>
+                <button class="btn btn-danger" t-on-click="onConfirmation">
+                    Delete Thread
+                </button>
+            </div>
+        </ActionPanel>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -1,7 +1,9 @@
+import { ACTION_TAGS } from "@mail/core/common/action";
 import { registerThreadAction } from "@mail/core/common/thread_actions";
 import { AttachmentPanel } from "@mail/discuss/core/common/attachment_panel";
 import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation";
 import { ChannelMemberList } from "@mail/discuss/core/common/channel_member_list";
+import { DeleteThreadDialog } from "@mail/discuss/core/common/delete_thread_dialog";
 import { NotificationSettings } from "@mail/discuss/core/common/notification_settings";
 
 import { Component, xml } from "@odoo/owl";
@@ -157,4 +159,39 @@ registerThreadAction("mark-read", {
     name: _t("Mark Read"),
     sequence: 10,
     sequenceGroup: 20,
+});
+registerThreadAction("delete-thread", {
+    actionPanelComponent: DeleteThreadDialog,
+    actionPanelComponentProps({ action }) {
+        return { close: () => action.close() };
+    },
+    condition({ owner, store, thread }) {
+        return (
+            thread?.parent_channel_id &&
+            store.self.main_user_id &&
+            store.self.main_user_id.eq(thread.create_uid) &&
+            !owner.isDiscussContent
+        );
+    },
+    panelOuterClass: "bg-100",
+    icon: "fa fa-fw fa-trash",
+    iconLarge: "fa fa-fw fa-lg fa-trash",
+    name: _t("Delete Thread"),
+    close: ({ action }) => action.popover?.close(),
+    toggle: true,
+    open: ({ action, owner, store, thread }) => {
+        if (owner.isDiscussSidebarChannelActions) {
+            store.env.services.dialog?.add(ChannelActionDialog, {
+                title: thread.name,
+                contentComponent: DeleteThreadDialog,
+                contentProps: {
+                    close: () => store.env.services.dialog.closeAll(),
+                    thread,
+                },
+            });
+        }
+    },
+    sequence: ({ owner }) => (owner.props.chatWindow ? 50 : 40),
+    sequenceGroup: 40,
+    tags: [ACTION_TAGS.DANGER],
 });

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -44,7 +44,7 @@ export class DiscussSidebarSubchannel extends Component {
     }
 
     get actionsTitle() {
-        return _t("Threads Actions");
+        return _t("Thread Actions");
     }
 
     get thread() {

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -22,6 +22,7 @@ export function assignGetter(obj, data) {
         ])
     );
     Object.defineProperties(obj, properties);
+    return obj;
 }
 
 export function assignIn(obj, data, keys = Object.keys(data)) {

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -53,7 +53,7 @@ test("can manually unpin a sub-thread", async () => {
     await click("button[title='Threads']");
     await click("button[aria-label='Create Thread']");
     await contains(".o-mail-DiscussContent-threadName", { value: "New Thread" });
-    await click("[title='Threads Actions']");
+    await click("[title='Thread Actions']");
     await click(".o-dropdown-item:contains('Unpin Conversation')");
     await contains(".o-mail-DiscussSidebar-item", { text: "New Thread", count: 0 });
 });
@@ -326,4 +326,23 @@ test("show notification when clicking on deleted thread", async () => {
     await contains(".o_notification:has(.o_notification_bar.bg-danger)", {
         text: "This thread is no longer available.",
     });
+});
+
+test("Can delete channel thread as author of thread", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+    });
+    const subChannelID = pyEnv["discuss.channel"].create({
+        name: "test thread",
+        parent_channel_id: channelId,
+    });
+    await start();
+    await openDiscuss(subChannelID);
+    await contains(".o-mail-DiscussContent-threadName[title='test thread']");
+    await click(".o-mail-DiscussSidebar-item:contains('test thread') [title='Thread Actions']");
+    await click(".o-dropdown-item:contains('Delete Thread')");
+    await click(".modal button:contains('Delete Thread')");
+    await contains(".o-mail-DiscussContent-threadName[title='General']");
+    await contains(`.o-mail-NotificationMessage:contains('deleted the thread "test thread"')`);
 });

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -321,6 +321,14 @@ async function discuss_channel_sub_channel_create(request) {
     );
 }
 
+registerRoute("/discuss/channel/sub_channel/delete", discuss_channel_sub_channel_delete);
+async function discuss_channel_sub_channel_delete(request) {
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
+    const { sub_channel_id } = await parseRequestParams(request);
+    return DiscussChannel._delete_sub_channel(sub_channel_id);
+}
+
 registerRoute("/discuss/channel/sub_channel/fetch", discuss_channel_sub_channel_fetch);
 async function discuss_channel_sub_channel_fetch(request) {
     /** @type {import("mock_models").DiscussChannel} */


### PR DESCRIPTION
**purpose of PR:**
added action to permanently delete a thread with confirmation input users must type 'delete' to confirm the deletion, preventing accidental removal of the thread and its associated data.

This commit is available in discuss sidebar and chat window, similarly to "leave" / "unpin" action.

task-4629867

<img width="491" height="144" alt="image" src="https://github.com/user-attachments/assets/7f0fa5ff-0927-4c06-81d2-7503e68e3a95" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
