### PR TITLE
[IMP] account, base, l10n_*: hide unnecessary elements

### DIFF
--- a/addons/account/data/res_country_group.xml
+++ b/addons/account/data/res_country_group.xml
@@ -18,5 +18,18 @@
                 ref('base.state_nl_bq3'),
             ])]"/>
         </record>
+
+        <record id="intrastat" model="res.country.group">
+            <field name="name">Intrastat</field>
+            <field name="code">INTRASTAT</field>
+            <field name="country_ids" eval="[Command.set([
+                ref('base.at'),ref('base.be'),ref('base.bg'),ref('base.hr'),ref('base.cy'),
+                ref('base.cz'),ref('base.dk'),ref('base.ee'),ref('base.fi'),ref('base.fr'),
+                ref('base.de'),ref('base.gr'),ref('base.hu'),ref('base.ie'),ref('base.it'),
+                ref('base.lv'),ref('base.lt'),ref('base.lu'),ref('base.mt'),ref('base.nl'),
+                ref('base.pl'),ref('base.pt'),ref('base.ro'),ref('base.sk'),ref('base.si'),
+                ref('base.es'),ref('base.se'),ref('base.uk'),ref('base.xi'),
+            ])]"/>
+        </record>
     </data>
 </odoo>

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -160,6 +160,7 @@ class AccountJournal(models.Model):
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True, index=True, default=lambda self: self.env.company,
         help="Company related to this journal")
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
+    account_fiscal_country_group_codes = fields.Json(related="company_id.account_fiscal_country_group_codes")
 
     refund_sequence = fields.Boolean(
         string="Dedicated Credit Note Sequence",

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -323,6 +323,7 @@ class AccountMove(models.Model):
     show_name_warning = fields.Boolean(store=False)
     type_name = fields.Char('Type Name', compute='_compute_type_name')
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
+    account_fiscal_country_group_codes = fields.Json(related="company_id.account_fiscal_country_group_codes")
     company_price_include = fields.Selection(related='company_id.account_price_include', readonly=True)
     attachment_ids = fields.One2many('ir.attachment', 'res_id', domain=[('res_model', '=', 'account.move')], string='Attachments')
     audit_trail_message_ids = fields.One2many(

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -213,6 +213,7 @@ class ResCompany(models.Model):
         store=True,
         readonly=False,
         help="The country to use the tax reports from for this company")
+    account_fiscal_country_group_codes = fields.Json(compute="_compute_account_fiscal_country_group_codes")
 
     account_enabled_tax_country_ids = fields.Many2many(
         string="l10n-used countries",
@@ -357,6 +358,13 @@ class ResCompany(models.Model):
         for company in self:
             potential_domestic_fps = company.fiscal_position_ids.filtered_domain([('country_id', '=', company.country_id.id)]).sorted('sequence')
             company.domestic_fiscal_position_id = potential_domestic_fps[0] if potential_domestic_fps else False
+
+    @api.depends('account_fiscal_country_id')
+    def _compute_account_fiscal_country_group_codes(self):
+        for company in self:
+            company.account_fiscal_country_group_codes = (
+                company.account_fiscal_country_id.country_group_codes if company.account_fiscal_country_id else ['']
+            )
 
     @api.depends('fiscal_position_ids.foreign_vat')
     def _compute_multi_vat_foreign_country(self):

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -129,7 +129,7 @@
                             </setting>
                             <setting id="intrastat_statistics" help="Collect information and produce statistics on the trade in goods in Europe with intrastat"
                                 documentation="/applications/finance/accounting/reporting/declarations/intrastat.html"
-                                invisible="'EU' not in company_country_group_codes">
+                                invisible="'INTRASTAT' not in company_country_group_codes">
                                 <field name="module_account_intrastat" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="default_incoterm" string="Default Incoterm" help="Default Incoterm of your company">

--- a/addons/l10n_bg_ledger/views/account_move_views.xml
+++ b/addons/l10n_bg_ledger/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_info_group']" position="after">
-                <group string="Bulgaria VAT Document" name="l10n_bg_documents">
+                <group string="Bulgaria VAT Document" name="l10n_bg_documents" invisible="country_code != 'BG'">
                     <field string="Document Type" name="l10n_bg_document_type"/>
                     <field string="Document Number" name="l10n_bg_document_number"/>
                     <field string="Exemption reason" name="l10n_bg_exemption_reason"/>

--- a/addons/l10n_latam_base/__manifest__.py
+++ b/addons/l10n_latam_base/__manifest__.py
@@ -50,6 +50,7 @@ This module is compatible with base_vat module in order to be able to validate V
         'base_vat',
     ],
     'data': [
+        'data/res_country_group.xml',
         'data/l10n_latam.identification.type.csv',
         'views/res_partner_view.xml',
         'views/l10n_latam_identification_type_view.xml',

--- a/addons/l10n_latam_base/data/res_country_group.xml
+++ b/addons/l10n_latam_base/data/res_country_group.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="latam" model="res.country.group">
+            <field name="name">Latin America Identification</field>
+            <field name="code">LATAMID</field>
+            <field name="country_ids" eval="[Command.set([
+                ref('base.ar'),ref('base.br'),ref('base.cl'),ref('base.co'),
+                ref('base.ec'),ref('base.pe'),ref('base.uy')])]"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_latam_base/models/res_partner.py
+++ b/addons/l10n_latam_base/models/res_partner.py
@@ -11,6 +11,7 @@ class ResPartner(models.Model):
         default=lambda self: self.env.ref('l10n_latam_base.it_vat', raise_if_not_found=False),
         inverse="_inverse_vat",  # To trigger the vat checking
         help="The type of identification")
+    is_vat = fields.Boolean(related='l10n_latam_identification_type_id.is_vat')
     vat = fields.Char(string='Identification Number', help="Identification Number for selected type")
 
     @api.model

--- a/addons/l10n_latam_base/views/res_partner_view.xml
+++ b/addons/l10n_latam_base/views/res_partner_view.xml
@@ -8,12 +8,16 @@
         <field name="priority">100</field>
         <field type="xml" name="arch">
             <xpath expr="//label[@for='vat']" position="replace">
-                <label for="l10n_latam_identification_type_id" string="Identification Number"/>
+                <label for="l10n_latam_identification_type_id" string="Identification Number" invisible="is_vat and 'LATAMID' not in fiscal_country_group_codes"/>
+                <label for="vat" string="Tax ID" invisible="not is_vat or 'LATAMID' in fiscal_country_group_codes"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="replace">
-                <field name="l10n_latam_identification_type_id" options="{'no_open': True, 'no_create': True}" placeholder="Type" class="oe_inline" domain="country_id and ['|', ('country_id', '=', False), ('country_id', '=', country_id)] or []" required="True" readonly="parent_id"/>
-                <span class="oe_read_only"> - </span>
-                <field name="vat" placeholder="Number" class="oe_inline"/>
+                <field name="l10n_latam_identification_type_id" options="{'no_open': True, 'no_create': True}"
+                       placeholder="Type" class="oe_inline" required="True" readonly="parent_id"
+                       domain="country_id and ['|', ('country_id', '=', False), ('country_id', '=', country_id)] or []"
+                       invisible="is_vat and 'LATAMID' not in fiscal_country_group_codes"/>
+                <span class="oe_read_only" invisible="is_vat and 'LATAMID' not in fiscal_country_group_codes"> - </span>
+                <field name="vat" placeholder="Number" class="oe_inline" />
             </xpath>
         </field>
     </record>

--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1602,6 +1602,12 @@
             <field name="currency_id" ref="ZIG" />
             <field eval="263" name="phone_code" />
         </record>
+        <record id="xi" model="res.country">
+            <field name="name">Northern Ireland</field>
+            <field name="code">xi</field>
+            <field name="currency_id" ref="GBP"/>
+            <field eval="44" name="phone_code"/>
+        </record>
         <record id="xk" model="res.country">
             <field name="name">Kosovo</field>
             <field name="code">xk</field>


### PR DESCRIPTION
This **PR** enhances the user experience by conditionally hiding irrelevant elements across various accounting and localization modules (l10n_*), based on the user's country group or country code. This ensures a cleaner, more region-specific interface.

Major Change:

Before this **PR**:
When the base LATAM module was installed, it introduced a new Identification Type field in the view, which replaced the VAT (Tax ID) field. In a multi-company setup, this caused issues for companies using other localizations, as they were forced to see the Identification Type instead of the VAT field.

After this **PR**:
Visibility of the Identification Type is now conditional. It will only appear in other localizations when the type is not is_vat and the allowed company is not a LATAM company.

**task**-4613288

Enterprise **PR** - https://github.com/odoo/enterprise/pull/83609
Upgrade **PR** - https://github.com/odoo/upgrade/pull/8191