### PR TITLE
[FIX] hr_recruitment: send no email on recruiter change for job position

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -294,7 +294,7 @@ class HrJob(models.Model):
                 )
                 if application_ids:
                     application_ids.message_unsubscribe(to_unsubscribe)
-                    application_ids.user_id = job.user_id
+                    application_ids.with_context(mail_auto_subscribe_no_notify=True).user_id = job.user_id
 
         # Since the alias is created upon record creation, the default values do not reflect the current values unless
         # specifically rewritten


### PR DESCRIPTION
### Steps to Reproduce:
- Create a job position and assign a recruiter to it.
- Create multiple applicants for the job position.
- Go to the job configuration and change the recruiter.

### Fix:
- After this commit, the new recruiter will no longer be spammed with multiple emails.

task-4735500

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
