### PR TITLE
[FIX] website_slides: block suggested_recipients computation

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -1283,3 +1283,6 @@ class Channel(models.Model):
         if self.website_id:
             return super().open_website_url()
         return self.env['website'].get_client_action(f'/slides/{self.env["ir.http"]._slug(self)}')
+
+    def _mail_get_partner_fields(self, introspect_fields=False):
+        return []

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -1398,3 +1398,6 @@ class Slide(models.Model):
         if self.website_id:
             return super().open_website_url()
         return self.env['website'].get_client_action(f'/slides/slide/{self.env["ir.http"]._slug(self)}')
+
+    def _mail_get_partner_fields(self, introspect_fields=False):
+        return []

--- a/addons/website_slides/tests/__init__.py
+++ b/addons/website_slides/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_attendee
 from . import test_embed_detection
 from . import test_gamification_karma
 from . import test_load_chatter_bundle
+from . import test_mail
 from . import test_security
 from . import test_slide_channel
 from . import test_slide_question

--- a/addons/website_slides/tests/test_mail.py
+++ b/addons/website_slides/tests/test_mail.py
@@ -1,0 +1,76 @@
+from odoo.addons.website_slides.tests.common import SlidesCase
+
+
+class TestSlidesMail(SlidesCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        common_vals = {
+            'auto_delete': True,
+            'body_html': '<p>Fist fight with <t t-out="object.user_id.name"/></p>',
+            'email_from': '{{ object.user_id.email_formatted or user.email_formatted or "" }}',
+            'subject': 'Test {{ object.name }}'
+        }
+        cls.test_template_slides = cls.env['mail.template'].with_user(cls.user_manager).create({
+            **common_vals,
+            'model_id': cls.env['ir.model']._get_id('slide.slide'),
+            'name': 'Test Slide Template',
+        })
+        cls.test_template_channel = cls.env['mail.template'].with_user(cls.user_manager).create({
+            **common_vals,
+            'model_id': cls.env['ir.model']._get_id('slide.channel'),
+            'name': 'Test Channel Template',
+        })
+        cls.slide.write({
+            'partner_ids': [(6, 0, [cls.customer.id, cls.user_emp.partner_id.id, cls.user_portal.partner_id.id])],
+        })
+        cls.channel.write({
+            'partner_ids': [(6, 0, [cls.customer.id, cls.user_emp.partner_id.id, cls.user_portal.partner_id.id])],
+        })
+
+    def test_slide_channel_get_default_recipients(self):
+        channel = self.channel.with_user(self.user_manager)
+        default_recipients = channel._message_get_default_recipients()
+        self.assertDictEqual(default_recipients[channel.id], {'email_cc': False, 'email_to': False, 'partner_ids': []})
+
+    def test_slide_slide_get_default_recipients(self):
+        slide = self.slide.with_user(self.user_manager)
+        default_recipients = slide._message_get_default_recipients()
+        self.assertDictEqual(default_recipients[slide.id], {'email_cc': False, 'email_to': False, 'partner_ids': []})
+
+    def test_slide_channel_get_suggested_recipients(self):
+        channel = self.channel.with_user(self.user_manager)
+        suggested_recipient = channel._message_get_suggested_recipients()[0]
+        user_id = channel.user_id
+        self.assertDictEqual(
+            suggested_recipient,
+            {
+                'lang': None, 'email': user_id.email, 'name': user_id.name,
+                'partner_id': user_id.partner_id.id, 'reason': 'Responsible'
+            }
+        )
+
+    def test_slide_slide_get_suggested_recipients(self):
+        slide = self.slide.with_user(self.user_manager)
+        suggested_recipient = slide._message_get_suggested_recipients()
+        self.assertFalse(suggested_recipient, "The user_id is already subscribed => no suggested_recipients")
+
+    def test_slide_and_channel_templates(self):
+        values = [self.channel.with_user(self.user_manager), self.slide.with_user(self.user_manager)]
+        templates = [
+            self.test_template_channel.with_user(self.user_manager),
+            self.test_template_slides.with_user(self.user_manager),
+        ]
+        expected_values = [self.env['res.partner'], values[1].user_id.partner_id]
+        error_messages = [
+            'No auto subscribe => no notified partner_ids',
+            "auto subscribe => only slide's user_id is subscribed + notified",
+        ]
+        for channel_or_slide, template, expected_value, error_message in zip(values, templates, expected_values, error_messages):
+            with self.subTest(channel_or_slide=channel_or_slide, template=template, expected_value=expected_value):
+                message = channel_or_slide.message_post_with_source(
+                    template,
+                    message_type='comment',
+                    subtype_id=self.env.ref('mail.mt_comment').id,
+                )
+                self.assertEqual(message.notified_partner_ids, expected_value, error_message)


### PR DESCRIPTION
This commit fixes an issue with the slide.slide and slide.channel models from website_slides. When a user tries to send a message via the chatter the default_recipients and suggested_recipients added the attendees for slides and courses.
This means that everytime someone sends a message on slide.channel or slide.slide potentially hundreds of people would be spammed.

To fix this, we override in both models _mail_get_partner_fields. This method is supposed to return the name of the fields linked to customers. In the case of the above models, we don't want to send a message to all the attendees (they were stored in partner_ids which is the default field read). Thus by returning an empty list we block the computation of suggested_recipients and default_recipients. Letting full control to the user sending the email which people to notify.

task-4736015

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
