### PR TITLE
[FIX] l10n_pe: tax id string clarification

### DIFF
--- a/addons/l10n_pe/data/l10n_latam_identification_type_data.xml
+++ b/addons/l10n_pe/data/l10n_latam_identification_type_data.xml
@@ -12,7 +12,7 @@
 
     <record model='l10n_latam.identification.type' id='it_RUC'>
         <field name='name'>RUC</field>
-        <field name="name@es_419">Número de identificación fiscal</field>
+        <field name="name@es_419">Número de identificación fiscal (RUC)</field>
         <field name='description'>Taxpayer Identification Number</field>
         <field name='country_id' ref='base.pe'/>
         <field name='is_vat' eval='True'/>
@@ -21,7 +21,7 @@
     </record>
     <record model='l10n_latam.identification.type' id='it_DNI'>
         <field name='name'>DNI</field>
-        <field name="name@es_419">Documento nacional de identidad</field>
+        <field name="name@es_419">Documento nacional de identidad (DNI)</field>
         <field name='description'>National Identity Document</field>
         <field name='country_id' ref='base.pe'/>
         <field name='l10n_pe_vat_code'>1</field>
@@ -75,7 +75,7 @@
     </record>
     <record model='l10n_latam.identification.type' id='it_PTP'>
         <field name='name'>PTP</field>
-        <field name="name@es_419">Permiso de residencia temporal</field>
+        <field name="name@es_419">Permiso de residencia temporal (PTP)</field>
         <field name='description'>Temporary Residence Permit</field>
         <field name='country_id' ref='base.pe'/>
         <field name='l10n_pe_vat_code'>F</field>


### PR DESCRIPTION
This 'bug' was introduced when translating strings from data files became possible (87fc0d6b).

The translation of some fields in Spanish did not include their respective abbreviations leading to confusion of clients.

This commit appends the abbreviations of the problematic strings.

RD Feedback task: 4679704

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
