### PR TITLE
[FIX] product: create product data for tests

### DIFF
--- a/addons/product/tests/common.py
+++ b/addons/product/tests/common.py
@@ -33,6 +33,13 @@ class ProductCommon(UomCommon):
         cls.env['product.pricelist'].search([
             ('id', '!=', cls.pricelist.id),
         ]).action_archive()
+        
+        cls.product_product_4 = cls.env['product.product'].create({
+            'name': 'Customizable Desk',
+            'default_code': 'FURN_0096',
+            'standard_price': 500.0,
+            'weight': 0.01,
+        })
 
     @classmethod
     def get_default_groups(cls):


### PR DESCRIPTION
The Issue:
Before this commit, some tests tried to get a record that was created as demo data, but in case the demo data wasn't loaded during the test, the test would fail

The Fix:
Create the product

runbot-161657

Enterprise PR: https://github.com/odoo/enterprise/pull/83618
