### PR TITLE
[FIX] web: don't export raw properties by default

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -336,7 +336,9 @@ export class KanbanController extends Component {
     }
 
     getExportableFields() {
-        return Object.keys(this.model.root.config.activeFields).map((e) => this.props.fields[e]);
+        return Object.keys(this.model.root.config.activeFields)
+            .map((e) => this.props.fields[e])
+            .filter((field) => field.type !== "properties");
     }
 
     async onSelectionChanged() {

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -256,6 +256,7 @@ export class ListController extends Component {
                 .filter((col) => !evaluateBooleanExpr(col.column_invisible, this.props.context))
                 .map((col) => this.props.fields[col.name])
                 .filter((field) => field.exportable !== false)
+                .filter((field) => field.type !== "properties")
         );
     }
 


### PR DESCRIPTION
The behavior of export is by default selecting every visible fields of
the list/kanban views. While properties fields are intentionally not
flagged as invisible (to allow users to select them in the "optionals"
view), export them returns their raw JSON content that is not
user-friendly.

This commit modifies the default export behavior to exclude raw
properties fields. Note that users can still explicitly select specific
property to export.
This change improves the usability of the export by providing a cleaner
and more readable output by default.

task-4730406