### PR TITLE
[FIX] l10n_ae: report invoice title

### DIFF
--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -14,76 +14,76 @@
             <t name="tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Tax Invoice</t>
         </t>
         <t name="invoice_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
         <t name="draft_invoice_title" position="before">
             <t name="draft_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Draft Tax Invoice</t>
         </t>
         <t name="draft_invoice_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
         <t name="cancelled_invoice_title" position="before">
             <t name="cancelled_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Tax Invoice</t>
         </t>
         <t name="cancelled_invoice_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
 
         <t name="credit_note_title" position="before">
             <t name="tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Tax Credit Note</t>
         </t>
         <t name="credit_note_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
         <t name="draft_credit_note_title" position="before">
             <t name="draft_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Draft Tax Credit Note</t>
         </t>
         <t name="draft_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
         <t name="cancelled_credit_note_title" position="before">
             <t name="cancelled_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Tax Credit Note</t>
         </t>
         <t name="cancelled_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
 
         <t name="proforma_invoice_title" position="before">
             <t name="proforma_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Proforma Tax Invoice</t>
         </t>
         <t name="proforma_invoice_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
         <t name="draft_proforma_invoice_title" position="before">
             <t name="draft_proforma_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Draft Proforma Tax Invoice</t>
         </t>
         <t name="draft_proforma_invoice_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
         <t name="cancelled_proforma_invoice_title" position="before">
             <t name="cancelled_proforma_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Proforma Tax Invoice</t>
         </t>
         <t name="cancelled_proforma_invoice_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
 
         <t name="proforma_credit_note_title" position="before">
             <t name="proforma_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Proforma Tax Credit Note</t>
         </t>
         <t name="proforma_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
         <t name="draft_proforma_credit_note_title" position="before">
             <t name="draft_proforma_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Draft Proforma Tax Credit Note</t>
         </t>
         <t name="draft_proforma_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
         <t name="cancelled_proforma_credit_note_title" position="before">
             <t name="cancelled_proforma_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Proforma Tax Credit Note</t>
         </t>
         <t name="cancelled_proforma_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
+            <attribute name="t-else"> </attribute>
         </t>
 
         <xpath expr="//thead//th[@name='th_taxes']" position="replace">


### PR DESCRIPTION
With AE Company setup:
- Create an invoice
- Actions > Print

Issue: Title will be 'Tax Invoice Invoice <name>'
This occurs because in l10n_ae we extend the template, prepending a string instead of replacing the title

opw-4700381