### PR TITLE
[IMP] html_editor: register every editor version in the html_editor manifest

### DIFF
--- a/addons/html_editor/static/src/html_migrations/html_upgrade_manager.js
+++ b/addons/html_editor/static/src/html_migrations/html_upgrade_manager.js
@@ -22,8 +22,9 @@ import { fixInvalidHTML } from "@html_editor/utils/sanitize";
  * !!!  ALWAYS assume that the `env` may not have the resource used in your
  *      migrate function and adjust accordingly.
  * - Refer to that file in the `html_editor_upgrade` registry, in the version
- *   category related to your change: `major.minor` (bump major for an IMP,
- *   minor for a FIX), in a sub-category related to your module.
+ *   category related to your change: `major.minor` (bump major for a change in
+ *   master, and minor for a change in stable), in a sub-category related to
+ *   your module.
  *   Example for the version 1.1 in `html_editor`:
  *   `registry
  *        .category("html_editor_upgrade")

--- a/addons/html_editor/static/src/html_migrations/manifest.js
+++ b/addons/html_editor/static/src/html_migrations/manifest.js
@@ -1,9 +1,16 @@
 import { registry } from "@web/core/registry";
 
+// See `HtmlUpgradeManager` docstring for usage details.
 const html_upgrade = registry.category("html_editor_upgrade");
+
+// Introduction of embedded components based on Knowledge Behaviors (Odoo 18).
+html_upgrade.category("1.0");
 
 // Remove the Excalidraw EmbeddedComponent and replace it with a link.
 html_upgrade.category("1.1").add("html_editor", "@html_editor/html_migrations/migration-1.1");
 
 // Fix Banner classes to properly handle `contenteditable` attribute
 html_upgrade.category("1.2").add("html_editor", "@html_editor/html_migrations/migration-1.2");
+
+// Knowledge embeddedViews favorite irFilters should have a `user_ids` property.
+html_upgrade.category("2.0");


### PR DESCRIPTION
Any modules (most notably Knowledge) can register new html_editor versions. To
ensure the version consistency no matter if the Knowledge module is installed or
not, every version should be registered in the `html_editor` manifest, even if
they do not apply any change in the `html_editor` itself.

task-4718129