### PR TITLE
[FIX] point_of_sale: reduce chunk size

### DIFF
--- a/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py
+++ b/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py
@@ -28,7 +28,7 @@ def migrate(cr, version):
             cr.execute(query)
             if not cr.rowcount:
                 break
-            ids = [r[0] for r in cr.fetchmany(100000)]
+            ids = [r[0] for r in cr.fetchmany(10000)]
             cr.execute(
                 f"UPDATE {table} SET uuid = (%s::json)->>(id::text) WHERE id IN %s",
                 [Json({id_: str(uuid.uuid4()) for id_ in ids}), tuple(ids)]


### PR DESCRIPTION
Before this commit odoo/odoo@5bb76504425082cfd654a2860350aa94d9782dbd, the update query for UUID deduplication used [cr.split_for_in_conditions()](https://github.com/odoo/odoo/blob/13133b40eb545c4d4f7427c2145b3d57074fa74b/odoo/sql_db.py#L402-L405) to chunk IDs properly for the `WHERE id IN (...)` clause.

However, after the mentioned commit, all IDs are passed at once, especially when `fetchmany()` returns up to 1 lac records. This significantly slows down the update query due to large `IN` clauses and memory overhead.

To address this, reduce the processing chunk from 1lac to 10k IDs. This reduces update time from over 2 hours to under 10 minutes in practice for recordset shown below:

```sql
apan_2760231=> select count(*) from pos_order;
 count
--------
 146885
(1 row)

apan_2760231=> select count(*) from pos_order_line;
 count
--------
 378860
(1 row)

apan_2760231=> select count(*) from pos_payment;
 count
--------
 184679
(1 row)
```

Logs:

Before fix (Almost 3 hrs):
```py
2025-04-17 07:06:31,094 31 INFO db_2760231 odoo.modules.migration: module point_of_sale: Running migration [1.0.2>] post-deduplicate-uuids
2025-04-17 10:08:39,397 31 INFO db_2760231 odoo.addons.base.models.ir_module: module point_of_sale: loading translation file /home/odoo/src/odoo/18.0/addons/point_of_sale/i18n/nl.po for language nl_NL
```

After fix (reduces to 10 mins):
```py
2025-04-17 11:29:44,294 23 INFO apan_2760231_18.0 odoo.modules.migration: module point_of_sale: Running migration [1.0.2>] post-deduplicate-uuids
2025-04-17 11:39:58,582 23 INFO apan_2760231_18.0 odoo.addons.base.models.ir_module: module point_of_sale: loading translation file /home/odoo/src/odoo/18.0/addons/point_of_sale/i18n/nl.po for language nl_NL
```

opw-4734894
upg-2760231


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
