### PR TITLE
[FIX] website_sale: fix pricelist not being applied in test

### DIFF
--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -423,7 +423,11 @@ class TestWebsiteSaleProductConfigurator(
 
     def test_product_configurator_strikethrough_price(self):
         """ Test that the product configurator displays the strikethrough price correctly. """
-        self.env['res.config.settings'].create({'group_product_price_comparison': True}).execute()
+        self.env['res.config.settings'].create({
+            'group_product_price_comparison': True,
+            # Need to enable pricelists for self.pricelist to be considered and applied
+            'group_product_pricelist': True,
+        }).execute()
         self.website.show_line_subtotals_tax_selection = 'tax_included'
         tax = self.env['account.tax'].create({'name': "Tax", 'amount': 10})
         optional_product = self.env['product.template'].create({


### PR DESCRIPTION
The `group_product_pricelist` group needs to be explicitly applied, otherwise the test fails when ran without demo data.

See https://runbot.odoo.com/odoo/error/161606