### PR TITLE
[FIX] html_editor: ensure `.btn` links inherit parent font size

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3886,8 +3886,23 @@ export class OdooEditor extends EventTarget {
                     this.deselectTable();
                     setSelection(anchorTD.firstChild, 0, anchorTD.lastChild, nodeSize(anchorTD.lastChild));
                 }
-                if (ev.inputType === 'insertLineBreak' || this._applyCommand('oEnter') === UNBREAKABLE_ROLLBACK_CODE) {
-                    this._applyCommand('oShiftEnter');
+                const { anchorNode, anchorOffset, focusNode, focusOffset } = newSelection;
+
+                const anchorButton = closestElement(anchorNode, "a.btn");
+                const focusButton = closestElement(focusNode, "a.btn");
+
+                const isSameButton = anchorButton && focusButton && anchorButton === focusButton;
+                const isSelectionWithinButton =
+                    isSameButton &&
+                    anchorOffset >= 0 &&
+                    focusOffset <= anchorButton.textContent.length - 1;
+
+                if (
+                    (ev.inputType === "insertParagraph" && isSelectionWithinButton) ||
+                    ev.inputType === "insertLineBreak" ||
+                    this._applyCommand("oEnter") === UNBREAKABLE_ROLLBACK_CODE
+                ) {
+                    this._applyCommand("oShiftEnter");
                 }
             } else if (['insertText', 'insertCompositionText'].includes(ev.inputType)) {
                 const selection = this.document.getSelection();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1693,7 +1693,7 @@ export function isUnbreakable(node) {
                 node.getAttribute('t-out') ||
                 node.getAttribute('t-raw')) ||
                 node.getAttribute('t-field')) ||
-        node.matches(".oe_unbreakable, a.btn, a[role='tab'], a[role='button'], li.nav-item")
+        node.matches(".oe_unbreakable, a[role='tab'], a[role='button'], li.nav-item")
     );
 }
 

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -4102,6 +4102,15 @@ X[]
                         contentAfter: '<p><a class="btn btn-primary" href="#" role="button">Ho<br>[]me</a></p>',
                     });
                 });
+                it("should insert a line break inside a link with the btn class", async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><a class="btn btn-primary" href="#" role="button">Ho<br>[]me</a></p>',
+                        stepFunction: async editor => {
+                            await triggerEvent(editor.editable, 'input', { data: 'Enter', inputType: 'insertParagraph' });
+                        },
+                        contentAfter: '<p><a class="btn btn-primary" href="#" role="button">Ho<br><br>[]me</a></p>',
+                    });
+                });
                 it("should insert a linebreak on the list with nav-item class", async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<ul><li class="nav-item"><a class="nav-link" href="#" role="tab">Home[]</a></li></ul>',

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -15,7 +15,15 @@ import {
 } from "@odoo/owl";
 import { deduceURLfromText } from "@web_editor/js/editor/odoo-editor/src/utils/sanitize";
 
-const { getDeepRange, getInSelection, EMAIL_REGEX, PHONE_REGEX } = OdooEditorLib;
+const {
+    closestElement,
+    getDeepRange,
+    getInSelection,
+    EMAIL_REGEX,
+    FONT_SIZE_CLASSES,
+    PHONE_REGEX,
+    splitAroundUntil,
+} = OdooEditorLib;
 
 /**
  * Allows to customize link content and style.
@@ -725,7 +733,18 @@ export function getOrCreateLink({ containerNode, startNode } = {}) {
             range.insertNode(link);
             needLabel = true;
         } else {
-            link.appendChild(range.extractContents());
+            const fontSizeWrapper = closestElement(
+                commonAncestor,
+                (el) =>
+                    el.tagName === "SPAN" &&
+                    FONT_SIZE_CLASSES.some((cls) => el.classList.contains(cls))
+            );
+
+            const contentToLink = fontSizeWrapper
+                ? splitAroundUntil(commonAncestor, fontSizeWrapper)
+                : range.extractContents();
+
+            link.appendChild(contentToLink);
             range.insertNode(link);
         }
     }

--- a/addons/web_editor/static/tests/link_tests.js
+++ b/addons/web_editor/static/tests/link_tests.js
@@ -211,6 +211,43 @@ QUnit.module(
             );
         });
 
+        QUnit.test("should wrap font-size element inside link element", async function (assert) {
+            const { editor, editable } = onMount();
+            const p = editable.querySelector("p");
+            setSelection(p, 0);
+            insertText(editor, "Testing");
+            setSelection(p, 0, p, 7);
+            await nextTick();
+
+            // Click on font size button from floating toolbar.
+            editor.document.querySelector("#toolbar #fontSizeCurrentValue").click();
+            await nextTick();
+            // Select font size item.
+            const fontSizeItem = editor.document.querySelector(
+                '#toolbar a[data-apply-class="display-1-fs"]'
+            );
+            await fontSizeItem.dispatchEvent(new Event("mousedown"));
+            assert.strictEqual(
+                editable.innerHTML,
+                `<p><span class="display-1-fs">Testing</span></p>`
+            );
+
+            // Click on link button from floating toolbar
+            editor.document.querySelector("#toolbar .fa-link").click();
+            await nextTick();
+            // Insert link url
+            inputText('input[id="o_link_dialog_url_input"]', "#");
+            await nextTick();
+            editor.document.querySelector("span.btn-primary").click();
+            await nextTick();
+            // Click on Insert button
+            editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                `<p>\ufeff<a class="o_translate_inline btn btn-primary" href="#" target="_blank">\ufeff<span class="display-1-fs">Testing</span>\ufeff</a>\ufeff</p>`
+            );
+        });
 
         QUnit.module("PowerBox related");
 


### PR DESCRIPTION
### Steps to reproduce:

- Go to To-Do.
- Type some text and increase its font size to 80.
- Select the text and convert it into a button.
- The font size appears as 80 in the toolbar but is not visually reflected.

### Description of the issue/feature this PR addresses:

- Links with `.btn` class inside elements styled with font-size classes (e.g., display-3-fs) did not inherit the parent's font size.
- The `.btn` class's own font-size definition overrode the expected styling.

### Desired behavior after PR is merged:

- `.btn` links now use `font-size: inherit`, allowing them to respect and adopt their parent element’s font size.

task-4731416

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
