### PR TITLE
[FIX] payment_paypal: don't set shipping address if no address is given

### DIFF
--- a/addons/payment_paypal/tests/test_paypal.py
+++ b/addons/payment_paypal/tests/test_paypal.py
@@ -31,6 +31,7 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
             'item_number': self.reference,
             'last_name': 'Buyer',
             'lc': 'en_US',
+            'no_shipping': '0',
             'address_override': '1',
             'notify_url': self._build_url(PaypalController._webhook_url),
             'return': return_url,

--- a/addons/payment_paypal/views/payment_paypal_templates.xml
+++ b/addons/payment_paypal/views/payment_paypal_templates.xml
@@ -20,6 +20,7 @@
             <input type="hidden" name="item_number" t-att-value="item_number"/>
             <input type="hidden" name="last_name" t-att-value="last_name"/>
             <input type="hidden" name="lc" t-att-value="lc"/>
+            <input type="hidden" name="no_shipping" t-att-value="no_shipping"/>
             <input type="hidden" name="address_override" t-att-value="address_override"/>
             <input t-if="notify_url"
                    type="hidden" name="notify_url" t-att-value="notify_url"/>


### PR DESCRIPTION
Versions
--------
- 16.0
- 17.0
- saas-17.4

used API changed starting from 18.0

Steps
-----
1. Set up PayPal;
2. have a partner with no address;
3. send a payment link to the partner;
4. attempt to pay using PayPal.

Issue
-----
> There's a problem with your shipping address.

Cause
-----
Commit 449b62d129f1 changed the `no_shipping` value in the form data to `address_override` to prevent users from changing their shipping address without losing seller protection.

Issues is that if `address_override` is set, PayPal expects a shipping address to be given, which isn't always possible.

Solution
--------
If the partner has no valid shipping address, leave `no_shipping` on `1`, and set `address_override` to `0`.

opw-4681336
