### PR TITLE
[FIX] stock: make lot readonly in stock picking form view

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -320,6 +320,7 @@
                                     <field name="lot_ids" widget="many2many_tags"
                                         column_invisible="parent.state == 'draft'"
                                         groups="stock.group_production_lot"
+                                        readonly="1"
                                         invisible="not show_details_visible or has_tracking == 'none'"
                                         optional="hide"
                                         options="{'create': [('parent.use_create_lots', '=', True)]}"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -320,7 +320,7 @@
                                     <field name="lot_ids" widget="many2many_tags"
                                         column_invisible="parent.state == 'draft'"
                                         groups="stock.group_production_lot"
-                                        readonly="1"
+                                        readonly="parent.state != 'draft'"
                                         invisible="not show_details_visible or has_tracking == 'none'"
                                         optional="hide"
                                         options="{'create': [('parent.use_create_lots', '=', True)]}"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Editing the lot in a picking stock move using the column "serial number (lot_ids)" can lead to inconsistency between stock quant and stock move

Current behavior before PR:

- Create a product tracked by lot without adding quantities
- Create a lot for that product
- Create a sale order for that product and validate it
- Go to the stock picking created and put the quantity to 1, and instead of clicking on the burger icon to manage lots, go to the list filters and tick the "serial number (lot_ids)"
- Then you can add a lot in the ticked serial number column and validate the picking
- This can create inconsistencies between stock move and stock quant, as the stock move has a lot, and the stock quant doesn't

![lot_readonly](https://github.com/user-attachments/assets/efad8f7b-9fdb-4275-902c-3d55a88aa9ef)


Desired behavior after PR is merged:

- Avoid the possibility of creating inconsistencies between stock quant and stock move

![image](https://github.com/user-attachments/assets/d936b02f-8bf2-42a8-b1d9-4580ce4b2aa9)

opw-4719010
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
