### PR TITLE
[FIX] stock: open empty history quant

### DIFF
--- a/addons/stock/static/src/widgets/counted_quantity_widget.js
+++ b/addons/stock/static/src/widgets/counted_quantity_widget.js
@@ -15,13 +15,16 @@ export class CountedQuantityWidgetField extends FloatField {
         useEffect(
             (inputEl) => {
                 if (inputEl) {
-                    inputEl.addEventListener("input", this.onInput.bind(this));
-                    inputEl.addEventListener("keydown", this.onKeydown.bind(this));
-                    inputEl.addEventListener("blur", this.onBlur.bind(this));
+                    const boundOnInput = this.onInput.bind(this);
+                    const boundOnKeydown = this.onKeydown.bind(this);
+                    const boundOnBlur = this.onBlur.bind(this);
+                    inputEl.addEventListener("input", boundOnInput);
+                    inputEl.addEventListener("keydown", boundOnKeydown);
+                    inputEl.addEventListener("blur", boundOnBlur);
                     return () => {
-                        inputEl.removeEventListener("input", this.onInput.bind(this));
-                        inputEl.removeEventListener("keydown", this.onKeydown.bind(this));
-                        inputEl.removeEventListener("blur", this.onBlur.bind(this));
+                        inputEl.removeEventListener("input", boundOnInput);
+                        inputEl.removeEventListener("keydown", boundOnKeydown);
+                        inputEl.removeEventListener("blur", boundOnBlur);
                     };
                 }
             },


### PR DESCRIPTION
**Steps to reproduce:**
- Create a new product storable product
- Open Inventory/Operations/Physical Inventory
- Add a new line
- Choose your product
- Click on History

**Current behavior:**
An Odoo Client Error window appears

**Cause of the issue:**
Inside the counted quantity widget's useEffect,
When adding the event listener "this.onInput.bind(this)" creates a new function reference
https://github.com/odoo/odoo/blob/4775c0ff640c4a092c7430a03f6324659b9bbca4/addons/stock/static/src/widgets/counted_quantity_widget.js#L18
when removing the event listener "this.onInput.bind(this)" creates another function reference
https://github.com/odoo/odoo/blob/4775c0ff640c4a092c7430a03f6324659b9bbca4/addons/stock/static/src/widgets/counted_quantity_widget.js#L22
As a consequence the event listener is not properly removed

**Fix:**
If the new function reference is created before in a variable the same function reference will be passed the two times and it will be properly removed

opw-4711101
