### PR TITLE
[FIX] web,*: improve clean up in interactions MailGroup and WebsiteForumSpam

### DIFF
--- a/addons/mail_group/static/src/interactions/mail_group.js
+++ b/addons/mail_group/static/src/interactions/mail_group.js
@@ -16,6 +16,12 @@ export class MailGroup extends Interaction {
         ".o_mg_subscribe_btn": {
             "t-on-click.prevent": this.onToggleSubscribeClick,
         },
+        ".o_mg_email_input_group": {
+            "t-att-class": () => ({ "d-none": this.isMember }),
+        },
+        ".o_mg_unsubscribe_btn": {
+            "t-att-class": () => ({ "d-none": !this.isMember }),
+        },
     };
 
     setup() {
@@ -27,11 +33,6 @@ export class MailGroup extends Interaction {
         const searchParams = (new URL(document.location.href)).searchParams;
         this.token = searchParams.get("token");
         this.forceUnsubscribe = searchParams.has("unsubscribe");
-    }
-
-    _toggleSubscribeButton(isSubscribe) {
-        this.el.querySelector(".o_mg_email_input_group").classList.toggle("d-none", isSubscribe);
-        this.el.querySelector(".o_mg_unsubscribe_btn").classList.toggle("d-none", !isSubscribe);
     }
 
     _displayAlert(textContent, classes){
@@ -67,22 +68,18 @@ export class MailGroup extends Interaction {
 
         if (response === "added") {
             this.isMember = true;
-            this._toggleSubscribeButton(true);
         } else if (response === "removed") {
             this.isMember = false;
-            this._toggleSubscribeButton(false);
         } else if (response === "email_sent") {
             this._displayAlert(_t("An email with instructions has been sent."), "alert-success");
         } else if (response === "is_already_member") {
             this.isMember = true;
-            this._toggleSubscribeButton(true);
             this._displayAlert(_t("This email is already subscribed."), "alert-warning");
         } else if (response === "is_not_member") {
             if (!this.forceUnsubscribe) {
                 this.isMember = false;
-                this._toggleSubscribeButton(false);
             }
-        this._displayAlert(_t("This email is not subscribed."), "alert-warning");
+            this._displayAlert(_t("This email is not subscribed."), "alert-warning");
         }
     }
 }

--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -392,6 +392,24 @@ export class Interaction {
     }
 
     /**
+     * Remove the children of an element.
+     * The children will be inserted back when the interaction is destroyed.
+     *
+     * @param { HTMLElement } el
+     * @param { boolean } [insertBackOnClean]
+     */
+    removeChildren(el, insertBackOnClean = true) {
+        for (const child of el.children) {
+            this.services["public.interactions"].stopInteractions(child);
+        }
+        const children = [...el.childNodes];
+        el.replaceChildren();
+        if (insertBackOnClean) {
+            this.registerCleanup(() => el.replaceChildren(...children));
+        }
+    }
+
+    /**
      * Renders, insert and activate an element at a specific location.
      * The inserted element will be removed when the interaction is destroyed.
      *

--- a/addons/website_forum/static/src/interactions/website_forum_spam.js
+++ b/addons/website_forum/static/src/interactions/website_forum_spam.js
@@ -41,9 +41,7 @@ export class WebsiteForumSpam extends Interaction {
             ))
         ));
         const postSpamEl = this.el.querySelector("div.post_spam");
-        const postSpamElContent = postSpamEl.children;
-        postSpamEl.replaceChildren();
-        this.registerCleanup(() => postSpamEl.replaceChildren(postSpamElContent));
+        this.removeChildren(postSpamEl);
         if (!posts.length) {
             return;
         }

--- a/addons/website_mail_group/static/src/snippets/s_group/mail_group.js
+++ b/addons/website_mail_group/static/src/snippets/s_group/mail_group.js
@@ -12,6 +12,19 @@ patch(MailGroup.prototype, {
                 "t-att-class": () => ({
                     "d-none": false,
                 }),
+                "t-att-data-is-member": () => `${this.isMember}`,
+            },
+            ".o_mg_email_input_group": {
+                "t-att-class": () => ({
+                    "input-group": !this.hasMemberEmail,
+                    "d-flex": !!this.hasMemberEmail,
+                    "justify-content-end": !!this.hasMemberEmail,
+                }),
+            },
+            ".o_mg_email_input_group .o_mg_subscribe_email": {
+                "t-att-class": () => ({
+                    "d-none": !!this.hasMemberEmail,
+                }),
             },
         });
     },
@@ -31,28 +44,16 @@ patch(MailGroup.prototype, {
 
         if (!response) {
             // We do not access to the mail group, just remove the widget
-            this.el.replaceChildren();
+            this.removeChildren(this.el);
             return;
         }
 
         const userEmail = response.email;
         this.isMember = response.is_member;
 
-        const inputGroup = this.el.querySelector(".o_mg_email_input_group")
-
         if (userEmail && userEmail.length) {
-            inputGroup.classList.remove("input-group")
-            inputGroup.classList.add("d-flex", "justify-content-end");
-            const emailInputEl = inputGroup.querySelector(".o_mg_subscribe_email");
-            emailInputEl.value = userEmail;
-            emailInputEl.classList.add("d-none");
+            this.hasMemberEmail = true;
+            this.el.querySelector(".o_mg_email_input_group .o_mg_subscribe_email").value = userEmail;
         }
-
-        if (this.isMember) {
-            this.el.querySelector(".o_mg_unsubscribe_btn").classList.remove("d-none");
-            inputGroup.classList.add("d-none");
-        }
-
-        this.el.dataset.isMember = this.isMember;
     },
 });


### PR DESCRIPTION
These interactions did not correctly clean up the changes they do on the dom, leading to these changes being saved if the user goes in the website editor after the changes.

The method `Interaction.removeChildren` is added to remove the children of a node, and restore them on clean up.

The cleanup of removed children in interaction `WebsiteForumSpam` is fixed by using `Interaction.removeChildren` (before, it restored nothing because `element.children` is a live list, that means it is always updated to contain the current list of children)

The interaction `MailGroup` did not do any cleanup. The new implementation mostly rely on `dynamicContent` to do the changes instead of doing them directly, and on `Interaction.removeChildren`; they both do a cleanup of the changes they made.