### PR TITLE
[FIX] l10n_es_edi_tbai_pos: fix 2 tests for tbai pos

### DIFF
--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -159,9 +159,6 @@ class L10nEsEdiTbaiDocument(models.Model):
         if error:
             return error
 
-        if not self.xml_attachment_id:
-            self._generate_xml(values)
-
         if (
             not self.chain_index
             and not self.is_cancel

--- a/addons/l10n_es_edi_tbai_pos/tests/test_tbai_pos.py
+++ b/addons/l10n_es_edi_tbai_pos/tests/test_tbai_pos.py
@@ -62,6 +62,7 @@ class TestPosEdi(TestEsEdiTbaiCommonGipuzkoa, TestPointOfSaleCommon):
 
         pos_order = self.create_pos_order(current_session, 100.0)
         self.pay_pos_order(pos_order)
+        pos_order.action_pos_order_paid()
 
         self.assertEqual(pos_order.state, 'paid')
         self.assertEqual(pos_order.l10n_es_tbai_state, 'sent')
@@ -92,6 +93,7 @@ class TestPosEdi(TestEsEdiTbaiCommonGipuzkoa, TestPointOfSaleCommon):
         # Create and pay a pos order not invoiced
         pos_order = self.create_pos_order(current_session, 100.0)
         self.pay_pos_order(pos_order)
+        pos_order.action_pos_order_paid()
 
         # Create the refund
         refund_action = pos_order.refund()


### PR DESCRIPTION
the compute method for l10n_es_tbai_state it checks for order.l10n_es_tbai_post_document_id.state == 'accepted' but the state isn't accepted yet, so needed to call the method action_pos_order_paid to change the state to 'accepted' and removed the generate of xml lines it have no use and errors (the certificate in not valid)

build_error-161065
build_error-161064

relative to this  PR : https://github.com/odoo/odoo/pull/207074/files

