### PR TITLE
[FIX] partner_autocomplete: fix crash when empty data on GST enrichment

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -80,7 +80,9 @@ export class PartnerAutoCompleteCharField extends CharField {
         data.company = this.partnerAutocomplete.removeUselessFields(data.company, Object.keys(this.props.record.fields));
 
         // Update record with retrieved values
-        await this.props.record.update({name: data.company.name});  // Needed otherwise name it is not saved
+        if (data.company.name) {
+            await this.props.record.update({name: data.company.name});  // Needed otherwise name it is not saved
+        }
         await this.props.record.update(data.company);
 
         // Add UNSPSC codes (tags)


### PR DESCRIPTION
This happened because the Partner Autocomplete service was returning an empty response for this particular GST number and the code was assuming that the name was always present.

Sentry - 6327760196
